### PR TITLE
Fix UrlInput initialization

### DIFF
--- a/resources/ext.neowiki/src/components/Value/UrlInput.vue
+++ b/resources/ext.neowiki/src/components/Value/UrlInput.vue
@@ -43,11 +43,11 @@
 </template>
 
 <script setup lang="ts">
-import { watch, PropType, ref, nextTick, computed } from 'vue';
+import { PropType, ref, nextTick, computed } from 'vue';
 import { CdxField, CdxTextInput, CdxButton, CdxIcon, ValidationStatusType, ValidationMessages } from '@wikimedia/codex';
 import { cdxIconAdd, cdxIconLink, cdxIconTrash } from '@wikimedia/codex-icons';
-import type { Value } from '@neo/domain/Value';
-import { newStringValue, StringValue, ValueType } from '@neo/domain/Value';
+import { StringValue, Value, ValueType } from '@neo/domain/Value';
+import { newStringValue } from '@neo/domain/Value';
 import { UrlProperty } from '@neo/domain/valueFormats/Url.ts';
 
 type ValidationResult = {
@@ -74,7 +74,16 @@ const props = defineProps( {
 
 const emit = defineEmits( [ 'update:modelValue', 'validation' ] );
 
-const inputValues = ref<string[]>( [] );
+const buildInitialInputValues = ( value: Value ): string[] => {
+	if ( value.type === ValueType.String ) {
+		const strings = ( value as StringValue ).strings;
+		return strings.length > 0 ? strings : [ '' ];
+	}
+
+	return [ '' ];
+};
+
+const inputValues = ref<string[]>( buildInitialInputValues( props.modelValue ) );
 
 const isAddButtonDisabled = computed( (): boolean => inputValues.value.some( ( value: string ) => value.trim() === '' || !validationState.value.isValid ) );
 
@@ -153,15 +162,6 @@ const focusInput = ( inputRef: string ): void => {
 	const input = document.querySelector( `[input-ref="${ inputRef }"]` ) as HTMLInputElement | null;
 	input?.focus();
 };
-
-watch( () => props.modelValue, ( newValue ) => {
-	if ( newValue.type === ValueType.String ) {
-		const parts = ( newValue as StringValue ).strings;
-		inputValues.value = parts.length === 0 ? [ '' ] : parts;
-	} else {
-		inputValues.value = [ '' ];
-	}
-}, { immediate: true, deep: true } );
 
 defineExpose( {
 	inputValues,


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/NeoWiki/pull/225#discussion_r1810845313

The first empty input will now show (without this PR it does not)
![image](https://github.com/user-attachments/assets/1d6135bb-772a-428b-ad1d-ad15d714c7f7)

Adding additional values is still broken.

Cause: 

```ts
const addUrl = async (): Promise<void> => {
	inputValues.value.push( '' );

	emit( 'update:modelValue', newStringValue( ...inputValues.value ) );
	emit( 'validation', false );
	await nextTick();

	const inputRef = `${ inputValues.value.length - 1 }-${ props.property.name }-url-input`;
	focusInput( inputRef );
};
```
```ts
watch( () => props.modelValue, ( newValue ) => {
	if ( newValue.type === ValueType.String ) {
		const parts = ( newValue as StringValue ).strings;
		inputValues.value = parts.length === 0 ? [ '' ] : parts;
	} else {
		inputValues.value = [ '' ];
	}
}, { immediate: true, deep: true } );
```

`addUrl` adds an empty string as value to `inputValues`. This would work, except that it's emitting an event with the normalized StringValue (which omits the empty Part), which is then observed by the `watch` code which overrides the correct `inputValues` with an incorrect version.

The above flow seems rather roundabout. There is no need to a change to `inputValues` by emitting an event to the parent component which then updates something the child is watching. Too much reactivity? Poor use of Vue, or Vue being poor?

What is the benefit of this reactivity here? The only thing that updates the state of the UrlInput is the component itself.

Imagine how much simpler it would be without reactivity. Give the Value to the UlrInput on construction time and on save in InfoboxEditor ask all UrlInput and XyzInput for their Value. No events, no by-reference magic, and no issues like the one we are seeing here.

Maybe we still need or otherwise want to keep the communication from UrlInput to the parent. I don't see any point of the binding from parent to UrlInput.