### PR TITLE
Disable Composer block-insecure in CI

### DIFF
--- a/.github/workflows/ci-php.yml
+++ b/.github/workflows/ci-php.yml
@@ -57,6 +57,10 @@ jobs:
           extensions: mbstring, intl
           tools: composer
 
+      - name: Disable Composer block-insecure
+        working-directory: ~
+        run: composer config --global audit.block-insecure false
+
       - name: Cache MediaWiki
         id: cache-mediawiki
         uses: actions/cache@v4
@@ -146,6 +150,10 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: mbstring, intl
           tools: composer
+
+      - name: Disable Composer block-insecure
+        working-directory: ~
+        run: composer config --global audit.block-insecure false
 
       - name: Cache MediaWiki
         id: cache-mediawiki

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -51,7 +51,7 @@ RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 COPY --chown=www-data:www-data mediawiki /var/www/html/w
 COPY --chown=www-data:www-data composer.local.json /var/www/html/w/composer.local.json
 
-RUN cd w && composer update --no-interaction --optimize-autoloader
+RUN cd w && composer config --global audit.block-insecure false && composer update --no-interaction --optimize-autoloader
 
 WORKDIR /var/www/html/w
 


### PR DESCRIPTION
PHPUnit 9.x is blocked by security advisory PKSA-z3gr-8qht-p93v. This is not a concern in CI, so disable block-insecure globally.