### PR TITLE
Fix subject null check

### DIFF
--- a/resources/ext.neowiki/src/components/Editor/InfoboxEditor.vue
+++ b/resources/ext.neowiki/src/components/Editor/InfoboxEditor.vue
@@ -259,7 +259,7 @@ const handlePropertySave = ( savedProperty: PropertyDefinition ): void => {
 };
 
 const handleAddProperty = ( savedProperty: PropertyDefinition ): void => {
-	if ( localSubject.value !== undefined && localSchema.value !== null ) {
+	if ( localSubject.value !== null && localSchema.value !== null ) {
 		// TODO: replace the below lines with a localSchema.value.addPropertyDefinition( savedProperty );
 		const updatedProperties = [ ...localSchema.value.getPropertyDefinitions(), savedProperty ];
 


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/NeoExtension/pull/199#discussion_r1806748683

Because `localSubject` is `Subject | null`, therefore not `undefined`.