### PR TITLE
Rename callback parameter from url to part in TextDisplay

### DIFF
--- a/resources/ext.neowiki/src/components/Value/TextDisplay.vue
+++ b/resources/ext.neowiki/src/components/Value/TextDisplay.vue
@@ -16,6 +16,6 @@ const values = computed( () => {
 	if ( props.value.type !== ValueType.String ) {
 		return [ '' ];
 	}
-	return props.value.parts.filter( ( url ) => url.trim() !== '' );
+	return props.value.parts.filter( ( part ) => part.trim() !== '' );
 } );
 </script>


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/556

## Summary
- Rename the filter callback parameter in `TextDisplay.vue` from `url` (copy-pasted from `UrlDisplay.vue`) to `part`, matching the domain term

## Test plan
- [x] `make ts-build` passes
- [x] `make ts-lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)