### PR TITLE
Schema: Add edit and delete actions to Special:Schemas

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -339,7 +339,14 @@
 				"neowiki-schema-abandonment-message",
 				"neowiki-schema-abandonment-abandon",
 				"neowiki-schema-abandonment-keep-editing",
-				"neowiki-schema-abandonment-save-schema"
+				"neowiki-schema-abandonment-save-schema",
+				"neowiki-schema-delete",
+				"neowiki-schema-delete-confirm-title",
+				"neowiki-schema-delete-confirm-message",
+				"neowiki-schema-delete-confirm-delete",
+				"neowiki-schema-delete-summary-default",
+				"neowiki-schema-delete-success",
+				"neowiki-schema-delete-error"
 			],
 			"@group:": "TODO: Load code separately while in development. Remove later.",
 			"group": "ext.neowiki"

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -126,6 +126,14 @@
 	"neowiki-schemas-column-properties": "Properties",
 	"neowiki-schemas-empty": "No schemas have been created yet.",
 
+	"neowiki-schema-delete": "Delete schema",
+	"neowiki-schema-delete-confirm-title": "Delete schema?",
+	"neowiki-schema-delete-confirm-message": "The schema $1 will be permanently deleted.",
+	"neowiki-schema-delete-confirm-delete": "Delete",
+	"neowiki-schema-delete-summary-default": "Delete schema via NeoWiki UI",
+	"neowiki-schema-delete-success": "Deleted $1 schema",
+	"neowiki-schema-delete-error": "Failed to delete $1 schema.",
+
 	"neowiki-close-confirmation-title": "Discard unsaved changes?",
 	"neowiki-close-confirmation-message": "Your changes have not been saved and will be lost.",
 	"neowiki-close-confirmation-discard": "Discard",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -53,6 +53,14 @@
 	"neowiki-schemas-column-properties": "Column header for the number of property definitions in the schemas list table on [[Special:Schemas]].",
 	"neowiki-schemas-empty": "Message shown when no schemas exist yet on [[Special:Schemas]].",
 
+	"neowiki-schema-delete": "Aria label for the delete button on a Schema row in the schemas list.",
+	"neowiki-schema-delete-confirm-title": "Title of the confirmation dialog shown when deleting a schema.",
+	"neowiki-schema-delete-confirm-message": "Message in the delete confirmation dialog. $1 is the schema name.",
+	"neowiki-schema-delete-confirm-delete": "Label for the delete button in the schema deletion dialog.",
+	"neowiki-schema-delete-summary-default": "Default deletion reason used when deleting a schema via the UI.",
+	"neowiki-schema-delete-success": "Success notification shown after deleting a schema. $1 is the schema name.",
+	"neowiki-schema-delete-error": "Error notification title shown when deleting a schema fails. $1 is the schema name.",
+
 	"neowiki-close-confirmation-title": "Title of the confirmation dialog shown when closing a dialog with unsaved changes.",
 	"neowiki-close-confirmation-message": "Message in the confirmation dialog asking the user to confirm discarding unsaved changes.",
 	"neowiki-close-confirmation-discard": "Label for the destructive button that discards unsaved changes and closes the dialog.",

--- a/resources/ext.neowiki/src/components/SchemasPage/SchemasPage.vue
+++ b/resources/ext.neowiki/src/components/SchemasPage/SchemasPage.vue
@@ -36,6 +36,29 @@
 				</template>
 			</template>
 
+			<template #item-actions="{ row }">
+				<span
+					v-if="canEditSchema"
+					class="ext-neowiki-schemas-page__actions"
+				>
+					<CdxButton
+						weight="quiet"
+						:aria-label="$i18n( 'neowiki-edit-schema' ).text()"
+						@click="openEditor( row.name )"
+					>
+						<CdxIcon :icon="cdxIconEdit" />
+					</CdxButton>
+					<CdxButton
+						weight="quiet"
+						action="destructive"
+						:aria-label="$i18n( 'neowiki-schema-delete' ).text()"
+						@click="confirmDelete( row.name )"
+					>
+						<CdxIcon :icon="cdxIconTrash" />
+					</CdxButton>
+				</span>
+			</template>
+
 			<template #empty-state>
 				{{ $i18n( 'neowiki-schemas-empty' ).text() }}
 			</template>
@@ -47,19 +70,52 @@
 			@update:open="isCreatorOpen = $event"
 			@created="fetchSchemas( 0, pageSize )"
 		/>
+
+		<SchemaEditorDialog
+			v-if="canEditSchema && editingSchema !== null"
+			:open="isEditorOpen"
+			:initial-schema="editingSchema"
+			:on-save="handleSaveSchema"
+			@saved="onSchemaSaved"
+			@update:open="onEditorOpenChange"
+		/>
+
+		<CdxDialog
+			:open="isDeleteConfirmOpen"
+			:title="$i18n( 'neowiki-schema-delete-confirm-title' ).text()"
+			:use-close-button="true"
+			@update:open="isDeleteConfirmOpen = $event"
+		>
+			<I18nSlot message-key="neowiki-schema-delete-confirm-message">
+				<strong>{{ deletingSchemaName }}</strong>
+			</I18nSlot>
+
+			<template #footer>
+				<EditSummary
+					help-text=""
+					:save-button-label="$i18n( 'neowiki-schema-delete-confirm-delete' ).text()"
+					:save-disabled="false"
+					@save="executeDelete"
+				/>
+			</template>
+		</CdxDialog>
 	</div>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
-import { CdxButton, CdxIcon, CdxTable } from '@wikimedia/codex';
+import { ref, shallowRef, onMounted, nextTick } from 'vue';
+import { CdxButton, CdxDialog, CdxIcon, CdxTable } from '@wikimedia/codex';
 import type { TableColumn } from '@wikimedia/codex';
-import { cdxIconAdd } from '@wikimedia/codex-icons';
+import { cdxIconAdd, cdxIconEdit, cdxIconTrash } from '@wikimedia/codex-icons';
 import { NeoWikiExtension } from '@/NeoWikiExtension.ts';
 import { useSchemaPermissions } from '@/composables/useSchemaPermissions.ts';
+import { useSchemaStore } from '@/stores/SchemaStore.ts';
+import { Schema } from '@/domain/Schema.ts';
 import SchemaCreatorDialog from './SchemaCreatorDialog.vue';
+import SchemaEditorDialog from '@/components/SchemaEditor/SchemaEditorDialog.vue';
+import EditSummary from '@/components/common/EditSummary.vue';
+import I18nSlot from '@/components/common/I18nSlot.vue';
 
-// TablePaginationSizeOption is not exported from Codex
 const paginationSizeOptions: { value: number }[] = [
 	{ value: 10 },
 	{ value: 20 },
@@ -67,11 +123,18 @@ const paginationSizeOptions: { value: number }[] = [
 ];
 
 const loading = ref( true );
-const isCreatorOpen = ref( false );
 const totalRows = ref( 0 );
+const isCreatorOpen = ref( false );
 const pageSize = ref( paginationSizeOptions[ 0 ].value );
+const lastOffset = ref( 0 );
+const { canEditSchema, canCreateSchemas, checkEditPermission, checkCreatePermission } = useSchemaPermissions();
+const schemaStore = useSchemaStore();
 
-const { canCreateSchemas, checkCreatePermission } = useSchemaPermissions();
+const isEditorOpen = ref( false );
+const editingSchema = shallowRef<Schema | null>( null );
+
+const isDeleteConfirmOpen = ref( false );
+const deletingSchemaName = ref( '' );
 
 interface SchemaRow {
 	name: string;
@@ -93,6 +156,10 @@ const columns: TableColumn[] = [
 	{
 		id: 'properties',
 		label: mw.msg( 'neowiki-schemas-column-properties' )
+	},
+	{
+		id: 'actions',
+		label: ''
 	}
 ];
 
@@ -109,6 +176,7 @@ interface SchemaSummary {
 async function fetchSchemas( offset: number, limit: number ): Promise<void> {
 	loading.value = true;
 	pageSize.value = limit;
+	lastOffset.value = offset;
 
 	const restApiUrl = NeoWikiExtension.getInstance().getMediaWiki().util.wikiScript( 'rest' );
 	const httpClient = NeoWikiExtension.getInstance().newHttpClient();
@@ -138,8 +206,75 @@ function onLoadMore( offset: number, limit: number ): void {
 	fetchSchemas( offset, limit );
 }
 
+async function openEditor( schemaName: string ): Promise<void> {
+	try {
+		editingSchema.value = null;
+		await nextTick();
+
+		await Promise.all( [
+			schemaStore.fetchSchema( schemaName ),
+			fetchSchemas( lastOffset.value, pageSize.value )
+		] );
+		editingSchema.value = schemaStore.getSchema( schemaName ) ?? null;
+		isEditorOpen.value = true;
+	} catch ( error ) {
+		mw.notify(
+			error instanceof Error ? error.message : String( error ),
+			{ type: 'error' }
+		);
+	}
+}
+
+const handleSaveSchema = async ( updatedSchema: Schema, comment: string ): Promise<void> => {
+	await schemaStore.saveSchema( updatedSchema, comment );
+};
+
+function onSchemaSaved(): void {
+	fetchSchemas( lastOffset.value, pageSize.value );
+}
+
+function onEditorOpenChange( value: boolean ): void {
+	isEditorOpen.value = value;
+	if ( !value ) {
+		editingSchema.value = null;
+	}
+}
+
+function confirmDelete( schemaName: string ): void {
+	deletingSchemaName.value = schemaName;
+	isDeleteConfirmOpen.value = true;
+}
+
+async function executeDelete( summary: string ): Promise<void> {
+	isDeleteConfirmOpen.value = false;
+	const name = deletingSchemaName.value;
+	const reason = summary || mw.msg( 'neowiki-schema-delete-summary-default' );
+
+	try {
+		const api = new mw.Api();
+		const token = await api.getEditToken();
+		await api.post( {
+			action: 'delete',
+			title: `Schema:${ name }`,
+			reason: reason,
+			token: token
+		} );
+		mw.notify( mw.msg( 'neowiki-schema-delete-success', name ), { type: 'success' } );
+		await fetchSchemas( lastOffset.value, pageSize.value );
+	} catch ( error ) {
+		mw.notify(
+			error instanceof Error ? error.message : String( error ),
+			{
+				title: mw.msg( 'neowiki-schema-delete-error', name ),
+				type: 'error'
+			}
+		);
+	}
+}
+
 onMounted( async () => {
 	await checkCreatePermission();
+	await checkEditPermission( '' );
 	await fetchSchemas( 0, paginationSizeOptions[ 0 ].value );
 } );
 </script>
@@ -153,6 +288,11 @@ onMounted( async () => {
 	&__empty-value {
 		color: @color-subtle;
 		user-select: none;
+	}
+
+	&__actions {
+		display: inline-flex;
+		gap: @spacing-25;
 	}
 }
 </style>

--- a/resources/ext.neowiki/src/composables/useSchemaPermissions.ts
+++ b/resources/ext.neowiki/src/composables/useSchemaPermissions.ts
@@ -1,5 +1,6 @@
 import { ref, type Ref } from 'vue';
 import { NeoWikiServices } from '@/NeoWikiServices.ts';
+import type { SchemaAuthorizer } from '@/application/SchemaAuthorizer.ts';
 
 export interface SchemaPermissions {
 	canEditSchema: Ref<boolean>;
@@ -11,10 +12,11 @@ export interface SchemaPermissions {
 export function useSchemaPermissions(): SchemaPermissions {
 	const canEditSchema = ref( false );
 	const canCreateSchemas = ref( false );
+	const authorizer: SchemaAuthorizer = NeoWikiServices.getSchemaAuthorizer();
 
 	async function checkEditPermission( schemaName: string ): Promise<void> {
 		try {
-			canEditSchema.value = await NeoWikiServices.getSchemaAuthorizer().canEditSchema( schemaName );
+			canEditSchema.value = await authorizer.canEditSchema( schemaName );
 		} catch ( error ) {
 			console.error( 'Failed to check schema permissions:', error );
 			canEditSchema.value = false;
@@ -23,7 +25,7 @@ export function useSchemaPermissions(): SchemaPermissions {
 
 	async function checkCreatePermission(): Promise<void> {
 		try {
-			canCreateSchemas.value = await NeoWikiServices.getSchemaAuthorizer().canCreateSchemas();
+			canCreateSchemas.value = await authorizer.canCreateSchemas();
 		} catch ( error ) {
 			console.error( 'Failed to check schema creation permissions:', error );
 			canCreateSchemas.value = false;

--- a/resources/ext.neowiki/tests/components/SchemasPage/SchemasPage.spec.ts
+++ b/resources/ext.neowiki/tests/components/SchemasPage/SchemasPage.spec.ts
@@ -3,18 +3,36 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ref } from 'vue';
 import SchemasPage from '@/components/SchemasPage/SchemasPage.vue';
 import SchemaCreatorDialog from '@/components/SchemasPage/SchemaCreatorDialog.vue';
+import SchemaEditorDialog from '@/components/SchemaEditor/SchemaEditorDialog.vue';
 import { createI18nMock, setupMwMock } from '../../VueTestHelpers.ts';
-import { CdxButton } from '@wikimedia/codex';
+import { CdxButton, CdxDialog } from '@wikimedia/codex';
+import { Schema } from '@/domain/Schema.ts';
+import { PropertyDefinitionList } from '@/domain/PropertyDefinitionList.ts';
 
 const canCreateSchemasRef = ref( false );
+const canEditSchemaRef = ref( false );
 const checkCreatePermissionMock = vi.fn();
+const checkEditPermissionMock = vi.fn();
 
 let schemasResponse: { schemas: unknown[]; totalRows: number } = { schemas: [], totalRows: 0 };
 
 vi.mock( '@/composables/useSchemaPermissions.ts', () => ( {
 	useSchemaPermissions: () => ( {
 		canCreateSchemas: canCreateSchemasRef,
+		canEditSchema: canEditSchemaRef,
 		checkCreatePermission: checkCreatePermissionMock,
+		checkEditPermission: checkEditPermissionMock,
+	} ),
+} ) );
+
+const fetchSchemaMock = vi.fn();
+const getSchemaMock = vi.fn();
+
+vi.mock( '@/stores/SchemaStore.ts', () => ( {
+	useSchemaStore: () => ( {
+		fetchSchema: fetchSchemaMock,
+		getSchema: getSchemaMock,
+		saveSchema: vi.fn(),
 	} ),
 } ) );
 
@@ -40,9 +58,25 @@ const SchemaCreatorDialogStub = {
 	emits: [ 'update:open', 'created' ],
 };
 
+const SchemaEditorDialogStub = {
+	template: '<div class="schema-editor-dialog-stub"></div>',
+	props: [ 'open', 'initialSchema', 'onSave' ],
+	emits: [ 'update:open', 'saved' ],
+};
+
 function findCreateButton( wrapper: VueWrapper ): VueWrapper | undefined {
 	return wrapper.findAllComponents( CdxButton )
 		.find( ( btn ) => btn.text().includes( 'neowiki-schema-creator-button' ) );
+}
+
+function findEditButtons( wrapper: VueWrapper ): VueWrapper[] {
+	return wrapper.findAllComponents( CdxButton )
+		.filter( ( btn ) => btn.attributes( 'aria-label' ) === 'neowiki-edit-schema' );
+}
+
+function findDeleteButtons( wrapper: VueWrapper ): VueWrapper[] {
+	return wrapper.findAllComponents( CdxButton )
+		.filter( ( btn ) => btn.attributes( 'aria-label' ) === 'neowiki-schema-delete' );
 }
 
 function mountComponent( summaries: unknown[] = [] ): VueWrapper {
@@ -50,13 +84,16 @@ function mountComponent( summaries: unknown[] = [] ): VueWrapper {
 		schemas: summaries,
 		totalRows: summaries.length,
 	};
-	setupMwMock( { functions: [ 'msg', 'util' ] } );
+	setupMwMock( { functions: [ 'msg', 'util', 'message', 'notify' ] } );
 
 	return mount( SchemasPage, {
 		global: {
 			mocks: { $i18n: createI18nMock() },
 			stubs: {
 				SchemaCreatorDialog: SchemaCreatorDialogStub,
+				SchemaEditorDialog: SchemaEditorDialogStub,
+				EditSummary: true,
+				I18nSlot: true,
 				CdxIcon: true,
 			},
 		},
@@ -66,7 +103,11 @@ function mountComponent( summaries: unknown[] = [] ): VueWrapper {
 describe( 'SchemasPage', () => {
 	beforeEach( () => {
 		canCreateSchemasRef.value = false;
+		canEditSchemaRef.value = false;
 		checkCreatePermissionMock.mockClear();
+		checkEditPermissionMock.mockClear();
+		fetchSchemaMock.mockClear();
+		getSchemaMock.mockClear();
 		schemasResponse = { schemas: [], totalRows: 0 };
 	} );
 
@@ -126,5 +167,79 @@ describe( 'SchemasPage', () => {
 
 		expect( wrapper.find( '.ext-neowiki-schemas-page__empty-value' ).exists() ).toBe( false );
 		expect( wrapper.text() ).toContain( 'A human being' );
+	} );
+
+	it( 'shows edit and delete buttons when user has edit permission', async () => {
+		canEditSchemaRef.value = true;
+		const wrapper = mountComponent( [
+			{ name: 'Person', description: '', propertyCount: 3 },
+			{ name: 'Company', description: '', propertyCount: 2 },
+		] );
+		await flushPromises();
+
+		expect( findEditButtons( wrapper ) ).toHaveLength( 2 );
+		expect( findDeleteButtons( wrapper ) ).toHaveLength( 2 );
+	} );
+
+	it( 'hides edit and delete buttons when user lacks edit permission', async () => {
+		canEditSchemaRef.value = false;
+		const wrapper = mountComponent( [
+			{ name: 'Person', description: '', propertyCount: 3 },
+		] );
+		await flushPromises();
+
+		expect( findEditButtons( wrapper ) ).toHaveLength( 0 );
+		expect( findDeleteButtons( wrapper ) ).toHaveLength( 0 );
+	} );
+
+	it( 'opens editor dialog when edit button is clicked', async () => {
+		canEditSchemaRef.value = true;
+		const mockSchema = new Schema( 'Person', '', new PropertyDefinitionList( [] ) );
+		getSchemaMock.mockReturnValue( mockSchema );
+
+		const wrapper = mountComponent( [
+			{ name: 'Person', description: '', propertyCount: 3 },
+		] );
+		await flushPromises();
+
+		await findEditButtons( wrapper )[ 0 ].trigger( 'click' );
+		await flushPromises();
+
+		expect( fetchSchemaMock ).toHaveBeenCalledWith( 'Person' );
+		expect( wrapper.findComponent( SchemaEditorDialog ).props( 'open' ) ).toBe( true );
+	} );
+
+	it( 'does not render SchemaEditorDialog when user lacks edit permission', async () => {
+		canEditSchemaRef.value = true;
+		const mockSchema = new Schema( 'Person', '', new PropertyDefinitionList( [] ) );
+		getSchemaMock.mockReturnValue( mockSchema );
+
+		const wrapper = mountComponent( [
+			{ name: 'Person', description: '', propertyCount: 3 },
+		] );
+		await flushPromises();
+
+		await findEditButtons( wrapper )[ 0 ].trigger( 'click' );
+		await flushPromises();
+
+		expect( wrapper.findComponent( SchemaEditorDialog ).exists() ).toBe( true );
+
+		canEditSchemaRef.value = false;
+		await flushPromises();
+
+		expect( wrapper.findComponent( SchemaEditorDialog ).exists() ).toBe( false );
+	} );
+
+	it( 'opens delete confirmation when delete button is clicked', async () => {
+		canEditSchemaRef.value = true;
+		const wrapper = mountComponent( [
+			{ name: 'Person', description: '', propertyCount: 3 },
+		] );
+		await flushPromises();
+
+		await findDeleteButtons( wrapper )[ 0 ].trigger( 'click' );
+
+		const dialog = wrapper.findComponent( CdxDialog );
+		expect( dialog.props( 'open' ) ).toBe( true );
 	} );
 } );


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/697

Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/692

Add inline edit (opens editor dialog) and delete (with confirmation and optional summary) actions
per row on Special:Schemas, matching the pattern established for Special:Layouts in PR #692.

## Summary

- Add actions column with edit and delete buttons to the schemas table
- Edit button fetches the schema and opens SchemaEditorDialog inline
- Delete button shows a confirmation dialog with optional edit summary, then deletes via MediaWiki API
- Actions only shown when user has `neowiki-schema-edit` permission
- Add 7 new i18n messages for schema deletion UI

## Test plan

- [x] Visit `Special:Schemas` and verify edit/delete buttons appear for each schema row
- [x] Click the edit button and verify the schema editor dialog opens with the correct schema
- [x] Edit a schema, save, and verify the list refreshes
- [x] Click the delete button and verify the confirmation dialog appears
- [x] Confirm deletion and verify the schema is removed from the list
- [x] Verify edit/delete buttons do not appear for users without `neowiki-schema-edit` permission

> Result of back and forth with @JeroenDeDauw.
> Context: the NeoWiki codebase, PR #692 (Layout Management UI), and issues #697/#698.
> <sub>Written by Claude Code, `Opus 4.6`</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)