### PR TITLE
Add dynamic subtitle and button text to SubjectCreator dialog

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -270,6 +270,8 @@
 				"neowiki-subject-creator-schema-created",
 				"neowiki-subject-creator-schema-name-required",
 				"neowiki-subject-creator-schema-name-taken",
+				"neowiki-subject-creator-save-with-schema",
+				"neowiki-subject-creator-creating-schema",
 				"neowiki-edit-schema",
 				"neowiki-schema-editor-summary-default",
 				"neowiki-schema-editor-success",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -72,6 +72,8 @@
 	"neowiki-subject-creator-label-field": "Subject label",
 	"neowiki-subject-creator-label-placeholder": "Enter a label for the subject",
 	"neowiki-subject-creator-save": "Create subject",
+	"neowiki-subject-creator-save-with-schema": "Create $1",
+	"neowiki-subject-creator-creating-schema": "Creating schema",
 	"neowiki-subject-creator-success": "Subject created successfully",
 	"neowiki-subject-creator-error": "Failed to create subject",
 	"neowiki-subject-creator-schema-name-field": "Schema name",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -14,6 +14,8 @@
 	"neowiki-cypher-raw-error-write-query": "Error message shown when a write query is rejected by the cypher_raw parser function.",
 	"neowiki-cypher-raw-error-query-failed": "Error message shown when Cypher query execution fails. $1 is the exception message.",
 	"neowiki-cypher-raw-error-json-encode": "Error message shown when JSON encoding of query results fails.",
+	"neowiki-subject-creator-save-with-schema": "Label for the save button in the subject creator dialog after a schema is selected. $1 is the schema name.",
+	"neowiki-subject-creator-creating-schema": "Subtitle shown in the subject creator dialog header when the user is creating a new schema.",
 	"neowiki-subject-creator-schema-name-field": "Label for the schema name input field in the subject creator dialog.",
 	"neowiki-subject-creator-schema-name-placeholder": "Placeholder text for the schema name input field.",
 	"neowiki-subject-creator-create-schema": "Label for the button that creates a new schema in the subject creator dialog.",

--- a/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
@@ -11,9 +11,32 @@
 			class="ext-neowiki-subject-creator-dialog"
 			:class="{ 'ext-neowiki-subject-creator-dialog--wide': selectedSchemaOption === 'new' && !selectedSchemaName }"
 			:title="$i18n( 'neowiki-subject-creator-title' ).text()"
-			:use-close-button="true"
 			@default="open = false"
 		>
+			<template #header>
+				<div class="cdx-dialog__header__title-group">
+					<h2 class="cdx-dialog__header__title">
+						{{ $i18n( 'neowiki-subject-creator-title' ).text() }}
+					</h2>
+
+					<p
+						v-if="headerSubtitle"
+						class="cdx-dialog__header__subtitle"
+					>
+						{{ headerSubtitle }}
+					</p>
+				</div>
+
+				<CdxButton
+					class="cdx-dialog__header__close-button"
+					weight="quiet"
+					type="button"
+					:aria-label="$i18n( 'cdx-dialog-close-button-label' ).text()"
+					@click="open = false"
+				>
+					<CdxIcon :icon="cdxIconClose" />
+				</CdxButton>
+			</template>
 			<template v-if="!selectedSchemaName">
 				<p>
 					{{ $i18n( 'neowiki-subject-creator-schema-title' ).text() }}
@@ -97,7 +120,7 @@
 			>
 				<EditSummary
 					help-text=""
-					:save-button-label="$i18n( 'neowiki-subject-creator-save' ).text()"
+					:save-button-label="$i18n( 'neowiki-subject-creator-save-with-schema', selectedSchemaName ).text()"
 					@save="handleSave"
 				/>
 			</template>
@@ -107,8 +130,8 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, nextTick, onMounted } from 'vue';
-import { CdxButton, CdxDialog, CdxField, CdxTextInput, CdxToggleButtonGroup } from '@wikimedia/codex';
-import { cdxIconSearch, cdxIconAdd } from '@wikimedia/codex-icons';
+import { CdxButton, CdxDialog, CdxField, CdxIcon, CdxTextInput, CdxToggleButtonGroup } from '@wikimedia/codex';
+import { cdxIconAdd, cdxIconClose, cdxIconSearch } from '@wikimedia/codex-icons';
 import type { ButtonGroupItem, ValidationStatusType } from '@wikimedia/codex';
 import { useSubjectStore } from '@/stores/SubjectStore.ts';
 import { useSchemaStore } from '@/stores/SchemaStore.ts';
@@ -146,6 +169,18 @@ interface SubjectEditorInstance {
 }
 
 const subjectEditorRef = ref<SubjectEditorInstance | null>( null );
+
+const headerSubtitle = computed( (): string | null => {
+	if ( selectedSchemaOption.value === 'new' && !selectedSchemaName.value ) {
+		return mw.msg( 'neowiki-subject-creator-creating-schema' );
+	}
+
+	if ( selectedSchemaName.value ) {
+		return mw.msg( 'neowiki-schema-label', selectedSchemaName.value );
+	}
+
+	return null;
+} );
 
 const schemaNameStatus = computed( (): ValidationStatusType =>
 	schemaNameError.value ? 'error' : 'default'
@@ -323,6 +358,17 @@ const handleSave = async ( _summary: string ): Promise<void> => {
 @import ( reference ) '@wikimedia/codex-design-tokens/theme-wikimedia-ui.less';
 
 .ext-neowiki-subject-creator {
+	&-dialog.cdx-dialog {
+		/* Replicate the Codex default dialog header styles */
+		.cdx-dialog__header {
+			display: flex;
+			align-items: baseline;
+			justify-content: flex-end;
+			box-sizing: @box-sizing-base;
+			width: @size-full;
+		}
+	}
+
 	&-dialog--wide.cdx-dialog {
 		max-width: @size-5600;
 	}


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/535

Instead of changing the dialog title per step, use a subtitle to indicate context while keeping "Creating subject" as the title throughout. Show "Creating schema" subtitle during schema creation, and "Schema: X" after selection. Update the save button to "Create (SchemaName)" after a schema is selected.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>


https://github.com/user-attachments/assets/93bcc41c-fc83-4a6e-8f1c-942fa9f7072d

