### PR TITLE
Show Properties and Statements when creating a new Subject

### DIFF
--- a/resources/ext.neowiki/src/components/CreateSubject/CreateSubjectButton.vue
+++ b/resources/ext.neowiki/src/components/CreateSubject/CreateSubjectButton.vue
@@ -46,7 +46,7 @@ const onSubjectTypeSelected = ( type: string ): void => {
 	}
 
 	selectedSchema.value = type;
-	infoboxEditorDialog.value?.openDialog();
+	infoboxEditorDialog.value.openDialog();
 };
 
 const onCreationComplete = (): void => {


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/NeoExtension/issues/141 and https://github.com/ProfessionalWiki/NeoExtension/issues/139

The UI now shows the properties/statements for existing Schemas, and allows adding new Properties for existing and blank Schemas.

This PR touches only the UI. It does not address saving/creating Schemas or Subject yet.

[Screencast_20241007_212214.webm](https://github.com/user-attachments/assets/45acbe1a-2100-4e20-a509-965d544ed337)
