### PR TITLE
Fixes wrong input type for 'CdxTextInput'

### DIFF
--- a/resources/ext.neowiki/src/components/Editor/Property/NumberAttributesEditor.vue
+++ b/resources/ext.neowiki/src/components/Editor/Property/NumberAttributesEditor.vue
@@ -5,7 +5,7 @@
 		>
 			<CdxTextInput
 				:model-value="property.minimum?.toString()"
-				type="number"
+				input-type="number"
 				@update:model-value="updateMinimum"
 			/>
 		</CdxField>
@@ -14,7 +14,7 @@
 		>
 			<CdxTextInput
 				:model-value="property.maximum?.toString()"
-				type="number"
+				input-type="number"
 				@update:model-value="updateMaximum"
 			/>
 		</CdxField>
@@ -23,7 +23,7 @@
 		>
 			<CdxTextInput
 				:model-value="property.precision?.toString()"
-				type="number"
+				input-type="number"
 				@update:model-value="updatePrecision"
 			/>
 		</CdxField>


### PR DESCRIPTION
`CdxTextInput` doesn't have attr "type"

https://doc.wikimedia.org/codex/latest/components/demos/text-input.html

![image](https://github.com/user-attachments/assets/e84d606f-02fe-47f3-80b3-e308f8edc060)
