### PR TITLE
Defer schema save until subject is saved in SubjectCreator

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -195,6 +195,7 @@
 						"cdxIconAdd",
 						"cdxIconTrash",
 						"cdxIconArrowPrevious",
+						"cdxIconArrowNext",
 						"cdxIconInfo",
 						"cdxIconEdit",
 						"cdxIconLink",
@@ -273,8 +274,8 @@
 				"neowiki-subject-creator-success",
 				"neowiki-subject-creator-error",
 				"neowiki-subject-creator-create-schema",
+				"neowiki-subject-creator-continue",
 				"neowiki-subject-creator-schema-created",
-				"neowiki-subject-creator-save-with-schema",
 				"neowiki-subject-creator-creating-schema",
 				"neowiki-subject-creator-back",
 				"neowiki-edit-schema",
@@ -304,7 +305,12 @@
 				"neowiki-close-confirmation-title",
 				"neowiki-close-confirmation-message",
 				"neowiki-close-confirmation-discard",
-				"neowiki-close-confirmation-keep-editing"
+				"neowiki-close-confirmation-keep-editing",
+				"neowiki-schema-abandonment-title",
+				"neowiki-schema-abandonment-message",
+				"neowiki-schema-abandonment-abandon",
+				"neowiki-schema-abandonment-keep-editing",
+				"neowiki-schema-abandonment-save-schema"
 			],
 			"@group:": "TODO: Load code separately while in development. Remove later.",
 			"group": "ext.neowiki"

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -76,11 +76,11 @@
 	"neowiki-subject-creator-label-field": "Subject label",
 	"neowiki-subject-creator-label-placeholder": "Enter a label for the subject",
 	"neowiki-subject-creator-save": "Create subject",
-	"neowiki-subject-creator-save-with-schema": "Create $1",
 	"neowiki-subject-creator-creating-schema": "Creating schema",
 	"neowiki-subject-creator-success": "Subject created successfully",
 	"neowiki-subject-creator-error": "Failed to create subject",
 	"neowiki-subject-creator-create-schema": "Create schema",
+	"neowiki-subject-creator-continue": "Continue",
 	"neowiki-subject-creator-schema-created": "Schema created successfully",
 	"neowiki-subject-creator-back": "Back",
 
@@ -129,5 +129,11 @@
 	"neowiki-close-confirmation-title": "Discard unsaved changes?",
 	"neowiki-close-confirmation-message": "Your changes have not been saved and will be lost.",
 	"neowiki-close-confirmation-discard": "Discard",
-	"neowiki-close-confirmation-keep-editing": "Keep editing"
+	"neowiki-close-confirmation-keep-editing": "Keep editing",
+
+	"neowiki-schema-abandonment-title": "Discard unsaved changes?",
+	"neowiki-schema-abandonment-message": "Your new schema and subject have not been saved and will be lost.",
+	"neowiki-schema-abandonment-abandon": "Discard all",
+	"neowiki-schema-abandonment-keep-editing": "Keep editing",
+	"neowiki-schema-abandonment-save-schema": "Save schema only"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -16,9 +16,9 @@
 	"neowiki-cypher-raw-error-write-query": "Error message shown when a write query is rejected by the cypher_raw parser function.",
 	"neowiki-cypher-raw-error-query-failed": "Error message shown when Cypher query execution fails. $1 is the exception message.",
 	"neowiki-cypher-raw-error-json-encode": "Error message shown when JSON encoding of query results fails.",
-	"neowiki-subject-creator-save-with-schema": "Label for the save button in the subject creator dialog after a schema is selected. $1 is the schema name.",
 	"neowiki-subject-creator-creating-schema": "Subtitle shown in the subject creator dialog header when the user is creating a new schema.",
 	"neowiki-subject-creator-create-schema": "Label for the button that creates a new schema in the subject creator dialog.",
+	"neowiki-subject-creator-continue": "Label for the button that continues from schema creation to subject editing in the subject creator dialog.",
 	"neowiki-subject-creator-schema-created": "Success notification shown after creating a schema.",
 	"neowiki-subject-creator-back": "Aria label for the back button in the subject creator dialog, used to return to schema selection.",
 
@@ -56,5 +56,11 @@
 	"neowiki-close-confirmation-title": "Title of the confirmation dialog shown when closing a dialog with unsaved changes.",
 	"neowiki-close-confirmation-message": "Message in the confirmation dialog asking the user to confirm discarding unsaved changes.",
 	"neowiki-close-confirmation-discard": "Label for the destructive button that discards unsaved changes and closes the dialog.",
-	"neowiki-close-confirmation-keep-editing": "Label for the button that dismisses the confirmation and returns to editing."
+	"neowiki-close-confirmation-keep-editing": "Label for the button that dismisses the confirmation and returns to editing.",
+
+	"neowiki-schema-abandonment-title": "Title of the confirmation dialog shown when closing the subject creator with an unsaved draft schema.",
+	"neowiki-schema-abandonment-message": "Message explaining that both the new schema and subject will be lost.",
+	"neowiki-schema-abandonment-abandon": "Label for the destructive button that discards both the schema and subject.",
+	"neowiki-schema-abandonment-keep-editing": "Label for the button that returns to editing the subject.",
+	"neowiki-schema-abandonment-save-schema": "Label for the quiet button that saves only the schema and discards the subject."
 }

--- a/resources/ext.neowiki/src/components/SchemaCreator/SchemaCreator.vue
+++ b/resources/ext.neowiki/src/components/SchemaCreator/SchemaCreator.vue
@@ -19,7 +19,7 @@
 
 		<SchemaEditor
 			ref="schemaEditorRef"
-			:initial-schema="emptySchema"
+			:initial-schema="baseSchema"
 			@overflow="onOverflow"
 			@change="onChange"
 		/>
@@ -27,7 +27,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 import { CdxField, CdxTextInput } from '@wikimedia/codex';
 import type { ValidationStatusType } from '@wikimedia/codex';
 import SchemaEditor from '@/components/SchemaEditor/SchemaEditor.vue';
@@ -35,6 +35,12 @@ import type { SchemaEditorExposes } from '@/components/SchemaEditor/SchemaEditor
 import { Schema } from '@/domain/Schema.ts';
 import { PropertyDefinitionList } from '@/domain/PropertyDefinitionList.ts';
 import { useSchemaStore } from '@/stores/SchemaStore.ts';
+
+const props = withDefaults( defineProps<{
+	initialSchema?: Schema;
+}>(), {
+	initialSchema: undefined
+} );
 
 const emit = defineEmits<{
 	overflow: [ hasOverflow: boolean ];
@@ -45,9 +51,11 @@ const schemaStore = useSchemaStore();
 
 const DEBOUNCE_DELAY = 300;
 
-const emptySchema = new Schema( '', '', new PropertyDefinitionList( [] ) );
+const baseSchema = computed( () =>
+	props.initialSchema ?? new Schema( '', '', new PropertyDefinitionList( [] ) )
+);
 
-const schemaName = ref( '' );
+const schemaName = ref( props.initialSchema?.getName() ?? '' );
 const nameError = ref( '' );
 const nameStatus = ref<ValidationStatusType>( 'default' );
 const nameInputRef = ref<InstanceType<typeof CdxTextInput> | null>( null );

--- a/resources/ext.neowiki/src/components/SubjectCreator/SchemaAbandonmentDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectCreator/SchemaAbandonmentDialog.vue
@@ -1,0 +1,67 @@
+<template>
+	<CdxDialog
+		:open="open"
+		:title="$i18n( 'neowiki-schema-abandonment-title' ).text()"
+		:use-close-button="true"
+		@update:open="onUpdateOpen"
+	>
+		{{ $i18n( 'neowiki-schema-abandonment-message' ).text() }}
+
+		<template #footer>
+			<div class="ext-neowiki-schema-abandonment-dialog__actions">
+				<CdxButton
+					weight="primary"
+					action="destructive"
+					@click="$emit( 'abandon' )"
+				>
+					{{ $i18n( 'neowiki-schema-abandonment-abandon' ).text() }}
+				</CdxButton>
+				<CdxButton
+					@click="$emit( 'save-schema' )"
+				>
+					{{ $i18n( 'neowiki-schema-abandonment-save-schema' ).text() }}
+				</CdxButton>
+				<CdxButton
+					@click="$emit( 'keep-editing' )"
+				>
+					{{ $i18n( 'neowiki-schema-abandonment-keep-editing' ).text() }}
+				</CdxButton>
+			</div>
+		</template>
+	</CdxDialog>
+</template>
+
+<script setup lang="ts">
+import { CdxButton, CdxDialog } from '@wikimedia/codex';
+
+defineProps<{
+	open: boolean;
+}>();
+
+const emit = defineEmits<{
+	'abandon': [];
+	'save-schema': [];
+	'keep-editing': [];
+}>();
+
+function onUpdateOpen( value: boolean ): void {
+	if ( !value ) {
+		emit( 'keep-editing' );
+	}
+}
+</script>
+
+<style lang="less">
+@import ( reference ) '@wikimedia/codex-design-tokens/theme-wikimedia-ui.less';
+
+.ext-neowiki-schema-abandonment-dialog__actions {
+	display: flex;
+	flex-direction: column;
+	gap: @spacing-75;
+	width: @size-full;
+
+	.cdx-button {
+		max-width: none;
+	}
+}
+</style>

--- a/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
@@ -78,6 +78,7 @@
 				>
 					<SchemaCreator
 						ref="schemaCreatorRef"
+						:initial-schema="draftSchema ?? undefined"
 						@change="markChanged"
 					/>
 				</div>
@@ -108,12 +109,17 @@
 				v-if="selectedSchemaOption === 'new' && !selectedSchemaName"
 				#footer
 			>
-				<EditSummary
-					help-text=""
-					:save-button-label="$i18n( 'neowiki-subject-creator-create-schema' ).text()"
-					:save-disabled="!hasChanged"
-					@save="handleCreateSchema"
-				/>
+				<div class="ext-neowiki-subject-creator-continue">
+					<CdxButton
+						action="progressive"
+						weight="primary"
+						:disabled="!hasChanged"
+						@click="handleCreateSchema"
+					>
+						{{ $i18n( 'neowiki-subject-creator-continue' ).text() }}
+						<CdxIcon :icon="cdxIconArrowNext" />
+					</CdxButton>
+				</div>
 			</template>
 			<template
 				v-else-if="selectedSchemaName"
@@ -121,7 +127,7 @@
 			>
 				<EditSummary
 					help-text=""
-					:save-button-label="$i18n( 'neowiki-subject-creator-save-with-schema', selectedSchemaName ).text()"
+					:save-button-label="$i18n( 'neowiki-subject-creator-save' ).text()"
 					:save-disabled="!hasChanged"
 					@save="handleSave"
 				/>
@@ -133,13 +139,20 @@
 			@discard="confirmClose"
 			@keep-editing="cancelClose"
 		/>
+
+		<SchemaAbandonmentDialog
+			:open="schemaAbandonmentOpen"
+			@abandon="abandonAll"
+			@save-schema="saveSchemaAndClose"
+			@keep-editing="cancelSchemaAbandonment"
+		/>
 	</div>
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, nextTick, onMounted } from 'vue';
+import { ref, shallowRef, computed, watch, nextTick, onMounted } from 'vue';
 import { CdxButton, CdxDialog, CdxField, CdxIcon, CdxTextInput, CdxToggleButtonGroup } from '@wikimedia/codex';
-import { cdxIconAdd, cdxIconArrowPrevious, cdxIconClose, cdxIconSearch } from '@wikimedia/codex-icons';
+import { cdxIconAdd, cdxIconArrowNext, cdxIconArrowPrevious, cdxIconClose, cdxIconSearch } from '@wikimedia/codex-icons';
 import type { ButtonGroupItem } from '@wikimedia/codex';
 import { useSubjectStore } from '@/stores/SubjectStore.ts';
 import { useSchemaStore } from '@/stores/SchemaStore.ts';
@@ -153,6 +166,7 @@ import type { SchemaCreatorExposes } from '@/components/SchemaCreator/SchemaCrea
 import EditSummary from '@/components/common/EditSummary.vue';
 import SchemaLookup from '@/components/SubjectCreator/SchemaLookup.vue';
 import CloseConfirmationDialog from '@/components/common/CloseConfirmationDialog.vue';
+import SchemaAbandonmentDialog from '@/components/SubjectCreator/SchemaAbandonmentDialog.vue';
 import { useSchemaPermissions } from '@/composables/useSchemaPermissions.ts';
 import { useChangeDetection } from '@/composables/useChangeDetection.ts';
 import { useCloseConfirmation } from '@/composables/useCloseConfirmation.ts';
@@ -166,6 +180,8 @@ const subjectLabel = ref( '' );
 const schemaLookupRef = ref<any | null>( null );
 const schemaCreatorRef = ref<SchemaCreatorExposes | null>( null );
 
+const draftSchema = shallowRef<Schema | null>( null );
+
 const subjectStore = useSubjectStore();
 const schemaStore = useSchemaStore();
 const { canCreateSchemas, checkCreatePermission } = useSchemaPermissions();
@@ -175,7 +191,37 @@ function close(): void {
 	open.value = false;
 }
 
-const { confirmationOpen, requestClose, confirmClose, cancelClose } = useCloseConfirmation( hasChanged, close );
+const hasDraftSchema = computed( () => draftSchema.value !== null );
+
+const {
+	confirmationOpen,
+	alternateConfirmationOpen: schemaAbandonmentOpen,
+	requestClose,
+	confirmClose,
+	cancelClose,
+	confirmAlternateClose: abandonAll,
+	cancelAlternateClose: cancelSchemaAbandonment
+} = useCloseConfirmation( hasChanged, close, hasDraftSchema );
+
+async function saveSchemaAndClose(): Promise<void> {
+	if ( draftSchema.value ) {
+		try {
+			await schemaStore.saveSchema( draftSchema.value );
+			mw.notify( mw.msg( 'neowiki-subject-creator-schema-created' ), { type: 'success' } );
+		} catch ( error ) {
+			mw.notify(
+				error instanceof Error ? error.message : String( error ),
+				{
+					title: mw.msg( 'neowiki-subject-creator-error' ),
+					type: 'error'
+				}
+			);
+			cancelSchemaAbandonment();
+			return;
+		}
+	}
+	abandonAll();
+}
 
 function onDialogUpdateOpen( value: boolean ): void {
 	if ( !value ) {
@@ -248,7 +294,7 @@ async function onSchemaSelected( schemaName: string ): Promise<void> {
 	}
 }
 
-async function handleCreateSchema( summary: string ): Promise<void> {
+async function handleCreateSchema(): Promise<void> {
 	if ( !schemaCreatorRef.value ) {
 		return;
 	}
@@ -265,22 +311,11 @@ async function handleCreateSchema( summary: string ): Promise<void> {
 		return;
 	}
 
-	try {
-		await schemaStore.saveSchema( schema, summary || undefined );
-		mw.notify( mw.msg( 'neowiki-subject-creator-schema-created' ), { type: 'success' } );
-
-		selectedSchemaName.value = schema.getName();
-		loadedSchema.value = schema;
-		subjectLabel.value = String( mw.config.get( 'wgTitle' ) ?? '' );
-	} catch ( error ) {
-		mw.notify(
-			error instanceof Error ? error.message : String( error ),
-			{
-				title: mw.msg( 'neowiki-subject-creator-error' ),
-				type: 'error'
-			}
-		);
-	}
+	draftSchema.value = schema;
+	selectedSchemaName.value = schema.getName();
+	loadedSchema.value = schema;
+	subjectLabel.value = String( mw.config.get( 'wgTitle' ) ?? '' );
+	markChanged();
 }
 
 const schemaProperties = computed( (): PropertyDefinitionList =>
@@ -319,6 +354,7 @@ watch( open, async ( isOpen ) => {
 function resetForm(): void {
 	selectedSchemaName.value = null;
 	loadedSchema.value = null;
+	draftSchema.value = null;
 	subjectLabel.value = '';
 	selectedSchemaOption.value = 'existing';
 	schemaCreatorRef.value?.reset();
@@ -329,10 +365,15 @@ function goBack(): void {
 	selectedSchemaName.value = null;
 	loadedSchema.value = null;
 	subjectLabel.value = '';
-	resetChanged();
+
+	if ( draftSchema.value ) {
+		selectedSchemaOption.value = 'new';
+	} else {
+		resetChanged();
+	}
 }
 
-const handleSave = async ( _summary: string ): Promise<void> => {
+const handleSave = async ( summary: string ): Promise<void> => {
 	await nextTick();
 
 	const label = subjectLabel.value.trim();
@@ -346,10 +387,15 @@ const handleSave = async ( _summary: string ): Promise<void> => {
 		return;
 	}
 
-	const updatedStatements = subjectEditorRef.value.getSubjectData();
-	const statementsToSave = [ ...updatedStatements ].filter( ( statement ) => statement.hasValue() );
-
 	try {
+		if ( draftSchema.value ) {
+			await schemaStore.saveSchema( draftSchema.value, summary || undefined );
+			draftSchema.value = null;
+		}
+
+		const updatedStatements = subjectEditorRef.value.getSubjectData();
+		const statementsToSave = [ ...updatedStatements ].filter( ( statement ) => statement.hasValue() );
+
 		await subjectStore.createMainSubject(
 			mw.config.get( 'wgArticleId' ),
 			label,
@@ -424,6 +470,15 @@ defineExpose( { hasChanged } );
 
 	&-label-field {
 		margin-top: @spacing-100;
+	}
+
+	&-continue {
+		display: flex;
+
+		.cdx-button {
+			flex-grow: 1;
+			max-width: none;
+		}
 	}
 
 	&-new {

--- a/resources/ext.neowiki/src/composables/useCloseConfirmation.ts
+++ b/resources/ext.neowiki/src/composables/useCloseConfirmation.ts
@@ -2,19 +2,32 @@ import { ref, Ref } from 'vue';
 
 interface CloseConfirmation {
 	confirmationOpen: Ref<boolean>;
+	alternateConfirmationOpen: Ref<boolean>;
 	requestClose: () => void;
 	confirmClose: () => void;
 	cancelClose: () => void;
+	confirmAlternateClose: () => void;
+	cancelAlternateClose: () => void;
 }
 
-export function useCloseConfirmation( hasChanged: Ref<boolean>, close: () => void ): CloseConfirmation {
+export function useCloseConfirmation(
+	hasChanged: Ref<boolean>,
+	close: () => void,
+	useAlternateConfirmation: Ref<boolean> = ref( false ),
+): CloseConfirmation {
 	const confirmationOpen = ref( false );
+	const alternateConfirmationOpen = ref( false );
 
 	function requestClose(): void {
-		if ( hasChanged.value ) {
-			confirmationOpen.value = true;
-		} else {
+		if ( !hasChanged.value ) {
 			close();
+			return;
+		}
+
+		if ( useAlternateConfirmation.value ) {
+			alternateConfirmationOpen.value = true;
+		} else {
+			confirmationOpen.value = true;
 		}
 	}
 
@@ -27,10 +40,22 @@ export function useCloseConfirmation( hasChanged: Ref<boolean>, close: () => voi
 		confirmationOpen.value = false;
 	}
 
+	function confirmAlternateClose(): void {
+		alternateConfirmationOpen.value = false;
+		close();
+	}
+
+	function cancelAlternateClose(): void {
+		alternateConfirmationOpen.value = false;
+	}
+
 	return {
 		confirmationOpen,
+		alternateConfirmationOpen,
 		requestClose,
 		confirmClose,
 		cancelClose,
+		confirmAlternateClose,
+		cancelAlternateClose,
 	};
 }

--- a/resources/ext.neowiki/tests/components/SchemaCreator/SchemaCreator.spec.ts
+++ b/resources/ext.neowiki/tests/components/SchemaCreator/SchemaCreator.spec.ts
@@ -15,6 +15,7 @@ const NEW_SCHEMA_NAME = 'Company';
 const DEBOUNCE_DELAY = 300;
 
 const SchemaEditorStub = {
+	name: 'SchemaEditor',
 	template: '<div class="schema-editor-stub"></div>',
 	props: [ 'initialSchema' ],
 	emits: [ 'change', 'overflow' ],
@@ -28,9 +29,10 @@ describe( 'SchemaCreator', () => {
 	let pinia: ReturnType<typeof createPinia>;
 	let schemaStore: ReturnType<typeof useSchemaStore>;
 
-	function mountComponent( { attachTo }: { attachTo?: Element } = {} ): VueWrapper {
+	function mountComponent( { attachTo, initialSchema }: { attachTo?: Element; initialSchema?: Schema } = {} ): VueWrapper {
 		return mount( SchemaCreator, {
 			attachTo,
+			props: initialSchema ? { initialSchema } : {},
 			global: {
 				plugins: [ pinia ],
 				stubs: {
@@ -292,5 +294,44 @@ describe( 'SchemaCreator', () => {
 		await nameInput.setValue( 'A' );
 
 		expect( wrapper.emitted( 'change' ) ).toBeTruthy();
+	} );
+
+	describe( 'initialSchema prop', () => {
+		it( 'pre-populates name from initialSchema', () => {
+			const wrapper = mountComponent( {
+				initialSchema: new Schema( 'PreFilledName', 'A desc', new PropertyDefinitionList( [] ) ),
+			} );
+
+			const nameInput = wrapper.find( '.cdx-text-input-stub' );
+			expect( ( nameInput.element as HTMLInputElement ).value ).toBe( 'PreFilledName' );
+		} );
+
+		it( 'passes initialSchema to SchemaEditor', () => {
+			const wrapper = mountComponent( {
+				initialSchema: new Schema( 'PreFilledName', 'A desc', new PropertyDefinitionList( [] ) ),
+			} );
+
+			const schemaEditor = wrapper.findComponent( { name: 'SchemaEditor' } );
+			expect( schemaEditor.props( 'initialSchema' ).getName() ).toBe( 'PreFilledName' );
+		} );
+
+		it( 'uses empty schema when no initialSchema provided', () => {
+			const wrapper = mountComponent();
+
+			const schemaEditor = wrapper.findComponent( { name: 'SchemaEditor' } );
+			expect( schemaEditor.props( 'initialSchema' ).getName() ).toBe( '' );
+		} );
+
+		it( 'reset clears to empty state even with initialSchema', async () => {
+			const wrapper = mountComponent( {
+				initialSchema: new Schema( 'PreFilledName', 'A desc', new PropertyDefinitionList( [] ) ),
+			} );
+
+			( wrapper.vm as any ).reset();
+			await flushPromises();
+
+			const nameInput = wrapper.find( '.cdx-text-input-stub' );
+			expect( ( nameInput.element as HTMLInputElement ).value ).toBe( '' );
+		} );
 	} );
 } );

--- a/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
@@ -12,6 +12,7 @@ import { createI18nMock, setupMwMock } from '../../VueTestHelpers.ts';
 import { newSchema } from '@/TestHelpers.ts';
 import { CdxDialog } from '@wikimedia/codex';
 import CloseConfirmationDialog from '@/components/common/CloseConfirmationDialog.vue';
+import SchemaAbandonmentDialog from '@/components/SubjectCreator/SchemaAbandonmentDialog.vue';
 import { NeoWikiExtension } from '@/NeoWikiExtension.ts';
 import { Service } from '@/NeoWikiServices.ts';
 import { SubjectId } from '@/domain/SubjectId.ts';
@@ -54,6 +55,9 @@ const SubjectEditorStub = {
 
 const SchemaCreatorStub = {
 	template: '<div class="schema-creator-stub"></div>',
+	props: {
+		initialSchema: { type: Object, default: undefined },
+	},
 	emits: [ 'change', 'overflow' ],
 	setup() {
 		let valid = true;
@@ -94,6 +98,12 @@ const CloseConfirmationDialogStub = {
 	emits: [ 'discard', 'keep-editing' ],
 };
 
+const SchemaAbandonmentDialogStub = {
+	template: '<div class="schema-abandonment-stub"></div>',
+	props: [ 'open' ],
+	emits: [ 'abandon', 'save-schema', 'keep-editing' ],
+};
+
 const CdxToggleButtonGroupStub = {
 	name: 'CdxToggleButtonGroup',
 	template: '<div class="cdx-toggle-button-group-stub"></div>',
@@ -119,6 +129,7 @@ describe( 'SubjectCreatorDialog', () => {
 					SchemaCreator: SchemaCreatorStub,
 					EditSummary: EditSummaryStub,
 					CloseConfirmationDialog: CloseConfirmationDialogStub,
+					SchemaAbandonmentDialog: SchemaAbandonmentDialogStub,
 					CdxButton: true,
 					CdxDialog: CdxDialogStub,
 					CdxToggleButtonGroup: CdxToggleButtonGroupStub,
@@ -149,6 +160,11 @@ describe( 'SubjectCreatorDialog', () => {
 	async function switchToNewSchema( wrapper: VueWrapper ): Promise<void> {
 		wrapper.findComponent( { name: 'CdxToggleButtonGroup' } )
 			.vm.$emit( 'update:modelValue', 'new' );
+		await flushPromises();
+	}
+
+	async function clickContinue( wrapper: VueWrapper ): Promise<void> {
+		await wrapper.find( '.ext-neowiki-subject-creator-continue cdx-button-stub' ).trigger( 'click' );
 		await flushPromises();
 	}
 
@@ -330,7 +346,7 @@ describe( 'SubjectCreatorDialog', () => {
 			await switchToNewSchema( wrapper );
 
 			expect( wrapper.find( '.schema-creator-stub' ).exists() ).toBe( true );
-			expect( wrapper.find( '.edit-summary-stub' ).exists() ).toBe( true );
+			expect( wrapper.find( '.ext-neowiki-subject-creator-continue' ).exists() ).toBe( true );
 		} );
 
 		it( 'does not show SchemaLookup when "Create new" is selected', async () => {
@@ -357,8 +373,7 @@ describe( 'SubjectCreatorDialog', () => {
 
 			( wrapper.findComponent( SchemaCreator ).vm as any ).setStubValid( false );
 
-			await wrapper.findComponent( EditSummary ).vm.$emit( 'save', '' );
-			await flushPromises();
+			await clickContinue( wrapper );
 
 			expect( schemaStore.saveSchema ).not.toHaveBeenCalled();
 		} );
@@ -371,34 +386,19 @@ describe( 'SubjectCreatorDialog', () => {
 			expect( wrapper.find( '.cdx-toggle-button-group-stub' ).exists() ).toBe( true );
 			expect( wrapper.find( '.schema-creator-stub' ).exists() ).toBe( true );
 
-			await wrapper.findComponent( EditSummary ).vm.$emit( 'save', '' );
-			await flushPromises();
+			await clickContinue( wrapper );
 
 			expect( wrapper.find( '.cdx-toggle-button-group-stub' ).exists() ).toBe( false );
 			expect( wrapper.find( '.schema-creator-stub' ).exists() ).toBe( false );
 		} );
 
-		it( 'saves schema and transitions to subject step on success', async () => {
+		it( 'transitions to subject step without saving schema', async () => {
 			const wrapper = mountComponent();
-
 			await switchToNewSchema( wrapper );
 
-			await wrapper.findComponent( EditSummary ).vm.$emit( 'save', 'Created schema' );
-			await flushPromises();
+			await clickContinue( wrapper );
 
-			expect( schemaStore.saveSchema ).toHaveBeenCalledWith(
-				expect.any( Schema ),
-				'Created schema',
-			);
-
-			const savedSchema = ( schemaStore.saveSchema as ReturnType<typeof vi.fn> ).mock.calls[ 0 ][ 0 ] as Schema;
-			expect( savedSchema.getName() ).toBe( NEW_SCHEMA_NAME );
-
-			expect( mw.notify ).toHaveBeenCalledWith(
-				expect.any( String ),
-				expect.objectContaining( { type: 'success' } ),
-			);
-
+			expect( schemaStore.saveSchema ).not.toHaveBeenCalled();
 			expect( wrapper.find( '.subject-editor-stub' ).exists() ).toBe( true );
 			expect( wrapper.find( '.schema-creator-stub' ).exists() ).toBe( false );
 		} );
@@ -408,41 +408,29 @@ describe( 'SubjectCreatorDialog', () => {
 
 			await switchToNewSchema( wrapper );
 
-			await wrapper.findComponent( EditSummary ).vm.$emit( 'save', '' );
-			await flushPromises();
+			await clickContinue( wrapper );
 
 			const labelInput = wrapper.find( '.cdx-text-input-stub' );
 			expect( ( labelInput.element as HTMLInputElement ).value ).toBe( PAGE_TITLE );
 		} );
 
-		it( 'stays on schema step when save fails', async () => {
-			schemaStore.saveSchema = vi.fn().mockRejectedValue( new Error( 'Save failed' ) );
+		it( 'saves schema and creates subject on final save', async () => {
 			const wrapper = mountComponent();
 
 			await switchToNewSchema( wrapper );
 
-			await wrapper.findComponent( EditSummary ).vm.$emit( 'save', '' );
-			await flushPromises();
-
-			expect( mw.notify ).toHaveBeenCalledWith(
-				'Save failed',
-				expect.objectContaining( { type: 'error' } ),
-			);
-
-			expect( wrapper.find( '.schema-creator-stub' ).exists() ).toBe( true );
-			expect( wrapper.find( '.subject-editor-stub' ).exists() ).toBe( false );
-		} );
-
-		it( 'creates subject after schema creation', async () => {
-			const wrapper = mountComponent();
-
-			await switchToNewSchema( wrapper );
-
-			await wrapper.findComponent( EditSummary ).vm.$emit( 'save', '' );
-			await flushPromises();
+			await clickContinue( wrapper );
 
 			await wrapper.findComponent( EditSummary ).vm.$emit( 'save', 'Created subject' );
 			await flushPromises();
+
+			expect( schemaStore.saveSchema ).toHaveBeenCalledWith(
+				expect.any( Schema ),
+				'Created subject',
+			);
+
+			const savedSchema = ( schemaStore.saveSchema as ReturnType<typeof vi.fn> ).mock.calls[ 0 ][ 0 ] as Schema;
+			expect( savedSchema.getName() ).toBe( NEW_SCHEMA_NAME );
 
 			expect( subjectStore.createMainSubject ).toHaveBeenCalledWith(
 				PAGE_ID,
@@ -452,19 +440,70 @@ describe( 'SubjectCreatorDialog', () => {
 			);
 		} );
 
+		it( 'passes edit summary to saveSchema on final save', async () => {
+			const wrapper = mountComponent();
+
+			await switchToNewSchema( wrapper );
+			await clickContinue( wrapper );
+
+			await wrapper.findComponent( EditSummary ).vm.$emit( 'save', 'My edit summary' );
+			await flushPromises();
+
+			expect( schemaStore.saveSchema ).toHaveBeenCalledWith(
+				expect.any( Schema ),
+				'My edit summary',
+			);
+		} );
+
+		it( 'does not pass empty edit summary to saveSchema', async () => {
+			const wrapper = mountComponent();
+
+			await switchToNewSchema( wrapper );
+			await clickContinue( wrapper );
+
+			await wrapper.findComponent( EditSummary ).vm.$emit( 'save', '' );
+			await flushPromises();
+
+			expect( schemaStore.saveSchema ).toHaveBeenCalledWith(
+				expect.any( Schema ),
+				undefined,
+			);
+		} );
+
+		it( 'shows error and does not create subject when schema save fails', async () => {
+			schemaStore.saveSchema = vi.fn().mockRejectedValue( new Error( 'Schema save failed' ) );
+			const wrapper = mountComponent();
+
+			await wrapper.find( '.ext-neowiki-subject-creator-trigger' ).trigger( 'click' );
+			await switchToNewSchema( wrapper );
+
+			await clickContinue( wrapper );
+
+			await wrapper.findComponent( EditSummary ).vm.$emit( 'save', '' );
+			await flushPromises();
+
+			expect( mw.notify ).toHaveBeenCalledWith(
+				'Schema save failed',
+				expect.objectContaining( { type: 'error' } ),
+			);
+			expect( subjectStore.createMainSubject ).not.toHaveBeenCalled();
+
+			const dialog = wrapper.findComponent( CdxDialog );
+			expect( dialog.props( 'open' ) ).toBe( true );
+		} );
+
 		it( 'resets to schema step when dialog closes', async () => {
 			const wrapper = mountComponent();
 
 			await wrapper.find( '.ext-neowiki-subject-creator-trigger' ).trigger( 'click' );
 			await switchToNewSchema( wrapper );
 
-			await wrapper.findComponent( EditSummary ).vm.$emit( 'save', '' );
-			await flushPromises();
+			await clickContinue( wrapper );
 
 			wrapper.findComponent( CdxDialog ).vm.$emit( 'update:open', false );
 			await flushPromises();
 
-			wrapper.findComponent( CloseConfirmationDialog ).vm.$emit( 'discard' );
+			wrapper.findComponent( SchemaAbandonmentDialog ).vm.$emit( 'abandon' );
 			await flushPromises();
 
 			await wrapper.find( '.ext-neowiki-subject-creator-trigger' ).trigger( 'click' );
@@ -512,28 +551,41 @@ describe( 'SubjectCreatorDialog', () => {
 
 			await switchToNewSchema( wrapper );
 
-			await wrapper.findComponent( EditSummary ).vm.$emit( 'save', '' );
-			await flushPromises();
+			await clickContinue( wrapper );
 
 			expect( wrapper.find( '.ext-neowiki-subject-creator-back-button' ).exists() ).toBe( true );
 		} );
 
-		it( 'returns to schema selection after creating a schema and clicking back', async () => {
+		it( 'returns to schema editor with draft when clicking back after creating schema', async () => {
 			const wrapper = mountComponent();
-
 			await switchToNewSchema( wrapper );
 
-			await wrapper.findComponent( EditSummary ).vm.$emit( 'save', '' );
-			await flushPromises();
+			await clickContinue( wrapper );
 
 			await wrapper.find( '.ext-neowiki-subject-creator-back-button' ).trigger( 'click' );
 			await flushPromises();
 
-			expect( wrapper.find( '.cdx-toggle-button-group-stub' ).exists() ).toBe( true );
+			expect( wrapper.find( '.schema-creator-stub' ).exists() ).toBe( true );
 			expect( wrapper.find( '.subject-editor-stub' ).exists() ).toBe( false );
+			expect( wrapper.find( '.schema-lookup-stub' ).exists() ).toBe( false );
 		} );
 
-		it( 'preserves schema option when going back from existing schema', async () => {
+		it( 'passes draft schema to SchemaCreator when going back', async () => {
+			const wrapper = mountComponent();
+			await switchToNewSchema( wrapper );
+
+			await clickContinue( wrapper );
+
+			await wrapper.find( '.ext-neowiki-subject-creator-back-button' ).trigger( 'click' );
+			await flushPromises();
+
+			const creator = wrapper.findComponent( SchemaCreator );
+			const initialSchema = creator.props( 'initialSchema' ) as Schema;
+			expect( initialSchema ).toBeTruthy();
+			expect( initialSchema.getName() ).toBe( NEW_SCHEMA_NAME );
+		} );
+
+		it( 'returns to schema selector when clicking back after selecting existing schema', async () => {
 			const wrapper = mountComponent();
 
 			await wrapper.findComponent( SchemaLookup ).vm.$emit( 'select', SCHEMA_NAME );
@@ -543,7 +595,7 @@ describe( 'SubjectCreatorDialog', () => {
 			await flushPromises();
 
 			expect( wrapper.find( '.schema-lookup-stub' ).exists() ).toBe( true );
-			expect( wrapper.find( '.cdx-toggle-button-group-stub' ).exists() ).toBe( true );
+			expect( wrapper.find( '.schema-creator-stub' ).exists() ).toBe( false );
 		} );
 	} );
 
@@ -623,6 +675,152 @@ describe( 'SubjectCreatorDialog', () => {
 			const dialog = wrapper.findComponent( CdxDialog );
 			expect( dialog.props( 'open' ) ).toBe( true );
 			expect( wrapper.findComponent( CloseConfirmationDialog ).props( 'open' ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'Close confirmation with draft schema', () => {
+		it( 'shows three-option dialog when closing with draft schema on subject step', async () => {
+			const wrapper = mountComponent();
+
+			await wrapper.find( '.ext-neowiki-subject-creator-trigger' ).trigger( 'click' );
+			await switchToNewSchema( wrapper );
+
+			await clickContinue( wrapper );
+
+			wrapper.findComponent( CdxDialog ).vm.$emit( 'update:open', false );
+			await flushPromises();
+
+			expect( wrapper.findComponent( SchemaAbandonmentDialog ).props( 'open' ) ).toBe( true );
+			expect( wrapper.findComponent( CloseConfirmationDialog ).props( 'open' ) ).toBe( false );
+		} );
+
+		it( 'closes without saving on abandon', async () => {
+			const wrapper = mountComponent();
+
+			await wrapper.find( '.ext-neowiki-subject-creator-trigger' ).trigger( 'click' );
+			await switchToNewSchema( wrapper );
+
+			await clickContinue( wrapper );
+
+			wrapper.findComponent( CdxDialog ).vm.$emit( 'update:open', false );
+			await flushPromises();
+
+			wrapper.findComponent( SchemaAbandonmentDialog ).vm.$emit( 'abandon' );
+			await flushPromises();
+
+			expect( schemaStore.saveSchema ).not.toHaveBeenCalled();
+			expect( wrapper.findComponent( CdxDialog ).props( 'open' ) ).toBe( false );
+		} );
+
+		it( 'saves schema and closes on save-schema', async () => {
+			const wrapper = mountComponent();
+
+			await wrapper.find( '.ext-neowiki-subject-creator-trigger' ).trigger( 'click' );
+			await switchToNewSchema( wrapper );
+
+			await clickContinue( wrapper );
+
+			wrapper.findComponent( CdxDialog ).vm.$emit( 'update:open', false );
+			await flushPromises();
+
+			wrapper.findComponent( SchemaAbandonmentDialog ).vm.$emit( 'save-schema' );
+			await flushPromises();
+
+			expect( schemaStore.saveSchema ).toHaveBeenCalledWith(
+				expect.any( Schema ),
+			);
+			expect( wrapper.findComponent( CdxDialog ).props( 'open' ) ).toBe( false );
+		} );
+
+		it( 'keeps dialog open on keep-editing', async () => {
+			const wrapper = mountComponent();
+
+			await wrapper.find( '.ext-neowiki-subject-creator-trigger' ).trigger( 'click' );
+			await switchToNewSchema( wrapper );
+
+			await clickContinue( wrapper );
+
+			wrapper.findComponent( CdxDialog ).vm.$emit( 'update:open', false );
+			await flushPromises();
+
+			wrapper.findComponent( SchemaAbandonmentDialog ).vm.$emit( 'keep-editing' );
+			await flushPromises();
+
+			expect( wrapper.findComponent( CdxDialog ).props( 'open' ) ).toBe( true );
+			expect( wrapper.findComponent( SchemaAbandonmentDialog ).props( 'open' ) ).toBe( false );
+		} );
+
+		it( 'uses standard close confirmation when closing with existing schema', async () => {
+			const wrapper = mountComponent();
+
+			await wrapper.find( '.ext-neowiki-subject-creator-trigger' ).trigger( 'click' );
+			await wrapper.findComponent( SchemaLookup ).vm.$emit( 'select', SCHEMA_NAME );
+			await flushPromises();
+
+			const labelInput = wrapper.find( '.cdx-text-input-stub' );
+			await labelInput.setValue( 'Something' );
+			await labelInput.trigger( 'input' );
+			await flushPromises();
+
+			wrapper.findComponent( CdxDialog ).vm.$emit( 'update:open', false );
+			await flushPromises();
+
+			expect( wrapper.findComponent( CloseConfirmationDialog ).props( 'open' ) ).toBe( true );
+		} );
+
+		it( 'uses standard close confirmation on schema editor step without draft', async () => {
+			const wrapper = mountComponent();
+
+			await wrapper.find( '.ext-neowiki-subject-creator-trigger' ).trigger( 'click' );
+			await switchToNewSchema( wrapper );
+
+			wrapper.findComponent( SchemaCreator ).vm.$emit( 'change' );
+			await flushPromises();
+
+			wrapper.findComponent( CdxDialog ).vm.$emit( 'update:open', false );
+			await flushPromises();
+
+			expect( wrapper.findComponent( CloseConfirmationDialog ).props( 'open' ) ).toBe( true );
+		} );
+
+		it( 'shows three-option dialog on schema editor step when draft exists', async () => {
+			const wrapper = mountComponent();
+
+			await wrapper.find( '.ext-neowiki-subject-creator-trigger' ).trigger( 'click' );
+			await switchToNewSchema( wrapper );
+
+			await clickContinue( wrapper );
+
+			await wrapper.find( '.ext-neowiki-subject-creator-back-button' ).trigger( 'click' );
+			await flushPromises();
+
+			wrapper.findComponent( CdxDialog ).vm.$emit( 'update:open', false );
+			await flushPromises();
+
+			expect( wrapper.findComponent( SchemaAbandonmentDialog ).props( 'open' ) ).toBe( true );
+			expect( wrapper.findComponent( CloseConfirmationDialog ).props( 'open' ) ).toBe( false );
+		} );
+
+		it( 'shows error and keeps dialog open when save-schema fails', async () => {
+			schemaStore.saveSchema = vi.fn().mockRejectedValue( new Error( 'Save failed' ) );
+			const wrapper = mountComponent();
+
+			await wrapper.find( '.ext-neowiki-subject-creator-trigger' ).trigger( 'click' );
+			await switchToNewSchema( wrapper );
+
+			await clickContinue( wrapper );
+
+			wrapper.findComponent( CdxDialog ).vm.$emit( 'update:open', false );
+			await flushPromises();
+
+			wrapper.findComponent( SchemaAbandonmentDialog ).vm.$emit( 'save-schema' );
+			await flushPromises();
+
+			expect( mw.notify ).toHaveBeenCalledWith(
+				'Save failed',
+				expect.objectContaining( { type: 'error' } ),
+			);
+			expect( wrapper.findComponent( CdxDialog ).props( 'open' ) ).toBe( true );
 		} );
 	} );
 } );

--- a/resources/ext.neowiki/tests/composables/useCloseConfirmation.spec.ts
+++ b/resources/ext.neowiki/tests/composables/useCloseConfirmation.spec.ts
@@ -46,4 +46,67 @@ describe( 'useCloseConfirmation', () => {
 		expect( confirmationOpen.value ).toBe( false );
 	} );
 
+	describe( 'with alternate confirmation', () => {
+
+		it( 'opens alternate confirmation when condition is met', () => {
+			const close = vi.fn();
+			const { requestClose, alternateConfirmationOpen, confirmationOpen } =
+				useCloseConfirmation( ref( true ), close, ref( true ) );
+
+			requestClose();
+
+			expect( alternateConfirmationOpen.value ).toBe( true );
+			expect( confirmationOpen.value ).toBe( false );
+			expect( close ).not.toHaveBeenCalled();
+		} );
+
+		it( 'opens standard confirmation when alternate condition is false', () => {
+			const close = vi.fn();
+			const { requestClose, alternateConfirmationOpen, confirmationOpen } =
+				useCloseConfirmation( ref( true ), close, ref( false ) );
+
+			requestClose();
+
+			expect( confirmationOpen.value ).toBe( true );
+			expect( alternateConfirmationOpen.value ).toBe( false );
+		} );
+
+		it( 'closes on confirmAlternateClose', () => {
+			const close = vi.fn();
+			const { requestClose, confirmAlternateClose, alternateConfirmationOpen } =
+				useCloseConfirmation( ref( true ), close, ref( true ) );
+
+			requestClose();
+			confirmAlternateClose();
+
+			expect( close ).toHaveBeenCalled();
+			expect( alternateConfirmationOpen.value ).toBe( false );
+		} );
+
+		it( 'hides alternate confirmation without closing on cancelAlternateClose', () => {
+			const close = vi.fn();
+			const { requestClose, cancelAlternateClose, alternateConfirmationOpen } =
+				useCloseConfirmation( ref( true ), close, ref( true ) );
+
+			requestClose();
+			cancelAlternateClose();
+
+			expect( close ).not.toHaveBeenCalled();
+			expect( alternateConfirmationOpen.value ).toBe( false );
+		} );
+
+		it( 'closes immediately when hasChanged is false regardless of alternate condition', () => {
+			const close = vi.fn();
+			const { requestClose, alternateConfirmationOpen, confirmationOpen } =
+				useCloseConfirmation( ref( false ), close, ref( true ) );
+
+			requestClose();
+
+			expect( close ).toHaveBeenCalled();
+			expect( alternateConfirmationOpen.value ).toBe( false );
+			expect( confirmationOpen.value ).toBe( false );
+		} );
+
+	} );
+
 } );


### PR DESCRIPTION
Tested with both manual and automated browser testing.

Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/537
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/646

## Summary
- When creating a subject with a new schema, the schema is held as a draft and saved atomically with the subject on final save (instead of being saved immediately on "Continue")
- Back button returns to the schema editor with the draft preserved, rather than resetting to the schema selector
- Adds a three-option abandonment dialog (Discard all / Keep editing / Save schema only) when closing with an unsaved draft schema

## Test plan
- [x] Create subject with new schema: verify schema is not saved until subject is saved
- [x] Click back button after Continue: verify schema editor shows with draft preserved
- [x] Close dialog on subject step with draft: verify three-option abandonment dialog
- [x] Close dialog on schema editor step with draft: verify three-option abandonment dialog
- [x] Close dialog without draft: verify standard two-option close confirmation
- [x] "Save schema only" saves schema and closes dialog
- [x] "Discard all" closes without saving
- [x] Continue button is full-width with arrow icon
- [x] Save button shows "Create subject" (not schema name)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


https://github.com/user-attachments/assets/1bbfc647-d77f-42fe-93b9-90034951c2ee