### PR TITLE
Patch for hiding property and value label

### DIFF
--- a/resources/ext.neowiki/src/components/Editor/InfoboxEditor.vue
+++ b/resources/ext.neowiki/src/components/Editor/InfoboxEditor.vue
@@ -30,7 +30,7 @@
 			<span class="schema-name-value">{{ localSubject.getSchemaName() }}</span>
 		</div>
 
-		<div v-if="statements.length > 0" class="statement-editor-heading">
+		<div v-if="statements.length > 0 && schemaHasPropertyDefinitions" class="statement-editor-heading">
 			<h4 class="property">
 				{{ $i18n( 'neowiki-infobox-editor-property-label' ).text() }}
 			</h4>
@@ -161,6 +161,13 @@ const getPropertyDefinition = ( propertyName: PropertyName ): PropertyDefinition
 	}
 	return undefined;
 };
+
+const schemaHasPropertyDefinitions = computed( (): boolean => {
+	if ( !localSchema.value ) {
+		return false;
+	}
+	return Object.keys( localSchema.value.getPropertyDefinitions().asRecord() ).length > 0;
+} );
 
 const addMissingStatements = (): void => {
 	if ( localSubject.value !== undefined && localSchema.value !== null ) {


### PR DESCRIPTION
For: https://github.com/ProfessionalWiki/NeoWiki/issues/274

This turns out to be a sorta bug. It works fine for cases when we create a new schema. When we delete the property, on the UI, BE doesn't delete it.

There are a number of problems:

1- In our infobox editor, on the UI, it looks like we are deleting the statement along with the property but we don't send the HTTP request with the removed statement for the subject.

2- Even when we actually do send the right payload for the subject with the removed statement the BE doesn't remove it. 


3- If not removing the statement when removing the property is desired, then how do we remove the statement?


This PR is a mere patch for hiding the underlying problem.


![image](https://github.com/user-attachments/assets/fcf87a5d-19c4-4391-8c47-4b1aa6eecaf8)


I musted up the courage to address the underlying problem here, if you don't want this can be merged then:

https://github.com/ProfessionalWiki/NeoWiki/pull/275

BE still does need to address problem 2.

