### PR TITLE
Expand validation options: implementation approach and severity levels

### DIFF
--- a/docs/planning/Validation-Severity.md
+++ b/docs/planning/Validation-Severity.md
@@ -1,0 +1,42 @@
+# Validation Severity Levels
+
+Related to [Validation Architecture](Validation.md). This is a separate concern from where validation
+happens (frontend, backend, or both).
+
+## Context
+
+[ADR 12: Backend Validation](../adr/012_Backend_Validation.md) established that invalid Subjects can be
+persisted. This is necessary because Schemas can change after Subjects have been saved, making previously
+valid Subjects invalid. The system already handles this case.
+
+Severity levels formalize this by distinguishing between violations that should block persistence and
+violations that should be surfaced but allowed.
+
+## Proposal
+
+Validation results are split into two severity levels:
+
+* **Errors**: the Subject is rejected and not persisted. Represents hard constraints that must always
+  be satisfied.
+* **Warnings**: the Subject is flagged as invalid but still persisted. Represents soft constraints where
+  the data does not conform to the Schema but is still acceptable for storage.
+
+Severity is **user-defined at the Schema level**: each constraint in a Property Definition specifies whether
+violation is an error or a warning. The default severity when unspecified is warning (permissive by default),
+since the system already needs to handle invalid Subjects due to Schema changes.
+
+This maps to two real categories:
+
+1. **Errors**: hard constraints the schema author considers essential for data integrity
+   (e.g., a required identifier field)
+2. **Warnings**: conformance issues that should be surfaced but not block persistence
+   (e.g., a number out of preferred range, a missing optional-but-recommended field)
+
+Pros:
+* Schema authors control which constraints are strict vs. lenient, matching their domain needs
+* Addresses the ECHOLOT CH import scenario: messy data is accepted with warnings rather than rejected
+
+Cons:
+* Warning/error severity on constraints in the Schema model and UIs
+* API responses that distinguish warnings from errors
+* Adds a concept (severity) to the Schema model that schema authors need to understand

--- a/docs/planning/Validation.md
+++ b/docs/planning/Validation.md
@@ -100,4 +100,53 @@ Cons:
     * Strict-mode or similar for Subject writing APIs with validation status responses
     * Potentially dedicated REST validation endpoint
 
+**Option 3: Backend validation with warning/error severity**
 
+Backend validation as in Option 2, but with validation results split into two severity levels:
+
+* **Errors**: the Subject is rejected and not persisted. Represents hard constraints that must always be satisfied.
+* **Warnings**: the Subject is flagged as invalid but still persisted. Represents soft constraints where the data
+  does not conform to the Schema but is still acceptable for storage.
+
+Severity is **user-defined at the Schema level**: each constraint in a Property Definition specifies whether
+violation is an error or a warning. The default severity when unspecified is warning (permissive by default),
+since the system already needs to handle invalid Subjects due to Schema changes.
+
+This maps to two real categories:
+
+1. **Errors** — hard constraints the schema author considers essential for data integrity
+   (e.g., a required identifier field)
+2. **Warnings** — conformance issues that should be surfaced but not block persistence
+   (e.g., a number out of preferred range, a missing optional-but-recommended field)
+
+For instant feedback, the Schema serves as the **single source of truth** for validation rules. Both the
+TypeScript library and the PHP backend contain a generic constraint interpreter that reads the Schema and
+executes validation — similar to how JSON Schema validation works, where the schema is defined once and
+interpreters exist in multiple languages. The interpreters are generic: they handle constraint types
+(required, min/max, regex, etc.), not specific business rules. Adding a new constraint type (e.g., regex)
+means updating both interpreters, but the actual constraint values are defined once in the Schema.
+
+This approach scales well for future custom validations. For instance, a user-defined regex check is a
+declarative rule stored in the Schema (`pattern: "^[A-Z]"`), executable natively by both TS and PHP without
+new interpreter logic — only the "regex" constraint type needs to be added once to each interpreter.
+
+A shared test suite with the same inputs and expected outputs run against both interpreters keeps them in sync.
+
+The same declarative constraint metadata could also drive the Schema Editor UI, replacing per-Property-Type
+editor components with a generic renderer.
+
+Pros:
+* API users get validation feedback with meaningful severity levels
+* Schema authors control which constraints are strict vs. lenient, matching their domain needs
+* Addresses the ECHOLOT CH import scenario: messy data is accepted with warnings rather than rejected
+* The Schema remains the single source of truth for rules. Interpreters are generic and stable.
+* Scales for future custom validations (regex, enums, etc.) without growing maintenance burden per-rule
+* Instant feedback preserved via the TypeScript interpreter; TS library stays usable standalone
+
+Cons:
+* Cost of implementation and cost of carry
+    * Validation system in PHP (same as Option 2)
+    * Constraint interpreters in both TS and PHP, kept in sync via shared test suite
+    * Warning/error severity on constraints in the Schema model and UIs
+    * API responses that distinguish warnings from errors
+* Adds a concept (severity) to the Schema model that schema authors need to understand

--- a/docs/planning/Validation.md
+++ b/docs/planning/Validation.md
@@ -80,6 +80,7 @@ Currently, we assume we will have these:
 Pros:
 * No cost of implementation, we can build other things instead
 * No cost of carry. Simpler system
+* Instant feedback when editing in the frontend
 
 Cons:
 * API users have to validate their data before sending it to the API if they want to ensure correctness
@@ -90,8 +91,12 @@ We implement a backend validation service similar to the existing TypeScript one
 adding a dedicated validation endpoint and adding a strict mode to the subject writing API. Details TBD.
 
 Pros:
+* Constraints defined on a Schema are enforced for everyone, not only for users who edit via the NeoWiki
+  frontend
 * API users can edit Subjects without prior validation without risking creating "invalid" Subjects
 * API users can potentially validate Subjects without editing via a new dedicated endpoint
+* Schemas are increasingly likely to be managed through the API, whether from LLM clients, third-party tools,
+  or import pipelines. Consumers do not need to implement their own validation.
 
 Cons:
 * Need to figure out those TBD details
@@ -100,53 +105,37 @@ Cons:
     * Strict-mode or similar for Subject writing APIs with validation status responses
     * Potentially dedicated REST validation endpoint
 
-**Option 3: Backend validation with warning/error severity**
+**Option 3: Both frontend and backend validation**
 
-Backend validation as in Option 2, but with validation results split into two severity levels:
+The Schema is the **single source of truth** for validation rules. Both the TypeScript library and the PHP
+backend have a generic constraint interpreter that reads the Schema and validates against it. This is the same
+pattern as JSON Schema: one schema, multiple interpreters. The interpreters handle constraint types (required,
+min/max, regex, etc.), not specific business rules. Adding a new constraint type means updating both
+interpreters, but the constraint values themselves are defined once in the Schema.
 
-* **Errors**: the Subject is rejected and not persisted. Represents hard constraints that must always be satisfied.
-* **Warnings**: the Subject is flagged as invalid but still persisted. Represents soft constraints where the data
-  does not conform to the Schema but is still acceptable for storage.
+A shared test suite runs the same inputs and expected outputs against both interpreters to keep them in sync.
 
-Severity is **user-defined at the Schema level**: each constraint in a Property Definition specifies whether
-violation is an error or a warning. The default severity when unspecified is warning (permissive by default),
-since the system already needs to handle invalid Subjects due to Schema changes.
-
-This maps to two real categories:
-
-1. **Errors** — hard constraints the schema author considers essential for data integrity
-   (e.g., a required identifier field)
-2. **Warnings** — conformance issues that should be surfaced but not block persistence
-   (e.g., a number out of preferred range, a missing optional-but-recommended field)
-
-For instant feedback, the Schema serves as the **single source of truth** for validation rules. Both the
-TypeScript library and the PHP backend contain a generic constraint interpreter that reads the Schema and
-executes validation — similar to how JSON Schema validation works, where the schema is defined once and
-interpreters exist in multiple languages. The interpreters are generic: they handle constraint types
-(required, min/max, regex, etc.), not specific business rules. Adding a new constraint type (e.g., regex)
-means updating both interpreters, but the actual constraint values are defined once in the Schema.
-
-This approach scales well for future custom validations. For instance, a user-defined regex check is a
-declarative rule stored in the Schema (`pattern: "^[A-Z]"`), executable natively by both TS and PHP without
-new interpreter logic — only the "regex" constraint type needs to be added once to each interpreter.
-
-A shared test suite with the same inputs and expected outputs run against both interpreters keeps them in sync.
+New constraint types scale without per-rule maintenance. For example, a user-defined regex check is a
+declarative rule in the Schema (`pattern: "^[A-Z]"`). Both TS and PHP execute it natively. Only the "regex"
+constraint type needs to be added once to each interpreter.
 
 The same declarative constraint metadata could also drive the Schema Editor UI, replacing per-Property-Type
 editor components with a generic renderer.
 
 Pros:
-* API users get validation feedback with meaningful severity levels
-* Schema authors control which constraints are strict vs. lenient, matching their domain needs
-* Addresses the ECHOLOT CH import scenario: messy data is accepted with warnings rather than rejected
-* The Schema remains the single source of truth for rules. Interpreters are generic and stable.
-* Scales for future custom validations (regex, enums, etc.) without growing maintenance burden per-rule
-* Instant feedback preserved via the TypeScript interpreter; TS library stays usable standalone
+* Constraints defined on a Schema are enforced for everyone, not only users who edit via the NeoWiki frontend
+* API consumers get validation without implementing their own
+* API users can validate Subjects via a dedicated endpoint without persisting
+* Instant feedback when editing in the frontend
+* Single source of truth and generic interpreters keep the two implementations manageable
+* Scales for new constraint types without growing per-rule maintenance
 
 Cons:
-* Cost of implementation and cost of carry
-    * Validation system in PHP (same as Option 2)
+* More complex to implement than either option alone
+    * Validation system in PHP
     * Constraint interpreters in both TS and PHP, kept in sync via shared test suite
-    * Warning/error severity on constraints in the Schema model and UIs
-    * API responses that distinguish warnings from errors
-* Adds a concept (severity) to the Schema model that schema authors need to understand
+    * Strict-mode or similar for Subject writing APIs with validation status responses
+    * Potentially dedicated REST validation endpoint
+
+See also: [Validation Severity](Validation-Severity.md) for a related but separate discussion on
+warning/error severity levels for validation results.


### PR DESCRIPTION
## Summary

- Adds additional pros to Option 1 and Option 2
- Adds Option 3: both frontend and backend validation, with a generic interpreter approach
  and single source of truth
- Extracts warning/error severity levels into a separate document as an independent concern

## Test plan

- [ ] Review the document for clarity and completeness

_Written by Claude Code, Opus 4.6. Result of extensive back and forth with @alistair3149.
Context: the NeoWiki codebase and existing Validation Architecture document._

Generated with [Claude Code](https://claude.com/claude-code)