### PR TITLE
Fix npm cache permissions for non-default OS users

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,32 +39,32 @@ psalm-baseline:
 	vendor/bin/psalm --config=psalm.xml --set-baseline=psalm-baseline.xml
 
 ts-install:
-	docker run --rm -v "$(CURDIR)":/home/node/app:z $(EXEC_USER) -w /home/node/app/resources/ext.neowiki docker.io/library/node:24 npm install
+	docker run --rm -v "$(CURDIR)":/home/node/app:z $(EXEC_USER) -e npm_config_cache=/tmp/.npm -w /home/node/app/resources/ext.neowiki docker.io/library/node:24 npm install
 
 ts-update:
-	docker run --rm -v "$(CURDIR)":/home/node/app:z $(EXEC_USER) -w /home/node/app/resources/ext.neowiki docker.io/library/node:24 npm update
+	docker run --rm -v "$(CURDIR)":/home/node/app:z $(EXEC_USER) -e npm_config_cache=/tmp/.npm -w /home/node/app/resources/ext.neowiki docker.io/library/node:24 npm update
 
 ts-build:
-	docker run --rm -v "$(CURDIR)":/home/node/app:z $(EXEC_USER) -w /home/node/app/resources/ext.neowiki docker.io/library/node:24 npm run build
+	docker run --rm -v "$(CURDIR)":/home/node/app:z $(EXEC_USER) -e npm_config_cache=/tmp/.npm -w /home/node/app/resources/ext.neowiki docker.io/library/node:24 npm run build
 
 ts-build-watch:
-	docker run --rm -v "$(CURDIR)":/home/node/app:z $(EXEC_USER) -w /home/node/app/resources/ext.neowiki docker.io/library/node:24 npm run build:watch
+	docker run --rm -v "$(CURDIR)":/home/node/app:z $(EXEC_USER) -e npm_config_cache=/tmp/.npm -w /home/node/app/resources/ext.neowiki docker.io/library/node:24 npm run build:watch
 
 ts-ci:
 	$(MAKE) ts-test && $(MAKE) ts-build && $(MAKE) ts-lint
 
 ts-test:
 ifdef filter
-	docker run --rm -v "$(CURDIR)":/home/node/app:z $(EXEC_USER) -w /home/node/app/resources/ext.neowiki docker.io/library/node:24 npm run test -- $(filter)
+	docker run --rm -v "$(CURDIR)":/home/node/app:z $(EXEC_USER) -e npm_config_cache=/tmp/.npm -w /home/node/app/resources/ext.neowiki docker.io/library/node:24 npm run test -- $(filter)
 else
-	docker run --rm -v "$(CURDIR)":/home/node/app:z $(EXEC_USER) -w /home/node/app/resources/ext.neowiki docker.io/library/node:24 npm run test
+	docker run --rm -v "$(CURDIR)":/home/node/app:z $(EXEC_USER) -e npm_config_cache=/tmp/.npm -w /home/node/app/resources/ext.neowiki docker.io/library/node:24 npm run test
 endif
 
 ts-test-watch:
-	docker run --rm -v "$(CURDIR)":/home/node/app:z $(EXEC_USER) -w /home/node/app/resources/ext.neowiki docker.io/library/node:24 npm run test:watch
+	docker run --rm -v "$(CURDIR)":/home/node/app:z $(EXEC_USER) -e npm_config_cache=/tmp/.npm -w /home/node/app/resources/ext.neowiki docker.io/library/node:24 npm run test:watch
 
 ts-coverage:
-	docker run --rm -v "$(CURDIR)":/home/node/app:z $(EXEC_USER) -w /home/node/app/resources/ext.neowiki docker.io/library/node:24 npm run coverage
+	docker run --rm -v "$(CURDIR)":/home/node/app:z $(EXEC_USER) -e npm_config_cache=/tmp/.npm -w /home/node/app/resources/ext.neowiki docker.io/library/node:24 npm run coverage
 
 ts-lint:
-	docker run --rm -v "$(CURDIR)":/home/node/app:z $(EXEC_USER) -w /home/node/app/resources/ext.neowiki docker.io/library/node:24 npm run lint
+	docker run --rm -v "$(CURDIR)":/home/node/app:z $(EXEC_USER) -e npm_config_cache=/tmp/.npm -w /home/node/app/resources/ext.neowiki docker.io/library/node:24 npm run lint


### PR DESCRIPTION
## Summary

- Set `npm_config_cache=/tmp/.npm` in all Node docker commands in the Makefile
- Without this, npm tries to write its cache to `/.npm`, which fails when running as a user whose UID has no home directory inside the container (i.e. any UID other than 1000/node)

## Test plan

- Run `make ts-install` and `make ts-build` as a user with a non-default UID (e.g. UID 1001)
- Verify npm commands complete without permission errors

> Commit by @JeroenDeDauw with Claude Code, `Opus 4.6`