### PR TITLE
Fix: Make Schema reactive in AutomaticInfobox

### DIFF
--- a/resources/ext.neowiki/src/components/Views/AutomaticInfobox.vue
+++ b/resources/ext.neowiki/src/components/Views/AutomaticInfobox.vue
@@ -14,7 +14,7 @@
 					role="heading"
 					aria-level="3"
 				>
-					{{ schema.getName() }}
+					{{ schema?.getName() }}
 				</div>
 			</div>
 			<SubjectEditorDialog
@@ -72,11 +72,7 @@ const subjectStore = useSubjectStore();
 const schemaStore = useSchemaStore();
 
 const subject = computed( () => subjectStore.getSubject( props.subjectId ) as Subject ); // TODO: handle not found
-const schema = schemaStore.getSchema( subject.value.getSchemaName() ); // TODO: handle not found
-
-if ( !schema ) {
-	console.error( `Schema not found for name: ${ subject.value.getSchemaName() }` );
-}
+const schema = computed( () => schemaStore.getSchema( subject.value.getSchemaName() ) ); // TODO: handle not found
 
 const handleSaveSubject = async ( updatedSubject: Subject, comment: string ): Promise<void> => {
 	await subjectStore.updateSubject( updatedSubject, comment );
@@ -91,7 +87,7 @@ function getComponent( propertyType: string ): Component {
 }
 
 const propertiesToDisplay = computed( function(): Record<string, PropertyDefinition> {
-	return schema.getPropertyDefinitions()
+	return schema.value.getPropertyDefinitions()
 		.withNames( subject.value.getNamesOfNonEmptyProperties() )
 		.asRecord();
 } );


### PR DESCRIPTION
Schema was fetched once at mount time and never updated, so changes
made via the SchemaEditor were not reflected in the infobox until
page reload. Wrapping it in computed() makes it reactive.

Steps to reproduce:
1. Open a page with a Subject infobox (e.g. Professional Wiki)
2. Click edit on the infobox to open SubjectEditorDialog
3. Open the schema editor and change a property type (e.g. change
   Websites from URL to Text)
4. Save the schema and close the dialogs
5. Bug: the infobox still shows the old property type until reload

Manually verified, both the bug and the fix