### PR TITLE
Remove unused inputMessages from RelationInput

### DIFF
--- a/resources/ext.neowiki/src/components/Value/RelationInput.vue
+++ b/resources/ext.neowiki/src/components/Value/RelationInput.vue
@@ -19,7 +19,6 @@
 			v-if="props.property.multiple"
 			:model-value="selectedIds"
 			:label="props.label"
-			:messages="inputMessages"
 			@update:model-value="onSelectionsChanged"
 		>
 			<template #input="{ value, onUpdate, onBlur, onFocus, status, ariaLabel }">
@@ -72,7 +71,6 @@ const emit = defineEmits<ValueInputEmits>();
 
 const internalValue = ref<RelationValue | undefined>( undefined );
 const fieldMessages = ref<ValidationMessages>( {} );
-const inputMessages = ref<ValidationMessages[]>( [] );
 const touched = ref( false );
 
 const displayedFieldMessages = computed( (): ValidationMessages => {


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/566

`inputMessages` was always an empty array — it was never populated after the refactor from `NeoMultiTextInput` to `SubjectLookup`, since the lookup only allows selecting valid subjects from a dropdown.

## Test plan

- [x] `make ts-test`, `make ts-lint`, `make ts-build` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)