### PR TITLE
Remove .map

### DIFF
--- a/resources/ext.neowiki/src/components/Editor/InfoboxEditor.vue
+++ b/resources/ext.neowiki/src/components/Editor/InfoboxEditor.vue
@@ -311,13 +311,7 @@ const submit = async (): Promise<void> => {
 
 	await schemaStore.saveSchema( localSchema.value as Schema );
 
-	const properStatements = statements.value.map( ( stmt ) => new Statement(
-		new PropertyName( stmt.propertyName.toString() ),
-		stmt.format,
-		stmt.value
-	) );
-
-	localSubject.value = localSubject.value.withStatements( new StatementList( properStatements ) );
+	localSubject.value = localSubject.value.withStatements( new StatementList( statements.value as Statement[] ) );
 
 	if ( isNewSubject.value ) {
 		await subjectStore.createMainSubject( localSubject.value as Subject );


### PR DESCRIPTION
For: https://github.com/ProfessionalWiki/NeoExtension/pull/199#discussion_r1806862908

Claude or GPT suggest or come up with .map by default but I am not sure if we have to do.

 `statements.value as Statement[]` looks clear enough to me.
 
 The reason why we have to do that is because `statements.value` is not of type `Statement[]` in reality. Its of type "Proxy" something that Vue uses to keep track of variables.  
 
 Although it doesn't look like but we are not directly mutating the objects when we use composition API(ref, Reactive) or Pinia behind the scenes Vue uses these Proxies to trigger updates when changes occur.