### PR TITLE
Style SchemaEditor

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -171,7 +171,8 @@
 				"CdxMenuButton",
 				"useResizeObserver",
 				"CdxMessage",
-				"CdxToggleSwitch"
+				"CdxToggleSwitch",
+				"CdxMenu"
 			],
 			"packageFiles": [
 				"resources/ext.neowiki/dist/neowiki.js",
@@ -256,7 +257,8 @@
 				"neowiki-edit-summary-help-text-schema",
 				"neowiki-subject-editor-title",
 				"neowiki-subject-editor-save",
-				"neowiki-schema-editor-new-property"
+				"neowiki-schema-editor-new-property",
+				"neowiki-schema-editor-optional"
 			],
 			"@group:": "TODO: Load code separately while in development. Remove later.",
 			"group": "ext.neowiki"

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -87,5 +87,6 @@
 	"neowiki-subject-editor-title": "Editing $1",
 	"neowiki-subject-editor-save": "Save changes",
 
-	"neowiki-schema-editor-new-property": "Add new property"
+	"neowiki-schema-editor-new-property": "Add new property",
+	"neowiki-schema-editor-optional": "Optional"
 }

--- a/resources/ext.neowiki/src/assets/scss/global.scss
+++ b/resources/ext.neowiki/src/assets/scss/global.scss
@@ -1,43 +1,5 @@
 @use '@wikimedia/codex-design-tokens/theme-wikimedia-ui.scss' as *;
 
-.neo-cdx-field-inline {
-	display: grid;
-	grid-template-columns: auto 1fr;
-	grid-column-gap: $spacing-75;
-
-	.cdx-label {
-		width: $size-1600;
-	}
-
-	.cdx-field__control {
-		grid-column: 2 / 3;
-		grid-row: 1 / 2;
-
-		.cdx-select-vue {
-			display: block;
-		}
-	}
-
-	.cdx-label__description {
-		margin-top: $spacing-25;
-	}
-
-	.cdx-field__help-text {
-		grid-column: 2 / 3;
-		grid-row: 3 / 4;
-		margin-top: 0;
-		display: block;
-	}
-
-	:has( .cdx-label__description:empty ) .cdx-field__control {
-		margin-bottom: $spacing-35;
-	}
-
-	:has( .cdx-field__help-text:empty ) {
-		grid-template-rows: auto auto;
-	}
-}
-
 input[ type='number' ] {
 	-moz-appearance: textfield;
 
@@ -53,15 +15,6 @@ input[ type='number' ] {
 
 		&:hover {
 			background: $background-color-interactive;
-		}
-	}
-}
-
-.cdx-field {
-	&__validation-message {
-		svg {
-			height: $size-icon-small !important;
-			width: $size-icon-small !important;
 		}
 	}
 }
@@ -88,46 +41,6 @@ input[ type='number' ] {
 
 .neo-float-right {
 	float: right;
-}
-
-.cdx-text-input {
-	&--status-default {
-		input {
-			border: $border-width-base solid rgba( $border-color-disabled, 0.55 ) !important;
-		}
-	}
-
-	&__end-icon {
-		svg {
-			color: $color-success !important;
-		}
-	}
-}
-
-.cdx-checkbox {
-	cursor: pointer !important;
-	padding: 5px;
-
-	small {
-		cursor: pointer !important;
-		font-size: $font-size-small !important;
-	}
-}
-
-$background-color-backdrop-light: #6c757dbf;
-
-.cdx-dialog-backdrop {
-	background-color: $background-color-backdrop-light !important;
-}
-
-.cdx-dialog {
-	border-radius: 10px !important;
-}
-
-.cdx-select-vue--enabled .cdx-select-vue__handle {
-	border-radius: 5px !important;
-	background-color: #fff !important;
-	border: $border-width-base solid rgba( $border-color-disabled, 0.55 ) !important;
 }
 
 .neo-button {

--- a/resources/ext.neowiki/src/components/SchemaEditor/EditSchemaPage.vue
+++ b/resources/ext.neowiki/src/components/SchemaEditor/EditSchemaPage.vue
@@ -5,23 +5,16 @@
 			:initial-schema="initialSchema as Schema"
 		/>
 
-		<CdxTextArea />
-
-		<CdxButton
-			action="progressive"
-			weight="primary"
-			@click="saveSchema"
-		>
-			<CdxIcon :icon="cdxIconCheck" />
-			{{ $i18n( 'neowiki-save-schema' ).text() }}
-		</CdxButton>
+		<EditSummary
+			:save-button-label="$i18n( 'neowiki-save-schema' ).text()"
+			@save="saveSchema"
+		/>
 	</div>
 </template>
 
 <script setup lang="ts">
 import SchemaEditor, { SchemaEditorExposes } from '@/components/SchemaEditor/SchemaEditor.vue';
-import { CdxButton, CdxIcon, CdxTextArea } from '@wikimedia/codex';
-import { cdxIconCheck } from '@wikimedia/codex-icons';
+import EditSummary from '@/components/common/EditSummary.vue';
 import { Schema } from '@neo/domain/Schema.ts';
 import { ref } from 'vue';
 import { NeoWikiServices } from '@/NeoWikiServices.ts';
@@ -55,3 +48,21 @@ const saveSchema = async (): Promise<void> => {
 	}
 };
 </script>
+
+<style lang="scss">
+@use '@wikimedia/codex-design-tokens/theme-wikimedia-ui.scss' as *;
+
+.ext-neowiki-edit-schema-action {
+	border: $border-base;
+	border-radius: $border-radius-base;
+
+	.ext-neowiki-edit-summary {
+		border-block-start: $border-subtle;
+		padding: $spacing-100;
+
+		@media ( min-width: $min-width-breakpoint-desktop ) {
+			padding: $spacing-150;
+		}
+	}
+}
+</style>

--- a/resources/ext.neowiki/src/components/SchemaEditor/Property/NumberAttributesEditor.vue
+++ b/resources/ext.neowiki/src/components/SchemaEditor/Property/NumberAttributesEditor.vue
@@ -1,5 +1,6 @@
 <template>
-	<div class="number-attributes">
+	<!-- cdx-field class is used for spacing -->
+	<div class="number-attributes cdx-field">
 		<CdxField>
 			<template #label>
 				{{ $i18n( 'neowiki-property-editor-minimum' ).text() }}

--- a/resources/ext.neowiki/src/components/SchemaEditor/Property/TextAttributesEditor.vue
+++ b/resources/ext.neowiki/src/components/SchemaEditor/Property/TextAttributesEditor.vue
@@ -1,28 +1,37 @@
 <template>
-	<div class="text-attributes">
-		<CdxCheckbox
-			:model-value="property.multiple"
-			:label="$i18n( 'neowiki-property-editor-multiple' ).text()"
-			@update:model-value="updateMultiple"
-		>
-			<small>{{ $i18n( 'neowiki-property-editor-multiple' ).text() }}</small>
-		</CdxCheckbox>
+	<!-- cdx-field class is used for spacing -->
+	<div class="text-attributes cdx-field">
+		<CdxField :hide-label="true">
+			<CdxToggleSwitch
+				:model-value="property.multiple"
+				:align-switch="true"
+				:label="$i18n( 'neowiki-property-editor-multiple' ).text()"
+				@update:model-value="updateMultiple"
+			>
+				{{ $i18n( 'neowiki-property-editor-multiple' ).text() }}
+			</CdxToggleSwitch>
+		</CdxField>
 
-		<CdxCheckbox
+		<CdxField
 			v-if="property.multiple"
-			:model-value="property.uniqueItems"
-			:label="$i18n( 'neowiki-property-editor-unique-items' ).text()"
-			@update:model-value="updateUniqueItems"
+			:hide-label="true"
 		>
-			<small>{{ $i18n( 'neowiki-property-editor-unique-items' ).text() }}</small>
-		</CdxCheckbox>
+			<CdxToggleSwitch
+				:model-value="property.uniqueItems"
+				:align-switch="true"
+				:label="$i18n( 'neowiki-property-editor-unique-items' ).text()"
+				@update:model-value="updateUniqueItems"
+			>
+				{{ $i18n( 'neowiki-property-editor-unique-items' ).text() }}
+			</CdxToggleSwitch>
+		</CdxField>
 	</div>
 </template>
 
 <script setup lang="ts">
 import { MultiStringProperty } from '@neo/domain/PropertyDefinition.ts';
 import { AttributesEditorEmits, AttributesEditorProps } from '@/components/SchemaEditor/Property/AttributesEditorContract.ts';
-import { CdxCheckbox } from '@wikimedia/codex';
+import { CdxToggleSwitch, CdxField } from '@wikimedia/codex';
 
 defineProps<AttributesEditorProps<MultiStringProperty>>();
 const emit = defineEmits<AttributesEditorEmits<MultiStringProperty>>();

--- a/resources/ext.neowiki/src/components/SchemaEditor/PropertyDefinitionEditor.vue
+++ b/resources/ext.neowiki/src/components/SchemaEditor/PropertyDefinitionEditor.vue
@@ -31,9 +31,11 @@
 			/>
 		</CdxField>
 
-		<CdxField>
+		<CdxField :hide-label="true">
 			<CdxToggleSwitch
-				v-model="localProperty.required">
+				v-model="localProperty.required"
+				:align-switch="true"
+			>
 				{{ $i18n( 'neowiki-property-editor-required' ).text() }}
 			</CdxToggleSwitch>
 		</CdxField>

--- a/resources/ext.neowiki/src/components/SchemaEditor/SchemaEditor.vue
+++ b/resources/ext.neowiki/src/components/SchemaEditor/SchemaEditor.vue
@@ -1,5 +1,8 @@
 <template>
-	<div class="ext-neowiki-schema-editor">
+	<div
+		class="ext-neowiki-schema-editor"
+		:class="{ 'ext-neowiki-schema-editor--has-selected-property': selectedProperty !== undefined }"
+	>
 		<PropertyList
 			:properties="currentSchema.getPropertyDefinitions()"
 			@property-selected="onPropertySelected"
@@ -91,8 +94,86 @@ defineExpose( {
 } );
 </script>
 
-<style scoped>
+<style lang="scss">
+@use '@wikimedia/codex-design-tokens/theme-wikimedia-ui.scss' as *;
+
 .ext-neowiki-schema-editor {
-	display: flex;
+	display: grid;
+
+	.ext-neowiki-schema-editor {
+		&__property-list,
+		&__property-editor {
+			padding: $spacing-100;
+
+			@media ( min-width: $min-width-breakpoint-desktop ) {
+				padding: $spacing-150;
+			}
+		}
+
+		&__property-list__menu {
+			width: auto;
+
+			@media ( min-width: $min-width-breakpoint-desktop ) {
+				margin: (-$spacing-50) (-$spacing-75);
+
+				.cdx-menu-item {
+					border-top-right-radius: 0;
+					border-bottom-right-radius: 0;
+				}
+			}
+		}
+	}
+
+	.cdx-select-vue {
+		display: block; /* Make the select element take the full width of the parent element */
+	}
+
+	&--has-selected-property {
+		/*
+			TODO: Temporary solution for responsive layout.
+			Property list and editor should be in multiple steps for mobile.
+		*/
+		@media ( max-width: $max-width-breakpoint-tablet ) {
+			.ext-neowiki-schema-editor {
+				&__property-list {
+					overflow-x: auto;
+					padding: 0;
+				}
+
+				&__property-list__menu {
+					.cdx-menu__listbox {
+						display: flex;
+						white-space: nowrap;
+					}
+
+					&.cdx-menu--has-footer .cdx-menu-item:last-of-type:not( :first-of-type ) {
+						margin-top: 0;
+					}
+
+					.cdx-menu-item {
+						border-radius: 0;
+					}
+				}
+
+				&__property-editor {
+					border-block-start: $border-subtle;
+				}
+			}
+		}
+
+		@media ( min-width: $min-width-breakpoint-desktop ) {
+			grid-template-columns: minmax( 0, 20rem ) auto;
+
+			.ext-neowiki-schema-editor {
+				&__property-list__menu {
+					margin-inline-end: -$spacing-150;
+				}
+
+				&__property-editor {
+					border-inline-start: $border-subtle;
+				}
+			}
+		}
+	}
 }
 </style>

--- a/resources/ext.neowiki/src/components/SchemaEditor/SchemaEditorDialog.vue
+++ b/resources/ext.neowiki/src/components/SchemaEditor/SchemaEditorDialog.vue
@@ -6,24 +6,20 @@
 				:initial-schema="initialSchema"
 			/>
 
-			<CdxTextArea />
-
-			<CdxButton
-				action="progressive"
-				weight="primary"
-				@click="saveSchema"
-			>
-				<CdxIcon :icon="cdxIconCheck" />
-				{{ $i18n( 'neowiki-save-schema' ).text() }}
-			</CdxButton>
+			<template #footer>
+				<EditSummary
+					:save-button-label="$i18n( 'neowiki-save-schema' ).text()"
+					@save="saveSchema"
+				/>
+			</template>
 		</CdxDialog>
 	</div>
 </template>
 
 <script setup lang="ts">
 import SchemaEditor, { SchemaEditorExposes } from '@/components/SchemaEditor/SchemaEditor.vue';
-import { CdxButton, CdxDialog, CdxIcon, CdxTextArea } from '@wikimedia/codex';
-import { cdxIconCheck } from '@wikimedia/codex-icons';
+import EditSummary from '@/components/common/EditSummary.vue';
+import { CdxDialog } from '@wikimedia/codex';
 import { Schema } from '@neo/domain/Schema.ts';
 import { ref } from 'vue';
 

--- a/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditorDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditorDialog.vue
@@ -26,7 +26,10 @@
 
 			<!-- TODO: We should make this into a component-->
 			<template #footer>
-				<DialogFooter @save="handleSave" />
+				<EditSummary
+					:save-button-label="$i18n( 'neowiki-subject-editor-save' ).text()"
+					@save="handleSave"
+				/>
 			</template>
 		</CdxDialog>
 	</div>
@@ -35,7 +38,7 @@
 <script setup lang="ts">
 import { ref, nextTick, computed, onMounted } from 'vue';
 import SubjectEditor from '@/components/SubjectEditor/SubjectEditor.vue';
-import DialogFooter from '@/components/common/DialogFooter.vue';
+import EditSummary from '@/components/common/EditSummary.vue';
 import { CdxButton, CdxDialog, CdxIcon } from '@wikimedia/codex';
 import { cdxIconEdit } from '@wikimedia/codex-icons';
 import { StatementList } from '@neo/domain/StatementList.ts';

--- a/resources/ext.neowiki/src/components/common/EditSummary.vue
+++ b/resources/ext.neowiki/src/components/common/EditSummary.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="ext-neowiki-dialog-footer">
+	<div class="ext-neowiki-edit-summary">
 		<CdxField
 			:optional="true"
 		>
@@ -14,14 +14,14 @@
 				{{ $i18n( 'neowiki-edit-summary-help-text-subject' ).text() }}
 			</template>
 		</CdxField>
-		<div class="ext-neowiki-dialog-footer__actions">
+		<div class="ext-neowiki-edit-summary__actions">
 			<CdxButton
 				action="progressive"
 				weight="primary"
 				@click="onSaveClick"
 			>
 				<CdxIcon :icon="cdxIconCheck" />
-				{{ $i18n( 'neowiki-subject-editor-save' ).text() }}
+				{{ props.saveButtonLabel }}
 			</CdxButton>
 		</div>
 	</div>
@@ -31,6 +31,10 @@
 import { ref } from 'vue';
 import { CdxButton, CdxField, CdxIcon, CdxTextArea } from '@wikimedia/codex';
 import { cdxIconCheck } from '@wikimedia/codex-icons';
+
+const props = defineProps<{
+	saveButtonLabel: string;
+}>();
 
 const editSummary = ref( '' );
 
@@ -47,7 +51,7 @@ const onSaveClick = (): void => {
 <style lang="scss">
 @use '@wikimedia/codex-design-tokens/theme-wikimedia-ui.scss' as *;
 
-.ext-neowiki-dialog-footer {
+.ext-neowiki-edit-summary {
 	display: flex;
 	flex-direction: column;
 	gap: $spacing-50;


### PR DESCRIPTION
Closes: #391, #388

Key changes:
- Implement styles to `SchemaEditor` according to Figma spec
- Refactor `DialogFooter` component into `EditSummary` to be more generic
- Use `EditSummary` component for edit summary in `SchemaEditor`
- Use `CdxMenu` for property list
- Use `CdxToggleSwitch` for boolean values instead of `CdxCheckbox`
- Drop unused Codex override styles from `global.scss`

https://github.com/user-attachments/assets/ad22dda5-e17d-452b-8504-3486edfaab04


