### PR TITLE
Set default values for inputs

### DIFF
--- a/resources/ext.neowiki/src/components/Value/NumberInput.vue
+++ b/resources/ext.neowiki/src/components/Value/NumberInput.vue
@@ -24,7 +24,7 @@ import type { Value } from '@neo/domain/Value';
 const props = defineProps( {
 	modelValue: {
 		type: Object as PropType<Value>,
-		required: true
+		default: () => newNumberValue( NaN )
 	},
 	label: {
 		type: String,

--- a/resources/ext.neowiki/src/components/Value/TextInput.vue
+++ b/resources/ext.neowiki/src/components/Value/TextInput.vue
@@ -31,7 +31,7 @@ import type { Value } from '@neo/domain/Value';
 const props = defineProps( {
 	modelValue: {
 		type: Object as PropType<Value>,
-		required: true
+		default: () => newStringValue( '' )
 	},
 	label: {
 		type: String,

--- a/resources/ext.neowiki/src/components/Value/UrlInput.vue
+++ b/resources/ext.neowiki/src/components/Value/UrlInput.vue
@@ -27,7 +27,7 @@ import type { Value } from '@neo/domain/Value';
 const props = defineProps( {
 	modelValue: {
 		type: Object as PropType<Value>,
-		required: true
+		default: () => newStringValue( '' )
 	},
 	label: {
 		type: String,


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/NeoExtension/pull/162#issuecomment-2395215594

Looks like each input component will need to handle its own default value. If we try to create default values in `StatementEditor` or `InfoboxEditor` then we'd need if-elses, or something else coming from the component registry to set the appropriate default.

With this change it seems to be working fine:

[Screencast_20241006_013448.webm](https://github.com/user-attachments/assets/f9ea52da-8148-47dc-82e8-c36e689c612b)

This will change once we add default values for properties.