### PR TITLE
Fix View→Layout namespace prefix in demo data import

### DIFF
--- a/src/Application/Actions/ImportPages/ImportPagesAction.php
+++ b/src/Application/Actions/ImportPages/ImportPagesAction.php
@@ -39,7 +39,7 @@ class ImportPagesAction {
 
 		foreach ( $this->layoutContentSource->getLayouts() as $layoutName => $layoutContent ) {
 			$this->createPage(
-				"View:$layoutName",
+				"Layout:$layoutName",
 				[
 					'main' => $layoutContent,
 				]


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/671

The View→Layout rename missed the namespace prefix used when saving layouts in `ImportPagesAction`, causing the demo data import to fail with:

> "NeoWikiLayout" content is not allowed on page [[:View:CompanyOverview]] in slot "Main"

`View:` is not a registered namespace, so MediaWiki treated it as a main namespace page where `NeoWikiLayout` content isn't allowed.

> Reported by @malberts, fixed with Claude Code.
> Context: NeoWiki codebase, demo data import maintenance script.
> <sub>Written by Claude Code, `Opus 4.6`</sub>