### PR TITLE
Disable save button in editor dialogs when there are no changes

### DIFF
--- a/resources/ext.neowiki/src/components/SchemaEditor/SchemaEditorDialog.vue
+++ b/resources/ext.neowiki/src/components/SchemaEditor/SchemaEditorDialog.vue
@@ -19,6 +19,7 @@
 				<EditSummary
 					:help-text="$i18n( 'neowiki-edit-summary-help-text-schema' ).text()"
 					:save-button-label="$i18n( 'neowiki-save-schema' ).text()"
+					:save-disabled="!hasChanged"
 					@save="handleSave"
 				/>
 			</template>

--- a/resources/ext.neowiki/src/components/SchemasPage/SchemaCreatorDialog.vue
+++ b/resources/ext.neowiki/src/components/SchemasPage/SchemaCreatorDialog.vue
@@ -35,6 +35,7 @@
 				<EditSummary
 					help-text=""
 					:save-button-label="$i18n( 'neowiki-schema-creator-save' ).text()"
+					:save-disabled="!hasChanged"
 					@save="handleSave"
 				/>
 			</template>

--- a/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
@@ -115,6 +115,7 @@
 				<EditSummary
 					help-text=""
 					:save-button-label="$i18n( 'neowiki-subject-creator-create-schema' ).text()"
+					:save-disabled="!hasChanged"
 					@save="handleCreateSchema"
 				/>
 			</template>
@@ -125,6 +126,7 @@
 				<EditSummary
 					help-text=""
 					:save-button-label="$i18n( 'neowiki-subject-creator-save-with-schema', selectedSchemaName ).text()"
+					:save-disabled="!hasChanged"
 					@save="handleSave"
 				/>
 			</template>
@@ -250,6 +252,7 @@ async function onSchemaSelected( schemaName: string ): Promise<void> {
 
 	selectedSchemaName.value = schemaName;
 	subjectLabel.value = String( mw.config.get( 'wgTitle' ) ?? '' );
+	markChanged();
 
 	try {
 		loadedSchema.value = await schemaStore.getOrFetchSchema( schemaName );

--- a/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditorDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditorDialog.vue
@@ -63,6 +63,7 @@
 				<EditSummary
 					help-text=""
 					:save-button-label="$i18n( 'neowiki-subject-editor-save' ).text()"
+					:save-disabled="!hasChanged"
 					@save="handleSave"
 				/>
 			</template>

--- a/resources/ext.neowiki/src/components/common/EditSummary.vue
+++ b/resources/ext.neowiki/src/components/common/EditSummary.vue
@@ -37,6 +37,7 @@
 			<CdxButton
 				action="progressive"
 				weight="primary"
+				:disabled="props.saveDisabled"
 				@click="onSaveClick"
 			>
 				<CdxIcon :icon="cdxIconCheck" />
@@ -54,6 +55,7 @@ import { cdxIconCheck } from '@wikimedia/codex-icons';
 const props = defineProps<{
 	helpText: string;
 	saveButtonLabel: string;
+	saveDisabled: boolean;
 }>();
 
 const editSummary = ref( '' );

--- a/resources/ext.neowiki/tests/components/SchemasPage/SchemaCreatorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SchemasPage/SchemaCreatorDialog.spec.ts
@@ -27,7 +27,7 @@ const SchemaEditorStub = {
 
 const EditSummaryStub = {
 	template: '<div class="edit-summary-stub"><button class="save-button" @click="$emit( \'save\', \'\' )">Save</button></div>',
-	props: [ 'helpText', 'saveButtonLabel' ],
+	props: [ 'helpText', 'saveButtonLabel', 'saveDisabled' ],
 	emits: [ 'save' ],
 };
 

--- a/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
@@ -62,7 +62,7 @@ const SchemaEditorStub = {
 
 const EditSummaryStub = {
 	template: '<div class="edit-summary-stub"><button class="save-button" @click="$emit( \'save\', \'\' )">Save</button></div>',
-	props: [ 'helpText', 'saveButtonLabel' ],
+	props: [ 'helpText', 'saveButtonLabel', 'saveDisabled' ],
 	emits: [ 'save' ],
 };
 

--- a/resources/ext.neowiki/tests/components/common/EditSummary.spec.ts
+++ b/resources/ext.neowiki/tests/components/common/EditSummary.spec.ts
@@ -1,0 +1,48 @@
+import { mount, VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it } from 'vitest';
+import EditSummary from '@/components/common/EditSummary.vue';
+import { CdxButton } from '@wikimedia/codex';
+import { createI18nMock, setupMwMock } from '../../VueTestHelpers.ts';
+
+const $i18n = createI18nMock();
+
+describe( 'EditSummary', () => {
+	beforeEach( () => {
+		setupMwMock( { functions: [ 'message', 'msg' ] } );
+	} );
+
+	function mountComponent( saveDisabled: boolean ): VueWrapper {
+		return mount( EditSummary, {
+			props: {
+				helpText: '',
+				saveButtonLabel: 'Save',
+				saveDisabled,
+			},
+			global: {
+				mocks: { $i18n },
+			},
+		} );
+	}
+
+	it( 'disables save button when saveDisabled is true', () => {
+		const wrapper = mountComponent( true );
+
+		const button = wrapper.findComponent( CdxButton );
+		expect( button.attributes( 'disabled' ) ).toBe( '' );
+	} );
+
+	it( 'enables save button when saveDisabled is false', () => {
+		const wrapper = mountComponent( false );
+
+		const button = wrapper.findComponent( CdxButton );
+		expect( button.attributes( 'disabled' ) ).toBeUndefined();
+	} );
+
+	it( 'emits save with summary when button is clicked', async () => {
+		const wrapper = mountComponent( false );
+
+		await wrapper.findComponent( CdxButton ).trigger( 'click' );
+
+		expect( wrapper.emitted( 'save' ) ).toEqual( [ [ '' ] ] );
+	} );
+} );


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/432

Add a saveDisabled prop to EditSummary and wire it to the existing
change detection in all four dialog components: SchemaEditorDialog,
SubjectEditorDialog, SchemaCreatorDialog, and SubjectCreatorDialog.

Also mark schema selection as a change in SubjectCreatorDialog so the
save button enables on the subject creation step after selecting an
existing schema.

## Test plan
- [x] Open a schema editor dialog — save button should be disabled
- [x] Make a change — save button should enable
- [x] Close and reopen — save button should be disabled again
- [x] Repeat for subject editor, schema creator, and subject creator dialogs
- [x] In subject creator, select an existing schema — save button should be enabled on the subject step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://github.com/user-attachments/assets/190f9654-46e0-48c3-8ea0-2c1618ffe2c0