### PR TITLE
Add View Type plugin system

### DIFF
--- a/resources/ext.neowiki/src/NeoWikiExtension.ts
+++ b/resources/ext.neowiki/src/NeoWikiExtension.ts
@@ -9,6 +9,8 @@ import { NumberType } from '@/domain/propertyTypes/Number.ts';
 import NumberDisplay from '@/components/Value/NumberDisplay.vue';
 import { RelationType } from '@/domain/propertyTypes/Relation.ts';
 import { TypeSpecificComponentRegistry } from '@/TypeSpecificComponentRegistry.ts';
+import { ViewTypeRegistry } from '@/ViewTypeRegistry.ts';
+import AutomaticInfobox from '@/components/Views/AutomaticInfobox.vue';
 import RelationDisplay from '@/components/Value/RelationDisplay.vue';
 import { HttpClient } from '@/infrastructure/HttpClient/HttpClient';
 import { ProductionHttpClient } from '@/infrastructure/HttpClient/ProductionHttpClient';
@@ -85,6 +87,12 @@ export class NeoWikiExtension {
 			icon: cdxIconArticles,
 		} );
 
+		return registry;
+	}
+
+	public getViewTypeRegistry(): ViewTypeRegistry {
+		const registry = new ViewTypeRegistry();
+		registry.registerType( 'infobox', AutomaticInfobox );
 		return registry;
 	}
 

--- a/resources/ext.neowiki/src/NeoWikiServices.ts
+++ b/resources/ext.neowiki/src/NeoWikiServices.ts
@@ -7,6 +7,7 @@ import { SubjectValidator } from '@/domain/SubjectValidator.ts';
 import { PropertyTypeRegistry } from '@/domain/PropertyType.ts';
 import { SchemaRepository } from '@/application/SchemaRepository.ts';
 import { SubjectLabelSearch } from '@/domain/SubjectLabelSearch.ts';
+import { ViewTypeRegistry } from '@/ViewTypeRegistry.ts';
 
 export enum Service { // TODO: make private
 	ComponentRegistry = 'ComponentRegistry',
@@ -15,7 +16,8 @@ export enum Service { // TODO: make private
 	SubjectValidator = 'SubjectValidator',
 	PropertyTypeRegistry = 'PropertyTypeRegistry',
 	SchemaRepository = 'SchemaRepository',
-	SubjectLabelSearch = 'SubjectLabelSearch'
+	SubjectLabelSearch = 'SubjectLabelSearch',
+	ViewTypeRegistry = 'ViewTypeRegistry'
 }
 
 export class NeoWikiServices {
@@ -37,6 +39,7 @@ export class NeoWikiServices {
 			[ Service.PropertyTypeRegistry ]: neoWiki.getPropertyTypeRegistry(),
 			[ Service.SchemaRepository ]: neoWiki.getSchemaRepository(),
 			[ Service.SubjectLabelSearch ]: neoWiki.getSubjectLabelSearch(),
+			[ Service.ViewTypeRegistry ]: neoWiki.getViewTypeRegistry(),
 		};
 	}
 
@@ -66,6 +69,10 @@ export class NeoWikiServices {
 
 	public static getSubjectLabelSearch(): SubjectLabelSearch {
 		return inject( Service.SubjectLabelSearch ) as SubjectLabelSearch;
+	}
+
+	public static getViewTypeRegistry(): ViewTypeRegistry {
+		return inject( Service.ViewTypeRegistry ) as ViewTypeRegistry;
 	}
 
 }

--- a/resources/ext.neowiki/src/ViewTypeRegistry.ts
+++ b/resources/ext.neowiki/src/ViewTypeRegistry.ts
@@ -1,0 +1,25 @@
+import type { Component } from 'vue';
+
+export class ViewTypeRegistry {
+
+	private types: Map<string, Component> = new Map();
+
+	public registerType( typeName: string, component: Component ): void {
+		this.types.set( typeName, component );
+	}
+
+	public getComponent( typeName: string ): Component {
+		const component = this.types.get( typeName );
+
+		if ( component === undefined ) {
+			throw new Error( `Unknown view type: ${ typeName }` );
+		}
+
+		return component;
+	}
+
+	public hasType( typeName: string ): boolean {
+		return this.types.has( typeName );
+	}
+
+}

--- a/resources/ext.neowiki/src/components/NeoWikiApp.vue
+++ b/resources/ext.neowiki/src/components/NeoWikiApp.vue
@@ -5,8 +5,8 @@
 		:key="`view-${view.id}`"
 		:to="view.element"
 	>
-		<!-- TODO: Implement other views -->
-		<AutomaticInfobox
+		<component
+			:is="resolveViewComponent( view.viewType )"
 			:subject-id="view.subjectId"
 			:can-edit-subject="view.canEditSubject"
 		/>
@@ -18,6 +18,7 @@
 </template>
 
 <script setup lang="ts">
+import type { Component } from 'vue';
 import { onMounted, ref } from 'vue';
 import { SubjectId } from '@/domain/SubjectId';
 import AutomaticInfobox from '@/components/Views/AutomaticInfobox.vue';
@@ -30,6 +31,7 @@ interface ViewData {
 	element: HTMLElement;
 	subjectId: SubjectId;
 	canEditSubject: boolean;
+	viewType?: string;
 }
 
 const props = defineProps<{
@@ -40,6 +42,14 @@ const viewsData = ref<ViewData[]>( [] );
 
 const shouldShowSubjectCreator = ref( props.showSubjectCreator );
 const subjectAuthorizer = NeoWikiServices.getSubjectAuthorizer();
+const viewTypeRegistry = NeoWikiServices.getViewTypeRegistry();
+
+function resolveViewComponent( viewType?: string ): Component {
+	if ( viewType !== undefined && viewTypeRegistry.hasType( viewType ) ) {
+		return viewTypeRegistry.getComponent( viewType );
+	}
+	return AutomaticInfobox;
+}
 
 function isLatestRevision(): boolean {
 	return mw.config.get( 'wgRevisionId' ) === mw.config.get( 'wgCurRevisionId' );
@@ -79,7 +89,8 @@ async function getViewData( element: HTMLElement ): Promise<ViewData|null> {
 			id: subjectId.text,
 			element: element,
 			subjectId: subjectId,
-			canEditSubject: isLatestRevision() && await subjectAuthorizer.canEditSubject( subjectId )
+			canEditSubject: isLatestRevision() && await subjectAuthorizer.canEditSubject( subjectId ),
+			viewType: element.dataset.mwNeowikiViewType
 		};
 	} catch ( error ) {
 		console.error( error );

--- a/resources/ext.neowiki/tests/NeoWikiTestServices.ts
+++ b/resources/ext.neowiki/tests/NeoWikiTestServices.ts
@@ -16,6 +16,7 @@ export class NeoWikiTestServices extends NeoWikiServices {
 			[ Service.PropertyTypeRegistry ]: neoWiki.getPropertyTypeRegistry(),
 			[ Service.SchemaRepository ]: new InMemorySchemaRepository( [] ),
 			[ Service.SubjectLabelSearch ]: { searchSubjectLabels: () => Promise.resolve( [] ) } as SubjectLabelSearch,
+			[ Service.ViewTypeRegistry ]: neoWiki.getViewTypeRegistry(),
 		};
 	}
 

--- a/resources/ext.neowiki/tests/ViewTypeRegistry.spec.ts
+++ b/resources/ext.neowiki/tests/ViewTypeRegistry.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { ViewTypeRegistry } from '@/ViewTypeRegistry.ts';
+import type { Component } from 'vue';
+
+describe( 'ViewTypeRegistry', () => {
+
+	describe( 'getComponent', () => {
+
+		it( 'returns the component for a registered type', () => {
+			const registry = new ViewTypeRegistry();
+			const infoboxComponent = { name: 'InfoboxWrong' } as unknown as Component;
+			const tableComponent = { name: 'TableRight' } as unknown as Component;
+			const factboxComponent = { name: 'FactboxWrong' } as unknown as Component;
+
+			registry.registerType( 'infobox', infoboxComponent );
+			registry.registerType( 'table', tableComponent );
+			registry.registerType( 'factbox', factboxComponent );
+
+			expect( registry.getComponent( 'table' ) ).toBe( tableComponent );
+		} );
+
+		it( 'throws for an unregistered type', () => {
+			const registry = new ViewTypeRegistry();
+
+			expect( () => registry.getComponent( 'unknown' ) )
+				.toThrow( 'Unknown view type: unknown' );
+		} );
+
+	} );
+
+	describe( 'hasType', () => {
+
+		it( 'returns true for a registered type', () => {
+			const registry = new ViewTypeRegistry();
+			registry.registerType( 'infobox', {} as Component );
+
+			expect( registry.hasType( 'infobox' ) ).toBe( true );
+		} );
+
+		it( 'returns false for an unregistered type', () => {
+			const registry = new ViewTypeRegistry();
+
+			expect( registry.hasType( 'infobox' ) ).toBe( false );
+		} );
+
+	} );
+
+} );


### PR DESCRIPTION
Manually tested in browser, infobox is still rendered as before.

Closes: https://github.com/ProfessionalWiki/NeoWiki/issues/659

Introduce `ViewTypeRegistry` that maps view type names to Vue components. `NeoWikiApp.vue` resolves the component
dynamically from `data-mw-neowiki-view-type`, falling back to `AutomaticInfobox` when no type is specified. Infobox
is the first registered type.

## Summary

- Add `ViewTypeRegistry` class (TS) with `registerType`, `getComponent`, `hasType`
- Register it in `NeoWikiExtension`, `NeoWikiServices`, and test services
- Update `NeoWikiApp.vue` to resolve view components dynamically via the registry
- Register `infobox` as the first built-in View Type, mapped to `AutomaticInfobox`

## Test plan

- [x] `ViewTypeRegistry` unit tests (4 tests)
- [x] All 623 existing TS tests pass
- [x] TS lint clean
- [x] TS build succeeds
- [x] Browser verification: infobox renders correctly on Subject pages

> Planned and implemented by @alistair3149.
> Context: the NeoWiki codebase, ADR 018, and issue #659.
> <sub>Written by Claude Code, `Opus 4.6`</sub>