### PR TITLE
Rename demo page and restructure Main Page

### DIFF
--- a/DemoData/Page/Main_Page.wikitext
+++ b/DemoData/Page/Main_Page.wikitext
@@ -35,6 +35,8 @@ Terminology is explained in [https://github.com/ProfessionalWiki/NeoWiki/blob/ma
 
 * View Subject JSON: [[Special:NeoJson/ACME_Inc]] (developer UI, normal users will not see JSON. [https://github.com/ProfessionalWiki/NeoWiki/blob/master/docs/SubjectFormat.md View docs])
 * Query the graph database: [[Cypher|Cypher raw example]]
+* Read values in wikitext: [[Value parser function]]
+* Read values in Lua: [[Lua Data Access]]
 * [[#REST_API_endpoints|Explore the REST API]]
 
 == European Museums ==
@@ -53,7 +55,7 @@ A dataset of European museums, artists, and artworks showcasing cross-schema rel
 
 '''Overview:''' [[Museum Collection]]
 
-== Other Demo Pages ==
+== Demo Pages ==
 
 * Simple page with automatic infobox and edit form: [[NeoWiki]], [[ProWiki]]
 * Subject with relations: [[Professional Wiki]]
@@ -61,20 +63,20 @@ A dataset of European museums, artists, and artworks showcasing cross-schema rel
 * Wikibase Statement emulation: [[Berlin]]
 * Displaying data from other pages: [[Company Infoboxes]]
 * [[Reactive UI example]]
-* Lua/Scribunto data access: [[Lua Data Access]]
 
-'''Schemas''' allow you to define the structure of your data. For instance, you can define that a Employee has a
-compensation in EUR with a value between 0 and 1000000.
+== Schemas and Layouts ==
 
-* [[Schema:Company]]
-* [[Schema:Product]]
-* [[Schema:Employee]]
-* [[Schema:Museum]]
-* [[Schema:Artist]]
-* [[Schema:Artwork]]
-* [[Schema:Exhibition]]
-* [[Schema:Attendance]]
+'''Schemas''' define the structure of your data. For instance, you can define that an Employee has a compensation
+in EUR with a value between 0 and 1000000.
+
+* [[Schema:Company]], [[Schema:Product]], [[Schema:Employee]]
+* [[Schema:Museum]], [[Schema:Artist]], [[Schema:Artwork]], [[Schema:Exhibition]], [[Schema:Attendance]]
 * [[Special:Schemas|View all schemas]]
+
+'''Layouts''' customize how Subjects are displayed by selecting which properties to show and in what order.
+
+* [[Layout:CompanyOverview]]
+* [[Special:Layouts|View all layouts]]
 
 == REST API Endpoints ==
 

--- a/DemoData/Page/Value_parser_function.wikitext
+++ b/DemoData/Page/Value_parser_function.wikitext
@@ -1,4 +1,4 @@
-This page demonstrates the <code>neowiki_value</code> parser function for reading individual property values from Subjects.
+This page demonstrates the <code>neowiki_value</code> parser function for reading values from Subjects.
 
 == Reading from the Current Page's Subject ==
 


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/720

- Renames "Property Values" demo page to "Value parser function" — avoids the term "property values" which is not part of the domain vocabulary
- Adds Value parser function and Lua Data Access links to the developer section on Main Page
- Adds "Schemas and Layouts" section with `Layout:CompanyOverview` and `Special:Layouts` (both previously missing)
- Removes Lua Data Access from the demo pages list (now in developer section)
- Groups schema links more compactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)