### PR TITLE
make schema name text

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -212,7 +212,6 @@
 				"neowiki-field-max-value",
 				"neowiki-field-invalid-url",
 				"neowiki-infobox-edit-link",
-				"neowiki-create-subject-dialog-schema",
 				"neowiki-create-subject-dialog-select-schema",
 				"neowiki-create-subject-dialog-start-blank-description",
 				"neowiki-create-subject-dialog-go-back",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -24,7 +24,6 @@
 	"neowiki-create-subject-dialog-start-blank-description": "Tooltip for Start blank description",
 	"neowiki-create-subject-dialog-or-select": "Or use a schema",
 	"neowiki-create-subject-dialog-select-schema": "Select a schema",
-	"neowiki-create-subject-dialog-schema": "Schema",
 	"neowiki-create-subject-dialog-go-back": "Go back",
 
 	"neowiki-infobox-editor-dialog-title": "Manage Infobox",

--- a/resources/ext.neowiki/src/components/Editor/InfoboxEditor.vue
+++ b/resources/ext.neowiki/src/components/Editor/InfoboxEditor.vue
@@ -19,7 +19,7 @@
 			v-if="isNewSchema"
 			:model-value="localSubject.getSchemaName()"
 			:required="true"
-			:label="$i18n( 'neowiki-create-subject-dialog-schema' ).text()"
+			:label="$i18n( 'neowiki-infobox-editor-schema-label' ).text()"
 			@update:model-value="updateSchemaName"
 		/>
 


### PR DESCRIPTION
For: https://github.com/ProfessionalWiki/NeoWiki/issues/202

I am not able to come up with a user-intuitive design for the schema name, but at least let's do this.

![image](https://github.com/user-attachments/assets/81637daf-a038-46b2-8019-d7b61b93db81)

Works the same for new schema.

![image](https://github.com/user-attachments/assets/8e74d3e7-80d3-41b5-95cc-9c0b1fabb747)

