### PR TITLE
Design Fix for overflowing URL Values in Automatic Infobox

### DIFF
--- a/resources/ext.neowiki/src/components/AutomaticInfobox.vue
+++ b/resources/ext.neowiki/src/components/AutomaticInfobox.vue
@@ -175,7 +175,7 @@ onMounted( async (): Promise<void> => {
 	}
 
 	&__property {
-		flex: 0 0 50%;
+		flex: 0 0 40%;
 		font-weight: $font-weight-bold;
 		color: $color-emphasized;
 		font-size: $font-size-small;
@@ -184,7 +184,7 @@ onMounted( async (): Promise<void> => {
 	}
 
 	&__value {
-		flex: 1;
+		flex: 0 0 60%;
 		color: $color-subtle;
 		font-size: $font-size-small;
 		line-height: $line-height-xx-small;


### PR DESCRIPTION
Its easier for me to quickly fix it than to create the ticket.

Before:
![Before](https://github.com/user-attachments/assets/9ef73632-be7b-48ee-ab0b-e4e3e5cbd61e)

After:
![After](https://github.com/user-attachments/assets/d893c242-99fb-45f4-81fe-8478229d96ea)


Of course we can still make minor adjustments too but let it not block this PR.