### PR TITLE
Remove PageIdentifiers from Subject

### DIFF
--- a/Neo/neojs/src/TestHelpers.ts
+++ b/Neo/neojs/src/TestHelpers.ts
@@ -1,9 +1,9 @@
-import { Subject } from '@neo/domain/Subject';
 import { SubjectId } from '@neo/domain/SubjectId';
 import { PageIdentifiers } from '@neo/domain/PageIdentifiers';
 import { Schema } from '@neo/domain/Schema';
 import { StatementList } from '@neo/domain/StatementList';
 import { PropertyDefinitionList } from '@neo/domain/PropertyDefinitionList';
+import { SubjectWithContext } from '@neo/domain/SubjectWithContext';
 
 export const DEFAULT_SUBJECT_ID = 's11111111111111';
 export const DEFAULT_TEST_SUBJECT_LABEL = 'Test subject';
@@ -23,8 +23,8 @@ export function newSubject( {
 	schemaId = DEFAULT_TEST_SCHEMA_ID,
 	statements = new StatementList( [] ),
 	pageIdentifiers = new PageIdentifiers( 0, 'TestSubjectPage' )
-}: NewTestSubjectOptions = {} ): Subject {
-	return new Subject(
+}: NewTestSubjectOptions = {} ): SubjectWithContext {
+	return new SubjectWithContext(
 		id instanceof SubjectId ? id : new SubjectId( id ),
 		label,
 		schemaId,

--- a/Neo/neojs/src/domain/Subject.ts
+++ b/Neo/neojs/src/domain/Subject.ts
@@ -1,5 +1,4 @@
 import type { SubjectLookup } from '@neo/domain/SubjectLookup';
-import type { PageIdentifiers } from '@neo/domain/PageIdentifiers';
 import type { SchemaName } from '@neo/domain/Schema';
 import type { SubjectMap } from '@neo/domain/SubjectMap';
 import type { SubjectId } from '@neo/domain/SubjectId';
@@ -13,8 +12,7 @@ export class Subject {
 		private readonly id: SubjectId,
 		private readonly label: string,
 		private readonly schemaName: SchemaName,
-		private readonly statements: StatementList,
-		private readonly pageIdentifiers: PageIdentifiers
+		private readonly statements: StatementList
 	) {
 	}
 
@@ -38,10 +36,6 @@ export class Subject {
 		return this.statements.get( propertyName ).value;
 	}
 
-	public getPageIdentifiers(): PageIdentifiers {
-		return this.pageIdentifiers;
-	}
-
 	public async getReferencedSubjects( lookup: SubjectLookup ): Promise<SubjectMap> {
 		return this.statements?.getReferencedSubjects( lookup );
 	}
@@ -52,15 +46,15 @@ export class Subject {
 	}
 
 	public withLabel( label: string ): Subject {
-		return new Subject( this.id, label, this.schemaName, this.statements, this.pageIdentifiers );
+		return new Subject( this.id, label, this.schemaName, this.statements );
 	}
 
 	public withStatements( statements: StatementList ): Subject {
-		return new Subject( this.id, this.label, this.schemaName, statements, this.pageIdentifiers );
+		return new Subject( this.id, this.label, this.schemaName, statements );
 	}
 
 	public withSchemaName( schemaName: SchemaName ): Subject {
-		return new Subject( this.id, this.label, schemaName, this.statements, this.pageIdentifiers );
+		return new Subject( this.id, this.label, schemaName, this.statements );
 	}
 
 }

--- a/Neo/neojs/src/domain/SubjectWithContext.ts
+++ b/Neo/neojs/src/domain/SubjectWithContext.ts
@@ -1,0 +1,23 @@
+import { Subject } from '@neo/domain/Subject';
+import type { SubjectId } from '@neo/domain/SubjectId';
+import type { SchemaName } from '@neo/domain/Schema';
+import type { StatementList } from '@neo/domain/StatementList';
+import type { PageIdentifiers } from '@neo/domain/PageIdentifiers';
+
+export class SubjectWithContext extends Subject {
+
+	public constructor(
+		id: SubjectId,
+		label: string,
+		schemaName: SchemaName,
+		statements: StatementList,
+		private readonly pageIdentifiers: PageIdentifiers
+	) {
+		super( id, label, schemaName, statements );
+	}
+
+	public getPageIdentifiers(): PageIdentifiers {
+		return this.pageIdentifiers;
+	}
+
+}

--- a/Neo/neojs/src/persistence/SubjectDeserializer.ts
+++ b/Neo/neojs/src/persistence/SubjectDeserializer.ts
@@ -1,8 +1,8 @@
 import { SubjectId } from '@neo/domain/SubjectId';
-import { Subject } from '@neo/domain/Subject';
 import { PageIdentifiers } from '@neo/domain/PageIdentifiers';
 import { StatementList } from '@neo/domain/StatementList';
 import { StatementDeserializer } from '@neo/persistence/StatementDeserializer';
+import { SubjectWithContext } from '@neo/domain/SubjectWithContext';
 
 export class SubjectDeserializer {
 
@@ -11,7 +11,7 @@ export class SubjectDeserializer {
 	) {
 	}
 
-	public deserialize( json: any ): Subject {
+	public deserialize( json: any ): SubjectWithContext {
 		const id = new SubjectId( json.id );
 		const label = json.label;
 		const schema = json.schema;
@@ -19,7 +19,7 @@ export class SubjectDeserializer {
 		const pageIdentifiers = new PageIdentifiers( json.pageId, json.pageTitle );
 		const statementList = this.deserializeStatements( json.statements );
 
-		return new Subject( id, label, schema, statementList, pageIdentifiers );
+		return new SubjectWithContext( id, label, schema, statementList, pageIdentifiers );
 	}
 
 	public deserializeStatements( json: any ): StatementList {

--- a/Neo/neojs/src/persistence/__tests__/SubjectDeserializer.spec.ts
+++ b/Neo/neojs/src/persistence/__tests__/SubjectDeserializer.spec.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
 import { Neo } from '@neo/Neo';
-import { Subject } from '@neo/domain/Subject';
 import { SubjectId } from '@neo/domain/SubjectId';
 import { StatementList } from '@neo/domain/StatementList';
 import { PageIdentifiers } from '@neo/domain/PageIdentifiers';
@@ -9,6 +8,7 @@ import { Statement } from '@neo/domain/Statement';
 import { PropertyName } from '@neo/domain/PropertyDefinition';
 import { newNumberValue, newStringValue } from '@neo/domain/Value';
 import { NumberFormat } from '@neo/domain/valueFormats/Number';
+import { SubjectWithContext } from '@neo/domain/SubjectWithContext';
 
 describe( 'SubjectDeserializer', () => {
 
@@ -26,7 +26,7 @@ describe( 'SubjectDeserializer', () => {
 
 		const subject = deserializer.deserialize( json );
 
-		expect( subject ).toEqual( new Subject(
+		expect( subject ).toEqual( new SubjectWithContext(
 			new SubjectId( 's13333333333337' ),
 			'SubjectDeserializer',
 			'SDSchema',
@@ -56,7 +56,7 @@ describe( 'SubjectDeserializer', () => {
 
 		const subject = deserializer.deserialize( json );
 
-		expect( subject ).toEqual( new Subject(
+		expect( subject ).toEqual( new SubjectWithContext(
 			new SubjectId( 's13333333333337' ),
 			'SubjectDeserializer',
 			'SDSchema',

--- a/resources/ext.neowiki/src/components/Editor/SubjectEditor.vue
+++ b/resources/ext.neowiki/src/components/Editor/SubjectEditor.vue
@@ -135,7 +135,6 @@ import DeleteDialog from '@/components/Editor/DeleteDialog.vue';
 import { useSchemaStore } from '@/stores/SchemaStore';
 import PropertyDefinitionEditor from '@/components/Editor/PropertyDefinitionEditor.vue';
 import { PropertyDefinitionList } from '@neo/domain/PropertyDefinitionList.ts';
-import { PageIdentifiers } from '@neo/domain/PageIdentifiers.ts';
 import { useSubjectStore } from '@/stores/SubjectStore.ts';
 import { Value } from '@neo/domain/Value.ts';
 import { NeoWikiServices } from '@/NeoWikiServices.ts';
@@ -247,8 +246,7 @@ const setupExistingSubject = ( subject: Subject ): void => {
 		subject.getId(),
 		subject.getLabel(),
 		subject.getSchemaName(),
-		subject.getStatements(),
-		subject.getPageIdentifiers()
+		subject.getStatements()
 	);
 };
 
@@ -269,8 +267,7 @@ const setupNewSubject = ( schemaName: string ): void => {
 		new SubjectId( 'stodotodotodo42' ),
 		'',
 		schemaName as SchemaName,
-		new StatementList( [] ),
-		new PageIdentifiers( mw.config.get( 'wgArticleId' ), 'page-title' )
+		new StatementList( [] )
 	);
 };
 

--- a/resources/ext.neowiki/src/stores/SubjectStore.ts
+++ b/resources/ext.neowiki/src/stores/SubjectStore.ts
@@ -5,6 +5,7 @@ import { NeoWikiExtension } from '@/NeoWikiExtension';
 import { SchemaName } from '@neo/domain/Schema.ts';
 import { StatementList } from '@neo/domain/StatementList.ts';
 import { PageIdentifiers } from '@neo/domain/PageIdentifiers.ts';
+import { SubjectWithContext } from '@neo/domain/SubjectWithContext.ts';
 
 export const useSubjectStore = defineStore( 'subject', {
 	state: () => ( {
@@ -52,7 +53,7 @@ export const useSubjectStore = defineStore( 'subject', {
 
 			this.setSubject(
 				subjectId,
-				new Subject(
+				new SubjectWithContext(
 					subjectId,
 					label,
 					schemaName,

--- a/resources/ext.neowiki/tests/components/AutomaticInfobox.spec.ts
+++ b/resources/ext.neowiki/tests/components/AutomaticInfobox.spec.ts
@@ -1,21 +1,19 @@
 import { mount, VueWrapper } from '@vue/test-utils';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import AutomaticInfobox from '@/components/AutomaticInfobox.vue';
 import { Subject } from '@neo/domain/Subject';
 import { SubjectId } from '@neo/domain/SubjectId';
 import { StatementList } from '@neo/domain/StatementList';
 import { Statement } from '@neo/domain/Statement';
-import { PropertyName } from '@neo/domain/PropertyDefinition';
+import { createPropertyDefinitionFromJson, PropertyName } from '@neo/domain/PropertyDefinition';
 import { TextFormat } from '@neo/domain/valueFormats/Text';
 import { NumberFormat } from '@neo/domain/valueFormats/Number';
 import { UrlFormat } from '@neo/domain/valueFormats/Url';
-import { newStringValue, newNumberValue } from '@neo/domain/Value';
-import { PageIdentifiers } from '@neo/domain/PageIdentifiers';
+import { newNumberValue, newStringValue } from '@neo/domain/Value';
 import { NeoWikiExtension } from '@/NeoWikiExtension';
 import { Schema } from '@neo/domain/Schema';
 import { PropertyDefinitionList } from '@neo/domain/PropertyDefinitionList';
-import { createPropertyDefinitionFromJson } from '@neo/domain/PropertyDefinition';
-import { setActivePinia, createPinia } from 'pinia';
+import { createPinia, setActivePinia } from 'pinia';
 import { useSchemaStore } from '@/stores/SchemaStore';
 import { Service } from '@/NeoWikiServices.ts';
 
@@ -60,8 +58,7 @@ describe( 'AutomaticInfobox', () => {
 			new Statement(
 				new PropertyName( 'website' ), UrlFormat.formatName, newStringValue( 'https://example.com' )
 			)
-		] ),
-		new PageIdentifiers( 1, 'Test_Subject' )
+		] )
 	);
 
 	const mountComponent = ( subject: Subject, schema: Schema, canEditSubject: boolean ): VueWrapper => mount( AutomaticInfobox, {
@@ -120,8 +117,7 @@ describe( 'AutomaticInfobox', () => {
 			new SubjectId( 's1demo6sssssss1' ),
 			'Empty Subject',
 			'TestSchema',
-			new StatementList( [] ),
-			new PageIdentifiers( 2, 'Empty_Subject' )
+			new StatementList( [] )
 		);
 
 		const wrapper = mountComponent( emptySubject, mockSchema, false );

--- a/resources/ext.neowiki/tests/components/Editor/SubjectEditor.spec.ts
+++ b/resources/ext.neowiki/tests/components/Editor/SubjectEditor.spec.ts
@@ -5,7 +5,6 @@ import DeleteDialog from '@/components/Editor/DeleteDialog.vue';
 import { Subject } from '@neo/domain/Subject';
 import { SubjectId } from '@neo/domain/SubjectId';
 import { StatementList } from '@neo/domain/StatementList';
-import { PageIdentifiers } from '@neo/domain/PageIdentifiers';
 import { Schema, SchemaName } from '@neo/domain/Schema';
 import { PropertyDefinitionList } from '@neo/domain/PropertyDefinitionList';
 import { createPropertyDefinitionFromJson } from '@neo/domain/PropertyDefinition';
@@ -35,8 +34,7 @@ describe( 'SubjectEditor - Delete Subject', () => {
 		new SubjectId( 's1demo1aaaaaaa1' ),
 		'Test Subject',
 		'TestSchema' as SchemaName,
-		new StatementList( [] ),
-		new PageIdentifiers( 1, 'Test_Subject' )
+		new StatementList( [] )
 	);
 
 	const mountComponent = async ( subject?: Subject ): Promise<VueWrapper> => {

--- a/resources/ext.neowiki/tests/persistence/RestSubjectRepository.neo4j.spec.ts
+++ b/resources/ext.neowiki/tests/persistence/RestSubjectRepository.neo4j.spec.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { RestSubjectRepository } from '@/persistence/RestSubjectRepository';
 import { SubjectId } from '@neo/domain/SubjectId';
-import { Subject } from '@neo/domain/Subject';
 import { PageIdentifiers } from '@neo/domain/PageIdentifiers';
 import { StatementList } from '@neo/domain/StatementList';
 import { Statement } from '@neo/domain/Statement';
@@ -11,6 +10,7 @@ import { TextFormat } from '@neo/domain/valueFormats/Text';
 import { InMemoryHttpClient } from '@/infrastructure/HttpClient/InMemoryHttpClient';
 import { UrlFormat } from '@neo/domain/valueFormats/Url';
 import { NeoWikiExtension } from '@/NeoWikiExtension';
+import { SubjectWithContext } from '@neo/domain/SubjectWithContext.ts';
 
 function newRepository( apiUrl: string, httpClient: InMemoryHttpClient ): RestSubjectRepository {
 	return new RestSubjectRepository(
@@ -74,7 +74,7 @@ describe( 'RestSubjectRepository', () => {
 
 			const subject = await repository.getSubject( new SubjectId( 's11111111111111' ) );
 
-			expect( subject ).toEqual( new Subject(
+			expect( subject ).toEqual( new SubjectWithContext(
 				new SubjectId( subjectResponse.id ),
 				subjectResponse.label,
 				subjectResponse.schema,


### PR DESCRIPTION
Most code dealing with subjects does not need this info, and sometimes need to consturct a Subject without having this info.