### PR TITLE
Add View namespace and storage layer

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -55,7 +55,8 @@
 
 	"ContentHandlers": {
 		"NeoWikiSubject": "ProfessionalWiki\\NeoWiki\\EntryPoints\\Content\\SubjectContentHandler",
-		"NeoWikiSchema": "ProfessionalWiki\\NeoWiki\\EntryPoints\\Content\\SchemaContentHandler"
+		"NeoWikiSchema": "ProfessionalWiki\\NeoWiki\\EntryPoints\\Content\\SchemaContentHandler",
+		"NeoWikiView": "ProfessionalWiki\\NeoWiki\\EntryPoints\\Content\\ViewContentHandler"
 	},
 
 	"namespaces": [
@@ -68,19 +69,42 @@
 			"content": false,
 			"movable": false,
 			"protection": "neowiki-schema-edit"
+		},
+		{
+			"id": 7475,
+			"constant": "NS_NEOWIKI_SCHEMA_TALK",
+			"name": "Schema_talk"
+		},
+		{
+			"id": 7476,
+			"constant": "NS_NEOWIKI_VIEW",
+			"name": "View",
+			"defaultcontentmodel": "NeoWikiView",
+			"subpages": false,
+			"content": false,
+			"movable": false,
+			"protection": "neowiki-view-edit"
+		},
+		{
+			"id": 7477,
+			"constant": "NS_NEOWIKI_VIEW_TALK",
+			"name": "View_talk"
 		}
 	],
 
 	"AvailableRights": [
-		"neowiki-schema-edit"
+		"neowiki-schema-edit",
+		"neowiki-view-edit"
 	],
 
 	"GroupPermissions": {
 		"sysop": {
-			"neowiki-schema-edit": true
+			"neowiki-schema-edit": true,
+			"neowiki-view-edit": true
 		},
 		"interface-admin": {
-			"neowiki-schema-edit": true
+			"neowiki-schema-edit": true,
+			"neowiki-view-edit": true
 		}
 	},
 

--- a/i18n/_Namespaces.php
+++ b/i18n/_Namespaces.php
@@ -5,5 +5,8 @@ use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 $namespaceNames = [];
 
 $namespaceNames['en'] = [
-	NeoWikiExtension::NS_SCHEMA => 'Schema'
+	NeoWikiExtension::NS_SCHEMA => 'Schema',
+	NeoWikiExtension::NS_SCHEMA + 1 => 'Schema_talk',
+	NeoWikiExtension::NS_VIEW => 'View',
+	NeoWikiExtension::NS_VIEW + 1 => 'View_talk',
 ];

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -135,5 +135,7 @@
 	"neowiki-schema-abandonment-message": "Your new schema and subject have not been saved and will be lost.",
 	"neowiki-schema-abandonment-abandon": "Discard all",
 	"neowiki-schema-abandonment-keep-editing": "Keep editing",
-	"neowiki-schema-abandonment-save-schema": "Save schema only"
+	"neowiki-schema-abandonment-save-schema": "Save schema only",
+
+	"neowiki-view-invalid": "View content is invalid ({{PLURAL:$1|$1 error|$1 errors}}):"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -62,5 +62,7 @@
 	"neowiki-schema-abandonment-message": "Message explaining that both the new schema and subject will be lost.",
 	"neowiki-schema-abandonment-abandon": "Label for the destructive button that discards both the schema and subject.",
 	"neowiki-schema-abandonment-keep-editing": "Label for the button that returns to editing the subject.",
-	"neowiki-schema-abandonment-save-schema": "Label for the quiet button that saves only the schema and discards the subject."
+	"neowiki-schema-abandonment-save-schema": "Label for the quiet button that saves only the schema and discards the subject.",
+
+	"neowiki-view-invalid": "Error message shown when saving an invalid View. Parameters:\n* $1 - number of validation errors"
 }

--- a/src/Application/ViewLookup.php
+++ b/src/Application/ViewLookup.php
@@ -1,0 +1,14 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application;
+
+use ProfessionalWiki\NeoWiki\Domain\View\View;
+use ProfessionalWiki\NeoWiki\Domain\View\ViewName;
+
+interface ViewLookup {
+
+	public function getView( ViewName $viewName ): ?View;
+
+}

--- a/src/EntryPoints/Content/ViewContent.php
+++ b/src/EntryPoints/Content/ViewContent.php
@@ -1,0 +1,20 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\EntryPoints\Content;
+
+use MediaWiki\Content\JsonContent;
+
+class ViewContent extends JsonContent {
+
+	public const string CONTENT_MODEL_ID = 'NeoWikiView';
+
+	public function __construct( string $text, string $modelId = self::CONTENT_MODEL_ID ) {
+		parent::__construct(
+			$text,
+			$modelId
+		);
+	}
+
+}

--- a/src/EntryPoints/Content/ViewContentHandler.php
+++ b/src/EntryPoints/Content/ViewContentHandler.php
@@ -1,0 +1,31 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\EntryPoints\Content;
+
+use MediaWiki\Content\JsonContentHandler;
+use MediaWiki\Title\Title;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+
+class ViewContentHandler extends JsonContentHandler {
+
+	protected function getContentClass(): string {
+		return ViewContent::class;
+	}
+
+	public function makeEmptyContent(): ViewContent {
+		return new ViewContent( <<<JSON
+{
+	"schema": "",
+	"type": ""
+}
+JSON
+		);
+	}
+
+	public function canBeUsedOn( Title $title ): bool {
+		return $title->getNamespace() === NeoWikiExtension::NS_VIEW;
+	}
+
+}

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -18,11 +18,14 @@ use MediaWiki\Revision\SlotRoleRegistry;
 use MediaWiki\Title\Title;
 use MediaWiki\User\UserIdentity;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\View\ViewName;
 use ProfessionalWiki\NeoWiki\EntryPoints\Content\SchemaContent;
 use ProfessionalWiki\NeoWiki\EntryPoints\Content\SubjectContent;
+use ProfessionalWiki\NeoWiki\EntryPoints\Content\ViewContent;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\SchemaContentValidator;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\MediaWikiSubjectRepository;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\ViewContentValidator;
 use ProfessionalWiki\NeoWiki\Presentation\JsonSchemaErrorFormatter;
 use Skin;
 use WikiPage;
@@ -141,7 +144,7 @@ class NeoWikiHooks {
 	}
 
 	public static function onCodeEditorGetPageLanguage( Title $title, ?string &$lang, ?string $model, ?string $format ): void {
-		if ( in_array( $model, [ SubjectContent::CONTENT_MODEL_ID, SchemaContent::CONTENT_MODEL_ID ] ) ) {
+		if ( in_array( $model, [ SubjectContent::CONTENT_MODEL_ID, SchemaContent::CONTENT_MODEL_ID, ViewContent::CONTENT_MODEL_ID ] ) ) {
 			$lang = 'json';
 		}
 	}
@@ -169,6 +172,10 @@ class NeoWikiHooks {
 		if ( $editPage->getTitle()->getNamespace() === NeoWikiExtension::NS_SCHEMA ) {
 			self::validateSchemaEdit( $editPage, $text, $section, $error );
 		}
+
+		if ( $editPage->getTitle()->getNamespace() === NeoWikiExtension::NS_VIEW ) {
+			self::validateViewEdit( $editPage, $text, $error );
+		}
 	}
 
 	private static function validateSchemaEdit( EditPage $editPage, ?string $text, ?string $section, string &$error ): void {
@@ -191,6 +198,26 @@ class NeoWikiHooks {
 		}
 	}
 
+	private static function validateViewEdit( EditPage $editPage, ?string $text, string &$error ): void {
+		try {
+			new ViewName( $editPage->getTitle()->getText() );
+		} catch ( InvalidArgumentException $exception ) {
+			$error = Html::errorBox(
+				$exception->getMessage()
+			);
+		}
+
+		$contentValidator = ViewContentValidator::newInstance();
+
+		if ( !$contentValidator->validate( $text ) ) {
+			$errors = $contentValidator->getErrors();
+			$error = Html::errorBox(
+				wfMessage( 'neowiki-view-invalid', count( $errors ) )->escaped() .
+				JsonSchemaErrorFormatter::format( $errors )
+			);
+		}
+	}
+
 	public static function onSpecialPageInitList( array &$specialPages ): void {
 		if ( !NeoWikiExtension::getInstance()->isDevelopmentUIEnabled() ) {
 			unset( $specialPages['NeoJson'] );
@@ -200,6 +227,10 @@ class NeoWikiHooks {
 	public static function onContentModelCanBeUsedOn( string $modelId, Title $title, bool &$ok ): void {
 		if ( $title->getNamespace() === NeoWikiExtension::NS_SCHEMA ) {
 			$ok = $modelId === SchemaContent::CONTENT_MODEL_ID;
+		}
+
+		if ( $title->getNamespace() === NeoWikiExtension::NS_VIEW ) {
+			$ok = $modelId === ViewContent::CONTENT_MODEL_ID;
 		}
 	}
 

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -30,6 +30,7 @@ use ProfessionalWiki\NeoWiki\Persistence\CompositeGraphDatabasePlugin;
 use ProfessionalWiki\NeoWiki\Persistence\GraphDatabasePlugin;
 use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
 use ProfessionalWiki\NeoWiki\Application\SubjectLabelLookup;
+use ProfessionalWiki\NeoWiki\Application\ViewLookup;
 use ProfessionalWiki\NeoWiki\Application\StatementListPatcher;
 use ProfessionalWiki\NeoWiki\Application\SubjectAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\SubjectRepository;
@@ -56,7 +57,9 @@ use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\PointInTimeSubjectLoo
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\StatementDeserializer;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\SubjectContentDataDeserializer;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\SubjectContentRepository;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\ViewPersistenceDeserializer;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\WikiPageSchemaLookup;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\WikiPageViewLookup;
 use ProfessionalWiki\NeoWiki\Persistence\Neo4j\Neo4jPageIdentifiersLookup;
 use ProfessionalWiki\NeoWiki\Persistence\Neo4j\ExplainCypherQueryValidator;
 use ProfessionalWiki\NeoWiki\Persistence\Neo4j\KeywordCypherQueryValidator;
@@ -75,6 +78,7 @@ use Wikimedia\Rdbms\IDatabase;
 class NeoWikiExtension {
 
 	public const int NS_SCHEMA = 7474;
+	public const int NS_VIEW = 7476;
 
 	private PropertyTypeRegistry $propertyTypeRegistry;
 	private SubjectRepository $subjectRepository;
@@ -314,6 +318,18 @@ class NeoWikiExtension {
 		return new SchemaPersistenceDeserializer(
 			propertyTypeLookup: $this->getPropertyTypeLookup(),
 		);
+	}
+
+	public function getViewLookup(): ViewLookup {
+		return new WikiPageViewLookup(
+			pageContentFetcher: $this->getPageContentFetcher(),
+			authority: $this->getRequestAuthority(),
+			viewDeserializer: $this->getViewPersistenceDeserializer()
+		);
+	}
+
+	private function getViewPersistenceDeserializer(): ViewPersistenceDeserializer {
+		return new ViewPersistenceDeserializer();
 	}
 
 	public function getSchemaNameLookup(): SchemaNameLookup {

--- a/src/Persistence/MediaWiki/ViewContentValidator.php
+++ b/src/Persistence/MediaWiki/ViewContentValidator.php
@@ -1,0 +1,69 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Persistence\MediaWiki;
+
+use Opis\JsonSchema\Errors\ErrorFormatter;
+use Opis\JsonSchema\Errors\ValidationError;
+use Opis\JsonSchema\Validator;
+use RuntimeException;
+
+class ViewContentValidator {
+
+	/**
+	 * @var string[]
+	 */
+	private array $errors = [];
+
+	public static function newInstance(): self {
+		$json = file_get_contents( __DIR__ . '/viewContentSchema.json' );
+
+		if ( !is_string( $json ) ) {
+			throw new RuntimeException( 'Could not obtain JSON Schema' );
+		}
+
+		$schema = json_decode( $json );
+
+		if ( !is_object( $schema ) ) {
+			throw new RuntimeException( 'Failed to deserialize JSON Schema' );
+		}
+
+		return new self( $schema );
+	}
+
+	private function __construct(
+		private object $jsonSchema
+	) {
+	}
+
+	public function validate( string $config ): bool {
+		$validator = new Validator();
+		$validator->setMaxErrors( 10 );
+
+		$validationResult = $validator->validate( json_decode( $config ), $this->jsonSchema );
+
+		$error = $validationResult->error();
+
+		if ( $error !== null ) {
+			$this->errors = $this->formatErrors( $error );
+		}
+
+		return $error === null;
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public function getErrors(): array {
+		return $this->errors;
+	}
+
+	/**
+	 * @return array<string, string>
+	 */
+	private function formatErrors( ValidationError $error ): array {
+		return ( new ErrorFormatter() )->format( $error, false );
+	}
+
+}

--- a/src/Persistence/MediaWiki/ViewPersistenceDeserializer.php
+++ b/src/Persistence/MediaWiki/ViewPersistenceDeserializer.php
@@ -1,0 +1,60 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Persistence\MediaWiki;
+
+use InvalidArgumentException;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyName;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\View\DisplayRule;
+use ProfessionalWiki\NeoWiki\Domain\View\DisplayRules;
+use ProfessionalWiki\NeoWiki\Domain\View\View;
+use ProfessionalWiki\NeoWiki\Domain\View\ViewName;
+
+class ViewPersistenceDeserializer {
+
+	/**
+	 * @throws InvalidArgumentException
+	 */
+	public function deserialize( ViewName $viewName, string $json ): View {
+		$data = json_decode( $json, true );
+
+		if ( !is_array( $data ) ) {
+			throw new InvalidArgumentException( 'Invalid JSON' );
+		}
+
+		return new View(
+			name: $viewName,
+			schema: new SchemaName( $data['schema'] ),
+			type: $data['type'],
+			description: $data['description'] ?? '',
+			displayRules: $this->displayRulesFromJson( $data ),
+			settings: $data['settings'] ?? [],
+		);
+	}
+
+	/**
+	 * @param array<string, mixed> $data
+	 */
+	private function displayRulesFromJson( array $data ): DisplayRules {
+		$rules = [];
+		$displayRules = $data['displayRules'] ?? [];
+
+		if ( !is_array( $displayRules ) ) {
+			return new DisplayRules( [] );
+		}
+
+		foreach ( $displayRules as $rule ) {
+			if ( is_array( $rule ) && isset( $rule['property'] ) && is_string( $rule['property'] ) ) {
+				$rules[] = new DisplayRule(
+					property: new PropertyName( $rule['property'] ),
+					displayAttributes: $rule['displayAttributes'] ?? [],
+				);
+			}
+		}
+
+		return new DisplayRules( $rules );
+	}
+
+}

--- a/src/Persistence/MediaWiki/WikiPageViewLookup.php
+++ b/src/Persistence/MediaWiki/WikiPageViewLookup.php
@@ -1,0 +1,57 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Persistence\MediaWiki;
+
+use InvalidArgumentException;
+use MediaWiki\Permissions\Authority;
+use ProfessionalWiki\NeoWiki\Application\ViewLookup;
+use ProfessionalWiki\NeoWiki\Domain\View\View;
+use ProfessionalWiki\NeoWiki\Domain\View\ViewName;
+use ProfessionalWiki\NeoWiki\EntryPoints\Content\ViewContent;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+
+class WikiPageViewLookup implements ViewLookup {
+
+	public function __construct(
+		private readonly PageContentFetcher $pageContentFetcher,
+		private readonly Authority $authority,
+		private readonly ViewPersistenceDeserializer $viewDeserializer,
+	) {
+	}
+
+	public function getView( ViewName $viewName ): ?View {
+		$content = $this->getContent( $viewName );
+
+		if ( $content === null ) {
+			return null;
+		}
+
+		try {
+			return $this->viewDeserializer->deserialize( $viewName, $content->getText() );
+		}
+		catch ( InvalidArgumentException ) {
+			return null;
+		}
+	}
+
+	private function getContent( ViewName $viewName ): ?ViewContent {
+		$content = $this->pageContentFetcher->getPageContent(
+			$viewName->getText(),
+			$this->authority,
+			NeoWikiExtension::NS_VIEW
+		);
+
+		if ( $content instanceof ViewContent ) {
+			return $content;
+		}
+
+		if ( $content === null ) {
+			return null;
+		}
+
+		throw new \LogicException( 'Unexpected content type: not a ViewContent' );
+	}
+
+}

--- a/src/Persistence/MediaWiki/viewContentSchema.json
+++ b/src/Persistence/MediaWiki/viewContentSchema.json
@@ -1,0 +1,44 @@
+{
+	"$schema": "https://json-schema.org/draft/2020-12/schema#",
+	"type": "object",
+	"required": [
+		"schema",
+		"type"
+	],
+	"properties": {
+		"schema": {
+			"type": "string",
+			"minLength": 1
+		},
+		"type": {
+			"type": "string",
+			"minLength": 1
+		},
+		"description": {
+			"type": "string"
+		},
+		"displayRules": {
+			"type": "array",
+			"items": {
+				"type": "object",
+				"required": [
+					"property"
+				],
+				"properties": {
+					"property": {
+						"type": "string",
+						"minLength": 1
+					},
+					"displayAttributes": {
+						"type": "object"
+					}
+				},
+				"additionalProperties": false
+			}
+		},
+		"settings": {
+			"type": "object"
+		}
+	},
+	"additionalProperties": false
+}

--- a/tests/phpunit/Persistence/MediaWiki/ViewContentValidatorTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/ViewContentValidatorTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Persistence\MediaWiki;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\ViewContentValidator;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Persistence\MediaWiki\ViewContentValidator
+ */
+class ViewContentValidatorTest extends TestCase {
+
+	public function testMinimalValidView(): void {
+		$this->assertTrue(
+			ViewContentValidator::newInstance()->validate(
+				'{ "schema": "Company", "type": "infobox" }'
+			)
+		);
+	}
+
+	public function testFullValidView(): void {
+		$this->assertTrue(
+			ViewContentValidator::newInstance()->validate( json_encode( [
+				'schema' => 'Company',
+				'type' => 'infobox',
+				'description' => 'Key financial data',
+				'displayRules' => [
+					[ 'property' => 'Revenue', 'displayAttributes' => [ 'precision' => 0 ] ],
+					[ 'property' => 'Net Income' ],
+				],
+				'settings' => [ 'borderColor' => '#336699' ],
+			] ) )
+		);
+	}
+
+	public function testEmptyDisplayRulesIsValid(): void {
+		$this->assertTrue(
+			ViewContentValidator::newInstance()->validate(
+				'{ "schema": "Company", "type": "infobox", "displayRules": [] }'
+			)
+		);
+	}
+
+	public function testEmptyJsonFails(): void {
+		$this->assertFalse(
+			ViewContentValidator::newInstance()->validate( '{}' )
+		);
+	}
+
+	public function testMissingSchemaFails(): void {
+		$validator = ViewContentValidator::newInstance();
+
+		$this->assertFalse(
+			$validator->validate( '{ "type": "infobox" }' )
+		);
+
+		$this->assertSame(
+			[ '/' => 'The required properties (schema) are missing' ],
+			$validator->getErrors()
+		);
+	}
+
+	public function testMissingTypeFails(): void {
+		$validator = ViewContentValidator::newInstance();
+
+		$this->assertFalse(
+			$validator->validate( '{ "schema": "Company" }' )
+		);
+
+		$this->assertSame(
+			[ '/' => 'The required properties (type) are missing' ],
+			$validator->getErrors()
+		);
+	}
+
+	public function testEmptySchemaNameFails(): void {
+		$this->assertFalse(
+			ViewContentValidator::newInstance()->validate(
+				'{ "schema": "", "type": "infobox" }'
+			)
+		);
+	}
+
+	public function testEmptyTypeNameFails(): void {
+		$this->assertFalse(
+			ViewContentValidator::newInstance()->validate(
+				'{ "schema": "Company", "type": "" }'
+			)
+		);
+	}
+
+	public function testDisplayRuleWithoutPropertyFails(): void {
+		$this->assertFalse(
+			ViewContentValidator::newInstance()->validate( json_encode( [
+				'schema' => 'Company',
+				'type' => 'infobox',
+				'displayRules' => [
+					[ 'displayAttributes' => [ 'precision' => 0 ] ],
+				],
+			] ) )
+		);
+	}
+
+	public function testStructurallyInvalidJsonFails(): void {
+		$this->assertFalse(
+			ViewContentValidator::newInstance()->validate( '}{' )
+		);
+	}
+
+}

--- a/tests/phpunit/Persistence/MediaWiki/ViewPersistenceDeserializerTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/ViewPersistenceDeserializerTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Persistence\MediaWiki;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\View\ViewName;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\ViewPersistenceDeserializer;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Persistence\MediaWiki\ViewPersistenceDeserializer
+ */
+class ViewPersistenceDeserializerTest extends TestCase {
+
+	public function testDeserializesMinimalView(): void {
+		$deserializer = new ViewPersistenceDeserializer();
+
+		$view = $deserializer->deserialize(
+			new ViewName( 'FinancialOverview' ),
+			'{ "schema": "Company", "type": "infobox" }'
+		);
+
+		$this->assertSame( 'FinancialOverview', $view->getName()->getText() );
+		$this->assertSame( 'Company', $view->getSchema()->getText() );
+		$this->assertSame( 'infobox', $view->getType() );
+		$this->assertSame( '', $view->getDescription() );
+		$this->assertTrue( $view->getDisplayRules()->isEmpty() );
+		$this->assertSame( [], $view->getSettings() );
+	}
+
+	public function testDeserializesFullView(): void {
+		$deserializer = new ViewPersistenceDeserializer();
+
+		$view = $deserializer->deserialize(
+			new ViewName( 'FinancialOverview' ),
+			json_encode( [
+				'schema' => 'Company',
+				'type' => 'infobox',
+				'description' => 'Key financial data',
+				'displayRules' => [
+					[ 'property' => 'Revenue', 'displayAttributes' => [ 'precision' => 0 ] ],
+					[ 'property' => 'Net Income' ],
+					[ 'property' => 'Total Assets' ],
+				],
+				'settings' => [ 'borderColor' => '#336699' ],
+			] )
+		);
+
+		$this->assertSame( 'Key financial data', $view->getDescription() );
+		$this->assertFalse( $view->getDisplayRules()->isEmpty() );
+
+		$rules = iterator_to_array( $view->getDisplayRules() );
+		$this->assertCount( 3, $rules );
+
+		$this->assertSame( 'Revenue', (string)$rules[0]->getProperty() );
+		$this->assertSame( [ 'precision' => 0 ], $rules[0]->getDisplayAttributes() );
+
+		$this->assertSame( 'Net Income', (string)$rules[1]->getProperty() );
+		$this->assertSame( [], $rules[1]->getDisplayAttributes() );
+
+		$this->assertSame( 'Total Assets', (string)$rules[2]->getProperty() );
+
+		$this->assertSame( [ 'borderColor' => '#336699' ], $view->getSettings() );
+	}
+
+	public function testInvalidJsonThrows(): void {
+		$deserializer = new ViewPersistenceDeserializer();
+
+		$this->expectException( InvalidArgumentException::class );
+
+		$deserializer->deserialize(
+			new ViewName( 'Foo' ),
+			'not json'
+		);
+	}
+
+}


### PR DESCRIPTION
Went through the browser steps manually and automatically.

> Result of extensive back and forth with @alistair3149.
> Context: the NeoWiki codebase, ADR 018 (Views), and the View domain model from PR #655.
> <sub>Written by Claude Code, `Opus 4.6`</sub>

## Summary

- Register View namespace (7476) with `NeoWikiView` content model and `neowiki-view-edit` permission
- Add `ViewContent` / `ViewContentHandler` (extends `JsonContentHandler`, shows JSON on View pages)
- Add JSON Schema validation for View content (`ViewContentValidator`) with edit-time rejection
- Add `ViewPersistenceDeserializer` to convert stored JSON into domain `View` objects
- Add `ViewLookup` interface and `WikiPageViewLookup` implementation
- Register talk namespaces for both Schema (7475) and View (7477) to fix `PageAssertionException` on delete actions
- Wire up hooks: `onEditFilter`, `onContentModelCanBeUsedOn`, `onCodeEditorGetPageLanguage`

## Test plan

- [x] PHPStan clean
- [x] PHPCS clean
- [x] `ViewContentValidatorTest` (10 tests) passes
- [x] `ViewPersistenceDeserializerTest` (3 tests) passes
- [x] Browser tested: saving valid View JSON succeeds, invalid JSON (`{}`) rejected with error
- [x] Browser tested: View page displays JSON content in table format
- [x] Browser tested: delete action works (no more `PageAssertionException`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)