### PR TITLE
Use MediaWiki-namespaced class imports

### DIFF
--- a/src/EntryPoints/Content/SchemaContentHandler.php
+++ b/src/EntryPoints/Content/SchemaContentHandler.php
@@ -8,7 +8,7 @@ use MediaWiki\Content\Content;
 use MediaWiki\Content\JsonContentHandler;
 use MediaWiki\Content\Renderer\ContentParseParams;
 use MediaWiki\Title\Title;
-use ParserOutput;
+use MediaWiki\Parser\ParserOutput;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 
 class SchemaContentHandler extends JsonContentHandler {

--- a/src/EntryPoints/Content/SubjectContent.php
+++ b/src/EntryPoints/Content/SubjectContent.php
@@ -4,7 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\EntryPoints\Content;
 
-use FormatJson;
+use MediaWiki\Json\FormatJson;
 use MediaWiki\Content\JsonContent;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;

--- a/src/EntryPoints/Content/SubjectContentHandler.php
+++ b/src/EntryPoints/Content/SubjectContentHandler.php
@@ -7,7 +7,7 @@ namespace ProfessionalWiki\NeoWiki\EntryPoints\Content;
 use MediaWiki\Content\Content;
 use MediaWiki\Content\JsonContentHandler;
 use MediaWiki\Content\Renderer\ContentParseParams;
-use ParserOutput;
+use MediaWiki\Parser\ParserOutput;
 
 class SubjectContentHandler extends JsonContentHandler {
 

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -25,7 +25,6 @@ use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\SchemaContentValidator;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\MediaWikiSubjectRepository;
 use ProfessionalWiki\NeoWiki\Presentation\JsonSchemaErrorFormatter;
 use Skin;
-use Status;
 use WikiPage;
 
 class NeoWikiHooks {
@@ -202,7 +201,7 @@ class NeoWikiHooks {
 		try {
 			new SchemaName( $editPage->getTitle()->getText() );
 		} catch ( InvalidArgumentException $exception ) {
-			$error = \Html::errorBox(
+			$error = Html::errorBox(
 				$exception->getMessage()
 			);
 		}
@@ -211,7 +210,7 @@ class NeoWikiHooks {
 
 		if ( !$contentValidator->validate( $text ) ) {
 			$errors = $contentValidator->getErrors();
-			$error = \Html::errorBox(
+			$error = Html::errorBox(
 				wfMessage( 'neowiki-schema-invalid', count( $errors ) )->escaped() .
 				JsonSchemaErrorFormatter::format( $errors )
 			);

--- a/src/EntryPoints/SpecialPages/SpecialNeoJson.php
+++ b/src/EntryPoints/SpecialPages/SpecialNeoJson.php
@@ -4,13 +4,13 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\EntryPoints\SpecialPages;
 
-use HTMLForm;
+use MediaWiki\HTMLForm\HTMLForm;
 use MediaWiki\Message\Message;
+use MediaWiki\SpecialPage\SpecialPage;
+use MediaWiki\Title\Title;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\EntryPoints\Content\SubjectContent;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
-use SpecialPage;
-use Title;
 
 class SpecialNeoJson extends SpecialPage {
 

--- a/src/EntryPoints/SpecialPages/SpecialSchemas.php
+++ b/src/EntryPoints/SpecialPages/SpecialSchemas.php
@@ -5,7 +5,7 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\EntryPoints\SpecialPages;
 
 use MediaWiki\Message\Message;
-use SpecialPage;
+use MediaWiki\SpecialPage\SpecialPage;
 
 class SpecialSchemas extends SpecialPage {
 

--- a/src/Persistence/MediaWiki/DatabaseSchemaNameLookup.php
+++ b/src/Persistence/MediaWiki/DatabaseSchemaNameLookup.php
@@ -8,7 +8,7 @@ use RuntimeException;
 use SearchEngine;
 use SearchSuggestion;
 use SearchSuggestionSet;
-use TitleValue;
+use MediaWiki\Title\TitleValue;
 use Wikimedia\Rdbms\IDatabase;
 use Wikimedia\Rdbms\IResultWrapper;
 

--- a/src/Persistence/MediaWiki/PageContentFetcher.php
+++ b/src/Persistence/MediaWiki/PageContentFetcher.php
@@ -4,16 +4,16 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Persistence\MediaWiki;
 
-use Content;
-use MalformedTitleException;
+use MediaWiki\Content\Content;
 use MediaWiki\Permissions\Authority;
 use MediaWiki\Revision\RevisionAccessException;
 use MediaWiki\Revision\RevisionLookup;
 use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Revision\SlotRecord;
-use Title;
-use TitleParser;
-use TitleValue;
+use MediaWiki\Title\MalformedTitleException;
+use MediaWiki\Title\Title;
+use MediaWiki\Title\TitleParser;
+use MediaWiki\Title\TitleValue;
 
 class PageContentFetcher {
 

--- a/src/Persistence/MediaWiki/Subject/MediaWikiSubjectRepository.php
+++ b/src/Persistence/MediaWiki/Subject/MediaWikiSubjectRepository.php
@@ -4,7 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject;
 
-use CommentStoreComment;
+use MediaWiki\CommentStore\CommentStoreComment;
 use MediaWiki\Revision\RevisionAccessException;
 use MediaWiki\Revision\RevisionLookup;
 use ProfessionalWiki\NeoWiki\Application\PageIdentifiersLookup;

--- a/src/Persistence/MediaWiki/Subject/SubjectContentRepository.php
+++ b/src/Persistence/MediaWiki/Subject/SubjectContentRepository.php
@@ -4,7 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject;
 
-use CommentStoreComment;
+use MediaWiki\CommentStore\CommentStoreComment;
 use MediaWiki\Page\PageIdentity;
 use MediaWiki\Page\WikiPageFactory;
 use MediaWiki\Permissions\Authority;

--- a/src/Persistence/SchemaNameLookup.php
+++ b/src/Persistence/SchemaNameLookup.php
@@ -2,7 +2,7 @@
 
 namespace ProfessionalWiki\NeoWiki\Persistence;
 
-use TitleValue;
+use MediaWiki\Title\TitleValue;
 
 interface SchemaNameLookup {
 

--- a/src/Presentation/FactBox.php
+++ b/src/Presentation/FactBox.php
@@ -4,10 +4,10 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Presentation;
 
+use MediaWiki\SpecialPage\SpecialPage;
+use MediaWiki\Title\Title;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectMap;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\SubjectContentRepository;
-use SpecialPage;
-use Title;
 
 class FactBox {
 

--- a/src/Presentation/TwigTemplateRenderer.php
+++ b/src/Presentation/TwigTemplateRenderer.php
@@ -4,7 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Presentation;
 
-use Html;
+use MediaWiki\Html\Html;
 use Psr\Log\LoggerInterface;
 use Throwable;
 use Twig\Environment;

--- a/tests/phpunit/Application/Actions/ImportPagesActionTest.php
+++ b/tests/phpunit/Application/Actions/ImportPagesActionTest.php
@@ -12,7 +12,7 @@ use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\SchemaContentSource
 use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\SubjectPageData;
 use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\SubjectPageSource;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\PageContentSaver;
-use WikitextContent;
+use MediaWiki\Content\WikitextContent;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\ImportPagesAction

--- a/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
@@ -15,8 +15,8 @@ use ProfessionalWiki\NeoWiki\EntryPoints\REST\CreateSubjectApi;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Presentation\CsrfValidator;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestStatement;
+use MediaWiki\Title\Title;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
-use Title;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\EntryPoints\REST\CreateSubjectApi

--- a/tests/phpunit/NeoWikiIntegrationTestCase.php
+++ b/tests/phpunit/NeoWikiIntegrationTestCase.php
@@ -4,9 +4,11 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Tests;
 
-use CommentStoreComment;
+use MediaWiki\CommentStore\CommentStoreComment;
+use MediaWiki\Content\TextContent;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Revision\RevisionRecord;
+use MediaWiki\Title\Title;
 use MediaWikiIntegrationTestCase;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
@@ -39,10 +41,10 @@ class NeoWikiIntegrationTestCase extends MediaWikiIntegrationTestCase {
 		?Subject $mainSubject = null,
 		SubjectMap $childSubjects = new SubjectMap()
 	): ?RevisionRecord {
-		$wikiPage = MediaWikiServices::getInstance()->getWikiPageFactory()->newFromTitle( \Title::newFromText( $pageName ) );
+		$wikiPage = MediaWikiServices::getInstance()->getWikiPageFactory()->newFromTitle( Title::newFromText( $pageName ) );
 		$updater = $wikiPage->newPageUpdater( $this->getTestSysop()->getUser() );
 
-		$updater->setContent( 'main', new \TextContent( '' ) );
+		$updater->setContent( 'main', new TextContent( '' ) );
 
 		$updater->setContent(
 			MediaWikiSubjectRepository::SLOT_NAME,
@@ -54,7 +56,7 @@ class NeoWikiIntegrationTestCase extends MediaWikiIntegrationTestCase {
 
 	protected function createSchema( string $name, string $json = null ): ?RevisionRecord {
 		$wikiPage = MediaWikiServices::getInstance()->getWikiPageFactory()->newFromTitle(
-			\Title::newFromText( $name, NeoWikiExtension::NS_SCHEMA )
+			Title::newFromText( $name, NeoWikiExtension::NS_SCHEMA )
 		);
 
 		$updater = $wikiPage->newPageUpdater( $this->getTestSysop()->getUser() );

--- a/tests/phpunit/Persistence/MediaWiki/DatabaseSchemaNameLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/DatabaseSchemaNameLookupTest.php
@@ -7,7 +7,7 @@ namespace ProfessionalWiki\NeoWiki\Tests\Persistence\MediaWiki;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\DatabaseSchemaNameLookup;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
-use TitleValue;
+use MediaWiki\Title\TitleValue;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\Persistence\MediaWiki\DatabaseSchemaNameLookup

--- a/tests/phpunit/Persistence/MediaWiki/PageContentFetcherIntegrationTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/PageContentFetcherIntegrationTest.php
@@ -4,11 +4,11 @@ declare( strict_types=1 );
 
 namespace ProfessionalWiki\NeoWiki\Tests\Persistence\MediaWiki;
 
-use CommentStoreComment;
+use MediaWiki\CommentStore\CommentStoreComment;
+use MediaWiki\Content\WikitextContent;
+use MediaWiki\Title\Title;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
-use Title;
-use WikitextContent;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\Persistence\MediaWiki\PageContentFetcher

--- a/tests/phpunit/Persistence/MediaWiki/PageContentFetcherTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/PageContentFetcherTest.php
@@ -4,15 +4,15 @@ declare( strict_types=1 );
 
 namespace ProfessionalWiki\NeoWiki\Tests\Persistence\MediaWiki;
 
-use Content;
-use MalformedTitleException;
+use MediaWiki\Content\Content;
 use MediaWiki\Permissions\Authority;
 use MediaWiki\Revision\RevisionLookup;
 use MediaWiki\Revision\RevisionRecord;
+use MediaWiki\Title\MalformedTitleException;
+use MediaWiki\Title\Title;
+use MediaWiki\Title\TitleParser;
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\PageContentFetcher;
-use Title;
-use TitleParser;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\Persistence\MediaWiki\PageContentFetcher

--- a/tests/phpunit/Presentation/FactBoxTest.php
+++ b/tests/phpunit/Presentation/FactBoxTest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace Presentation;
 
+use MediaWiki\Title\Title;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
@@ -22,7 +23,7 @@ class FactBoxTest extends NeoWikiIntegrationTestCase {
 
 		$this->assertStringContainsString(
 			'This page defines 1 NeoWiki subjects',
-			NeoWikiExtension::getInstance()->getFactBox()->htmlFor( \Title::newFromText( 'FactBoxSmokeTest' ) )
+			NeoWikiExtension::getInstance()->getFactBox()->htmlFor( Title::newFromText( 'FactBoxSmokeTest' ) )
 		);
 	}
 


### PR DESCRIPTION
## Summary
- Replace 30 legacy non-namespaced `use` statements with their `MediaWiki\` equivalents across 20 files
- Replace backslash-prefixed inline usages (`\Title::`, `\Html::`, `\TextContent`) with proper imports
- Sort import blocks alphabetically where reordered

The old names are `class_alias` shims that may be removed in a future MediaWiki release.

Companion PR for AGENTS.md guideline: ProfessionalWiki/NeoWiki-Docker#101 (to be created)

> Result of back and forth with @alistair3149.
> Context: the NeoWiki codebase and MediaWiki core namespace migration.
> <sub>Written by Claude Code, `Opus 4.6`</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)