### PR TITLE
Remove deprecated test helper form

### DIFF
--- a/Neo/neojs/src/domain/valueFormats/Number.ts
+++ b/Neo/neojs/src/domain/valueFormats/Number.ts
@@ -36,16 +36,7 @@ type NumberPropertyAttributes = Omit<Partial<NumberProperty>, 'name'> & {
 	name?: string | PropertyName;
 };
 
-export function newNumberProperty( attributes: string|NumberPropertyAttributes = {} ): NumberProperty {
-	if ( typeof attributes === 'string' ) { // TODO: remove deprecated form
-		return {
-			name: new PropertyName( attributes ),
-			format: NumberFormat.formatName,
-			description: '',
-			required: false
-		};
-	}
-
+export function newNumberProperty( attributes: NumberPropertyAttributes = {} ): NumberProperty {
 	return {
 		name: attributes.name instanceof PropertyName ? attributes.name : new PropertyName( attributes.name || 'Number' ),
 		format: NumberFormat.formatName,

--- a/Neo/neojs/src/domain/valueFormats/Relation.ts
+++ b/Neo/neojs/src/domain/valueFormats/Relation.ts
@@ -42,24 +42,7 @@ type RelationPropertyAttributes = Omit<Partial<RelationProperty>, 'name'> & {
 	name?: string | PropertyName;
 };
 
-export function newRelationProperty(
-	attributes: string|RelationPropertyAttributes = {},
-	targetSchema: string = 'MyTargetSchema',
-	multiple: boolean = false
-): RelationProperty {
-	if ( typeof attributes === 'string' ) { // TODO: remove deprecated form
-		return {
-			name: new PropertyName( attributes ),
-			format: RelationFormat.formatName,
-			description: '',
-			required: false,
-			default: undefined,
-			relation: 'MyRelation',
-			targetSchema: targetSchema,
-			multiple: multiple
-		};
-	}
-
+export function newRelationProperty( attributes: RelationPropertyAttributes = {} ): RelationProperty {
 	return {
 		name: attributes.name instanceof PropertyName ? attributes.name : new PropertyName( attributes.name || 'Relation' ),
 		format: RelationFormat.formatName,

--- a/Neo/neojs/src/domain/valueFormats/Text.ts
+++ b/Neo/neojs/src/domain/valueFormats/Text.ts
@@ -34,24 +34,7 @@ type TextPropertyAttributes = Omit<Partial<TextProperty>, 'name'> & {
 	name?: string | PropertyName;
 };
 
-export function newTextProperty(
-	attributes: string|TextPropertyAttributes = {},
-	name = 'MyTextProperty',
-	multiple = false,
-	format = TextFormat.formatName
-): TextProperty {
-	if ( typeof attributes === 'string' ) { // TODO: remove deprecated form
-		return {
-			name: new PropertyName( name ),
-			format: format,
-			description: '',
-			required: false,
-			default: newStringValue( '' ),
-			multiple: multiple,
-			uniqueItems: true
-		};
-	}
-
+export function newTextProperty( attributes: TextPropertyAttributes = {} ): TextProperty {
 	return {
 		name: attributes.name instanceof PropertyName ? attributes.name : new PropertyName( attributes.name || 'Text' ),
 		format: TextFormat.formatName,

--- a/Neo/neojs/src/domain/valueFormats/Url.ts
+++ b/Neo/neojs/src/domain/valueFormats/Url.ts
@@ -2,7 +2,6 @@ import { MultiStringProperty, PropertyDefinition, PropertyName } from '@neo/doma
 import { newStringValue, type StringValue, ValueType } from '@neo/domain/Value';
 import { BaseValueFormat } from '@neo/domain/ValueFormat';
 import DOMPurify from 'dompurify';
-import { TextProperty } from '@neo/domain/valueFormats/Text';
 
 export interface UrlProperty extends MultiStringProperty {
 


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/NeoWiki/pull/246#discussion_r1818912229

Nothing in our current code uses the deprecated form.

Not sure if we want to keep this in case we paste tests from the old code. But that might also be a good point to update the tests anyway.