### PR TITLE
Add View domain model

### DIFF
--- a/resources/ext.neowiki/src/domain/View.ts
+++ b/resources/ext.neowiki/src/domain/View.ts
@@ -1,0 +1,47 @@
+import type { SchemaName } from '@/domain/Schema';
+import type { PropertyName } from '@/domain/PropertyDefinition';
+
+export type ViewName = string;
+
+export interface DisplayRule {
+	readonly property: PropertyName;
+	readonly displayAttributes?: Record<string, unknown>;
+}
+
+export class View {
+
+	public constructor(
+		private readonly name: ViewName,
+		private readonly schema: SchemaName,
+		private readonly type: string,
+		private readonly description: string,
+		private readonly displayRules: DisplayRule[],
+		private readonly settings: Record<string, unknown>,
+	) {
+	}
+
+	public getName(): ViewName {
+		return this.name;
+	}
+
+	public getSchema(): SchemaName {
+		return this.schema;
+	}
+
+	public getType(): string {
+		return this.type;
+	}
+
+	public getDescription(): string {
+		return this.description;
+	}
+
+	public getDisplayRules(): DisplayRule[] {
+		return this.displayRules;
+	}
+
+	public getSettings(): Record<string, unknown> {
+		return this.settings;
+	}
+
+}

--- a/resources/ext.neowiki/tests/domain/View.unit.spec.ts
+++ b/resources/ext.neowiki/tests/domain/View.unit.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { View } from '@/domain/View';
+import { PropertyName } from '@/domain/PropertyDefinition';
+
+describe( 'View', () => {
+
+	it( 'exposes all constructor values via getters', () => {
+		const view = new View(
+			'FinancialOverview',
+			'Company',
+			'infobox',
+			'Key financial data',
+			[
+				{ property: new PropertyName( 'Revenue' ), displayAttributes: { precision: 0 } },
+				{ property: new PropertyName( 'Net Income' ) },
+			],
+			{ borderColor: '#336699' },
+		);
+
+		expect( view.getName() ).toBe( 'FinancialOverview' );
+		expect( view.getSchema() ).toBe( 'Company' );
+		expect( view.getType() ).toBe( 'infobox' );
+		expect( view.getDescription() ).toBe( 'Key financial data' );
+		expect( view.getDisplayRules() ).toHaveLength( 2 );
+		expect( view.getDisplayRules()[ 0 ].property.toString() ).toBe( 'Revenue' );
+		expect( view.getDisplayRules()[ 0 ].displayAttributes ).toEqual( { precision: 0 } );
+		expect( view.getDisplayRules()[ 1 ].displayAttributes ).toBeUndefined();
+		expect( view.getSettings() ).toEqual( { borderColor: '#336699' } );
+	} );
+
+} );

--- a/src/Domain/View/DisplayRule.php
+++ b/src/Domain/View/DisplayRule.php
@@ -1,0 +1,31 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\View;
+
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyName;
+
+readonly class DisplayRule {
+
+	/**
+	 * @param array<string, mixed> $displayAttributes
+	 */
+	public function __construct(
+		private PropertyName $property,
+		private array $displayAttributes,
+	) {
+	}
+
+	public function getProperty(): PropertyName {
+		return $this->property;
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function getDisplayAttributes(): array {
+		return $this->displayAttributes;
+	}
+
+}

--- a/src/Domain/View/DisplayRules.php
+++ b/src/Domain/View/DisplayRules.php
@@ -1,0 +1,36 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\View;
+
+use ArrayIterator;
+use IteratorAggregate;
+use Traversable;
+
+/**
+ * @implements IteratorAggregate<int, DisplayRule>
+ */
+class DisplayRules implements IteratorAggregate {
+
+	/**
+	 * @var DisplayRule[]
+	 */
+	private readonly array $rules;
+
+	/**
+	 * @param DisplayRule[] $rules
+	 */
+	public function __construct( array $rules ) {
+		$this->rules = array_values( $rules );
+	}
+
+	public function isEmpty(): bool {
+		return $this->rules === [];
+	}
+
+	public function getIterator(): Traversable {
+		return new ArrayIterator( $this->rules );
+	}
+
+}

--- a/src/Domain/View/View.php
+++ b/src/Domain/View/View.php
@@ -1,0 +1,51 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\View;
+
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+
+readonly class View {
+
+	/**
+	 * @param array<string, mixed> $settings
+	 */
+	public function __construct(
+		private ViewName $name,
+		private SchemaName $schema,
+		private string $type,
+		private string $description,
+		private DisplayRules $displayRules,
+		private array $settings,
+	) {
+	}
+
+	public function getName(): ViewName {
+		return $this->name;
+	}
+
+	public function getSchema(): SchemaName {
+		return $this->schema;
+	}
+
+	public function getType(): string {
+		return $this->type;
+	}
+
+	public function getDescription(): string {
+		return $this->description;
+	}
+
+	public function getDisplayRules(): DisplayRules {
+		return $this->displayRules;
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function getSettings(): array {
+		return $this->settings;
+	}
+
+}

--- a/src/Domain/View/ViewName.php
+++ b/src/Domain/View/ViewName.php
@@ -1,0 +1,23 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\View;
+
+use InvalidArgumentException;
+
+readonly class ViewName {
+
+	public function __construct(
+		private string $text,
+	) {
+		if ( trim( $this->text ) === '' ) {
+			throw new InvalidArgumentException( 'View name cannot be empty' );
+		}
+	}
+
+	public function getText(): string {
+		return $this->text;
+	}
+
+}

--- a/tests/phpunit/Domain/View/DisplayRulesTest.php
+++ b/tests/phpunit/Domain/View/DisplayRulesTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Domain\View;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyName;
+use ProfessionalWiki\NeoWiki\Domain\View\DisplayRule;
+use ProfessionalWiki\NeoWiki\Domain\View\DisplayRules;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Domain\View\DisplayRules
+ */
+class DisplayRulesTest extends TestCase {
+
+	public function testEmptyCollectionIsEmpty(): void {
+		$rules = new DisplayRules( [] );
+
+		$this->assertTrue( $rules->isEmpty() );
+	}
+
+	public function testNonEmptyCollectionIsNotEmpty(): void {
+		$rules = new DisplayRules( [
+			new DisplayRule( new PropertyName( 'Revenue' ), [] ),
+		] );
+
+		$this->assertFalse( $rules->isEmpty() );
+	}
+
+	public function testIterationPreservesOrder(): void {
+		$first = new DisplayRule( new PropertyName( 'Revenue' ), [] );
+		$second = new DisplayRule( new PropertyName( 'Profit' ), [ 'precision' => 2 ] );
+		$third = new DisplayRule( new PropertyName( 'Assets' ), [] );
+
+		$rules = new DisplayRules( [ $first, $second, $third ] );
+
+		$this->assertSame( [ $first, $second, $third ], iterator_to_array( $rules ) );
+	}
+
+}

--- a/tests/phpunit/Domain/View/ViewNameTest.php
+++ b/tests/phpunit/Domain/View/ViewNameTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Domain\View;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\View\ViewName;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Domain\View\ViewName
+ */
+class ViewNameTest extends TestCase {
+
+	public function testGetText(): void {
+		$viewName = new ViewName( 'FinancialOverview' );
+
+		$this->assertSame( 'FinancialOverview', $viewName->getText() );
+	}
+
+	public function testEmptyNameIsInvalid(): void {
+		$this->expectException( InvalidArgumentException::class );
+
+		new ViewName( '' );
+	}
+
+	public function testWhitespaceOnlyNameIsInvalid(): void {
+		$this->expectException( InvalidArgumentException::class );
+
+		new ViewName( '   ' );
+	}
+
+}


### PR DESCRIPTION
Introduces the View domain classes (PHP and TypeScript) as the first
implementation step for Views (ADR 18).

PHP (src/Domain/View/):
- ViewName: immutable value object, validates non-empty
- DisplayRule: pairs a PropertyName with display attribute overrides
- DisplayRules: ordered iterable collection
- View: composes ViewName, SchemaName, type, description, DisplayRules, settings

TypeScript (resources/ext.neowiki/src/domain/):
- ViewName type alias, DisplayRule interface, View class

> Directed by @alistair3149.
> Context: the NeoWiki codebase and ADR 18 (Views).
> <sub>Written by Claude Code, `Opus 4.6`</sub>