### PR TITLE
Rename guidGenerator to idGenerator

### DIFF
--- a/src/Application/Actions/CreateSubject/CreateSubjectAction.php
+++ b/src/Application/Actions/CreateSubject/CreateSubjectAction.php
@@ -20,7 +20,7 @@ readonly class CreateSubjectAction {
 	public function __construct(
 		private CreateSubjectPresenter $presenter,
 		private SubjectRepository $subjectRepository,
-		private IdGenerator $guidGenerator,
+		private IdGenerator $idGenerator,
 		private SubjectAuthorizer $subjectAuthorizer,
 		private StatementListPatcher $statementListPatcher,
 	) {
@@ -54,7 +54,7 @@ readonly class CreateSubjectAction {
 
 	private function buildSubject( CreateSubjectRequest $request ): Subject {
 		return Subject::createNew(
-			guidGenerator: $this->guidGenerator,
+			idGenerator: $this->idGenerator,
 			label: new SubjectLabel( $request->label ),
 			schemaId: new SchemaName( $request->schemaId ),
 			statements: $this->statementListPatcher->buildStatementList(

--- a/src/Domain/Subject/Subject.php
+++ b/src/Domain/Subject/Subject.php
@@ -21,13 +21,13 @@ class Subject {
 	}
 
 	public static function createNew(
-		IdGenerator $guidGenerator,
+		IdGenerator $idGenerator,
 		SubjectLabel $label,
 		SchemaName $schemaId,
 		?StatementList $statements = null,
 	): self {
 		return new self(
-			id: SubjectId::createNew( $guidGenerator ),
+			id: SubjectId::createNew( $idGenerator ),
 			label: $label,
 			schemaId: $schemaId,
 			statements: $statements ?? new StatementList( [] ),

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -215,7 +215,7 @@ class NeoWikiExtension {
 		return new CreateSubjectAction(
 			presenter: $presenter,
 			subjectRepository: $this->getSubjectRepository(),
-			guidGenerator: $this->getIdGenerator(),
+			idGenerator: $this->getIdGenerator(),
 			subjectAuthorizer: $this->newSubjectAuthorizer( $authority ),
 			statementListPatcher: $this->getStatementListPatcher()
 		);


### PR DESCRIPTION
The `IdGenerator` interface replaced the old UUID-based `GuidGenerator` (ADR 014), but 3 PHP files still used the old `$guidGenerator` parameter name. This renames them to `$idGenerator` for consistency.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>