### PR TITLE
Remove unused hook

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -44,9 +44,7 @@
 
 		"BeforePageDisplay": "ProfessionalWiki\\NeoWiki\\MediaWiki\\EntryPoints\\NeoWikiHooks::onBeforePageDisplay",
 
-		"EditFilter": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onEditFilter",
-
-		"SpecialPage_initList": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onSpecialPageInitList"
+		"EditFilter": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onEditFilter"
 	},
 
 	"ContentHandlers": {

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -158,10 +158,4 @@ class NeoWikiHooks {
 		}
 	}
 
-	public static function onSpecialPageInitList( array &$specialPages ): void {
-		if ( !NeoWikiExtension::getInstance()->isDevelopmentUIEnabled() ) {
-			unset( $specialPages['NeoJson'] );
-		}
-	}
-
 }


### PR DESCRIPTION
Functionality was replaced by unlisting the page directly:
https://github.com/ProfessionalWiki/NeoWiki/blob/f5f6a349caf8599a19ee3be34f8c170f5ec419cd/src/EntryPoints/SpecialPages/SpecialNeoJson.php#L17-L19