### PR TITLE
Silence missing aria-label warning

### DIFF
--- a/resources/ext.neowiki/src/components/UIComponents/PropertyNameField.vue
+++ b/resources/ext.neowiki/src/components/UIComponents/PropertyNameField.vue
@@ -9,6 +9,7 @@
 			class="neo-property-name__menu-button"
 			:selected="null"
 			:menu-items="menuItems"
+			aria-label=" "
 			@update:selected="onMenuSelect"
 		>
 			<CdxIcon :icon="cdxIconMenu" />


### PR DESCRIPTION
To get rid of this CdxToggleButton spam in the dev tools console:
![Screenshot_20241006_004545](https://github.com/user-attachments/assets/1f00ba9f-1a41-4169-b95d-5c19be4d4795)

This is an accessibility/screen reader concern, but we're not focusing on that so this won't cause any side-effects unrelated to that. 