### PR TITLE
Remove hover effect on button and label

### DIFF
--- a/resources/ext.neowiki/src/assets/scss/global.scss
+++ b/resources/ext.neowiki/src/assets/scss/global.scss
@@ -110,10 +110,6 @@ input {
 		cursor: pointer !important;
 		font-size: $font-size-small !important;
 	}
-
-	small:hover {
-		color: #000 !important;
-	}
 }
 
 $background-color-backdrop-light: #6c757dbf;


### PR DESCRIPTION
Although this is a low P but wanted to warm myself up.

For:

https://github.com/ProfessionalWiki/NeoExtension/issues/126
https://github.com/ProfessionalWiki/NeoExtension/issues/129

![hover](https://github.com/user-attachments/assets/461aea55-4051-4e28-aa41-b727a0869b3f)


I am not sure if "This field is required " is the right copy here. It can confuse the user into thinking that they have to "Check" this checkbox. Perhaps it should be like, "Make it a required Property" or "This Property is required" or something.
