### PR TITLE
Rename schemaId to schemaName

### DIFF
--- a/resources/ext.neowiki/src/TestHelpers.ts
+++ b/resources/ext.neowiki/src/TestHelpers.ts
@@ -7,12 +7,12 @@ import { SubjectWithContext } from '@/domain/SubjectWithContext';
 
 export const DEFAULT_SUBJECT_ID = 's11111111111111';
 export const DEFAULT_TEST_SUBJECT_LABEL = 'Test subject';
-export const DEFAULT_TEST_SCHEMA_ID = 'TestSchema';
+export const DEFAULT_TEST_SCHEMA_NAME = 'TestSchema';
 
 interface NewTestSubjectOptions {
 	id?: string|SubjectId;
 	label?: string;
-	schemaId?: string;
+	schemaName?: string;
 	statements?: StatementList;
 	pageIdentifiers?: PageIdentifiers;
 }
@@ -20,14 +20,14 @@ interface NewTestSubjectOptions {
 export function newSubject( {
 	id = DEFAULT_SUBJECT_ID,
 	label = DEFAULT_TEST_SUBJECT_LABEL,
-	schemaId = DEFAULT_TEST_SCHEMA_ID,
+	schemaName = DEFAULT_TEST_SCHEMA_NAME,
 	statements = new StatementList( [] ),
 	pageIdentifiers = new PageIdentifiers( 0, 'TestSubjectPage' ),
 }: NewTestSubjectOptions = {} ): SubjectWithContext {
 	return new SubjectWithContext(
 		id instanceof SubjectId ? id : new SubjectId( id ),
 		label,
-		schemaId,
+		schemaName,
 		statements,
 		pageIdentifiers,
 	);

--- a/resources/ext.neowiki/tests/domain/Subject.unit.spec.ts
+++ b/resources/ext.neowiki/tests/domain/Subject.unit.spec.ts
@@ -16,7 +16,7 @@ describe( 'Subject', () => {
 	it( 'should be constructable via newSubject', () => {
 		const subject = newSubject( {
 			label: 'I am a tomato',
-			schemaId: 'Tomato',
+			schemaName: 'Tomato',
 		} );
 
 		expect( subject.getId().text ).toBe( DEFAULT_SUBJECT_ID );

--- a/src/Application/Actions/CreateSubject/CreateSubjectAction.php
+++ b/src/Application/Actions/CreateSubject/CreateSubjectAction.php
@@ -56,7 +56,7 @@ readonly class CreateSubjectAction {
 		return Subject::createNew(
 			guidGenerator: $this->guidGenerator,
 			label: new SubjectLabel( $request->label ),
-			schemaId: new SchemaName( $request->schemaId ),
+			schemaName: new SchemaName( $request->schemaName ),
 			statements: $this->statementListPatcher->buildStatementList(
 				statements: new StatementList(),
 				patch: $request->statements

--- a/src/Application/Actions/CreateSubject/CreateSubjectRequest.php
+++ b/src/Application/Actions/CreateSubject/CreateSubjectRequest.php
@@ -12,7 +12,7 @@ readonly class CreateSubjectRequest {
 
 		public string $label,
 
-		public string $schemaId,
+		public string $schemaName,
 
 		/**
 		 * @var array<string, mixed[]>

--- a/src/Application/Queries/GetSubject/GetSubjectQuery.php
+++ b/src/Application/Queries/GetSubject/GetSubjectQuery.php
@@ -59,7 +59,7 @@ readonly class GetSubjectQuery {
 		return new GetSubjectResponseItem(
 			id: $subject->id->text,
 			label: $subject->label->text,
-			schemaId: $subject->getSchemaId()->getText(),
+			schemaName: $subject->getSchemaName()->getText(),
 			statements: $this->arrayifyStatements( $subject->getStatements() ),
 			pageId: $pageIdentifiers?->getId()->id,
 			pageTitle: $pageIdentifiers?->getTitle(),

--- a/src/Application/Queries/GetSubject/GetSubjectResponseItem.php
+++ b/src/Application/Queries/GetSubject/GetSubjectResponseItem.php
@@ -9,7 +9,7 @@ readonly class GetSubjectResponseItem {
 	public function __construct(
 		public string $id,
 		public string $label,
-		public string $schemaId,
+		public string $schemaName,
 		/**
 		 * @var array<string, mixed>
 		 */

--- a/src/Application/SchemaLookup.php
+++ b/src/Application/SchemaLookup.php
@@ -9,6 +9,6 @@ use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 
 interface SchemaLookup {
 
-	public function getSchema( SchemaName $schemaId ): ?Schema;
+	public function getSchema( SchemaName $schemaName ): ?Schema;
 
 }

--- a/src/Domain/Subject/Subject.php
+++ b/src/Domain/Subject/Subject.php
@@ -15,7 +15,7 @@ class Subject {
 	public function __construct(
 		public readonly SubjectId $id,
 		public SubjectLabel $label,
-		private readonly SchemaName $schemaId,
+		private readonly SchemaName $schemaName,
 		private StatementList $statements,
 	) {
 	}
@@ -23,22 +23,22 @@ class Subject {
 	public static function createNew(
 		IdGenerator $guidGenerator,
 		SubjectLabel $label,
-		SchemaName $schemaId,
+		SchemaName $schemaName,
 		?StatementList $statements = null,
 	): self {
 		return new self(
 			id: SubjectId::createNew( $guidGenerator ),
 			label: $label,
-			schemaId: $schemaId,
+			schemaName: $schemaName,
 			statements: $statements ?? new StatementList( [] ),
 		);
 	}
 
-	public static function newSubject( SubjectId $id, SubjectLabel $label, SchemaName $schemaId ): self {
+	public static function newSubject( SubjectId $id, SubjectLabel $label, SchemaName $schemaName ): self {
 		return new self(
 			id: $id,
 			label: $label,
-			schemaId: $schemaId,
+			schemaName: $schemaName,
 			statements: new StatementList( [] ),
 		);
 	}
@@ -55,8 +55,8 @@ class Subject {
 		return $this->label;
 	}
 
-	public function getSchemaId(): SchemaName {
-		return $this->schemaId;
+	public function getSchemaName(): SchemaName {
+		return $this->schemaName;
 	}
 
 	public function getStatements(): StatementList {

--- a/src/EntryPoints/REST/CreateSubjectApi.php
+++ b/src/EntryPoints/REST/CreateSubjectApi.php
@@ -34,7 +34,7 @@ class CreateSubjectApi extends SimpleHandler implements CreateSubjectPresenter {
 					pageId: $pageId,
 					isMainSubject: $this->isMainSubject,
 					label: $request['label'],
-					schemaId: $request['schema'],
+					schemaName: $request['schema'],
 					statements: $request['statements'],
 				)
 			);

--- a/src/Persistence/MediaWiki/SchemaPersistenceDeserializer.php
+++ b/src/Persistence/MediaWiki/SchemaPersistenceDeserializer.php
@@ -27,7 +27,7 @@ class SchemaPersistenceDeserializer {
 	/**
 	 * @throws InvalidArgumentException
 	 */
-	public function deserialize( SchemaName $schemaId, string $json ): Schema {
+	public function deserialize( SchemaName $schemaName, string $json ): Schema {
 		$json = json_decode( $json, true );
 
 		if ( !is_array( $json ) ) {
@@ -35,7 +35,7 @@ class SchemaPersistenceDeserializer {
 		}
 
 		return new Schema(
-			name: $schemaId,
+			name: $schemaName,
 			description: $json['description'] ?? '',
 			properties: $this->propertiesFromJson( $json ),
 		);

--- a/src/Persistence/MediaWiki/Subject/SubjectContentDataDeserializer.php
+++ b/src/Persistence/MediaWiki/Subject/SubjectContentDataDeserializer.php
@@ -57,7 +57,7 @@ class SubjectContentDataDeserializer {
 		return new Subject(
 			id: new SubjectId( $id ),
 			label: new SubjectLabel( $jsonArray['label'] ),
-			schemaId: new SchemaName( $jsonArray['schema'] ),
+			schemaName: new SchemaName( $jsonArray['schema'] ),
 			statements: $this->buildStatementList( $jsonArray ),
 		);
 	}

--- a/src/Persistence/MediaWiki/Subject/SubjectContentDataSerializer.php
+++ b/src/Persistence/MediaWiki/Subject/SubjectContentDataSerializer.php
@@ -30,7 +30,7 @@ class SubjectContentDataSerializer {
 		foreach ( $subjectMap->asArray() as $subject ) {
 			$serializedSubjects[$subject->id->text] = [
 				'label' => $subject->label->text,
-				'schema' => $subject->getSchemaId()->getText(),
+				'schema' => $subject->getSchemaName()->getText(),
 				'statements' => $this->serializeStatementList( $subject->getStatements() ),
 			];
 		}

--- a/src/Persistence/MediaWiki/WikiPageSchemaLookup.php
+++ b/src/Persistence/MediaWiki/WikiPageSchemaLookup.php
@@ -21,15 +21,15 @@ class WikiPageSchemaLookup implements SchemaLookup {
 	) {
 	}
 
-	public function getSchema( SchemaName $schemaId ): ?Schema {
-		$content = $this->getContent( $schemaId );
+	public function getSchema( SchemaName $schemaName ): ?Schema {
+		$content = $this->getContent( $schemaName );
 
 		if ( $content === null ) {
 			return null;
 		}
 
 		try {
-			return $this->schemaDeserializer->deserialize( $schemaId, $content->getText() );
+			return $this->schemaDeserializer->deserialize( $schemaName, $content->getText() );
 		}
 		catch ( InvalidArgumentException ) {
 			return null;

--- a/src/Persistence/Neo4j/SubjectUpdater.php
+++ b/src/Persistence/Neo4j/SubjectUpdater.php
@@ -30,10 +30,10 @@ class SubjectUpdater {
 
 	public function updateSubject( Subject $subject, bool $isMainSubject ): void {
 		// TODO: we should make sure this schema retrieval is cached
-		$schema = $this->schemaRepository->getSchema( $subject->getSchemaId() );
+		$schema = $this->schemaRepository->getSchema( $subject->getSchemaName() );
 
 		if ( $schema === null ) {
-			$this->logger->warning( 'Schema not found: ' . $subject->getSchemaId()->getText() );
+			$this->logger->warning( 'Schema not found: ' . $subject->getSchemaName()->getText() );
 			return;
 		}
 
@@ -98,7 +98,7 @@ class SubjectUpdater {
 
 	private function updateNodeLabels( Subject $subject ): void {
 		$oldLabels = $this->getNodeLabels( $subject->id );
-		$newLabels = [ 'Subject', $subject->getSchemaId()->getText() ];
+		$newLabels = [ 'Subject', $subject->getSchemaName()->getText() ];
 
 		$labelsToRemove = array_diff( $oldLabels, $newLabels );
 

--- a/src/Presentation/RestGetSubjectPresenter.php
+++ b/src/Presentation/RestGetSubjectPresenter.php
@@ -33,7 +33,7 @@ class RestGetSubjectPresenter implements GetSubjectPresenter {
 			$map[$subject->id] = [
 				'id' => $subject->id,
 				'label' => $subject->label,
-				'schema' => $subject->schemaId,
+				'schema' => $subject->schemaName,
 			];
 
 			if ( $subject->pageId !== null ) {

--- a/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
@@ -65,7 +65,7 @@ class CreateSubjectActionTest extends TestCase {
 				pageId: 1,
 				isMainSubject: true,
 				label: 'Some Label',
-				schemaId: 'some-schema-id',
+				schemaName: 'some-schema-id',
 				statements: []
 			)
 		);
@@ -88,7 +88,7 @@ class CreateSubjectActionTest extends TestCase {
 				pageId: 1,
 				isMainSubject: true,
 				label: 'Existing Label',
-				schemaId: 'existing-schema-id',
+				schemaName: 'existing-schema-id',
 				statements: []
 			)
 		);
@@ -110,7 +110,7 @@ class CreateSubjectActionTest extends TestCase {
 				pageId: 1,
 				isMainSubject: true,
 				label: 'Some Label',
-				schemaId: 'some-schema-id',
+				schemaName: 'some-schema-id',
 				statements: []
 			)
 		);
@@ -122,7 +122,7 @@ class CreateSubjectActionTest extends TestCase {
 				pageId: 145345,
 				isMainSubject: true,
 				label: 'Some Label',
-				schemaId: '00000000-8888-0000-0000-000000000022',
+				schemaName: '00000000-8888-0000-0000-000000000022',
 				statements: [
 					'Has product' => [
 						'propertyType' => 'relation',

--- a/tests/phpunit/Application/Queries/GetSubject/GetSubjectQueryTest.php
+++ b/tests/phpunit/Application/Queries/GetSubject/GetSubjectQueryTest.php
@@ -39,7 +39,7 @@ class GetSubjectQueryTest extends TestCase {
 				TestSubject::build(
 					id: 's11111111111129',
 					label: new SubjectLabel( 'expected label' ),
-					schemaId: new SchemaName( 'GetSubjectQueryTestSchema' ),
+					schemaName: new SchemaName( 'GetSubjectQueryTestSchema' ),
 					statements: new StatementList( [
 						TestStatement::build( 'expected property 1', 'expected value 1' ),
 						TestStatement::build( 'expected property 2', value: new NumberValue( 2 ), propertyType: 'number' ),
@@ -71,7 +71,7 @@ class GetSubjectQueryTest extends TestCase {
 					's11111111111129' => new GetSubjectResponseItem(
 						id: 's11111111111129',
 						label: 'expected label',
-						schemaId: 'GetSubjectQueryTestSchema',
+						schemaName: 'GetSubjectQueryTestSchema',
 						statements: [
 							'expected property 1' => [
 								'type' => 'text',
@@ -165,12 +165,12 @@ class GetSubjectQueryTest extends TestCase {
 
 	public function testIncludeReferencedSubjects(): void {
 		$spyPresenter = $this->getSpyPresenter();
-		$schemaId = new SchemaName( 'GetSubjectQueryTest' );
+		$schemaName = new SchemaName( 'GetSubjectQueryTest' );
 
 		$subject = TestSubject::build(
 			id: 's11111111111132',
 			label: new SubjectLabel( 'requested subject' ),
-			schemaId: $schemaId,
+			schemaName: $schemaName,
 			statements: new StatementList( [
 				TestStatement::build(
 					'FriendOf',

--- a/tests/phpunit/Data/TestSubject.php
+++ b/tests/phpunit/Data/TestSubject.php
@@ -20,13 +20,13 @@ class TestSubject {
 	public static function build(
 		string|SubjectId $id = self::ZERO_GUID,
 		SubjectLabel|string $label = 'Test subject',
-		?SchemaName $schemaId = null,
+		?SchemaName $schemaName = null,
 		?StatementList $statements = null,
 	): Subject {
 		return new Subject(
 			id: $id instanceof SubjectId ? $id : new SubjectId( $id ),
 			label: $label instanceof SubjectLabel ? $label : new SubjectLabel( $label ),
-			schemaId: $schemaId ?? new SchemaName( self::DEFAULT_SCHEMA_ID ),
+			schemaName: $schemaName ?? new SchemaName( self::DEFAULT_SCHEMA_ID ),
 			statements: $statements ?? new StatementList( [] ),
 		);
 	}

--- a/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
@@ -43,7 +43,7 @@ class CreateSubjectApiTest extends NeoWikiIntegrationTestCase {
 		$subject = NeoWikiExtension::getInstance()->newSubjectRepository()->getSubject( new SubjectId( $responseData['subjectId'] ) );
 
 		$this->assertSame( 'Test subject', $subject->label->text );
-		$this->assertSame( 'Employee', $subject->getSchemaId()->getText() );
+		$this->assertSame( 'Employee', $subject->getSchemaName()->getText() );
 		$this->assertEquals(
 			new StatementList( [
 				TestStatement::build( property: 'animal', value: 'bunny' ),

--- a/tests/phpunit/EntryPoints/REST/GetSchemaApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/GetSchemaApiTest.php
@@ -17,7 +17,7 @@ use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
 class GetSchemaApiTest extends NeoWikiIntegrationTestCase {
 	use HandlerTestTrait;
 
-	private SchemaName $schemaId;
+	private SchemaName $schemaName;
 	private const SCHEMA_ID = 'TestSchema';
 
 	public function setUp(): void {

--- a/tests/phpunit/EntryPoints/REST/GetSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/GetSubjectApiTest.php
@@ -50,7 +50,7 @@ JSON
 			mainSubject: TestSubject::build(
 				id: 'sTestGSA1111114',
 				label: new SubjectLabel( 'Test subject sTestGSA1111114' ),
-				schemaId: new SchemaName( 'GetSubjectApiTestSchema' )
+				schemaName: new SchemaName( 'GetSubjectApiTestSchema' )
 			)
 		);
 
@@ -106,7 +106,7 @@ JSON,
 			'GetSubjectApiTest0000',
 			mainSubject: TestSubject::build(
 				id: 'sTestGSA1111111',
-				schemaId: new SchemaName( 'GetSubjectApiTestSchema' ),
+				schemaName: new SchemaName( 'GetSubjectApiTestSchema' ),
 				statements: new StatementList( [
 					TestStatement::buildRelation(
 						'MyRelation',
@@ -120,7 +120,7 @@ JSON,
 			childSubjects: new SubjectMap(
 				TestSubject::build(
 					id: 'sTestGSA1111112',
-					schemaId: new SchemaName( 'GetSubjectApiTestSchema' ),
+					schemaName: new SchemaName( 'GetSubjectApiTestSchema' ),
 				)
 			)
 		)->getPage()->getId();
@@ -129,7 +129,7 @@ JSON,
 			'GetSubjectApiTest0002',
 			mainSubject: TestSubject::build(
 				id: 'sTestGSA1111113',
-				schemaId: new SchemaName( 'GetSubjectApiTestSchema' ),
+				schemaName: new SchemaName( 'GetSubjectApiTestSchema' ),
 				statements: new StatementList( [
 					TestStatement::buildRelation(
 						'MyRelation',

--- a/tests/phpunit/Persistence/MediaWiki/Subject/SubjectContentDataSerializerTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/Subject/SubjectContentDataSerializerTest.php
@@ -173,7 +173,7 @@ class SubjectContentDataSerializerTest extends TestCase {
 			mainSubject: TestSubject::build(
 				id: 'sTestSCDST11112',
 				label: new SubjectLabel( 'Test subject 112' ),
-				schemaId: new SchemaName( 'Employee' ),
+				schemaName: new SchemaName( 'Employee' ),
 				statements: new StatementList( [
 					new Statement(
 						property: new PropertyName( 'founded' ),

--- a/tests/phpunit/Persistence/Neo4j/Neo4jQueryStoreTest.php
+++ b/tests/phpunit/Persistence/Neo4j/Neo4jQueryStoreTest.php
@@ -256,10 +256,10 @@ class Neo4jQueryStoreTest extends NeoWikiIntegrationTestCase {
 
 		$store->savePage( TestPage::build(
 			id: 42,
-			mainSubject: TestSubject::build( id: self::GUID_1, schemaId: new SchemaName( self::SCHEMA_ID_A ) ),
+			mainSubject: TestSubject::build( id: self::GUID_1, schemaName: new SchemaName( self::SCHEMA_ID_A ) ),
 			childSubjects: new SubjectMap(
-				TestSubject::build( id: self::GUID_2, schemaId: new SchemaName( TestSubject::DEFAULT_SCHEMA_ID ) ),
-				TestSubject::build( id: self::GUID_3, schemaId: new SchemaName( self::SCHEMA_ID_Z ) ),
+				TestSubject::build( id: self::GUID_2, schemaName: new SchemaName( TestSubject::DEFAULT_SCHEMA_ID ) ),
+				TestSubject::build( id: self::GUID_3, schemaName: new SchemaName( self::SCHEMA_ID_Z ) ),
 			)
 		) );
 
@@ -350,20 +350,20 @@ class Neo4jQueryStoreTest extends NeoWikiIntegrationTestCase {
 
 		$store->savePage( TestPage::build(
 			id: 42,
-			mainSubject: TestSubject::build( id: self::GUID_1, schemaId: new SchemaName( self::SCHEMA_ID_A ) ),
+			mainSubject: TestSubject::build( id: self::GUID_1, schemaName: new SchemaName( self::SCHEMA_ID_A ) ),
 			childSubjects: new SubjectMap(
-				TestSubject::build( id: self::GUID_2, schemaId: new SchemaName( TestSubject::DEFAULT_SCHEMA_ID ) ),
-				TestSubject::build( id: self::GUID_3, schemaId: new SchemaName( self::SCHEMA_ID_Z ) ),
+				TestSubject::build( id: self::GUID_2, schemaName: new SchemaName( TestSubject::DEFAULT_SCHEMA_ID ) ),
+				TestSubject::build( id: self::GUID_3, schemaName: new SchemaName( self::SCHEMA_ID_Z ) ),
 			)
 		) );
 
 		$store->savePage( TestPage::build(
 			id: 42,
-			mainSubject: TestSubject::build( id: self::GUID_1, schemaId: new SchemaName( self::SCHEMA_ID_A ) ),
+			mainSubject: TestSubject::build( id: self::GUID_1, schemaName: new SchemaName( self::SCHEMA_ID_A ) ),
 			childSubjects: new SubjectMap(
-				TestSubject::build( id: self::GUID_2, schemaId: new SchemaName( TestSubject::DEFAULT_SCHEMA_ID ) ),
-				TestSubject::build( id: self::GUID_3, schemaId: new SchemaName( self::SCHEMA_ID_Z ) ),
-				TestSubject::build( id: self::GUID_4, schemaId: new SchemaName( TestSubject::DEFAULT_SCHEMA_ID ) ),
+				TestSubject::build( id: self::GUID_2, schemaName: new SchemaName( TestSubject::DEFAULT_SCHEMA_ID ) ),
+				TestSubject::build( id: self::GUID_3, schemaName: new SchemaName( self::SCHEMA_ID_Z ) ),
+				TestSubject::build( id: self::GUID_4, schemaName: new SchemaName( TestSubject::DEFAULT_SCHEMA_ID ) ),
 			)
 		) );
 

--- a/tests/phpunit/Persistence/Neo4j/Neo4jSubjectLabelLookupTest.php
+++ b/tests/phpunit/Persistence/Neo4j/Neo4jSubjectLabelLookupTest.php
@@ -92,9 +92,9 @@ class Neo4jSubjectLabelLookupTest extends NeoWikiIntegrationTestCase {
 
 	public function testFiltersBySchema(): void {
 		$this->saveSubjects( new SubjectMap(
-			TestSubject::build( id: 'sTestSLL1111116', label: new SubjectLabel( 'Apple Pie' ), schemaId: new SchemaName( 'Recipe' ) ),
-			TestSubject::build( id: 'sTestSLL1111117', label: new SubjectLabel( 'Apple Tree' ), schemaId: new SchemaName( 'Plant' ) ),
-			TestSubject::build( id: 'sTestSLL1111118', label: new SubjectLabel( 'Apple Inc.' ), schemaId: new SchemaName( 'Company' ) ),
+			TestSubject::build( id: 'sTestSLL1111116', label: new SubjectLabel( 'Apple Pie' ), schemaName: new SchemaName( 'Recipe' ) ),
+			TestSubject::build( id: 'sTestSLL1111117', label: new SubjectLabel( 'Apple Tree' ), schemaName: new SchemaName( 'Plant' ) ),
+			TestSubject::build( id: 'sTestSLL1111118', label: new SubjectLabel( 'Apple Inc.' ), schemaName: new SchemaName( 'Company' ) ),
 		) );
 
 		$results = $this->newLookup()->getSubjectLabelsMatching( 'Apple', 10, 'Recipe' );
@@ -105,7 +105,7 @@ class Neo4jSubjectLabelLookupTest extends NeoWikiIntegrationTestCase {
 
 	public function testDoesNotReturnSubjectsFromOtherSchemas(): void {
 		$this->saveSubjects( new SubjectMap(
-			TestSubject::build( id: 'sTestSLL1111119', label: new SubjectLabel( 'Apple Tree' ), schemaId: new SchemaName( 'Plant' ) ),
+			TestSubject::build( id: 'sTestSLL1111119', label: new SubjectLabel( 'Apple Tree' ), schemaName: new SchemaName( 'Plant' ) ),
 		) );
 
 		$this->assertSame( [], $this->newLookup()->getSubjectLabelsMatching( 'Apple', 10, 'Recipe' ) );

--- a/tests/phpunit/TestDoubles/InMemorySchemaLookup.php
+++ b/tests/phpunit/TestDoubles/InMemorySchemaLookup.php
@@ -19,8 +19,8 @@ class InMemorySchemaLookup implements SchemaLookup {
 		array_walk( $schemas, $this->updateSchema( ... ) );
 	}
 
-	public function getSchema( SchemaName $schemaId ): ?Schema {
-		return $this->schemas[$schemaId->getText()] ?? null;
+	public function getSchema( SchemaName $schemaName ): ?Schema {
+		return $this->schemas[$schemaName->getText()] ?? null;
 	}
 
 	public function updateSchema( Schema $schema ): void {


### PR DESCRIPTION
This fixes inconsistency. We already have schemaName in bunch of places, but some older code still had schemaId.

## Summary
- Rename `schemaId` to `schemaName` in PHP and TypeScript code
- The type is `SchemaName` and ADR 017 decided that names are the identifiers for schemas
- Standardizes variable/field/method names to match the type and domain language
- TS domain code already used `schemaName`; this aligns PHP and TS test helpers

## Test plan
- [x] PHPUnit tests pass
- [x] Vitest tests pass
- [x] phpcs + phpstan pass
- [x] TS lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)