### PR TITLE
Fix broken ts-build step

### DIFF
--- a/resources/ext.neowiki/src/mediawiki-vue.d.ts
+++ b/resources/ext.neowiki/src/mediawiki-vue.d.ts
@@ -1,17 +1,10 @@
 import { Vue } from 'vue';
 import { Component } from '@vue/runtime-core';
-import { mw } from 'types-mediawiki';
 
 declare module '@vue/runtime-core' {
 	export function createMwApp( rootComponent: Component, rootProps?: rootProps ): Vue.App<Element>;
 
 	interface ComponentCustomProperties {
 		$i18n: ( ...args: Parameters<typeof window.mw.message> ) => mw.Message;
-	}
-}
-
-declare global {
-	interface Window {
-		mw: typeof mw;
 	}
 }

--- a/resources/ext.neowiki/tsconfig.app.json
+++ b/resources/ext.neowiki/tsconfig.app.json
@@ -24,5 +24,10 @@
 			"@neo/*": ["../../Neo/neojs/src/*"]
 		}
 	},
-	"include": ["src/**/*.ts", "src/**/*.vue", "../../Neo/neojs/src/**/*.ts"]
+	"include": [
+		"./node_modules/types-mediawiki",
+		"src/**/*.ts",
+		"src/**/*.vue",
+		"../../Neo/neojs/src/**/*.ts"
+	]
 }

--- a/resources/ext.neowiki/tsconfig.node.json
+++ b/resources/ext.neowiki/tsconfig.node.json
@@ -16,5 +16,8 @@
 		"strict": true,
 		"noFallthroughCasesInSwitch": true
 	},
-	"include": ["vite.config.ts"]
+	"include": [
+		"./node_modules/types-mediawiki",
+		"vite.config.ts"
+	]
 }

--- a/resources/ext.neowiki/tsconfig.vitest.json
+++ b/resources/ext.neowiki/tsconfig.vitest.json
@@ -1,6 +1,12 @@
 {
 	"extends": "./tsconfig.app.json",
-	"include": ["src/**/*.ts", "src/**/*.vue", "../../Neo/neojs/src/**/*.ts", "tests/**/*.ts"],
+	"include": [
+		"./node_modules/types-mediawiki",
+		"src/**/*.ts",
+		"src/**/*.vue",
+		"../../Neo/neojs/src/**/*.ts",
+		"tests/**/*.ts"
+	],
 	"exclude": [],
 	"compilerOptions": {
 		"composite": true,


### PR DESCRIPTION
Fixed by including `types-mediawiki` in tsconfig.

```sh
> ext.neowiki@0.0.0 build
> vue-tsc -b && vite build

src/neowiki.ts:1:10 - error TS2724: '"vue"' has no exported member named 'createMwApp'. Did you mean 'createApp'?

1 import { createMwApp } from 'vue';
           ~~~~~~~~~~~

  node_modules/@vue/runtime-dom/dist/runtime-dom.d.ts:1313:22
    1313 export declare const createApp: CreateAppFunction<Element>;
                              ~~~~~~~~~
    'createApp' is declared here.

src/neowiki.ts:1:10 - error TS2724: '"vue"' has no exported member named 'createMwApp'. Did you mean 'createApp'?

1 import { createMwApp } from 'vue';
           ~~~~~~~~~~~

  node_modules/@vue/runtime-dom/dist/runtime-dom.d.ts:1313:22
    1313 export declare const createApp: CreateAppFunction<Element>;
                              ~~~~~~~~~
    'createApp' is declared here.


Found 2 errors.
```