### PR TITLE
Resolve extra infobox editor space

### DIFF
--- a/resources/ext.neowiki/src/components/Editor/InfoboxEditor.vue
+++ b/resources/ext.neowiki/src/components/Editor/InfoboxEditor.vue
@@ -349,7 +349,7 @@ defineExpose( { openDialog } );
 @use '@wikimedia/codex-design-tokens/theme-wikimedia-ui.scss' as *;
 
 .cdx-dialog.infobox-editor {
-	max-width: 54rem;
+	max-width: 48rem;
 	max-height: 90vh;
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
For: https://github.com/ProfessionalWiki/NeoWiki/issues/144


That's the solution I implemented:

1st:
![one](https://github.com/user-attachments/assets/0ead9321-2c5f-423d-ac8b-8c57bc530f18)

I've 2 other options here as well, I am not sure which one is better.

2nd:
![two](https://github.com/user-attachments/assets/a6fc6f36-bedb-42d5-955d-b830dc0c8136)

3rd:
![3rd](https://github.com/user-attachments/assets/7f52db67-abf9-4455-a53b-8040776206a3)


