### PR TITLE
Update GitHub Actions to fix Node.js 20 deprecation

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -15,9 +15,9 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
 
@@ -30,7 +30,7 @@ jobs:
         working-directory: resources/ext.neowiki
 
       - name: Get MediaWiki 1.43
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: wikimedia/mediawiki
           path: Docker/mediawiki
@@ -75,7 +75,7 @@ jobs:
         working-directory: Docker
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/ci-php.yml
+++ b/.github/workflows/ci-php.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Cache MediaWiki
         id: cache-mediawiki
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             mediawiki
@@ -72,12 +72,12 @@ jobs:
           key: mw_${{ matrix.mw }}-php${{ matrix.php }}
 
       - name: Cache Composer cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.composer/cache
           key: composer-php${{ matrix.php }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
             path: EarlyCopy
 
@@ -86,7 +86,7 @@ jobs:
         working-directory: ~
         run: bash EarlyCopy/.github/workflows/installMediaWiki.sh ${{ matrix.mw }} NeoWiki
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           path: mediawiki/extensions/NeoWiki
 
@@ -123,7 +123,7 @@ jobs:
           php-version: 8.3
 
       - name: Checkout NeoExtension
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: composer install
@@ -160,7 +160,7 @@ jobs:
 
       - name: Cache MediaWiki
         id: cache-mediawiki
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             mediawiki
@@ -169,12 +169,12 @@ jobs:
           key: mw_${{ matrix.mw }}-php${{ matrix.php }}
 
       - name: Cache Composer cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.composer/cache
           key: composer-php${{ matrix.php }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           path: EarlyCopy
 
@@ -183,7 +183,7 @@ jobs:
         working-directory: ~
         run: bash EarlyCopy/.github/workflows/installMediaWiki.sh ${{ matrix.mw }} NeoWiki
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           path: mediawiki/extensions/NeoWiki
 
@@ -222,7 +222,7 @@ jobs:
 #
 #      - name: Cache MediaWiki
 #        id: cache-mediawiki
-#        uses: actions/cache@v4
+#        uses: actions/cache@v5
 #        with:
 #          path: |
 #            mediawiki
@@ -231,12 +231,12 @@ jobs:
 #          key: mw_${{ matrix.mw }}-php${{ matrix.php }}
 #
 #      - name: Cache Composer cache
-#        uses: actions/cache@v4
+#        uses: actions/cache@v5
 #        with:
 #          path: ~/.composer/cache
 #          key: composer-php${{ matrix.php }}
 #
-#      - uses: actions/checkout@v4
+#      - uses: actions/checkout@v6
 #        with:
 #          path: EarlyCopy
 #
@@ -245,11 +245,11 @@ jobs:
 #        working-directory: ~
 #        run: bash EarlyCopy/.github/workflows/installMediaWiki.sh ${{ matrix.mw }} NeoWiki
 #
-#      - uses: actions/checkout@v4
+#      - uses: actions/checkout@v6
 #        with:
 #          path: mediawiki/extensions/NeoWiki
 #
-#      - uses: actions/checkout@v4
+#      - uses: actions/checkout@v6
 #        with:
 #          repository: ProfessionalWiki/Neo
 #          path: mediawiki/extensions/NeoWiki/Neo

--- a/.github/workflows/ci-ts.yml
+++ b/.github/workflows/ci-ts.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
 
@@ -47,10 +47,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
 
@@ -71,10 +71,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
 
@@ -96,10 +96,10 @@ jobs:
 #
 #    steps:
 #      - name: Checkout
-#        uses: actions/checkout@v4
+#        uses: actions/checkout@v6
 #
 #      - name: Setup Node.js
-#        uses: actions/setup-node@v4
+#        uses: actions/setup-node@v6
 #        with:
 #          node-version: '24'
 #


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/DockerWiki/pull/570

## Summary
- Update `actions/checkout` from v4 to v6
- Update `actions/cache` from v4 to v5
- Update `actions/setup-node` from v4 to v6
- Update `docker/login-action` from v3 to v4

This resolves the CI warning about Node.js 20 actions being deprecated ahead of the June 2nd 2026 deadline.

## Test plan
- [ ] Verify CI workflows pass on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)