### PR TITLE
Add DateTime min/max cross-validation and generalize minExceedsMax

### DIFF
--- a/resources/ext.neowiki/src/components/SchemaEditor/Property/DateTimeAttributesEditor.vue
+++ b/resources/ext.neowiki/src/components/SchemaEditor/Property/DateTimeAttributesEditor.vue
@@ -5,7 +5,11 @@
 				{{ $i18n( 'neowiki-property-editor-range' ).text() }}
 			</template>
 
-			<CdxField>
+			<CdxField
+				class="datetime-attributes__minimum"
+				:status="minimumError === null ? 'default' : 'error'"
+				:messages="minimumError === null ? {} : { error: minimumError }"
+			>
 				<template #label>
 					{{ $i18n( 'neowiki-property-editor-minimum' ).text() }}
 				</template>
@@ -14,12 +18,16 @@
 				<input
 					type="datetime-local"
 					class="cdx-text-input__input"
-					:value="toLocalInputValue( property.minimum )"
+					:value="minimumInput"
 					@input="updateMinimum"
 				>
 			</CdxField>
 
-			<CdxField>
+			<CdxField
+				class="datetime-attributes__maximum"
+				:status="maximumError === null ? 'default' : 'error'"
+				:messages="maximumError === null ? {} : { error: maximumError }"
+			>
 				<template #label>
 					{{ $i18n( 'neowiki-property-editor-maximum' ).text() }}
 				</template>
@@ -28,7 +36,7 @@
 				<input
 					type="datetime-local"
 					class="cdx-text-input__input"
-					:value="toLocalInputValue( property.maximum )"
+					:value="maximumInput"
 					@input="updateMaximum"
 				>
 			</CdxField>
@@ -37,13 +45,27 @@
 </template>
 
 <script setup lang="ts">
+import { ref, watch } from 'vue';
 import { CdxField } from '@wikimedia/codex';
 import { DateTimeProperty } from '@/domain/propertyTypes/DateTime.ts';
 import { AttributesEditorEmits, AttributesEditorProps } from '@/components/SchemaEditor/Property/AttributesEditorContract.ts';
 import NeoNestedField from '@/components/common/NeoNestedField.vue';
 
-defineProps<AttributesEditorProps<DateTimeProperty>>();
+const props = defineProps<AttributesEditorProps<DateTimeProperty>>();
 const emit = defineEmits<AttributesEditorEmits<DateTimeProperty>>();
+
+const minimumInput = ref( toLocalInputValue( props.property.minimum ) );
+const maximumInput = ref( toLocalInputValue( props.property.maximum ) );
+const minimumError = ref<string | null>( null );
+const maximumError = ref<string | null>( null );
+
+watch( () => props.property.minimum, ( newVal ) => {
+	minimumInput.value = toLocalInputValue( newVal );
+} );
+
+watch( () => props.property.maximum, ( newVal ) => {
+	maximumInput.value = toLocalInputValue( newVal );
+} );
 
 function toLocalInputValue( isoString: string | undefined ): string {
 	if ( !isoString ) {
@@ -56,13 +78,40 @@ function fromLocalInputValue( localValue: string ): string | undefined {
 	return localValue ? localValue + ':00Z' : undefined;
 }
 
+function minExceedsMax( min: string, max: string ): boolean {
+	if ( min === '' || max === '' ) {
+		return false;
+	}
+	const minTime = Date.parse( min );
+	const maxTime = Date.parse( max );
+	return !Number.isNaN( minTime ) && !Number.isNaN( maxTime ) && minTime > maxTime;
+}
+
 const updateMinimum = ( event: Event ): void => {
-	const target = event.target as HTMLInputElement;
-	emit( 'update:property', { minimum: fromLocalInputValue( target.value ) } );
+	const value = ( event.target as HTMLInputElement ).value;
+	minimumInput.value = value;
+
+	if ( minExceedsMax( value, maximumInput.value ) ) {
+		minimumError.value = mw.message( 'neowiki-property-editor-min-exceeds-max' ).text();
+		return;
+	}
+
+	minimumError.value = null;
+	maximumError.value = null;
+	emit( 'update:property', { minimum: fromLocalInputValue( value ) } );
 };
 
 const updateMaximum = ( event: Event ): void => {
-	const target = event.target as HTMLInputElement;
-	emit( 'update:property', { maximum: fromLocalInputValue( target.value ) } );
+	const value = ( event.target as HTMLInputElement ).value;
+	maximumInput.value = value;
+
+	if ( minExceedsMax( minimumInput.value, value ) ) {
+		maximumError.value = mw.message( 'neowiki-property-editor-min-exceeds-max' ).text();
+		return;
+	}
+
+	maximumError.value = null;
+	minimumError.value = null;
+	emit( 'update:property', { maximum: fromLocalInputValue( value ) } );
 };
 </script>

--- a/resources/ext.neowiki/tests/components/SchemaEditor/Property/DateTimeAttributesEditor.spec.ts
+++ b/resources/ext.neowiki/tests/components/SchemaEditor/Property/DateTimeAttributesEditor.spec.ts
@@ -1,11 +1,20 @@
 import { DOMWrapper, VueWrapper } from '@vue/test-utils';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import DateTimeAttributesEditor from '@/components/SchemaEditor/Property/DateTimeAttributesEditor.vue';
 import { newDateTimeProperty, DateTimeProperty } from '@/domain/propertyTypes/DateTime';
 import { AttributesEditorProps } from '@/components/SchemaEditor/Property/AttributesEditorContract.ts';
-import { createTestWrapper } from '../../../VueTestHelpers.ts';
+import { createTestWrapper, FieldProps, setupMwMock } from '../../../VueTestHelpers.ts';
 
 describe( 'DateTimeAttributesEditor', () => {
+	beforeEach( () => {
+		setupMwMock( {
+			messages: {
+				'neowiki-property-editor-min-exceeds-max': 'Minimum cannot exceed maximum.',
+			},
+			functions: [ 'message' ],
+		} );
+	} );
+
 	function newWrapper( props: Partial<AttributesEditorProps<DateTimeProperty>> = {} ): VueWrapper {
 		return createTestWrapper( DateTimeAttributesEditor, {
 			property: newDateTimeProperty( {} ),
@@ -15,6 +24,14 @@ describe( 'DateTimeAttributesEditor', () => {
 
 	function getInputs( wrapper: VueWrapper ): DOMWrapper<HTMLInputElement>[] {
 		return wrapper.findAll<HTMLInputElement>( 'input[type="datetime-local"]' );
+	}
+
+	function getMinimumFieldProps( wrapper: VueWrapper ): FieldProps {
+		return ( wrapper.findComponent( '.datetime-attributes__minimum' ) as VueWrapper ).props() as FieldProps;
+	}
+
+	function getMaximumFieldProps( wrapper: VueWrapper ): FieldProps {
+		return ( wrapper.findComponent( '.datetime-attributes__maximum' ) as VueWrapper ).props() as FieldProps;
 	}
 
 	describe( 'displaying existing values', () => {
@@ -38,6 +55,84 @@ describe( 'DateTimeAttributesEditor', () => {
 
 			expect( inputs[ 0 ].element.value ).toBe( '' );
 			expect( inputs[ 1 ].element.value ).toBe( '' );
+		} );
+	} );
+
+	describe( 'range validation', () => {
+		it( 'shows no error when both fields are empty', () => {
+			const wrapper = newWrapper();
+
+			expect( getMinimumFieldProps( wrapper ).status ).toBe( 'default' );
+			expect( getMaximumFieldProps( wrapper ).status ).toBe( 'default' );
+		} );
+
+		it( 'shows error on min field when min exceeds max', async () => {
+			const wrapper = newWrapper( {
+				property: newDateTimeProperty( { maximum: '2020-01-01T00:00:00Z' } ),
+			} );
+			const inputs = getInputs( wrapper );
+
+			await inputs[ 0 ].setValue( '2030-01-01T00:00' );
+
+			expect( getMinimumFieldProps( wrapper ).status ).toBe( 'error' );
+			expect( getMinimumFieldProps( wrapper ).messages ).toEqual( {
+				error: 'Minimum cannot exceed maximum.',
+			} );
+			expect( wrapper.emitted( 'update:property' ) ).toBeFalsy();
+		} );
+
+		it( 'shows error on max field when max is less than min', async () => {
+			const wrapper = newWrapper( {
+				property: newDateTimeProperty( { minimum: '2030-01-01T00:00:00Z' } ),
+			} );
+			const inputs = getInputs( wrapper );
+
+			await inputs[ 1 ].setValue( '2020-01-01T00:00' );
+
+			expect( getMaximumFieldProps( wrapper ).status ).toBe( 'error' );
+			expect( getMaximumFieldProps( wrapper ).messages ).toEqual( {
+				error: 'Minimum cannot exceed maximum.',
+			} );
+			expect( wrapper.emitted( 'update:property' ) ).toBeFalsy();
+		} );
+
+		it( 'allows min equal to max', async () => {
+			const wrapper = newWrapper( {
+				property: newDateTimeProperty( { maximum: '2020-01-01T00:00:00Z' } ),
+			} );
+			const inputs = getInputs( wrapper );
+
+			await inputs[ 0 ].setValue( '2020-01-01T00:00' );
+
+			expect( getMinimumFieldProps( wrapper ).status ).toBe( 'default' );
+			expect( wrapper.emitted( 'update:property' )?.[ 0 ] ).toEqual( [ { minimum: '2020-01-01T00:00:00Z' } ] );
+		} );
+
+		it( 'clears min error when valid value resolves conflict', async () => {
+			const wrapper = newWrapper( {
+				property: newDateTimeProperty( { maximum: '2020-01-01T00:00:00Z' } ),
+			} );
+			const inputs = getInputs( wrapper );
+
+			await inputs[ 0 ].setValue( '2030-01-01T00:00' );
+			expect( getMinimumFieldProps( wrapper ).status ).toBe( 'error' );
+
+			await inputs[ 0 ].setValue( '2010-01-01T00:00' );
+			expect( getMinimumFieldProps( wrapper ).status ).toBe( 'default' );
+		} );
+
+		it( 'clears max error when valid min resolves conflict', async () => {
+			const wrapper = newWrapper( {
+				property: newDateTimeProperty( { minimum: '2030-01-01T00:00:00Z' } ),
+			} );
+			const inputs = getInputs( wrapper );
+
+			await inputs[ 1 ].setValue( '2020-01-01T00:00' );
+			expect( getMaximumFieldProps( wrapper ).status ).toBe( 'error' );
+
+			await inputs[ 0 ].setValue( '2010-01-01T00:00' );
+			expect( getMinimumFieldProps( wrapper ).status ).toBe( 'default' );
+			expect( getMaximumFieldProps( wrapper ).status ).toBe( 'default' );
 		} );
 	} );
 


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/730

`DateTimeAttributesEditor.vue` now refuses to emit an update when the
minimum timestamp exceeds the maximum and surfaces the existing
`neowiki-property-editor-min-exceeds-max` message on the offending
field, matching the behavior the number editor already had.

The comparison is a local 6-line helper that parses each input via
`Date.parse` and treats empty or unparseable input as "no value" so
typos don't produce spurious range errors. I considered generalizing
the existing `minExceedsMax` helper to take a parser callback (the
original plan in #730), but that turned out to be net-negative: the
two existing consumers (`NumberAttributesEditor`, `TextAttributesEditor`)
both already reduce to `Number(...)`, so the generalization
parameterized a variation that didn't actually vary between current
consumers, while adding indirection at every call site. Keeping the
shared helper untouched and inlining DateTime's check reads more
simply.

> Result of extensive back-and-forth with @JeroenDeDauw (including an explicit
> course-correction away from the `minExceedsMax` refactor originally proposed
> in #730).
> Context: the NeoWiki codebase and the review of #685.
> <sub>Written by Claude Code, `Opus 4.7`</sub>