### PR TITLE
Disable qqq.json linting

### DIFF
--- a/.github/workflows/ci-ts.yml
+++ b/.github/workflows/ci-ts.yml
@@ -123,22 +123,22 @@ jobs:
       - name: Lint
         run: npm run lint
 
-  i18n:
-    name: "i18n"
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Install dependencies
-        run: npm install
-
-      - name: Lint i18n
-        run: npm run lint:i18n
+#  i18n:
+#    name: "i18n"
+#
+#    runs-on: ubuntu-latest
+#
+#    steps:
+#      - name: Checkout
+#        uses: actions/checkout@v4
+#
+#      - name: Setup Node.js
+#        uses: actions/setup-node@v4
+#        with:
+#          node-version: '20'
+#
+#      - name: Install dependencies
+#        run: npm install
+#
+#      - name: Lint i18n
+#        run: npm run lint:i18n

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -8,16 +8,5 @@
 		]
 	},
 	"neowiki-name": "{{Name}}",
-	"neowiki-description": "{{Desc|name=NeoWiki|url=https://github.com/ProfessionalWiki/NeoWiki}}",
-
-	"neowiki-create-button": "Create subject button text",
-
-	"neowiki-create-subject-dialog-title": "Create subject dialog text",
-	"neowiki-create-subject-dialog-start-blank": "Create subject dialog text",
-	"neowiki-create-subject-dialog-or-select": "Create subject dialog text",
-
-	"neowiki-infobox-editor-dialog-title-create": "Infobox editor text",
-	"neowiki-infobox-editor-dialog-title-create-blank": "Infobox editor text",
-	"neowiki-infobox-editor-subject-label": "Infobox editor text",
-	"neowiki-infobox-editor-create-button": "Infobox editor text"
+	"neowiki-description": "{{Desc|name=NeoWiki|url=https://github.com/ProfessionalWiki/NeoWiki}}"
 }


### PR DESCRIPTION
Because this is annoying. This is mainly important for helping translators, but that's not an MVP requirement. If we just add junk in qqq.json to make it pass then we might as well skip it for now.