### PR TITLE
reduce size of neowiki.js

### DIFF
--- a/resources/ext.neowiki/vite.config.ts
+++ b/resources/ext.neowiki/vite.config.ts
@@ -40,6 +40,6 @@ export default defineConfig( {
 		},
 		target: 'es2015',
 		sourcemap: true,
-		minify: false
+		minify: true
 	}
 } );


### PR DESCRIPTION
@malberts  This improves file size by 50%; I think it can make a good difference when we have a lot of code. 

Is there a good reason why we were using `minify: false`?

After compression:

![neoextension-after](https://github.com/user-attachments/assets/1efc3f79-6b5e-4cdb-a86c-a7e6d49d0865)

Before compression:

![neoextension-before](https://github.com/user-attachments/assets/04b6a142-1087-459b-852f-d3e0bd178384)
