### PR TITLE
Inline Field

### DIFF
--- a/resources/ext.neowiki/src/assets/scss/global.scss
+++ b/resources/ext.neowiki/src/assets/scss/global.scss
@@ -1,0 +1,37 @@
+.neo-cdx-field-inline {
+	display: grid;
+	grid-template-columns: auto 1fr;
+	grid-column-gap: 10px;
+
+	.cdx-label {
+		width: 150px;
+	}
+
+	.cdx-field__control {
+		grid-column: 2 / 3;
+		grid-row: 1 / 2;
+
+		.cdx-select-vue {
+			display: block;
+		}
+	}
+
+	.cdx-label__description {
+		margin-top: 3px;
+	}
+
+	.cdx-field__help-text {
+		grid-column: 2 / 3;
+		grid-row: 3 / 4;
+		margin-top: 0;
+		display: block;
+	}
+
+	:has( .cdx-label__description:empty ) .cdx-field__control {
+		margin-bottom: 5px;
+	}
+
+	:has( .cdx-field__help-text:empty ) {
+		grid-template-rows: auto auto;
+	}
+}

--- a/resources/ext.neowiki/src/neowiki.ts
+++ b/resources/ext.neowiki/src/neowiki.ts
@@ -1,5 +1,6 @@
 import { createMwApp } from 'vue';
 import { createPinia } from 'pinia';
+import '@/assets/scss/global.scss';
 import NeoWikiApp from '@/components/NeoWikiApp.vue';
 import { Neo } from '@neo/Neo.ts';
 


### PR DESCRIPTION
For: https://github.com/ProfessionalWiki/NeoExtension/issues/47

It becomes a little challenging because of the helping text and description. However, simply adding this class to `CdxField` should get the job done.  This class works for fields with and without helping text or description. Here is an example:

```vue
<CdxField class="neo-cdx-field-inline">
			<CdxSelect
				v-model:selected="selection"
				:menu-items="menuItems"
				default-label="Choose an option"
			/>

			<template #label>
				Input type
			</template>
			<template #description>
				Descriptin for the label
			</template>
			<template #help-text>
				What kind of data does the function accept? See <a href="https://wikifunctions.beta.wmflabs.org/wiki/Special:ListZObjectsByType/Z4">list of input types</a>.
			</template>
		</CdxField>
``` 

![inline-fields](https://github.com/user-attachments/assets/7937e362-ce23-47ce-824b-a0e6791ccc68)
