### PR TITLE
Fix typos in docs and source comments

### DIFF
--- a/docs/GraphModel.md
+++ b/docs/GraphModel.md
@@ -1,6 +1,6 @@
 # Graph Model
 
-NeoWiki stores a query-optimized projection of its data in a Neo4j graph database ([ADR 3](adr/003_Neo4j.md)).
+NeoWiki stores a query-optimized projection of its data in a Neo4j graph database ([ADR 3](adr/003_Neo4j_as_Graph_Database.md)).
 The source of truth for all data remains in MediaWiki revision slots ([ADR 4](adr/004_Use_Dedicated_Slot.md));
 the graph is a secondary store that enables efficient querying and relationship traversal.
 
@@ -93,7 +93,7 @@ Two uniqueness constraints are created on initialization:
 
 ## Related Documentation
 
-- [ADR 3: Neo4j as Graph Database](adr/003_Neo4j.md)
+- [ADR 3: Neo4j as Graph Database](adr/003_Neo4j_as_Graph_Database.md)
 - [ADR 4: Use Dedicated Slot](adr/004_Use_Dedicated_Slot.md) — primary storage in MediaWiki revision slots
 - [ADR 13: Restrict Neo4j Access](adr/013_Restrict_Neo4j_Access.md) — backend-only access to Neo4j
 - [SubjectFormat.md](SubjectFormat.md) — JSON format for Subject data in revision slots

--- a/docs/adr/003_Neo4j_as_Graph_Database.md
+++ b/docs/adr/003_Neo4j_as_Graph_Database.md
@@ -31,6 +31,6 @@ Consider neo4j as part of NeoWiki's public API. This means consumers can directl
 * We do not need to develop and maintain our own persistence solution.
 * We can use existing tools and libraries to work with Neo4j.
 * Users will be able to use Cypher queries.
-* Various parts of the software will bind to Cyprher and Neo4j. Additional implementation and
+* Various parts of the software will bind to Cypher and Neo4j. Additional implementation and
   abstractions will need to be created to support other graph databases.
 * Potential out-of-the-box visualization options that can be integrated into NeoWiki.

--- a/docs/adr/005_Subject_GUIDs.md
+++ b/docs/adr/005_Subject_GUIDs.md
@@ -10,7 +10,7 @@ We need unique identifiers for Subjects.
 
 Semantic MediaWiki uses page titles. This is not viable since we support multiple Subjects per page.
 
-Wikibase use incrementing numeric IDs. It generates those by storing the current highest ID in
+Wikibase uses incrementing numeric IDs. It generates those by storing the current highest ID in
 database table and doing a query to generate a new ID. This means IDs can only be generated with
 access to the database, and that conflicts occur when transferring data between wikis.
 

--- a/docs/adr/009_Move_Away_from_JSON_Schema.md
+++ b/docs/adr/009_Move_Away_from_JSON_Schema.md
@@ -23,7 +23,7 @@ Including:
 ## Consequences
 
 * We can simplify our code dealing with schemas, especially code related to handling of multiple values.
-* We can no longer use standard JSON-schema-bases validators to validate Subjects. Then again, we anticipated those
+* We can no longer use standard JSON-schema-based validators to validate Subjects. Then again, we anticipated those
   would not have sufficed anyway.
 * We no longer expose schemas in a standard format. If such a requirement arises we can still implement it via a
   web API that converts our custom schema format to JSON schema.

--- a/docs/adr/010_Add_GUIDs_to_Relations.md
+++ b/docs/adr/010_Add_GUIDs_to_Relations.md
@@ -8,8 +8,8 @@ Status: Accepted, ID format superseded by [ADR 014](014_Improved_ID_Format.md)
 
 In our domain model, relations do not currently have an ID.
 
-In early versions of the NeoWiki prototype had relation IDs to identify them for updates in Neo4j. However, we removed
-them because we figured we could just use the relations target subject ID and the relation type to identify a relation.
+Early versions of the NeoWiki prototype had relation IDs to identify them for updates in Neo4j. However, we removed
+them because we figured we could just use the relation's target subject ID and the relation type to identify a relation.
 This turns out to be insufficient for our use cases.
 
 We need to be able to have multiple relations of the same type to a single target subject. Example:

--- a/docs/adr/014_Improved_ID_Format.md
+++ b/docs/adr/014_Improved_ID_Format.md
@@ -31,9 +31,9 @@ We do not provide backwards compatibility with or migration for the old format s
 ### Staying UUID Version 7
 
 * Least work (no change needed)
-* IDs are harder to copy to due to the hyphens
+* IDs are harder to copy due to the hyphens
 * More storage is used due to unnecessary ID length
-* IDs might offend some peoples' sense of aesthetics
+* IDs might offend some people's sense of aesthetics
 
 ### Using Standard Nanoid
 

--- a/docs/planning/Validation.md
+++ b/docs/planning/Validation.md
@@ -43,7 +43,7 @@ need to be kept in sync. (Aside: we could have the validation just in PHP and ha
 API endpoint, but this comes with usability downsides we wish to avoid.)
 
 If there are substantial users of the REST APIs that do not use our TypeScript library,
-then we may need to add backend validation. This seems plausable for ECHOLOT, both in the form
+then we may need to add backend validation. This seems plausible for ECHOLOT, both in the form
 of external applications (for instance, for import) and for the end users of the software.
 
 ## Scenarios to Consider
@@ -94,7 +94,7 @@ Pros:
 * API users can potentially validate Subjects without editing via a new dedicated endpoint
 
 Cons:
-* Need to figure out those TDB details
+* Need to figure out those TBD details
 * Cost of implementation and cost of carry
     * Validation system in PHP
     * Strict-mode or similar for Subject writing APIs with validation status responses

--- a/resources/ext.neowiki/src/NeoWikiExtension.ts
+++ b/resources/ext.neowiki/src/NeoWikiExtension.ts
@@ -72,7 +72,7 @@ export class NeoWikiExtension {
 			valueEditor: NumberInput,
 			attributesEditor: NumberAttributesEditor,
 			label: 'neowiki-property-type-number',
-			icon: cdxIconListNumbered, // TOOD: Add a custom icon
+			icon: cdxIconListNumbered, // TODO: Add a custom icon
 		} );
 
 		registry.registerType( RelationType.typeName, {

--- a/resources/ext.neowiki/src/composables/useStringValueInput.ts
+++ b/resources/ext.neowiki/src/composables/useStringValueInput.ts
@@ -111,7 +111,7 @@ export function useStringValueInput<P extends MultiStringProperty>(
 			newStringValueInstance = undefined;
 		}
 
-		// TODO: Maybe we should have an unified way to handle deep comparison of values
+		// TODO: Maybe we should have a unified way to handle deep comparison of values
 		// https://github.com/ProfessionalWiki/NeoWiki/pull/382#discussion_r2075610162
 		if ( JSON.stringify( internalValue.value ) !== JSON.stringify( newStringValueInstance ) ) {
 			internalValue.value = newStringValueInstance;

--- a/resources/ext.neowiki/src/persistence/StoreStateLoader.ts
+++ b/resources/ext.neowiki/src/persistence/StoreStateLoader.ts
@@ -43,7 +43,7 @@ export class StoreStateLoader {
 			}
 
 			// TODO: we can just call await schemaStore.getOrFetchSchema().
-			// Shall we remvoe the getOrFetch methods from the Stores?
+			// Shall we remove the getOrFetch methods from the Stores?
 			// If we keep them, we can just as well use them here.
 			// Argument for removal: keep the Stores simple.
 		}


### PR DESCRIPTION
## Summary
- Fix broken ADR links in GraphModel.md (`003_Neo4j.md` → `003_Neo4j_as_Graph_Database.md`)
- Fix `Cyprher` → `Cypher` in ADR 003
- Fix `Wikibase use` → `Wikibase uses` in ADR 005
- Fix `JSON-schema-bases` → `JSON-schema-based` in ADR 009
- Fix grammar and missing possessive in ADR 010
- Fix `copy to due` → `copy due to` and `peoples'` → `people's` in ADR 014
- Fix `plausable` → `plausible` and `TDB` → `TBD` in Validation.md
- Fix `TOOD` → `TODO` in NeoWikiExtension.ts
- Fix `remvoe` → `remove` in StoreStateLoader.ts
- Fix `an unified` → `a unified` in useStringValueInput.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)