### PR TITLE
DateTime: stricter ISO 8601 value validation

### DIFF
--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -146,7 +146,7 @@
 	"neowiki-field-single-value-only": "Validation error shown when multiple values are selected for a single-select property.",
 	"neowiki-select-placeholder": "Placeholder text shown in the select dropdown before any option is chosen.",
 	"neowiki-select-no-results": "Message shown in the multi-select dropdown when the typed text does not match any available option.",
-	"neowiki-field-invalid-datetime": "Validation error shown when the entered date and time value cannot be parsed.",
+	"neowiki-field-invalid-datetime": "Validation error shown when the entered date and time value cannot be parsed. DateTime values must be strict ISO 8601 / xsd:dateTime strings with an explicit timezone offset or 'Z' (for example, '2025-06-15T12:00:00Z' or '2025-06-15T12:00:00+02:00'). Partial values such as year-only or date-only are rejected, and min/max bounds are inclusive.",
 	"neowiki-property-type-datetime": "Label for the date and time property type in the schema editor",
 	"neowiki-select-unknown-option": "Placeholder shown in a select-property display when a stored option ID cannot be resolved to a label (e.g. the option was removed from the Schema)."
 }

--- a/resources/ext.neowiki/src/domain/propertyTypes/DateTime.ts
+++ b/resources/ext.neowiki/src/domain/propertyTypes/DateTime.ts
@@ -5,11 +5,85 @@ import { BasePropertyType, ValueValidationError } from '@/domain/PropertyType';
 
 export interface DateTimeProperty extends PropertyDefinition {
 
+	/**
+	 * Inclusive lower bound. Must be a strict ISO 8601 / xsd:dateTime string
+	 * with an explicit timezone offset (e.g. `2025-06-15T12:00:00Z` or
+	 * `2025-06-15T12:00:00+02:00`).
+	 */
 	readonly minimum?: string;
+
+	/**
+	 * Inclusive upper bound. Same shape rules as the minimum.
+	 */
 	readonly maximum?: string;
 
 }
 
+/**
+ * Matches xsd:dateTime-like strings with an explicit timezone offset or `Z`.
+ * A subsequent calendar-overflow check is used to reject inputs like
+ * `2025-02-30T00:00:00Z` that the regex alone cannot detect.
+ */
+// The only quantifier `\d{1,9}` is bounded and followed by a distinct
+// character class, so this is not subject to catastrophic backtracking.
+// eslint-disable-next-line security/detect-unsafe-regex
+const ISO_DATE_TIME_REGEX = /^(-?\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])T([01]\d|2[0-3]):([0-5]\d):([0-5]\d)(?:\.\d{1,9})?(?<offset>Z|[+-](?:[01]\d|2[0-3]):[0-5]\d)$/;
+
+function parseStrictDateTime( value: string ): number | null {
+	const match = ISO_DATE_TIME_REGEX.exec( value );
+	if ( match === null || match.groups === undefined ) {
+		return null;
+	}
+
+	const timestamp = Date.parse( value );
+	if ( isNaN( timestamp ) ) {
+		return null;
+	}
+
+	// Reject calendar overflows (e.g. Feb 30) that Date silently rolls over.
+	// Compare the declared year/month/day against the shifted-to-local date
+	// using UTC getters, so the check is independent of the host timezone.
+	const offsetSegment = match.groups.offset;
+	const offsetMinutes = offsetSegment === 'Z' ? 0 : isoOffsetToMinutes( offsetSegment );
+	const local = new Date( timestamp + offsetMinutes * 60_000 );
+
+	if (
+		local.getUTCFullYear() !== Number( match[ 1 ] ) ||
+		local.getUTCMonth() + 1 !== Number( match[ 2 ] ) ||
+		local.getUTCDate() !== Number( match[ 3 ] )
+	) {
+		return null;
+	}
+
+	return timestamp;
+}
+
+function isoOffsetToMinutes( offset: string ): number {
+	const sign = offset.startsWith( '-' ) ? -1 : 1;
+	const [ hours, minutes ] = offset.slice( 1 ).split( ':' ).map( Number );
+	return sign * ( hours * 60 + minutes );
+}
+
+/**
+ * Property type for xsd:dateTime-style timestamps.
+ *
+ * Values must be strict ISO 8601 strings with an explicit timezone offset or
+ * `Z` (e.g. `2025-06-15T12:00:00Z`, `2025-06-15T12:00:00+02:00`). Partial
+ * values such as year-only (`2025`), year-month (`2025-06`), or date-only
+ * (`2025-06-15`), as well as calendar overflows like `2025-02-30T00:00:00Z`,
+ * are rejected. The `minimum` and `maximum` bounds are inclusive and must
+ * themselves be well-formed ISO 8601 strings.
+ *
+ * Deliberately not accepted: lowercase `t` separator, colonless offsets
+ * (`+0200`), leap seconds (`23:59:60`), `24:00` end-of-day, and expanded
+ * `+YYYYY` years — narrower than xsd:dateTime but sufficient for the
+ * property-bound use case.
+ *
+ * If `minimum` or `maximum` on the passed-in property is itself malformed,
+ * that bound is silently ignored during validation (fail-open). The PHP
+ * persistence layer rejects malformed bounds at construction, so this only
+ * matters if something bypasses that path.
+ */
 export class DateTimeType extends BasePropertyType<DateTimeProperty, StringValue> {
 
 	public static readonly valueType = ValueType.String;
@@ -41,25 +115,28 @@ export class DateTimeType extends BasePropertyType<DateTimeProperty, StringValue
 		}
 
 		if ( value !== undefined && value.parts.length > 0 ) {
-			const dateString = value.parts[ 0 ];
-			const timestamp = Date.parse( dateString );
+			const timestamp = parseStrictDateTime( value.parts[ 0 ] );
 
-			if ( isNaN( timestamp ) ) {
+			if ( timestamp === null ) {
 				errors.push( { code: 'invalid-datetime' } );
 				return errors;
 			}
 
-			if ( property.minimum !== undefined && timestamp < Date.parse( property.minimum ) ) {
+			const minimum = property.minimum;
+			const minimumTimestamp = minimum !== undefined ? parseStrictDateTime( minimum ) : null;
+			if ( minimum !== undefined && minimumTimestamp !== null && timestamp < minimumTimestamp ) {
 				errors.push( {
 					code: 'min-value',
-					args: [ property.minimum ],
+					args: [ minimum ],
 				} );
 			}
 
-			if ( property.maximum !== undefined && timestamp > Date.parse( property.maximum ) ) {
+			const maximum = property.maximum;
+			const maximumTimestamp = maximum !== undefined ? parseStrictDateTime( maximum ) : null;
+			if ( maximum !== undefined && maximumTimestamp !== null && timestamp > maximumTimestamp ) {
 				errors.push( {
 					code: 'max-value',
-					args: [ property.maximum ],
+					args: [ maximum ],
 				} );
 			}
 		}

--- a/resources/ext.neowiki/tests/domain/propertyTypes/DateTime.spec.ts
+++ b/resources/ext.neowiki/tests/domain/propertyTypes/DateTime.spec.ts
@@ -82,12 +82,90 @@ describe( 'validate', () => {
 		] );
 	} );
 
+	it( 'returns invalid-datetime error for year-only string', () => {
+		const property = newDateTimeProperty();
+
+		expect( dateTimeType.validate( newStringValue( '2025' ), property ) ).toEqual( [
+			{ code: 'invalid-datetime' },
+		] );
+	} );
+
+	it( 'returns invalid-datetime error for year-month string', () => {
+		const property = newDateTimeProperty();
+
+		expect( dateTimeType.validate( newStringValue( '2025-06' ), property ) ).toEqual( [
+			{ code: 'invalid-datetime' },
+		] );
+	} );
+
+	it( 'returns invalid-datetime error for date-only string', () => {
+		const property = newDateTimeProperty();
+
+		expect( dateTimeType.validate( newStringValue( '2025-06-15' ), property ) ).toEqual( [
+			{ code: 'invalid-datetime' },
+		] );
+	} );
+
+	it( 'returns invalid-datetime error for overflowing calendar date', () => {
+		const property = newDateTimeProperty();
+
+		expect( dateTimeType.validate( newStringValue( '2025-02-30T00:00:00Z' ), property ) ).toEqual( [
+			{ code: 'invalid-datetime' },
+		] );
+	} );
+
+	it( 'returns invalid-datetime error when timezone offset is missing', () => {
+		const property = newDateTimeProperty();
+
+		expect( dateTimeType.validate( newStringValue( '2025-06-15T12:00:00' ), property ) ).toEqual( [
+			{ code: 'invalid-datetime' },
+		] );
+	} );
+
+	it( 'accepts explicit positive timezone offset', () => {
+		const property = newDateTimeProperty();
+
+		expect( dateTimeType.validate( newStringValue( '2025-06-15T12:00:00+02:00' ), property ) ).toEqual( [] );
+	} );
+
+	it( 'accepts explicit negative timezone offset', () => {
+		const property = newDateTimeProperty();
+
+		expect( dateTimeType.validate( newStringValue( '2025-06-15T12:00:00-05:00' ), property ) ).toEqual( [] );
+	} );
+
+	it( 'accepts fractional seconds with Z offset', () => {
+		const property = newDateTimeProperty();
+
+		expect( dateTimeType.validate( newStringValue( '2025-06-15T12:00:00.123Z' ), property ) ).toEqual( [] );
+	} );
+
+	it( 'accepts nanosecond-precision fractional seconds (9 digits)', () => {
+		const property = newDateTimeProperty();
+
+		expect( dateTimeType.validate( newStringValue( '2025-06-15T12:00:00.123456789Z' ), property ) ).toEqual( [] );
+	} );
+
 	it( 'returns min-value error when before minimum', () => {
 		const property = newDateTimeProperty( { minimum: '2025-01-01T00:00:00Z' } );
 
 		expect( dateTimeType.validate( newStringValue( '2024-12-31T23:59:59Z' ), property ) ).toEqual( [
 			{ code: 'min-value', args: [ '2025-01-01T00:00:00Z' ] },
 		] );
+	} );
+
+	it( 'returns min-value error when one millisecond before minimum', () => {
+		const property = newDateTimeProperty( { minimum: '2025-01-01T00:00:00.000Z' } );
+
+		expect( dateTimeType.validate( newStringValue( '2024-12-31T23:59:59.999Z' ), property ) ).toEqual( [
+			{ code: 'min-value', args: [ '2025-01-01T00:00:00.000Z' ] },
+		] );
+	} );
+
+	it( 'returns no errors one millisecond after minimum', () => {
+		const property = newDateTimeProperty( { minimum: '2025-01-01T00:00:00.000Z' } );
+
+		expect( dateTimeType.validate( newStringValue( '2025-01-01T00:00:00.001Z' ), property ) ).toEqual( [] );
 	} );
 
 	it( 'returns max-value error when after maximum', () => {
@@ -98,11 +176,45 @@ describe( 'validate', () => {
 		] );
 	} );
 
-	it( 'returns no errors for datetime equal to bounds', () => {
+	it( 'returns max-value error when one millisecond after maximum', () => {
+		const property = newDateTimeProperty( { maximum: '2025-12-31T23:59:59.999Z' } );
+
+		expect( dateTimeType.validate( newStringValue( '2026-01-01T00:00:00.000Z' ), property ) ).toEqual( [
+			{ code: 'max-value', args: [ '2025-12-31T23:59:59.999Z' ] },
+		] );
+	} );
+
+	it( 'returns no errors one millisecond before maximum', () => {
+		const property = newDateTimeProperty( { maximum: '2025-12-31T23:59:59.999Z' } );
+
+		expect( dateTimeType.validate( newStringValue( '2025-12-31T23:59:59.998Z' ), property ) ).toEqual( [] );
+	} );
+
+	it( 'returns no errors for datetime equal to bounds (inclusive min and max)', () => {
 		const property = newDateTimeProperty( {
 			minimum: '2025-06-15T12:00:00Z',
 			maximum: '2025-06-15T12:00:00Z',
 		} );
+
+		expect( dateTimeType.validate( newStringValue( '2025-06-15T12:00:00Z' ), property ) ).toEqual( [] );
+	} );
+
+	it( 'returns no errors when value is empty because newStringValue strips empty parts', () => {
+		const property = newDateTimeProperty( { required: false } );
+		const emptyValue = newStringValue( '' );
+
+		expect( emptyValue.parts ).toEqual( [] );
+		expect( dateTimeType.validate( emptyValue, property ) ).toEqual( [] );
+	} );
+
+	it( 'silently ignores a malformed minimum rather than rejecting the value', () => {
+		const property = newDateTimeProperty( { minimum: 'garbage' } );
+
+		expect( dateTimeType.validate( newStringValue( '2025-06-15T12:00:00Z' ), property ) ).toEqual( [] );
+	} );
+
+	it( 'silently ignores a malformed maximum rather than rejecting the value', () => {
+		const property = newDateTimeProperty( { maximum: 'garbage' } );
 
 		expect( dateTimeType.validate( newStringValue( '2025-06-15T12:00:00Z' ), property ) ).toEqual( [] );
 	} );

--- a/tests/RedHerb/src/DateTimeProperty.php
+++ b/tests/RedHerb/src/DateTimeProperty.php
@@ -4,17 +4,54 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\RedHerb;
 
+use InvalidArgumentException;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinition;
 
 class DateTimeProperty extends PropertyDefinition {
+
+	/**
+	 * Matches xsd:dateTime-like strings with an explicit timezone offset or `Z`.
+	 * Mirrors the regex used in the TypeScript DateTimeType; a subsequent
+	 * calendar-overflow check rejects inputs like `2025-02-30T00:00:00Z`.
+	 */
+	private const ISO_DATE_TIME_REGEX =
+		'/^(-?\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])T([01]\d|2[0-3]):([0-5]\d):([0-5]\d)(?:\.\d{1,9})?(?<offset>Z|[+-](?:[01]\d|2[0-3]):[0-5]\d)$/';
 
 	public function __construct(
 		PropertyCore $core,
 		private readonly ?string $minimum,
 		private readonly ?string $maximum,
 	) {
+		self::ensureValidBoundOrNull( 'minimum', $minimum );
+		self::ensureValidBoundOrNull( 'maximum', $maximum );
+
+		if ( is_string( $core->default ) ) {
+			self::ensureValidBoundOrNull( 'default', $core->default );
+		}
+
 		parent::__construct( $core );
+	}
+
+	private static function ensureValidBoundOrNull( string $field, ?string $value ): void {
+		if ( $value === null ) {
+			return;
+		}
+
+		if ( !self::isValidIsoDateTime( $value ) ) {
+			throw new InvalidArgumentException(
+				"DateTimeProperty {$field} must be a strict ISO 8601 datetime with an explicit timezone, got '{$value}'"
+			);
+		}
+	}
+
+	private static function isValidIsoDateTime( string $value ): bool {
+		if ( preg_match( self::ISO_DATE_TIME_REGEX, $value, $matches ) !== 1 ) {
+			return false;
+		}
+
+		// Reject calendar overflows that the regex alone cannot detect (e.g. Feb 30).
+		return checkdate( (int)$matches[2], (int)$matches[3], (int)$matches[1] );
 	}
 
 	public function getPropertyType(): string {

--- a/tests/phpunit/RedHerb/DateTimePropertyTest.php
+++ b/tests/phpunit/RedHerb/DateTimePropertyTest.php
@@ -70,6 +70,99 @@ class DateTimePropertyTest extends TestCase {
 		$this->assertNull( $property->getMaximum() );
 	}
 
+	public function testConstructorAcceptsOffsetWithColon(): void {
+		$property = new DateTimeProperty(
+			core: new PropertyCore( description: '', required: false, default: null ),
+			minimum: '2020-01-01T00:00:00+02:00',
+			maximum: '2030-12-31T23:59:59-05:30',
+		);
+
+		$this->assertSame( '2020-01-01T00:00:00+02:00', $property->getMinimum() );
+		$this->assertSame( '2030-12-31T23:59:59-05:30', $property->getMaximum() );
+	}
+
+	public function testConstructorAcceptsFractionalSeconds(): void {
+		$property = new DateTimeProperty(
+			core: new PropertyCore( description: '', required: false, default: null ),
+			minimum: '2020-01-01T00:00:00.123Z',
+			maximum: null,
+		);
+
+		$this->assertSame( '2020-01-01T00:00:00.123Z', $property->getMinimum() );
+	}
+
+	public function testConstructorAcceptsNanosecondPrecision(): void {
+		$property = new DateTimeProperty(
+			core: new PropertyCore( description: '', required: false, default: null ),
+			minimum: '2020-01-01T00:00:00.123456789Z',
+			maximum: null,
+		);
+
+		$this->assertSame( '2020-01-01T00:00:00.123456789Z', $property->getMinimum() );
+	}
+
+	/**
+	 * @dataProvider malformedDateTimeProvider
+	 */
+	public function testConstructorRejectsMalformedMinimum( string $malformed ): void {
+		$this->expectException( \InvalidArgumentException::class );
+
+		new DateTimeProperty(
+			core: new PropertyCore( description: '', required: false, default: null ),
+			minimum: $malformed,
+			maximum: null,
+		);
+	}
+
+	/**
+	 * @dataProvider malformedDateTimeProvider
+	 */
+	public function testConstructorRejectsMalformedMaximum( string $malformed ): void {
+		$this->expectException( \InvalidArgumentException::class );
+
+		new DateTimeProperty(
+			core: new PropertyCore( description: '', required: false, default: null ),
+			minimum: null,
+			maximum: $malformed,
+		);
+	}
+
+	/**
+	 * @dataProvider malformedDateTimeProvider
+	 */
+	public function testConstructorRejectsMalformedDefault( string $malformed ): void {
+		$this->expectException( \InvalidArgumentException::class );
+
+		new DateTimeProperty(
+			core: new PropertyCore( description: '', required: false, default: $malformed ),
+			minimum: null,
+			maximum: null,
+		);
+	}
+
+	/**
+	 * @dataProvider malformedDateTimeProvider
+	 */
+	public function testFromPartialJsonRejectsMalformedBounds( string $malformed ): void {
+		$this->expectException( \InvalidArgumentException::class );
+
+		DateTimeProperty::fromPartialJson(
+			new PropertyCore( description: '', required: false, default: null ),
+			[ 'minimum' => $malformed ]
+		);
+	}
+
+	public static function malformedDateTimeProvider(): iterable {
+		yield 'year only' => [ '2025' ];
+		yield 'year and month' => [ '2025-06' ];
+		yield 'date only' => [ '2025-06-15' ];
+		yield 'missing timezone' => [ '2025-06-15T12:00:00' ];
+		yield 'invalid month' => [ '2025-13-01T00:00:00Z' ];
+		yield 'invalid day' => [ '2025-02-30T00:00:00Z' ];
+		yield 'garbage' => [ 'not-a-date' ];
+		yield 'empty string' => [ '' ];
+	}
+
 	private function buildProperty(): DateTimeProperty {
 		return new DateTimeProperty(
 			core: new PropertyCore( description: '', required: false, default: null ),


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/729

`DateTimeType.validate` and `DateTimeProperty` (PHP) now gate values
through a strict ISO 8601 regex before `Date.parse` / `checkdate`,
rejecting year-only (`2025`), year-month (`2025-06`), date-only
(`2025-06-15`), timezone-less (`...T12:00:00`) and calendar-overflow
(`2025-02-30T00:00:00Z`) inputs. An explicit offset or `Z` is required
so that min/max comparisons cannot silently mix local and UTC epochs.

The calendar-overflow check reconstructs the declared local date from
the UTC timestamp plus the declared offset and compares it against the
regex-extracted Y/M/D using UTC getters — no host-timezone influence.

PHP rejects malformed \`minimum\` / \`maximum\` / string \`default\` at
construction (including via \`fromPartialJson\`) with \`InvalidArgumentException\`.
TypeScript is fail-open on malformed bounds during validation — a
conscious choice so the UI does not hard-fail on bad server-side data —
documented in the \`DateTimeType\` docblock and pinned with tests.

Also pins year/time-invariants the PR deliberately does not accept
(leap seconds, \`24:00\`, colonless offsets, lowercase \`t\`, expanded
years) in the docblock, and uses a named \`offset\` capture group to
avoid a magic \`match[8]\` index.

As a side effect this also closes the local/UTC epoch-mixing subset of #728
(the one where timezone-less inputs were compared against \`Z\` bounds).
The remaining #728 scope — the \`datetime-local\` input silently treating
user entries as UTC via \`Z$\` stripping — is untouched here.

> Result of extensive back-and-forth with @JeroenDeDauw and a critical review pass by an Opus subagent that flagged a fragile \`match[8]\` magic index (now a named group), missing tests for negative offsets, nanosecond precision, and fail-open-on-malformed-bound behavior, an \`as string\` cast that hid a TypeScript narrowing gap, and an unacknowledged side-effect fix for part of #728 (now documented).
> Context: the NeoWiki codebase, the review of #685, and the strict ISO 8601 / xsd:dateTime shape ECHOLOT partners need for round-tripping.
> <sub>Written by Claude Code, \`Opus 4.7\`</sub>