### PR TITLE
Add require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
 	],
 	"require": {
 		"php": "^8.3",
-		"composer/installers": "^2|^1.0.1"
+		"composer/installers": "^2|^1.0.1",
+		"professional-wiki/neo": "@dev"
 	},
 	"require-dev": {
 		"vimeo/psalm": "^5.25.0",


### PR DESCRIPTION
From https://github.com/ProfessionalWiki/NeoExtension/pull/10#discussion_r1758389938

PHPUnit runs and passes in this PR. Also, the current NeoExtension tests aren't actually calling any code that needs those dependencies. That's why it was working without the require line.

In this PR it gets the dependencies:
https://github.com/ProfessionalWiki/NeoExtension/actions/runs/10845571490/job/30096694935#step:9:1
![Screenshot_20240913_103121](https://github.com/user-attachments/assets/d4be36a8-fc94-40dc-afb6-075cea21d435)

On master it doesn't:
https://github.com/ProfessionalWiki/NeoExtension/actions/runs/10839226622/job/30079152746#step:9:1
![Screenshot_20240913_103147](https://github.com/user-attachments/assets/743707ef-1164-433d-926d-0872996baa0a)
