### PR TITLE
Add min/max cross-validation to NumberAttributesEditor

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -284,6 +284,7 @@
 				"neowiki-property-editor-maximum",
 				"neowiki-property-editor-precision",
 				"neowiki-property-editor-precision-non-negative",
+				"neowiki-property-editor-min-exceeds-max",
 				"neowiki-property-editor-character-length",
 				"neowiki-property-editor-length-whole-number",
 				"neowiki-property-editor-length-min-exceeds-max",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -31,6 +31,7 @@
 	"neowiki-property-editor-maximum": "Maximum",
 	"neowiki-property-editor-precision": "Precision",
 	"neowiki-property-editor-precision-non-negative": "Precision cannot be negative.",
+	"neowiki-property-editor-min-exceeds-max": "Minimum cannot exceed maximum.",
 	"neowiki-property-editor-character-length": "Character length",
 	"neowiki-property-editor-length-whole-number": "Must be a whole number of at least 1.",
 	"neowiki-property-editor-length-min-exceeds-max": "Minimum cannot exceed maximum.",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -131,6 +131,7 @@
 	"neowiki-layout-delete-success": "Success notification shown after deleting a layout. $1 is the layout name.",
 	"neowiki-layout-delete-error": "Error notification title shown when deleting a layout fails. $1 is the layout name.",
 	"neowiki-property-type-select": "Label for the select/dropdown property type shown in the property type selector.",
+	"neowiki-property-editor-min-exceeds-max": "Error shown in the schema editor when the minimum value exceeds the maximum value for a number property.",
 	"neowiki-property-editor-options": "Label for the options field in the select property type editor, where schema creators define the allowed values.",
 	"neowiki-property-editor-options-unique": "Error shown in the schema editor when duplicate option values are entered for a select property.",
 	"neowiki-field-invalid-option": "Validation error shown when a selected value is not in the allowed options list. $1 is the invalid value.",

--- a/resources/ext.neowiki/src/components/SchemaEditor/Property/NumberAttributesEditor.vue
+++ b/resources/ext.neowiki/src/components/SchemaEditor/Property/NumberAttributesEditor.vue
@@ -6,25 +6,33 @@
 				{{ $i18n( 'neowiki-property-editor-range' ).text() }}
 			</template>
 
-			<CdxField>
+			<CdxField
+				class="number-attributes__minimum"
+				:status="minimumError === null ? 'default' : 'error'"
+				:messages="minimumError === null ? {} : { error: minimumError }"
+			>
 				<template #label>
 					{{ $i18n( 'neowiki-property-editor-minimum' ).text() }}
 				</template>
 
 				<CdxTextInput
-					:model-value="property.minimum?.toString()"
+					:model-value="minimumInput"
 					input-type="number"
 					@update:model-value="updateMinimum"
 				/>
 			</CdxField>
 
-			<CdxField>
+			<CdxField
+				class="number-attributes__maximum"
+				:status="maximumError === null ? 'default' : 'error'"
+				:messages="maximumError === null ? {} : { error: maximumError }"
+			>
 				<template #label>
 					{{ $i18n( 'neowiki-property-editor-maximum' ).text() }}
 				</template>
 
 				<CdxTextInput
-					:model-value="property.maximum?.toString()"
+					:model-value="maximumInput"
 					input-type="number"
 					@update:model-value="updateMaximum"
 				/>
@@ -40,7 +48,7 @@
 				{{ $i18n( 'neowiki-property-editor-precision' ).text() }}
 			</template>
 			<CdxTextInput
-				:model-value="property.precision?.toString()"
+				:model-value="precisionInput"
 				input-type="number"
 				min="0"
 				@update:model-value="updatePrecision"
@@ -50,16 +58,34 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, watch } from 'vue';
 import { CdxField, CdxTextInput } from '@wikimedia/codex';
 import { NumberProperty } from '@/domain/propertyTypes/Number.ts';
 import { AttributesEditorEmits, AttributesEditorProps } from '@/components/SchemaEditor/Property/AttributesEditorContract.ts';
+import { minExceedsMax } from '@/components/SchemaEditor/Property/minExceedsMax.ts';
 import NeoNestedField from '@/components/common/NeoNestedField.vue';
 
-defineProps<AttributesEditorProps<NumberProperty>>();
+const props = defineProps<AttributesEditorProps<NumberProperty>>();
 const emit = defineEmits<AttributesEditorEmits<NumberProperty>>();
 
+const minimumInput = ref( props.property.minimum?.toString() ?? '' );
+const maximumInput = ref( props.property.maximum?.toString() ?? '' );
+const precisionInput = ref( props.property.precision?.toString() ?? '' );
+const minimumError = ref<string | null>( null );
+const maximumError = ref<string | null>( null );
 const precisionError = ref<string | null>( null );
+
+watch( () => props.property.minimum, ( newVal ) => {
+	minimumInput.value = newVal?.toString() ?? '';
+} );
+
+watch( () => props.property.maximum, ( newVal ) => {
+	maximumInput.value = newVal?.toString() ?? '';
+} );
+
+watch( () => props.property.precision, ( newVal ) => {
+	precisionInput.value = newVal?.toString() ?? '';
+} );
 
 const parseNumber = ( value: string ): number | undefined =>
 	value ? Number( value ) : undefined;
@@ -68,14 +94,33 @@ const isValidPrecision = ( value: number | undefined ): boolean =>
 	value === undefined || value >= 0;
 
 const updateMinimum = ( value: string ): void => {
+	minimumInput.value = value;
+
+	if ( minExceedsMax( value, maximumInput.value ) ) {
+		minimumError.value = mw.message( 'neowiki-property-editor-min-exceeds-max' ).text();
+		return;
+	}
+
+	minimumError.value = null;
+	maximumError.value = null;
 	emit( 'update:property', { minimum: parseNumber( value ) } );
 };
 
 const updateMaximum = ( value: string ): void => {
+	maximumInput.value = value;
+
+	if ( minExceedsMax( minimumInput.value, value ) ) {
+		maximumError.value = mw.message( 'neowiki-property-editor-min-exceeds-max' ).text();
+		return;
+	}
+
+	maximumError.value = null;
+	minimumError.value = null;
 	emit( 'update:property', { maximum: parseNumber( value ) } );
 };
 
 const updatePrecision = ( value: string ): void => {
+	precisionInput.value = value;
 	const numValue = parseNumber( value );
 
 	if ( isValidPrecision( numValue ) ) {

--- a/resources/ext.neowiki/src/components/SchemaEditor/Property/TextAttributesEditor.vue
+++ b/resources/ext.neowiki/src/components/SchemaEditor/Property/TextAttributesEditor.vue
@@ -71,6 +71,7 @@ import { ref, watch } from 'vue';
 import { TextProperty } from '@/domain/propertyTypes/Text.ts';
 import { AttributesEditorEmits, AttributesEditorProps } from '@/components/SchemaEditor/Property/AttributesEditorContract.ts';
 import { CdxToggleSwitch, CdxField, CdxTextInput } from '@wikimedia/codex';
+import { minExceedsMax } from '@/components/SchemaEditor/Property/minExceedsMax.ts';
 import NeoNestedField from '@/components/common/NeoNestedField.vue';
 
 const props = defineProps<AttributesEditorProps<TextProperty>>();
@@ -102,12 +103,6 @@ const validateValue = ( value: string ): string | null => {
 		return mw.message( 'neowiki-property-editor-length-whole-number' ).text();
 	}
 	return null;
-};
-
-const minExceedsMax = ( minValue: string, maxValue: string ): boolean => {
-	const min = minValue === '' ? undefined : Number( minValue );
-	const max = maxValue === '' ? undefined : Number( maxValue );
-	return min !== undefined && max !== undefined && min > max;
 };
 
 const updateMinLength = ( value: string ): void => {

--- a/resources/ext.neowiki/src/components/SchemaEditor/Property/minExceedsMax.ts
+++ b/resources/ext.neowiki/src/components/SchemaEditor/Property/minExceedsMax.ts
@@ -1,0 +1,5 @@
+export function minExceedsMax( minValue: string, maxValue: string ): boolean {
+	const min = minValue === '' ? undefined : Number( minValue );
+	const max = maxValue === '' ? undefined : Number( maxValue );
+	return min !== undefined && max !== undefined && min > max;
+}

--- a/resources/ext.neowiki/tests/VueTestHelpers.ts
+++ b/resources/ext.neowiki/tests/VueTestHelpers.ts
@@ -1,7 +1,13 @@
 import { mount, VueWrapper } from '@vue/test-utils';
 import { Component, DefineComponent } from 'vue';
 import { vi } from 'vitest';
+import { ValidationMessages, ValidationStatusType } from '@wikimedia/codex';
 import { NeoWikiTestServices } from './NeoWikiTestServices.ts';
+
+export interface FieldProps {
+	status: ValidationStatusType;
+	messages: ValidationMessages;
+}
 
 export function createI18nMock(): ReturnType<typeof vi.fn> {
 	return vi.fn().mockImplementation( ( key ) => ( {

--- a/resources/ext.neowiki/tests/components/SchemaEditor/Property/NumberAttributesEditor.spec.ts
+++ b/resources/ext.neowiki/tests/components/SchemaEditor/Property/NumberAttributesEditor.spec.ts
@@ -1,21 +1,17 @@
 import { VueWrapper } from '@vue/test-utils';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { CdxTextInput, ValidationMessages, ValidationStatusType } from '@wikimedia/codex';
+import { CdxTextInput } from '@wikimedia/codex';
 import NumberAttributesEditor from '@/components/SchemaEditor/Property/NumberAttributesEditor.vue';
 import { newNumberProperty, NumberProperty } from '@/domain/propertyTypes/Number';
 import { AttributesEditorProps } from '@/components/SchemaEditor/Property/AttributesEditorContract.ts';
-import { createTestWrapper, setupMwMock } from '../../../VueTestHelpers.ts';
-
-interface FieldProps {
-	status: ValidationStatusType;
-	messages: ValidationMessages;
-}
+import { createTestWrapper, FieldProps, setupMwMock } from '../../../VueTestHelpers.ts';
 
 describe( 'NumberAttributesEditor', () => {
 	beforeEach( () => {
 		setupMwMock( {
 			messages: {
 				'neowiki-property-editor-precision-non-negative': 'Precision cannot be negative.',
+				'neowiki-property-editor-min-exceeds-max': 'Minimum cannot exceed maximum.',
 			},
 			functions: [ 'message' ],
 		} );
@@ -28,86 +24,197 @@ describe( 'NumberAttributesEditor', () => {
 		} );
 	}
 
-	it( 'displays property values correctly', () => {
-		const wrapper = newWrapper( {
-			property: newNumberProperty( { minimum: 5, maximum: 100, precision: 2 } ),
-		} );
-
-		const inputs = wrapper.findAllComponents( CdxTextInput );
-		const modelValues = inputs.map( ( input ) => input.props( 'modelValue' ) );
-
-		expect( modelValues ).toContain( '5' );
-		expect( modelValues ).toContain( '100' );
-		expect( modelValues ).toContain( '2' );
-	} );
-
-	function getPrecisionFieldProps( wrapper: VueWrapper ): FieldProps {
-		const field = wrapper.findComponent( '.number-attributes__precision' ) as VueWrapper;
-		return field.props() as FieldProps;
+	function getMinimumFieldProps( wrapper: VueWrapper ): FieldProps {
+		return ( wrapper.findComponent( '.number-attributes__minimum' ) as VueWrapper ).props() as FieldProps;
 	}
 
-	it( 'shows error and does not emit when precision is negative', async () => {
-		const wrapper = newWrapper();
-		const inputs = wrapper.findAllComponents( CdxTextInput );
+	function getMaximumFieldProps( wrapper: VueWrapper ): FieldProps {
+		return ( wrapper.findComponent( '.number-attributes__maximum' ) as VueWrapper ).props() as FieldProps;
+	}
 
-		await inputs[ 2 ].vm.$emit( 'update:modelValue', '-5' );
+	function getPrecisionFieldProps( wrapper: VueWrapper ): FieldProps {
+		return ( wrapper.findComponent( '.number-attributes__precision' ) as VueWrapper ).props() as FieldProps;
+	}
 
-		const fieldProps = getPrecisionFieldProps( wrapper );
-		expect( fieldProps.status ).toBe( 'error' );
-		expect( fieldProps.messages ).toEqual( { error: 'Precision cannot be negative.' } );
-		expect( wrapper.emitted( 'update:property' ) ).toBeFalsy();
+	describe( 'displaying existing values', () => {
+		it( 'displays existing minimum, maximum and precision', () => {
+			const wrapper = newWrapper( {
+				property: newNumberProperty( { minimum: 5, maximum: 100, precision: 2 } ),
+			} );
+			const inputs = wrapper.findAllComponents( CdxTextInput );
+
+			expect( inputs[ 0 ].props( 'modelValue' ) ).toBe( '5' );
+			expect( inputs[ 1 ].props( 'modelValue' ) ).toBe( '100' );
+			expect( inputs[ 2 ].props( 'modelValue' ) ).toBe( '2' );
+		} );
 	} );
 
-	it( 'shows no error when precision is zero or positive', async () => {
-		const wrapper = newWrapper();
-		const inputs = wrapper.findAllComponents( CdxTextInput );
+	describe( 'range validation', () => {
+		it( 'shows no error when both fields are empty', () => {
+			const wrapper = newWrapper();
 
-		await inputs[ 2 ].vm.$emit( 'update:modelValue', '0' );
-		expect( getPrecisionFieldProps( wrapper ).status ).toBe( 'default' );
-
-		await inputs[ 2 ].vm.$emit( 'update:modelValue', '5' );
-		expect( getPrecisionFieldProps( wrapper ).status ).toBe( 'default' );
-	} );
-
-	it( 'emits update event when minimum is changed', async () => {
-		const wrapper = newWrapper();
-
-		const inputs = wrapper.findAllComponents( CdxTextInput );
-		await inputs[ 0 ].vm.$emit( 'update:modelValue', '10' );
-
-		expect( wrapper.emitted( 'update:property' ) ).toBeTruthy();
-		expect( wrapper.emitted( 'update:property' )?.[ 0 ] ).toEqual( [ { minimum: 10 } ] );
-	} );
-
-	it( 'emits update event when maximum is changed', async () => {
-		const wrapper = newWrapper();
-
-		const inputs = wrapper.findAllComponents( CdxTextInput );
-		await inputs[ 1 ].vm.$emit( 'update:modelValue', '50' );
-
-		expect( wrapper.emitted( 'update:property' ) ).toBeTruthy();
-		expect( wrapper.emitted( 'update:property' )?.[ 0 ] ).toEqual( [ { maximum: 50 } ] );
-	} );
-
-	it( 'emits update event when precision is changed', async () => {
-		const wrapper = newWrapper();
-
-		const inputs = wrapper.findAllComponents( CdxTextInput );
-		await inputs[ 2 ].vm.$emit( 'update:modelValue', '3' );
-
-		expect( wrapper.emitted( 'update:property' ) ).toBeTruthy();
-		expect( wrapper.emitted( 'update:property' )?.[ 0 ] ).toEqual( [ { precision: 3 } ] );
-	} );
-
-	it( 'emits undefined when input is cleared', async () => {
-		const wrapper = newWrapper( {
-			property: newNumberProperty( { minimum: 10 } ),
+			expect( getMinimumFieldProps( wrapper ).status ).toBe( 'default' );
+			expect( getMaximumFieldProps( wrapper ).status ).toBe( 'default' );
 		} );
 
-		const inputs = wrapper.findAllComponents( CdxTextInput );
-		await inputs[ 0 ].vm.$emit( 'update:modelValue', '' );
+		it( 'shows error on min field when min exceeds max', async () => {
+			const wrapper = newWrapper( {
+				property: newNumberProperty( { maximum: 10 } ),
+			} );
+			const inputs = wrapper.findAllComponents( CdxTextInput );
 
-		expect( wrapper.emitted( 'update:property' ) ).toBeTruthy();
-		expect( wrapper.emitted( 'update:property' )?.[ 0 ] ).toEqual( [ { minimum: undefined } ] );
+			await inputs[ 0 ].vm.$emit( 'update:modelValue', '20' );
+
+			expect( getMinimumFieldProps( wrapper ).status ).toBe( 'error' );
+			expect( getMinimumFieldProps( wrapper ).messages ).toEqual( {
+				error: 'Minimum cannot exceed maximum.',
+			} );
+			expect( wrapper.emitted( 'update:property' ) ).toBeFalsy();
+		} );
+
+		it( 'shows error on max field when max is less than min', async () => {
+			const wrapper = newWrapper( {
+				property: newNumberProperty( { minimum: 20 } ),
+			} );
+			const inputs = wrapper.findAllComponents( CdxTextInput );
+
+			await inputs[ 1 ].vm.$emit( 'update:modelValue', '10' );
+
+			expect( getMaximumFieldProps( wrapper ).status ).toBe( 'error' );
+			expect( getMaximumFieldProps( wrapper ).messages ).toEqual( {
+				error: 'Minimum cannot exceed maximum.',
+			} );
+			expect( wrapper.emitted( 'update:property' ) ).toBeFalsy();
+		} );
+
+		it( 'allows min equal to max', async () => {
+			const wrapper = newWrapper( {
+				property: newNumberProperty( { maximum: 10 } ),
+			} );
+			const inputs = wrapper.findAllComponents( CdxTextInput );
+
+			await inputs[ 0 ].vm.$emit( 'update:modelValue', '10' );
+
+			expect( getMinimumFieldProps( wrapper ).status ).toBe( 'default' );
+			expect( wrapper.emitted( 'update:property' ) ).toBeTruthy();
+		} );
+
+		it( 'clears min error when valid value resolves conflict', async () => {
+			const wrapper = newWrapper( {
+				property: newNumberProperty( { maximum: 10 } ),
+			} );
+			const inputs = wrapper.findAllComponents( CdxTextInput );
+
+			await inputs[ 0 ].vm.$emit( 'update:modelValue', '20' );
+			expect( getMinimumFieldProps( wrapper ).status ).toBe( 'error' );
+
+			await inputs[ 0 ].vm.$emit( 'update:modelValue', '5' );
+			expect( getMinimumFieldProps( wrapper ).status ).toBe( 'default' );
+		} );
+
+		it( 'clears max error when valid min resolves conflict', async () => {
+			const wrapper = newWrapper( {
+				property: newNumberProperty( { minimum: 20 } ),
+			} );
+			const inputs = wrapper.findAllComponents( CdxTextInput );
+
+			await inputs[ 1 ].vm.$emit( 'update:modelValue', '10' );
+			expect( getMaximumFieldProps( wrapper ).status ).toBe( 'error' );
+
+			await inputs[ 0 ].vm.$emit( 'update:modelValue', '5' );
+			expect( getMinimumFieldProps( wrapper ).status ).toBe( 'default' );
+			expect( getMaximumFieldProps( wrapper ).status ).toBe( 'default' );
+		} );
+
+		it( 'allows negative numbers for min and max', async () => {
+			const wrapper = newWrapper();
+			const inputs = wrapper.findAllComponents( CdxTextInput );
+
+			await inputs[ 0 ].vm.$emit( 'update:modelValue', '-10' );
+			expect( getMinimumFieldProps( wrapper ).status ).toBe( 'default' );
+			expect( wrapper.emitted( 'update:property' )?.[ 0 ] ).toEqual( [ { minimum: -10 } ] );
+
+			await inputs[ 1 ].vm.$emit( 'update:modelValue', '-5' );
+			expect( getMaximumFieldProps( wrapper ).status ).toBe( 'default' );
+		} );
+	} );
+
+	describe( 'precision validation', () => {
+		it( 'shows error and does not emit when precision is negative', async () => {
+			const wrapper = newWrapper();
+			const inputs = wrapper.findAllComponents( CdxTextInput );
+
+			await inputs[ 2 ].vm.$emit( 'update:modelValue', '-5' );
+
+			expect( getPrecisionFieldProps( wrapper ).status ).toBe( 'error' );
+			expect( getPrecisionFieldProps( wrapper ).messages ).toEqual( { error: 'Precision cannot be negative.' } );
+			expect( wrapper.emitted( 'update:property' ) ).toBeFalsy();
+		} );
+
+		it( 'preserves invalid input in the precision field', async () => {
+			const wrapper = newWrapper( {
+				property: newNumberProperty( { precision: 2 } ),
+			} );
+			const inputs = wrapper.findAllComponents( CdxTextInput );
+
+			await inputs[ 2 ].vm.$emit( 'update:modelValue', '-5' );
+
+			expect( inputs[ 2 ].props( 'modelValue' ) ).toBe( '-5' );
+		} );
+
+		it( 'shows no error when precision is zero or positive', async () => {
+			const wrapper = newWrapper();
+			const inputs = wrapper.findAllComponents( CdxTextInput );
+
+			await inputs[ 2 ].vm.$emit( 'update:modelValue', '0' );
+			expect( getPrecisionFieldProps( wrapper ).status ).toBe( 'default' );
+
+			await inputs[ 2 ].vm.$emit( 'update:modelValue', '5' );
+			expect( getPrecisionFieldProps( wrapper ).status ).toBe( 'default' );
+		} );
+	} );
+
+	describe( 'emitting updates', () => {
+		it( 'emits minimum when valid value is entered', async () => {
+			const wrapper = newWrapper();
+			const inputs = wrapper.findAllComponents( CdxTextInput );
+
+			await inputs[ 0 ].vm.$emit( 'update:modelValue', '10' );
+
+			expect( wrapper.emitted( 'update:property' ) ).toBeTruthy();
+			expect( wrapper.emitted( 'update:property' )?.[ 0 ] ).toEqual( [ { minimum: 10 } ] );
+		} );
+
+		it( 'emits maximum when valid value is entered', async () => {
+			const wrapper = newWrapper();
+			const inputs = wrapper.findAllComponents( CdxTextInput );
+
+			await inputs[ 1 ].vm.$emit( 'update:modelValue', '50' );
+
+			expect( wrapper.emitted( 'update:property' ) ).toBeTruthy();
+			expect( wrapper.emitted( 'update:property' )?.[ 0 ] ).toEqual( [ { maximum: 50 } ] );
+		} );
+
+		it( 'emits precision when valid value is entered', async () => {
+			const wrapper = newWrapper();
+			const inputs = wrapper.findAllComponents( CdxTextInput );
+
+			await inputs[ 2 ].vm.$emit( 'update:modelValue', '3' );
+
+			expect( wrapper.emitted( 'update:property' ) ).toBeTruthy();
+			expect( wrapper.emitted( 'update:property' )?.[ 0 ] ).toEqual( [ { precision: 3 } ] );
+		} );
+
+		it( 'emits undefined when input is cleared', async () => {
+			const wrapper = newWrapper( {
+				property: newNumberProperty( { minimum: 10 } ),
+			} );
+			const inputs = wrapper.findAllComponents( CdxTextInput );
+
+			await inputs[ 0 ].vm.$emit( 'update:modelValue', '' );
+
+			expect( wrapper.emitted( 'update:property' ) ).toBeTruthy();
+			expect( wrapper.emitted( 'update:property' )?.[ 0 ] ).toEqual( [ { minimum: undefined } ] );
+		} );
 	} );
 } );

--- a/resources/ext.neowiki/tests/components/SchemaEditor/Property/TextAttributesEditor.spec.ts
+++ b/resources/ext.neowiki/tests/components/SchemaEditor/Property/TextAttributesEditor.spec.ts
@@ -1,15 +1,10 @@
 import { VueWrapper } from '@vue/test-utils';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { CdxField, CdxTextInput, ValidationMessages, ValidationStatusType } from '@wikimedia/codex';
+import { CdxField, CdxTextInput } from '@wikimedia/codex';
 import TextAttributesEditor from '@/components/SchemaEditor/Property/TextAttributesEditor.vue';
 import { newTextProperty, TextProperty } from '@/domain/propertyTypes/Text';
 import { AttributesEditorProps } from '@/components/SchemaEditor/Property/AttributesEditorContract.ts';
-import { createTestWrapper, setupMwMock } from '../../../VueTestHelpers.ts';
-
-interface FieldProps {
-	status: ValidationStatusType;
-	messages: ValidationMessages;
-}
+import { createTestWrapper, FieldProps, setupMwMock } from '../../../VueTestHelpers.ts';
 
 describe( 'TextAttributesEditor', () => {
 	beforeEach( () => {


### PR DESCRIPTION
> Prompted by @JeroenDeDauw, implemented autonomously by Claude Code.
> Context: the NeoWiki codebase, issue #476 and comment, and TextAttributesEditor as reference.
> <sub>Written by Claude Code, `Opus 4.6`</sub>

Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/476

NumberAttributesEditor was missing the validation refinements that
TextAttributesEditor received in PR #551. This adds:

- Error state when minimum exceeds maximum (and vice versa)
- Local input refs with watchers for all fields (minimum, maximum,
  and precision) so in-progress input is preserved even when invalid
- New i18n message `neowiki-property-editor-min-exceeds-max`
- Extracted shared `minExceedsMax` helper used by both Text and Number
  editors
- Moved `FieldProps` test interface to shared `VueTestHelpers`
- CSS classes on min/max fields for robust test selectors