### PR TITLE
Add Schema description field to Schema Editor and SchemaLookup

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -237,6 +237,7 @@
 				"neowiki-schema-editor-new-property",
 				"neowiki-schema-editor-delete-property",
 				"neowiki-schema-editor-optional",
+				"neowiki-schema-editor-description",
 				"neowiki-editing-schema",
 				"neowiki-schema-label",
 				"neowiki-subject-creator-title",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -61,6 +61,7 @@
 	"neowiki-schema-editor-new-property": "Add new property",
 	"neowiki-schema-editor-delete-property": "Delete property",
 	"neowiki-schema-editor-optional": "Optional",
+	"neowiki-schema-editor-description": "Description",
 
 	"neowiki-subject-creator-title": "Creating subject",
 	"neowiki-subject-creator-button-label": "Create subject",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -24,6 +24,7 @@
 	"neowiki-schema-editor-summary-default": "Default edit summary used when updating a schema via the UI.",
 	"neowiki-schema-editor-success": "Success notification shown after updating a schema. $1 is the schema name.",
 	"neowiki-schema-editor-error": "Error notification title shown when updating a schema fails. $1 is the schema name.",
+	"neowiki-schema-editor-description": "Label for the description field in the schema editor.",
 
 	"neowiki-subject-editor-summary-default": "Default edit summary used when updating a subject via the UI.",
 	"neowiki-subject-editor-success": "Success notification shown after updating a subject. $1 is the subject label.",

--- a/resources/ext.neowiki/src/components/SchemaEditor/SchemaEditor.vue
+++ b/resources/ext.neowiki/src/components/SchemaEditor/SchemaEditor.vue
@@ -3,6 +3,17 @@
 		class="ext-neowiki-schema-editor"
 		:class="{ 'ext-neowiki-schema-editor--has-selected-property': selectedProperty !== undefined }"
 	>
+		<div class="ext-neowiki-schema-editor__description">
+			<CdxField>
+				<template #label>
+					{{ $i18n( 'neowiki-schema-editor-description' ).text() }}
+				</template>
+				<CdxTextArea
+					:model-value="currentSchema.getDescription()"
+					@update:model-value="onDescriptionChanged"
+				/>
+			</CdxField>
+		</div>
 		<PropertyList
 			ref="propertyList"
 			:properties="currentSchema.getPropertyDefinitions()"
@@ -25,6 +36,7 @@
 import { PropertyDefinition, PropertyName } from '@/domain/PropertyDefinition';
 import { Schema } from '@/domain/Schema.ts';
 import { ComponentPublicInstance, computed, onUpdated, ref, watch } from 'vue';
+import { CdxField, CdxTextArea } from '@wikimedia/codex';
 import PropertyList from '@/components/SchemaEditor/PropertyList.vue';
 import PropertyDefinitionEditor from '@/components/SchemaEditor/PropertyDefinitionEditor.vue';
 import { PropertyDefinitionList } from '@/domain/PropertyDefinitionList.ts';
@@ -64,6 +76,10 @@ const selectedProperty = computed( () => {
 
 function onPropertySelected( name: PropertyName ): void {
 	selectedPropertyName.value = name.toString();
+}
+
+function onDescriptionChanged( value: string ): void {
+	currentSchema.value = currentSchema.value.withDescription( value );
 }
 
 function onPropertyCreated( newProperty: PropertyDefinition ): void {
@@ -136,6 +152,15 @@ defineExpose( {
 	display: grid;
 
 	.ext-neowiki-schema-editor {
+		&__description {
+			padding: @spacing-100;
+			border-block-end: @border-subtle;
+
+			@media ( min-width: @min-width-breakpoint-desktop ) {
+				padding: @spacing-150;
+			}
+		}
+
 		&__property-list,
 		&__property-editor {
 			padding: @spacing-100;
@@ -199,9 +224,13 @@ defineExpose( {
 		@media ( min-width: @min-width-breakpoint-desktop ) {
 			min-height: 0;
 			grid-template-columns: minmax( 0, 20rem ) auto;
-			grid-template-rows: minmax( 0, 1fr );
+			grid-template-rows: auto minmax( 0, 1fr );
 
 			.ext-neowiki-schema-editor {
+				&__description {
+					grid-column: 1 / -1;
+				}
+
 				&__property-list,
 				&__property-editor {
 					overflow-y: auto;

--- a/resources/ext.neowiki/src/components/SubjectCreator/SchemaLookup.vue
+++ b/resources/ext.neowiki/src/components/SubjectCreator/SchemaLookup.vue
@@ -38,7 +38,8 @@ async function onLookupInput( value: string ): Promise<void> {
 		const schemaNames = await schemaStore.searchAndFetchMissingSchemas( value );
 		menuItems.value = schemaNames.map( ( name ) => ( {
 			label: name,
-			value: name
+			value: name,
+			description: schemaStore.getSchema( name ).getDescription() || undefined
 		} ) );
 	} catch ( error ) {
 		console.error( 'Error searching schemas:', error );

--- a/resources/ext.neowiki/src/domain/Schema.ts
+++ b/resources/ext.neowiki/src/domain/Schema.ts
@@ -35,6 +35,10 @@ export class Schema {
 		return new Schema( name, this.description, this.properties );
 	}
 
+	public withDescription( description: string ): Schema {
+		return new Schema( this.name, description, this.properties );
+	}
+
 	public withAddedPropertyDefinition( property: PropertyDefinition ): Schema {
 		return new Schema(
 			this.name,

--- a/resources/ext.neowiki/tests/components/SubjectCreator/SchemaLookup.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectCreator/SchemaLookup.spec.ts
@@ -5,6 +5,8 @@ import { createPinia, setActivePinia } from 'pinia';
 import { useSchemaStore } from '@/stores/SchemaStore.ts';
 import { CdxLookup } from '@wikimedia/codex';
 import { createI18nMock } from '../../VueTestHelpers.ts';
+import { Schema } from '@/domain/Schema.ts';
+import { PropertyDefinitionList } from '@/domain/PropertyDefinitionList.ts';
 
 const $i18n = createI18nMock();
 
@@ -46,6 +48,8 @@ describe( 'SchemaLookup', () => {
 	it( 'updates menu items with search results', async () => {
 		const mockResults = [ 'Schema1', 'Schema2' ];
 		schemaStore.searchAndFetchMissingSchemas.mockResolvedValue( mockResults );
+		schemaStore.schemas.set( 'Schema1', new Schema( 'Schema1', 'First description', new PropertyDefinitionList( [] ) ) );
+		schemaStore.schemas.set( 'Schema2', new Schema( 'Schema2', 'Second description', new PropertyDefinitionList( [] ) ) );
 
 		const wrapper = mountComponent();
 		const lookup = wrapper.findComponent( CdxLookup );
@@ -54,8 +58,25 @@ describe( 'SchemaLookup', () => {
 		await flushPromises();
 
 		expect( lookup.props( 'menuItems' ) ).toEqual( [
-			{ label: 'Schema1', value: 'Schema1' },
-			{ label: 'Schema2', value: 'Schema2' },
+			{ label: 'Schema1', value: 'Schema1', description: 'First description' },
+			{ label: 'Schema2', value: 'Schema2', description: 'Second description' },
+		] );
+	} );
+
+	it( 'omits description from menu items when schema has empty description', async () => {
+		schemaStore.searchAndFetchMissingSchemas.mockResolvedValue( [ 'WithDesc', 'NoDesc' ] );
+		schemaStore.schemas.set( 'WithDesc', new Schema( 'WithDesc', 'Has a description', new PropertyDefinitionList( [] ) ) );
+		schemaStore.schemas.set( 'NoDesc', new Schema( 'NoDesc', '', new PropertyDefinitionList( [] ) ) );
+
+		const wrapper = mountComponent();
+		const lookup = wrapper.findComponent( CdxLookup );
+
+		lookup.vm.$emit( 'input', 'test' );
+		await flushPromises();
+
+		expect( lookup.props( 'menuItems' ) ).toEqual( [
+			{ label: 'WithDesc', value: 'WithDesc', description: 'Has a description' },
+			{ label: 'NoDesc', value: 'NoDesc', description: undefined },
 		] );
 	} );
 

--- a/resources/ext.neowiki/tests/domain/Schema.unit.spec.ts
+++ b/resources/ext.neowiki/tests/domain/Schema.unit.spec.ts
@@ -43,6 +43,21 @@ describe( 'Schema', () => {
 
 	} );
 
+	describe( 'withDescription', () => {
+
+		it( 'returns a new Schema with the updated description', () => {
+			const originalSchema = newSchema();
+
+			const updatedSchema = originalSchema.withDescription( 'Updated description' );
+
+			expect( updatedSchema.getDescription() ).toBe( 'Updated description' );
+			expect( updatedSchema.getName() ).toBe( originalSchema.getName() );
+			expect( updatedSchema.getPropertyDefinitions() ).toEqual( originalSchema.getPropertyDefinitions() );
+			expect( updatedSchema ).not.toBe( originalSchema );
+		} );
+
+	} );
+
 	describe( 'withAddedPropertyDefinition', () => {
 
 		it( 'adds a Property Definition when Schema has no properties', () => {


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/503

Add a description textarea to the Schema Editor so users can set and
change Schema descriptions. Also add Schema descriptions to the
SchemaLookup dropdown in the SubjectCreator.

## Test plan

- [x] Schema Editor has a text field for the Schema description
- [x] Existing descriptions are loaded into the field when editing
- [x] Changed descriptions are saved
- [x] Empty descriptions are handled sensibly
- [x] Schema descriptions are added to SchemaLookup

🤖 Generated with [Claude Code](https://claude.com/claude-code)