### PR TITLE
Use ValueInputExposes interface

### DIFF
--- a/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditor.vue
+++ b/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditor.vue
@@ -22,12 +22,8 @@ import { ref, onBeforeUpdate } from 'vue';
 import { CdxField } from '@wikimedia/codex';
 import { StatementList } from '@neo/domain/StatementList.ts';
 import { Statement } from '@neo/domain/Statement.ts';
-import { Value } from '@neo/domain/Value.ts';
 import { NeoWikiServices } from '@/NeoWikiServices.ts';
-
-interface ValueEditorComponent {
-	getCurrentValue: () => Value | undefined;
-}
+import { ValueInputExposes } from '@/components/Value/ValueInputContract.ts';
 
 const props = defineProps<{
 	schemaStatements: StatementList;
@@ -37,7 +33,7 @@ onBeforeUpdate( () => {
 	valueEditors.value = [];
 } );
 
-const valueEditors = ref<ValueEditorComponent[]>( [] );
+const valueEditors = ref<ValueInputExposes[]>( [] );
 
 const getSubjectData = (): StatementList => {
 	const newStatements = [ ...props.schemaStatements ].map( ( statement, index ) =>


### PR DESCRIPTION
Follow-up to #354 

The interface used by the actual input components is this:
https://github.com/ProfessionalWiki/NeoWiki/blob/99e829331f8ca47f5860449dd6d5417146327b40/resources/ext.neowiki/src/components/Value/ValueInputContract.ts#L14-L16

Defining an additional, superficially similar interface means there are 2 places where the public interface can change. Also, `SubjectEditor` uses the input components, and should not be responsible for defining the interface for them. It should just use the already defined interface.

Perhaps a more generic name should be used instead of `ValueInputExposes` (maybe even `ValueEditorComponent` instead).

Or am I missing something here?