### PR TITLE
Reset property definition on type change

### DIFF
--- a/resources/ext.neowiki/src/components/Editor/PropertyDefinitionEditor.vue
+++ b/resources/ext.neowiki/src/components/Editor/PropertyDefinitionEditor.vue
@@ -19,6 +19,7 @@
 					<CdxSelect
 						v-model:selected="localProperty.format"
 						:menu-items="formatOptions"
+						@update:selected="updateFormat"
 					/>
 				</div>
 			</div>
@@ -98,6 +99,15 @@ const emit = defineEmits( [ 'cancel', 'save' ] );
 
 const localProperty = ref<PropertyDefinition>( { ...props.property } );
 const componentRegistry = NeoWikiServices.getComponentRegistry();
+
+const updateFormat = (): void => {
+	localProperty.value = {
+		name: localProperty.value.name,
+		format: localProperty.value.format,
+		description: localProperty.value.description,
+		required: localProperty.value.required
+	};
+};
 
 const updatePropertyAttributes = <T extends PropertyDefinition>( updatedAttributes: Partial<T> ): void => {
 	localProperty.value = {


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/NeoWiki/issues/319

This is an initial change to reset the property definition. We're doing a bunch of spread operators in here to avoid the type system. Perhaps this component needs more attention in general? At least the change in this PR should probably instantiate the correct class for the property type, instead of what I'm doing here.