### PR TITLE
Add close confirmation dialog for dialogs with unsaved changes

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -292,7 +292,11 @@
 				"neowiki-schemas-column-name",
 				"neowiki-schemas-column-description",
 				"neowiki-schemas-column-properties",
-				"neowiki-schemas-empty"
+				"neowiki-schemas-empty",
+				"neowiki-close-confirmation-title",
+				"neowiki-close-confirmation-message",
+				"neowiki-close-confirmation-discard",
+				"neowiki-close-confirmation-keep-editing"
 			],
 			"@group:": "TODO: Load code separately while in development. Remove later.",
 			"group": "ext.neowiki"

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -115,5 +115,10 @@
 	"neowiki-schemas-column-name": "Name",
 	"neowiki-schemas-column-description": "Description",
 	"neowiki-schemas-column-properties": "Properties",
-	"neowiki-schemas-empty": "No schemas have been created yet."
+	"neowiki-schemas-empty": "No schemas have been created yet.",
+
+	"neowiki-close-confirmation-title": "You have unsaved changes",
+	"neowiki-close-confirmation-message": "Are you sure you want to discard your unsaved changes?",
+	"neowiki-close-confirmation-discard": "Discard",
+	"neowiki-close-confirmation-keep-editing": "Keep editing"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -42,5 +42,10 @@
 	"neowiki-schemas-column-name": "Column header for schema name in the schemas list table on [[Special:Schemas]].",
 	"neowiki-schemas-column-description": "Column header for schema description in the schemas list table on [[Special:Schemas]].",
 	"neowiki-schemas-column-properties": "Column header for the number of property definitions in the schemas list table on [[Special:Schemas]].",
-	"neowiki-schemas-empty": "Message shown when no schemas exist yet on [[Special:Schemas]]."
+	"neowiki-schemas-empty": "Message shown when no schemas exist yet on [[Special:Schemas]].",
+
+	"neowiki-close-confirmation-title": "Title of the confirmation dialog shown when closing a dialog with unsaved changes.",
+	"neowiki-close-confirmation-message": "Message in the confirmation dialog asking the user to confirm discarding unsaved changes.",
+	"neowiki-close-confirmation-discard": "Label for the destructive button that discards unsaved changes and closes the dialog.",
+	"neowiki-close-confirmation-keep-editing": "Label for the button that dismisses the confirmation and returns to editing."
 }

--- a/resources/ext.neowiki/src/components/common/CloseConfirmationDialog.vue
+++ b/resources/ext.neowiki/src/components/common/CloseConfirmationDialog.vue
@@ -1,0 +1,57 @@
+<template>
+	<CdxDialog
+		:open="open"
+		:title="$i18n( 'neowiki-close-confirmation-title' ).text()"
+		@update:open="onUpdateOpen"
+	>
+		{{ $i18n( 'neowiki-close-confirmation-message' ).text() }}
+
+		<template #footer>
+			<div class="cdx-dialog__footer__actions">
+				<CdxButton
+					ref="discardButtonRef"
+					weight="primary"
+					action="destructive"
+					@click="$emit( 'discard' )"
+				>
+					{{ $i18n( 'neowiki-close-confirmation-discard' ).text() }}
+				</CdxButton>
+				<CdxButton
+					@click="$emit( 'keep-editing' )"
+				>
+					{{ $i18n( 'neowiki-close-confirmation-keep-editing' ).text() }}
+				</CdxButton>
+			</div>
+		</template>
+	</CdxDialog>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, nextTick } from 'vue';
+import { CdxButton, CdxDialog } from '@wikimedia/codex';
+
+const props = defineProps<{
+	open: boolean;
+}>();
+
+const emit = defineEmits<{
+	'discard': [];
+	'keep-editing': [];
+}>();
+
+const discardButtonRef = ref<InstanceType<typeof CdxButton> | null>( null );
+
+watch( () => props.open, async ( isOpen ) => {
+	if ( isOpen ) {
+		await nextTick();
+		await nextTick();
+		( discardButtonRef.value?.$el as HTMLElement | undefined )?.focus();
+	}
+} );
+
+function onUpdateOpen( value: boolean ): void {
+	if ( !value ) {
+		emit( 'keep-editing' );
+	}
+}
+</script>

--- a/resources/ext.neowiki/src/composables/useCloseConfirmation.ts
+++ b/resources/ext.neowiki/src/composables/useCloseConfirmation.ts
@@ -1,0 +1,36 @@
+import { ref, Ref } from 'vue';
+
+interface CloseConfirmation {
+	confirmationOpen: Ref<boolean>;
+	requestClose: () => void;
+	confirmClose: () => void;
+	cancelClose: () => void;
+}
+
+export function useCloseConfirmation( hasChanged: Ref<boolean>, close: () => void ): CloseConfirmation {
+	const confirmationOpen = ref( false );
+
+	function requestClose(): void {
+		if ( hasChanged.value ) {
+			confirmationOpen.value = true;
+		} else {
+			close();
+		}
+	}
+
+	function confirmClose(): void {
+		confirmationOpen.value = false;
+		close();
+	}
+
+	function cancelClose(): void {
+		confirmationOpen.value = false;
+	}
+
+	return {
+		confirmationOpen,
+		requestClose,
+		confirmClose,
+		cancelClose,
+	};
+}

--- a/resources/ext.neowiki/tests/components/Views/AutomaticInfobox.spec.ts
+++ b/resources/ext.neowiki/tests/components/Views/AutomaticInfobox.spec.ts
@@ -25,7 +25,7 @@ const $i18n = createI18nMock();
 
 describe( 'AutomaticInfobox', () => {
 	beforeEach( () => {
-		setupMwMock( { functions: [ 'message' ] } );
+		setupMwMock( { functions: [ 'message', 'msg' ] } );
 		( globalThis as any ).mw.util = {
 			getUrl: vi.fn( ( title: string ) => `/wiki/${ title }` ),
 		};

--- a/resources/ext.neowiki/tests/components/common/CloseConfirmationDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/common/CloseConfirmationDialog.spec.ts
@@ -1,0 +1,45 @@
+import { mount, VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it } from 'vitest';
+import CloseConfirmationDialog from '@/components/common/CloseConfirmationDialog.vue';
+import { CdxDialog } from '@wikimedia/codex';
+import { createI18nMock, setupMwMock } from '../../VueTestHelpers.ts';
+
+describe( 'CloseConfirmationDialog', () => {
+	beforeEach( () => {
+		setupMwMock( { functions: [ 'msg' ] } );
+	} );
+
+	function mountComponent(): VueWrapper {
+		return mount( CloseConfirmationDialog, {
+			props: { open: true },
+			global: {
+				mocks: { $i18n: createI18nMock() },
+				stubs: { teleport: true },
+			},
+		} );
+	}
+
+	it( 'emits discard when discard button is clicked', async () => {
+		const wrapper = mountComponent();
+
+		await wrapper.find( '.cdx-button--action-destructive' ).trigger( 'click' );
+
+		expect( wrapper.emitted( 'discard' ) ).toHaveLength( 1 );
+	} );
+
+	it( 'emits keep-editing when keep-editing button is clicked', async () => {
+		const wrapper = mountComponent();
+
+		await wrapper.find( '.cdx-button--action-default' ).trigger( 'click' );
+
+		expect( wrapper.emitted( 'keep-editing' ) ).toHaveLength( 1 );
+	} );
+
+	it( 'emits keep-editing on backdrop/escape dismiss', async () => {
+		const wrapper = mountComponent();
+
+		wrapper.findComponent( CdxDialog ).vm.$emit( 'update:open', false );
+
+		expect( wrapper.emitted( 'keep-editing' ) ).toHaveLength( 1 );
+	} );
+} );

--- a/resources/ext.neowiki/tests/composables/useCloseConfirmation.spec.ts
+++ b/resources/ext.neowiki/tests/composables/useCloseConfirmation.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ref } from 'vue';
+import { useCloseConfirmation } from '@/composables/useCloseConfirmation';
+
+describe( 'useCloseConfirmation', () => {
+
+	it( 'closes immediately when hasChanged is false', () => {
+		const close = vi.fn();
+		const { requestClose, confirmationOpen } = useCloseConfirmation( ref( false ), close );
+
+		requestClose();
+
+		expect( close ).toHaveBeenCalled();
+		expect( confirmationOpen.value ).toBe( false );
+	} );
+
+	it( 'opens confirmation when hasChanged is true', () => {
+		const close = vi.fn();
+		const { requestClose, confirmationOpen } = useCloseConfirmation( ref( true ), close );
+
+		requestClose();
+
+		expect( close ).not.toHaveBeenCalled();
+		expect( confirmationOpen.value ).toBe( true );
+	} );
+
+	it( 'closes and hides confirmation on confirmClose', () => {
+		const close = vi.fn();
+		const { requestClose, confirmClose, confirmationOpen } = useCloseConfirmation( ref( true ), close );
+
+		requestClose();
+		confirmClose();
+
+		expect( close ).toHaveBeenCalled();
+		expect( confirmationOpen.value ).toBe( false );
+	} );
+
+	it( 'hides confirmation without closing on cancelClose', () => {
+		const close = vi.fn();
+		const { requestClose, cancelClose, confirmationOpen } = useCloseConfirmation( ref( true ), close );
+
+		requestClose();
+		cancelClose();
+
+		expect( close ).not.toHaveBeenCalled();
+		expect( confirmationOpen.value ).toBe( false );
+	} );
+
+} );


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/520
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/564

When a user tries to close a dialog (via close button, backdrop click,
or Escape) after making changes, a confirmation dialog now asks whether
to discard or keep editing. Saving bypasses the confirmation.

Adds a `useCloseConfirmation` composable for the shared logic and a
`CloseConfirmationDialog` component for the UI. Integrates both into
SchemaEditorDialog, SubjectEditorDialog, and SubjectCreatorDialog.

_Written by Claude Code, Opus 4.6. Result of back and forth with @JeroenDeDauw.
Context: the NeoWiki codebase._

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>