### PR TITLE
Handle nullable $text in edit validation hooks

### DIFF
--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -169,6 +169,8 @@ class NeoWikiHooks {
 	}
 
 	public static function onEditFilter( EditPage $editPage, ?string $text, ?string $section, string &$error ): void {
+		$text = $text ?? '';
+
 		if ( $editPage->getTitle()->getNamespace() === NeoWikiExtension::NS_SCHEMA ) {
 			self::validateSchemaEdit( $editPage, $text, $section, $error );
 		}
@@ -178,7 +180,7 @@ class NeoWikiHooks {
 		}
 	}
 
-	private static function validateSchemaEdit( EditPage $editPage, ?string $text, ?string $section, string &$error ): void {
+	private static function validateSchemaEdit( EditPage $editPage, string $text, ?string $section, string &$error ): void {
 		try {
 			new SchemaName( $editPage->getTitle()->getText() );
 		} catch ( InvalidArgumentException $exception ) {
@@ -198,7 +200,7 @@ class NeoWikiHooks {
 		}
 	}
 
-	private static function validateViewEdit( EditPage $editPage, ?string $text, string &$error ): void {
+	private static function validateViewEdit( EditPage $editPage, string $text, string &$error ): void {
 		try {
 			new ViewName( $editPage->getTitle()->getText() );
 		} catch ( InvalidArgumentException $exception ) {


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/657#discussion_r2935942200

The `EditFilter` hook provides `$text` as `?string`, but `SchemaContentValidator::validate()` and
`ViewContentValidator::validate()` require `string`. This adds a null guard in `onEditFilter` and
narrows the parameter types of the private validation methods.

> Follow-up to review comment by @JeroenDeDauw, investigated and fixed by @alistair3149.
> Context: the NeoWiki codebase.
> <sub>Written by Claude Code, `Opus 4.6`</sub>