### PR TITLE
Use more accurate terms for property definition in UI messages

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -58,8 +58,8 @@
 	"neowiki-subject-editor-title": "Editing $1",
 	"neowiki-subject-editor-save": "Save changes",
 
-	"neowiki-schema-editor-new-property": "Add new property",
-	"neowiki-schema-editor-delete-property": "Delete property",
+	"neowiki-schema-editor-new-property": "Add property definition",
+	"neowiki-schema-editor-delete-property": "Delete property definition",
 	"neowiki-schema-editor-optional": "Optional",
 	"neowiki-schema-editor-description": "Description",
 

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -24,6 +24,8 @@
 	"neowiki-schema-editor-summary-default": "Default edit summary used when updating a schema via the UI.",
 	"neowiki-schema-editor-success": "Success notification shown after updating a schema. $1 is the schema name.",
 	"neowiki-schema-editor-error": "Error notification title shown when updating a schema fails. $1 is the schema name.",
+	"neowiki-schema-editor-new-property": "Label for the button that adds a new property definition in the schema editor. Translations can only exceed the English length a little bit.",
+	"neowiki-schema-editor-delete-property": "Aria label for the button that deletes a property definition in the schema editor.",
 	"neowiki-schema-editor-description": "Label for the description field in the schema editor.",
 
 	"neowiki-subject-editor-summary-default": "Default edit summary used when updating a subject via the UI.",


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/552

- `neowiki-schema-editor-new-property`: "Add new property" → "Add new property definition"
- `neowiki-schema-editor-delete-property`: "Delete property" → "Delete property definition"
- Added missing qqq.json documentation for both messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)