### PR TITLE
Add RDF mapping design draft for SPARQL plugin

### DIFF
--- a/docs/planning/RdfMapping.md
+++ b/docs/planning/RdfMapping.md
@@ -1,6 +1,6 @@
 # RDF Mapping Design
 
-Written 2026-02-21 by Jeroen De Dauw with help from Claude Code, Opus 4.6
+Written 2026-02-23 by Jeroen De Dauw with help from Claude Opus 4.6
 
 Status: Early draft for discussion with ECHOLOT partners
 


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/NeoWiki/issues/586

Strawman proposal for how NeoWiki's data model maps to RDF triples, as needed for the SPARQL plugin
described in ADR 19. Intended as a basis for discussion with ECHOLOT partners who have RDF/LOD expertise.

Covers URI namespace design, Subject/Statement/Relation/Page mapping, named graphs for sync, and a
complete TriG example. Open questions Q1–Q7 are specifically flagged for partner input (property predicate
scope, standard vocabulary, relation representation, CIDOC-CRM, named graph conventions, base URI, URI
encoding).

_Written by Claude Code, Opus 4.6. Result of back and forth with @JeroenDeDauw.
Context: the NeoWiki codebase and docs, ECHOLOT grant documents, and web research on RDF mapping
conventions, Wikibase RDF model, QLever capabilities, and cultural heritage LOD practices._

Fully reviewed by me, seems a solid starting point