### PR TITLE
Show empty string for wrong value type in AutomaticInfobox

### DIFF
--- a/resources/ext.neowiki/src/components/AutomaticInfobox/Values/NumberValue.vue
+++ b/resources/ext.neowiki/src/components/AutomaticInfobox/Values/NumberValue.vue
@@ -1,17 +1,17 @@
 <template>
 	<div>
-		{{ getNumber() }}
+		{{ value }}
 	</div>
 </template>
 
 <script setup lang="ts">
-import { NumberValue } from '@neo/domain/Value.ts';
-import { PropType } from 'vue';
+import { Value, ValueType } from '@neo/domain/Value.ts';
+import { computed, PropType } from 'vue';
 import { NumberProperty } from '@neo/domain/valueFormats/Number.ts';
 
 const props = defineProps( {
 	value: {
-		type: Object as PropType<NumberValue>,
+		type: Object as PropType<Value>,
 		required: true
 	},
 	property: {
@@ -20,13 +20,15 @@ const props = defineProps( {
 	}
 } );
 
-const getNumber = (): string => {
-	// TODO: handle non-NumberValue
+const value = computed( (): string => {
+	if ( props.value.type !== ValueType.Number ) {
+		return '';
+	}
 
 	if ( props.property.precision !== undefined ) {
 		return props.value.number.toFixed( props.property.precision );
 	}
 
 	return props.value.number.toString();
-};
+} );
 </script>

--- a/resources/ext.neowiki/src/components/AutomaticInfobox/Values/TextValue.vue
+++ b/resources/ext.neowiki/src/components/AutomaticInfobox/Values/TextValue.vue
@@ -5,15 +5,20 @@
 </template>
 
 <script setup lang="ts">
-import { StringValue } from '@neo/domain/Value.ts';
+import { Value, ValueType } from '@neo/domain/Value.ts';
 import { PropType, computed } from 'vue';
 
 const props = defineProps( {
 	value: {
-		type: Object as PropType<StringValue>,
+		type: Object as PropType<Value>,
 		required: true
 	}
 } );
 
-const values = computed( () => props.value.strings.filter( ( value ) => value.trim() !== '' ) );
+const values = computed( () => {
+	if ( props.value.type !== ValueType.String ) {
+		return [ '' ];
+	}
+	return props.value.strings.filter( ( url ) => url.trim() !== '' );
+} );
 </script>

--- a/resources/ext.neowiki/src/components/AutomaticInfobox/Values/UrlValue.vue
+++ b/resources/ext.neowiki/src/components/AutomaticInfobox/Values/UrlValue.vue
@@ -9,15 +9,20 @@
 </template>
 
 <script setup lang="ts">
-import { StringValue } from '@neo/domain/Value.ts';
+import { Value, ValueType } from '@neo/domain/Value.ts';
 import { computed, PropType } from 'vue';
 
 const props = defineProps( {
 	value: {
-		type: Object as PropType<StringValue>,
+		type: Object as PropType<Value>,
 		required: true
 	}
 } );
 
-const urls = computed( () => props.value.strings.filter( ( url ) => url.trim() !== '' ) );
+const urls = computed( () => {
+	if ( props.value.type !== ValueType.String ) {
+		return '';
+	}
+	return props.value.strings.filter( ( url ) => url.trim() !== '' );
+} );
 </script>

--- a/resources/ext.neowiki/tests/components/AutomaticInfobox/Values/NumberValue.spec.ts
+++ b/resources/ext.neowiki/tests/components/AutomaticInfobox/Values/NumberValue.spec.ts
@@ -1,7 +1,7 @@
 import { mount } from '@vue/test-utils';
 import { describe, it, expect } from 'vitest';
 import NumberValue from '@/components/AutomaticInfobox/Values/NumberValue.vue';
-import { newNumberValue } from '@neo/domain/Value';
+import { newNumberValue, newStringValue } from '@neo/domain/Value';
 import { NumberProperty } from '@neo/domain/valueFormats/Number';
 
 describe( 'NumberValue', () => {
@@ -69,5 +69,15 @@ describe( 'NumberValue', () => {
 		} );
 
 		expect( wrapper.text() ).toBe( '3.14000' );
+	} );
+
+	it( 'returns empty string for wrong value type', () => {
+		const wrapper = mount( NumberValue, {
+			props: {
+				value: newStringValue( 'not a number' ),
+				property: {} as NumberProperty
+			}
+		} );
+		expect( wrapper.text() ).toBe( '' );
 	} );
 } );

--- a/resources/ext.neowiki/tests/components/AutomaticInfobox/Values/TextValue.spec.ts
+++ b/resources/ext.neowiki/tests/components/AutomaticInfobox/Values/TextValue.spec.ts
@@ -1,7 +1,7 @@
 import { mount } from '@vue/test-utils';
 import { describe, it, expect } from 'vitest';
 import TextValue from '@/components/AutomaticInfobox/Values/TextValue.vue';
-import { newStringValue } from '@neo/domain/Value';
+import { newNumberValue, newStringValue } from '@neo/domain/Value';
 
 describe( 'TextValue', () => {
 	it( 'renders a single text value correctly', () => {
@@ -52,6 +52,15 @@ describe( 'TextValue', () => {
 			}
 		} );
 
+		expect( wrapper.text() ).toBe( '' );
+	} );
+
+	it( 'returns empty string for wrong value type', () => {
+		const wrapper = mount( TextValue, {
+			props: {
+				value: newNumberValue( 42 )
+			}
+		} );
 		expect( wrapper.text() ).toBe( '' );
 	} );
 } );

--- a/resources/ext.neowiki/tests/components/AutomaticInfobox/Values/UrlValue.spec.ts
+++ b/resources/ext.neowiki/tests/components/AutomaticInfobox/Values/UrlValue.spec.ts
@@ -1,7 +1,7 @@
 import { mount } from '@vue/test-utils';
 import { describe, it, expect } from 'vitest';
 import UrlValue from '@/components/AutomaticInfobox/Values/UrlValue.vue';
-import { newStringValue } from '@neo/domain/Value';
+import { newNumberValue, newStringValue } from '@neo/domain/Value';
 
 describe( 'UrlValue', () => {
 	it( 'renders a single URL correctly', () => {
@@ -63,5 +63,14 @@ describe( 'UrlValue', () => {
 		} );
 
 		expect( wrapper.find( 'a' ).exists() ).toBe( false );
+	} );
+
+	it( 'returns no links for wrong value type', () => {
+		const wrapper = mount( UrlValue, {
+			props: {
+				value: newNumberValue( 42 )
+			}
+		} );
+		expect( wrapper.findAll( 'a' ) ).toHaveLength( 0 );
 	} );
 } );


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoExtension/issues/171

Minimal handling for MVP. Just display empty string.

If it makes it a bit more obvious, we could instead show something like "(invalid)".