### PR TITLE
Improve overflow handling for SchemaEditor

### DIFF
--- a/resources/ext.neowiki/src/components/SchemaEditor/SchemaEditorDialog.vue
+++ b/resources/ext.neowiki/src/components/SchemaEditor/SchemaEditorDialog.vue
@@ -4,11 +4,13 @@
 			v-model:open="open"
 			:use-close-button="true"
 			class="ext-neowiki-schema-editor-dialog"
+			:class="{ 'cdx-dialog--dividers': hasOverflow }"
 			:title="$i18n( 'neowiki-editing-schema', props.initialSchema.getName() ).text()"
 		>
 			<SchemaEditor
 				ref="schemaEditor"
 				:initial-schema="initialSchema"
+				@overflow="onOverflow"
 			/>
 
 			<template #footer>
@@ -46,7 +48,12 @@ const open = computed( {
 } );
 
 const schemaEditor = ref<SchemaEditorExposes | null>( null );
+const hasOverflow = ref( false );
 const { saveSchema } = useSchemaSaver();
+
+function onOverflow( overflow: boolean ): void {
+	hasOverflow.value = overflow;
+}
 
 const handleSave = async ( summary: string ): Promise<void> => {
 	if ( !schemaEditor.value ) {
@@ -69,6 +76,8 @@ const handleSave = async ( summary: string ): Promise<void> => {
 
 		.cdx-dialog__body {
 			padding: 0;
+			display: grid;
+			overflow: hidden;
 		}
 	}
 }

--- a/resources/ext.neowiki/src/composables/useOverflowDetection.ts
+++ b/resources/ext.neowiki/src/composables/useOverflowDetection.ts
@@ -1,0 +1,54 @@
+import { computed, onMounted, Ref, ref, unref, watch } from 'vue';
+import { useResizeObserver } from '@wikimedia/codex';
+
+export function useOverflowDetection(
+	elements: Ref<HTMLElement | { $el: HTMLElement } | null>[],
+): {
+		hasOverflow: Ref<boolean>;
+		checkOverflow: () => void;
+	} {
+	const hasOverflow = ref( false );
+
+	function getElement( elementRef: Ref<HTMLElement | { $el: HTMLElement } | null> ): HTMLElement | null {
+		const element = unref( elementRef );
+		return element && '$el' in element ? element.$el : element;
+	}
+
+	function checkOverflow(): void {
+		hasOverflow.value = elements.some( ( elementRef ) => {
+			const el = getElement( elementRef );
+
+			if ( !el ) {
+				return false;
+			}
+
+			return el.scrollHeight > el.clientHeight;
+		} );
+	}
+
+	elements.forEach( ( elementRef ) => {
+		const domElement = computed( () => {
+			const val = unref( elementRef );
+			return ( val && '$el' in val ? val.$el : val ) || undefined;
+		} );
+
+		const dimensions = useResizeObserver( domElement );
+
+		watch( dimensions, () => {
+			checkOverflow();
+		} );
+	} );
+
+	watch( elements, () => {
+		checkOverflow();
+	} );
+
+	onMounted( () => {
+		checkOverflow();
+	} );
+
+	return {
+		hasOverflow,
+		checkOverflow,
+	};
+}

--- a/resources/ext.neowiki/tests/composables/useOverflowDetection.spec.ts
+++ b/resources/ext.neowiki/tests/composables/useOverflowDetection.spec.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useOverflowDetection } from '@/composables/useOverflowDetection';
+import { ref, nextTick, Ref } from 'vue';
+import { enableAutoUnmount, mount } from '@vue/test-utils';
+
+// Mock @wikimedia/codex
+const mockDimensions = ref( { width: 0, height: 0 } );
+vi.mock( '@wikimedia/codex', () => ( {
+	useResizeObserver: () => mockDimensions,
+} ) );
+
+enableAutoUnmount( afterEach );
+
+describe( 'useOverflowDetection', () => {
+	beforeEach( () => {
+		mockDimensions.value = { width: 0, height: 0 };
+	} );
+
+	function mountComposable( composable: () => ReturnType<typeof useOverflowDetection> ): ReturnType<typeof useOverflowDetection> {
+		let result: ReturnType<typeof useOverflowDetection>;
+		mount( {
+			setup() {
+				result = composable();
+				return () => {
+					// Dummy render function
+				};
+			},
+		} );
+		// @ts-expect-error: result is assigned in setup
+		return result;
+	}
+
+	const createMockElementRef = ( scrollHeight: number, clientHeight: number ): Ref<HTMLElement> => {
+		const element = {
+			scrollHeight,
+			clientHeight,
+		} as HTMLElement;
+		return ref( element );
+	};
+
+	it( 'initializes with hasOverflow as false', () => {
+		const elRef = ref<HTMLElement | null>( null );
+		const result = mountComposable( () => useOverflowDetection( [ elRef ] ) );
+
+		expect( result.hasOverflow.value ).toBe( false );
+	} );
+
+	it( 'detects overflow when scrollHeight > clientHeight', () => {
+		const elRef = createMockElementRef( 200, 100 );
+		const result = mountComposable( () => useOverflowDetection( [ elRef ] ) );
+
+		result.checkOverflow();
+
+		expect( result.hasOverflow.value ).toBe( true );
+	} );
+
+	it( 'does not detect overflow when scrollHeight <= clientHeight', () => {
+		const elRef = createMockElementRef( 100, 100 );
+		const result = mountComposable( () => useOverflowDetection( [ elRef ] ) );
+
+		result.checkOverflow();
+
+		expect( result.hasOverflow.value ).toBe( false );
+	} );
+
+	it( 'detects overflow if any of multiple elements overflow', () => {
+		const el1Ref = createMockElementRef( 100, 100 );
+		const el2Ref = createMockElementRef( 200, 100 );
+		const result = mountComposable( () => useOverflowDetection( [ el1Ref, el2Ref ] ) );
+
+		result.checkOverflow();
+
+		expect( result.hasOverflow.value ).toBe( true );
+	} );
+
+	it( 'updates hasOverflow when resize occurs', async () => {
+		const elementRef = createMockElementRef( 100, 100 );
+		const result = mountComposable( () => useOverflowDetection( [ elementRef ] ) );
+
+		expect( result.hasOverflow.value ).toBe( false );
+
+		// Simulate content growth
+		Object.defineProperty( elementRef.value, 'scrollHeight', { value: 200 } );
+		// Simulate resize event
+		mockDimensions.value = { width: 100, height: 100 };
+		await nextTick();
+
+		expect( result.hasOverflow.value ).toBe( true );
+	} );
+
+	it( 'handles ComponentPublicInstance refs', () => {
+		const el = { scrollHeight: 200, clientHeight: 100 } as HTMLElement;
+		const componentRef = ref( { $el: el } );
+		const result = mountComposable( () => useOverflowDetection( [ componentRef ] ) );
+
+		result.checkOverflow();
+
+		expect( result.hasOverflow.value ).toBe( true );
+	} );
+} );


### PR DESCRIPTION
The property list and property editor can be scrolled individually now.

https://github.com/user-attachments/assets/c12fcecf-c699-4e30-b315-f22ff6e82b4a

