### PR TITLE
Schema: Fix stale editor state on namespace pages

### DIFF
--- a/resources/ext.neowiki/src/components/SchemaDisplay/SchemaDisplay.vue
+++ b/resources/ext.neowiki/src/components/SchemaDisplay/SchemaDisplay.vue
@@ -11,7 +11,7 @@
 				<SchemaDisplayHeader
 					:schema="currentSchema"
 					:can-edit-schema="canEditSchema"
-					@edit="isEditorOpen = true"
+					@edit="openEditor"
 				/>
 			</template>
 
@@ -135,6 +135,19 @@ function getIcon( propertyType: string ): Icon {
 
 function getTypeLabel( propertyType: string ): string {
 	return mw.msg( componentRegistry.getLabel( propertyType ) );
+}
+
+async function openEditor(): Promise<void> {
+	try {
+		await schemaStore.fetchSchema( currentSchema.value.getName() );
+		currentSchema.value = schemaStore.getSchema( currentSchema.value.getName() );
+		isEditorOpen.value = true;
+	} catch ( error ) {
+		mw.notify(
+			error instanceof Error ? error.message : String( error ),
+			{ type: 'error' }
+		);
+	}
 }
 
 const handleSaveSchema = async ( updatedSchema: Schema, comment: string ): Promise<void> => {

--- a/resources/ext.neowiki/src/components/SchemaEditor/SchemaEditor.vue
+++ b/resources/ext.neowiki/src/components/SchemaEditor/SchemaEditor.vue
@@ -56,9 +56,13 @@ const emit = defineEmits<{
 }>();
 
 const currentSchema = ref<Schema>( props.initialSchema );
+const selectedPropertyName = ref<string | undefined>();
 
-const firstProperty = [ ...props.initialSchema.getPropertyDefinitions() ][ 0 ];
-const selectedPropertyName = ref<string | undefined>( firstProperty?.name.toString() );
+watch( () => props.initialSchema, ( schema ) => {
+	currentSchema.value = schema;
+	const firstProperty = [ ...schema.getPropertyDefinitions() ][ 0 ];
+	selectedPropertyName.value = firstProperty?.name.toString();
+}, { immediate: true } );
 
 const propertyList = ref<ComponentPublicInstance | null>( null );
 const propertyDefinitionEditor = ref<ComponentPublicInstance | null>( null );

--- a/resources/ext.neowiki/tests/components/SchemaDisplay/SchemaDisplay.spec.ts
+++ b/resources/ext.neowiki/tests/components/SchemaDisplay/SchemaDisplay.spec.ts
@@ -1,4 +1,4 @@
-import { mount, VueWrapper } from '@vue/test-utils';
+import { mount, VueWrapper, flushPromises } from '@vue/test-utils';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { createPinia, setActivePinia } from 'pinia';
 import { ref } from 'vue';
@@ -14,6 +14,7 @@ import { NeoWikiExtension } from '@/NeoWikiExtension.ts';
 import { Service } from '@/NeoWikiServices.ts';
 import { setupMwMock, createI18nMock } from '../../VueTestHelpers.ts';
 import { newSchema } from '@/TestHelpers.ts';
+import { useSchemaStore } from '@/stores/SchemaStore.ts';
 
 const checkEditPermissionMock = vi.fn();
 const canEditSchemaRef = ref( false );
@@ -160,14 +161,25 @@ describe( 'SchemaDisplay', () => {
 		expect( wrapper.findComponent( SchemaEditorDialog ).exists() ).toBe( false );
 	} );
 
-	it( 'opens dialog when header emits edit event', async () => {
+	it( 'fetches latest schema and opens dialog when header emits edit event', async () => {
 		canEditSchemaRef.value = true;
+		setupMwMock( { functions: [ 'msg', 'notify' ] } );
 
-		const wrapper = mountComponent( newSchema() );
+		const schema = newSchema();
+		const pinia = createPinia();
+		setActivePinia( pinia );
+
+		const store = useSchemaStore();
+		store.fetchSchema = vi.fn().mockResolvedValue( undefined );
+		store.setSchema( schema.getName(), schema );
+
+		const wrapper = mountComponent( schema, pinia );
 		expect( wrapper.findComponent( SchemaEditorDialog ).props( 'open' ) ).toBe( false );
 
 		await wrapper.findComponent( SchemaDisplayHeader ).vm.$emit( 'edit' );
+		await flushPromises();
 
+		expect( store.fetchSchema ).toHaveBeenCalledWith( schema.getName() );
 		expect( wrapper.findComponent( SchemaEditorDialog ).props( 'open' ) ).toBe( true );
 	} );
 } );

--- a/resources/ext.neowiki/tests/components/SchemaEditor/SchemaEditor.spec.ts
+++ b/resources/ext.neowiki/tests/components/SchemaEditor/SchemaEditor.spec.ts
@@ -276,6 +276,35 @@ describe( 'SchemaEditor', () => {
 		expect( wrapper.emitted( 'change' ) ).toHaveLength( 1 );
 	} );
 
+	it( 'reinitializes state when initialSchema prop changes', async () => {
+		const schema = new Schema(
+			'TestSchema',
+			'Original',
+			new PropertyDefinitionList( [
+				createPropertyDefinitionFromJson( 'firstProp', { type: TextType.typeName } ),
+			] ),
+		);
+
+		const wrapper = createWrapper( schema );
+
+		expect( wrapper.findComponent( CdxTextArea ).props( 'modelValue' ) ).toBe( 'Original' );
+		expect( wrapper.findComponent( { name: 'PropertyList' } ).props( 'selectedPropertyName' ) ).toBe( 'firstProp' );
+
+		const newSchema = new Schema(
+			'UpdatedSchema',
+			'Updated description',
+			new PropertyDefinitionList( [
+				createPropertyDefinitionFromJson( 'alphaProperty', { type: TextType.typeName } ),
+				createPropertyDefinitionFromJson( 'betaProperty', { type: TextType.typeName } ),
+			] ),
+		);
+
+		await wrapper.setProps( { initialSchema: newSchema } );
+
+		expect( wrapper.findComponent( CdxTextArea ).props( 'modelValue' ) ).toBe( 'Updated description' );
+		expect( wrapper.findComponent( { name: 'PropertyList' } ).props( 'selectedPropertyName' ) ).toBe( 'alphaProperty' );
+	} );
+
 	it( 'does not emit change when a property is selected', async () => {
 		const schema = new Schema(
 			'TestSchema',


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/698

Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/692

The Schema editor initializes its refs once at setup and doesn't reinitialize when the dialog
reopens with updated data. Add a watch on `initialSchema` prop with `immediate: true` to
reinitialize `currentSchema` and `selectedPropertyName` on change, matching the fix applied to
the Layout editor in PR #692.

## Test plan

- [ ] Open a Schema page (e.g., `Schema:Company`), edit, save, then reopen the editor and verify it shows the updated data

> Result of back and forth with @JeroenDeDauw.
> Context: the NeoWiki codebase, PR #692 (Layout Management UI), and issues #697/#698.
> <sub>Written by Claude Code, `Opus 4.6`</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)