### PR TITLE
Use MW 1.43 in CI

### DIFF
--- a/.github/workflows/ci-php.yml
+++ b/.github/workflows/ci-php.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - mw: 'master'
+          - mw: 'REL1_43'
             php: '8.3'
 
     runs-on: ubuntu-latest
@@ -129,7 +129,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - mw: 'master'
+          - mw: 'REL1_43'
             php: '8.3'
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
Since the REL1_43 exists now. I don't think there's a need to continue running on master, since that's a very far away future release.