### PR TITLE
Don't run PHPCS on everything

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
         run: composer install
 
       - name: Run PHPCS
-        run: vendor/bin/phpcs -p -s --standard=phpcs.xml .
+        run: vendor/bin/phpcs -p -s --standard=phpcs.xml
 
   fe-npm-test:
     name: "NPM: npm test"

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -3,8 +3,6 @@
 	<file>src/</file>
 	<file>tests/</file>
 
-	<exclude-pattern>Neo/*</exclude-pattern>
-
 	<rule ref="./vendor/mediawiki/mediawiki-codesniffer/MediaWiki">
 		<exclude name="Generic.Files.LineLength.TooLong" />
 		<exclude name="MediaWiki.Commenting.FunctionComment" />


### PR DESCRIPTION
The `.` means everything. If the command uses only the config then it is not necessary to exclude a folder that was never included in the config.