### PR TITLE
Show validation error for unmatched text in SubjectLookup

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -289,6 +289,7 @@
 				"neowiki-subject-editor-error",
 				"neowiki-subject-lookup-placeholder",
 				"neowiki-subject-lookup-no-results",
+				"neowiki-subject-lookup-no-match",
 				"neowiki-schemas-column-name",
 				"neowiki-schemas-column-description",
 				"neowiki-schemas-column-properties",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -111,6 +111,7 @@
 
 	"neowiki-subject-lookup-placeholder": "Search for a subject",
 	"neowiki-subject-lookup-no-results": "No subjects found",
+	"neowiki-subject-lookup-no-match": "Please select a subject from the list.",
 
 	"neowiki-schemas-column-name": "Name",
 	"neowiki-schemas-column-description": "Description",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -38,6 +38,7 @@
 	"neowiki-subject-editor-error": "Error notification title shown when updating a subject fails. $1 is the subject label.",
 	"neowiki-subject-lookup-placeholder": "Placeholder text shown in the subject search input field.",
 	"neowiki-subject-lookup-no-results": "Message shown in the subject lookup dropdown when no subjects match the search query.",
+	"neowiki-subject-lookup-no-match": "Error message shown in the subject lookup when the user types text but does not select a subject from the dropdown results.",
 
 	"neowiki-schemas-column-name": "Column header for schema name in the schemas list table on [[Special:Schemas]].",
 	"neowiki-schemas-column-description": "Column header for schema description in the schemas list table on [[Special:Schemas]].",

--- a/resources/ext.neowiki/src/components/Value/RelationInput.vue
+++ b/resources/ext.neowiki/src/components/Value/RelationInput.vue
@@ -72,8 +72,12 @@ const emit = defineEmits<ValueInputEmits>();
 const internalValue = ref<RelationValue | undefined>( undefined );
 const fieldMessages = ref<ValidationMessages>( {} );
 const touched = ref( false );
+const singleHasUnmatchedText = ref( false );
 
 const displayedFieldMessages = computed( (): ValidationMessages => {
+	if ( singleHasUnmatchedText.value ) {
+		return {};
+	}
 	if ( props.property.multiple || touched.value ) {
 		return fieldMessages.value;
 	}
@@ -81,7 +85,7 @@ const displayedFieldMessages = computed( (): ValidationMessages => {
 } );
 
 const fieldStatus = computed( (): 'error' | 'default' => {
-	if ( props.property.multiple ) {
+	if ( props.property.multiple || singleHasUnmatchedText.value ) {
 		return 'default';
 	}
 	if ( touched.value && fieldMessages.value.error ) {
@@ -152,8 +156,9 @@ function onSingleSelectionChanged( id: string | null ): void {
 	emit( 'update:modelValue', newRelationValue );
 }
 
-function onSingleBlur(): void {
+function onSingleBlur( hasUnmatchedText: boolean ): void {
 	touched.value = true;
+	singleHasUnmatchedText.value = hasUnmatchedText;
 }
 
 function onSelectionsChanged( ids: ( string | null )[] ): void {

--- a/resources/ext.neowiki/tests/components/Value/RelationInput.spec.ts
+++ b/resources/ext.neowiki/tests/components/Value/RelationInput.spec.ts
@@ -132,7 +132,7 @@ describe( 'RelationInput', () => {
 				property: newRelationProperty( { required: true } ),
 			} );
 
-			wrapper.findComponent( SubjectLookup ).vm.$emit( 'blur' );
+			wrapper.findComponent( SubjectLookup ).vm.$emit( 'blur', false );
 			await wrapper.vm.$nextTick();
 
 			const field = wrapper.findComponent( CdxField );
@@ -148,10 +148,23 @@ describe( 'RelationInput', () => {
 
 			expect( lookup.props( 'status' ) ).toBe( 'default' );
 
-			lookup.vm.$emit( 'blur' );
+			lookup.vm.$emit( 'blur', false );
 			await wrapper.vm.$nextTick();
 
 			expect( lookup.props( 'status' ) ).toBe( 'error' );
+		} );
+
+		it( 'suppresses required error when SubjectLookup reports unmatched text', async () => {
+			const wrapper = newWrapper( {
+				property: newRelationProperty( { required: true } ),
+			} );
+
+			wrapper.findComponent( SubjectLookup ).vm.$emit( 'blur', true );
+			await wrapper.vm.$nextTick();
+
+			const field = wrapper.findComponent( CdxField );
+			expect( field.props( 'messages' ) ).toEqual( {} );
+			expect( field.props( 'status' ) ).toBe( 'default' );
 		} );
 	} );
 


### PR DESCRIPTION
## Summary

- When a user types text in a SubjectLookup but does not select a subject from the dropdown, an inline error message is shown after blur
- SubjectLookup owns this validation internally and reports it to the parent via the blur event
- RelationInput suppresses its own required-field error when SubjectLookup reports unmatched text, avoiding duplicate error messages

## Test plan

- [x] Edit a subject with a relation property, type text without selecting from dropdown, blur the field — error message appears
- [x] Select a subject from the dropdown — error clears
- [x] After error shows, type new text — error clears
- [x] Clear the input entirely — no error shown
- [x] Required relation field with unmatched text shows only the SubjectLookup error, not both errors

<img width="535" height="223" alt="image" src="https://github.com/user-attachments/assets/bbea4d7c-cfc9-4bfd-b5af-d164703d5d1c" />