### PR TITLE
Use SchemaRepository via SchemaStore in CreateSubjectDialog

### DIFF
--- a/resources/ext.neowiki/src/components/NeoWikiApp.vue
+++ b/resources/ext.neowiki/src/components/NeoWikiApp.vue
@@ -49,14 +49,13 @@ onMounted( async (): Promise<void> => {
 		elements.map( async ( element ): Promise<InfoboxData> => {
 			const subjectId = element.getAttribute( 'data-subject-id' )!;
 			const subject = getSubject( subjectId );
-			await schemaStore.fetchSchema( subject.getSchemaName() );
 			// TODO: handle schema not found
 
 			return {
 				id: subjectId,
 				element,
 				subject: subject,
-				schema: schemaStore.getSchema( subject.getSchemaName() ),
+				schema: await schemaStore.getOrFetchSchema( subject.getSchemaName() ),
 				canEdit: await canEdit( subjectId )
 			};
 		} )

--- a/resources/ext.neowiki/src/stores/SchemaStore.ts
+++ b/resources/ext.neowiki/src/stores/SchemaStore.ts
@@ -24,6 +24,17 @@ export const useSchemaStore = defineStore( 'schema', {
 		async fetchSchema( name: string ): Promise<void> {
 			const schema = await NeoWikiExtension.getInstance().getSchemaRepository().getSchema( name );
 			this.setSchema( name, schema );
+		},
+		async getOrFetchSchema( name: string ): Promise<Schema> {
+			if ( !this.schemas.has( name ) ) {
+				await this.fetchSchema( name );
+			}
+			return this.getSchema( name );
+		},
+		async searchAndFetchMissingSchemas( search: string ): Promise<string[]> {
+			const schemaNames = await NeoWikiExtension.getInstance().getSchemaRepository().getSchemaNames( search );
+			await Promise.all( schemaNames.map( ( name ) => this.getOrFetchSchema( name ) ) );
+			return schemaNames;
 		}
 	}
 } );


### PR DESCRIPTION
For #83 

Schemas are added to the store as they are fetched.
They are not refetched every time a search result contains a previously fetched Schema. This basically acts like a cache until page reload. If this behavior is not desirable (i.e. tradeoff between always having latest Schema vs. repeatedly hitting the server), then we can easily change it to always fetch the Schema again and update it in the store.

----

Store gets updated only when new Schemas are fetched:

[schema-search-store.webm](https://github.com/user-attachments/assets/b6b755f4-1b44-485b-9759-840d7ea04737)

And API only gets called when new Schemas are fetched:

[schema-search-api.webm](https://github.com/user-attachments/assets/374ca114-57c5-4370-8e9c-96f4b12f04bd)
