### PR TITLE
Use schema-scoped REST route for subject label lookup

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -138,7 +138,7 @@
 			"factory": "ProfessionalWiki\\NeoWiki\\NeoWikiExtension::newGetSchemaNamesApi"
 		},
 		{
-			"path": "/neowiki/v0/subject-labels/{search}",
+			"path": "/neowiki/v0/subject-labels",
 			"method": [ "GET" ],
 			"factory": "ProfessionalWiki\\NeoWiki\\NeoWikiExtension::newGetSubjectLabelsApi"
 		}

--- a/src/Application/SubjectLabelLookup.php
+++ b/src/Application/SubjectLabelLookup.php
@@ -9,6 +9,6 @@ interface SubjectLabelLookup {
 	/**
 	 * @return SubjectLabelLookupResult[]
 	 */
-	public function getSubjectLabelsMatching( string $search, int $limit, array $schemaNames = [] ): array;
+	public function getSubjectLabelsMatching( string $search, int $limit, string $schemaName ): array;
 
 }

--- a/src/EntryPoints/REST/GetSubjectLabelsApi.php
+++ b/src/EntryPoints/REST/GetSubjectLabelsApi.php
@@ -13,7 +13,7 @@ use Wikimedia\ParamValidator\ParamValidator;
 
 class GetSubjectLabelsApi extends SimpleHandler {
 
-	public function run( string $search ): Response {
+	public function run(): Response {
 		$params = $this->getValidatedParams();
 
 		$subjects = array_map(
@@ -24,9 +24,9 @@ class GetSubjectLabelsApi extends SimpleHandler {
 				];
 			},
 			NeoWikiExtension::getInstance()->getSubjectLabelLookup()->getSubjectLabelsMatching(
-				$search,
+				$params['search'],
 				$params['limit'],
-				$params['schemas'],
+				$params['schema'],
 			)
 		);
 
@@ -40,22 +40,21 @@ class GetSubjectLabelsApi extends SimpleHandler {
 	public function getParamSettings(): array {
 		return [
 			'search' => [
-				self::PARAM_SOURCE => 'path',
+				self::PARAM_SOURCE => 'query',
 				ParamValidator::PARAM_TYPE => 'string',
-				ParamValidator::PARAM_REQUIRED => false
+				ParamValidator::PARAM_REQUIRED => false,
+				ParamValidator::PARAM_DEFAULT => '',
+			],
+			'schema' => [
+				self::PARAM_SOURCE => 'query',
+				ParamValidator::PARAM_TYPE => 'string',
+				ParamValidator::PARAM_REQUIRED => true,
 			],
 			'limit' => [
 				self::PARAM_SOURCE => 'query',
 				ParamValidator::PARAM_TYPE => 'integer',
 				ParamValidator::PARAM_REQUIRED => false,
 				ParamValidator::PARAM_DEFAULT => 10,
-			],
-			'schemas' => [
-				self::PARAM_SOURCE => 'query',
-				ParamValidator::PARAM_TYPE => 'string',
-				ParamValidator::PARAM_ISMULTI => true,
-				ParamValidator::PARAM_REQUIRED => false,
-				ParamValidator::PARAM_DEFAULT => [],
 			],
 		];
 	}

--- a/tests/phpunit/Persistence/Neo4j/Neo4jSubjectLabelLookupTest.php
+++ b/tests/phpunit/Persistence/Neo4j/Neo4jSubjectLabelLookupTest.php
@@ -97,11 +97,18 @@ class Neo4jSubjectLabelLookupTest extends NeoWikiIntegrationTestCase {
 			TestSubject::build( id: 'sTestSLL1111118', label: new SubjectLabel( 'Apple Inc.' ), schemaId: new SchemaName( 'Company' ) ),
 		) );
 
-		$results = $this->getSubjectLabelsMatching( 'Apple', 10, [ 'Recipe', 'Company' ] );
+		$results = $this->newLookup()->getSubjectLabelsMatching( 'Apple', 10, 'Recipe' );
 
-		$this->assertCount( 2, $results );
+		$this->assertCount( 1, $results );
 		$this->assertContainsEquals( new SubjectLabelLookupResult( 'sTestSLL1111116', 'Apple Pie' ), $results );
-		$this->assertContainsEquals( new SubjectLabelLookupResult( 'sTestSLL1111118', 'Apple Inc.' ), $results );
+	}
+
+	public function testDoesNotReturnSubjectsFromOtherSchemas(): void {
+		$this->saveSubjects( new SubjectMap(
+			TestSubject::build( id: 'sTestSLL1111119', label: new SubjectLabel( 'Apple Tree' ), schemaId: new SchemaName( 'Plant' ) ),
+		) );
+
+		$this->assertSame( [], $this->newLookup()->getSubjectLabelsMatching( 'Apple', 10, 'Recipe' ) );
 	}
 
 	private function saveSubjects( SubjectMap $subjects ): void {
@@ -123,8 +130,8 @@ class Neo4jSubjectLabelLookupTest extends NeoWikiIntegrationTestCase {
 		);
 	}
 
-	private function getSubjectLabelsMatching( string $search, int $limit = 10, array $schemas = [] ): array {
-		return $this->newLookup()->getSubjectLabelsMatching( $search, $limit, $schemas );
+	private function getSubjectLabelsMatching( string $search, int $limit = 10 ): array {
+		return $this->newLookup()->getSubjectLabelsMatching( $search, $limit, TestSubject::DEFAULT_SCHEMA_ID );
 	}
 
 	private function newLookup( ClientInterface $client = null ): Neo4jSubjectLabelLookup {


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/NeoWiki/issues/371

Change the route from `/neowiki/v0/subject-labels/{search}` with optional `schemas[]` filter to
`/neowiki/v0/subject-labels` with all parameters as query params. Schema is a filter on the global subjects
collection, not a scoping container, so it belongs in query params rather than the path. Follows the
`schema-names` naming pattern.

Example: `GET /rest.php/neowiki/v0/subject-labels?search=John&schema=Person&limit=10`

`schema` is required for now but can be relaxed to optional later without changing the URL structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)