### PR TITLE
Clear floats on headings following infobox views

### DIFF
--- a/resources/ext.neowiki/src/components/Views/AutomaticInfobox.vue
+++ b/resources/ext.neowiki/src/components/Views/AutomaticInfobox.vue
@@ -188,6 +188,7 @@ const propertiesToDisplay = computed( function(): Record<string, PropertyDefinit
 	}
 }
 
+// TODO: This is a temporary fix until we implement Views.
 @media ( min-width: @min-width-breakpoint-tablet ) {
 	.ext-neowiki-view ~ h2,
 	.ext-neowiki-view ~ h3,


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/pull/510#discussion_r2759309458

## Summary

- Headings between groups of floated infoboxes (e.g. on Museum_Collection) appeared beside the infoboxes instead of below them
- Add a CSS rule to clear floats on headings that follow `.ext-neowiki-view` elements, scoped to tablet+ to match the float rule
- Covers both legacy heading elements (`h2`-`h6`) and MW 1.42+ `.mw-heading` wrapper for forward compatibility

## Test plan

- [x] Visit Museum_Collection page
- [x] Verify "Selected Artworks" heading appears below the museum infoboxes, not beside them
- [x] Verify infobox float behavior on tablet+ is otherwise unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)