### PR TITLE
Add hook to prevent Schema content model change

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -46,7 +46,9 @@
 
 		"EditFilter": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onEditFilter",
 
-		"SpecialPage_initList": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onSpecialPageInitList"
+		"SpecialPage_initList": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onSpecialPageInitList",
+
+		"ContentModelCanBeUsedOn": "ProfessionalWiki\\NeoWiki\\MediaWiki\\EntryPoints\\NeoWikiHooks::onContentModelCanBeUsedOn"
 	},
 
 	"ContentHandlers": {

--- a/src/EntryPoints/Content/SchemaContentHandler.php
+++ b/src/EntryPoints/Content/SchemaContentHandler.php
@@ -5,6 +5,8 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\MediaWiki\EntryPoints\Content;
 
 use MediaWiki\Content\JsonContentHandler;
+use MediaWiki\Title\Title;
+use ProfessionalWiki\NeoWiki\MediaWiki\NeoWikiExtension;
 
 class SchemaContentHandler extends JsonContentHandler {
 
@@ -21,6 +23,10 @@ class SchemaContentHandler extends JsonContentHandler {
 }
 JSON
 		);
+	}
+
+	public function canBeUsedOn( Title $title ) {
+		return $title->getNamespace() === NeoWikiExtension::NS_SCHEMA;
 	}
 
 }

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -23,6 +23,7 @@ use ProfessionalWiki\NeoWiki\MediaWiki\Persistence\MediaWiki\SchemaContentValida
 use ProfessionalWiki\NeoWiki\MediaWiki\Persistence\MediaWiki\Subject\MediaWikiSubjectRepository;
 use ProfessionalWiki\NeoWiki\MediaWiki\Presentation\JsonSchemaErrorFormatter;
 use Skin;
+use Status;
 use WikiPage;
 
 class NeoWikiHooks {
@@ -161,6 +162,12 @@ class NeoWikiHooks {
 	public static function onSpecialPageInitList( array &$specialPages ): void {
 		if ( !NeoWikiExtension::getInstance()->isDevelopmentUIEnabled() ) {
 			unset( $specialPages['NeoJson'] );
+		}
+	}
+
+	public static function onContentModelCanBeUsedOn( string $modelId, Title $title, bool &$ok ): void {
+		if ( $title->getNamespace() === NeoWikiExtension::NS_SCHEMA ) {
+			$ok = $modelId === SchemaContent::CONTENT_MODEL_ID;
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/205


Cannot change it via API:
![Screenshot_20241022_150439](https://github.com/user-attachments/assets/5d12ff43-5c07-4d34-a907-9b2f8d73f9f7)

Other content models are not shown on UI:
![Screenshot_20241022_150509](https://github.com/user-attachments/assets/92d7fc05-7d74-4912-b492-5a2c3d040fbd)

Other pages are not allowed to use Schema content model:
![Screenshot_20241022_150552](https://github.com/user-attachments/assets/b2c70291-2931-4e57-997e-f1575439e6e0)

