### PR TITLE
Fix Neo4j casing in Neo4JPageIdentifiersLookup

### DIFF
--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -51,7 +51,7 @@ use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\StatementDeserializer
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\SubjectContentDataDeserializer;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\SubjectContentRepository;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\WikiPageSchemaLookup;
-use ProfessionalWiki\NeoWiki\Persistence\Neo4j\Neo4JPageIdentifiersLookup;
+use ProfessionalWiki\NeoWiki\Persistence\Neo4j\Neo4jPageIdentifiersLookup;
 use ProfessionalWiki\NeoWiki\Persistence\Neo4j\Neo4jQueryStore;
 use ProfessionalWiki\NeoWiki\Persistence\Neo4j\Neo4jSubjectLabelLookup;
 use ProfessionalWiki\NeoWiki\Persistence\Neo4j\SubjectUpdaterFactory;
@@ -250,7 +250,7 @@ class NeoWikiExtension {
 	}
 
 	private function getPageIdentifiersLookup(): PageIdentifiersLookup {
-		return new Neo4JPageIdentifiersLookup( $this->getReadOnlyNeo4jClient() );
+		return new Neo4jPageIdentifiersLookup( $this->getReadOnlyNeo4jClient() );
 	}
 
 	public function newDeleteSubjectAction( Authority $authority ): DeleteSubjectAction {

--- a/src/Persistence/Neo4j/Neo4jPageIdentifiersLookup.php
+++ b/src/Persistence/Neo4j/Neo4jPageIdentifiersLookup.php
@@ -12,7 +12,7 @@ use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageIdentifiers;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 
-class Neo4JPageIdentifiersLookup implements PageIdentifiersLookup {
+class Neo4jPageIdentifiersLookup implements PageIdentifiersLookup {
 
 	public function __construct(
 		private ClientInterface $client,

--- a/tests/phpunit/Persistence/MediaWiki/Subject/MediaWikiSubjectRepositoryTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/Subject/MediaWikiSubjectRepositoryTest.php
@@ -16,7 +16,7 @@ use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\MediaWikiSubjectRepository
- * @covers \ProfessionalWiki\NeoWiki\Persistence\Neo4j\Neo4JPageIdentifiersLookup
+ * @covers \ProfessionalWiki\NeoWiki\Persistence\Neo4j\Neo4jPageIdentifiersLookup
  * @group Database
  */
 class MediaWikiSubjectRepositoryTest extends NeoWikiIntegrationTestCase {

--- a/tests/phpunit/Persistence/Neo4j/Neo4jPageIdentifiersLookupTest.php
+++ b/tests/phpunit/Persistence/Neo4j/Neo4jPageIdentifiersLookupTest.php
@@ -10,7 +10,7 @@ use ProfessionalWiki\NeoWiki\Domain\Page\PageIdentifiers;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectMap;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
-use ProfessionalWiki\NeoWiki\Persistence\Neo4j\Neo4JPageIdentifiersLookup;
+use ProfessionalWiki\NeoWiki\Persistence\Neo4j\Neo4jPageIdentifiersLookup;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestPage;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestPageProperties;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSchema;
@@ -19,9 +19,9 @@ use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySchemaLookup;
 
 /**
- * @covers \ProfessionalWiki\NeoWiki\Persistence\Neo4j\Neo4JPageIdentifiersLookup
+ * @covers \ProfessionalWiki\NeoWiki\Persistence\Neo4j\Neo4jPageIdentifiersLookup
  */
-class Neo4JPageIdentifiersLookupTest extends NeoWikiIntegrationTestCase {
+class Neo4jPageIdentifiersLookupTest extends NeoWikiIntegrationTestCase {
 
 	private const string GUID_1 = 'sTestNPL1111111';
 	private const string GUID_2 = 'sTestNPL1111112';
@@ -38,8 +38,8 @@ class Neo4JPageIdentifiersLookupTest extends NeoWikiIntegrationTestCase {
 		$this->assertNull( $this->newLookup()->getPageIdOfSubject( new SubjectId( self::GUID_404 ) ) );
 	}
 
-	private function newLookup( ClientInterface $client = null ): Neo4JPageIdentifiersLookup {
-		return new Neo4JPageIdentifiersLookup(
+	private function newLookup( ClientInterface $client = null ): Neo4jPageIdentifiersLookup {
+		return new Neo4jPageIdentifiersLookup(
 			client: $client ?? $this->getClient()
 		);
 	}


### PR DESCRIPTION
## Summary
- Rename `Neo4JPageIdentifiersLookup` to `Neo4jPageIdentifiersLookup`
- All other Neo4j classes use lowercase j; this was the only inconsistency

## Test plan
- [ ] PHPUnit tests pass
- [ ] phpcs + phpstan pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)