### PR TITLE
Revert "Add docker image labels"

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -58,9 +58,4 @@ WORKDIR /var/www/html/w
 
 FROM production-mw AS final-mw
 
-LABEL org.opencontainers.image.source="https://github.com/ProfessionalWiki/NeoWiki"
-LABEL org.opencontainers.image.title="NeoWiki Experimental PoC Demo"
-LABEL org.opencontainers.image.licenses="GPL-2.0-or-later"
-LABEL org.opencontainers.image.authors="Professional Wiki <https://Professional.Wiki>"
-
 COPY SettingsTemplate.php /var/www/html/w/LocalSettings.php


### PR DESCRIPTION
Reverts ProfessionalWiki/NeoWiki#441

The CI delete step keeps failing. It started happening when this was merged, but I am not sure if that is just a coincidence. Reverting to see if it makes a difference, otherwise I'll revert the revert.