### PR TITLE
Add infobox editor to automatic infobox

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -155,7 +155,8 @@
 					"name": "icons.json",
 					"callback": "MediaWiki\\ResourceLoader\\CodexModule::getIcons",
 					"callbackParam": [
-						"cdxIconAdd"
+						"cdxIconAdd",
+						"cdxIconTrash"
 					]
 				}
 			],
@@ -167,8 +168,15 @@
 				"neowiki-create-subject-dialog-or-select",
 				"neowiki-infobox-editor-dialog-title-create",
 				"neowiki-infobox-editor-dialog-title-create-blank",
+				"neowiki-infobox-editor-dialog-title-edit",
 				"neowiki-infobox-editor-subject-label",
-				"neowiki-infobox-editor-create-button"
+				"neowiki-infobox-editor-property-label",
+				"neowiki-infobox-editor-value-label",
+				"neowiki-infobox-editor-remove-statement",
+				"neowiki-infobox-editor-add-statement",
+				"neowiki-infobox-editor-create-button",
+				"neowiki-infobox-editor-save-button",
+				"neowiki-infobox-edit-link"
 			],
 			"@group:": "TODO: Load code separately while in development. Remove later.",
 			"group": "ext.neowiki"

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -18,6 +18,14 @@
 
 	"neowiki-infobox-editor-dialog-title-create": "Create new $1",
 	"neowiki-infobox-editor-dialog-title-create-blank": "Create new subject",
+	"neowiki-infobox-editor-dialog-title-edit": "Edit $1",
 	"neowiki-infobox-editor-subject-label": "Subject label",
-	"neowiki-infobox-editor-create-button": "Create"
+	"neowiki-infobox-editor-property-label": "Property",
+	"neowiki-infobox-editor-value-label": "Value",
+	"neowiki-infobox-editor-remove-statement": "Remove",
+	"neowiki-infobox-editor-add-statement": "Add statement",
+	"neowiki-infobox-editor-create-button": "Create",
+	"neowiki-infobox-editor-save-button": "Save",
+
+	"neowiki-infobox-edit-link": "Edit"
 }

--- a/resources/ext.neowiki/src/components/AutomaticInfobox.vue
+++ b/resources/ext.neowiki/src/components/AutomaticInfobox.vue
@@ -16,14 +16,41 @@
 				</div>
 			</div>
 		</div>
+		<div class="infobox-edit">
+			<a href="#" @click.prevent="openEditor">
+				{{ $i18n( 'neowiki-infobox-edit-link' ).text() }}
+			</a>
+		</div>
+		<InfoboxEditor
+			ref="infoboxEditorDialog"
+			:selected-type="title"
+			:initial-statements="statements"
+			:is-edit-mode="true"
+			@complete="onEditComplete"
+		/>
 	</div>
 </template>
 
 <script setup lang="ts">
+import { ref } from 'vue';
+import InfoboxEditor from '@/components/Infobox/InfoboxEditor.vue';
+
 defineProps<{
 	title: string;
 	statements?: { property: string; value: string }[];
 }>();
+
+const infoboxEditorDialog = ref<typeof InfoboxEditor | null>( null );
+
+const openEditor = (): void => {
+	if ( infoboxEditorDialog.value ) {
+		infoboxEditorDialog.value.openDialog();
+	}
+};
+
+const onEditComplete = ( updatedStatements: { property: string; value: string }[] ): void => {
+	console.log( 'Updated statements:', updatedStatements );
+};
 </script>
 
 <style scoped>
@@ -38,5 +65,19 @@ defineProps<{
 
 .infobox-statement {
 	display: flex;
+}
+
+.infobox-edit {
+	text-align: right;
+	padding: 5px;
+}
+
+.infobox-edit a {
+	color: #0645ad;
+	text-decoration: none;
+}
+
+.infobox-edit a:hover {
+	text-decoration: underline;
 }
 </style>

--- a/resources/ext.neowiki/src/components/CreateSubject/CreateSubjectButton.vue
+++ b/resources/ext.neowiki/src/components/CreateSubject/CreateSubjectButton.vue
@@ -8,6 +8,7 @@
 		<InfoboxEditor
 			ref="infoboxEditorDialog"
 			:selected-type="selectedType"
+			:is-edit-mode="false"
 			@complete="onCreationComplete"
 		/>
 	</div>

--- a/resources/ext.neowiki/src/components/Infobox/InfoboxEditor.vue
+++ b/resources/ext.neowiki/src/components/Infobox/InfoboxEditor.vue
@@ -1,9 +1,13 @@
 <template>
 	<CdxDialog
 		v-model:open="isOpen"
-		:title="props.selectedType ?
-			$i18n( 'neowiki-infobox-editor-dialog-title-create', props.selectedType ).text() :
-			$i18n( 'neowiki-infobox-editor-dialog-title-create-blank' ).text()"
+		:title="isEditMode ?
+			( selectedType ?
+				$i18n( 'neowiki-infobox-editor-dialog-title-edit', selectedType ).text() :
+				$i18n( 'neowiki-infobox-editor-dialog-title-edit-blank' ).text() ) :
+			( selectedType ?
+				$i18n( 'neowiki-infobox-editor-dialog-title-create', selectedType ).text() :
+				$i18n( 'neowiki-infobox-editor-dialog-title-create-blank' ).text() )"
 		class="infobox-editor">
 		<CdxField>
 			<CdxTextInput v-model="name" />
@@ -12,33 +16,79 @@
 				{{ $i18n( 'neowiki-infobox-editor-subject-label' ).text() }}
 			</template>
 		</CdxField>
-		<CdxButton @click="submit">
-			{{ $i18n( 'neowiki-infobox-editor-create-button' ).text() }}
+		<div
+			v-for="( statement, index ) in statements"
+			:key="index"
+			class="statement-editor">
+			<CdxField>
+				<CdxTextInput v-model="statement.property" />
+				<template #label>
+					{{ $i18n( 'neowiki-infobox-editor-property-label' ).text() }}
+				</template>
+			</CdxField>
+			<CdxField>
+				<CdxTextInput v-model="statement.value" />
+				<template #label>
+					{{ $i18n( 'neowiki-infobox-editor-value-label' ).text() }}
+				</template>
+			</CdxField>
+			<CdxButton action="destructive" @click="removeStatement( index )">
+				<CdxIcon :icon="cdxIconTrash" />
+				{{ $i18n( 'neowiki-infobox-editor-remove-statement' ).text() }}
+			</CdxButton>
+		</div>
+		<CdxButton @click="addStatement">
+			<CdxIcon :icon="cdxIconAdd" />
+			{{ $i18n( 'neowiki-infobox-editor-add-statement' ).text() }}
 		</CdxButton>
+		<div>
+			<CdxButton
+				action="progressive"
+				weight="primary"
+				@click="submit">
+				{{ $i18n( 'neowiki-infobox-editor-save-button' ).text() }}
+			</CdxButton>
+		</div>
 	</CdxDialog>
 </template>
 
 <script setup lang="ts">
 import { ref } from 'vue';
-import { CdxDialog, CdxTextInput, CdxButton, CdxField } from '@wikimedia/codex';
+import { CdxDialog, CdxTextInput, CdxButton, CdxField, CdxIcon } from '@wikimedia/codex';
+import { cdxIconAdd, cdxIconTrash } from '@wikimedia/codex-icons';
 
 const props = defineProps<{
 	selectedType: string;
+	initialStatements?: { property: string; value: string }[];
+	isEditMode: boolean;
 }>();
 
 const emit = defineEmits( [ 'complete' ] );
 const isOpen = ref( false );
 const name = ref( '' );
+const statements = ref<{ property: string; value: string }[]>( [] );
 
 const openDialog = (): void => {
 	isOpen.value = true;
-	name.value = '';
+	name.value = props.selectedType || '';
+	statements.value = props.initialStatements ? [ ...props.initialStatements ] : [];
+};
+
+const addStatement = (): void => {
+	statements.value.push( { property: '', value: '' } );
+};
+
+const removeStatement = ( index: number ): void => {
+	statements.value.splice( index, 1 );
 };
 
 const submit = (): void => {
-	console.log( `Creating ${ props.selectedType || 'subject' }: ${ name.value }` );
+	console.log(
+		`${ props.isEditMode ? 'Updating' : 'Creating' } ${ props.selectedType || 'subject' }: ${ name.value }`
+	);
+	console.log( 'Statements:', statements.value );
 	isOpen.value = false;
-	emit( 'complete' );
+	emit( 'complete', statements.value );
 };
 
 defineExpose( { openDialog } );
@@ -47,5 +97,11 @@ defineExpose( { openDialog } );
 <style>
 .cdx-dialog.infobox-editor {
 	max-width: 800px;
+}
+
+.statement-editor {
+	margin-bottom: 10px;
+	padding-bottom: 10px;
+	border-bottom: 1px solid #eaecf0;
 }
 </style>

--- a/resources/ext.neowiki/tests/components/AutomaticInfobox.spec.ts
+++ b/resources/ext.neowiki/tests/components/AutomaticInfobox.spec.ts
@@ -1,12 +1,22 @@
-import { describe, it, expect } from 'vitest';
 import { mount } from '@vue/test-utils';
+import { describe, it, expect, vi } from 'vitest';
 import AutomaticInfobox from '@/components/AutomaticInfobox.vue';
+
+const $i18n = vi.fn().mockImplementation( ( key ) => ( {
+	text: () => key
+} ) );
 
 describe( 'AutomaticInfobox', () => {
 	it( 'renders the title correctly', () => {
 		const wrapper = mount( AutomaticInfobox, {
 			props: {
-				title: 'Test Title'
+				title: 'Test Title',
+				statements: []
+			},
+			global: {
+				mocks: {
+					$i18n
+				}
 			}
 		} );
 
@@ -23,6 +33,11 @@ describe( 'AutomaticInfobox', () => {
 			props: {
 				title: 'Test Title',
 				statements
+			},
+			global: {
+				mocks: {
+					$i18n
+				}
 			}
 		} );
 
@@ -40,10 +55,32 @@ describe( 'AutomaticInfobox', () => {
 		const wrapper = mount( AutomaticInfobox, {
 			props: {
 				title: 'Test Title'
+			},
+			global: {
+				mocks: {
+					$i18n
+				}
 			}
 		} );
 
-		expect( wrapper.find( '.infobox-statements' ).exists() ).toBe( true );
 		expect( wrapper.findAll( '.infobox-statement' ) ).toHaveLength( 0 );
+	} );
+
+	it( 'renders the edit link correctly', () => {
+		const wrapper = mount( AutomaticInfobox, {
+			props: {
+				title: 'Test Title',
+				statements: []
+			},
+			global: {
+				mocks: {
+					$i18n
+				}
+			}
+		} );
+
+		const editLink = wrapper.find( '.infobox-edit a' );
+		expect( editLink.exists() ).toBe( true );
+		expect( editLink.text() ).toBe( 'neowiki-infobox-edit-link' );
 	} );
 } );


### PR DESCRIPTION
* Adds an edit link on the infobox.
* Adds "add/remove statements" in infobox editor.
* Shows existing statements in infobox editor.

Mostly Claude-generated with tweaks. I think this is the last of the stubbing for now.

[Screencast_20240917_102228.webm](https://github.com/user-attachments/assets/0ba55ee9-f7c7-4c26-a243-aa63afce4815)
