### PR TITLE
Add European museums demo data

### DIFF
--- a/DemoData/Page/Main_Page.wikitext
+++ b/DemoData/Page/Main_Page.wikitext
@@ -27,7 +27,7 @@ Terminology is explained in [https://github.com/ProfessionalWiki/NeoWiki/blob/ma
 
 * Edit a Subject: [[Professional Wiki]] (login required)
 * Edit a Schema: either via a Subject using it, i.e. [[Professional Wiki]], or directly on the Schema page, i.e. [[Schema:Company]]
-* Create a Subject: TODO
+* Create a Subject: Create a new page with any content and click "Create subject". That button is there just for the PoC.
 
 '''As a developer:'''
 
@@ -35,7 +35,23 @@ Terminology is explained in [https://github.com/ProfessionalWiki/NeoWiki/blob/ma
 * Query the graph database: [[Cypher|Cypher raw example]]
 * [[#REST_API_endpoints|Explore the REST API]]
 
-== Demo pages ==
+== European Museums ==
+
+A dataset of European museums, artists, and artworks showcasing cross-schema relations and rich property types.
+
+'''Museums:''' [[Musee dOrsay|Musée d'Orsay]], [[Rijksmuseum]], [[Kunsthistorisches Museum]], [[Museo del Prado]]
+
+'''Artists:''' [[Claude Monet]], [[Vincent van Gogh]], [[Johannes Vermeer]], [[Diego Velazquez|Diego Velázquez]], [[Gustav Klimt]]
+
+'''Artworks:''' [[Water Lilies]], [[Starry Night Over the Rhone|Starry Night Over the Rhône]], [[The Milkmaid]], [[Las Meninas]], [[The Kiss]], [[The Art of Painting]]
+
+'''Exhibitions:''' [[Impressionist Masters]], [[Dutch Golden Age Highlights]]
+
+'''Cities:''' [[Paris]], [[Amsterdam]], [[Vienna]], [[Madrid]]
+
+'''Overview:''' [[Museum Collection]]
+
+== Other Demo Pages ==
 
 * Simple page with automatic infobox and edit form: [[NeoWiki]], [[ProWiki]]
 * Subject with relations: [[Professional Wiki]]
@@ -50,10 +66,14 @@ compensation in EUR with a value between 0 and 1000000.
 * [[Schema:Company]]
 * [[Schema:Product]]
 * [[Schema:Employee]]
-* [[Schema:Everything]]
+* [[Schema:Museum]]
+* [[Schema:Artist]]
+* [[Schema:Artwork]]
+* [[Schema:Exhibition]]
+* [[Schema:Attendance]]
 * [{{fullurl:Special:AllPages|from=&to=&namespace=7474}} View all schemas]
 
-== REST API endpoints ==
+== REST API Endpoints ==
 
 We will have OpenAPI docs later. For now, you can find a complete and up-to-date list by looking at the
 [https://github.com/ProfessionalWiki/NeoWiki/blob/master/extension.json MediaWiki API route definitions].
@@ -61,12 +81,12 @@ Search for "RestRoutes".
 
 Example URL: https://neowiki.dev/w/rest.php/neowiki/v0/subject/s1demo4sssssss1
 
-=== Read endpoints ===
+=== Read Endpoints ===
 
 * <code>GET /neowiki/v0/subject/{subjectId}</code> Gets the JSON definition of a subject
 * <code>GET /neowiki/v0/schema/{schemaName}</code> Gets the JSON definition of a schema
 
-=== Write endpoints ===
+=== Write Endpoints ===
 
 These require a CSRF token, first obtained via <code>api.php?action=query&format=json&meta=tokens&type=csrf</code>
 

--- a/DemoData/Page/Museum_Collection.wikitext
+++ b/DemoData/Page/Museum_Collection.wikitext
@@ -1,0 +1,14 @@
+This page shows infoboxes with data from various museum and artwork pages, demonstrating cross-page subject display.
+
+== Museums ==
+
+<div class="ext-neowiki-view" data-subject-id="sEpfwJLnx3Kze3t"></div>
+<div class="ext-neowiki-view" data-subject-id="sEpfwJLnxyQy6vR"></div>
+<div class="ext-neowiki-view" data-subject-id="sEpfwJLnyuR5E4i"></div>
+<div class="ext-neowiki-view" data-subject-id="sEpfwJLnzqsDMs5"></div>
+
+== Selected Artworks ==
+
+<div class="ext-neowiki-view" data-subject-id="sEpfwJLo6Si6kJo"></div>
+<div class="ext-neowiki-view" data-subject-id="sEpfwJLo8KqKsUP"></div>
+<div class="ext-neowiki-view" data-subject-id="sEpfwJLoABDZ18D"></div>

--- a/DemoData/Schema/Artist.json
+++ b/DemoData/Schema/Artist.json
@@ -1,0 +1,27 @@
+{
+	"description": "A person who creates works of art such as paintings, sculptures, or other visual media.",
+	"propertyDefinitions": {
+		"Born": {
+			"type": "number",
+			"required": true
+		},
+		"Died": {
+			"type": "number"
+		},
+		"Nationality": {
+			"type": "text",
+			"required": true
+		},
+		"Movement": {
+			"type": "text",
+			"multiple": true
+		},
+		"Wikipedia": {
+			"type": "url"
+		},
+		"Active period": {
+			"type": "text",
+			"description": "Period when the artist was professionally active"
+		}
+	}
+}

--- a/DemoData/Schema/Artwork.json
+++ b/DemoData/Schema/Artwork.json
@@ -1,0 +1,38 @@
+{
+	"description": "A work of art such as a painting, sculpture, or other creative piece held in a museum collection.",
+	"propertyDefinitions": {
+		"Year": {
+			"type": "number",
+			"required": true,
+			"description": "Year the artwork was created or completed"
+		},
+		"Medium": {
+			"type": "text",
+			"required": true
+		},
+		"Condition": {
+			"type": "text",
+			"default": "Good"
+		},
+		"Creator": {
+			"type": "relation",
+			"relation": "Created by",
+			"targetSchema": "Artist",
+			"required": true
+		},
+		"Located at": {
+			"type": "relation",
+			"relation": "Held at",
+			"targetSchema": "Museum"
+		},
+		"Image": {
+			"type": "url"
+		},
+		"Estimated value": {
+			"type": "number",
+			"minimum": 0,
+			"precision": 2,
+			"description": "Estimated value in millions EUR"
+		}
+	}
+}

--- a/DemoData/Schema/Attendance.json
+++ b/DemoData/Schema/Attendance.json
@@ -1,0 +1,17 @@
+{
+	"description": "Annual attendance record for a museum, used as child subjects on museum pages.",
+	"propertyDefinitions": {
+		"Year": {
+			"type": "number",
+			"required": true
+		},
+		"Visitors": {
+			"type": "number",
+			"minimum": 0,
+			"precision": 0
+		},
+		"Source": {
+			"type": "url"
+		}
+	}
+}

--- a/DemoData/Schema/City.json
+++ b/DemoData/Schema/City.json
@@ -1,7 +1,15 @@
 {
 	"propertyDefinitions": {
 		"Country": {
-			"type": "text"
+			"type": "text",
+			"required": true
+		},
+		"Population": {
+			"type": "number",
+			"minimum": 0
+		},
+		"Website": {
+			"type": "url"
 		}
 	}
 }

--- a/DemoData/Schema/Exhibition.json
+++ b/DemoData/Schema/Exhibition.json
@@ -1,0 +1,35 @@
+{
+	"description": "A temporary or permanent exhibition hosted at a museum, showcasing works by one or more artists around a theme.",
+	"propertyDefinitions": {
+		"Start year": {
+			"type": "number",
+			"required": true
+		},
+		"End year": {
+			"type": "number"
+		},
+		"Venue": {
+			"type": "relation",
+			"relation": "Hosted at",
+			"targetSchema": "Museum",
+			"required": true
+		},
+		"Featured artists": {
+			"type": "relation",
+			"relation": "Features",
+			"targetSchema": "Artist",
+			"multiple": true
+		},
+		"Website": {
+			"type": "url"
+		},
+		"Theme": {
+			"type": "text"
+		},
+		"Visitor count": {
+			"type": "number",
+			"minimum": 0,
+			"precision": 0
+		}
+	}
+}

--- a/DemoData/Schema/Museum.json
+++ b/DemoData/Schema/Museum.json
@@ -1,0 +1,42 @@
+{
+	"description": "A museum or gallery that houses and displays collections of art, artifacts, or other objects of cultural, historical, or scientific significance.",
+	"propertyDefinitions": {
+		"Description": {
+			"type": "text"
+		},
+		"Founded": {
+			"type": "number"
+		},
+		"City": {
+			"type": "relation",
+			"relation": "Located in",
+			"targetSchema": "City"
+		},
+		"Website": {
+			"type": "url",
+			"required": true
+		},
+		"Specialization": {
+			"type": "text",
+			"multiple": true,
+			"uniqueItems": true
+		},
+		"Annual visitors": {
+			"type": "number",
+			"minimum": 0,
+			"precision": 0
+		},
+		"Admission fee": {
+			"type": "number",
+			"minimum": 0,
+			"maximum": 200,
+			"precision": 2,
+			"default": 0
+		},
+		"Links": {
+			"type": "url",
+			"multiple": true,
+			"description": "Social media and review sites"
+		}
+	}
+}

--- a/DemoData/Subject/Amsterdam.json
+++ b/DemoData/Subject/Amsterdam.json
@@ -1,0 +1,23 @@
+{
+	"mainSubject": "sEpfwJLnuwcxvuJ",
+	"subjects": {
+		"sEpfwJLnuwcxvuJ": {
+			"label": "Amsterdam",
+			"schema": "City",
+			"statements": {
+				"Country": {
+					"type": "text",
+					"value": [ "Netherlands" ]
+				},
+				"Population": {
+					"type": "number",
+					"value": 921402
+				},
+				"Website": {
+					"type": "url",
+					"value": [ "https://www.amsterdam.nl" ]
+				}
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Claude_Monet.json
+++ b/DemoData/Subject/Claude_Monet.json
@@ -1,0 +1,35 @@
+{
+	"mainSubject": "sEpfwJLo1kFh84j",
+	"subjects": {
+		"sEpfwJLo1kFh84j": {
+			"label": "Claude Monet",
+			"schema": "Artist",
+			"statements": {
+				"Born": {
+					"type": "number",
+					"value": 1840
+				},
+				"Died": {
+					"type": "number",
+					"value": 1926
+				},
+				"Nationality": {
+					"type": "text",
+					"value": [ "French" ]
+				},
+				"Movement": {
+					"type": "text",
+					"value": [ "Impressionism" ]
+				},
+				"Wikipedia": {
+					"type": "url",
+					"value": [ "https://en.wikipedia.org/wiki/Claude_Monet" ]
+				},
+				"Active period": {
+					"type": "text",
+					"value": [ "1858–1926" ]
+				}
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Claude_Monet.wikitext
+++ b/DemoData/Subject/Claude_Monet.wikitext
@@ -1,0 +1,3 @@
+Claude Monet was a French painter and founder of Impressionist painting. He is seen as a key precursor to Modernism, especially in his later series paintings of water lilies, haystacks, and the Rouen Cathedral.
+
+Monet's ambition of documenting the French countryside led him to adopt a method of painting the same scene many times in order to capture the changing of light and the passing of the seasons.

--- a/DemoData/Subject/Diego_Velazquez.json
+++ b/DemoData/Subject/Diego_Velazquez.json
@@ -1,0 +1,35 @@
+{
+	"mainSubject": "sEpfwJLo4ZAfkFw",
+	"subjects": {
+		"sEpfwJLo4ZAfkFw": {
+			"label": "Diego Velázquez",
+			"schema": "Artist",
+			"statements": {
+				"Born": {
+					"type": "number",
+					"value": 1599
+				},
+				"Died": {
+					"type": "number",
+					"value": 1660
+				},
+				"Nationality": {
+					"type": "text",
+					"value": [ "Spanish" ]
+				},
+				"Movement": {
+					"type": "text",
+					"value": [ "Baroque" ]
+				},
+				"Wikipedia": {
+					"type": "url",
+					"value": [ "https://en.wikipedia.org/wiki/Diego_Vel%C3%A1zquez" ]
+				},
+				"Active period": {
+					"type": "text",
+					"value": [ "1617–1660" ]
+				}
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Dutch_Golden_Age_Highlights.json
+++ b/DemoData/Subject/Dutch_Golden_Age_Highlights.json
@@ -1,0 +1,49 @@
+{
+	"mainSubject": "sEpfwJLoD1XRhhP",
+	"subjects": {
+		"sEpfwJLoD1XRhhP": {
+			"label": "Dutch Golden Age Highlights",
+			"schema": "Exhibition",
+			"statements": {
+				"Start year": {
+					"type": "number",
+					"value": 2023
+				},
+				"End year": {
+					"type": "number",
+					"value": 2024
+				},
+				"Venue": {
+					"type": "relation",
+					"value": [
+						{
+							"id": "rEpfwJLoXU13f3X",
+							"target": "sEpfwJLnxyQy6vR"
+						}
+					]
+				},
+				"Featured artists": {
+					"type": "relation",
+					"value": [
+						{
+							"id": "rEpfwJLoYRSxeGY",
+							"target": "sEpfwJLo3dEPj2Z"
+						}
+					]
+				},
+				"Website": {
+					"type": "url",
+					"value": [ "https://www.rijksmuseum.nl/en/whats-on/exhibitions" ]
+				},
+				"Theme": {
+					"type": "text",
+					"value": [ "Masterworks from the Dutch Republic's golden century of art and trade" ]
+				},
+				"Visitor count": {
+					"type": "number",
+					"value": 380000
+				}
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Gustav_Klimt.json
+++ b/DemoData/Subject/Gustav_Klimt.json
@@ -1,0 +1,35 @@
+{
+	"mainSubject": "sEpfwJLo5VchgS9",
+	"subjects": {
+		"sEpfwJLo5VchgS9": {
+			"label": "Gustav Klimt",
+			"schema": "Artist",
+			"statements": {
+				"Born": {
+					"type": "number",
+					"value": 1862
+				},
+				"Died": {
+					"type": "number",
+					"value": 1918
+				},
+				"Nationality": {
+					"type": "text",
+					"value": [ "Austrian" ]
+				},
+				"Movement": {
+					"type": "text",
+					"value": [ "Symbolism", "Art Nouveau", "Vienna Secession" ]
+				},
+				"Wikipedia": {
+					"type": "url",
+					"value": [ "https://en.wikipedia.org/wiki/Gustav_Klimt" ]
+				},
+				"Active period": {
+					"type": "text",
+					"value": [ "1880–1918" ]
+				}
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Impressionist_Masters.json
+++ b/DemoData/Subject/Impressionist_Masters.json
@@ -1,0 +1,49 @@
+{
+	"mainSubject": "sEpfwJLoC5fMpx9",
+	"subjects": {
+		"sEpfwJLoC5fMpx9": {
+			"label": "Impressionist Masters",
+			"schema": "Exhibition",
+			"statements": {
+				"Start year": {
+					"type": "number",
+					"value": 2024
+				},
+				"End year": {
+					"type": "number",
+					"value": 2025
+				},
+				"Venue": {
+					"type": "relation",
+					"value": [
+						{
+							"id": "rEpfwJLoUY71QX2",
+							"target": "sEpfwJLnx3Kze3t"
+						}
+					]
+				},
+				"Featured artists": {
+					"type": "relation",
+					"value": [
+						{
+							"id": "rEpfwJLoVW2qior",
+							"target": "sEpfwJLo1kFh84j"
+						},
+						{
+							"id": "rEpfwJLoWXLVHQK",
+							"target": "sEpfwJLo2hCAw9G"
+						}
+					]
+				},
+				"Theme": {
+					"type": "text",
+					"value": [ "The evolution of light and color in French Impressionism" ]
+				},
+				"Visitor count": {
+					"type": "number",
+					"value": 450000
+				}
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Johannes_Vermeer.json
+++ b/DemoData/Subject/Johannes_Vermeer.json
@@ -1,0 +1,35 @@
+{
+	"mainSubject": "sEpfwJLo3dEPj2Z",
+	"subjects": {
+		"sEpfwJLo3dEPj2Z": {
+			"label": "Johannes Vermeer",
+			"schema": "Artist",
+			"statements": {
+				"Born": {
+					"type": "number",
+					"value": 1632
+				},
+				"Died": {
+					"type": "number",
+					"value": 1675
+				},
+				"Nationality": {
+					"type": "text",
+					"value": [ "Dutch" ]
+				},
+				"Movement": {
+					"type": "text",
+					"value": [ "Dutch Golden Age", "Baroque" ]
+				},
+				"Wikipedia": {
+					"type": "url",
+					"value": [ "https://en.wikipedia.org/wiki/Johannes_Vermeer" ]
+				},
+				"Active period": {
+					"type": "text",
+					"value": [ "1653–1675" ]
+				}
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Kunsthistorisches_Museum.json
+++ b/DemoData/Subject/Kunsthistorisches_Museum.json
@@ -1,0 +1,44 @@
+{
+	"mainSubject": "sEpfwJLnyuR5E4i",
+	"subjects": {
+		"sEpfwJLnyuR5E4i": {
+			"label": "Kunsthistorisches Museum",
+			"schema": "Museum",
+			"statements": {
+				"Description": {
+					"type": "text",
+					"value": [ "Austrian art museum housing the extensive collections of the Habsburg monarchy" ]
+				},
+				"Founded": {
+					"type": "number",
+					"value": 1891
+				},
+				"City": {
+					"type": "relation",
+					"value": [
+						{
+							"id": "rEpfwJLoF7AQMbe",
+							"target": "sEpfwJLnv9T9nKk"
+						}
+					]
+				},
+				"Website": {
+					"type": "url",
+					"value": [ "https://www.khm.at" ]
+				},
+				"Specialization": {
+					"type": "text",
+					"value": [ "Old Masters", "Egyptian Antiquities", "Habsburg Collections" ]
+				},
+				"Annual visitors": {
+					"type": "number",
+					"value": 1800000
+				},
+				"Admission fee": {
+					"type": "number",
+					"value": 21
+				}
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Las_Meninas.json
+++ b/DemoData/Subject/Las_Meninas.json
@@ -1,0 +1,45 @@
+{
+	"mainSubject": "sEpfwJLo9FKBGqn",
+	"subjects": {
+		"sEpfwJLo9FKBGqn": {
+			"label": "Las Meninas",
+			"schema": "Artwork",
+			"statements": {
+				"Year": {
+					"type": "number",
+					"value": 1656
+				},
+				"Medium": {
+					"type": "text",
+					"value": [ "Oil on canvas" ]
+				},
+				"Creator": {
+					"type": "relation",
+					"value": [
+						{
+							"id": "rEpfwJLoNnEbFfz",
+							"target": "sEpfwJLo4ZAfkFw"
+						}
+					]
+				},
+				"Located at": {
+					"type": "relation",
+					"value": [
+						{
+							"id": "rEpfwJLoPk5pFTM",
+							"target": "sEpfwJLnzqsDMs5"
+						}
+					]
+				},
+				"Image": {
+					"type": "url",
+					"value": [ "https://upload.wikimedia.org/wikipedia/commons/3/31/Las_Meninas%2C_by_Diego_Vel%C3%A1zquez%2C_from_Prado_in_Google_Earth.jpg" ]
+				},
+				"Estimated value": {
+					"type": "number",
+					"value": 300
+				}
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Madrid.json
+++ b/DemoData/Subject/Madrid.json
@@ -1,0 +1,23 @@
+{
+	"mainSubject": "sEpfwJLnw6zMVhC",
+	"subjects": {
+		"sEpfwJLnw6zMVhC": {
+			"label": "Madrid",
+			"schema": "City",
+			"statements": {
+				"Country": {
+					"type": "text",
+					"value": [ "Spain" ]
+				},
+				"Population": {
+					"type": "number",
+					"value": 3332035
+				},
+				"Website": {
+					"type": "url",
+					"value": [ "https://www.madrid.es" ]
+				}
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Musee_dOrsay.json
+++ b/DemoData/Subject/Musee_dOrsay.json
@@ -1,0 +1,105 @@
+{
+	"mainSubject": "sEpfwJLnx3Kze3t",
+	"subjects": {
+		"sEpfwJLnx3Kze3t": {
+			"label": "Musée d'Orsay",
+			"schema": "Museum",
+			"statements": {
+				"Description": {
+					"type": "text",
+					"value": [ "French national museum housing the world's largest collection of Impressionist and Post-Impressionist masterpieces" ]
+				},
+				"Founded": {
+					"type": "number",
+					"value": 1986
+				},
+				"City": {
+					"type": "relation",
+					"value": [
+						{
+							"id": "rEpfwJLoDErEFnn",
+							"target": "sEpfwJLntf7EQg6"
+						}
+					]
+				},
+				"Website": {
+					"type": "url",
+					"value": [ "https://www.musee-orsay.fr" ]
+				},
+				"Specialization": {
+					"type": "text",
+					"value": [ "Impressionism", "Post-Impressionism", "Art Nouveau" ]
+				},
+				"Annual visitors": {
+					"type": "number",
+					"value": 3270000
+				},
+				"Admission fee": {
+					"type": "number",
+					"value": 16
+				},
+				"Links": {
+					"type": "url",
+					"value": [
+						"https://www.instagram.com/museeorsay",
+						"https://twitter.com/MuseeOrsay"
+					]
+				}
+			}
+		},
+		"sEpfwLY8VcdQZJL": {
+			"label": "2019",
+			"schema": "Attendance",
+			"statements": {
+				"Year": {
+					"type": "number",
+					"value": 2019
+				},
+				"Visitors": {
+					"type": "number",
+					"value": 3651616
+				},
+				"Source": {
+					"type": "url",
+					"value": [ "https://www.musee-orsay.fr/en/articles/key-figures" ]
+				}
+			}
+		},
+		"sEpfwLY8WnceT2y": {
+			"label": "2022",
+			"schema": "Attendance",
+			"statements": {
+				"Year": {
+					"type": "number",
+					"value": 2022
+				},
+				"Visitors": {
+					"type": "number",
+					"value": 3270000
+				},
+				"Source": {
+					"type": "url",
+					"value": [ "https://www.musee-orsay.fr/en/articles/key-figures" ]
+				}
+			}
+		},
+		"sEpfwLY8XjJ8gE1": {
+			"label": "2023",
+			"schema": "Attendance",
+			"statements": {
+				"Year": {
+					"type": "number",
+					"value": 2023
+				},
+				"Visitors": {
+					"type": "number",
+					"value": 3960000
+				},
+				"Source": {
+					"type": "url",
+					"value": [ "https://www.musee-orsay.fr/en/articles/key-figures" ]
+				}
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Musee_dOrsay.wikitext
+++ b/DemoData/Subject/Musee_dOrsay.wikitext
@@ -1,0 +1,3 @@
+The Musée d'Orsay is a museum in Paris, France, on the Left Bank of the Seine. It is housed in the former Gare d'Orsay, a Beaux-Arts railway station built between 1898 and 1900.
+
+The museum holds mainly French art dating from 1848 to 1914, including paintings, sculptures, furniture, and photography. It is home to the world's largest collection of Impressionist and Post-Impressionist masterpieces by painters including Monet, Manet, Degas, Renoir, Cézanne, Seurat, Sisley, Gauguin, and Van Gogh.

--- a/DemoData/Subject/Museo_del_Prado.json
+++ b/DemoData/Subject/Museo_del_Prado.json
@@ -1,0 +1,50 @@
+{
+	"mainSubject": "sEpfwJLnzqsDMs5",
+	"subjects": {
+		"sEpfwJLnzqsDMs5": {
+			"label": "Museo del Prado",
+			"schema": "Museum",
+			"statements": {
+				"Description": {
+					"type": "text",
+					"value": [ "Spain's main national art museum, featuring one of the finest collections of European art from the 12th to early 20th century" ]
+				},
+				"Founded": {
+					"type": "number",
+					"value": 1819
+				},
+				"City": {
+					"type": "relation",
+					"value": [
+						{
+							"id": "rEpfwJLoG5ZtGDZ",
+							"target": "sEpfwJLnw6zMVhC"
+						}
+					]
+				},
+				"Website": {
+					"type": "url",
+					"value": [ "https://www.museodelprado.es" ]
+				},
+				"Specialization": {
+					"type": "text",
+					"value": [ "Spanish Art", "Italian Renaissance", "Flemish Painting" ]
+				},
+				"Annual visitors": {
+					"type": "number",
+					"value": 3200000
+				},
+				"Admission fee": {
+					"type": "number",
+					"value": 15
+				},
+				"Links": {
+					"type": "url",
+					"value": [
+						"https://www.instagram.com/museoprado"
+					]
+				}
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Paris.json
+++ b/DemoData/Subject/Paris.json
@@ -1,0 +1,23 @@
+{
+	"mainSubject": "sEpfwJLntf7EQg6",
+	"subjects": {
+		"sEpfwJLntf7EQg6": {
+			"label": "Paris",
+			"schema": "City",
+			"statements": {
+				"Country": {
+					"type": "text",
+					"value": [ "France" ]
+				},
+				"Population": {
+					"type": "number",
+					"value": 2102650
+				},
+				"Website": {
+					"type": "url",
+					"value": [ "https://www.paris.fr" ]
+				}
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Rijksmuseum.json
+++ b/DemoData/Subject/Rijksmuseum.json
@@ -1,0 +1,51 @@
+{
+	"mainSubject": "sEpfwJLnxyQy6vR",
+	"subjects": {
+		"sEpfwJLnxyQy6vR": {
+			"label": "Rijksmuseum",
+			"schema": "Museum",
+			"statements": {
+				"Description": {
+					"type": "text",
+					"value": [ "Dutch national museum dedicated to arts and history, home to masterpieces of the Dutch Golden Age" ]
+				},
+				"Founded": {
+					"type": "number",
+					"value": 1800
+				},
+				"City": {
+					"type": "relation",
+					"value": [
+						{
+							"id": "rEpfwJLoEB5UuQS",
+							"target": "sEpfwJLnuwcxvuJ"
+						}
+					]
+				},
+				"Website": {
+					"type": "url",
+					"value": [ "https://www.rijksmuseum.nl" ]
+				},
+				"Specialization": {
+					"type": "text",
+					"value": [ "Dutch Golden Age", "Dutch History", "Asian Art" ]
+				},
+				"Annual visitors": {
+					"type": "number",
+					"value": 2700000
+				},
+				"Admission fee": {
+					"type": "number",
+					"value": 22.50
+				},
+				"Links": {
+					"type": "url",
+					"value": [
+						"https://www.instagram.com/rijksmuseum",
+						"https://twitter.com/rijksmuseum"
+					]
+				}
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Starry_Night_Over_the_Rhone.json
+++ b/DemoData/Subject/Starry_Night_Over_the_Rhone.json
@@ -1,0 +1,45 @@
+{
+	"mainSubject": "sEpfwJLo7NSDS5F",
+	"subjects": {
+		"sEpfwJLo7NSDS5F": {
+			"label": "Starry Night Over the Rhône",
+			"schema": "Artwork",
+			"statements": {
+				"Year": {
+					"type": "number",
+					"value": 1888
+				},
+				"Medium": {
+					"type": "text",
+					"value": [ "Oil on canvas" ]
+				},
+				"Creator": {
+					"type": "relation",
+					"value": [
+						{
+							"id": "rEpfwJLoJv75wqU",
+							"target": "sEpfwJLo2hCAw9G"
+						}
+					]
+				},
+				"Located at": {
+					"type": "relation",
+					"value": [
+						{
+							"id": "rEpfwJLoKte65Di",
+							"target": "sEpfwJLnx3Kze3t"
+						}
+					]
+				},
+				"Image": {
+					"type": "url",
+					"value": [ "https://upload.wikimedia.org/wikipedia/commons/9/94/Starry_Night_Over_the_Rhone.jpg" ]
+				},
+				"Estimated value": {
+					"type": "number",
+					"value": 100
+				}
+			}
+		}
+	}
+}

--- a/DemoData/Subject/The_Art_of_Painting.json
+++ b/DemoData/Subject/The_Art_of_Painting.json
@@ -1,0 +1,45 @@
+{
+	"mainSubject": "sEpfwJLoB8WxiXG",
+	"subjects": {
+		"sEpfwJLoB8WxiXG": {
+			"label": "The Art of Painting",
+			"schema": "Artwork",
+			"statements": {
+				"Year": {
+					"type": "number",
+					"value": 1666
+				},
+				"Medium": {
+					"type": "text",
+					"value": [ "Oil on canvas" ]
+				},
+				"Creator": {
+					"type": "relation",
+					"value": [
+						{
+							"id": "rEpfwJLoScyfU3j",
+							"target": "sEpfwJLo3dEPj2Z"
+						}
+					]
+				},
+				"Located at": {
+					"type": "relation",
+					"value": [
+						{
+							"id": "rEpfwJLoTZQ5HBf",
+							"target": "sEpfwJLnyuR5E4i"
+						}
+					]
+				},
+				"Image": {
+					"type": "url",
+					"value": [ "https://upload.wikimedia.org/wikipedia/commons/4/4a/Johannes_Vermeer_-_The_Art_of_Painting_-_Google_Art_Project.jpg" ]
+				},
+				"Estimated value": {
+					"type": "number",
+					"value": 200
+				}
+			}
+		}
+	}
+}

--- a/DemoData/Subject/The_Kiss.json
+++ b/DemoData/Subject/The_Kiss.json
@@ -1,0 +1,45 @@
+{
+	"mainSubject": "sEpfwJLoABDZ18D",
+	"subjects": {
+		"sEpfwJLoABDZ18D": {
+			"label": "The Kiss",
+			"schema": "Artwork",
+			"statements": {
+				"Year": {
+					"type": "number",
+					"value": 1908
+				},
+				"Medium": {
+					"type": "text",
+					"value": [ "Oil on canvas with gold leaf" ]
+				},
+				"Creator": {
+					"type": "relation",
+					"value": [
+						{
+							"id": "rEpfwJLoQh2vtqV",
+							"target": "sEpfwJLo5VchgS9"
+						}
+					]
+				},
+				"Located at": {
+					"type": "relation",
+					"value": [
+						{
+							"id": "rEpfwJLoReZ4kwu",
+							"target": "sEpfwJLnyuR5E4i"
+						}
+					]
+				},
+				"Image": {
+					"type": "url",
+					"value": [ "https://upload.wikimedia.org/wikipedia/commons/4/40/The_Kiss_-_Gustav_Klimt_-_Google_Cultural_Institute.jpg" ]
+				},
+				"Estimated value": {
+					"type": "number",
+					"value": 240
+				}
+			}
+		}
+	}
+}

--- a/DemoData/Subject/The_Milkmaid.json
+++ b/DemoData/Subject/The_Milkmaid.json
@@ -1,0 +1,45 @@
+{
+	"mainSubject": "sEpfwJLo8KqKsUP",
+	"subjects": {
+		"sEpfwJLo8KqKsUP": {
+			"label": "The Milkmaid",
+			"schema": "Artwork",
+			"statements": {
+				"Year": {
+					"type": "number",
+					"value": 1658
+				},
+				"Medium": {
+					"type": "text",
+					"value": [ "Oil on canvas" ]
+				},
+				"Creator": {
+					"type": "relation",
+					"value": [
+						{
+							"id": "rEpfwJLoLsv7dAs",
+							"target": "sEpfwJLo3dEPj2Z"
+						}
+					]
+				},
+				"Located at": {
+					"type": "relation",
+					"value": [
+						{
+							"id": "rEpfwJLoMpL8EVs",
+							"target": "sEpfwJLnxyQy6vR"
+						}
+					]
+				},
+				"Image": {
+					"type": "url",
+					"value": [ "https://upload.wikimedia.org/wikipedia/commons/2/20/Johannes_Vermeer_-_Het_melkmeisje_-_Google_Art_Project.jpg" ]
+				},
+				"Estimated value": {
+					"type": "number",
+					"value": 150
+				}
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Vienna.json
+++ b/DemoData/Subject/Vienna.json
@@ -1,0 +1,23 @@
+{
+	"mainSubject": "sEpfwJLnv9T9nKk",
+	"subjects": {
+		"sEpfwJLnv9T9nKk": {
+			"label": "Vienna",
+			"schema": "City",
+			"statements": {
+				"Country": {
+					"type": "text",
+					"value": [ "Austria" ]
+				},
+				"Population": {
+					"type": "number",
+					"value": 1982097
+				},
+				"Website": {
+					"type": "url",
+					"value": [ "https://www.wien.gv.at" ]
+				}
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Vincent_van_Gogh.json
+++ b/DemoData/Subject/Vincent_van_Gogh.json
@@ -1,0 +1,35 @@
+{
+	"mainSubject": "sEpfwJLo2hCAw9G",
+	"subjects": {
+		"sEpfwJLo2hCAw9G": {
+			"label": "Vincent van Gogh",
+			"schema": "Artist",
+			"statements": {
+				"Born": {
+					"type": "number",
+					"value": 1853
+				},
+				"Died": {
+					"type": "number",
+					"value": 1890
+				},
+				"Nationality": {
+					"type": "text",
+					"value": [ "Dutch" ]
+				},
+				"Movement": {
+					"type": "text",
+					"value": [ "Post-Impressionism", "Neo-Impressionism" ]
+				},
+				"Wikipedia": {
+					"type": "url",
+					"value": [ "https://en.wikipedia.org/wiki/Vincent_van_Gogh" ]
+				},
+				"Active period": {
+					"type": "text",
+					"value": [ "1881–1890" ]
+				}
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Water_Lilies.json
+++ b/DemoData/Subject/Water_Lilies.json
@@ -1,0 +1,45 @@
+{
+	"mainSubject": "sEpfwJLo6Si6kJo",
+	"subjects": {
+		"sEpfwJLo6Si6kJo": {
+			"label": "Water Lilies",
+			"schema": "Artwork",
+			"statements": {
+				"Year": {
+					"type": "number",
+					"value": 1906
+				},
+				"Medium": {
+					"type": "text",
+					"value": [ "Oil on canvas" ]
+				},
+				"Creator": {
+					"type": "relation",
+					"value": [
+						{
+							"id": "rEpfwJLoH2dWKCs",
+							"target": "sEpfwJLo1kFh84j"
+						}
+					]
+				},
+				"Located at": {
+					"type": "relation",
+					"value": [
+						{
+							"id": "rEpfwJLoHyZeBJC",
+							"target": "sEpfwJLnx3Kze3t"
+						}
+					]
+				},
+				"Image": {
+					"type": "url",
+					"value": [ "https://upload.wikimedia.org/wikipedia/commons/a/aa/Claude_Monet_-_Water_Lilies_-_1906%2C_Ryerson.jpg" ]
+				},
+				"Estimated value": {
+					"type": "number",
+					"value": 80
+				}
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Water_Lilies.wikitext
+++ b/DemoData/Subject/Water_Lilies.wikitext
@@ -1,0 +1,3 @@
+Water Lilies (or Nymphéas) is a series of approximately 250 oil paintings by French Impressionist Claude Monet. The paintings depict his flower garden at his home in Giverny and were the main focus of his artistic production during the last thirty years of his life.
+
+This particular painting from 1906 is part of the Musée d'Orsay collection and exemplifies Monet's fascination with light, color, and reflection on water.

--- a/src/Application/Actions/ImportPages/SubjectPageSource.php
+++ b/src/Application/Actions/ImportPages/SubjectPageSource.php
@@ -47,7 +47,7 @@ class SubjectPageSource {
 
 	private function getWikitext( string $pageName ): string {
 		$wikitextFilePath = $this->directoryPath . '/' . $pageName . '.wikitext';
-		return is_file( $wikitextFilePath ) ? $this->fileFetcher->fetchFile( $wikitextFilePath ) : '{{#infobox:}}';
+		return is_file( $wikitextFilePath ) ? $this->fileFetcher->fetchFile( $wikitextFilePath ) : '';
 	}
 
 }


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/506

Add a European museums dataset (museums, artists, artworks, exhibitions,
cities) that naturally showcases all currently implemented NeoWiki features
including cross-schema relations, child subjects, multiple value types,
and property constraints.

## Summary

- **5 new schemas**: Museum, Artist, Artwork, Exhibition, Attendance
- **21 new subject pages**: 4 cities, 4 museums, 5 artists, 6 artworks, 2 exhibitions
- **3 child subjects** (Attendance records on Musée d'Orsay page)
- **1 new page**: Museum Collection (cross-page infobox display)
- **Modify** City schema (add Population, Website), Main Page
- **Fix** default wikitext fallback in SubjectPageSource (remove defunct `{{#infobox:}}`)
