### PR TITLE
Decreased height threshold to show dropdown for add property

### DIFF
--- a/resources/ext.neowiki/src/components/Editor/InfoboxEditor.vue
+++ b/resources/ext.neowiki/src/components/Editor/InfoboxEditor.vue
@@ -132,7 +132,7 @@ const statementEditorBody = ref<Element | undefined>( undefined );
 const statementEditorDimensions = useResizeObserver( statementEditorBody );
 const shouldDropUp = computed( () => {
 	if ( statementEditorDimensions.value.height !== undefined ) {
-		return statementEditorDimensions.value.height > 600;
+		return statementEditorDimensions.value.height > 320;
 	}
 	return false;
 } );


### PR DESCRIPTION
For: https://github.com/ProfessionalWiki/NeoWiki/issues/165#issuecomment-2451176831


Tested on laptop.

We can show a dropdown in the bottom position only if there are 3 or fewer than 3 props with no multiples. We might just as well show it "top" position all the time for laptop or tablet screens.

![image](https://github.com/user-attachments/assets/14bf5866-1424-4858-92b4-7000a6191440)


Now it is a bit of a problem for bigger screens since there is enough space but it still goes up:

![image](https://github.com/user-attachments/assets/40e1a6e3-3c7e-4eff-9b4e-a449cc2de13c)


If we start tracking space under the window instead of the "statement editor" area, then we can't resolve this case where the dialog body becomes so big that it shows a scroll bar. 

![image](https://github.com/user-attachments/assets/00f5ec8e-b73c-4c8b-b52b-42f4ab38ff71)

Feel free to push commit if you can resolve all cases, I can't resolve it for all screens without spending too much time.
 