### PR TITLE
Update expected Neo4j constraint type to NODE_PROPERTY_UNIQUENESS

### DIFF
--- a/tests/phpunit/Persistence/Neo4j/Neo4jConstraintUpdaterTest.php
+++ b/tests/phpunit/Persistence/Neo4j/Neo4jConstraintUpdaterTest.php
@@ -39,14 +39,14 @@ class Neo4jConstraintUpdaterTest extends NeoWikiIntegrationTestCase {
 			[
 				[
 					'name' => 'Page id',
-					'type' => 'UNIQUENESS',
+					'type' => 'NODE_PROPERTY_UNIQUENESS',
 					'entityType' => 'NODE',
 					'labelsOrTypes' => [ 'Page' ],
 					'properties' => [ 'id' ],
 				],
 				[
 					'name' => 'Subject id',
-					'type' => 'UNIQUENESS',
+					'type' => 'NODE_PROPERTY_UNIQUENESS',
 					'entityType' => 'NODE',
 					'labelsOrTypes' => [ 'Subject' ],
 					'properties' => [ 'id' ],


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/663

Neo4j [renamed](https://neo4j.com/docs/cypher-manual/current/deprecations-additions-removals-compatibility/#_updated_in_cypher_25_7) the uniqueness constraint type from `UNIQUENESS` to
`NODE_PROPERTY_UNIQUENESS`. This broke CI which always starts with
a fresh Neo4j database.

> Investigated and fixed by @alistair3149.
> Context: CI failure logs and the NeoWiki codebase.
> <sub>Written by Claude Code, `Opus 4.6`</sub>