### PR TITLE
Add edit summary support for subject editing

### DIFF
--- a/resources/ext.neowiki/src/composables/useSubjectSaver.ts
+++ b/resources/ext.neowiki/src/composables/useSubjectSaver.ts
@@ -1,0 +1,34 @@
+import { useSubjectStore } from '@/stores/SubjectStore';
+import { Subject } from '@/domain/Subject';
+
+interface UseSubjectSaverReturn {
+	saveSubject: ( subject: Subject, comment?: string ) => Promise<boolean>;
+}
+
+export function useSubjectSaver(): UseSubjectSaverReturn {
+	const subjectStore = useSubjectStore();
+
+	const saveSubject = async ( subject: Subject, comment?: string ): Promise<boolean> => {
+		const subjectName = subject.getLabel();
+		try {
+			await subjectStore.updateSubject( subject, comment );
+			// TODO: i18n
+			mw.notify( `Updated ${ subjectName }.`, { type: 'success' } );
+			return true;
+		} catch ( error ) {
+			mw.notify(
+				error instanceof Error ? error.message : String( error ),
+				{
+					// TODO: i18n
+					title: `Failed to update ${ subjectName }.`,
+					type: 'error',
+				},
+			);
+			return false;
+		}
+	};
+
+	return {
+		saveSubject,
+	};
+}

--- a/resources/ext.neowiki/src/domain/SubjectRepository.ts
+++ b/resources/ext.neowiki/src/domain/SubjectRepository.ts
@@ -21,7 +21,7 @@ export interface SubjectRepository extends SubjectLookup {
 	): Promise<SubjectId>;
 
 	// TODO: return something to indicate status
-	updateSubject( id: SubjectId, label: string, statements: StatementList ): Promise<object>;
+	updateSubject( id: SubjectId, label: string, statements: StatementList, comment?: string ): Promise<object>;
 
 	deleteSubject( id: SubjectId ): Promise<boolean>;
 
@@ -37,7 +37,7 @@ export class StubSubjectRepository extends InMemorySubjectLookup implements Subj
 		return Promise.resolve( new SubjectId( 's11111111111112' ) );
 	}
 
-	public updateSubject( _id: SubjectId, _label: string, _statements: StatementList ): Promise<object> {
+	public updateSubject( _id: SubjectId, _label: string, _statements: StatementList, _comment?: string ): Promise<object> {
 		return Promise.resolve( {} );
 	}
 

--- a/resources/ext.neowiki/src/persistence/RestSubjectRepository.ts
+++ b/resources/ext.neowiki/src/persistence/RestSubjectRepository.ts
@@ -106,12 +106,13 @@ export class RestSubjectRepository implements SubjectRepository {
 		return new SubjectId( data.subjectId );
 	}
 
-	public async updateSubject( id: SubjectId, label: string, statements: StatementList ): Promise<object> {
+	public async updateSubject( id: SubjectId, label: string, statements: StatementList, comment?: string ): Promise<object> {
 		const response = await this.httpClient.patch(
 			`${ this.mediaWikiRestApiUrl }/neowiki/v0/subject/${ id.text }`,
 			{
 				label,
 				statements: statementsToJson( statements ),
+				comment,
 			},
 			{
 				headers: {

--- a/resources/ext.neowiki/src/stores/SubjectStore.ts
+++ b/resources/ext.neowiki/src/stores/SubjectStore.ts
@@ -36,8 +36,8 @@ export const useSubjectStore = defineStore( 'subject', {
 			}
 			return this.getSubject( id );
 		},
-		async updateSubject( subject: Subject ): Promise<void> {
-			await NeoWikiExtension.getInstance().getSubjectRepository().updateSubject( subject.getId(), subject.getLabel(), subject.getStatements() );
+		async updateSubject( subject: Subject, comment?: string ): Promise<void> {
+			await NeoWikiExtension.getInstance().getSubjectRepository().updateSubject( subject.getId(), subject.getLabel(), subject.getStatements(), comment );
 			this.setSubject( subject );
 		},
 		async deleteSubject( subjectId: SubjectId ): Promise<void> {

--- a/resources/ext.neowiki/tests/composables/useSubjectSaver.spec.ts
+++ b/resources/ext.neowiki/tests/composables/useSubjectSaver.spec.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useSubjectSaver } from '@/composables/useSubjectSaver';
+import { useSubjectStore } from '@/stores/SubjectStore';
+import { Subject } from '@/domain/Subject';
+import { newSubject } from '@/TestHelpers';
+
+vi.mock( '@/stores/SubjectStore', () => ( {
+	useSubjectStore: vi.fn(),
+} ) );
+
+describe( 'useSubjectSaver', () => {
+	const mockUpdateSubject = vi.fn();
+
+	beforeEach( () => {
+		vi.clearAllMocks();
+		( useSubjectStore as any ).mockReturnValue( {
+			updateSubject: mockUpdateSubject,
+		} );
+
+		vi.stubGlobal( 'mw', {
+			notify: vi.fn(),
+		} );
+	} );
+
+	const expectSuccessNotification = ( subject: Subject ): void => expect( mw.notify ).toHaveBeenCalledWith(
+		`Updated ${ subject.getLabel() }.`,
+		{ type: 'success' },
+	);
+
+	const expectErrorNotification = ( subject: Subject, error: Error ): void => expect( mw.notify ).toHaveBeenCalledWith(
+		error.message,
+		{
+			title: `Failed to update ${ subject.getLabel() }.`,
+			type: 'error',
+		},
+	);
+
+	it( 'saves subject successfully and notifies user', async () => {
+		const { saveSubject } = useSubjectSaver();
+		const subject = newSubject();
+		const summary = 'Test Summary';
+
+		await saveSubject( subject, summary );
+
+		expect( mockUpdateSubject ).toHaveBeenCalledWith( subject, summary );
+		expectSuccessNotification( subject );
+	} );
+
+	it( 'uses default summary if none provided', async () => {
+		const { saveSubject } = useSubjectSaver();
+		const subject = newSubject();
+
+		const success = await saveSubject( subject );
+
+		expect( success ).toBe( true );
+		expect( mockUpdateSubject ).toHaveBeenCalledWith( subject, undefined );
+		expectSuccessNotification( subject );
+	} );
+
+	it( 'handles save error and notifies user', async () => {
+		const error = new Error( 'Save failed' );
+		mockUpdateSubject.mockRejectedValue( error );
+
+		const { saveSubject } = useSubjectSaver();
+		const subject = newSubject();
+
+		const success = await saveSubject( subject, 'summary' );
+
+		expect( success ).toBe( false );
+		expectErrorNotification( subject, error );
+	} );
+} );

--- a/resources/ext.neowiki/tests/persistence/RestSubjectRepository.neo4j.spec.ts
+++ b/resources/ext.neowiki/tests/persistence/RestSubjectRepository.neo4j.spec.ts
@@ -172,6 +172,7 @@ describe( 'RestSubjectRepository', () => {
 					new Statement( new PropertyName( 'label' ), TextType.typeName, newStringValue( 'John Doe' ) ),
 					new Statement( new PropertyName( 'WorkUrl' ), UrlType.typeName, newStringValue( 'https://pro.wiki' ) ),
 				] ),
+				comment: 'Edit comment',
 			};
 
 			const inMemoryHttpClient = new InMemoryHttpClient( {
@@ -185,6 +186,7 @@ describe( 'RestSubjectRepository', () => {
 				new SubjectId( 's11111111111111' ),
 				'Subject label',
 				mockUpdateResponse.properties,
+				mockUpdateResponse.comment,
 			);
 
 			expect( response ).toEqual( mockUpdateResponse );

--- a/src/Application/Actions/PatchSubject/PatchSubjectAction.php
+++ b/src/Application/Actions/PatchSubject/PatchSubjectAction.php
@@ -28,7 +28,7 @@ readonly class PatchSubjectAction {
 	 * @param string|null $label
 	 * @param array<string, mixed> $patch
 	 */
-	public function patch( SubjectId $subjectId, ?string $label, array $patch ): void {
+	public function patch( SubjectId $subjectId, ?string $label, array $patch, ?string $comment = null ): void {
 		if ( !$this->subjectActionAuthorizer->canEditSubject() ) {
 			throw new RuntimeException( 'You do not have the necessary permissions to edit this subject' );
 		}
@@ -45,7 +45,7 @@ readonly class PatchSubjectAction {
 
 		$subject->patchStatements( $this->patcher, $patch );
 
-		$this->subjectRepository->updateSubject( $subject );
+		$this->subjectRepository->updateSubject( $subject, $comment );
 	}
 
 }

--- a/src/Application/SubjectRepository.php
+++ b/src/Application/SubjectRepository.php
@@ -16,7 +16,7 @@ interface SubjectRepository extends SubjectLookup {
 	 * TODO: throw exception on not found?
 	 * TODO: document exceptions
 	 */
-	public function updateSubject( Subject $subject ): void;
+	public function updateSubject( Subject $subject, ?string $comment = null ): void;
 
 	/**
 	 * TODO: document exceptions

--- a/src/EntryPoints/REST/PatchSubjectApi.php
+++ b/src/EntryPoints/REST/PatchSubjectApi.php
@@ -34,7 +34,8 @@ class PatchSubjectApi extends SimpleHandler {
 			NeoWikiExtension::getInstance()->newPatchSubjectAction( $this->getAuthority() )->patch(
 				new SubjectId( $subjectId ),
 				$request['label'] ?? null,
-				$request['statements'] // TODO: support property removal. https://github.com/ProfessionalWiki/NeoWiki/issues/280
+				$request['statements'], // TODO: support property removal. https://github.com/ProfessionalWiki/NeoWiki/issues/280
+				$request['comment'] ?? null
 			);
 		} catch ( \RuntimeException $e ) {
 			return $this->getResponseFactory()->createHttpError( 403, [

--- a/src/Persistence/MediaWiki/Subject/MediaWikiSubjectRepository.php
+++ b/src/Persistence/MediaWiki/Subject/MediaWikiSubjectRepository.php
@@ -68,7 +68,7 @@ class MediaWikiSubjectRepository implements SubjectRepository {
 		throw new \RuntimeException( 'Content is not a SubjectContent' );
 	}
 
-	public function updateSubject( Subject $subject ): void {
+	public function updateSubject( Subject $subject, ?string $comment = null ): void {
 		$pageId = $this->getPageIdForSubject( $subject->id );
 
 		if ( $pageId === null ) {
@@ -79,7 +79,7 @@ class MediaWikiSubjectRepository implements SubjectRepository {
 
 		if ( $content !== null ) {
 			$this->updateSubjectContent( $content, $subject );
-			$this->saveContent( $content, $pageId );
+			$this->saveContent( $content, $pageId, $comment );
 		}
 	}
 
@@ -89,13 +89,13 @@ class MediaWikiSubjectRepository implements SubjectRepository {
 		$content->setPageSubjects( $contentData );
 	}
 
-	private function saveContent( SubjectContent $content, PageId $pageId ): void {
+	private function saveContent( SubjectContent $content, PageId $pageId, ?string $comment = null ): void {
 		$this->pageContentSaver->saveContent(
 			$pageId,
 			[
 				self::SLOT_NAME => $content,
 			],
-			CommentStoreComment::newUnsavedComment( 'TODO' ) // TODO
+			CommentStoreComment::newUnsavedComment( $comment ?? 'Update NeoWiki subject' )
 		);
 
 		// TODO: expose failure information

--- a/tests/phpunit/Application/Actions/PatchSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/PatchSubjectActionTest.php
@@ -63,6 +63,20 @@ class PatchSubjectActionTest extends TestCase {
 		);
 	}
 
+	public function testPatchSubjectWithComment(): void {
+		$subject = TestSubject::build( id: new SubjectId( self::SUBJECT_ID ) );
+		$this->inMemorySubjectRepository->updateSubject( $subject );
+
+		$patchSubjectAction = $this->newPatchSubjectAction();
+		$patchSubjectAction->patch( $subject->getId(), null, [], 'Edit comment' );
+
+		$this->assertSame(
+			'Edit comment',
+			$this->inMemorySubjectRepository->comments[self::SUBJECT_ID],
+			'Subject comment was not passed correctly'
+		);
+	}
+
 	public function testPatchSubjectLabel(): void {
 		$subject = TestSubject::build(
 			id: new SubjectId( self::SUBJECT_ID ),

--- a/tests/phpunit/EntryPoints/REST/PatchSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/PatchSubjectApiTest.php
@@ -96,6 +96,28 @@ JSON,
 		] );
 	}
 
+	public function testPatchSubjectWithComment(): void {
+		$this->createPages();
+
+		$requestData = $this->createValidRequestData();
+		$requestBody = json_decode( $requestData->getBody()->getContents(), true );
+		$requestBody['comment'] = 'My edit summary';
+		$requestData = new RequestData( [
+			'method' => 'PATCH',
+			'pathParams' => $requestData->getPathParams(),
+			'bodyContents' => json_encode( $requestBody ),
+			'headers' => $requestData->getHeaders()
+		] );
+
+		$response = $this->executeHandler(
+			$this->newPatchSubjectApi(),
+			$requestData
+		);
+
+		$this->assertSame( 200, $response->getStatusCode() );
+		// TODO: Should we verify the comment was saved in the revision?
+	}
+
 	public function testPermissionDenied(): void {
 		$this->createPages();
 

--- a/tests/phpunit/TestDoubles/InMemorySubjectRepository.php
+++ b/tests/phpunit/TestDoubles/InMemorySubjectRepository.php
@@ -22,12 +22,18 @@ class InMemorySubjectRepository implements SubjectRepository {
 	 */
 	private array $subjectsByPage = [];
 
+	/**
+	 * @var array<string, string|null>
+	 */
+	public array $comments = [];
+
 	public function getSubject( SubjectId $subjectId ): ?Subject {
 		return $this->subjects[$subjectId->text] ?? null;
 	}
 
-	public function updateSubject( Subject $subject ): void {
+	public function updateSubject( Subject $subject, ?string $comment = null ): void {
 		$this->subjects[$subject->id->text] = $subject;
+		$this->comments[$subject->id->text] = $comment;
 	}
 
 	public function deleteSubject( SubjectId $id ): void {


### PR DESCRIPTION
Closes: #385 

- Make edit summary in SubjectEditor writes to page revision
- Add comment support for updating subject
- Update SubjectEditor save success toast


https://github.com/user-attachments/assets/20eb0769-dd05-4e85-8b50-8133a85fb8b4

