### PR TITLE
Replace dummy Subject ID

### DIFF
--- a/resources/ext.neowiki/src/components/Infobox/InfoboxEditor.vue
+++ b/resources/ext.neowiki/src/components/Infobox/InfoboxEditor.vue
@@ -135,7 +135,7 @@ const openDialog = (): void => {
 
 	} else {
 		localSubject.value = new Subject(
-			new SubjectId( '12345678-0000-0000-0000-000000000123' ),
+			new SubjectId( 'stodotodotodo42' ),
 			'',
 			props.selectedSchema as SchemaName,
 			new StatementList( [] ),


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoExtension/issues/134

Follow-up to #112 

This makes the InfoboxEditor show up again, although there are follow-up issues there.