### PR TITLE
Add saveSchema method

### DIFF
--- a/resources/ext.neowiki/.eslintrc.cjs
+++ b/resources/ext.neowiki/.eslintrc.cjs
@@ -47,6 +47,7 @@ module.exports = {
 		// Overrides.
 		'n/no-missing-import': 'off',
 		'max-len': 'off',
+		camelcase: 'off',
 		'vue/no-v-model-argument': 'off',
 		'es-x/no-optional-chaining': 'off',
 		'no-unused-vars': 'off',
@@ -61,7 +62,7 @@ module.exports = {
 		{
 			files: [
 				'src/infrastructure/**/*.ts',
-				'src/persistence/RestSchemaRepository.ts'
+				'src/persistence/*.ts'
 			],
 			rules: {
 				'@typescript-eslint/no-explicit-any': 'off'

--- a/resources/ext.neowiki/src/NeoWikiExtension.ts
+++ b/resources/ext.neowiki/src/NeoWikiExtension.ts
@@ -18,6 +18,7 @@ import { ProductionHttpClient } from '@/infrastructure/HttpClient/ProductionHttp
 import { RestSchemaRepository } from '@/persistence/RestSchemaRepository.ts';
 import { SchemaRepository } from '@/application/SchemaRepository.ts';
 import { CsrfSendingHttpClient } from '@/infrastructure/HttpClient/CsrfSendingHttpClient.ts';
+import { SchemaSerializer } from '@/persistence/SchemaSerializer.ts';
 
 export class NeoWikiExtension {
 	private static instance: NeoWikiExtension;
@@ -60,7 +61,8 @@ export class NeoWikiExtension {
 	public getSchemaRepository(): SchemaRepository {
 		return new RestSchemaRepository(
 			this.getMediaWiki().util.wikiScript( 'rest' ),
-			this.newHttpClient()
+			this.newHttpClient(),
+			new SchemaSerializer()
 		);
 	}
 

--- a/resources/ext.neowiki/src/application/SchemaRepository.ts
+++ b/resources/ext.neowiki/src/application/SchemaRepository.ts
@@ -1,5 +1,8 @@
 import type { SchemaLookup } from '@/application/SchemaLookup';
+import { Schema } from '@neo/domain/Schema.ts';
 
 export interface SchemaRepository extends SchemaLookup {
-	// TODO: createSchema()
+
+	saveSchema( schema: Schema ): Promise<void>;
+
 }

--- a/resources/ext.neowiki/src/persistence/SchemaSerializer.ts
+++ b/resources/ext.neowiki/src/persistence/SchemaSerializer.ts
@@ -1,0 +1,30 @@
+import { Schema } from '@neo/domain/Schema';
+import { PropertyDefinitionList } from '@neo/domain/PropertyDefinitionList';
+import { PropertyDefinition } from '@neo/domain/PropertyDefinition';
+
+export class SchemaSerializer {
+
+	public serializeSchema( schema: Schema ): string {
+		return JSON.stringify(
+			{
+				description: schema.getDescription(),
+				propertyDefinitions: this.serializePropertyDefinitions( schema.getPropertyDefinitions() )
+			},
+			null,
+			4
+		);
+	}
+
+	private serializePropertyDefinitions( propertyDefinitions: PropertyDefinitionList ): Record<string, any> {
+		const serializedDefinitions: Record<string, any> = {};
+		for ( const property of propertyDefinitions ) {
+			serializedDefinitions[ property.name.toString() ] = this.serializePropertyDefinition( property );
+		}
+		return serializedDefinitions;
+	}
+
+	private serializePropertyDefinition( property: PropertyDefinition ): any {
+		const { name, ...propertyWithoutName } = property;
+		return propertyWithoutName;
+	}
+}

--- a/resources/ext.neowiki/tests/persistence/RestSchemaRepository.neo4j.spec.ts
+++ b/resources/ext.neowiki/tests/persistence/RestSchemaRepository.neo4j.spec.ts
@@ -1,12 +1,20 @@
 import { RestSchemaRepository } from '@/persistence/RestSchemaRepository';
-import { describe, expect, it } from 'vitest';
+import { SchemaSerializer } from '@/persistence/SchemaSerializer';
+import { describe, expect, it, vi, beforeEach, Mock } from 'vitest';
 import { PropertyName } from '@neo/domain/PropertyDefinition';
+import { Schema } from '@neo/domain/Schema';
+import { PropertyDefinitionList } from '@neo/domain/PropertyDefinitionList';
 import { InMemoryHttpClient } from '@/infrastructure/HttpClient/InMemoryHttpClient';
 import { TextFormat } from '@neo/domain/valueFormats/Text';
+import { HttpClient } from '@/infrastructure/HttpClient/HttpClient';
 
 describe( 'RestSchemaRepository', () => {
 
 	describe( 'getSchema', () => {
+
+		function newSchemaRepository( httpClient: HttpClient ): RestSchemaRepository {
+			return new RestSchemaRepository( 'https://example.com/rest.php', httpClient, new SchemaSerializer() );
+		}
 
 		it( 'throws error when the API call fails', async () => {
 			const inMemoryHttpClient = new InMemoryHttpClient( {
@@ -14,7 +22,7 @@ describe( 'RestSchemaRepository', () => {
 					new Response( JSON.stringify( { httpCode: 404, httpReason: 'Not Found' } ), { status: 404 } )
 			} );
 
-			const schemaRepository = new RestSchemaRepository( 'https://example.com/rest.php', inMemoryHttpClient );
+			const schemaRepository = newSchemaRepository( inMemoryHttpClient );
 
 			try {
 				await schemaRepository.getSchema( 'Employee' );
@@ -41,7 +49,7 @@ describe( 'RestSchemaRepository', () => {
 					new Response( JSON.stringify( { source: JSON.stringify( mockSchemaContent ) } ), { status: 200 } )
 			} );
 
-			const schemaRepository = new RestSchemaRepository( 'https://example.com/rest.php', inMemoryHttpClient );
+			const schemaRepository = newSchemaRepository( inMemoryHttpClient );
 			const schema = await schemaRepository.getSchema( 'Employee' );
 
 			expect( schema.getName() ).toEqual( 'Employee' );
@@ -53,12 +61,77 @@ describe( 'RestSchemaRepository', () => {
 					format: TextFormat.formatName,
 					description: '',
 					required: true,
-					multiple: false, // TODO: use dedicated format for multi-valued properties?
+					multiple: false,
 					uniqueItems: true
 				}
 			} );
 		} );
 
+	} );
+
+	describe( 'saveSchema', () => {
+		let repository: RestSchemaRepository;
+		let mockHttpClient: HttpClient;
+		let mockSerializer: SchemaSerializer;
+		const apiUrl = 'https://test.api.url';
+
+		beforeEach( () => {
+			mockHttpClient = {
+				get: vi.fn(),
+				post: vi.fn(),
+				patch: vi.fn(),
+				delete: vi.fn()
+			};
+
+			mockSerializer = {
+				serializeSchema: vi.fn().mockImplementation(
+					( schema: Schema ) => '{"serialized":"' + schema.getName() + '"}'
+				)
+			} as unknown as SchemaSerializer;
+
+			repository = new RestSchemaRepository( apiUrl, mockHttpClient, mockSerializer );
+		} );
+
+		const testSchema = new Schema( 'TestSchema', 'Test Description', new PropertyDefinitionList( [] ) );
+
+		it( 'should call the correct API endpoint with the right parameters', async () => {
+			( mockHttpClient.post as Mock ).mockResolvedValue( { ok: true } );
+
+			await repository.saveSchema( testSchema );
+
+			expect( mockHttpClient.post ).toHaveBeenCalledWith(
+				`${ apiUrl }/v1/page/Schema:TestSchema`,
+				{
+					source: '{"serialized":"TestSchema"}',
+					comment: 'Update schema via NeoWiki UI',
+					content_model: 'json'
+				}
+			);
+		} );
+
+		it( 'should throw an error if the API response is not ok', async () => {
+			( mockHttpClient.post as Mock ).mockResolvedValue( { ok: false, statusText: 'Not Found' } );
+
+			await expect( repository.saveSchema( testSchema ) )
+				.rejects
+				.toThrow( 'Error saving schema: Not Found' );
+		} );
+
+		it( 'should encode the schema name in the URL', async () => {
+			const schemaWithSpecialChars = new Schema(
+				'Test/Schema With:Spaces',
+				'Description',
+				new PropertyDefinitionList( [] )
+			);
+
+			( mockHttpClient.post as Mock ).mockResolvedValue( { ok: true } );
+			await repository.saveSchema( schemaWithSpecialChars );
+
+			expect( mockHttpClient.post ).toHaveBeenCalledWith(
+				`${ apiUrl }/v1/page/Schema:Test%2FSchema%20With%3ASpaces`,
+				expect.anything()
+			);
+		} );
 	} );
 
 } );

--- a/resources/ext.neowiki/tests/persistence/SchemaSerializer.unit.spec.ts
+++ b/resources/ext.neowiki/tests/persistence/SchemaSerializer.unit.spec.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import { SchemaSerializer } from '@/persistence/SchemaSerializer';
+import { Schema } from '@neo/domain/Schema';
+import { PropertyDefinitionList } from '@neo/domain/PropertyDefinitionList';
+import { PropertyDefinition, PropertyName } from '@neo/domain/PropertyDefinition';
+import { ValueType } from '@neo/domain/Value';
+import { TextFormat, TextProperty } from '@neo/domain/valueFormats/Text';
+import { UrlFormat, UrlProperty } from '@neo/domain/valueFormats/Url';
+import { NumberFormat, NumberProperty } from '@neo/domain/valueFormats/Number';
+import { RelationFormat, RelationProperty } from '@neo/domain/valueFormats/Relation';
+
+describe( 'SchemaSerializer', () => {
+	const serializer = new SchemaSerializer();
+
+	describe( 'serializeSchema', () => {
+		it( 'serializes a schema with no properties', () => {
+			const schema = new Schema(
+				'TestSchema',
+				'Test Description',
+				new PropertyDefinitionList( [] )
+			);
+
+			const serialized = serializer.serializeSchema( schema );
+			const parsed = JSON.parse( serialized );
+
+			expect( parsed ).toEqual( {
+				description: 'Test Description',
+				propertyDefinitions: {}
+			} );
+		} );
+
+		it( 'serializes a schema with all property types', () => {
+			const propertyDefinitions = new PropertyDefinitionList( [
+				{
+					name: new PropertyName( 'textProperty' ),
+					type: ValueType.String,
+					format: TextFormat.formatName,
+					description: 'Text property',
+					required: true,
+					multiple: true,
+					uniqueItems: false
+				} as TextProperty,
+				{
+					name: new PropertyName( 'urlProperty' ),
+					type: ValueType.String,
+					format: UrlFormat.formatName,
+					description: 'URL property',
+					required: false,
+					multiple: false,
+					uniqueItems: true
+				} as UrlProperty,
+				{
+					name: new PropertyName( 'numberProperty' ),
+					type: ValueType.Number,
+					format: NumberFormat.formatName,
+					description: 'Number property',
+					required: true,
+					precision: 2,
+					minimum: 0,
+					maximum: 100
+				} as NumberProperty,
+				{
+					name: new PropertyName( 'relationProperty' ),
+					type: ValueType.Relation,
+					format: RelationFormat.formatName,
+					description: 'Relation property',
+					required: false,
+					relation: 'TestRelation',
+					targetSchema: 'TestTargetSchema',
+					multiple: true
+				} as RelationProperty
+			] );
+
+			const schema = new Schema(
+				'TestSchema',
+				'Test Description',
+				propertyDefinitions
+			);
+
+			const serialized = serializer.serializeSchema( schema );
+			const parsed = JSON.parse( serialized );
+
+			expect( parsed ).toEqual( {
+				description: 'Test Description',
+				propertyDefinitions: {
+					textProperty: {
+						type: 'string',
+						format: 'text',
+						description: 'Text property',
+						required: true,
+						multiple: true,
+						uniqueItems: false
+					},
+					urlProperty: {
+						type: 'string',
+						format: 'url',
+						description: 'URL property',
+						required: false,
+						multiple: false,
+						uniqueItems: true
+					},
+					numberProperty: {
+						type: 'number',
+						format: 'number',
+						description: 'Number property',
+						required: true,
+						precision: 2,
+						minimum: 0,
+						maximum: 100
+					},
+					relationProperty: {
+						type: 'relation',
+						format: 'relation',
+						description: 'Relation property',
+						required: false,
+						relation: 'TestRelation',
+						targetSchema: 'TestTargetSchema',
+						multiple: true
+					}
+				}
+			} );
+		} );
+	} );
+
+	describe( 'serialization formatting', () => {
+		it( 'uses 4 spaces for indentation', () => {
+			const schema = new Schema(
+				'TestSchema',
+				'Test Description',
+				new PropertyDefinitionList( [] )
+			);
+
+			const serialized = serializer.serializeSchema( schema );
+
+			expect( serialized ).toMatch( /{\n {4}"description": / );
+		} );
+	} );
+} );


### PR DESCRIPTION
And a SchemaSerializer used by said saveSchema method

Mostly finishes https://github.com/ProfessionalWiki/NeoExtension/issues/99, though the vue code / store still needs to actually call the new code.

Much is AI generated, though with many adjustments and close review by me. Especially the tests are AI generated. The beforeEach in the repo tests does not seem ideal (lots of mutation), but whatever, not worth improving ATM.