### PR TITLE
Use provide/inject for global dependencies

### DIFF
--- a/resources/ext.neowiki/src/Service.ts
+++ b/resources/ext.neowiki/src/Service.ts
@@ -1,0 +1,10 @@
+import { inject } from 'vue';
+import { FormatSpecificComponentRegistry } from '@/FormatSpecificComponentRegistry.ts';
+
+export enum Service {
+	ComponentRegistry = 'ComponentRegistry'
+}
+
+export function injectComponentRegistry(): FormatSpecificComponentRegistry {
+	return inject( Service.ComponentRegistry ) as FormatSpecificComponentRegistry;
+}

--- a/resources/ext.neowiki/src/components/AutomaticInfobox/AutomaticInfobox.vue
+++ b/resources/ext.neowiki/src/components/AutomaticInfobox/AutomaticInfobox.vue
@@ -43,7 +43,6 @@
 			ref="infoboxEditorDialog"
 			:is-edit-mode="true"
 			:subject="subjectRef as Subject"
-			:component-registry="componentRegistry"
 			@save="saveSubject"
 			@add-statement="addStatement"
 		/>
@@ -68,7 +67,7 @@ import PropertyDefinitionEditor from '@/components/UIComponents/PropertyDefiniti
 import { useSchemaStore } from '@/stores/SchemaStore';
 import { ValueType } from '@neo/domain/Value.ts';
 import { PropertyDefinitionList } from '@neo/domain/PropertyDefinitionList.ts';
-import { FormatSpecificComponentRegistry } from '@/FormatSpecificComponentRegistry.ts';
+import { injectComponentRegistry } from '@/Service.ts';
 
 const props = defineProps( {
 	subject: {
@@ -77,10 +76,6 @@ const props = defineProps( {
 	},
 	schema: {
 		type: Object as PropType<Schema>,
-		required: true
-	},
-	componentRegistry: {
-		type: Object as PropType<FormatSpecificComponentRegistry>,
 		required: true
 	},
 	canEdit: {
@@ -100,7 +95,7 @@ const selectedPropertyType = ref<string | null>( null );
 
 const editingProperty = ref<PropertyDefinition | null>( null );
 
-const getComponent = ( formatName: string ): Component => props.componentRegistry?.getValueDisplayComponent( formatName );
+const getComponent = ( formatName: string ): Component => injectComponentRegistry().getValueDisplayComponent( formatName );
 
 const propertiesToDisplay = computed( (): Record<string, PropertyDefinition> => {
 	if ( !subjectRef.value ) {

--- a/resources/ext.neowiki/src/components/CreateSubject/CreateSubjectButton.vue
+++ b/resources/ext.neowiki/src/components/CreateSubject/CreateSubjectButton.vue
@@ -12,7 +12,6 @@
 			ref="infoboxEditorDialog"
 			:selected-schema="selectedSchema"
 			:is-edit-mode="false"
-			:component-registry="NeoWikiExtension.getInstance().getFormatSpecificComponentRegistry()"
 			@complete="onCreationComplete"
 			@back="onInfoboxBack"
 		/>

--- a/resources/ext.neowiki/src/components/Infobox/InfoboxEditor.vue
+++ b/resources/ext.neowiki/src/components/Infobox/InfoboxEditor.vue
@@ -32,7 +32,6 @@
 			:key="index"
 			class="statement-editor-row"
 			:statement="<Statement>statement"
-			:component-registry="componentRegistry"
 			@update="updateStatement( index, $event )"
 			@remove="removeStatement( index )"
 			@edit="editProperty"
@@ -94,12 +93,10 @@ import type { PropertyDefinition } from '@neo/domain/PropertyDefinition';
 import { PropertyDefinitionList } from '@neo/domain/PropertyDefinitionList.ts';
 import { PageIdentifiers } from '@neo/domain/PageIdentifiers.ts';
 import { newSubject } from '@neo/TestHelpers.ts';
-import { FormatSpecificComponentRegistry } from '@/FormatSpecificComponentRegistry.ts';
 
 const props = defineProps<{
 	selectedSchema?: string;
 	subject?: Subject;
-	componentRegistry: FormatSpecificComponentRegistry;
 }>();
 
 const emit = defineEmits( [ 'save', 'back', 'addStatement' ] );

--- a/resources/ext.neowiki/src/components/NeoWikiApp.vue
+++ b/resources/ext.neowiki/src/components/NeoWikiApp.vue
@@ -8,7 +8,6 @@
 		<AutomaticInfobox
 			:subject="infobox.subject as Subject"
 			:schema="infobox.schema as Schema"
-			:component-registry="componentRegistry"
 			:can-edit="infobox.canEdit"
 		/>
 	</teleport>
@@ -19,7 +18,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, computed } from 'vue';
+import { ref, onMounted } from 'vue';
 import { useSubjectStore } from '@/stores/SubjectStore';
 import { SubjectId } from '@neo/domain/SubjectId';
 import { Subject } from '@neo/domain/Subject';
@@ -40,8 +39,6 @@ interface InfoboxData {
 const infoboxData = ref<InfoboxData[]>( [] );
 const subjectStore = useSubjectStore();
 const schemaStore = useSchemaStore();
-
-const componentRegistry = computed( () => NeoWikiExtension.getInstance().getFormatSpecificComponentRegistry() );
 
 const canCreateSubject = ref( false );
 

--- a/resources/ext.neowiki/src/components/UIComponents/StatementEditor.vue
+++ b/resources/ext.neowiki/src/components/UIComponents/StatementEditor.vue
@@ -23,17 +23,18 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch, Component } from 'vue';
+import { ref, watch, Component, inject } from 'vue';
 import { Statement } from '@neo/domain/Statement';
 import { Value, ValueType, StringValue, NumberValue, newStringValue, newNumberValue } from '@neo/domain/Value';
 import { PropertyName } from '@neo/domain/PropertyDefinition';
-import { FormatSpecificComponentRegistry } from '@/FormatSpecificComponentRegistry.ts';
 import PropertyNameField from '@/components/UIComponents/PropertyNameField.vue';
+import { injectComponentRegistry } from '@/Service.ts';
 
 const props = defineProps<{
 	statement: Statement;
-	componentRegistry: FormatSpecificComponentRegistry;
 }>();
+
+const componentRegistry = injectComponentRegistry();
 
 const emit = defineEmits( [ 'update', 'remove', 'edit' ] );
 

--- a/resources/ext.neowiki/src/neowiki.ts
+++ b/resources/ext.neowiki/src/neowiki.ts
@@ -2,12 +2,11 @@ import { createMwApp } from 'vue';
 import { createPinia } from 'pinia';
 import '@/assets/scss/global.scss';
 import NeoWikiApp from '@/components/NeoWikiApp.vue';
-import { Neo } from '@neo/Neo.ts';
 import { CdxTooltip } from '@wikimedia/codex';
+import { Service } from '@/Service.ts';
+import { NeoWikiExtension } from '@/NeoWikiExtension.ts';
 
 const app = createMwApp( NeoWikiApp ).directive( 'tooltip', CdxTooltip );
 app.use( createPinia() );
 app.mount( '#neowiki' );
-
-// TODO: this is just to include Neo code in the build. Remove when actually using it.
-Neo.getInstance();
+app.provide( Service.ComponentRegistry, NeoWikiExtension.getInstance().getFormatSpecificComponentRegistry() );

--- a/resources/ext.neowiki/tests/components/AutomaticInfobox/AutomaticInfobox.spec.ts
+++ b/resources/ext.neowiki/tests/components/AutomaticInfobox/AutomaticInfobox.spec.ts
@@ -17,6 +17,7 @@ import { PropertyDefinitionList } from '@neo/domain/PropertyDefinitionList';
 import { createPropertyDefinitionFromJson } from '@neo/domain/PropertyDefinition';
 import { setActivePinia, createPinia } from 'pinia';
 import { useSchemaStore } from '@/stores/SchemaStore';
+import { Service } from '@/Service';
 
 const $i18n = vi.fn().mockImplementation( ( key ) => ( {
 	text: () => key
@@ -65,12 +66,14 @@ describe( 'AutomaticInfobox', () => {
 		const wrapper = mount( AutomaticInfobox, {
 			props: {
 				subject: mockSubject,
-				schema: mockSchema,
-				componentRegistry: NeoWikiExtension.getInstance().getFormatSpecificComponentRegistry()
+				schema: mockSchema
 			},
 			global: {
 				mocks: {
 					$i18n
+				},
+				provide: {
+					[ Service.ComponentRegistry ]: NeoWikiExtension.getInstance().getFormatSpecificComponentRegistry()
 				}
 			}
 		} );
@@ -82,12 +85,14 @@ describe( 'AutomaticInfobox', () => {
 		const wrapper = mount( AutomaticInfobox, {
 			props: {
 				subject: mockSubject,
-				schema: mockSchema,
-				componentRegistry: NeoWikiExtension.getInstance().getFormatSpecificComponentRegistry()
+				schema: mockSchema
 			},
 			global: {
 				mocks: {
 					$i18n
+				},
+				provide: {
+					[ Service.ComponentRegistry ]: NeoWikiExtension.getInstance().getFormatSpecificComponentRegistry()
 				}
 			}
 		} );
@@ -122,12 +127,14 @@ describe( 'AutomaticInfobox', () => {
 		const wrapper = mount( AutomaticInfobox, {
 			props: {
 				subject: emptySubject,
-				schema: mockSchema,
-				componentRegistry: NeoWikiExtension.getInstance().getFormatSpecificComponentRegistry()
+				schema: mockSchema
 			},
 			global: {
 				mocks: {
 					$i18n
+				},
+				provide: {
+					[ Service.ComponentRegistry ]: NeoWikiExtension.getInstance().getFormatSpecificComponentRegistry()
 				}
 			}
 		} );
@@ -143,12 +150,14 @@ describe( 'AutomaticInfobox', () => {
 			props: {
 				subject: mockSubject,
 				schema: mockSchema,
-				componentRegistry: NeoWikiExtension.getInstance().getFormatSpecificComponentRegistry(),
 				canEdit: false
 			},
 			global: {
 				mocks: {
 					$i18n
+				},
+				provide: {
+					[ Service.ComponentRegistry ]: NeoWikiExtension.getInstance().getFormatSpecificComponentRegistry()
 				}
 			}
 		} );
@@ -161,12 +170,14 @@ describe( 'AutomaticInfobox', () => {
 			props: {
 				subject: mockSubject,
 				schema: mockSchema,
-				componentRegistry: NeoWikiExtension.getInstance().getFormatSpecificComponentRegistry(),
 				canEdit: true
 			},
 			global: {
 				mocks: {
 					$i18n
+				},
+				provide: {
+					[ Service.ComponentRegistry ]: NeoWikiExtension.getInstance().getFormatSpecificComponentRegistry()
 				}
 			}
 		} );


### PR DESCRIPTION
To avoid prop drilling.

@JeroenDeDauw this is what we talked about in the call.

This apparently fixes #124 too.