### PR TITLE
Add Text attribute fields

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -227,7 +227,9 @@
 				"neowiki-property-editor-save",
 				"neowiki-property-editor-minimum",
 				"neowiki-property-editor-maximum",
-				"neowiki-property-editor-precision"
+				"neowiki-property-editor-precision",
+				"neowiki-property-editor-multiple",
+				"neowiki-property-editor-unique-items"
 			],
 			"@group:": "TODO: Load code separately while in development. Remove later.",
 			"group": "ext.neowiki"

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -51,6 +51,8 @@
 	"neowiki-property-editor-minimum": "Minimum",
 	"neowiki-property-editor-maximum": "Maximum",
 	"neowiki-property-editor-precision": "Precision",
+	"neowiki-property-editor-multiple": "Allow multiple values",
+	"neowiki-property-editor-unique-items": "Values must be unique",
 
 	"neowiki-infobox-type": "Type",
 	"neowiki-infobox-edit-link": "Edit",

--- a/resources/ext.neowiki/src/components/Editor/Property/TextAttributesEditor.vue
+++ b/resources/ext.neowiki/src/components/Editor/Property/TextAttributesEditor.vue
@@ -1,14 +1,37 @@
 <template>
-	<div />
-	<!-- TODO -->
+	<div class="text-attributes">
+		<CdxCheckbox
+			:model-value="property.multiple"
+			:label="$i18n( 'neowiki-property-editor-multiple' ).text()"
+			@update:model-value="updateMultiple"
+		>
+			<small>{{ $i18n( 'neowiki-property-editor-multiple' ).text() }}</small>
+		</CdxCheckbox>
+
+		<CdxCheckbox
+			v-if="property.multiple"
+			:model-value="property.uniqueItems"
+			:label="$i18n( 'neowiki-property-editor-unique-items' ).text()"
+			@update:model-value="updateUniqueItems"
+		>
+			<small>{{ $i18n( 'neowiki-property-editor-unique-items' ).text() }}</small>
+		</CdxCheckbox>
+	</div>
 </template>
 
 <script setup lang="ts">
 import { MultiStringProperty } from '@neo/domain/PropertyDefinition.ts';
 import { AttributesEditorEmits, AttributesEditorProps } from '@/components/Editor/Property/AttributesEditorContract.ts';
+import { CdxCheckbox } from '@wikimedia/codex';
 
 defineProps<AttributesEditorProps<MultiStringProperty>>();
-defineEmits<AttributesEditorEmits<MultiStringProperty>>();
+const emit = defineEmits<AttributesEditorEmits<MultiStringProperty>>();
 
-// TODO: emit like in NumberAttributesEditor.vue
+const updateMultiple = ( value: boolean ): void => {
+	emit( 'update:property', { multiple: value } );
+};
+
+const updateUniqueItems = ( value: boolean ): void => {
+	emit( 'update:property', { uniqueItems: value } );
+};
 </script>


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/NeoWiki/issues/91 and https://github.com/ProfessionalWiki/NeoWiki/issues/92

Done:
* Reuses the same attribute fields for Text and URL
* Saves the config
* When `multiple` is false it hides the `uniqueItems` field. When saving `multiple` as `false`, it does not override `uniqueItems` to `false`. The code using `multiple` should check that, and it also makes it easier to "revert" the change later.

Follow-up:
* `TextInput` and `UrlInput` should not allow multiple values (i.e. hide the add/remove buttons)
* Does not validate uniqueness

[Screencast_20241028_192224.webm](https://github.com/user-attachments/assets/caf28cf8-b47d-4cd5-8387-60b8d12b6748)
