### PR TITLE
Rename SubjectActionAuthorizer to match interface

### DIFF
--- a/src/Application/Actions/CreateSubject/CreateSubjectAction.php
+++ b/src/Application/Actions/CreateSubject/CreateSubjectAction.php
@@ -21,14 +21,14 @@ readonly class CreateSubjectAction {
 		private CreateSubjectPresenter $presenter,
 		private SubjectRepository $subjectRepository,
 		private IdGenerator $guidGenerator,
-		private SubjectAuthorizer $subjectActionAuthorizer,
+		private SubjectAuthorizer $subjectAuthorizer,
 		private StatementListPatcher $statementListPatcher,
 	) {
 	}
 
 	public function createSubject( CreateSubjectRequest $request ): void {
-		if ( ( $request->isMainSubject && !$this->subjectActionAuthorizer->canCreateMainSubject(
-				) ) || !$this->subjectActionAuthorizer->canCreateChildSubject() ) {
+		if ( ( $request->isMainSubject && !$this->subjectAuthorizer->canCreateMainSubject(
+				) ) || !$this->subjectAuthorizer->canCreateChildSubject() ) {
 			throw new \RuntimeException( 'You do not have the necessary permissions to create this subject' );
 		}
 

--- a/src/Application/Actions/DeleteSubject/DeleteSubjectAction.php
+++ b/src/Application/Actions/DeleteSubject/DeleteSubjectAction.php
@@ -12,12 +12,12 @@ readonly class DeleteSubjectAction {
 
 	public function __construct(
 		private SubjectRepository $subjectRepository,
-		private SubjectAuthorizer $subjectActionAuthorizer
+		private SubjectAuthorizer $subjectAuthorizer
 	) {
 	}
 
 	public function deleteSubject( SubjectId $subjectId ): void {
-		if ( !$this->subjectActionAuthorizer->canDeleteSubject() ) {
+		if ( !$this->subjectAuthorizer->canDeleteSubject() ) {
 			throw new \RuntimeException( 'You do not have the necessary permissions to delete this subject' );
 		}
 

--- a/src/Application/Actions/PatchSubject/PatchSubjectAction.php
+++ b/src/Application/Actions/PatchSubject/PatchSubjectAction.php
@@ -15,7 +15,7 @@ readonly class PatchSubjectAction {
 
 	public function __construct(
 		private SubjectRepository $subjectRepository,
-		private SubjectAuthorizer $subjectActionAuthorizer,
+		private SubjectAuthorizer $subjectAuthorizer,
 		private StatementListPatcher $patcher
 	) {
 	}
@@ -29,7 +29,7 @@ readonly class PatchSubjectAction {
 	 * @param array<string, mixed> $patch
 	 */
 	public function patch( SubjectId $subjectId, ?string $label, array $patch, ?string $comment = null ): void {
-		if ( !$this->subjectActionAuthorizer->canEditSubject() ) {
+		if ( !$this->subjectAuthorizer->canEditSubject() ) {
 			throw new RuntimeException( 'You do not have the necessary permissions to edit this subject' );
 		}
 

--- a/src/Infrastructure/AuthorityBasedSubjectAuthorizer.php
+++ b/src/Infrastructure/AuthorityBasedSubjectAuthorizer.php
@@ -7,7 +7,7 @@ namespace ProfessionalWiki\NeoWiki\Infrastructure;
 use MediaWiki\Permissions\Authority;
 use ProfessionalWiki\NeoWiki\Application\SubjectAuthorizer;
 
-class AuthorityBasedSubjectActionAuthorizer implements SubjectAuthorizer {
+class AuthorityBasedSubjectAuthorizer implements SubjectAuthorizer {
 
 	public function __construct(
 		private Authority $authority

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -41,7 +41,7 @@ use ProfessionalWiki\NeoWiki\EntryPoints\REST\GetSchemaNamesApi;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\GetSubjectLabelsApi;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\GetSubjectApi;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\PatchSubjectApi;
-use ProfessionalWiki\NeoWiki\Infrastructure\AuthorityBasedSubjectActionAuthorizer;
+use ProfessionalWiki\NeoWiki\Infrastructure\AuthorityBasedSubjectAuthorizer;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\DatabaseSchemaNameLookup;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\PageContentFetcher;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\PageContentSaver;
@@ -216,7 +216,7 @@ class NeoWikiExtension {
 			presenter: $presenter,
 			subjectRepository: $this->getSubjectRepository(),
 			guidGenerator: $this->getIdGenerator(),
-			subjectActionAuthorizer: $this->newSubjectAuthorizer( $authority ),
+			subjectAuthorizer: $this->newSubjectAuthorizer( $authority ),
 			statementListPatcher: $this->getStatementListPatcher()
 		);
 	}
@@ -256,12 +256,12 @@ class NeoWikiExtension {
 	public function newDeleteSubjectAction( Authority $authority ): DeleteSubjectAction {
 		return new DeleteSubjectAction(
 			subjectRepository: $this->getSubjectRepository(),
-			subjectActionAuthorizer: $this->newSubjectAuthorizer( $authority )
+			subjectAuthorizer: $this->newSubjectAuthorizer( $authority )
 		);
 	}
 
 	public function newSubjectAuthorizer( Authority $authority ): SubjectAuthorizer {
-		return new AuthorityBasedSubjectActionAuthorizer(
+		return new AuthorityBasedSubjectAuthorizer(
 			authority: $authority
 		);
 	}
@@ -329,7 +329,7 @@ class NeoWikiExtension {
 	public function newPatchSubjectAction( Authority $authority ): PatchSubjectAction {
 		return new PatchSubjectAction(
 			subjectRepository: $this->getSubjectRepository(),
-			subjectActionAuthorizer: $this->newSubjectAuthorizer( $authority ),
+			subjectAuthorizer: $this->newSubjectAuthorizer( $authority ),
 			patcher: $this->getStatementListPatcher()
 		);
 	}


### PR DESCRIPTION
## Summary
- Rename `AuthorityBasedSubjectActionAuthorizer` to `AuthorityBasedSubjectAuthorizer`
- Rename `$subjectActionAuthorizer` to `$subjectAuthorizer`
- Aligns implementation and variable names with the `SubjectAuthorizer` interface

## Test plan
- [ ] PHPUnit tests pass
- [ ] phpcs + phpstan pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)