### PR TITLE
Update RDF mapping doc with partner feedback

### DIFF
--- a/docs/planning/RdfMapping.md
+++ b/docs/planning/RdfMapping.md
@@ -2,7 +2,7 @@
 
 Written 2026-02-23 by Jeroen De Dauw with help from Claude Opus 4.6
 
-Status: Early draft for discussion with ECHOLOT partners
+Status: Draft, incorporating feedback from ECHOLOT partners (Bilbao meeting March 2026 and async discussion)
 
 ## Purpose
 
@@ -12,7 +12,7 @@ and therefore what SPARQL queries users can write. It also defines the shape of 
 
 This is a strawman proposal. Many decisions here need input from partners with RDF and Linked Open Data expertise,
 particularly regarding ontology alignment and cultural heritage conventions. [Open questions](#open-questions) are
-collected at the end.
+collected at the end. Discussion is tracked in [#723](https://github.com/ProfessionalWiki/NeoWiki/issues/723).
 
 ## Design Principles
 
@@ -211,6 +211,12 @@ DROP SILENT GRAPH <neo-page:42>
   generating intermediate nodes that don't exist in NeoWiki's data. For example, a simple NeoWiki "Creator" relation
   from an Object to a Person would need to expand to `E22_Human-Made_Object → P108i_was_produced_by →
   E12_Production → P14_carried_out_by → E39_Actor` in CIDOC-CRM, creating the Production event node in RDF.
+  At the ECHOLOT meeting in Bilbao (March 2026), the consortium agreed that wiki admins should be able to define
+  mappings between ontologies they care about and the NeoWiki Schemas of their wiki. This confirms the mapping
+  layer approach and means several open questions below (Q1, Q2, Q4) are less critical for the base mapping,
+  since ontology alignment is handled separately. The plan is that NeoWiki provides the mapping mechanism, data
+  modellers in the project create standard mapping + Schema bundles (e.g., for CIDOC-CRM), and users can
+  optionally install those bundles where relevant.
 - **Schema definitions as RDF.** Schemas could be expressed as RDFS/OWL classes with property constraints (similar
   to SHACL shapes). This is potentially valuable for validation and documentation, but is a separate concern.
 - **RDF import.** This document covers the outbound direction (NeoWiki data to RDF). Importing RDF data into
@@ -230,9 +236,20 @@ are independent definitions. Should the RDF predicates reflect this (`$base/prop
 predicate? The flat approach is more natural for RDF and enables cross-schema queries, but implies a semantic
 equivalence that NeoWiki does not enforce. The scoped approach is faithful to the data model but unusual in RDF.
 
+*Feedback: The scoped approach would not be objectionable but makes ontology mapping harder — it duplicates
+properties and requires inference for mappings to function at a more general level. With the ontology mapping
+layer confirmed (see above), this question is less critical for the base mapping: NeoWiki-native predicates are
+emitted regardless, and the mapping layer translates to standard ontology terms. Tentative resolution: flat
+namespace (`$base/prop/Name`), since it is more natural for RDF and the mapping layer handles ontology
+alignment.*
+
 **Q2: Standard vocabulary in the base mapping.** The strawman uses `rdf:type`, `rdfs:label`, and `dcterms:created`
 / `dcterms:modified`. Should more standard predicates be used in the base mapping (e.g., `foaf:name` for labels,
 `dcterms:title` for page names)? Or should all standard vocabulary alignment happen in the ontology mapping layer?
+
+*Less critical given the confirmed ontology mapping layer. Tentative resolution: keep the base mapping minimal
+with the current standard predicates (`rdf:type`, `rdfs:label`, `dcterms:created/modified`). Further standard
+vocabulary alignment happens in the mapping layer.*
 
 **Q3: Relation representation.** The strawman uses Wikibase-style reification (a dedicated Relation node with
 `source`, `target`, `relationType`, and properties). Is this the right approach for the CH/LOD community? Are
@@ -245,16 +262,35 @@ example, a simple "Creator" relation in NeoWiki would correspond to the CIDOC-CR
 Production event is an intermediate entity that doesn't exist in NeoWiki's data. Does this affect the base RDF
 mapping, or is it purely an ontology mapping layer concern?
 
+*Feedback (KMA, from Wikibase experience): Three approaches exist: (1) basic entity-property — simplest,
+(2) event-centric — more performant for queries but data not visible on the subject's page, (3) qualifier-based
+— familiar from Wikidata, all data on one page. The event-centric UX downside could be mitigated by displaying
+related pages on a subject's page (like transclusion of the named graph up to a defined depth). For SPARQL, the
+query limitations that SMW had with qualifiers do not occur. Tentative resolution: confirmed as an ontology
+mapping layer concern, not a base mapping concern. The base mapping represents NeoWiki's native data model;
+CIDOC-CRM event expansion happens in the mapping layer.*
+
 **Q5: Named graph conventions.** Per-page named graphs are proposed for operational reasons (efficient sync). Are
 there CH/LOD conventions for named graph usage (e.g., per-source, per-dataset) that we should align with? Does
 ECHOLOT's provenance model (T2.4) have implications for named graph design?
 
+*Resolved: No CH conventions exist for named graph usage. Per-page named graphs are fine for operational
+purposes.*
+
 **Q6: Base URI conventions.** Should the base URI be the wiki's URL (e.g., `https://mywiki.example.org/`)? Is
 there a convention in the ECHOLOT/ECCCH context for how services should mint URIs?
+
+*Feedback: There is a URI policy being discussed within ECCCH. Aligning with it would be beneficial. To be
+followed up on.*
 
 **Q7: URI design for Properties.** Property Names can contain spaces and special characters (e.g., "Founded at",
 "Has author"). What's the convention — URL-encode them (`Has%20author`), replace spaces with underscores
 (`Has_author`), or something else?
+
+*Feedback: Two suggestions received. (1) CamelCase — upper-case for classes (`BeautifulClass`), lower-case for
+properties (`hasSomeFeature`). This is the most common RDF convention. (2) Underscores (`Has_author`) — more
+practical for cultural heritage users less familiar with URL encoding. Both are viable; this is a convention
+choice, not an architectural one.*
 
 ### Implementation decisions (can resolve ourselves)
 
@@ -266,6 +302,10 @@ in a "full export" mode.
 **Q9: Ordering of multi-valued properties.** NeoWiki stores multi-valued properties as ordered arrays. RDF triple
 sets are unordered. Accept the ordering loss for the base mapping? Or emit ordering information (adds complexity)?
 Tentative answer: accept the loss; ordering is a display concern handled by Views.
+
+*Feedback: Question raised whether ordering truly matters for some use cases (e.g., pages in a book). Tentative
+answer unchanged: accept ordering loss in the base mapping. If specific use cases require ordering, it can be
+added later (e.g., via `rdf:List` or index properties).*
 
 **Q10: Schema namespace page.** Should NeoWiki emit an RDFS/OWL definition for each Schema (as a class) and each
 Property Definition (as a property with domain/range)? This would make the RDF self-describing. Tentative answer:


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/NeoWiki/issues/723

## Summary

- Update status to reflect Bilbao meeting and async feedback
- Add Bilbao outcome: wiki admins define ontology mappings, with standard mapping + Schema bundles as optional content
- Add feedback annotations to Q1, Q2, Q4, Q5, Q6, Q7, Q9 with tentative resolutions
- Link to tracking issue #723

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>