### PR TITLE
Split Property Definition attributes into constraints/displayAttributes

### DIFF
--- a/DemoData/Schema/Artist.json
+++ b/DemoData/Schema/Artist.json
@@ -14,7 +14,9 @@
 		},
 		"Movement": {
 			"type": "text",
-			"multiple": true
+			"constraints": {
+				"multiple": true
+			}
 		},
 		"Wikipedia": {
 			"type": "url"

--- a/DemoData/Schema/Artwork.json
+++ b/DemoData/Schema/Artwork.json
@@ -30,8 +30,12 @@
 		},
 		"Estimated value": {
 			"type": "number",
-			"minimum": 0,
-			"precision": 2,
+			"constraints": {
+				"minimum": 0
+			},
+			"displayAttributes": {
+				"precision": 2
+			},
 			"description": "Estimated value in millions EUR"
 		}
 	}

--- a/DemoData/Schema/Attendance.json
+++ b/DemoData/Schema/Attendance.json
@@ -7,8 +7,12 @@
 		},
 		"Visitors": {
 			"type": "number",
-			"minimum": 0,
-			"precision": 0
+			"constraints": {
+				"minimum": 0
+			},
+			"displayAttributes": {
+				"precision": 0
+			}
 		},
 		"Source": {
 			"type": "url"

--- a/DemoData/Schema/City.json
+++ b/DemoData/Schema/City.json
@@ -6,7 +6,9 @@
 		},
 		"Population": {
 			"type": "number",
-			"minimum": 0
+			"constraints": {
+				"minimum": 0
+			}
 		},
 		"Website": {
 			"type": "url"

--- a/DemoData/Schema/Company.json
+++ b/DemoData/Schema/Company.json
@@ -5,7 +5,9 @@
 		},
 		"Websites": {
 			"type": "url",
-			"multiple": true
+			"constraints": {
+				"multiple": true
+			}
 		},
 		"Main product": {
 			"type": "relation",
@@ -16,7 +18,9 @@
 			"type": "relation",
 			"relation": "Has product",
 			"targetSchema": "Product",
-			"multiple": true
+			"constraints": {
+				"multiple": true
+			}
 		},
 		"World domination progress": {
 			"type": "number",

--- a/DemoData/Schema/Employee.json
+++ b/DemoData/Schema/Employee.json
@@ -9,21 +9,27 @@
 		},
 		"EmploymentFte": {
 			"type": "number",
-			"minimum": 0,
-			"maximum": 100,
+			"constraints": {
+				"minimum": 0,
+				"maximum": 100
+			},
 			"default": 100
 		},
 		"Skills": {
 			"type": "text",
-			"multiple": true,
-			"uniqueItems": true,
+			"constraints": {
+				"multiple": true,
+				"uniqueItems": true
+			},
 			"description": "A list of the person's skills"
 		},
 		"Employer": {
 			"type": "relation",
 			"relation": "Employer",
 			"targetSchema": "Company",
-			"multiple": false
+			"constraints": {
+				"multiple": false
+			}
 		}
 	}
 }

--- a/DemoData/Schema/Everything.json
+++ b/DemoData/Schema/Everything.json
@@ -10,12 +10,16 @@
 		},
 		"string/text (many)": {
 			"type": "text",
-			"multiple": true
+			"constraints": {
+				"multiple": true
+			}
 		},
 		"string/text (duplicates)": {
 			"type": "text",
-			"multiple": true,
-			"uniqueItems": false
+			"constraints": {
+				"multiple": true,
+				"uniqueItems": false
+			}
 		},
 		"string/text (default)": {
 			"type": "text",
@@ -26,19 +30,25 @@
 		},
 		"string/url (many)": {
 			"type": "url",
-			"multiple": true
+			"constraints": {
+				"multiple": true
+			}
 		},
 		"number/number": {
 			"type": "number"
 		},
 		"number/number (w precision)": {
 			"type": "number",
-			"precision": 2
+			"displayAttributes": {
+				"precision": 2
+			}
 		},
 		"number/number (w bounds)": {
 			"type": "number",
-			"minimum": 42,
-			"maximum": 100
+			"constraints": {
+				"minimum": 42,
+				"maximum": 100
+			}
 		},
 		"relation/relation": {
 			"type": "relation",
@@ -49,7 +59,9 @@
 			"type": "relation",
 			"relation": "Has product",
 			"targetSchema": "Product",
-			"multiple": true
+			"constraints": {
+				"multiple": true
+			}
 		}
 	}
 }

--- a/DemoData/Schema/Exhibition.json
+++ b/DemoData/Schema/Exhibition.json
@@ -18,7 +18,9 @@
 			"type": "relation",
 			"relation": "Features",
 			"targetSchema": "Artist",
-			"multiple": true
+			"constraints": {
+				"multiple": true
+			}
 		},
 		"Website": {
 			"type": "url"
@@ -28,8 +30,12 @@
 		},
 		"Visitor count": {
 			"type": "number",
-			"minimum": 0,
-			"precision": 0
+			"constraints": {
+				"minimum": 0
+			},
+			"displayAttributes": {
+				"precision": 0
+			}
 		}
 	}
 }

--- a/DemoData/Schema/Museum.json
+++ b/DemoData/Schema/Museum.json
@@ -18,24 +18,36 @@
 		},
 		"Specialization": {
 			"type": "text",
-			"multiple": true,
-			"uniqueItems": true
+			"constraints": {
+				"multiple": true,
+				"uniqueItems": true
+			}
 		},
 		"Annual visitors": {
 			"type": "number",
-			"minimum": 0,
-			"precision": 0
+			"constraints": {
+				"minimum": 0
+			},
+			"displayAttributes": {
+				"precision": 0
+			}
 		},
 		"Admission fee": {
 			"type": "number",
-			"minimum": 0,
-			"maximum": 200,
-			"precision": 2,
+			"constraints": {
+				"minimum": 0,
+				"maximum": 200
+			},
+			"displayAttributes": {
+				"precision": 2
+			},
 			"default": 0
 		},
 		"Links": {
 			"type": "url",
-			"multiple": true,
+			"constraints": {
+				"multiple": true
+			},
 			"description": "Social media and review sites"
 		}
 	}

--- a/DemoData/Schema/Population.json
+++ b/DemoData/Schema/Population.json
@@ -12,7 +12,9 @@
 		},
 		"References": {
 			"type": "url",
-			"multiple": true
+			"constraints": {
+				"multiple": true
+			}
 		}
 	}
 }

--- a/DemoData/Schema/Table.json
+++ b/DemoData/Schema/Table.json
@@ -5,7 +5,9 @@
 		},
 		"Part of": {
 			"type": "text",
-			"multiple": true
+			"constraints": {
+				"multiple": true
+			}
 		}
 	}
 }

--- a/resources/ext.neowiki/src/domain/PropertyDefinition.ts
+++ b/resources/ext.neowiki/src/domain/PropertyDefinition.ts
@@ -62,6 +62,11 @@ export class PropertyDefinitionDeserializer {
 
 	public propertyDefinitionFromJson( name: string | PropertyName, json: any ): PropertyDefinition {
 		const propertyType = this.registry.getType( json.type );
+		const typeSpecific = {
+			...json,
+			...json.constraints,
+			...json.displayAttributes,
+		};
 		return propertyType.createPropertyDefinitionFromJson(
 			{
 				name: typeof name === 'string' ? new PropertyName( name ) : name,
@@ -70,7 +75,7 @@ export class PropertyDefinitionDeserializer {
 				required: json.required ?? false,
 				default: json.default ? this.valueDeserializer.deserialize( json.default, json.type ) : undefined,
 			} as PropertyDefinition,
-			json,
+			typeSpecific,
 		);
 	}
 

--- a/resources/ext.neowiki/src/persistence/SchemaSerializer.ts
+++ b/resources/ext.neowiki/src/persistence/SchemaSerializer.ts
@@ -3,6 +3,16 @@ import { PropertyDefinitionList } from '@/domain/PropertyDefinitionList';
 import { PropertyDefinition } from '@/domain/PropertyDefinition';
 import { valueToJson } from '@/domain/Value';
 
+const CORE_FIELDS = new Set( [ 'name', 'type', 'description', 'required', 'default' ] );
+
+const TOP_LEVEL_FIELDS: Record<string, Set<string>> = {
+	relation: new Set( [ 'relation', 'targetSchema' ] ),
+};
+
+const DISPLAY_ATTRIBUTE_FIELDS: Record<string, Set<string>> = {
+	number: new Set( [ 'precision' ] ),
+};
+
 export class SchemaSerializer {
 
 	public serializeSchema( schema: Schema ): string {
@@ -25,10 +35,34 @@ export class SchemaSerializer {
 	}
 
 	private serializePropertyDefinition( property: PropertyDefinition ): any {
-		const { name, ...propertyWithoutName } = property;
+		const topLevelFields = TOP_LEVEL_FIELDS[ property.type ] ?? new Set();
+		const displayAttributeFields = DISPLAY_ATTRIBUTE_FIELDS[ property.type ] ?? new Set();
+		const topLevel: Record<string, any> = {};
+		const constraints: Record<string, any> = {};
+		const displayAttributes: Record<string, any> = {};
+
+		for ( const [ key, value ] of Object.entries( property ) ) {
+			if ( CORE_FIELDS.has( key ) ) {
+				continue;
+			}
+
+			if ( topLevelFields.has( key ) ) {
+				topLevel[ key ] = value;
+			} else if ( displayAttributeFields.has( key ) ) {
+				displayAttributes[ key ] = value;
+			} else {
+				constraints[ key ] = value;
+			}
+		}
+
 		return {
-			...propertyWithoutName,
+			type: property.type,
+			description: property.description,
+			required: property.required,
 			default: property.default !== undefined ? valueToJson( property.default ) : undefined,
+			...topLevel,
+			constraints,
+			displayAttributes,
 		};
 	}
 }

--- a/resources/ext.neowiki/tests/domain/PropertyDefinitionDeserializer.unit.spec.ts
+++ b/resources/ext.neowiki/tests/domain/PropertyDefinitionDeserializer.unit.spec.ts
@@ -37,8 +37,10 @@ it( 'creates a property definition with defaults specified', () => {
 it( 'creates a string property definition', () => {
 	const json = {
 		type: 'text',
-		multiple: true,
-		uniqueItems: false,
+		constraints: {
+			multiple: true,
+			uniqueItems: false,
+		},
 	};
 
 	const property = serializer.propertyDefinitionFromJson( 'test', json ) as TextProperty;
@@ -66,9 +68,13 @@ it( 'creates a number property definition with defaults', () => {
 it( 'creates a number property definition with all fields', () => {
 	const json = {
 		type: 'number',
-		minimum: 42,
-		maximum: 1337,
-		precision: 2,
+		constraints: {
+			minimum: 42,
+			maximum: 1337,
+		},
+		displayAttributes: {
+			precision: 2,
+		},
 	};
 
 	const property = serializer.propertyDefinitionFromJson( 'test', json ) as NumberProperty;
@@ -101,8 +107,10 @@ it( 'creates a relation property definition with all fields', () => {
 		type: 'relation',
 		relation: 'Employer',
 		targetSchema: 'Company',
-		multiple: true,
-		uniqueItems: false,
+		constraints: {
+			multiple: true,
+			uniqueItems: false,
+		},
 	};
 
 	const property = serializer.propertyDefinitionFromJson( 'test', json ) as RelationProperty;

--- a/resources/ext.neowiki/tests/persistence/SchemaSerializer.unit.spec.ts
+++ b/resources/ext.neowiki/tests/persistence/SchemaSerializer.unit.spec.ts
@@ -76,23 +76,33 @@ describe( 'SchemaSerializer', () => {
 						type: 'text',
 						description: 'Text property',
 						required: true,
-						multiple: true,
-						uniqueItems: false,
+						constraints: {
+							multiple: true,
+							uniqueItems: false,
+						},
+						displayAttributes: {},
 					},
 					urlProperty: {
 						type: 'url',
 						description: 'URL property',
 						required: false,
-						multiple: false,
-						uniqueItems: true,
+						constraints: {
+							multiple: false,
+							uniqueItems: true,
+						},
+						displayAttributes: {},
 					},
 					numberProperty: {
 						type: 'number',
 						description: 'Number property',
 						required: true,
-						precision: 2,
-						minimum: 0,
-						maximum: 100,
+						constraints: {
+							minimum: 0,
+							maximum: 100,
+						},
+						displayAttributes: {
+							precision: 2,
+						},
 					},
 					relationProperty: {
 						type: 'relation',
@@ -100,7 +110,10 @@ describe( 'SchemaSerializer', () => {
 						required: false,
 						relation: 'TestRelation',
 						targetSchema: 'TestTargetSchema',
-						multiple: true,
+						constraints: {
+							multiple: true,
+						},
+						displayAttributes: {},
 					},
 				},
 			} );

--- a/src/Domain/Schema/Property/NumberProperty.php
+++ b/src/Domain/Schema/Property/NumberProperty.php
@@ -57,11 +57,16 @@ class NumberProperty extends PropertyDefinition {
 		);
 	}
 
-	public function nonCoreToJson(): array {
+	protected function constraintsToJson(): array {
 		return [
-			'precision' => $this->getPrecision(),
 			'minimum' => $this->getMinimum(),
 			'maximum' => $this->getMaximum(),
+		];
+	}
+
+	protected function displayAttributesToJson(): array {
+		return [
+			'precision' => $this->getPrecision(),
 		];
 	}
 

--- a/src/Domain/Schema/Property/RelationProperty.php
+++ b/src/Domain/Schema/Property/RelationProperty.php
@@ -47,12 +47,24 @@ class RelationProperty extends PropertyDefinition {
 		);
 	}
 
-	public function nonCoreToJson(): array {
+	public function toJson(): array {
+		return array_merge(
+			parent::toJson(),
+			[
+				'relation' => $this->relationType->getText(),
+				'targetSchema' => $this->targetSchema->getText(),
+			]
+		);
+	}
+
+	protected function constraintsToJson(): array {
 		return [
-			'relation' => $this->relationType->getText(),
-			'targetSchema' => $this->targetSchema->getText(),
 			'multiple' => $this->multiple,
 		];
+	}
+
+	protected function displayAttributesToJson(): array {
+		return [];
 	}
 
 }

--- a/src/Domain/Schema/Property/TextProperty.php
+++ b/src/Domain/Schema/Property/TextProperty.php
@@ -38,11 +38,15 @@ class TextProperty extends PropertyDefinition {
 		);
 	}
 
-	public function nonCoreToJson(): array {
+	protected function constraintsToJson(): array {
 		return [
 			'multiple' => $this->allowsMultipleValues(),
 			'uniqueItems' => $this->enforcesUniqueValues(),
 		];
+	}
+
+	protected function displayAttributesToJson(): array {
+		return [];
 	}
 
 }

--- a/src/Domain/Schema/Property/UrlProperty.php
+++ b/src/Domain/Schema/Property/UrlProperty.php
@@ -38,11 +38,15 @@ class UrlProperty extends PropertyDefinition {
 		);
 	}
 
-	public function nonCoreToJson(): array {
+	protected function constraintsToJson(): array {
 		return [
 			'multiple' => $this->allowsMultipleValues(),
 			'uniqueItems' => $this->enforcesUniqueValues(),
 		];
+	}
+
+	protected function displayAttributesToJson(): array {
+		return [];
 	}
 
 }

--- a/src/Domain/Schema/PropertyDefinition.php
+++ b/src/Domain/Schema/PropertyDefinition.php
@@ -37,18 +37,21 @@ abstract class PropertyDefinition {
 	}
 
 	public function toJson(): array {
-		return array_merge(
-			[
-				'type' => $this->getPropertyType(),
-				'description' => $this->getDescription(),
-				'required' => $this->isRequired(),
-				'default' => $this->getDefault(),
-			],
-			$this->nonCoreToJson()
-		);
+		$displayAttributes = $this->displayAttributesToJson();
+
+		return [
+			'type' => $this->getPropertyType(),
+			'description' => $this->getDescription(),
+			'required' => $this->isRequired(),
+			'default' => $this->getDefault(),
+			'constraints' => $this->constraintsToJson(),
+			'displayAttributes' => $displayAttributes === [] ? (object)[] : $displayAttributes,
+		];
 	}
 
-	abstract protected function nonCoreToJson(): array;
+	abstract protected function constraintsToJson(): array;
+
+	abstract protected function displayAttributesToJson(): array;
 
 	/**
 	 * @throws InvalidArgumentException
@@ -66,8 +69,12 @@ abstract class PropertyDefinition {
 			default: $json['default'] ?? null
 		);
 
+		$constraints = $json['constraints'] ?? [];
+		$displayAttributes = $json['displayAttributes'] ?? [];
+		$typeSpecific = array_merge( $json, $constraints, $displayAttributes );
+
 		try {
-			return $propertyType->buildPropertyDefinitionFromJson( $propertyCore, $json );
+			return $propertyType->buildPropertyDefinitionFromJson( $propertyCore, $typeSpecific );
 		} catch ( \Throwable $e ) {
 			throw new InvalidArgumentException( 'Invalid property definition: ' . json_encode( $json ), 0, $e );
 		}

--- a/src/Persistence/MediaWiki/schemaContentSchema.json
+++ b/src/Persistence/MediaWiki/schemaContentSchema.json
@@ -39,11 +39,11 @@
 						"required": {
 							"type": "boolean"
 						},
-						"multiple": {
-							"type": "boolean"
+						"constraints": {
+							"type": "object"
 						},
-						"uniqueItems": {
-							"type": "boolean"
+						"displayAttributes": {
+							"type": "object"
 						}
 					},
 					"oneOf": [

--- a/tests/phpunit/Application/Queries/GetSchema/GetSchemaQueryTest.php
+++ b/tests/phpunit/Application/Queries/GetSchema/GetSchemaQueryTest.php
@@ -70,8 +70,11 @@ class GetSchemaQueryTest extends TestCase {
             "description": "A string property",
             "required": false,
             "default": null,
-            "multiple": false,
-            "uniqueItems": false
+            "constraints": {
+                "multiple": false,
+                "uniqueItems": false
+            },
+            "displayAttributes": {}
         }
     }
 }

--- a/tests/phpunit/Domain/Schema/Property/NumberPropertyTest.php
+++ b/tests/phpunit/Domain/Schema/Property/NumberPropertyTest.php
@@ -20,9 +20,13 @@ class NumberPropertyTest extends PropertyTestCase {
 	"description": "",
 	"required": false,
 	"default": null,
-	"precision": null,
-	"minimum": null,
-	"maximum": null
+	"constraints": {
+		"minimum": null,
+		"maximum": null
+	},
+	"displayAttributes": {
+		"precision": null
+	}
 }
 JSON,
 			$this->deserializeAndReserialize(
@@ -43,9 +47,13 @@ JSON
 	"description": "foo",
 	"required": true,
 	"default": 42,
-	"precision": 2,
-	"minimum": 0,
-	"maximum": 100
+	"constraints": {
+		"minimum": 0,
+		"maximum": 100
+	},
+	"displayAttributes": {
+		"precision": 2
+	}
 }
 JSON
 		);
@@ -59,9 +67,13 @@ JSON
 	"description": "",
 	"required": false,
 	"default": null,
-	"precision": null,
-	"minimum": null,
-	"maximum": null
+	"constraints": {
+		"minimum": null,
+		"maximum": null
+	},
+	"displayAttributes": {
+		"precision": null
+	}
 }
 JSON
 		);
@@ -73,7 +85,9 @@ JSON
 			<<<JSON
 {
 	"type": "number",
-	"precision": "yes"
+	"displayAttributes": {
+		"precision": "yes"
+	}
 }
 JSON
 		);
@@ -85,7 +99,9 @@ JSON
 			<<<JSON
 {
 	"type": "number",
-	"maximum": "yes"
+	"constraints": {
+		"maximum": "yes"
+	}
 }
 JSON
 		);
@@ -97,7 +113,9 @@ JSON
 			<<<JSON
 {
 	"type": "number",
-	"minimum": "yes"
+	"constraints": {
+		"minimum": "yes"
+	}
 }
 JSON
 		);

--- a/tests/phpunit/Domain/Schema/Property/RelationPropertyTest.php
+++ b/tests/phpunit/Domain/Schema/Property/RelationPropertyTest.php
@@ -49,7 +49,10 @@ class RelationPropertyTest extends PropertyTestCase {
 	"default": null,
 	"relation": "type",
 	"targetSchema": "schema",
-	"multiple": false
+	"constraints": {
+		"multiple": false
+	},
+	"displayAttributes": {}
 }
 JSON,
 			$this->deserializeAndReserialize(
@@ -74,7 +77,10 @@ JSON
 	"default": null,
 	"relation": "type",
 	"targetSchema": "schema",
-	"multiple": true
+	"constraints": {
+		"multiple": true
+	},
+	"displayAttributes": {}
 }
 JSON
 		);
@@ -90,7 +96,10 @@ JSON
 	"default": null,
 	"relation": "type",
 	"targetSchema": "schema",
-	"multiple": false
+	"constraints": {
+		"multiple": false
+	},
+	"displayAttributes": {}
 }
 JSON
 		);

--- a/tests/phpunit/Domain/Schema/Property/TextPropertyTest.php
+++ b/tests/phpunit/Domain/Schema/Property/TextPropertyTest.php
@@ -20,8 +20,11 @@ class TextPropertyTest extends PropertyTestCase {
 	"description": "",
 	"required": false,
 	"default": null,
-	"multiple": false,
-	"uniqueItems": false
+	"constraints": {
+		"multiple": false,
+		"uniqueItems": false
+	},
+	"displayAttributes": {}
 }
 JSON,
 			$this->deserializeAndReserialize(
@@ -42,8 +45,11 @@ JSON
 	"description": "foo",
 	"required": true,
 	"default": 42,
-	"multiple": true,
-	"uniqueItems": true
+	"constraints": {
+		"multiple": true,
+		"uniqueItems": true
+	},
+	"displayAttributes": {}
 }
 JSON
 		);
@@ -57,8 +63,11 @@ JSON
 	"description": "",
 	"required": false,
 	"default": null,
-	"multiple": false,
-	"uniqueItems": false
+	"constraints": {
+		"multiple": false,
+		"uniqueItems": false
+	},
+	"displayAttributes": {}
 }
 JSON
 		);
@@ -70,7 +79,9 @@ JSON
 			<<<JSON
 {
 	"type": "text",
-	"multiple": 42
+	"constraints": {
+		"multiple": 42
+	}
 }
 JSON
 		);
@@ -82,7 +93,9 @@ JSON
 			<<<JSON
 {
 	"type": "text",
-	"uniqueItems": "maybe"
+	"constraints": {
+		"uniqueItems": "maybe"
+	}
 }
 JSON
 		);

--- a/tests/phpunit/EntryPoints/REST/GetSchemaApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/GetSchemaApiTest.php
@@ -60,10 +60,13 @@ JSON
                 "description": "This is a test schema",
                 "required": false,
                 "default": null,
-                "multiple": false,
                 "type": "relation",
                 "relation": "MyRelation",
-                "targetSchema": "TestSchema"
+                "targetSchema": "TestSchema",
+                "constraints": {
+                    "multiple": false
+                },
+                "displayAttributes": {}
             }
         }
     }

--- a/tests/phpunit/Presentation/SchemaPresentationSerializerTest.php
+++ b/tests/phpunit/Presentation/SchemaPresentationSerializerTest.php
@@ -52,10 +52,13 @@ class SchemaPresentationSerializerTest extends TestCase {
 				'testText' => [
 					'description' => 'Test text property',
 					'required' => true,
-					'multiple' => false,
 					'default' => 'foo',
-					'uniqueItems' => false,
 					'type' => TextType::NAME,
+					'constraints' => [
+						'multiple' => false,
+						'uniqueItems' => false,
+					],
+					'displayAttributes' => (object)[],
 				]
 			]
 		] );
@@ -86,9 +89,13 @@ class SchemaPresentationSerializerTest extends TestCase {
 					'required' => false,
 					'default' => 0,
 					'type' => NumberType::NAME,
-					'maximum' => null,
-					'minimum' => null,
-					'precision' => null,
+					'constraints' => [
+						'minimum' => null,
+						'maximum' => null,
+					],
+					'displayAttributes' => [
+						'precision' => null,
+					],
 				]
 			]
 		] );
@@ -119,10 +126,13 @@ class SchemaPresentationSerializerTest extends TestCase {
 					'description' => 'Test relation property',
 					'required' => false,
 					'default' => null,
+					'type' => 'relation',
 					'relation' => 'testRelationType',
 					'targetSchema' => 'targetSchema',
-					'multiple' => false,
-					'type' => 'relation'
+					'constraints' => [
+						'multiple' => false,
+					],
+					'displayAttributes' => (object)[],
 				]
 			]
 		] );
@@ -152,8 +162,11 @@ class SchemaPresentationSerializerTest extends TestCase {
 					'required' => true,
 					'default' => 'default',
 					'type' => 'text',
-					'multiple' => false,
-					'uniqueItems' => false,
+					'constraints' => [
+						'multiple' => false,
+						'uniqueItems' => false,
+					],
+					'displayAttributes' => (object)[],
 				]
 			]
 		] );


### PR DESCRIPTION
**I now think this is the wrong approach**

First implementation step towards the proposed Views approach. Pending ADR acceptance.

Follows
* https://github.com/ProfessionalWiki/NeoWiki/pull/625

## Summary

- The JSON serialization format for Property Definitions now nests type-specific attributes into
  `constraints` and `displayAttributes` objects, preparing for the Views feature where display
  attributes can be overridden per-View while constraints cannot.
- Domain objects (PHP classes and TS interfaces) remain flat — the nesting is only at the
  serialization boundary, avoiding changes to internal consumers like renderers, validators,
  and editors.
- Only NumberProperty currently has a display attribute (`precision`). Other types have only
  constraints.

## Test plan

- [x] PHPUnit: 462 tests pass
- [x] PHPStan: 0 errors
- [x] TS tests: 584 tests pass
- [x] TS lint: 0 errors
- [x] TS build: successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)