### PR TITLE
Add back button to SubjectCreator dialog

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -276,6 +276,7 @@
 				"neowiki-subject-creator-schema-created",
 				"neowiki-subject-creator-save-with-schema",
 				"neowiki-subject-creator-creating-schema",
+				"neowiki-subject-creator-back",
 				"neowiki-edit-schema",
 				"neowiki-schema-editor-summary-default",
 				"neowiki-schema-editor-success",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -82,6 +82,7 @@
 	"neowiki-subject-creator-error": "Failed to create subject",
 	"neowiki-subject-creator-create-schema": "Create schema",
 	"neowiki-subject-creator-schema-created": "Schema created successfully",
+	"neowiki-subject-creator-back": "Back",
 
 	"neowiki-schema-display-property-name": "Property",
 	"neowiki-schema-display-property-type": "Type",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -20,6 +20,7 @@
 	"neowiki-subject-creator-creating-schema": "Subtitle shown in the subject creator dialog header when the user is creating a new schema.",
 	"neowiki-subject-creator-create-schema": "Label for the button that creates a new schema in the subject creator dialog.",
 	"neowiki-subject-creator-schema-created": "Success notification shown after creating a schema.",
+	"neowiki-subject-creator-back": "Aria label for the back button in the subject creator dialog, used to return to schema selection.",
 
 	"neowiki-schema-editor-summary-default": "Default edit summary used when updating a schema via the UI.",
 	"neowiki-schema-editor-success": "Success notification shown after updating a schema. $1 is the schema name.",

--- a/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
@@ -14,28 +14,41 @@
 			@update:open="onDialogUpdateOpen"
 		>
 			<template #header>
-				<div class="cdx-dialog__header__title-group">
-					<h2 class="cdx-dialog__header__title">
-						{{ $i18n( 'neowiki-subject-creator-title' ).text() }}
-					</h2>
-
-					<p
-						v-if="headerSubtitle"
-						class="cdx-dialog__header__subtitle"
+				<div class="ext-neowiki-subject-creator-dialog__header">
+					<CdxButton
+						v-if="selectedSchemaName"
+						class="ext-neowiki-subject-creator-back-button"
+						weight="quiet"
+						type="button"
+						:aria-label="$i18n( 'neowiki-subject-creator-back' ).text()"
+						@click="goBack"
 					>
-						{{ headerSubtitle }}
-					</p>
-				</div>
+						<CdxIcon :icon="cdxIconArrowPrevious" />
+					</CdxButton>
 
-				<CdxButton
-					class="cdx-dialog__header__close-button"
-					weight="quiet"
-					type="button"
-					:aria-label="$i18n( 'cdx-dialog-close-button-label' ).text()"
-					@click="requestClose"
-				>
-					<CdxIcon :icon="cdxIconClose" />
-				</CdxButton>
+					<div class="ext-neowiki-subject-creator-dialog__header__title-group">
+						<h2 class="cdx-dialog__header__title">
+							{{ $i18n( 'neowiki-subject-creator-title' ).text() }}
+						</h2>
+
+						<p
+							v-if="headerSubtitle"
+							class="cdx-dialog__header__subtitle"
+						>
+							{{ headerSubtitle }}
+						</p>
+					</div>
+
+					<CdxButton
+						class="cdx-dialog__header__close-button"
+						weight="quiet"
+						type="button"
+						:aria-label="$i18n( 'cdx-dialog-close-button-label' ).text()"
+						@click="requestClose"
+					>
+						<CdxIcon :icon="cdxIconClose" />
+					</CdxButton>
+				</div>
 			</template>
 			<template v-if="!selectedSchemaName">
 				<p>
@@ -126,7 +139,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, nextTick, onMounted } from 'vue';
 import { CdxButton, CdxDialog, CdxField, CdxIcon, CdxTextInput, CdxToggleButtonGroup } from '@wikimedia/codex';
-import { cdxIconAdd, cdxIconClose, cdxIconSearch } from '@wikimedia/codex-icons';
+import { cdxIconAdd, cdxIconArrowPrevious, cdxIconClose, cdxIconSearch } from '@wikimedia/codex-icons';
 import type { ButtonGroupItem } from '@wikimedia/codex';
 import { useSubjectStore } from '@/stores/SubjectStore.ts';
 import { useSchemaStore } from '@/stores/SchemaStore.ts';
@@ -312,6 +325,13 @@ function resetForm(): void {
 	resetChanged();
 }
 
+function goBack(): void {
+	selectedSchemaName.value = null;
+	loadedSchema.value = null;
+	subjectLabel.value = '';
+	resetChanged();
+}
+
 const handleSave = async ( _summary: string ): Promise<void> => {
 	await nextTick();
 
@@ -356,15 +376,35 @@ defineExpose( { hasChanged } );
 @import ( reference ) '@wikimedia/codex-design-tokens/theme-wikimedia-ui.less';
 
 .ext-neowiki-subject-creator {
-	&-dialog.cdx-dialog {
-		/* Replicate the Codex default dialog header styles */
-		.cdx-dialog__header {
-			display: flex;
-			align-items: baseline;
-			justify-content: flex-end;
-			box-sizing: @box-sizing-base;
-			width: @size-full;
+	&-dialog {
+		.cdx-dialog {
+			/* Replicate the Codex default dialog header styles */
+			.cdx-dialog__header {
+				display: flex;
+				align-items: baseline;
+				justify-content: flex-end;
+				box-sizing: @box-sizing-base;
+				width: @size-full;
+			}
 		}
+
+		&__header {
+			display: flex;
+			align-items: center;
+			width: @size-full;
+			column-gap: @spacing-75;
+
+			&__title-group {
+				display: flex;
+				flex-grow: 1;
+				flex-direction: column;
+			}
+		}
+	}
+
+	&-back-button.cdx-button {
+		margin-left: -@spacing-50;
+		flex-shrink: 0;
 	}
 
 	&-dialog--wide.cdx-dialog {

--- a/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
@@ -83,7 +83,7 @@ const EditSummaryStub = {
 };
 
 const CdxDialogStub = {
-	template: '<div class="cdx-dialog-stub"><slot /><slot name="footer" /></div>',
+	template: '<div class="cdx-dialog-stub"><slot name="header" /><slot /><slot name="footer" /></div>',
 	props: [ 'open', 'title', 'useCloseButton' ],
 	emits: [ 'update:open', 'default' ],
 };
@@ -472,6 +472,78 @@ describe( 'SubjectCreatorDialog', () => {
 
 			expect( wrapper.find( '.schema-lookup-stub' ).exists() ).toBe( true );
 			expect( wrapper.find( '.subject-editor-stub' ).exists() ).toBe( false );
+		} );
+	} );
+
+	describe( 'Back button', () => {
+		it( 'does not show back button on schema selection step', () => {
+			const wrapper = mountComponent();
+
+			expect( wrapper.find( '.ext-neowiki-subject-creator-back-button' ).exists() ).toBe( false );
+		} );
+
+		it( 'shows back button after selecting a schema', async () => {
+			const wrapper = mountComponent();
+
+			await wrapper.findComponent( SchemaLookup ).vm.$emit( 'select', SCHEMA_NAME );
+			await flushPromises();
+
+			expect( wrapper.find( '.ext-neowiki-subject-creator-back-button' ).exists() ).toBe( true );
+		} );
+
+		it( 'returns to schema selection when back button is clicked', async () => {
+			const wrapper = mountComponent();
+
+			await wrapper.findComponent( SchemaLookup ).vm.$emit( 'select', SCHEMA_NAME );
+			await flushPromises();
+
+			expect( wrapper.find( '.subject-editor-stub' ).exists() ).toBe( true );
+
+			await wrapper.find( '.ext-neowiki-subject-creator-back-button' ).trigger( 'click' );
+			await flushPromises();
+
+			expect( wrapper.find( '.schema-lookup-stub' ).exists() ).toBe( true );
+			expect( wrapper.find( '.subject-editor-stub' ).exists() ).toBe( false );
+			expect( wrapper.find( '.ext-neowiki-subject-creator-back-button' ).exists() ).toBe( false );
+		} );
+
+		it( 'shows back button after creating a new schema', async () => {
+			const wrapper = mountComponent();
+
+			await switchToNewSchema( wrapper );
+
+			await wrapper.findComponent( EditSummary ).vm.$emit( 'save', '' );
+			await flushPromises();
+
+			expect( wrapper.find( '.ext-neowiki-subject-creator-back-button' ).exists() ).toBe( true );
+		} );
+
+		it( 'returns to schema selection after creating a schema and clicking back', async () => {
+			const wrapper = mountComponent();
+
+			await switchToNewSchema( wrapper );
+
+			await wrapper.findComponent( EditSummary ).vm.$emit( 'save', '' );
+			await flushPromises();
+
+			await wrapper.find( '.ext-neowiki-subject-creator-back-button' ).trigger( 'click' );
+			await flushPromises();
+
+			expect( wrapper.find( '.cdx-toggle-button-group-stub' ).exists() ).toBe( true );
+			expect( wrapper.find( '.subject-editor-stub' ).exists() ).toBe( false );
+		} );
+
+		it( 'preserves schema option when going back from existing schema', async () => {
+			const wrapper = mountComponent();
+
+			await wrapper.findComponent( SchemaLookup ).vm.$emit( 'select', SCHEMA_NAME );
+			await flushPromises();
+
+			await wrapper.find( '.ext-neowiki-subject-creator-back-button' ).trigger( 'click' );
+			await flushPromises();
+
+			expect( wrapper.find( '.schema-lookup-stub' ).exists() ).toBe( true );
+			expect( wrapper.find( '.cdx-toggle-button-group-stub' ).exists() ).toBe( true );
 		} );
 	} );
 


### PR DESCRIPTION
Went through test plan manually.

Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/523

Allows returning to schema selection after choosing "Use existing" or
"Create new". Preserves the selected schema option (toggle state) when
going back.

## Test plan
- [x] Open SubjectCreator dialog
- [x] Select an existing schema → verify back button appears
- [x] Click back → verify return to schema selection with "Use existing" still selected
- [x] Switch to "Create new", create a schema → verify back button appears
- [x] Click back → verify return to schema selection with "Create new" still selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)


https://github.com/user-attachments/assets/b911cf3a-e5f5-4ca2-b522-814a9b949349

