### PR TITLE
Fetch latest subject before opening editor

### DIFF
--- a/resources/ext.neowiki/src/components/Views/Infobox.vue
+++ b/resources/ext.neowiki/src/components/Views/Infobox.vue
@@ -24,7 +24,7 @@
 				v-if="canEditSubject"
 				weight="quiet"
 				:aria-label="$i18n( 'neowiki-infobox-edit-link' ).text()"
-				@click="isEditorOpen = true"
+				@click="openEditor"
 			>
 				<CdxIcon :icon="cdxIconEdit" />
 			</CdxButton>
@@ -95,6 +95,18 @@ const isEditorOpen = ref( false );
 
 const subject = computed( () => subjectStore.getSubject( props.subjectId ) as Subject ); // TODO: handle not found
 const schema = computed( () => schemaStore.getSchema( subject.value.getSchemaName() ) ); // TODO: handle not found
+
+async function openEditor(): Promise<void> {
+	try {
+		await subjectStore.fetchSubject( props.subjectId );
+		isEditorOpen.value = true;
+	} catch ( error ) {
+		mw.notify(
+			error instanceof Error ? error.message : String( error ),
+			{ type: 'error' }
+		);
+	}
+}
 
 const handleSaveSubject = async ( updatedSubject: Subject, comment: string ): Promise<void> => {
 	await subjectStore.updateSubject( updatedSubject, comment );

--- a/resources/ext.neowiki/tests/components/Views/Infobox.spec.ts
+++ b/resources/ext.neowiki/tests/components/Views/Infobox.spec.ts
@@ -1,4 +1,4 @@
-import { mount, VueWrapper } from '@vue/test-utils';
+import { mount, VueWrapper, flushPromises } from '@vue/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import Infobox from '@/components/Views/Infobox.vue';
 import { Subject } from '@/domain/Subject.ts';
@@ -150,7 +150,9 @@ describe( 'Infobox', () => {
 		expect( editButton.exists() ).toBe( true );
 	} );
 
-	it( 'opens the SubjectEditorDialog when edit button is clicked', async () => {
+	it( 'fetches latest subject and opens dialog when edit button is clicked', async () => {
+		subjectStore.fetchSubject = vi.fn().mockResolvedValue( undefined );
+
 		const wrapper = mountComponent( mockSubject, true );
 
 		const dialog = wrapper.findComponent( SubjectEditorDialog );
@@ -158,7 +160,9 @@ describe( 'Infobox', () => {
 
 		const editButton = wrapper.findComponent( { name: 'CdxButton', props: { 'aria-label': 'neowiki-infobox-edit-link' } } );
 		await editButton.trigger( 'click' );
+		await flushPromises();
 
+		expect( subjectStore.fetchSubject ).toHaveBeenCalledWith( mockSubject.getId() );
 		expect( dialog.props( 'open' ) ).toBe( true );
 	} );
 


### PR DESCRIPTION
The Infobox opened the SubjectEditorDialog with whatever subject data
was in the store cache. If the subject was modified in another tab,
the editor would show stale data. Now fetch the latest subject from
the server before opening the editor, matching the pattern already
used by SchemaDisplay and LayoutDisplay.

## Test plan

- Open a subject page with an infobox in two tabs
- Edit the subject in the second tab and save
- In the first tab, click the edit button on the infobox
- Verify the editor shows the updated data from the second tab

> Prompted by @JeroenDeDauw after noticing the inconsistency with Schema/Layout editors.
> Context: the NeoWiki codebase and ADR 016 (Frontend State Management).
> <sub>Written by Claude Code, `Opus 4.6`</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)