### PR TITLE
Disable max-len linting

### DIFF
--- a/resources/ext.neowiki/.eslintrc.cjs
+++ b/resources/ext.neowiki/.eslintrc.cjs
@@ -45,7 +45,7 @@ module.exports = {
 		'@stylistic/semi': [ 'error', 'always' ],
 		// Overrides.
 		'n/no-missing-import': 'off',
-		'max-len': [ 'warn', { code: 120 } ],
+		'max-len': 'off',
 		'vue/no-v-model-argument': 'off',
 		'es-x/no-optional-chaining': 'off',
 		'no-unused-vars': 'off',


### PR DESCRIPTION
If we're going to use the max line length linting, then it should be an error.
Otherwise if it's a warning we're just going to ignore it, making it useless.