### PR TITLE
Automatic Infobox design

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -158,8 +158,7 @@
 				"CdxSelect",
 				"CdxCheckbox",
 				"CdxTextArea",
-				"CdxMenuButton",
-				"CdxInfoChip"
+				"CdxMenuButton"
 			],
 			"packageFiles": [
 				"resources/ext.neowiki/dist/neowiki.js",

--- a/resources/ext.neowiki/src/components/AutomaticInfobox/AutomaticInfobox.vue
+++ b/resources/ext.neowiki/src/components/AutomaticInfobox/AutomaticInfobox.vue
@@ -4,11 +4,16 @@
 			<h2 class="auto-infobox__title">
 				{{ subject.getLabel() }}
 			</h2>
-			<CdxInfoChip class="auto-infobox__schema-badge">
-				{{ schema.getName() }}
-			</CdxInfoChip>
 		</div>
 		<div class="auto-infobox__content">
+			<div class="auto-infobox__item auto-infobox__schema-badge">
+				<div class="auto-infobox__property">
+					{{ $i18n( 'neowiki-infobox-type' ).text() }}
+				</div>
+				<div class="auto-infobox__value">
+					{{ schema.getName() }}
+				</div>
+			</div>
 			<div
 				v-for="( propertyDefinition, propertyName ) in propertiesToDisplay"
 				:key="propertyName"
@@ -56,6 +61,7 @@ import { Component } from 'vue';
 import InfoboxEditor from '@/components/Infobox/InfoboxEditor.vue';
 import { useSchemaStore } from '@/stores/SchemaStore';
 import { NeoWikiServices } from '@/NeoWikiServices.ts';
+import { CdxButton } from '@wikimedia/codex';
 
 const props = defineProps( {
 	subject: {
@@ -124,40 +130,29 @@ onMounted( async (): Promise<void> => {
 @import '@wikimedia/codex-design-tokens/theme-wikimedia-ui.scss';
 
 .auto-infobox {
+	margin-left: $spacing-100;
 	margin-bottom: $spacing-100;
-	max-width: $size-2800;
+	max-width: 325px;
 	border-radius: 5px;
-	background-color: $background-color-interactive-subtle;
-	border: 1px solid #c8ccd1bf;
+	background-color: $background-color-interactive-subtle !important;
+	border: 1px solid $border-color-base;
+	float: right;
 
 	&__header {
-		background-color: #eaecf0a8;
-		position: relative;
+		background-color: #eaecf0a8 !important;
 		border-top-left-radius: 5px;
 		border-top-right-radius: 5px;
-		padding-top: $spacing-30;
+		padding-top: $spacing-125;
 		padding-left: $spacing-125;
 		padding-bottom: $spacing-30;
 	}
 
 	&__title {
 		font-size: $font-size-xx-large;
-		margin: $spacing-0;
+		margin: $spacing-0 !important;
 		position: relative;
 		z-index: $z-index-stacking-1;
 		border: none;
-	}
-
-	&__schema-badge,
-	.cdx-info-chip {
-		position: absolute;
-		top: $spacing-100;
-		right: $spacing-75;
-		border: $border-width-base $border-style-base $color-base;
-
-		.cdx-info-chip--text {
-			color: $color-base;
-		}
 	}
 
 	&__content {

--- a/resources/ext.neowiki/tests/components/AutomaticInfobox/AutomaticInfobox.spec.ts
+++ b/resources/ext.neowiki/tests/components/AutomaticInfobox/AutomaticInfobox.spec.ts
@@ -89,39 +89,21 @@ describe( 'AutomaticInfobox', () => {
 		const wrapper = mountComponent( mockSubject, mockSchema, false );
 
 		const statementElements = wrapper.findAll( '.auto-infobox__item' );
-		expect( statementElements ).toHaveLength( 3 ); // 3 properties
+		expect( statementElements ).toHaveLength( 4 ); // 3 properties + schema
 
-		expect( statementElements[ 0 ].find( '.auto-infobox__property' ).text() ).toBe( 'name' );
-		expect( statementElements[ 0 ].find( '.auto-infobox__value' ).text() ).toBe( 'John Doe, Jane Doe' );
+		expect( statementElements[ 0 ].find( '.auto-infobox__property' ).text() ).toBe( 'neowiki-infobox-type' );
+		expect( statementElements[ 0 ].find( '.auto-infobox__value' ).text() ).toBe( 'TestSchema' );
 
-		expect( statementElements[ 1 ].find( '.auto-infobox__property' ).text() ).toBe( 'age' );
-		expect( statementElements[ 1 ].find( '.auto-infobox__value' ).text() ).toBe( '30' );
+		expect( statementElements[ 1 ].find( '.auto-infobox__property' ).text() ).toBe( 'name' );
+		expect( statementElements[ 1 ].find( '.auto-infobox__value' ).text() ).toBe( 'John Doe, Jane Doe' );
 
-		expect( statementElements[ 2 ].find( '.auto-infobox__property' ).text() ).toBe( 'website' );
-		const linkElement = statementElements[ 2 ].find( '.auto-infobox__value a' );
+		expect( statementElements[ 2 ].find( '.auto-infobox__property' ).text() ).toBe( 'age' );
+		expect( statementElements[ 2 ].find( '.auto-infobox__value' ).text() ).toBe( '30' );
+
+		expect( statementElements[ 3 ].find( '.auto-infobox__property' ).text() ).toBe( 'website' );
+		const linkElement = statementElements[ 3 ].find( '.auto-infobox__value a' );
 		expect( linkElement.attributes( 'href' ) ).toBe( 'https://example.com' );
 		expect( linkElement.text() ).toBe( 'https://example.com' );
-	} );
-
-	it( 'renders schema badge correctly', () => {
-		const wrapper = mount( AutomaticInfobox, {
-			props: {
-				subject: mockSubject,
-				schema: mockSchema,
-				canEditSubject: false,
-				canEditSchema: false
-			},
-			global: {
-				mocks: {
-					$i18n
-				},
-				provide: {
-					[ Service.ComponentRegistry ]: NeoWikiExtension.getInstance().getFormatSpecificComponentRegistry()
-				}
-			}
-		} );
-
-		expect( wrapper.find( '.auto-infobox__schema-badge' ).text() ).toBe( 'TestSchema' );
 	} );
 
 	it( 'renders without statements when subject has no statements', () => {
@@ -136,19 +118,19 @@ describe( 'AutomaticInfobox', () => {
 		const wrapper = mountComponent( emptySubject, mockSchema, false );
 
 		const statementElements = wrapper.findAll( '.auto-infobox__item' );
-		expect( statementElements ).toHaveLength( 0 ); // No properties
+		expect( statementElements ).toHaveLength( 1 ); // Only schema badge
 	} );
 
 	it( 'does not render edit button when canEditSubject is false', () => {
 		const wrapper = mountComponent( mockSubject, mockSchema, false );
 
-		expect( wrapper.find( '.cdx-docs-link' ).exists() ).toBe( false );
+		expect( wrapper.find( '.auto-infobox__footer' ).exists() ).toBe( false );
 	} );
 
 	it( 'renders edit button when canEditSubject is true', () => {
 		const wrapper = mountComponent( mockSubject, mockSchema, true );
 
-		const editButton = wrapper.find( '.cdx-docs-link' );
+		const editButton = wrapper.find( '.auto-infobox__footer button' );
 		expect( editButton.exists() ).toBe( true );
 		expect( editButton.text() ).toBe( 'neowiki-infobox-edit-link' );
 	} );


### PR DESCRIPTION
For: https://github.com/ProfessionalWiki/NeoExtension/issues/82

Screen resolution is 1080p in this screenshot.

![image](https://github.com/user-attachments/assets/9b3f6a8c-ff75-4ed1-8122-3ec785b5e91a)



I quickly tried some other designs too using claude but even the simplest of them don't look like mediawiki website. So above is the final design.

![4th](https://github.com/user-attachments/assets/097081dc-96bf-40f4-a1a5-4e121e074702)

![2nd](https://github.com/user-attachments/assets/0be0f79e-a105-43a2-bc04-11c1e06b86ec)
![3rd](https://github.com/user-attachments/assets/8999e272-c947-4809-a4da-c665e64dcdf2)


![1st](https://github.com/user-attachments/assets/07da8f9c-9aa3-4ccd-966c-477f06ddab03)
