### PR TITLE
Avoid space in property name field

### DIFF
--- a/resources/ext.neowiki/src/components/Editor/InfoboxEditor.vue
+++ b/resources/ext.neowiki/src/components/Editor/InfoboxEditor.vue
@@ -284,7 +284,7 @@ const addProperty = ( type: string ): void => {
 	isDropdownOpen.value = false;
 	isEditingProperty.value = false;
 	editingProperty.value = { // TODO: do we need to get a basic property definition via the plugin system?
-		name: new PropertyName( ' ' ),
+		name: '' as unknown as PropertyName,
 		format: type, // TODO: is this correct? Name mismatch
 		description: '',
 		required: false


### PR DESCRIPTION
A temporary hack. This whole code block needs to be replaced.