### PR TITLE
Hide Property actions menu button when user cannot edit Schema

### DIFF
--- a/resources/ext.neowiki/src/components/Infobox/InfoboxEditor.vue
+++ b/resources/ext.neowiki/src/components/Infobox/InfoboxEditor.vue
@@ -32,6 +32,7 @@
 			:key="index"
 			class="statement-editor-row"
 			:statement="<Statement>statement"
+			:can-edit-schema="canEditSchema"
 			@update="updateStatement( index, $event )"
 			@remove="removeStatement( index )"
 			@edit="editProperty"

--- a/resources/ext.neowiki/src/components/UIComponents/PropertyNameField.vue
+++ b/resources/ext.neowiki/src/components/UIComponents/PropertyNameField.vue
@@ -5,6 +5,7 @@
 			{{ modelValue }}
 		</span>
 		<CdxMenuButton
+			v-if="canEditSchema"
 			class="neo-property-name__menu-button"
 			:selected="null"
 			:menu-items="menuItems"
@@ -28,6 +29,10 @@ import { cdxIconMenu } from '@/assets/CustomIcons';
 defineProps( {
 	modelValue: {
 		type: String,
+		required: true
+	},
+	canEditSchema: {
+		type: Boolean,
 		required: true
 	}
 } );

--- a/resources/ext.neowiki/src/components/UIComponents/StatementEditor.vue
+++ b/resources/ext.neowiki/src/components/UIComponents/StatementEditor.vue
@@ -5,6 +5,7 @@
 				<PropertyNameField
 					:model-value="localStatement.propertyName.toString()"
 					class="statement-editor__property"
+					:can-edit-schema="canEditSchema"
 					@edit="$emit( 'edit', statement.propertyName )"
 					@delete="$emit( 'remove' )"
 				/>
@@ -32,6 +33,7 @@ import { NeoWikiServices } from '@/NeoWikiServices.ts';
 
 const props = defineProps<{
 	statement: Statement;
+	canEditSchema: boolean;
 }>();
 
 const componentRegistry = NeoWikiServices.getComponentRegistry();


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoExtension/issues/158

With permission on the left, without on the right:
![Screenshot_20241005_183605](https://github.com/user-attachments/assets/3b45b9a5-c607-41a1-b3e5-ad964e3f9578)

----

There is a pre-existing height mismatch between the property name and the value:
![Screenshot_20241005_183914](https://github.com/user-attachments/assets/6f20c17f-f9f6-4030-9390-b2a947743690)
Without the button the height is smaller. But this can be fixed in a follow-up.
![Screenshot_20241005_183942](https://github.com/user-attachments/assets/04f5cd30-9adc-4d93-b4fb-ff4f5802f382)
