### PR TITLE
Hide Edit Subject button on old page revisions

### DIFF
--- a/resources/ext.neowiki/src/components/NeoWikiApp.vue
+++ b/resources/ext.neowiki/src/components/NeoWikiApp.vue
@@ -41,6 +41,10 @@ const viewsData = ref<ViewData[]>( [] );
 const shouldShowSubjectCreator = ref( props.showSubjectCreator );
 const subjectAuthorizer = NeoWikiServices.getSubjectAuthorizer();
 
+function isLatestRevision(): boolean {
+	return mw.config.get( 'wgRevisionId' ) === mw.config.get( 'wgCurRevisionId' );
+}
+
 onMounted( async (): Promise<void> => {
 	const localViewsData = await getViewsData( document.querySelectorAll( '.ext-neowiki-view' ) );
 
@@ -75,7 +79,7 @@ async function getViewData( element: HTMLElement ): Promise<ViewData|null> {
 			id: subjectId.text,
 			element: element,
 			subjectId: subjectId,
-			canEditSubject: await subjectAuthorizer.canEditSubject( subjectId )
+			canEditSubject: isLatestRevision() && await subjectAuthorizer.canEditSubject( subjectId )
 		};
 	} catch ( error ) {
 		console.error( error );


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/538

## Summary

- Check `wgRevisionId` against `wgCurRevisionId` before showing the Edit Subject button
- Also skips the authorization API call on old revisions via short-circuit evaluation
- The Create Subject button was already hidden via a server-side check in `NeoWikiHooks::pageIsLatestRevision()`

## Test plan

- [x] Navigate to a content page with a Subject and verify the edit button is visible
- [x] Navigate to an old revision of that page via `?oldid=` and verify the edit button is hidden
- [x] Verify the Create Subject button is also hidden on old revisions of pages without subjects

🤖 Generated with [Claude Code](https://claude.com/claude-code)