### PR TITLE
Add edit summary support for subject creation

### DIFF
--- a/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
@@ -332,7 +332,7 @@ function goBack(): void {
 	resetChanged();
 }
 
-const handleSave = async ( _summary: string ): Promise<void> => {
+const handleSave = async ( summary: string ): Promise<void> => {
 	await nextTick();
 
 	const label = subjectLabel.value.trim();
@@ -354,7 +354,8 @@ const handleSave = async ( _summary: string ): Promise<void> => {
 			mw.config.get( 'wgArticleId' ),
 			label,
 			selectedSchemaName.value,
-			new StatementList( statementsToSave )
+			new StatementList( statementsToSave ),
+			summary || undefined
 		);
 		mw.notify( mw.msg( 'neowiki-subject-creator-success' ), { type: 'success' } );
 		close();

--- a/resources/ext.neowiki/src/domain/SubjectRepository.ts
+++ b/resources/ext.neowiki/src/domain/SubjectRepository.ts
@@ -10,7 +10,8 @@ export interface SubjectRepository extends SubjectLookup {
 		pageId: number,
 		label: string,
 		schemaName: SchemaName,
-		statements: StatementList
+		statements: StatementList,
+		comment?: string
 	): Promise<SubjectId>;
 
 	createChildSubject(
@@ -29,7 +30,7 @@ export interface SubjectRepository extends SubjectLookup {
 
 export class StubSubjectRepository extends InMemorySubjectLookup implements SubjectRepository {
 
-	public createMainSubject( _pageId: number, _label: string, _schemaName: string, _statements: StatementList ): Promise<SubjectId> {
+	public createMainSubject( _pageId: number, _label: string, _schemaName: string, _statements: StatementList, _comment?: string ): Promise<SubjectId> {
 		return Promise.resolve( new SubjectId( 's11111111111111' ) );
 	}
 

--- a/resources/ext.neowiki/src/persistence/RestSubjectRepository.ts
+++ b/resources/ext.neowiki/src/persistence/RestSubjectRepository.ts
@@ -51,11 +51,13 @@ export class RestSubjectRepository implements SubjectRepository {
 		label: string,
 		schemaName: SchemaName,
 		statements: StatementList,
+		comment?: string,
 	): Promise<SubjectId> {
 		const payload = {
 			label: label,
 			schema: schemaName,
 			statements: statementsToJson( statements ),
+			comment,
 		};
 
 		const response = await this.httpClient.post(

--- a/resources/ext.neowiki/src/stores/SubjectStore.ts
+++ b/resources/ext.neowiki/src/stores/SubjectStore.ts
@@ -43,12 +43,13 @@ export const useSubjectStore = defineStore( 'subject', {
 			await NeoWikiExtension.getInstance().getSubjectRepository().deleteSubject( subjectId );
 			this.subjects.delete( subjectId.text );
 		},
-		async createMainSubject( pageId: number, label: string, schemaName: SchemaName, statements: StatementList ): Promise<SubjectId> {
+		async createMainSubject( pageId: number, label: string, schemaName: SchemaName, statements: StatementList, comment?: string ): Promise<SubjectId> {
 			const subjectId = await NeoWikiExtension.getInstance().getSubjectRepository().createMainSubject(
 				pageId,
 				label,
 				schemaName,
 				statements,
+				comment,
 			);
 
 			this.setSubject(

--- a/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
@@ -260,6 +260,25 @@ describe( 'SubjectCreatorDialog', () => {
 			PAGE_TITLE,
 			SCHEMA_NAME,
 			expect.any( StatementList ),
+			'test summary',
+		);
+	} );
+
+	it( 'does not pass summary when it is empty', async () => {
+		const wrapper = mountComponent();
+
+		await wrapper.findComponent( SchemaLookup ).vm.$emit( 'select', SCHEMA_NAME );
+		await flushPromises();
+
+		await wrapper.findComponent( EditSummary ).vm.$emit( 'save', '' );
+		await flushPromises();
+
+		expect( subjectStore.createMainSubject ).toHaveBeenCalledWith(
+			PAGE_ID,
+			PAGE_TITLE,
+			SCHEMA_NAME,
+			expect.any( StatementList ),
+			undefined,
 		);
 	} );
 
@@ -449,6 +468,7 @@ describe( 'SubjectCreatorDialog', () => {
 				PAGE_TITLE,
 				NEW_SCHEMA_NAME,
 				expect.any( StatementList ),
+				'Created subject',
 			);
 		} );
 

--- a/src/Application/Actions/CreateSubject/CreateSubjectAction.php
+++ b/src/Application/Actions/CreateSubject/CreateSubjectAction.php
@@ -48,7 +48,7 @@ readonly class CreateSubjectAction {
 			return;
 		}
 
-		$this->subjectRepository->savePageSubjects( $pageSubjects, new PageId( $request->pageId ) );
+		$this->subjectRepository->savePageSubjects( $pageSubjects, new PageId( $request->pageId ), $request->comment );
 		$this->presenter->presentCreated( $subject->id->text );
 	}
 

--- a/src/Application/Actions/CreateSubject/CreateSubjectRequest.php
+++ b/src/Application/Actions/CreateSubject/CreateSubjectRequest.php
@@ -18,6 +18,8 @@ readonly class CreateSubjectRequest {
 		 * @var array<string, mixed[]>
 		 */
 		public array $statements,
+
+		public ?string $comment = null,
 	) {
 	}
 

--- a/src/Application/SubjectRepository.php
+++ b/src/Application/SubjectRepository.php
@@ -31,6 +31,6 @@ interface SubjectRepository extends SubjectLookup {
 	/**
 	 * TODO: document exceptions
 	 */
-	public function savePageSubjects( PageSubjects $pageSubjects, PageId $pageId ): void;
+	public function savePageSubjects( PageSubjects $pageSubjects, PageId $pageId, ?string $comment = null ): void;
 
 }

--- a/src/EntryPoints/REST/CreateSubjectApi.php
+++ b/src/EntryPoints/REST/CreateSubjectApi.php
@@ -36,6 +36,7 @@ class CreateSubjectApi extends SimpleHandler implements CreateSubjectPresenter {
 					label: $request['label'],
 					schemaName: $request['schema'],
 					statements: $request['statements'],
+					comment: $request['comment'] ?? null,
 				)
 			);
 

--- a/src/Persistence/MediaWiki/Subject/MediaWikiSubjectRepository.php
+++ b/src/Persistence/MediaWiki/Subject/MediaWikiSubjectRepository.php
@@ -129,11 +129,11 @@ class MediaWikiSubjectRepository implements SubjectRepository {
 		return $this->getContentByPageId( $pageId )?->getPageSubjects() ?? PageSubjects::newEmpty();
 	}
 
-	public function savePageSubjects( PageSubjects $pageSubjects, PageId $pageId ): void {
+	public function savePageSubjects( PageSubjects $pageSubjects, PageId $pageId, ?string $comment = null ): void {
 		$content = $this->getContentByPageId( $pageId ) ?? SubjectContent::newEmpty();
 
 		$content->setPageSubjects( $pageSubjects );
 
-		$this->saveContent( $content, $pageId );
+		$this->saveContent( $content, $pageId, $comment );
 	}
 }

--- a/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
@@ -116,6 +116,39 @@ class CreateSubjectActionTest extends TestCase {
 		);
 	}
 
+	public function testCommentIsPassedToRepository(): void {
+		$this->subjectRepository->savePageSubjects( PageSubjects::newEmpty(), new PageId( 1 ) );
+
+		$this->newCreateSubjectAction()->createSubject(
+			new CreateSubjectRequest(
+				pageId: 1,
+				isMainSubject: true,
+				label: 'Some Label',
+				schemaName: 'some-schema-id',
+				statements: [],
+				comment: 'My custom comment'
+			)
+		);
+
+		$this->assertSame( 'My custom comment', $this->subjectRepository->comments[1] );
+	}
+
+	public function testNullCommentIsPassedToRepositoryByDefault(): void {
+		$this->subjectRepository->savePageSubjects( PageSubjects::newEmpty(), new PageId( 1 ) );
+
+		$this->newCreateSubjectAction()->createSubject(
+			new CreateSubjectRequest(
+				pageId: 1,
+				isMainSubject: true,
+				label: 'Some Label',
+				schemaName: 'some-schema-id',
+				statements: []
+			)
+		);
+
+		$this->assertNull( $this->subjectRepository->comments[1] );
+	}
+
 	public function testNewRelationGetsGuidAssigned(): void {
 		$this->newCreateSubjectAction()->createSubject(
 			new CreateSubjectRequest(

--- a/tests/phpunit/TestDoubles/InMemorySubjectRepository.php
+++ b/tests/phpunit/TestDoubles/InMemorySubjectRepository.php
@@ -48,8 +48,9 @@ class InMemorySubjectRepository implements SubjectRepository {
 		return PageSubjects::newEmpty();
 	}
 
-	public function savePageSubjects( PageSubjects $pageSubjects, PageId $pageId ): void {
+	public function savePageSubjects( PageSubjects $pageSubjects, PageId $pageId, ?string $comment = null ): void {
 		$this->subjectsByPage[$pageId->id] = $pageSubjects;
+		$this->comments[$pageId->id] = $comment;
 
 		foreach ( $pageSubjects->getAllSubjects()->asArray() as $subject ) {
 			$this->subjects[$subject->getId()->text] = $subject;


### PR DESCRIPTION
Discovered this while working on #651.
Tested manually by creating a subject with edit summary through the SubjectCreator.

---

Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/446.

Plumb the user-provided comment through the full subject creation stack, matching the existing updateSubject pattern.
Previously the edit summary entered in SubjectCreatorDialog was silently ignored for subject creation.

> Authored by @alistair3149 with Claude Code.
> <sub>Written by Claude Code, `Opus 4.6`</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)