### PR TITLE
Remove neo package and use path instead

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -128,19 +128,11 @@
 	},
 
 	"ResourceModules": {
-		"neo": {
-			"packageFiles": [
-				"Neo/neojs/dist/index.js"
-			],
-			"@group:": "TODO: Load code separately while in development. Remove later.",
-			"group": "neo"
-		},
 		"ext.neowiki": {
 			"class": "MediaWiki\\ResourceLoader\\CodexModule",
 			"dependencies": [
 				"vue",
-				"pinia",
-				"neo"
+				"pinia"
 			],
 			"codexComponents": [
 				"CdxButton",

--- a/resources/ext.neowiki/package.json
+++ b/resources/ext.neowiki/package.json
@@ -17,6 +17,7 @@
 	},
 	"devDependencies": {
 		"@stylistic/eslint-plugin": "^2.8.0",
+		"@types/jsdom": "^21.1.7",
 		"@types/node": "^22.5.5",
 		"@vitejs/plugin-vue": "^5.1.3",
 		"@vitest/coverage-v8": "^2.1.1",
@@ -27,7 +28,6 @@
 		"@wmde/eslint-config-wikimedia-typescript": "^0.2.12",
 		"eslint-config-wikimedia": "^0.28.2",
 		"jsdom": "^25.0.0",
-		"neo": "file:../../Neo/neojs",
 		"npm-run-all": "^4.1.5",
 		"pinia": "2.0.16",
 		"postcss-html": "^1.7.0",

--- a/resources/ext.neowiki/src/neowiki.ts
+++ b/resources/ext.neowiki/src/neowiki.ts
@@ -1,7 +1,11 @@
 import { createMwApp } from 'vue';
 import { createPinia } from 'pinia';
 import NeoWikiApp from '@/components/NeoWikiApp.vue';
+import { Neo } from '@neo/Neo.ts';
 
 const app = createMwApp( NeoWikiApp );
 app.use( createPinia() );
 app.mount( '#neowiki' );
+
+// TODO: this is just to include Neo code in the build. Remove when actually using it.
+Neo.getInstance();

--- a/resources/ext.neowiki/tsconfig.app.json
+++ b/resources/ext.neowiki/tsconfig.app.json
@@ -16,14 +16,13 @@
 
 		/* Linting */
 		"strict": true,
-		"noUnusedLocals": true,
-		"noUnusedParameters": true,
 		"noFallthroughCasesInSwitch": true,
 
 		"baseUrl": ".",
 		"paths": {
-			"@/*": ["./src/*"]
+			"@/*": ["./src/*"],
+			"@neo/*": ["../../Neo/neojs/src/*"]
 		}
 	},
-	"include": ["src/**/*.ts", "src/**/*.vue"]
+	"include": ["src/**/*.ts", "src/**/*.vue", "../../Neo/neojs/src/**/*.ts"]
 }

--- a/resources/ext.neowiki/tsconfig.json
+++ b/resources/ext.neowiki/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    { "path": "./tsconfig.node.json" },
+	{ "path": "./tsconfig.vitest.json" }
   ]
 }

--- a/resources/ext.neowiki/tsconfig.node.json
+++ b/resources/ext.neowiki/tsconfig.node.json
@@ -14,8 +14,6 @@
 
 		/* Linting */
 		"strict": true,
-		"noUnusedLocals": true,
-		"noUnusedParameters": true,
 		"noFallthroughCasesInSwitch": true
 	},
 	"include": ["vite.config.ts"]

--- a/resources/ext.neowiki/tsconfig.vitest.json
+++ b/resources/ext.neowiki/tsconfig.vitest.json
@@ -1,0 +1,14 @@
+{
+	"extends": "./tsconfig.app.json",
+	"include": ["src/**/*.ts", "src/**/*.vue", "../../Neo/neojs/src/**/*.ts", "tests/**/*.ts"],
+	"exclude": [],
+	"compilerOptions": {
+		"composite": true,
+		"lib": [],
+		"types": [
+			"node",
+			"jsdom"
+		],
+		"allowJs": false
+	}
+}

--- a/resources/ext.neowiki/vite.config.ts
+++ b/resources/ext.neowiki/vite.config.ts
@@ -7,7 +7,8 @@ export default defineConfig( {
 	plugins: [ vue(), mediawikiImportTransformer() ],
 	resolve: {
 		alias: {
-			'@': fileURLToPath( new URL( './src', import.meta.url ) )
+			'@': fileURLToPath( new URL( './src', import.meta.url ) ),
+			'@neo': fileURLToPath( new URL( '../../Neo/neojs/src', import.meta.url ) )
 		}
 	},
 	build: {


### PR DESCRIPTION
Depends on https://github.com/ProfessionalWiki/Neo/pull/32

This allows us to import the code from the Neo repo without building a library.

This also fixes some weirdness where the IDE would think some imports are missing, but everything builds/test correctly.