### PR TITLE
Remove unnecessary -it flags from docker run commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,28 +39,28 @@ psalm-baseline:
 	vendor/bin/psalm --config=psalm.xml --set-baseline=psalm-baseline.xml
 
 ts-install:
-	docker run -it --rm -v "$(CURDIR)":/home/node/app:z $(EXEC_USER) -w /home/node/app/resources/ext.neowiki docker.io/library/node:24 npm install
+	docker run --rm -v "$(CURDIR)":/home/node/app:z $(EXEC_USER) -w /home/node/app/resources/ext.neowiki docker.io/library/node:24 npm install
 
 ts-update:
-	docker run -it --rm -v "$(CURDIR)":/home/node/app:z $(EXEC_USER) -w /home/node/app/resources/ext.neowiki docker.io/library/node:24 npm update
+	docker run --rm -v "$(CURDIR)":/home/node/app:z $(EXEC_USER) -w /home/node/app/resources/ext.neowiki docker.io/library/node:24 npm update
 
 ts-build:
-	docker run -it --rm -v "$(CURDIR)":/home/node/app:z $(EXEC_USER) -w /home/node/app/resources/ext.neowiki docker.io/library/node:24 npm run build
+	docker run --rm -v "$(CURDIR)":/home/node/app:z $(EXEC_USER) -w /home/node/app/resources/ext.neowiki docker.io/library/node:24 npm run build
 
 ts-build-watch:
-	docker run -it --rm -v "$(CURDIR)":/home/node/app:z $(EXEC_USER) -w /home/node/app/resources/ext.neowiki docker.io/library/node:24 npm run build:watch
+	docker run --rm -v "$(CURDIR)":/home/node/app:z $(EXEC_USER) -w /home/node/app/resources/ext.neowiki docker.io/library/node:24 npm run build:watch
 
 ts-ci:
 	$(MAKE) ts-test && $(MAKE) ts-build && $(MAKE) ts-lint
 
 ts-test:
-	docker run -it --rm -v "$(CURDIR)":/home/node/app:z $(EXEC_USER) -w /home/node/app/resources/ext.neowiki docker.io/library/node:24 npm run test
+	docker run --rm -v "$(CURDIR)":/home/node/app:z $(EXEC_USER) -w /home/node/app/resources/ext.neowiki docker.io/library/node:24 npm run test
 
 ts-test-watch:
-	docker run -it --rm -v "$(CURDIR)":/home/node/app:z $(EXEC_USER) -w /home/node/app/resources/ext.neowiki docker.io/library/node:24 npm run test:watch
+	docker run --rm -v "$(CURDIR)":/home/node/app:z $(EXEC_USER) -w /home/node/app/resources/ext.neowiki docker.io/library/node:24 npm run test:watch
 
 ts-coverage:
-	docker run -it --rm -v "$(CURDIR)":/home/node/app:z $(EXEC_USER) -w /home/node/app/resources/ext.neowiki docker.io/library/node:24 npm run coverage
+	docker run --rm -v "$(CURDIR)":/home/node/app:z $(EXEC_USER) -w /home/node/app/resources/ext.neowiki docker.io/library/node:24 npm run coverage
 
 ts-lint:
-	docker run -it --rm -v "$(CURDIR)":/home/node/app:z $(EXEC_USER) -w /home/node/app/resources/ext.neowiki docker.io/library/node:24 npm run lint
+	docker run --rm -v "$(CURDIR)":/home/node/app:z $(EXEC_USER) -w /home/node/app/resources/ext.neowiki docker.io/library/node:24 npm run lint


### PR DESCRIPTION
For https://chat.professional.wiki/pro-wiki/pl/hay8q5izxfyhpedqo4wpbori1o

## Summary

- Remove `-it` flags from all `docker run` commands in the Makefile — these commands don't need interactive input or a TTY, and the flags cause `the input device is not a TTY` errors in non-interactive contexts

## Test plan

- [x] `make ts-test` runs successfully (383 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)