### PR TITLE
Add explicit dependency on mediawiki.user

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -144,7 +144,8 @@
 			"class": "MediaWiki\\ResourceLoader\\CodexModule",
 			"dependencies": [
 				"vue",
-				"pinia"
+				"pinia",
+				"mediawiki.user"
 			],
 			"codexComponents": [
 				"CdxButton",


### PR DESCRIPTION
Same as our old code. By adding it as a dependency the correct loading order is ensured. Otherwsie we run into intermittent errors where the `mw.user` object is not ready yet.
