### PR TITLE
Improve test quaility

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -176,7 +176,7 @@
 				"CdxToggleSwitch",
 				"CdxMenu",
 				"CdxToggleButtonGroup",
-				"CdxLookup",	
+				"CdxLookup",
 				"CdxTable",
 				"CdxInfoChip"
 			],


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/509

- Fix trailing tab in extension.json
- Add beforeEach to SchemaDisplayHeader tests to reset shared state
- Fix findComponent selector that didn't actually filter by props
- Replace prop-inspection tests with rendered-content tests using the
  real CdxTable component instead of a stub
- Add test for edit button click handler and URL generation
- Add test for default value rendering
- Remove unused imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)