### PR TITLE
Add RelationAttributesEditor stub

### DIFF
--- a/resources/ext.neowiki/src/NeoWikiExtension.ts
+++ b/resources/ext.neowiki/src/NeoWikiExtension.ts
@@ -32,6 +32,7 @@ import { Neo } from '@/Neo.ts';
 import { cdxIconLink, cdxIconSearchCaseSensitive, cdxIconArticles, cdxIconListNumbered } from '@wikimedia/codex-icons';
 import TextAttributesEditor from '@/components/SchemaEditor/Property/TextAttributesEditor.vue';
 import NumberAttributesEditor from '@/components/SchemaEditor/Property/NumberAttributesEditor.vue';
+import RelationAttributesEditor from '@/components/SchemaEditor/Property/RelationAttributesEditor.vue';
 import { SubjectValidator } from '@/domain/SubjectValidator.ts';
 import { PropertyTypeRegistry } from '@/domain/PropertyType.ts';
 import { StoreStateLoader } from '@/persistence/StoreStateLoader.ts';
@@ -76,7 +77,7 @@ export class NeoWikiExtension {
 		registry.registerType( RelationType.typeName, {
 			valueDisplayComponent: RelationDisplay,
 			valueEditor: RelationInput,
-			attributesEditor: TextAttributesEditor, // TODO
+			attributesEditor: RelationAttributesEditor,
 			label: 'neowiki-property-type-relation',
 			icon: cdxIconArticles,
 		} );

--- a/resources/ext.neowiki/src/components/SchemaEditor/Property/RelationAttributesEditor.vue
+++ b/resources/ext.neowiki/src/components/SchemaEditor/Property/RelationAttributesEditor.vue
@@ -1,0 +1,14 @@
+<template>
+	<!-- cdx-field class is used for spacing -->
+	<div class="relation-attributes cdx-field">
+		TODO
+	</div>
+</template>
+
+<script setup lang="ts">
+import { RelationProperty } from '@/domain/propertyTypes/Relation.ts';
+import { AttributesEditorEmits, AttributesEditorProps } from '@/components/SchemaEditor/Property/AttributesEditorContract.ts';
+
+defineProps<AttributesEditorProps<RelationProperty>>();
+defineEmits<AttributesEditorEmits<RelationProperty>>();
+</script>

--- a/resources/ext.neowiki/tests/components/SchemaEditor/Property/RelationAttributesEditor.spec.ts
+++ b/resources/ext.neowiki/tests/components/SchemaEditor/Property/RelationAttributesEditor.spec.ts
@@ -1,0 +1,23 @@
+import { VueWrapper } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import RelationAttributesEditor from '@/components/SchemaEditor/Property/RelationAttributesEditor.vue';
+import { newRelationProperty, RelationProperty } from '@/domain/propertyTypes/Relation';
+import { AttributesEditorProps } from '@/components/SchemaEditor/Property/AttributesEditorContract.ts';
+import { createTestWrapper } from '../../../VueTestHelpers.ts';
+
+describe( 'RelationAttributesEditor', () => {
+
+	function newWrapper( props: Partial<AttributesEditorProps<RelationProperty>> = {} ): VueWrapper {
+		return createTestWrapper( RelationAttributesEditor, {
+			property: newRelationProperty( {} ),
+			...props,
+		} );
+	}
+
+	it( 'renders without error', () => {
+		const wrapper = newWrapper();
+
+		expect( wrapper.find( '.relation-attributes' ).exists() ).toBe( true );
+	} );
+
+} );


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/NeoWiki/issues/383

The Schema Editor uses type-specific attribute editors for each property type.
The `relation` type currently falls back to `TextAttributesEditor` (with a `// TODO` comment).
This creates the dedicated `RelationAttributesEditor` stub so follow-up PRs can add the actual
inputs (`relation`, `targetSchema`, `multiple`, and change events).

- Create `RelationAttributesEditor.vue` with `defineProps`/`defineEmits` matching the established contract
- Register it in `NeoWikiExtension.ts`, replacing the `TextAttributesEditor` fallback
- Add test file with a "renders without error" test to establish scaffolding for follow-ups

🤖 Generated with [Claude Code](https://claude.com/claude-code)