### PR TITLE
Reload page after subject creation

### DIFF
--- a/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
@@ -170,6 +170,7 @@ import SchemaAbandonmentDialog from '@/components/SubjectCreator/SchemaAbandonme
 import { useSchemaPermissions } from '@/composables/useSchemaPermissions.ts';
 import { useChangeDetection } from '@/composables/useChangeDetection.ts';
 import { useCloseConfirmation } from '@/composables/useCloseConfirmation.ts';
+import { setPendingNotification } from '@/presentation/PendingNotification.ts';
 
 const open = ref( false );
 const selectedSchemaOption = ref( 'existing' );
@@ -402,8 +403,8 @@ const handleSave = async ( summary: string ): Promise<void> => {
 			selectedSchemaName.value,
 			new StatementList( statementsToSave )
 		);
-		mw.notify( mw.msg( 'neowiki-subject-creator-success' ), { type: 'success' } );
-		close();
+		setPendingNotification( 'neowiki-subject-creator-success' );
+		window.location.reload();
 	} catch ( error ) {
 		mw.notify(
 			error instanceof Error ? error.message : String( error ),

--- a/resources/ext.neowiki/src/neowiki.ts
+++ b/resources/ext.neowiki/src/neowiki.ts
@@ -8,11 +8,14 @@ import SchemasPage from '@/components/SchemasPage/SchemasPage.vue';
 import { NeoWikiExtension } from '@/NeoWikiExtension.ts';
 import { SchemaName } from '@/domain/Schema.ts';
 import { SchemaDeserializer } from '@/persistence/SchemaDeserializer.ts';
+import { showPendingNotification } from '@/presentation/PendingNotification.ts';
 
 async function initializeNeoWikiApp(): Promise<void> {
 	const neowikiApp = document.querySelector( '#mw-content-text > #ext-neowiki-app' );
 
 	if ( neowikiApp !== null ) {
+		showPendingNotification( 'neowiki-subject-creator-success' );
+
 		const showSubjectCreator = ( neowikiApp as HTMLElement ).dataset.mwNeowikiCreateSubject === 'true';
 
 		const app = createMwApp( NeoWikiApp, {

--- a/resources/ext.neowiki/src/presentation/PendingNotification.ts
+++ b/resources/ext.neowiki/src/presentation/PendingNotification.ts
@@ -1,0 +1,12 @@
+export function setPendingNotification( key: string ): void {
+	mw.storage.session.set( key, '1' );
+}
+
+export function showPendingNotification( key: string ): void {
+	if ( !mw.storage.session.get( key ) ) {
+		return;
+	}
+
+	mw.storage.session.remove( key );
+	mw.notify( mw.msg( key ), { type: 'success' } );
+}

--- a/resources/ext.neowiki/tests/VueTestHelpers.ts
+++ b/resources/ext.neowiki/tests/VueTestHelpers.ts
@@ -34,7 +34,7 @@ export interface MwMockOptions {
 	messages?: Record<string, string | ( ( ...params: string[] ) => string )>;
 	config?: Record<string, any>;
 	functions?: (
-		'config' | 'message' | 'msg' | 'notify' | 'util'
+		'config' | 'message' | 'msg' | 'notify' | 'storage' | 'util'
 	)[];
 }
 
@@ -75,6 +75,13 @@ export function setupMwMock(
 		} ) ),
 		msg: () => vi.fn( ( key: string, ...params: string[] ) => resolveMessage( key, params ) ),
 		notify: () => vi.fn(),
+		storage: () => ( {
+			session: {
+				get: vi.fn(),
+				set: vi.fn(),
+				remove: vi.fn(),
+			},
+		} ),
 		util: () => ( {
 			wikiScript: vi.fn( () => '/rest.php' ),
 			getUrl: vi.fn( ( title: string ) => `/wiki/${ title }` ),

--- a/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
@@ -168,9 +168,14 @@ describe( 'SubjectCreatorDialog', () => {
 		await flushPromises();
 	}
 
+	let reloadMock: ReturnType<typeof vi.fn>;
+
 	beforeEach( () => {
+		reloadMock = vi.fn();
+		vi.stubGlobal( 'location', { ...window.location, reload: reloadMock } );
+
 		setupMwMock( {
-			functions: [ 'msg', 'notify', 'config' ],
+			functions: [ 'msg', 'notify', 'config', 'storage' ],
 			config: {
 				wgArticleId: PAGE_ID,
 				wgTitle: PAGE_TITLE,
@@ -279,7 +284,7 @@ describe( 'SubjectCreatorDialog', () => {
 		);
 	} );
 
-	it( 'shows success notification and closes dialog after save', async () => {
+	it( 'reloads page after successful save', async () => {
 		const wrapper = mountComponent();
 
 		await wrapper.find( '.ext-neowiki-subject-creator-trigger' ).trigger( 'click' );
@@ -289,13 +294,8 @@ describe( 'SubjectCreatorDialog', () => {
 		await wrapper.findComponent( EditSummary ).vm.$emit( 'save', '' );
 		await flushPromises();
 
-		expect( mw.notify ).toHaveBeenCalledWith(
-			expect.any( String ),
-			expect.objectContaining( { type: 'success' } ),
-		);
-
-		const dialog = wrapper.findComponent( CdxDialog );
-		expect( dialog.props( 'open' ) ).toBe( false );
+		expect( mw.storage.session.set ).toHaveBeenCalledWith( 'neowiki-subject-creator-success', '1' );
+		expect( reloadMock ).toHaveBeenCalled();
 	} );
 
 	it( 'shows error notification on save failure and keeps dialog open', async () => {

--- a/resources/ext.neowiki/tests/presentation/PendingNotification.spec.ts
+++ b/resources/ext.neowiki/tests/presentation/PendingNotification.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { setPendingNotification, showPendingNotification } from '@/presentation/PendingNotification';
+
+describe( 'PendingNotification', () => {
+	beforeEach( () => {
+		vi.stubGlobal( 'mw', {
+			storage: {
+				session: {
+					get: vi.fn(),
+					set: vi.fn(),
+					remove: vi.fn(),
+				},
+			},
+			msg: vi.fn( ( key: string ) => `[${ key }]` ),
+			notify: vi.fn(),
+		} );
+	} );
+
+	describe( 'setPendingNotification', () => {
+		it( 'stores the key in session storage', () => {
+			setPendingNotification( 'neowiki-some-message' );
+
+			expect( mw.storage.session.set ).toHaveBeenCalledWith( 'neowiki-some-message', '1' );
+		} );
+	} );
+
+	describe( 'showPendingNotification', () => {
+		it( 'shows notification and removes key when present', () => {
+			( mw.storage.session.get as ReturnType<typeof vi.fn> ).mockReturnValue( '1' );
+
+			showPendingNotification( 'neowiki-some-message' );
+
+			expect( mw.storage.session.remove ).toHaveBeenCalledWith( 'neowiki-some-message' );
+			expect( mw.notify ).toHaveBeenCalledWith( '[neowiki-some-message]', { type: 'success' } );
+		} );
+
+		it( 'does nothing when key is not present', () => {
+			( mw.storage.session.get as ReturnType<typeof vi.fn> ).mockReturnValue( null );
+
+			showPendingNotification( 'neowiki-some-message' );
+
+			expect( mw.storage.session.remove ).not.toHaveBeenCalled();
+			expect( mw.notify ).not.toHaveBeenCalled();
+		} );
+	} );
+} );


### PR DESCRIPTION
**Question:** The notification key string `'neowiki-subject-creator-success'` is duplicated between `SubjectCreatorDialog.vue` and `neowiki.ts`. Should we extract a shared constant? If so, where should it live? It doesn't belong in `PendingNotification.ts` since that's a reusable utility.

## Summary

- After creating a subject, reload the page so the server-rendered infobox placeholder appears
- Persist the success notification across page reload using `mw.storage.session`
- Extract reusable `PendingNotification` utility for sessionStorage-based notification persistence

## Test plan

- [x] Create a subject on a page that doesn't have one yet
- [x] Verify the page reloads and the infobox appears
- [x] Verify the success toast notification appears after reload
- [x] Verify `make ts-test` passes
- [x] Verify `make ts-lint` passes

> Context: the NeoWiki codebase and discussion with @alistair3149.
> <sub>Written by Claude Code, `Opus 4.6`</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)