### PR TITLE
Show icon in property type select

### DIFF
--- a/resources/ext.neowiki/src/components/SchemaEditor/PropertyDefinitionEditor.vue
+++ b/resources/ext.neowiki/src/components/SchemaEditor/PropertyDefinitionEditor.vue
@@ -108,8 +108,9 @@ function updatePropertyAttributes<T extends PropertyDefinition>( attributes: Par
 
 const componentRegistry = NeoWikiServices.getComponentRegistry();
 
-const typeOptions = componentRegistry.getLabelsAndIcons().map( ( { value, label } ) => ( {
+const typeOptions = componentRegistry.getLabelsAndIcons().map( ( { value, label, icon } ) => ( {
 	value: value,
-	label: mw.message( label ).text()
+	label: mw.message( label ).text(),
+	icon: icon
 } ) );
 </script>


### PR DESCRIPTION
Related to `TypeSpecificComponentRegistry.getLabelsAndIcons()` mentioned on https://github.com/ProfessionalWiki/NeoWiki/issues/386: I suspect this code originally had the purpose as per this PR.

This is also part of the new design anyway.

![Screenshot_20250509_190130](https://github.com/user-attachments/assets/931cbd82-7e67-4d00-a3b7-14bc2b9fab0f)
