### PR TITLE
Expand the examples

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -32,7 +32,8 @@
 	},
 
 	"Hooks": {
-		"BeforePageDisplay": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onBeforePageDisplay"
+		"BeforePageDisplay": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onBeforePageDisplay",
+		"SkinAfterPortlet": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onSkinAfterPortlet"
 	},
 
 	"ResourceFileModulePaths": {
@@ -44,31 +45,62 @@
 		"ext.neowiki.addButton": {
 			"class": "MediaWiki\\ResourceLoader\\CodexModule",
 			"dependencies": [
-				"vue"
+				"vue",
+				"pinia"
+			],
+			"codexComponents": [
+				"CdxButton",
+				"CdxIcon"
 			],
 			"packageFiles": [
 				"ext.neowiki.addButton/init.js",
 				"ext.neowiki.addButton/components/App.vue",
-				"ext.neowiki.core/components/Message.vue"
+				"ext.neowiki.core/components/NeoMessage.vue",
+				"ext.neowiki.core/stores/counter.js",
+				{
+					"name": "icons.json",
+					"callback": "MediaWiki\\ResourceLoader\\CodexModule::getIcons",
+					"callbackParam": [
+						"cdxIconAdd"
+					]
+				}
 			],
 			"styles": [
 			],
 			"messages": [
+				"neowiki-add-button",
+				"neowiki-increment"
 			]
 		},
 		"ext.neowiki.infobox": {
 			"class": "MediaWiki\\ResourceLoader\\CodexModule",
 			"dependencies": [
-				"vue"
+				"vue",
+				"pinia"
+			],
+			"codexComponents": [
+				"CdxButton",
+				"CdxCard",
+				"CdxIcon"
 			],
 			"packageFiles": [
 				"ext.neowiki.infobox/init.js",
 				"ext.neowiki.infobox/components/App.vue",
-				"ext.neowiki.core/components/Message.vue"
+				"ext.neowiki.core/components/NeoMessage.vue",
+				"ext.neowiki.core/stores/counter.js",
+				{
+					"name": "icons.json",
+					"callback": "MediaWiki\\ResourceLoader\\CodexModule::getIcons",
+					"callbackParam": [
+						"cdxIconAdd"
+					]
+				}
 			],
 			"styles": [
 			],
 			"messages": [
+				"neowiki-infobox",
+				"neowiki-increment"
 			]
 		}
 	},

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -8,5 +8,9 @@
 		]
 	},
 	"neowiki-name": "NeoWiki",
-	"neowiki-description": "TODO"
+	"neowiki-description": "TODO",
+
+	"neowiki-add-button": "addButton",
+	"neowiki-infobox": "infobox",
+	"neowiki-increment": "increment"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -8,5 +8,9 @@
 		]
 	},
 	"neowiki-name": "{{Name}}",
-	"neowiki-description": "{{Desc|name=NeoWiki|url=https://github.com/ProfessionalWiki/NeoWiki}}"
+	"neowiki-description": "{{Desc|name=NeoWiki|url=https://github.com/ProfessionalWiki/NeoWiki}}",
+
+	"neowiki-add-button": "TODO: testing",
+	"neowiki-infobox": "TODO: testing",
+	"neowiki-increment": "TODO: testing"
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		"eslint-config-wikimedia": "0.28.2",
 		"grunt-banana-checker": "0.13.0",
 		"jest-environment-jsdom": "29.7.0",
+		"pinia": "2.0.16",
 		"stylelint-config-wikimedia": "0.17.2",
 		"vue": "3.4.27"
 	}

--- a/resources/ext.neowiki.addButton/components/App.vue
+++ b/resources/ext.neowiki.addButton/components/App.vue
@@ -1,5 +1,5 @@
 <template>
-	<neo-message message="addButton"></neo-message>
+	<neo-message :message="$i18n( 'neowiki-add-button' ).text()"></neo-message>
 </template>
 
 <script>

--- a/resources/ext.neowiki.addButton/init.js
+++ b/resources/ext.neowiki.addButton/init.js
@@ -1,7 +1,11 @@
 ( function () {
 	const Vue = require( 'vue' );
+	const Pinia = require( 'pinia' );
 	const App = require( './components/App.vue' );
 
+	const pinia = Pinia.createPinia();
+
 	Vue.createMwApp( App )
+		.use( pinia )
 		.mount( '#neowiki-add-button' );
 }() );

--- a/resources/ext.neowiki.core/components/NeoMessage.vue
+++ b/resources/ext.neowiki.core/components/NeoMessage.vue
@@ -1,14 +1,47 @@
 <template>
-	<strong>{{ message }}</strong>
+	<strong>{{ message }}: {{ counter }}</strong>
+	<cdx-button
+		action="progressive"
+		weight="primary"
+		@click="increment"
+	>
+		<cdx-icon :icon="cdxIconAdd"></cdx-icon>
+		{{ $i18n( 'neowiki-increment' ) }}
+	</cdx-button>
 </template>
 
 <script>
+const { CdxButton, CdxIcon } = require( '../../codex.js' );
+const { cdxIconAdd } = require( '../../icons.json' );
+const { useCounterStore } = require( '../stores/counter.js' );
+
 // @vue/component
 module.exports = exports = {
+	components: {
+		CdxButton,
+		CdxIcon
+	},
 	props: {
 		message: {
 			type: String,
 			required: true
+		}
+	},
+	data() {
+		return {
+			cdxIconAdd
+		};
+	},
+	computed: {
+		counter() {
+			const store = useCounterStore();
+			return store.count;
+		}
+	},
+	methods: {
+		increment() {
+			const store = useCounterStore();
+			store.increment();
 		}
 	}
 };

--- a/resources/ext.neowiki.core/stores/counter.js
+++ b/resources/ext.neowiki.core/stores/counter.js
@@ -1,0 +1,16 @@
+const { defineStore } = require( 'pinia' );
+
+const useCounterStore = defineStore( 'counter', {
+	state: () => ( {
+		count: 0
+	} ),
+	actions: {
+		increment() {
+			this.count++;
+		}
+	}
+} );
+
+module.exports = {
+	useCounterStore
+};

--- a/resources/ext.neowiki.infobox/components/App.vue
+++ b/resources/ext.neowiki.infobox/components/App.vue
@@ -1,13 +1,22 @@
 <template>
-	<neo-message message="infobox"></neo-message>
+	<cdx-card>
+		<template #title>
+			Infobox
+		</template>
+		<template #description>
+			<neo-message :message="$i18n( 'neowiki-infobox' ).text()"></neo-message>
+		</template>
+	</cdx-card>
 </template>
 
 <script>
+const { CdxCard } = require( '../../codex.js' );
 const NeoMessage = require( '../../ext.neowiki.core/components/NeoMessage.vue' );
 
 // @vue/component
 module.exports = exports = {
 	components: {
+		CdxCard,
 		NeoMessage
 	}
 };

--- a/resources/ext.neowiki.infobox/init.js
+++ b/resources/ext.neowiki.infobox/init.js
@@ -1,7 +1,11 @@
 ( function () {
 	const Vue = require( 'vue' );
+	const Pinia = require( 'pinia' );
 	const App = require( './components/App.vue' );
 
+	const pinia = Pinia.createPinia();
+
 	Vue.createMwApp( App )
+		.use( pinia )
 		.mount( '#neowiki-infobox' );
 }() );

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -9,6 +9,16 @@ use Skin;
 
 class NeoWikiHooks {
 
+	public static function onSkinAfterPortlet( Skin $skin, string $portletName, string &$html ) {
+		// TODO: just for testing
+		if ( $portletName === 'views' ) {
+			if ( str_contains( $skin->getOutput()->getHTML(), 'add' ) ) {
+				$html .= '<div id="neowiki-add-button"></div>';
+				$skin->getOutput()->addModules( 'ext.neowiki.addButton' );
+			}
+		}
+	}
+
 	public static function onBeforePageDisplay( OutputPage $out, Skin $skin ): void {
 		if ( !$out->isArticle() ) {
 			return;
@@ -18,10 +28,8 @@ class NeoWikiHooks {
 		if ( str_contains( $out->getHTML(), 'infobox' ) ) {
 			$out->addHTML( '<div id="neowiki-infobox"></div>' );
 			$out->addModules( 'ext.neowiki.infobox' );
-		} else {
-			$out->addHTML( '<div id="neowiki-add-button"></div>' );
-			$out->addModules( 'ext.neowiki.addButton' );
 		}
+
 	}
 
 }

--- a/tests/jest/ext.neowiki.addButton/App.test.js
+++ b/tests/jest/ext.neowiki.addButton/App.test.js
@@ -1,9 +1,18 @@
 const { mount } = require( '@vue/test-utils' );
 const App = require( '../../../resources/ext.neowiki.addButton/components/App.vue' );
+const { createPinia, setActivePinia } = require( 'pinia' );
 
 describe( 'Add button', () => {
+	beforeEach( () => {
+		setActivePinia( createPinia() );
+	} );
+
 	it( 'renders text', () => {
-		const wrapper = mount( App );
-		expect( wrapper.text() ).toContain( 'addButton' );
+		const wrapper = mount( App, {
+			global: {
+				plugins: [ createPinia() ]
+			}
+		} );
+		expect( wrapper.text() ).toContain( 'neowiki-add-button' );
 	} );
 } );

--- a/tests/jest/ext.neowiki.core/NeoButton.test.js
+++ b/tests/jest/ext.neowiki.core/NeoButton.test.js
@@ -1,11 +1,19 @@
 const { shallowMount } = require( '@vue/test-utils' );
 const NeoMessage = require( '../../../resources/ext.neowiki.core/components/NeoMessage.vue' );
+const { setActivePinia, createPinia } = require( 'pinia' );
 
 describe( 'Neo Message', () => {
+	beforeEach( () => {
+		setActivePinia( createPinia() );
+	} );
+
 	it( 'renders text', () => {
 		const wrapper = shallowMount( NeoMessage, {
 			propsData: {
 				message: 'test text'
+			},
+			global: {
+				plugins: [ createPinia() ]
 			}
 		} );
 		expect( wrapper.text() ).toContain( 'test text' );

--- a/tests/jest/ext.neowiki.infobox/App.test.js
+++ b/tests/jest/ext.neowiki.infobox/App.test.js
@@ -1,9 +1,18 @@
 const { mount } = require( '@vue/test-utils' );
 const App = require( '../../../resources/ext.neowiki.infobox/components/App.vue' );
+const { setActivePinia, createPinia } = require( 'pinia' );
 
 describe( 'Infobox', () => {
+	beforeEach( () => {
+		setActivePinia( createPinia() );
+	} );
+
 	it( 'renders text', () => {
-		const wrapper = mount( App );
-		expect( wrapper.text() ).toContain( 'infobox' );
+		const wrapper = mount( App, {
+			global: {
+				plugins: [ createPinia() ]
+			}
+		} );
+		expect( wrapper.text() ).toContain( 'neowiki-infobox' );
 	} );
 } );


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/2014adec-adb8-49fa-838b-290510a5d111)

Not the best example, but this shows why there are 2 "apps". And how they share some components/code and also have their own code.

There is a partially working Pinia store. Both buttons increment, but only of them shows the count correctly. This is very likely due to me doing something wrong.

----

Add "add" inside a page to show the add button app. Add "infobox" to show the infobox app. Add both for both.
Example use case: there is no need to load the infobox stuff on page load if there is no infobox and if it is supposed to show only the add button. If additional resource modules need to be loaded later during the page they can probably be done with: https://www.mediawiki.org/wiki/ResourceLoader/Developing_with_ResourceLoader#Client-side_(dynamically)