### PR TITLE
Remove success notification for schema update

### DIFF
--- a/resources/ext.neowiki/src/components/SchemaEditor/EditSchemaPage.vue
+++ b/resources/ext.neowiki/src/components/SchemaEditor/EditSchemaPage.vue
@@ -36,8 +36,6 @@ const handleSave = async ( summary: string ): Promise<void> => {
 
 	try {
 		await schemaStore.saveSchema( schema, editSummary );
-		// TODO: i18n
-		mw.notify( `Updated ${ schemaName } schema`, { type: 'success' } );
 		window.location.href = mw.util.getUrl( `Schema:${ schemaName }` );
 	} catch ( error ) {
 		mw.notify(


### PR DESCRIPTION
Since it is not shown if we insta-reload the page

Follow up to
* https://github.com/ProfessionalWiki/NeoWiki/pull/488