### PR TITLE
Pass revisionId from frontend to REST API for old revisions

### DIFF
--- a/resources/ext.neowiki/src/NeoWikiExtension.ts
+++ b/resources/ext.neowiki/src/NeoWikiExtension.ts
@@ -139,7 +139,17 @@ export class NeoWikiExtension {
 			this.getMediaWiki().util.wikiScript( 'rest' ),
 			this.newHttpClient(),
 			this.getSubjectDeserializer(),
+			this.getRevisionId(),
 		);
+	}
+
+	private getRevisionId(): number | undefined {
+		const current = mw.config.get( 'wgRevisionId' );
+		const latest = mw.config.get( 'wgCurRevisionId' );
+		if ( current !== latest ) {
+			return current;
+		}
+		return undefined;
 	}
 
 	public getSubjectDeserializer(): SubjectDeserializer {

--- a/resources/ext.neowiki/src/persistence/RestSubjectRepository.ts
+++ b/resources/ext.neowiki/src/persistence/RestSubjectRepository.ts
@@ -23,13 +23,18 @@ export class RestSubjectRepository implements SubjectRepository {
 		private readonly mediaWikiRestApiUrl: string,
 		private readonly httpClient: HttpClient,
 		private readonly subjectDeserializer: SubjectDeserializer,
+		private readonly revisionId?: number,
 	) {
 	}
 
 	public async getSubject( id: SubjectId ): Promise<Subject> {
-		const response = await this.httpClient.get(
-			`${ this.mediaWikiRestApiUrl }/neowiki/v0/subject/${ id.text }?expand=page|relations`,
-		);
+		let url = `${ this.mediaWikiRestApiUrl }/neowiki/v0/subject/${ id.text }?expand=page|relations`;
+
+		if ( this.revisionId !== undefined ) {
+			url += `&revisionId=${ this.revisionId }`;
+		}
+
+		const response = await this.httpClient.get( url );
 
 		if ( !response.ok ) {
 			throw new Error( 'Error fetching subject' );


### PR DESCRIPTION
Went through the test plans manually.

For https://github.com/ProfessionalWiki/NeoWiki/issues/539

## Summary

- Thread optional `revisionId` parameter through the frontend loading chain (`SubjectLookup` → `RestSubjectRepository` → `StoreStateLoader` → `NeoWikiApp.vue`)
- Read `data-mw-ext-neowiki-revision-id` from the DOM when viewing old revisions
- Append `&revisionId=N` to the REST API URL so the backend returns historical Subject data

## Test plan

- [x] Navigate to a page with a Subject
- [x] Edit the Subject data (change label or property)
- [x] View the previous revision via page history (`?oldid=...`)
- [x] Verify the infobox shows the old data
- [x] View the current revision and verify it shows current data

🤖 Generated with [Claude Code](https://claude.com/claude-code)


https://github.com/user-attachments/assets/13bd0896-79b6-463f-a1eb-fd980e00d62c

