### PR TITLE
Fix View→Layout rename missed in ImportDemoData

### DIFF
--- a/maintenance/ImportDemoData.php
+++ b/maintenance/ImportDemoData.php
@@ -63,7 +63,7 @@ class ImportDemoData extends Maintenance {
 				],
 				new SimpleFileFetcher()
 			),
-			viewContentSource: new LayoutContentSource(
+			layoutContentSource: new LayoutContentSource(
 				NeoWikiExtension::getInstance()->getNeoWikiRootDirectory() . '/DemoData/Layout',
 				new SimpleFileFetcher()
 			)


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/671

The View→Layout rename in PR #671 missed the named parameter in
ImportDemoData, causing the maintenance script to crash with
"Unknown named parameter $viewContentSource".

Related PRs:
- #670 View: Render Subjects using Display Rules
- #671 Rename stored entity from View to Layout

> Identified and fixed by @mornetang.
> Context: NeoWiki codebase, ImportDemoData maintenance script crash after View→Layout rename.
> <sub>Written by Claude Code, `Opus 4.6`</sub>