### PR TITLE
Remove double padding in Layout dialog bodies

### DIFF
--- a/resources/ext.neowiki/src/components/LayoutEditor/LayoutEditorDialog.vue
+++ b/resources/ext.neowiki/src/components/LayoutEditor/LayoutEditorDialog.vue
@@ -110,6 +110,10 @@ defineExpose( { hasChanged } );
 .ext-neowiki-layout-editor-dialog {
 	&.cdx-dialog {
 		max-width: @size-5600;
+
+		.cdx-dialog__body {
+			padding: 0;
+		}
 	}
 }
 </style>

--- a/resources/ext.neowiki/src/components/LayoutsPage/LayoutCreatorDialog.vue
+++ b/resources/ext.neowiki/src/components/LayoutsPage/LayoutCreatorDialog.vue
@@ -110,3 +110,13 @@ async function handleSave( summary: string ): Promise<void> {
 	}
 }
 </script>
+
+<style lang="less">
+.ext-neowiki-layout-creator-dialog {
+	&.cdx-dialog {
+		.cdx-dialog__body {
+			padding: 0;
+		}
+	}
+}
+</style>


### PR DESCRIPTION
The Codex CdxDialog adds default body padding (16px 24px). The LayoutEditor and LayoutCreator components also add their own padding, causing doubled spacing. Zero out the dialog body padding and let the inner components manage their own padding, consistent with how SchemaEditorDialog and SchemaCreatorDialog already handle this.

> Context: the NeoWiki codebase and [this review comment](https://github.com/ProfessionalWiki/NeoWiki/pull/692#issuecomment-4198454272).
> <sub>Written by Claude Code, `Opus 4.6`</sub>

## Test plan
- [x] Open Layout editor dialog on Special:Layouts — verify no extra margins around content
- [x] Open Layout creator dialog on Special:Layouts — verify no extra margins around content
- [ ] Compare spacing with Schema editor/creator dialogs — should be consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)