### PR TITLE
Improve SchemaDisplay UI

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -50,9 +50,7 @@
 
 		"SpecialPage_initList": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onSpecialPageInitList",
 
-		"ContentModelCanBeUsedOn": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onContentModelCanBeUsedOn",
-
-		"SkinTemplateNavigation::Universal": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onSkinTemplateNavigationUniversal"
+		"ContentModelCanBeUsedOn": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onContentModelCanBeUsedOn"
 	},
 
 	"Actions": {
@@ -178,7 +176,9 @@
 				"CdxToggleSwitch",
 				"CdxMenu",
 				"CdxToggleButtonGroup",
-				"CdxLookup"
+				"CdxLookup",	
+				"CdxTable",
+				"CdxInfoChip"
 			],
 			"packageFiles": [
 				"resources/ext.neowiki/dist/neowiki.js",
@@ -259,7 +259,8 @@
 				"neowiki-subject-creator-label-placeholder",
 				"neowiki-subject-creator-save",
 				"neowiki-subject-creator-success",
-				"neowiki-subject-creator-error"
+				"neowiki-subject-creator-error",
+				"neowiki-edit-schema"
 			],
 			"@group:": "TODO: Load code separately while in development. Remove later.",
 			"group": "ext.neowiki"

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -46,8 +46,8 @@
 	"neowiki-field-invalid-url": "Please enter a valid URL.",
 
 	"neowiki-property-editor-description": "Description",
+	"neowiki-edit-schema": "Edit schema",
 	"neowiki-editing-schema": "Editing $1 schema",
-	"neowiki-edit-with-form": "Edit with form",
 	"neowiki-save-schema": "Save schema",
 
 	"neowiki-edit-summary-label": "Edit summary",

--- a/resources/ext.neowiki/src/components/SchemaDisplay/SchemaDisplayHeader.vue
+++ b/resources/ext.neowiki/src/components/SchemaDisplay/SchemaDisplayHeader.vue
@@ -1,0 +1,73 @@
+<template>
+	<div class="ext-neowiki-schema-display-header">
+		<div class="ext-neowiki-schema-display-header__content">
+			<div class="ext-neowiki-schema-display-header__title">
+				{{ schema.getName() }}
+			</div>
+			<div
+				v-if="schema.getDescription()"
+				class="ext-neowiki-schema-display-header__description"
+			>
+				{{ schema.getDescription() }}
+			</div>
+		</div>
+		<div class="ext-neowiki-schema-display-header__actions">
+			<CdxButton
+				v-if="canEditSchema"
+				weight="quiet"
+				:aria-label="$i18n( 'neowiki-edit-schema' ).text()"
+				@click="onEditButtonClick( schema.getName() )"
+			>
+				<CdxIcon :icon="cdxIconEdit" />
+			</CdxButton>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { watch } from 'vue';
+import { Schema } from '@/domain/Schema.ts';
+import { CdxButton, CdxIcon } from '@wikimedia/codex';
+import { cdxIconEdit } from '@wikimedia/codex-icons';
+import { useSchemaPermissions } from '@/composables/useSchemaPermissions.ts';
+
+const props = defineProps( {
+	schema: {
+		type: Schema,
+		required: true
+	}
+} );
+
+const { canEditSchema, checkPermission } = useSchemaPermissions();
+
+watch( () => props.schema, ( newSchema ) => {
+	checkPermission( newSchema.getName() );
+}, { immediate: true } );
+
+function onEditButtonClick( schemaName: string ): void {
+	window.location.href = mw.util.getUrl( `Schema:${ schemaName }`, { action: 'edit-schema' } );
+}
+</script>
+
+<style lang="less">
+@import ( reference ) '@wikimedia/codex-design-tokens/theme-wikimedia-ui.less';
+
+.ext-neowiki-schema-display-header {
+	display: flex;
+	justify-content: space-between;
+	gap: @spacing-100;
+
+	&__content {
+		line-height: @line-height-xx-small;
+	}
+
+	&__title {
+		font-size: @font-size-large;
+		font-weight: @font-weight-bold;
+	}
+
+	&__description {
+		color: @color-subtle;
+	}
+}
+</style>

--- a/resources/ext.neowiki/src/composables/useSchemaPermissions.ts
+++ b/resources/ext.neowiki/src/composables/useSchemaPermissions.ts
@@ -1,0 +1,25 @@
+import { ref, type Ref } from 'vue';
+import { NeoWikiServices } from '@/NeoWikiServices.ts';
+
+export interface SchemaPermissions {
+	canEditSchema: Ref<boolean>;
+	checkPermission: ( schemaName: string ) => Promise<void>;
+}
+
+export function useSchemaPermissions(): SchemaPermissions {
+	const canEditSchema = ref( false );
+
+	async function checkPermission( schemaName: string ): Promise<void> {
+		try {
+			canEditSchema.value = await NeoWikiServices.getSchemaAuthorizer().canEditSchema( schemaName );
+		} catch ( error ) {
+			console.error( 'Failed to check schema permissions:', error );
+			canEditSchema.value = false;
+		}
+	}
+
+	return {
+		canEditSchema,
+		checkPermission,
+	};
+}

--- a/resources/ext.neowiki/tests/components/SchemaDisplay/SchemaDisplayHeader.spec.ts
+++ b/resources/ext.neowiki/tests/components/SchemaDisplay/SchemaDisplayHeader.spec.ts
@@ -1,0 +1,85 @@
+import { mount, VueWrapper } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import SchemaDisplayHeader from '@/components/SchemaDisplay/SchemaDisplayHeader.vue';
+import { Schema } from '@/domain/Schema.ts';
+import { setupMwMock, createI18nMock } from '../../VueTestHelpers.ts';
+import { newSchema } from '@/TestHelpers.ts';
+import { ref } from 'vue';
+
+const checkPermissionMock = vi.fn();
+const canEditSchemaRef = ref( false );
+
+vi.mock( '@/composables/useSchemaPermissions.ts', () => ( {
+	useSchemaPermissions: () => ( {
+		canEditSchema: canEditSchemaRef,
+		checkPermission: checkPermissionMock,
+	} ),
+} ) );
+
+function mountComponent( schema: Schema ): VueWrapper {
+	setupMwMock( { functions: [ 'msg' ] } );
+
+	return mount( SchemaDisplayHeader, {
+		props: { schema },
+		global: {
+			mocks: { $i18n: createI18nMock() },
+			stubs: {
+				CdxIcon: true,
+				CdxButton: true,
+			},
+		},
+	} );
+}
+
+describe( 'SchemaDisplayHeader', () => {
+	it( 'renders schema name and description', () => {
+		const schema = newSchema( {
+			title: 'Test schema',
+			description: 'Description for test schema',
+		} );
+
+		const wrapper = mountComponent( schema );
+
+		expect( wrapper.find( '.ext-neowiki-schema-display-header__title' ).text() ).toBe( 'Test schema' );
+		expect( wrapper.find( '.ext-neowiki-schema-display-header__description' ).text() ).toBe( 'Description for test schema' );
+	} );
+
+	it( 'renders schema name only when no description provided', () => {
+		const schema = newSchema( {
+			title: 'Test schema',
+			description: '',
+		} );
+
+		const wrapper = mountComponent( schema );
+
+		expect( wrapper.find( '.ext-neowiki-schema-display-header__title' ).text() ).toBe( 'Test schema' );
+		expect( wrapper.find( '.ext-neowiki-schema-display-header__description' ).exists() ).toBe( false );
+	} );
+
+	it( 'checks permissions on mount', () => {
+		const schema = newSchema( { title: 'Test Schema' } );
+		checkPermissionMock.mockClear();
+
+		mountComponent( schema );
+
+		expect( checkPermissionMock ).toHaveBeenCalledWith( 'Test Schema' );
+	} );
+
+	it( 'shows edit button when user has permission', async () => {
+		const schema = newSchema( { title: 'Test Schema' } );
+		canEditSchemaRef.value = true;
+
+		const wrapper = mountComponent( schema );
+
+		expect( wrapper.findComponent( { name: 'CdxButton', props: { 'aria-label': 'neowiki-edit-schema' } } ).exists() ).toBeTruthy();
+	} );
+
+	it( 'hides edit button when user lacks permission', async () => {
+		const schema = newSchema( { title: 'Test Schema' } );
+		canEditSchemaRef.value = false;
+
+		const wrapper = mountComponent( schema );
+
+		expect( wrapper.findComponent( { name: 'CdxButton', props: { 'aria-label': 'neowiki-edit-schema' } } ).exists() ).toBe( false );
+	} );
+} );

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -232,19 +232,6 @@ class NeoWikiHooks {
 		}
 	}
 
-	public static function onSkinTemplateNavigationUniversal( SkinTemplate $skinTemplate, array &$links ): void {
-		if ( !self::isSchemaPage( $skinTemplate->getOutput() ) || !self::userCanEditCurrentPage( $skinTemplate ) ) {
-			return;
-		}
-
-		// TODO: Rearrange link order.
-		$links['views']['edit-schema'] = [
-			'class' => ( $skinTemplate->getRequest()->getVal( 'action' ) == 'edit-schema' ) ? 'selected' : '',
-			'href' => $skinTemplate->getTitle()->getLocalUrl( 'action=edit-schema' ),
-			'text' => $skinTemplate->msg( 'neowiki-edit-with-form' )->text(),
-		];
-	}
-
 	private static function isSchemaPage( OutputPage $out ): bool {
 		return $out->getTitle()->getNamespace() === NeoWikiExtension::NS_SCHEMA;
 	}


### PR DESCRIPTION
Follow-up: #502 
Closes: #504, #505

- Wrap the whole UI into Codex Table
- Use Codex InfoChip for displaying property types
- Add edit button for editing schema
- Integrate schema description into the component
- Integrate empty state into the component
- Extract useSchemaPermissions
- Remove "edit with form" from MW view menu

<img width="1330" height="829" alt="image" src="https://github.com/user-attachments/assets/cedcdadf-ced4-4d7e-983b-90a57b4b5836" />
