### PR TITLE
Add DateTime property type

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -261,6 +261,7 @@
 				"neowiki-property-type-number",
 				"neowiki-property-type-relation",
 				"neowiki-property-type-select",
+				"neowiki-property-type-datetime",
 				"neowiki-infobox-type",
 				"neowiki-infobox-edit-link",
 				"neowiki-field-required",

--- a/extension.json
+++ b/extension.json
@@ -249,7 +249,8 @@
 						"cdxIconSearch",
 						"cdxIconDraggable",
 						"cdxIconEye",
-						"cdxIconEyeClosed"
+						"cdxIconEyeClosed",
+						"cdxIconClock"
 					]
 				}
 			],

--- a/extension.json
+++ b/extension.json
@@ -29,7 +29,8 @@
 	},
 
 	"TestAutoloadNamespaces": {
-		"ProfessionalWiki\\NeoWiki\\Tests\\": "tests/phpunit"
+		"ProfessionalWiki\\NeoWiki\\Tests\\": "tests/phpunit",
+		"ProfessionalWiki\\RedHerb\\": "tests/RedHerb/src"
 	},
 
 	"Hooks": {

--- a/extension.json
+++ b/extension.json
@@ -272,6 +272,7 @@
 				"neowiki-field-min-value",
 				"neowiki-field-max-value",
 				"neowiki-field-invalid-url",
+				"neowiki-field-invalid-datetime",
 				"neowiki-field-invalid-option",
 				"neowiki-field-single-value-only",
 				"neowiki-select-placeholder",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -53,6 +53,7 @@
 	"neowiki-field-min-value": "Minimum value is $1.",
 	"neowiki-field-max-value": "Maximum value is $1.",
 	"neowiki-field-invalid-url": "Please enter a valid URL.",
+	"neowiki-field-invalid-datetime": "Please enter a valid date and time.",
 	"neowiki-field-invalid-option": "\"$1\" is not a valid option.",
 	"neowiki-field-single-value-only": "Only one value can be selected.",
 	"neowiki-select-placeholder": "Select an option",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -18,6 +18,7 @@
 	"neowiki-property-type-number": "Number",
 	"neowiki-property-type-relation": "Relation",
 	"neowiki-property-type-select": "Select",
+	"neowiki-property-type-datetime": "Date & Time",
 
 	"neowiki-neojson-description": "Editing neo slot of \"$1\"",
 

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -137,5 +137,6 @@
 	"neowiki-field-invalid-option": "Validation error shown when a selected value is not in the allowed options list. $1 is the invalid value.",
 	"neowiki-field-single-value-only": "Validation error shown when multiple values are selected for a single-select property.",
 	"neowiki-select-placeholder": "Placeholder text shown in the select dropdown before any option is chosen.",
-	"neowiki-select-no-results": "Message shown in the multi-select dropdown when the typed text does not match any available option."
+	"neowiki-select-no-results": "Message shown in the multi-select dropdown when the typed text does not match any available option.",
+	"neowiki-property-type-datetime": "Label for the date and time property type in the schema editor"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -138,5 +138,6 @@
 	"neowiki-field-single-value-only": "Validation error shown when multiple values are selected for a single-select property.",
 	"neowiki-select-placeholder": "Placeholder text shown in the select dropdown before any option is chosen.",
 	"neowiki-select-no-results": "Message shown in the multi-select dropdown when the typed text does not match any available option.",
+	"neowiki-field-invalid-datetime": "Validation error shown when the entered date and time value cannot be parsed.",
 	"neowiki-property-type-datetime": "Label for the date and time property type in the schema editor"
 }

--- a/resources/ext.neowiki/src/Neo.ts
+++ b/resources/ext.neowiki/src/Neo.ts
@@ -3,6 +3,7 @@ import { NumberType } from '@/domain/propertyTypes/Number';
 import { SelectType } from '@/domain/propertyTypes/Select';
 import { RelationType } from '@/domain/propertyTypes/Relation';
 import { UrlType } from '@/domain/propertyTypes/Url';
+import { DateTimeType } from '@/domain/propertyTypes/DateTime';
 import { PropertyTypeRegistry } from '@/domain/PropertyType';
 import { PropertyDefinitionDeserializer } from '@/domain/PropertyDefinition';
 import { ValueDeserializer } from '@/persistence/ValueDeserializer';
@@ -26,6 +27,7 @@ export class Neo {
 		registry.registerType( new SelectType() );
 		registry.registerType( new RelationType() );
 		registry.registerType( new UrlType() );
+		registry.registerType( new DateTimeType() );
 
 		return registry;
 	}

--- a/resources/ext.neowiki/src/NeoWikiExtension.ts
+++ b/resources/ext.neowiki/src/NeoWikiExtension.ts
@@ -10,10 +10,13 @@ import NumberDisplay from '@/components/Value/NumberDisplay.vue';
 import { SelectType } from '@/domain/propertyTypes/Select.ts';
 import SelectDisplay from '@/components/Value/SelectDisplay.vue';
 import { RelationType } from '@/domain/propertyTypes/Relation.ts';
+import { DateTimeType } from '@/domain/propertyTypes/DateTime.ts';
 import { TypeSpecificComponentRegistry } from '@/TypeSpecificComponentRegistry.ts';
 import { ViewTypeRegistry } from '@/ViewTypeRegistry.ts';
 import Infobox from '@/components/Views/Infobox.vue';
 import RelationDisplay from '@/components/Value/RelationDisplay.vue';
+import DateTimeDisplay from '@/components/Value/DateTimeDisplay.vue';
+import DateTimeInput from '@/components/Value/DateTimeInput.vue';
 import { HttpClient } from '@/infrastructure/HttpClient/HttpClient';
 import { ProductionHttpClient } from '@/infrastructure/HttpClient/ProductionHttpClient';
 import { RestSchemaRepository } from '@/persistence/RestSchemaRepository.ts';
@@ -42,12 +45,13 @@ import { MediaWikiPageSaver } from '@/persistence/MediaWikiPageSaver.ts';
 import { SubjectDeserializer } from '@/persistence/SubjectDeserializer.ts';
 import { Neo } from '@/Neo.ts';
 // import { cdxIconStringInteger } from '@/assets/CustomIcons.ts';
-import { cdxIconLink, cdxIconSearchCaseSensitive, cdxIconArticles, cdxIconListBullet, cdxIconMathematics } from '@wikimedia/codex-icons';
+import { cdxIconLink, cdxIconSearchCaseSensitive, cdxIconArticles, cdxIconListBullet, cdxIconMathematics, cdxIconListNumbered, cdxIconClock } from '@wikimedia/codex-icons';
 import TextAttributesEditor from '@/components/SchemaEditor/Property/TextAttributesEditor.vue';
 import NumberAttributesEditor from '@/components/SchemaEditor/Property/NumberAttributesEditor.vue';
 import SelectAttributesEditor from '@/components/SchemaEditor/Property/SelectAttributesEditor.vue';
 import UrlAttributesEditor from '@/components/SchemaEditor/Property/UrlAttributesEditor.vue';
 import RelationAttributesEditor from '@/components/SchemaEditor/Property/RelationAttributesEditor.vue';
+import DateTimeAttributesEditor from '@/components/SchemaEditor/Property/DateTimeAttributesEditor.vue';
 import { SubjectValidator } from '@/domain/SubjectValidator.ts';
 import { PropertyTypeRegistry } from '@/domain/PropertyType.ts';
 import { StoreStateLoader } from '@/persistence/StoreStateLoader.ts';
@@ -103,6 +107,14 @@ export class NeoWikiExtension {
 			attributesEditor: RelationAttributesEditor,
 			label: 'neowiki-property-type-relation',
 			icon: cdxIconArticles,
+		} );
+
+		registry.registerType( DateTimeType.typeName, {
+			valueDisplayComponent: DateTimeDisplay,
+			valueEditor: DateTimeInput,
+			attributesEditor: DateTimeAttributesEditor,
+			label: 'neowiki-property-type-datetime',
+			icon: cdxIconClock,
 		} );
 
 		return registry;

--- a/resources/ext.neowiki/src/NeoWikiExtension.ts
+++ b/resources/ext.neowiki/src/NeoWikiExtension.ts
@@ -45,7 +45,7 @@ import { MediaWikiPageSaver } from '@/persistence/MediaWikiPageSaver.ts';
 import { SubjectDeserializer } from '@/persistence/SubjectDeserializer.ts';
 import { Neo } from '@/Neo.ts';
 // import { cdxIconStringInteger } from '@/assets/CustomIcons.ts';
-import { cdxIconLink, cdxIconSearchCaseSensitive, cdxIconArticles, cdxIconListBullet, cdxIconMathematics, cdxIconListNumbered, cdxIconClock } from '@wikimedia/codex-icons';
+import { cdxIconLink, cdxIconSearchCaseSensitive, cdxIconArticles, cdxIconListBullet, cdxIconMathematics, cdxIconClock } from '@wikimedia/codex-icons';
 import TextAttributesEditor from '@/components/SchemaEditor/Property/TextAttributesEditor.vue';
 import NumberAttributesEditor from '@/components/SchemaEditor/Property/NumberAttributesEditor.vue';
 import SelectAttributesEditor from '@/components/SchemaEditor/Property/SelectAttributesEditor.vue';

--- a/resources/ext.neowiki/src/components/SchemaEditor/Property/DateTimeAttributesEditor.vue
+++ b/resources/ext.neowiki/src/components/SchemaEditor/Property/DateTimeAttributesEditor.vue
@@ -1,0 +1,66 @@
+<template>
+	<div class="datetime-attributes cdx-field">
+		<NeoNestedField :optional="true">
+			<template #label>
+				{{ $i18n( 'neowiki-property-editor-range' ).text() }}
+			</template>
+
+			<CdxField>
+				<template #label>
+					{{ $i18n( 'neowiki-property-editor-minimum' ).text() }}
+				</template>
+
+				<input
+					type="datetime-local"
+					class="cdx-text-input__input"
+					:value="toLocalInputValue( property.minimum )"
+					@input="updateMinimum"
+				/>
+			</CdxField>
+
+			<CdxField>
+				<template #label>
+					{{ $i18n( 'neowiki-property-editor-maximum' ).text() }}
+				</template>
+
+				<input
+					type="datetime-local"
+					class="cdx-text-input__input"
+					:value="toLocalInputValue( property.maximum )"
+					@input="updateMaximum"
+				/>
+			</CdxField>
+		</NeoNestedField>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { CdxField } from '@wikimedia/codex';
+import { DateTimeProperty } from '@/domain/propertyTypes/DateTime.ts';
+import { AttributesEditorEmits, AttributesEditorProps } from '@/components/SchemaEditor/Property/AttributesEditorContract.ts';
+import NeoNestedField from '@/components/common/NeoNestedField.vue';
+
+defineProps<AttributesEditorProps<DateTimeProperty>>();
+const emit = defineEmits<AttributesEditorEmits<DateTimeProperty>>();
+
+function toLocalInputValue( isoString: string | undefined ): string {
+	if ( !isoString ) {
+		return '';
+	}
+	return isoString.replace( /Z$/, '' ).slice( 0, 16 );
+}
+
+function fromLocalInputValue( localValue: string ): string | undefined {
+	return localValue ? localValue + ':00Z' : undefined;
+}
+
+const updateMinimum = ( event: Event ): void => {
+	const target = event.target as HTMLInputElement;
+	emit( 'update:property', { minimum: fromLocalInputValue( target.value ) } );
+};
+
+const updateMaximum = ( event: Event ): void => {
+	const target = event.target as HTMLInputElement;
+	emit( 'update:property', { maximum: fromLocalInputValue( target.value ) } );
+};
+</script>

--- a/resources/ext.neowiki/src/components/SchemaEditor/Property/DateTimeAttributesEditor.vue
+++ b/resources/ext.neowiki/src/components/SchemaEditor/Property/DateTimeAttributesEditor.vue
@@ -10,12 +10,13 @@
 					{{ $i18n( 'neowiki-property-editor-minimum' ).text() }}
 				</template>
 
+				<!-- eslint-disable-next-line vue/html-self-closing -->
 				<input
 					type="datetime-local"
 					class="cdx-text-input__input"
 					:value="toLocalInputValue( property.minimum )"
 					@input="updateMinimum"
-				/>
+				>
 			</CdxField>
 
 			<CdxField>
@@ -23,12 +24,13 @@
 					{{ $i18n( 'neowiki-property-editor-maximum' ).text() }}
 				</template>
 
+				<!-- eslint-disable-next-line vue/html-self-closing -->
 				<input
 					type="datetime-local"
 					class="cdx-text-input__input"
 					:value="toLocalInputValue( property.maximum )"
 					@input="updateMaximum"
-				/>
+				>
 			</CdxField>
 		</NeoNestedField>
 	</div>

--- a/resources/ext.neowiki/src/components/Value/DateTimeDisplay.vue
+++ b/resources/ext.neowiki/src/components/Value/DateTimeDisplay.vue
@@ -27,6 +27,6 @@ const formattedValue = computed( (): string => {
 		return dateString;
 	}
 
-	return date.toLocaleString();
+	return date.toLocaleString( undefined, { timeZone: 'UTC' } );
 } );
 </script>

--- a/resources/ext.neowiki/src/components/Value/DateTimeDisplay.vue
+++ b/resources/ext.neowiki/src/components/Value/DateTimeDisplay.vue
@@ -1,0 +1,32 @@
+<template>
+	<div>
+		{{ formattedValue }}
+	</div>
+</template>
+
+<script setup lang="ts">
+import { ValueType } from '@/domain/Value.ts';
+import { computed } from 'vue';
+import { DateTimeProperty } from '@/domain/propertyTypes/DateTime.ts';
+import { ValueDisplayProps } from '@/components/Value/ValueDisplayContract.ts';
+
+const props = defineProps<ValueDisplayProps<DateTimeProperty>>();
+
+const formattedValue = computed( (): string => {
+	if ( props.value.type !== ValueType.String ) {
+		return '';
+	}
+
+	const dateString = props.value.parts[ 0 ];
+	if ( !dateString ) {
+		return '';
+	}
+
+	const date = new Date( dateString );
+	if ( isNaN( date.getTime() ) ) {
+		return dateString;
+	}
+
+	return date.toLocaleString();
+} );
+</script>

--- a/resources/ext.neowiki/src/components/Value/DateTimeInput.vue
+++ b/resources/ext.neowiki/src/components/Value/DateTimeInput.vue
@@ -1,0 +1,113 @@
+<template>
+	<CdxField
+		:status="validationError === null ? 'default' : 'error'"
+		:messages="validationError === null ? {} : { error: validationError }"
+		:optional="props.property.required === false"
+	>
+		<template #label>
+			{{ label }}
+			<CdxIcon
+				v-if="props.property.description"
+				v-tooltip="props.property.description"
+				:icon="cdxIconInfo"
+				class="ext-neowiki-value-input__description-icon"
+				size="small"
+			/>
+		</template>
+		<input
+			type="datetime-local"
+			class="cdx-text-input__input"
+			:value="internalInputValue"
+			:min="toLocalInputValue( props.property.minimum )"
+			:max="toLocalInputValue( props.property.maximum )"
+			@input="onInput"
+		/>
+	</CdxField>
+</template>
+
+<script lang="ts">
+import type { Value } from '@/domain/Value';
+</script>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+import { CdxField, CdxIcon } from '@wikimedia/codex';
+import { cdxIconInfo } from '@wikimedia/codex-icons';
+import { newStringValue, StringValue, ValueType } from '@/domain/Value';
+import { DateTimeType, DateTimeProperty } from '@/domain/propertyTypes/DateTime.ts';
+import { ValueInputEmits, ValueInputExposes, ValueInputProps } from '@/components/Value/ValueInputContract.ts';
+import { NeoWikiServices } from '@/NeoWikiServices.ts';
+
+const props = withDefaults(
+	defineProps<ValueInputProps<DateTimeProperty>>(),
+	{
+		modelValue: undefined,
+		label: '',
+	},
+);
+
+const emit = defineEmits<ValueInputEmits>();
+
+const validationError = ref<string | null>( null );
+const internalInputValue = ref<string>( '' );
+
+function toLocalInputValue( isoString: string | undefined ): string {
+	if ( !isoString ) {
+		return '';
+	}
+	return isoString.replace( /Z$/, '' ).slice( 0, 16 );
+}
+
+function fromLocalInputValue( localValue: string ): string {
+	if ( !localValue ) {
+		return '';
+	}
+	return localValue + ':00Z';
+}
+
+const initializeInputValue = ( value: Value | undefined ): void => {
+	if ( value && value.type === ValueType.String ) {
+		const str = ( value as StringValue ).parts[ 0 ];
+		internalInputValue.value = str ? toLocalInputValue( str ) : '';
+	} else {
+		internalInputValue.value = '';
+	}
+};
+
+initializeInputValue( props.modelValue );
+
+watch( () => props.modelValue, ( newValue ) => {
+	initializeInputValue( newValue );
+	validate( newValue && newValue.type === ValueType.String ? newValue as StringValue : undefined );
+} );
+
+const propertyType = NeoWikiServices.getPropertyTypeRegistry().getType( DateTimeType.typeName );
+
+function onInput( event: Event ): void {
+	const target = event.target as HTMLInputElement;
+	internalInputValue.value = target.value;
+	const isoValue = fromLocalInputValue( target.value );
+	const value = isoValue ? newStringValue( isoValue ) : undefined;
+	emit( 'update:modelValue', value );
+	validate( value );
+}
+
+function validate( value: StringValue | undefined ): void {
+	const errors = propertyType.validate( value, props.property );
+	validationError.value = errors.length === 0 ? null :
+		mw.message( `neowiki-field-${ errors[ 0 ].code }`, ...( errors[ 0 ].args ?? [] ) ).text();
+}
+
+watch( () => props.property, () => {
+	validate( props.modelValue && props.modelValue.type === ValueType.String ? props.modelValue as StringValue : undefined );
+} );
+
+defineExpose<ValueInputExposes>( {
+	getCurrentValue: function(): Value | undefined {
+		const isoValue = fromLocalInputValue( internalInputValue.value );
+		return isoValue ? newStringValue( isoValue ) : undefined;
+	},
+} );
+
+validate( props.modelValue && props.modelValue.type === ValueType.String ? props.modelValue as StringValue : undefined );
+</script>

--- a/resources/ext.neowiki/src/components/Value/DateTimeInput.vue
+++ b/resources/ext.neowiki/src/components/Value/DateTimeInput.vue
@@ -14,6 +14,7 @@
 				size="small"
 			/>
 		</template>
+		<!-- eslint-disable-next-line vue/html-self-closing -->
 		<input
 			type="datetime-local"
 			class="cdx-text-input__input"
@@ -21,7 +22,7 @@
 			:min="toLocalInputValue( props.property.minimum )"
 			:max="toLocalInputValue( props.property.maximum )"
 			@input="onInput"
-		/>
+		>
 	</CdxField>
 </template>
 
@@ -42,8 +43,8 @@ const props = withDefaults(
 	defineProps<ValueInputProps<DateTimeProperty>>(),
 	{
 		modelValue: undefined,
-		label: '',
-	},
+		label: ''
+	}
 );
 
 const emit = defineEmits<ValueInputEmits>();
@@ -106,7 +107,7 @@ defineExpose<ValueInputExposes>( {
 	getCurrentValue: function(): Value | undefined {
 		const isoValue = fromLocalInputValue( internalInputValue.value );
 		return isoValue ? newStringValue( isoValue ) : undefined;
-	},
+	}
 } );
 
 validate( props.modelValue && props.modelValue.type === ValueType.String ? props.modelValue as StringValue : undefined );

--- a/resources/ext.neowiki/src/domain/propertyTypes/DateTime.ts
+++ b/resources/ext.neowiki/src/domain/propertyTypes/DateTime.ts
@@ -42,20 +42,21 @@ export class DateTimeType extends BasePropertyType<DateTimeProperty, StringValue
 
 		if ( value !== undefined && value.parts.length > 0 ) {
 			const dateString = value.parts[ 0 ];
+			const timestamp = Date.parse( dateString );
 
-			if ( isNaN( Date.parse( dateString ) ) ) {
+			if ( isNaN( timestamp ) ) {
 				errors.push( { code: 'invalid-datetime' } );
 				return errors;
 			}
 
-			if ( property.minimum !== undefined && dateString < property.minimum ) {
+			if ( property.minimum !== undefined && timestamp < Date.parse( property.minimum ) ) {
 				errors.push( {
 					code: 'min-value',
 					args: [ property.minimum ],
 				} );
 			}
 
-			if ( property.maximum !== undefined && dateString > property.maximum ) {
+			if ( property.maximum !== undefined && timestamp > Date.parse( property.maximum ) ) {
 				errors.push( {
 					code: 'max-value',
 					args: [ property.maximum ],

--- a/resources/ext.neowiki/src/domain/propertyTypes/DateTime.ts
+++ b/resources/ext.neowiki/src/domain/propertyTypes/DateTime.ts
@@ -1,0 +1,85 @@
+import type { PropertyDefinition } from '@/domain/PropertyDefinition';
+import { PropertyName } from '@/domain/PropertyDefinition';
+import { newStringValue, type StringValue, ValueType } from '@/domain/Value';
+import { BasePropertyType, ValueValidationError } from '@/domain/PropertyType';
+
+export interface DateTimeProperty extends PropertyDefinition {
+
+	readonly minimum?: string;
+	readonly maximum?: string;
+
+}
+
+export class DateTimeType extends BasePropertyType<DateTimeProperty, StringValue> {
+
+	public static readonly valueType = ValueType.String;
+
+	public static readonly typeName = 'dateTime';
+
+	public getDisplayAttributeNames(): string[] {
+		return [];
+	}
+
+	public getExampleValue(): StringValue {
+		return newStringValue( '2026-01-01T12:00:00Z' );
+	}
+
+	public createPropertyDefinitionFromJson( base: PropertyDefinition, json: any ): DateTimeProperty {
+		return {
+			...base,
+			minimum: json.minimum,
+			maximum: json.maximum,
+		} as DateTimeProperty;
+	}
+
+	public validate( value: StringValue | undefined, property: DateTimeProperty ): ValueValidationError[] {
+		const errors: ValueValidationError[] = [];
+
+		if ( property.required && value === undefined ) {
+			errors.push( { code: 'required' } );
+			return errors;
+		}
+
+		if ( value !== undefined && value.parts.length > 0 ) {
+			const dateString = value.parts[ 0 ];
+
+			if ( isNaN( Date.parse( dateString ) ) ) {
+				errors.push( { code: 'invalid-datetime' } );
+				return errors;
+			}
+
+			if ( property.minimum !== undefined && dateString < property.minimum ) {
+				errors.push( {
+					code: 'min-value',
+					args: [ property.minimum ],
+				} );
+			}
+
+			if ( property.maximum !== undefined && dateString > property.maximum ) {
+				errors.push( {
+					code: 'max-value',
+					args: [ property.maximum ],
+				} );
+			}
+		}
+
+		return errors;
+	}
+
+}
+
+type DateTimePropertyAttributes = Omit<Partial<DateTimeProperty>, 'name'> & {
+	name?: string | PropertyName;
+};
+
+export function newDateTimeProperty( attributes: DateTimePropertyAttributes = {} ): DateTimeProperty {
+	return {
+		name: attributes.name instanceof PropertyName ? attributes.name : new PropertyName( attributes.name || 'DateTime' ),
+		type: DateTimeType.typeName,
+		description: attributes.description ?? '',
+		required: attributes.required ?? false,
+		default: attributes.default,
+		minimum: attributes.minimum,
+		maximum: attributes.maximum,
+	};
+}

--- a/resources/ext.neowiki/tests/domain/propertyTypes/DateTime.spec.ts
+++ b/resources/ext.neowiki/tests/domain/propertyTypes/DateTime.spec.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { newDateTimeProperty, DateTimeType } from '@/domain/propertyTypes/DateTime';
+import { PropertyName } from '@/domain/PropertyDefinition';
+import { newStringValue } from '@/domain/Value';
+
+describe( 'DateTimeType', () => {
+
+	it( 'returns no display attributes', () => {
+		expect( new DateTimeType().getDisplayAttributeNames() ).toEqual( [] );
+	} );
+
+} );
+
+describe( 'newDateTimeProperty', () => {
+
+	it( 'creates property with default values when no options provided', () => {
+		const property = newDateTimeProperty();
+
+		expect( property.name ).toEqual( new PropertyName( 'DateTime' ) );
+		expect( property.type ).toBe( DateTimeType.typeName );
+		expect( property.description ).toBe( '' );
+		expect( property.required ).toBe( false );
+		expect( property.default ).toBeUndefined();
+		expect( property.minimum ).toBeUndefined();
+		expect( property.maximum ).toBeUndefined();
+	} );
+
+	it( 'creates property with custom name', () => {
+		const property = newDateTimeProperty( { name: 'BirthDate' } );
+
+		expect( property.name ).toEqual( new PropertyName( 'BirthDate' ) );
+	} );
+
+	it( 'creates property with all optional fields', () => {
+		const property = newDateTimeProperty( {
+			name: 'EventDate',
+			description: 'When the event occurred',
+			required: true,
+			default: newStringValue( '2026-01-01T00:00:00Z' ),
+			minimum: '2020-01-01T00:00:00Z',
+			maximum: '2030-12-31T23:59:59Z',
+		} );
+
+		expect( property.name ).toEqual( new PropertyName( 'EventDate' ) );
+		expect( property.description ).toBe( 'When the event occurred' );
+		expect( property.required ).toBe( true );
+		expect( property.minimum ).toBe( '2020-01-01T00:00:00Z' );
+		expect( property.maximum ).toBe( '2030-12-31T23:59:59Z' );
+	} );
+
+} );
+
+describe( 'validate', () => {
+	const dateTimeType = new DateTimeType();
+
+	it( 'returns no errors for undefined value when optional', () => {
+		const property = newDateTimeProperty( { required: false } );
+
+		expect( dateTimeType.validate( undefined, property ) ).toEqual( [] );
+	} );
+
+	it( 'returns required error for required undefined value', () => {
+		const property = newDateTimeProperty( { required: true } );
+
+		expect( dateTimeType.validate( undefined, property ) ).toEqual( [ { code: 'required' } ] );
+	} );
+
+	it( 'returns no errors for valid datetime within bounds', () => {
+		const property = newDateTimeProperty( {
+			minimum: '2020-01-01T00:00:00Z',
+			maximum: '2030-12-31T23:59:59Z',
+		} );
+
+		expect( dateTimeType.validate( newStringValue( '2025-06-15T12:00:00Z' ), property ) ).toEqual( [] );
+	} );
+
+	it( 'returns invalid-datetime error for unparseable string', () => {
+		const property = newDateTimeProperty();
+
+		expect( dateTimeType.validate( newStringValue( 'not-a-date' ), property ) ).toEqual( [
+			{ code: 'invalid-datetime' },
+		] );
+	} );
+
+	it( 'returns min-value error when before minimum', () => {
+		const property = newDateTimeProperty( { minimum: '2025-01-01T00:00:00Z' } );
+
+		expect( dateTimeType.validate( newStringValue( '2024-12-31T23:59:59Z' ), property ) ).toEqual( [
+			{ code: 'min-value', args: [ '2025-01-01T00:00:00Z' ] },
+		] );
+	} );
+
+	it( 'returns max-value error when after maximum', () => {
+		const property = newDateTimeProperty( { maximum: '2025-12-31T23:59:59Z' } );
+
+		expect( dateTimeType.validate( newStringValue( '2026-01-01T00:00:00Z' ), property ) ).toEqual( [
+			{ code: 'max-value', args: [ '2025-12-31T23:59:59Z' ] },
+		] );
+	} );
+
+	it( 'returns no errors for datetime equal to bounds', () => {
+		const property = newDateTimeProperty( {
+			minimum: '2025-06-15T12:00:00Z',
+			maximum: '2025-06-15T12:00:00Z',
+		} );
+
+		expect( dateTimeType.validate( newStringValue( '2025-06-15T12:00:00Z' ), property ) ).toEqual( [] );
+	} );
+
+} );

--- a/tests/RedHerb/src/DateTimeProperty.php
+++ b/tests/RedHerb/src/DateTimeProperty.php
@@ -1,0 +1,55 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\RedHerb;
+
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinition;
+
+class DateTimeProperty extends PropertyDefinition {
+
+	public function __construct(
+		PropertyCore $core,
+		private readonly ?string $minimum,
+		private readonly ?string $maximum,
+	) {
+		parent::__construct( $core );
+	}
+
+	public function getPropertyType(): string {
+		return DateTimeType::NAME;
+	}
+
+	public function getMinimum(): ?string {
+		return $this->minimum;
+	}
+
+	public function hasMinimum(): bool {
+		return $this->minimum !== null;
+	}
+
+	public function getMaximum(): ?string {
+		return $this->maximum;
+	}
+
+	public function hasMaximum(): bool {
+		return $this->maximum !== null;
+	}
+
+	public static function fromPartialJson( PropertyCore $core, array $property ): self {
+		return new self(
+			core: $core,
+			minimum: $property['minimum'] ?? null,
+			maximum: $property['maximum'] ?? null,
+		);
+	}
+
+	protected function nonCoreToJson(): array {
+		return [
+			'minimum' => $this->getMinimum(),
+			'maximum' => $this->getMaximum(),
+		];
+	}
+
+}

--- a/tests/RedHerb/src/DateTimeType.php
+++ b/tests/RedHerb/src/DateTimeType.php
@@ -1,0 +1,31 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\RedHerb;
+
+use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyType;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
+use ProfessionalWiki\NeoWiki\Domain\Value\ValueType;
+
+class DateTimeType implements PropertyType {
+
+	public const NAME = 'dateTime';
+
+	public function getTypeName(): string {
+		return self::NAME;
+	}
+
+	public function getValueType(): ValueType {
+		return ValueType::String;
+	}
+
+	public function getDisplayAttributeNames(): array {
+		return [];
+	}
+
+	public function buildPropertyDefinitionFromJson( PropertyCore $core, array $property ): DateTimeProperty {
+		return DateTimeProperty::fromPartialJson( $core, $property );
+	}
+
+}

--- a/tests/RedHerb/src/RedHerbHooks.php
+++ b/tests/RedHerb/src/RedHerbHooks.php
@@ -11,6 +11,8 @@ class RedHerbHooks {
 	public static function onNeoWikiRegistration( NeoWikiRegistrar $registrar ): void {
 		$registrar->addPropertyType( new ColorType() );
 		$registrar->addNeo4jValueBuilder( ColorType::NAME, static fn( $value ) => $value->toScalars() );
+		$registrar->addPropertyType( new DateTimeType() );
+		$registrar->addNeo4jValueBuilder( DateTimeType::NAME, static fn( $value ) => $value->toScalars() );
 		$registrar->addPagePropertyProvider( new StaticPagePropertyProvider() );
 	}
 

--- a/tests/phpunit/EntryPoints/NeoWikiRegistrationHookTest.php
+++ b/tests/phpunit/EntryPoints/NeoWikiRegistrationHookTest.php
@@ -41,4 +41,16 @@ class NeoWikiRegistrationHookTest extends MediaWikiIntegrationTestCase {
 		$this->assertTrue( $registry->hasBuilder( 'color' ) );
 	}
 
+	public function testRedHerbRegistersDateTimePropertyType(): void {
+		$registry = NeoWikiExtension::getInstance()->getPropertyTypeRegistry();
+
+		$this->assertNotNull( $registry->getType( 'dateTime' ) );
+	}
+
+	public function testRedHerbRegistersDateTimeNeo4jValueBuilder(): void {
+		$registry = NeoWikiExtension::getInstance()->getValueBuilderRegistry();
+
+		$this->assertTrue( $registry->hasBuilder( 'dateTime' ) );
+	}
+
 }

--- a/tests/phpunit/RedHerb/DateTimePropertyTest.php
+++ b/tests/phpunit/RedHerb/DateTimePropertyTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\RedHerb;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
+use ProfessionalWiki\RedHerb\DateTimeProperty;
+use ProfessionalWiki\RedHerb\DateTimeType;
+
+/**
+ * @covers \ProfessionalWiki\RedHerb\DateTimeProperty
+ */
+class DateTimePropertyTest extends TestCase {
+
+	public function testPropertyTypeIsDateTime(): void {
+		$property = $this->buildProperty();
+
+		$this->assertSame( 'dateTime', $property->getPropertyType() );
+	}
+
+	public function testMinimumAndMaximumAreNullByDefault(): void {
+		$property = $this->buildProperty();
+
+		$this->assertNull( $property->getMinimum() );
+		$this->assertFalse( $property->hasMinimum() );
+		$this->assertNull( $property->getMaximum() );
+		$this->assertFalse( $property->hasMaximum() );
+	}
+
+	public function testMinimumAndMaximumFromJson(): void {
+		$property = DateTimeProperty::fromPartialJson(
+			new PropertyCore( description: '', required: false, default: null ),
+			[ 'minimum' => '2020-01-01T00:00:00Z', 'maximum' => '2030-12-31T23:59:59Z' ]
+		);
+
+		$this->assertSame( '2020-01-01T00:00:00Z', $property->getMinimum() );
+		$this->assertTrue( $property->hasMinimum() );
+		$this->assertSame( '2030-12-31T23:59:59Z', $property->getMaximum() );
+		$this->assertTrue( $property->hasMaximum() );
+	}
+
+	public function testSerializationRoundTrip(): void {
+		$property = DateTimeProperty::fromPartialJson(
+			new PropertyCore( description: 'A date', required: true, default: '2025-06-15T12:00:00Z' ),
+			[ 'minimum' => '2020-01-01T00:00:00Z', 'maximum' => '2030-12-31T23:59:59Z' ]
+		);
+
+		$json = $property->toJson();
+
+		$this->assertSame( 'dateTime', $json['type'] );
+		$this->assertSame( 'A date', $json['description'] );
+		$this->assertTrue( $json['required'] );
+		$this->assertSame( '2025-06-15T12:00:00Z', $json['default'] );
+		$this->assertSame( '2020-01-01T00:00:00Z', $json['minimum'] );
+		$this->assertSame( '2030-12-31T23:59:59Z', $json['maximum'] );
+	}
+
+	public function testBuildPropertyDefinitionFromJsonViaType(): void {
+		$type = new DateTimeType();
+		$core = new PropertyCore( description: '', required: false, default: null );
+
+		$property = $type->buildPropertyDefinitionFromJson( $core, [
+			'minimum' => '2020-01-01T00:00:00Z',
+		] );
+
+		$this->assertInstanceOf( DateTimeProperty::class, $property );
+		$this->assertSame( '2020-01-01T00:00:00Z', $property->getMinimum() );
+		$this->assertNull( $property->getMaximum() );
+	}
+
+	private function buildProperty(): DateTimeProperty {
+		return new DateTimeProperty(
+			core: new PropertyCore( description: '', required: false, default: null ),
+			minimum: null,
+			maximum: null,
+		);
+	}
+
+}


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/NeoWiki/issues/678

> Result of back and forth with @malberts.
> Context: the NeoWiki codebase, existing property type implementations, and RedHerb test extension.
> <sub>Written by Claude Code, `Opus 4.6`</sub>

## Summary

- Adds `DateTimeType` and `DateTimeProperty` to RedHerb test extension (PHP backend), proving the plugin system works for non-trivial property types with constraints
- Adds TypeScript `DateTimeType` with ISO 8601 validation and min/max constraint checking
- Adds Vue components: `DateTimeDisplay`, `DateTimeInput` (native `datetime-local`), `DateTimeAttributesEditor`
- Registers in frontend property type and component registries
- Integration tests via RedHerb hook + unit tests for `DateTimeProperty` serialization

## Still to do

- The frontend components are currently registered directly in NeoWiki core (`Neo.ts`, `NeoWikiExtension.ts`) rather than via RedHerb's plugin system. A frontend extension mechanism (`mw.hook`-based registration) is needed so external extensions can register property type components without rebuilding NeoWiki. This will be addressed in a follow-up.

## Test plan

- [x] PHP unit tests pass (`DateTimePropertyTest`)
- [x] PHP integration tests pass (`NeoWikiRegistrationHookTest` — skipped when RedHerb not loaded)
- [x] TypeScript unit tests pass (`DateTime.spec.ts` — 11 tests)
- [x] Full `make tsci` passes (test + build + lint)
- [x] Browser verified: "Date & Time" appears in schema editor type dropdown with min/max datetime pickers

🤖 Generated with [Claude Code](https://claude.com/claude-code)