### PR TITLE
Add Edit Schema button

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -236,8 +236,8 @@
 				"neowiki-property-editor-unique-items",
 				"neowiki-delete-property-confirmation-message",
 				"neowiki-delete-dialog-button",
-				"neowiki-delete-dialog-cancel-button"
-
+				"neowiki-delete-dialog-cancel-button",
+				"neowiki-edit-schema"
 			],
 			"@group:": "TODO: Load code separately while in development. Remove later.",
 			"group": "ext.neowiki"

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -74,5 +74,7 @@
 	"neowiki-infobox-editor-property-required": "Make it a required field",
 
 	"neowiki-delete-dialog-button": "Delete",
-	"neowiki-delete-dialog-cancel-button": "Cancel"
+	"neowiki-delete-dialog-cancel-button": "Cancel",
+
+	"neowiki-edit-schema": "Edit Schema"
 }

--- a/resources/ext.neowiki/src/components/EditSchemaButton.vue
+++ b/resources/ext.neowiki/src/components/EditSchemaButton.vue
@@ -1,0 +1,11 @@
+<template>
+	<CdxButton>
+		<CdxIcon :icon="cdxIconEdit" />
+		{{ $i18n( 'neowiki-edit-schema' ).text() }}
+	</CdxButton>
+</template>
+
+<script setup lang="ts">
+import { CdxButton, CdxIcon } from '@wikimedia/codex';
+import { cdxIconEdit } from '@wikimedia/codex-icons';
+</script>

--- a/resources/ext.neowiki/src/neowiki.ts
+++ b/resources/ext.neowiki/src/neowiki.ts
@@ -4,6 +4,7 @@ import '@/assets/scss/global.scss';
 import NeoWikiApp from '@/components/NeoWikiApp.vue';
 import { CdxTooltip } from '@wikimedia/codex';
 import { NeoWikiServices } from '@/NeoWikiServices.ts';
+import EditSchemaButton from '@/components/EditSchemaButton.vue';
 
 const automaticInfobox = document.querySelector( '#neowiki' );
 if ( automaticInfobox !== null ) {
@@ -11,4 +12,11 @@ if ( automaticInfobox !== null ) {
 	app.use( createPinia() );
 	NeoWikiServices.registerServices( app );
 	app.mount( automaticInfobox );
+}
+
+const editSchema = document.querySelector( '#ext-neowiki-edit-schema' );
+if ( editSchema !== null ) {
+	const app = createMwApp( EditSchemaButton );
+	NeoWikiServices.registerServices( app );
+	app.mount( editSchema );
 }

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -30,7 +30,9 @@ use WikiPage;
 class NeoWikiHooks {
 
 	public static function onBeforePageDisplay( OutputPage $out, Skin $skin ): void {
-		if ( self::isContentPage( $out ) ) {
+		if ( self::isSchemaPage( $out ) ) {
+			self::handleSchemaPage( $out );
+		} elseif ( self::isContentPage( $out ) ) {
 			self::handleContentPage( $out );
 		}
 	}
@@ -104,6 +106,35 @@ class NeoWikiHooks {
 				'data-subject-id' => $subject->getId()->text,
 			]
 		);
+	}
+
+	private static function isSchemaPage( OutputPage $out ): bool {
+		return $out->getTitle()->getNamespace() === NeoWikiExtension::NS_SCHEMA;
+	}
+
+	private static function handleSchemaPage( OutputPage $out ): void {
+		if ( !MediaWikiServices::getInstance()->getPermissionManager()->userCan( 'edit', $out->getUser(), $out->getTitle() ) ) {
+			return;
+		}
+
+		$out->addModules( 'ext.neowiki' );
+		$out->addModuleStyles( 'ext.neowiki.styles' );
+
+		self::addEditSchemaButton( $out );
+	}
+
+	private static function addEditSchemaButton( OutputPage $out ): void {
+		$html = $out->getHTML();
+		$out->clearHTML();
+		$out->addHtml(
+			Html::element(
+				'div',
+				[
+					'id' => 'ext-neowiki-edit-schema',
+				]
+			)
+		);
+		$out->addHTML( $html );
 	}
 
 	public static function onMediaWikiServices( MediaWikiServices $services ): void {


### PR DESCRIPTION
Part of https://github.com/ProfessionalWiki/NeoWiki/issues/328

Not functional yet. This is to split the entrypoints for standalone Schema Editor and Automatic Infoboxes.

![Screenshot_20250418_185909](https://github.com/user-attachments/assets/14e81737-b0d4-4242-a2ad-7e64c3f45a07)
