### PR TITLE
Hide Text/URL single value add button

### DIFF
--- a/resources/ext.neowiki/src/components/Value/TextInput.vue
+++ b/resources/ext.neowiki/src/components/Value/TextInput.vue
@@ -29,6 +29,7 @@
 			</CdxButton>
 		</div>
 		<CdxButton
+			v-if="property.multiple"
 			weight="quiet"
 			aria-hidden="false"
 			class="add-text-button"

--- a/resources/ext.neowiki/src/components/Value/UrlInput.vue
+++ b/resources/ext.neowiki/src/components/Value/UrlInput.vue
@@ -30,6 +30,7 @@
 			</CdxButton>
 		</div>
 		<CdxButton
+			v-if="property.multiple"
 			weight="quiet"
 			aria-hidden="false"
 			class="add-url-button"

--- a/resources/ext.neowiki/tests/components/Value/TextInput.spec.ts
+++ b/resources/ext.neowiki/tests/components/Value/TextInput.spec.ts
@@ -19,7 +19,7 @@ describe( 'TextInput', () => {
 		props: {
 			modelValue: newStringValue( 'Test' ),
 			label: 'Test Label',
-			property: newTextProperty( {} ),
+			property: newTextProperty( { multiple: true } ),
 			...propsData
 		}
 	} );
@@ -73,7 +73,7 @@ describe( 'TextInput', () => {
 	describe( 'Validation', () => {
 		it( 'does not allow all empty fields when property value is required', async () => {
 			const wrapper = createWrapper( {
-				property: newTextProperty( { required: true } ),
+				property: newTextProperty( { required: true, multiple: true } ),
 				modelValue: newStringValue( 'Text1', 'Text2' )
 			} );
 			await wrapper.findAll( 'input' )[ 0 ].setValue( '' );
@@ -134,7 +134,7 @@ describe( 'TextInput', () => {
 	describe( 'Add button state', () => {
 		it( 'disables add button when any text field is invalid', async () => {
 			const wrapper = createWrapper( {
-				property: newTextProperty( { minLength: 3 } ),
+				property: newTextProperty( { minLength: 3, multiple: true } ),
 				modelValue: newStringValue( 'Valid', '123' )
 			} );
 
@@ -145,7 +145,7 @@ describe( 'TextInput', () => {
 
 		it( 'enables add button when all text fields are valid', async () => {
 			const wrapper = createWrapper( {
-				property: newTextProperty( { minLength: 8 } ),
+				property: newTextProperty( { minLength: 8, multiple: true } ),
 				modelValue: newStringValue( 'ValidValue', 'InValid' )
 			} );
 

--- a/resources/ext.neowiki/tests/components/Value/UrlInput.spec.ts
+++ b/resources/ext.neowiki/tests/components/Value/UrlInput.spec.ts
@@ -20,7 +20,7 @@ describe( 'UrlInput', () => {
 	const createWrapper = ( propsData: Partial<InstanceType<typeof UrlInput>['$props']> = {} ): VueWrapper<InstanceType<typeof UrlInput>> => mount( UrlInput, {
 		props: {
 			modelValue: newStringValueWithUrls(),
-			property: newUrlProperty(),
+			property: newUrlProperty( { multiple: true } ),
 			...propsData
 		}
 	} );
@@ -103,7 +103,7 @@ describe( 'UrlInput', () => {
 
 		it( 'succeeds for empty value parts when the value is required but there are valid non-empty parts', async () => {
 			const wrapper = createWrapper( {
-				property: newUrlProperty( { required: true } ),
+				property: newUrlProperty( { required: true, multiple: true } ),
 				modelValue: newStringValue( 'https://valid1.com', 'https://valid2.com', 'https://valid3.com' )
 			} );
 


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/NeoWiki/issues/258

Partial handling for single-value text/URL fields. This hides the add button, which effectively allows it to capture only one value.

[Screencast_20241030_231110.webm](https://github.com/user-attachments/assets/83dfc6c9-c49c-4b68-a906-e318261a72b6)

TODO: update tests - new test cases, and ensure old tests are labeled clearly as being multi-value specific.