### PR TITLE
Rename Value.strings to Value.parts

### DIFF
--- a/resources/ext.neowiki/src/components/Value/TextDisplay.vue
+++ b/resources/ext.neowiki/src/components/Value/TextDisplay.vue
@@ -16,6 +16,6 @@ const values = computed( () => {
 	if ( props.value.type !== ValueType.String ) {
 		return [ '' ];
 	}
-	return props.value.strings.filter( ( url ) => url.trim() !== '' );
+	return props.value.parts.filter( ( url ) => url.trim() !== '' );
 } );
 </script>

--- a/resources/ext.neowiki/src/components/Value/UrlDisplay.vue
+++ b/resources/ext.neowiki/src/components/Value/UrlDisplay.vue
@@ -20,6 +20,6 @@ const urls = computed( () => {
 	if ( props.value.type !== ValueType.String ) {
 		return '';
 	}
-	return props.value.strings.filter( ( url ) => url.trim() !== '' );
+	return props.value.parts.filter( ( url ) => url.trim() !== '' );
 } );
 </script>

--- a/resources/ext.neowiki/src/composables/useStringValueInput.ts
+++ b/resources/ext.neowiki/src/composables/useStringValueInput.ts
@@ -35,7 +35,7 @@ export function useStringValueInput<P extends MultiStringProperty>(
 	function initializeInternalValue( value: Value | undefined ): void {
 		if ( value && value.type === ValueType.String ) {
 			const stringVal = value as StringValue;
-			if ( stringVal.strings.length > 0 && stringVal.strings.some( ( s ) => s !== '' ) ) {
+			if ( stringVal.parts.length > 0 && stringVal.parts.some( ( s ) => s !== '' ) ) {
 				internalValue.value = stringVal;
 			} else {
 				internalValue.value = undefined;
@@ -51,7 +51,7 @@ export function useStringValueInput<P extends MultiStringProperty>(
 		if ( userInputValues.value !== null ) {
 			return userInputValues.value;
 		}
-		return internalValue.value ? internalValue.value.strings : [];
+		return internalValue.value ? internalValue.value.parts : [];
 	} );
 
 	function doValidateInputs( valuesToValidate: string[] ): { errors: ValidationMessages[]; validStrings: string[] } {
@@ -102,7 +102,7 @@ export function useStringValueInput<P extends MultiStringProperty>(
 
 		if ( validStrings.length > 0 ) {
 			const tempValue = newStringValue( ...validStrings );
-			if ( tempValue.strings.length > 0 && tempValue.strings.some( ( s ) => s !== '' ) ) {
+			if ( tempValue.parts.length > 0 && tempValue.parts.some( ( s ) => s !== '' ) ) {
 				newStringValueInstance = tempValue;
 			} else {
 				newStringValueInstance = undefined;

--- a/resources/ext.neowiki/src/domain/Value.ts
+++ b/resources/ext.neowiki/src/domain/Value.ts
@@ -15,7 +15,7 @@ export interface BaseValueRepresentation {
 
 export interface StringValue extends BaseValueRepresentation {
 	readonly type: ValueType.String;
-	readonly strings: string[]; // TODO: rename to parts
+	readonly parts: string[];
 }
 
 export interface NumberValue extends BaseValueRepresentation {
@@ -55,11 +55,11 @@ export class Relation {
 export type Value = StringValue | NumberValue | BooleanValue | RelationValue;
 
 export function newStringValue( ...parts: string[] | [ string[] ] ): StringValue {
-	const strings = Array.isArray( parts[ 0 ] ) ? parts[ 0 ] : parts as string[];
+	const resolved = Array.isArray( parts[ 0 ] ) ? parts[ 0 ] : parts as string[];
 
 	return {
 		type: ValueType.String,
-		strings: strings
+		parts: resolved
 			.map( ( part ) => part.trim() )
 			.filter( ( part ) => part !== '' ),
 	} as StringValue;
@@ -89,7 +89,7 @@ export function newRelation( id: string | undefined, target: SubjectId | string 
 export function valueToJson( value: Value ): unknown {
 	switch ( value.type ) {
 		case ValueType.String:
-			return ( value as StringValue ).strings;
+			return ( value as StringValue ).parts;
 		case ValueType.Number:
 			return ( value as NumberValue ).number;
 		case ValueType.Boolean:

--- a/resources/ext.neowiki/src/domain/propertyTypes/Text.ts
+++ b/resources/ext.neowiki/src/domain/propertyTypes/Text.ts
@@ -34,14 +34,14 @@ export class TextType extends BasePropertyType<TextProperty, StringValue> {
 		const errors: ValueValidationError[] = [];
 		value = value === undefined ? newStringValue() : value;
 
-		if ( property.required && value.strings.length === 0 ) {
+		if ( property.required && value.parts.length === 0 ) {
 			errors.push( { code: 'required' } );
 			return errors;
 		}
 
 		// TODO: check property.multiple
 
-		for ( const part of value.strings ) {
+		for ( const part of value.parts ) {
 			if ( property.minLength !== undefined && part.trim().length < property.minLength ) {
 				errors.push( {
 					code: 'min-length',
@@ -59,7 +59,7 @@ export class TextType extends BasePropertyType<TextProperty, StringValue> {
 			}
 		}
 
-		if ( property.uniqueItems && new Set( value.strings ).size !== value.strings.length ) {
+		if ( property.uniqueItems && new Set( value.parts ).size !== value.parts.length ) {
 			errors.push( { code: 'unique' } ); // TODO: add source
 		}
 

--- a/resources/ext.neowiki/src/domain/propertyTypes/Url.ts
+++ b/resources/ext.neowiki/src/domain/propertyTypes/Url.ts
@@ -31,14 +31,14 @@ export class UrlType extends BasePropertyType<UrlProperty, StringValue> {
 		const errors: ValueValidationError[] = [];
 		value = value === undefined ? newStringValue() : value;
 
-		if ( property.required && value.strings.length === 0 ) {
+		if ( property.required && value.parts.length === 0 ) {
 			errors.push( { code: 'required' } );
 			return errors;
 		}
 
 		// TODO: check property.multiple
 
-		for ( const part of value.strings ) {
+		for ( const part of value.parts ) {
 			const url = part.trim();
 
 			if ( url !== '' && !isValidUrl( url ) ) {
@@ -46,7 +46,7 @@ export class UrlType extends BasePropertyType<UrlProperty, StringValue> {
 			}
 		}
 
-		if ( property.uniqueItems && new Set( value.strings ).size !== value.strings.length ) {
+		if ( property.uniqueItems && new Set( value.parts ).size !== value.parts.length ) {
 			errors.push( { code: 'unique' } ); // TODO: add source
 		}
 


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/541

Aligns the TypeScript domain model with the Glossary terminology,
where Values have "parts".

## Summary
- Renamed `StringValue.strings` to `StringValue.parts` in the interface and all usages
- Renamed local `strings` variable in `newStringValue()` to `resolved` to avoid shadowing the parameter name

No serialization changes — `valueToJson` outputs the parts array directly, not as a named key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)