### PR TITLE
Allow empty placeholder value for PropertyName

### DIFF
--- a/Neo/neojs/src/domain/PropertyDefinition.ts
+++ b/Neo/neojs/src/domain/PropertyDefinition.ts
@@ -7,10 +7,14 @@ export class PropertyName {
 
 	private readonly name: string;
 
-	public constructor( name: string ) {
+	/**
+	 * @param name - The name of the property.
+	 * @param placeholder - Whether the name is a placeholder, used when creating a new property.
+	 */
+	public constructor( name: string, placeholder: boolean = false ) {
 		this.name = name.trim();
 
-		if ( this.name === '' ) {
+		if ( this.name === '' && !placeholder ) {
 			throw new Error( 'Invalid PropertyName' );
 		}
 	}

--- a/resources/ext.neowiki/src/components/Editor/SubjectEditor.vue
+++ b/resources/ext.neowiki/src/components/Editor/SubjectEditor.vue
@@ -363,7 +363,7 @@ const addProperty = ( format: string ): void => {
 
 function createEmptyPropertyDefinition( format: string ): PropertyDefinition {
 	return { // TODO: do we need to get a basic property definition via the plugin system?
-		name: new PropertyName( '' ),
+		name: new PropertyName( '', true ),
 		format: format,
 		description: '',
 		required: false


### PR DESCRIPTION
That is required for creating new property through the PropertyDefinitionEditor, since an empty PropertyName value is passed.

Fixes: #326