### PR TITLE
Remove coverage from `make ts-test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,5 +51,8 @@ ts-test:
 ts-test-watch:
 	docker run -it --rm -v "$(CURDIR)":/home/node/app -w /home/node/app/resources/ext.neowiki -u node node:20 npm run test:watch
 
+ts-coverage:
+	docker run -it --rm -v "$(CURDIR)":/home/node/app -w /home/node/app/resources/ext.neowiki -u node node:20 npm run coverage
+
 ts-lint:
 	docker run -it --rm -v "$(CURDIR)":/home/node/app -w /home/node/app/resources/ext.neowiki -u node node:20 npm run lint

--- a/resources/ext.neowiki/package.json
+++ b/resources/ext.neowiki/package.json
@@ -12,7 +12,8 @@
 		"lint:code": "eslint . --ext .vue,.ts --ignore-path .gitignore",
 		"lint:styles": "NODE_NO_WARNINGS=1 stylelint \"src/**/*.{vue,scss}\"",
 		"lint": "npm-run-all lint:code lint:styles",
-		"test": "vitest run --coverage",
+		"test": "vitest run",
+		"coverage": "vitest run --coverage",
 		"test:watch": "vitest --coverage"
 	},
 	"devDependencies": {


### PR DESCRIPTION
So you can actually see if the tests passed without scrolling up

Added `make ts-coverage` to get the old behavior