### PR TITLE
Remove focus ring from edit button after closing schema editor

### DIFF
--- a/resources/ext.neowiki/src/components/SchemaDisplay/SchemaDisplay.vue
+++ b/resources/ext.neowiki/src/components/SchemaDisplay/SchemaDisplay.vue
@@ -52,13 +52,13 @@
 			:initial-schema="currentSchema"
 			:on-save="handleSaveSchema"
 			@saved="onSchemaSaved"
-			@update:open="isEditorOpen = $event"
+			@update:open="onEditorOpenChange"
 		/>
 	</div>
 </template>
 
 <script setup lang="ts">
-import { computed, shallowRef, watch } from 'vue';
+import { computed, nextTick, shallowRef, watch } from 'vue';
 import { Schema } from '@/domain/Schema.ts';
 import { NeoWikiServices } from '@/NeoWikiServices.ts';
 import { CdxTable, CdxInfoChip } from '@wikimedia/codex';
@@ -125,6 +125,16 @@ function getTypeLabel( propertyType: string ): string {
 
 const handleSaveSchema = async ( updatedSchema: Schema, comment: string ): Promise<void> => {
 	await schemaStore.saveSchema( updatedSchema, comment );
+};
+
+const onEditorOpenChange = ( value: boolean ): void => {
+	isEditorOpen.value = value;
+
+	if ( !value ) {
+		nextTick( () => {
+			( document.activeElement as HTMLElement )?.blur?.();
+		} );
+	}
 };
 
 const onSchemaSaved = ( schema: Schema ): void => {

--- a/resources/ext.neowiki/tests/components/SchemaDisplay/SchemaDisplay.spec.ts
+++ b/resources/ext.neowiki/tests/components/SchemaDisplay/SchemaDisplay.spec.ts
@@ -1,4 +1,4 @@
-import { mount, VueWrapper } from '@vue/test-utils';
+import { mount, VueWrapper, flushPromises } from '@vue/test-utils';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { createPinia, setActivePinia } from 'pinia';
 import { ref } from 'vue';
@@ -136,5 +136,20 @@ describe( 'SchemaDisplay', () => {
 		await wrapper.findComponent( SchemaDisplayHeader ).vm.$emit( 'edit' );
 
 		expect( wrapper.findComponent( SchemaEditorDialog ).props( 'open' ) ).toBe( true );
+	} );
+
+	it( 'blurs active element when dialog closes', async () => {
+		canEditSchemaRef.value = true;
+
+		const wrapper = mountComponent( newSchema() );
+		await wrapper.findComponent( SchemaDisplayHeader ).vm.$emit( 'edit' );
+
+		const blurSpy = vi.fn();
+		vi.spyOn( document, 'activeElement', 'get' ).mockReturnValue( { blur: blurSpy } as unknown as Element );
+
+		await wrapper.findComponent( SchemaEditorDialog ).vm.$emit( 'update:open', false );
+		await flushPromises();
+
+		expect( blurSpy ).toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
## Summary

- When closing the schema editor dialog, CdxDialog restores focus to the edit button, leaving a visible focus ring (blue border)
- Blur the active element via `nextTick` after the dialog closes to remove it

## Test plan

- [ ] Open a Schema page, click the edit icon to open the schema editor
- [ ] Close the editor (via close button or save)
- [ ] Verify the edit icon no longer has a blue border/focus ring

🤖 Generated with [Claude Code](https://claude.com/claude-code)