### PR TITLE
Save Subject

### DIFF
--- a/resources/ext.neowiki/src/stores/SubjectStore.ts
+++ b/resources/ext.neowiki/src/stores/SubjectStore.ts
@@ -30,6 +30,10 @@ export const useSubjectStore = defineStore( 'subject', {
 				await this.fetchSubject( id );
 			}
 			return this.getSubject( id );
+		},
+		async updateSubject( subject: Subject ): Promise<void> {
+			await NeoWikiExtension.getInstance().getSubjectRepository().updateSubject( subject.getId(), subject.getStatements() );
+			this.setSubject( subject.getId(), subject );
 		}
 	}
 } );


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/NeoExtension/issues/100

Only for updates. Subject creation is TODO in follow-up (although depends on things like https://github.com/ProfessionalWiki/NeoExtension/issues/138 and https://github.com/ProfessionalWiki/NeoExtension/issues/139).

[save-subject.webm](https://github.com/user-attachments/assets/791c7850-bc4f-4cbd-b687-45b822f555d0)
