### PR TITLE
Run update.php in make update target

### DIFF
--- a/Docker/Makefile
+++ b/Docker/Makefile
@@ -32,3 +32,4 @@ import-demo-data:
 update:
 	${dockerCompose} pull
 	${dockerCompose} up -d
+	${dockerCompose} exec -T mediawiki php maintenance/run.php update --quick


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/483

Without this, pulling a new image with DB schema changes would leave
the wiki broken until update.php is manually run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)