### PR TITLE
Footer top border

### DIFF
--- a/resources/ext.neowiki/src/components/Editor/InfoboxEditor.vue
+++ b/resources/ext.neowiki/src/components/Editor/InfoboxEditor.vue
@@ -106,7 +106,6 @@
 			</CdxButton>
 
 			<CdxButton
-				class="neo-button"
 				action="progressive"
 				weight="primary"
 				:disabled="!canSubmit"
@@ -460,7 +459,6 @@ defineExpose( { openDialog } );
 
 	footer {
 		display: flex;
-		align-items: baseline;
 		justify-content: space-between;
 		border-top: $border-subtle;
 	}


### PR DESCRIPTION
While working I found "Delete subject" button a bit distracting through my peripheral visual awareness. But adding the top border makes it a bit less distracting here is before and after:

**Before**
![Before](https://github.com/user-attachments/assets/e6aad869-e9b4-427f-a84f-ec0ffdb886b1)

**After**
![image](https://github.com/user-attachments/assets/110e58b3-0406-40f1-bda7-5526a65c4e7b)

Maybe we should add for header too but I am not sure.


By the way, codex also adds border automatically as soon as body content gets more than its height  and there is a scrollbar, take a look here:
![default-scrollbar](https://github.com/user-attachments/assets/a5c2395e-53e1-4a09-9605-f71d565d3723)

