### PR TITLE
Hide schema selector after schema is selected in SubjectCreatorDialog

### DIFF
--- a/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
@@ -13,29 +13,31 @@
 			:use-close-button="true"
 			@default="open = false"
 		>
-			<p>
-				{{ $i18n( 'neowiki-subject-creator-schema-title' ).text() }}
-			</p>
+			<template v-if="!selectedSchemaName">
+				<p>
+					{{ $i18n( 'neowiki-subject-creator-schema-title' ).text() }}
+				</p>
 
-			<CdxToggleButtonGroup
-				v-model="selectedSchemaOption"
-				class="ext-neowiki-subject-creator-schema-options"
-				:buttons="toggleButtons"
-			/>
-
-			<div
-				v-if="selectedSchemaOption === 'existing'"
-				class="ext-neowiki-subject-creator-existing"
-			>
-				<SchemaLookup
-					ref="schemaLookupRef"
-					@select="onSchemaSelected"
+				<CdxToggleButtonGroup
+					v-model="selectedSchemaOption"
+					class="ext-neowiki-subject-creator-schema-options"
+					:buttons="toggleButtons"
 				/>
-			</div>
 
-			<div v-if="selectedSchemaOption === 'new'">
-				TODO: New schema UI
-			</div>
+				<div
+					v-if="selectedSchemaOption === 'existing'"
+					class="ext-neowiki-subject-creator-existing"
+				>
+					<SchemaLookup
+						ref="schemaLookupRef"
+						@select="onSchemaSelected"
+					/>
+				</div>
+
+				<div v-if="selectedSchemaOption === 'new'">
+					TODO: New schema UI
+				</div>
+			</template>
 
 			<template v-if="selectedSchemaName">
 				<CdxField class="ext-neowiki-subject-creator-label-field">

--- a/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
@@ -129,6 +129,19 @@ describe( 'SubjectCreatorDialog', () => {
 		expect( wrapper.find( '.schema-lookup-stub' ).exists() ).toBe( true );
 	} );
 
+	it( 'hides schema selector after schema selection', async () => {
+		const wrapper = mountComponent();
+
+		expect( wrapper.find( '.schema-lookup-stub' ).exists() ).toBe( true );
+		expect( wrapper.find( 'cdx-toggle-button-group-stub' ).exists() ).toBe( true );
+
+		await wrapper.findComponent( SchemaLookup ).vm.$emit( 'select', SCHEMA_NAME );
+		await flushPromises();
+
+		expect( wrapper.find( '.schema-lookup-stub' ).exists() ).toBe( false );
+		expect( wrapper.find( 'cdx-toggle-button-group-stub' ).exists() ).toBe( false );
+	} );
+
 	it( 'does not show label input or SubjectEditor before schema selection', () => {
 		const wrapper = mountComponent();
 


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/NeoWiki/pull/491#issuecomment-3833732765

## Summary

- Wrap the schema selection section (title, toggle buttons, and schema lookup/new-schema blocks) in `v-if="!selectedSchemaName"` so it disappears once a schema is chosen
- `resetForm()` already clears `selectedSchemaName`, so reopening the dialog restores the selector

## Test plan

- [x] Verify in the browser that schema selector disappears after picking a schema
- [x] Verify reopening the dialog shows the selector again
- [x] All existing and new TS tests pass (`make ts-test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)