### PR TITLE
Lift schema permission check from header to parent component

### DIFF
--- a/resources/ext.neowiki/src/components/SchemaDisplay/SchemaDisplay.vue
+++ b/resources/ext.neowiki/src/components/SchemaDisplay/SchemaDisplay.vue
@@ -10,6 +10,7 @@
 			<template #header>
 				<SchemaDisplayHeader
 					:schema="currentSchema"
+					:can-edit="canEditSchema"
 					@edit="isEditorOpen = true"
 				/>
 			</template>

--- a/resources/ext.neowiki/src/components/SchemaDisplay/SchemaDisplayHeader.vue
+++ b/resources/ext.neowiki/src/components/SchemaDisplay/SchemaDisplayHeader.vue
@@ -13,7 +13,7 @@
 		</div>
 		<div class="ext-neowiki-schema-display-header__actions">
 			<CdxButton
-				v-if="canEditSchema"
+				v-if="canEdit"
 				weight="quiet"
 				:aria-label="$i18n( 'neowiki-edit-schema' ).text()"
 				@click="emit( 'edit' )"
@@ -25,15 +25,17 @@
 </template>
 
 <script setup lang="ts">
-import { watch } from 'vue';
 import { Schema } from '@/domain/Schema.ts';
 import { CdxButton, CdxIcon } from '@wikimedia/codex';
 import { cdxIconEdit } from '@wikimedia/codex-icons';
-import { useSchemaPermissions } from '@/composables/useSchemaPermissions.ts';
 
-const props = defineProps( {
+defineProps( {
 	schema: {
 		type: Schema,
+		required: true
+	},
+	canEdit: {
+		type: Boolean,
 		required: true
 	}
 } );
@@ -41,12 +43,6 @@ const props = defineProps( {
 const emit = defineEmits<{
 	edit: [];
 }>();
-
-const { canEditSchema, checkPermission } = useSchemaPermissions();
-
-watch( () => props.schema, ( newSchema ) => {
-	checkPermission( newSchema.getName() );
-}, { immediate: true } );
 </script>
 
 <style lang="less">

--- a/resources/ext.neowiki/tests/components/SchemaDisplay/SchemaDisplay.spec.ts
+++ b/resources/ext.neowiki/tests/components/SchemaDisplay/SchemaDisplay.spec.ts
@@ -53,12 +53,14 @@ describe( 'SchemaDisplay', () => {
 		checkPermissionMock.mockClear();
 	} );
 
-	it( 'passes schema to header component', () => {
+	it( 'passes schema and canEdit to header component', () => {
 		const schema = newSchema( { title: 'Test schema' } );
 
 		const wrapper = mountComponent( schema );
+		const header = wrapper.findComponent( SchemaDisplayHeader );
 
-		expect( wrapper.findComponent( SchemaDisplayHeader ).props( 'schema' ) ).toStrictEqual( schema );
+		expect( header.props( 'schema' ) ).toStrictEqual( schema );
+		expect( header.props( 'canEdit' ) ).toBe( false );
 	} );
 
 	it( 'renders property names, types, and required status', () => {


### PR DESCRIPTION
Follow-up to https://github.com/ProfessionalWiki/NeoWiki/pull/531#discussion_r2768150314

## Summary

- Removes duplicate `useSchemaPermissions()` call from `SchemaDisplayHeader`
- `SchemaDisplay` now owns the permission state and passes it down via a `canEdit` prop
- Eliminates redundant API calls for permission checking

🤖 Generated with [Claude Code](https://claude.ai/code)