### PR TITLE
Remove unused wgNeoWikiNeo4jExternal* settings

### DIFF
--- a/.github/workflows/installMediaWiki.sh
+++ b/.github/workflows/installMediaWiki.sh
@@ -25,9 +25,6 @@ $wgDevelopmentWarnings = true;
 
 $wgNeoWikiNeo4jInternalWriteUrl = 'bolt://neo4j:password@localhost:7689';
 $wgNeoWikiNeo4jInternalReadUrl = 'bolt://mediawiki_read:mediawiki_read@localhost:7689';
-$wgNeoWikiNeo4jExternalReadUrl = 'bolt://localhost:7687';
-$wgNeoWikiNeo4jExternalReadUserName = 'mediawiki_read';
-$wgNeoWikiNeo4jExternalReadPassword = 'mediawiki_read';
 EOT
 
 cat <<EOT >> LocalSettings.php

--- a/Docker/SettingsTemplate.php
+++ b/Docker/SettingsTemplate.php
@@ -199,9 +199,6 @@ $wgNeoWikiEnableDevelopmentUI = true;
 
 $wgNeoWikiNeo4jInternalWriteUrl = 'bolt://' . getenv( 'NEO4J_USERNAME' ) . ':' . getenv( 'NEO4J_PASSWORD' ) . '@neo:7687';
 $wgNeoWikiNeo4jInternalReadUrl = 'bolt://' . getenv( 'NEO4J_USERNAME_READ' ) . ':' . getenv( 'NEO4J_PASSWORD_READ' ) . '@neo:7687';
-$wgNeoWikiNeo4jExternalReadUrl = getenv( 'NEO4J_URL_EXTERNAL' );
-$wgNeoWikiNeo4jExternalReadUserName = getenv( 'NEO4J_USERNAME_READ' );
-$wgNeoWikiNeo4jExternalReadPassword = getenv( 'NEO4J_PASSWORD_READ' );
 
 // Allow anonymous REST API calls on the wiki.
 $wgCrossSiteAJAXdomains = [


### PR DESCRIPTION
These settings were set in Docker and CI config but never read
by any code.

> Prompted by @JeroenDeDauw.
> Context: the NeoWiki codebase.
> <sub>Written by Claude Code, `Opus 4.6`</sub>