### PR TITLE
Rename canEdit prop to canEditSchema in SchemaDisplayHeader

### DIFF
--- a/resources/ext.neowiki/src/components/SchemaDisplay/SchemaDisplay.vue
+++ b/resources/ext.neowiki/src/components/SchemaDisplay/SchemaDisplay.vue
@@ -10,7 +10,7 @@
 			<template #header>
 				<SchemaDisplayHeader
 					:schema="currentSchema"
-					:can-edit="canEditSchema"
+					:can-edit-schema="canEditSchema"
 					@edit="isEditorOpen = true"
 				/>
 			</template>

--- a/resources/ext.neowiki/src/components/SchemaDisplay/SchemaDisplayHeader.vue
+++ b/resources/ext.neowiki/src/components/SchemaDisplay/SchemaDisplayHeader.vue
@@ -13,7 +13,7 @@
 		</div>
 		<div class="ext-neowiki-schema-display-header__actions">
 			<CdxButton
-				v-if="canEdit"
+				v-if="canEditSchema"
 				weight="quiet"
 				:aria-label="$i18n( 'neowiki-edit-schema' ).text()"
 				@click="emit( 'edit' )"
@@ -34,7 +34,7 @@ defineProps( {
 		type: Schema,
 		required: true
 	},
-	canEdit: {
+	canEditSchema: {
 		type: Boolean,
 		required: true
 	}

--- a/resources/ext.neowiki/tests/components/SchemaDisplay/SchemaDisplay.spec.ts
+++ b/resources/ext.neowiki/tests/components/SchemaDisplay/SchemaDisplay.spec.ts
@@ -53,14 +53,14 @@ describe( 'SchemaDisplay', () => {
 		checkPermissionMock.mockClear();
 	} );
 
-	it( 'passes schema and canEdit to header component', () => {
+	it( 'passes schema and canEditSchema to header component', () => {
 		const schema = newSchema( { title: 'Test schema' } );
 
 		const wrapper = mountComponent( schema );
 		const header = wrapper.findComponent( SchemaDisplayHeader );
 
 		expect( header.props( 'schema' ) ).toStrictEqual( schema );
-		expect( header.props( 'canEdit' ) ).toBe( false );
+		expect( header.props( 'canEditSchema' ) ).toBe( false );
 	} );
 
 	it( 'renders property names, types, and required status', () => {

--- a/resources/ext.neowiki/tests/components/SchemaDisplay/SchemaDisplayHeader.spec.ts
+++ b/resources/ext.neowiki/tests/components/SchemaDisplay/SchemaDisplayHeader.spec.ts
@@ -5,11 +5,11 @@ import { Schema } from '@/domain/Schema.ts';
 import { setupMwMock, createI18nMock } from '../../VueTestHelpers.ts';
 import { newSchema } from '@/TestHelpers.ts';
 
-function mountComponent( schema: Schema, canEdit: boolean = false ): VueWrapper {
+function mountComponent( schema: Schema, canEditSchema: boolean = false ): VueWrapper {
 	setupMwMock( { functions: [ 'msg' ] } );
 
 	return mount( SchemaDisplayHeader, {
-		props: { schema, canEdit },
+		props: { schema, canEditSchema },
 		global: {
 			mocks: { $i18n: createI18nMock() },
 			stubs: {
@@ -36,13 +36,13 @@ describe( 'SchemaDisplayHeader', () => {
 		expect( wrapper.find( '.ext-neowiki-schema-display-header__description' ).exists() ).toBe( false );
 	} );
 
-	it( 'shows edit button when canEdit is true', () => {
+	it( 'shows edit button when canEditSchema is true', () => {
 		const wrapper = mountComponent( newSchema(), true );
 
 		expect( wrapper.find( '.ext-neowiki-schema-display-header__actions button' ).exists() ).toBe( true );
 	} );
 
-	it( 'hides edit button when canEdit is false', () => {
+	it( 'hides edit button when canEditSchema is false', () => {
 		const wrapper = mountComponent( newSchema(), false );
 
 		expect( wrapper.find( '.ext-neowiki-schema-display-header__actions button' ).exists() ).toBe( false );


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/532#discussion_r2769264972

## Summary
- Renames the `canEdit` prop to `canEditSchema` in `SchemaDisplayHeader` for clarity
- The more specific name makes it clear this is about schema-specific edit permission, not general edit permission

## Test plan
- [x] `make ts-lint` passes
- [x] `make ts-test filter=SchemaDisplay` passes (12 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)