### PR TITLE
Add view type handling to Vue entypoint

### DIFF
--- a/DemoData/Page/Company_Infoboxes.wikitext
+++ b/DemoData/Page/Company_Infoboxes.wikitext
@@ -1,13 +1,13 @@
-<div class="neowiki-infobox" data-subject-id="s1demo1aaaaaaa1"></div>
-<div class="neowiki-infobox" data-subject-id="s1demo5sssssss1"></div>
+<div class="ext-neowiki-view" data-subject-id="s1demo1aaaaaaa1"></div>
+<div class="ext-neowiki-view" data-subject-id="s1demo5sssssss1"></div>
 
 This page shows infoboxes with data from the [[Professional Wiki]] and [[ACME Inc]] pages.
 
 This is achieved with the following wikitext that references the IDs of the subjects:
 
 <pre>
-<div class="neowiki-infobox" data-subject-id="s1demo1aaaaaaa1"></div>
-<div class="neowiki-infobox" data-subject-id="s1demo5sssssss1"></div>
+<div class="ext-neowiki-view" data-subject-id="s1demo1aaaaaaa1"></div>
+<div class="ext-neowiki-view" data-subject-id="s1demo5sssssss1"></div>
 </pre>
 
 

--- a/DemoData/Page/Reactive_UI_example.wikitext
+++ b/DemoData/Page/Reactive_UI_example.wikitext
@@ -2,16 +2,16 @@ This page shows Subjects defined on [[ACME Inc]].
 
 Data is displayed multiple times in different forms, demonstrating automatic and immediate update everywhere once you edit it in one location.
 
-<div class="neowiki-infobox" data-subject-id="s1demo1aaaaaaa1"></div>
+<div class="ext-neowiki-view" data-subject-id="s1demo1aaaaaaa1"></div>
 
 {{#table:Product|ACME Inc}}
 
 {{#table:Company|ACME Inc}}
 
-<div class="neowiki-infobox" data-subject-id="s1demo1aaaaaaa4"></div>
-<div class="neowiki-infobox" data-subject-id="s1demo1aaaaaaa3"></div>
-<div class="neowiki-infobox" data-subject-id="s1demo1aaaaaaa2"></div>
-<div class="neowiki-infobox" data-subject-id="s1demo1aaaaaaa1"></div>
+<div class="ext-neowiki-view" data-subject-id="s1demo1aaaaaaa4"></div>
+<div class="ext-neowiki-view" data-subject-id="s1demo1aaaaaaa3"></div>
+<div class="ext-neowiki-view" data-subject-id="s1demo1aaaaaaa2"></div>
+<div class="ext-neowiki-view" data-subject-id="s1demo1aaaaaaa1"></div>
 
 {{#table:Product|ACME Inc}}
 

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -101,7 +101,7 @@ class NeoWikiHooks {
 		return Html::element(
 			'div',
 			[
-				'class' => 'neowiki-infobox',
+				'class' => 'ext-neowiki-view',
 				'data-subject-id' => $subject->getId()->text,
 			]
 		);


### PR DESCRIPTION
Key changes:
- Use a more generic `ext-neowiki-view` class for view container
- Break down onMounted into small and more focused functions
- Access the data attributes once, and use `dataset` property instead of `getAttribute`
- Exit early if a view contains invalid subjectId