### PR TITLE
Add reference docs for parser functions and Lua API

### DIFF
--- a/docs/LuaAPI.md
+++ b/docs/LuaAPI.md
@@ -1,0 +1,216 @@
+# Lua API
+
+NeoWiki provides a Scribunto library at `mw.neowiki` for accessing structured data from Lua
+modules. This is the programmatic complement to the [parser functions](ParserFunctions.md) — use
+parser functions for simple inline values, use Lua for templates that need to render multiple
+properties, iterate over collections, or build custom output.
+
+For definitions of terms like Subject, Schema, and Statement, see the [Glossary](Glossary.md).
+
+## Loading the library
+
+```lua
+local nw = require('mw.neowiki')
+```
+
+## Functions
+
+### `nw.getValue(propertyName, options)`
+
+Returns a single scalar value for a property. For multi-valued properties, returns the **first**
+value. Use [`nw.getAll()`](#nwgetallpropertyname-options) when you need every value.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `propertyName` | string | Required. The name of the property. |
+| `options` | table | Optional. `{ page = '...' }` or `{ subject = '...' }`. |
+
+#### Returns
+
+The first value of the property, type-converted for Lua:
+
+| Property type | Returned type |
+|---------------|---------------|
+| `text`, `url`, `select` | string |
+| `number` | number |
+| `boolean` | boolean |
+| `relation` | string (target Subject's label, falls back to target ID if lookup fails) |
+
+Returns `nil` when:
+
+- The property name is empty
+- The Subject does not exist (page has no Main Subject, page does not exist, Subject ID invalid
+  or not found)
+- The Subject has no statement for the property
+- The value is empty
+
+#### Examples
+
+```lua
+nw.getValue('Founded at')                              --> 2005
+nw.getValue('Status')                                  --> "Active"
+nw.getValue('Process owner')                           --> "Sarah Naumann"
+nw.getValue('Status', { page = 'ACME Inc' })           --> "Active"
+nw.getValue('City', { subject = 's1abc5def6ghi78' })   --> "Berlin"
+```
+
+### `nw.getAll(propertyName, options)`
+
+Returns every value for a property as a 1-indexed Lua table. Use this when a property is
+multi-valued and you need all values.
+
+Same parameters and resolution rules as [`nw.getValue()`](#nwgetvaluepropertyname-options).
+
+#### Returns
+
+A 1-indexed Lua table of values, type-converted as in `getValue`. For relations, each entry is
+the target Subject's label.
+
+Returns `nil` under the same conditions as `getValue`.
+
+#### Examples
+
+```lua
+nw.getAll('Websites')
+--> { [1] = "https://acme.com", [2] = "https://acme.org" }
+
+nw.getAll('Products')
+--> { [1] = "Foo", [2] = "Bar", [3] = "Baz" }
+
+local websites = nw.getAll('Websites')
+if websites then
+    for _, url in ipairs(websites) do
+        mw.log(url)
+    end
+end
+```
+
+### `nw.getMainSubject(pageName)`
+
+Returns the full data of a page's Main Subject as a Lua table.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `pageName` | string | Optional. Defaults to the current page. |
+
+#### Returns
+
+A Subject table (see [Subject table format](#subject-table-format)) or `nil` if the page does not
+exist or has no Main Subject.
+
+#### Examples
+
+```lua
+local subject = nw.getMainSubject()
+if subject then
+    mw.log(subject.label)         --> "ACME Inc."
+    mw.log(subject.schema)        --> "Company"
+end
+
+local other = nw.getMainSubject('Berlin')
+```
+
+### `nw.getSubject(subjectId)`
+
+Returns the full data of any Subject by its ID, regardless of which page it lives on.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `subjectId` | string | Required. A Subject ID (15 chars, starts with `s`). |
+
+#### Returns
+
+A Subject table (see [Subject table format](#subject-table-format)) or `nil` if the ID is invalid
+or no Subject exists with that ID.
+
+#### Example
+
+```lua
+local subject = nw.getSubject('s1abc5def6ghi78')
+```
+
+### `nw.getChildSubjects(pageName)`
+
+Returns every Child Subject on a page as a 1-indexed Lua table.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `pageName` | string | Optional. Defaults to the current page. |
+
+#### Returns
+
+A 1-indexed Lua table of Subject tables (see [Subject table format](#subject-table-format)).
+Returns an empty table `{}` if the page does not exist or has no Child Subjects.
+
+#### Example
+
+```lua
+local children = nw.getChildSubjects()
+
+for _, child in ipairs(children) do
+    mw.log(child.label)
+end
+```
+
+## Subject table format
+
+Subject tables returned by `getMainSubject`, `getSubject`, and `getChildSubjects` have this
+structure:
+
+```lua
+{
+    id = 's1abc5def6ghi78',
+    label = 'ACME Inc.',
+    schema = 'Company',
+    statements = {
+        ['Founded at']  = { type = 'number',  values = { [1] = 2005 } },
+        ['Status']      = { type = 'select',  values = { [1] = 'Active' } },
+        ['Websites']    = { type = 'url',     values = { [1] = 'https://acme.com', [2] = 'https://acme.org' } },
+        ['Active']      = { type = 'boolean', values = { [1] = true } },
+        ['Products']    = {
+            type = 'relation',
+            values = {
+                [1] = { id = 'r1...', target = 's1...', label = 'Foo' },
+                [2] = { id = 'r1...', target = 's1...', label = 'Bar' },
+            },
+        },
+    },
+}
+```
+
+Notes:
+
+- `statements` is keyed by property name (a regular Lua associative table, **not** 1-indexed).
+- `values` within each statement is a 1-indexed Lua table.
+- `type` is the property type at the time the Statement was last written
+  ([writer's schema](adr/011_Include_Writers_Schema.md)).
+- For relation values, `label` falls back to the target Subject ID if the label cannot be looked
+  up (e.g. broken reference).
+
+## Performance notes
+
+The following calls are marked as expensive (count against the parser's expensive function limit):
+
+- `getValue` and `getAll` when called with `page=` or `subject=` options
+- `getMainSubject(pageName)` when `pageName` is non-nil
+- `getSubject(subjectId)` (always)
+- `getChildSubjects(pageName)` when `pageName` is non-nil
+
+Calls that read from the current page are not expensive.
+
+## Planned additions
+
+The following are not yet implemented:
+
+- `nw.query(cypher, params)` — Execute Cypher queries from Lua. Tracked in
+  [#736](https://github.com/ProfessionalWiki/NeoWiki/issues/736).
+- `nw.getSchema(name)` — Schema introspection for generic templates. Tracked in
+  [#737](https://github.com/ProfessionalWiki/NeoWiki/issues/737).
+
+## Related Documentation
+
+- [Parser Functions](ParserFunctions.md) — Wikitext interface to the same data
+- [Glossary](Glossary.md) — Definitions of Subject, Schema, Statement, etc.
+- [SchemaFormat.md](SchemaFormat.md) — How Schemas and properties are defined
+- [SubjectFormat.md](SubjectFormat.md) — How Subject data is stored
+- [GraphModel.md](GraphModel.md) — Neo4j node and relationship structure

--- a/docs/LuaAPI.md
+++ b/docs/LuaAPI.md
@@ -22,8 +22,8 @@ value. Use [`nw.getAll()`](#nwgetallpropertyname-options) when you need every va
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `propertyName` | string | Required. The name of the property. |
-| `options` | table | Optional. `{ page = '...' }` or `{ subject = '...' }`. |
+| `propertyName` | string | Required. The name of the property. Trimmed; whitespace-only returns `nil`. Passing a non-string raises a Lua error (standard Scribunto type check). |
+| `options` | table | Optional. `{ page = '...' }` or `{ subject = '...' }`. If both are passed, `subject` takes precedence and `page` is silently ignored. |
 
 #### Returns
 
@@ -57,7 +57,8 @@ nw.getValue('City', { subject = 's1abc5def6ghi78' })   --> "Berlin"
 ### `nw.getAll(propertyName, options)`
 
 Returns every value for a property as a 1-indexed Lua table. Use this when a property is
-multi-valued and you need all values.
+multi-valued and you need all values. Even single-valued properties are wrapped in a 1-element
+table.
 
 Same parameters and resolution rules as [`nw.getValue()`](#nwgetvaluepropertyname-options).
 
@@ -121,9 +122,9 @@ Returns the full data of any Subject by its ID, regardless of which page it live
 #### Returns
 
 A Subject table (see [Subject table format](#subject-table-format)) or `nil` if the ID is invalid
-or no Subject exists with that ID.
+or no Subject exists with that ID. Invalid IDs return `nil` rather than raising an error.
 
-#### Example
+#### Examples
 
 ```lua
 local subject = nw.getSubject('s1abc5def6ghi78')
@@ -140,9 +141,10 @@ Returns every Child Subject on a page as a 1-indexed Lua table.
 #### Returns
 
 A 1-indexed Lua table of Subject tables (see [Subject table format](#subject-table-format)).
-Returns an empty table `{}` if the page does not exist or has no Child Subjects.
+Returns an empty table `{}` (not `nil`) if the page does not exist or has no Child Subjects —
+this is the only function in the API that returns an empty table instead of `nil` for "no data".
 
-#### Example
+#### Examples
 
 ```lua
 local children = nw.getChildSubjects()
@@ -163,11 +165,12 @@ structure:
     label = 'ACME Inc.',
     schema = 'Company',
     statements = {
-        ['Founded at']  = { type = 'number',  values = { [1] = 2005 } },
-        ['Status']      = { type = 'select',  values = { [1] = 'Active' } },
-        ['Websites']    = { type = 'url',     values = { [1] = 'https://acme.com', [2] = 'https://acme.org' } },
-        ['Active']      = { type = 'boolean', values = { [1] = true } },
-        ['Products']    = {
+        ['Headquarters'] = { type = 'text',     values = { [1] = 'Berlin' } },
+        ['Founded at']   = { type = 'number',   values = { [1] = 2005 } },
+        ['Status']       = { type = 'select',   values = { [1] = 'Active' } },
+        ['Websites']     = { type = 'url',      values = { [1] = 'https://acme.com', [2] = 'https://acme.org' } },
+        ['Active']       = { type = 'boolean',  values = { [1] = true } },
+        ['Products']     = {
             type = 'relation',
             values = {
                 [1] = { id = 'r1...', target = 's1...', label = 'Foo' },
@@ -186,6 +189,9 @@ Notes:
   ([writer's schema](adr/011_Include_Writers_Schema.md)).
 - For relation values, `label` falls back to the target Subject ID if the label cannot be looked
   up (e.g. broken reference).
+- Per-relation `properties` (qualifiers) are not currently exposed via Lua. Each relation entry
+  contains only `id`, `target`, and `label`. Use the REST API if you need to read relation
+  properties.
 
 ## Performance notes
 

--- a/docs/LuaAPI.md
+++ b/docs/LuaAPI.md
@@ -1,9 +1,17 @@
 # Lua API
 
 NeoWiki provides a Scribunto library at `mw.neowiki` for accessing structured data from Lua
-modules. This is the programmatic complement to the [parser functions](ParserFunctions.md) — use
-parser functions for simple inline values, use Lua for templates that need to render multiple
-properties, iterate over collections, or build custom output.
+modules. Use Lua when you need to render multiple properties, iterate over collections, or build
+custom output. For simple inline values, the [parser functions](ParserFunctions.md) are usually
+enough.
+
+| If you want to... | Use |
+|-------------------|-----|
+| Read one value from a property | [`nw.getValue`](#nwgetvaluepropertyname-options) |
+| Read every value from a multi-valued property | [`nw.getAll`](#nwgetallpropertyname-options) |
+| Get a page's Main Subject (label, schema, all properties) | [`nw.getMainSubject`](#nwgetmainsubjectpagename) |
+| Get a Subject by its ID, regardless of which page it's on | [`nw.getSubject`](#nwgetsubjectsubjectid) |
+| List all Child Subjects on a page | [`nw.getChildSubjects`](#nwgetchildsubjectspagename) |
 
 For definitions of terms like Subject, Schema, and Statement, see the [Glossary](Glossary.md).
 
@@ -22,8 +30,8 @@ value. Use [`nw.getAll()`](#nwgetallpropertyname-options) when you need every va
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `propertyName` | string | Required. The name of the property. Trimmed; whitespace-only returns `nil`. Passing a non-string raises a Lua error (standard Scribunto type check). |
-| `options` | table | Optional. `{ page = '...' }` or `{ subject = '...' }`. If both are passed, `subject` takes precedence and `page` is silently ignored. |
+| `propertyName` | string | Required. The name of the property. |
+| `options` | table | Optional. `{ page = '...' }` or `{ subject = '...' }`. If both are passed, `subject` takes precedence. |
 
 #### Returns
 
@@ -36,13 +44,8 @@ The first value of the property, type-converted for Lua:
 | `boolean` | boolean |
 | `relation` | string (target Subject's label, falls back to target ID if lookup fails) |
 
-Returns `nil` when:
-
-- The property name is empty
-- The Subject does not exist (page has no Main Subject, page does not exist, Subject ID invalid
-  or not found)
-- The Subject has no statement for the property
-- The value is empty
+Returns `nil` when the Subject does not exist, has no value for the property, or the value is
+empty.
 
 #### Examples
 
@@ -117,12 +120,12 @@ Returns the full data of any Subject by its ID, regardless of which page it live
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `subjectId` | string | Required. A Subject ID (15 chars, starts with `s`). |
+| `subjectId` | string | Required. A Subject ID. |
 
 #### Returns
 
-A Subject table (see [Subject table format](#subject-table-format)) or `nil` if the ID is invalid
-or no Subject exists with that ID. Invalid IDs return `nil` rather than raising an error.
+A Subject table (see [Subject table format](#subject-table-format)) or `nil` if no Subject exists
+with that ID (or the ID is malformed).
 
 #### Examples
 
@@ -141,8 +144,8 @@ Returns every Child Subject on a page as a 1-indexed Lua table.
 #### Returns
 
 A 1-indexed Lua table of Subject tables (see [Subject table format](#subject-table-format)).
-Returns an empty table `{}` (not `nil`) if the page does not exist or has no Child Subjects —
-this is the only function in the API that returns an empty table instead of `nil` for "no data".
+Returns an empty table `{}` (not `nil`) if the page has no Child Subjects, so it's safe to
+iterate the result directly with `ipairs`.
 
 #### Examples
 
@@ -183,26 +186,19 @@ structure:
 
 Notes:
 
-- `statements` is keyed by property name (a regular Lua associative table, **not** 1-indexed).
-- `values` within each statement is a 1-indexed Lua table.
-- `type` is the property type at the time the Statement was last written
-  ([writer's schema](adr/011_Include_Writers_Schema.md)).
-- For relation values, `label` falls back to the target Subject ID if the label cannot be looked
-  up (e.g. broken reference).
-- Per-relation `properties` (qualifiers) are not currently exposed via Lua. Each relation entry
-  contains only `id`, `target`, and `label`. Use the REST API if you need to read relation
-  properties.
+- `statements` is keyed by property name. `values` within each statement is 1-indexed.
+- `type` is the property type at the time the Subject was last edited. If the Schema has changed
+  since (e.g. a property was changed from `text` to `select`), older Subjects keep their original
+  type until they are re-saved.
+- A relation's `label` falls back to the target Subject ID if the label cannot be looked up
+  (e.g. a broken reference).
+- Per-relation `properties` (qualifiers) are not currently exposed via Lua. Use the REST API if
+  you need them.
 
-## Performance notes
+## Performance
 
-The following calls are marked as expensive (count against the parser's expensive function limit):
-
-- `getValue` and `getAll` when called with `page=` or `subject=` options
-- `getMainSubject(pageName)` when `pageName` is non-nil
-- `getSubject(subjectId)` (always)
-- `getChildSubjects(pageName)` when `pageName` is non-nil
-
-Calls that read from the current page are not expensive.
+Calls that look up another page or a specific Subject ID count as expensive parser functions
+(against the page's expensive function limit). Calls that read from the current page do not.
 
 ## Planned additions
 

--- a/docs/ParserFunctions.md
+++ b/docs/ParserFunctions.md
@@ -13,19 +13,29 @@ and how.
 ### Syntax
 
 ```
-{{#view: }}                         renders the current page's Main Subject
-{{#view: <subjectId>}}              renders the specified Subject
-{{#view: <subjectId> | <layout>}}   renders the specified Subject with the named Layout
-{{#view:  | <layout>}}              renders the current page's Main Subject with the named Layout
+{{#view: }}                              renders the current page's Main Subject
+{{#view: <subjectId>}}                   renders the specified Subject
+{{#view: <subjectId> | <layoutName>}}    renders the specified Subject with the named Layout
+{{#view:  | <layoutName>}}               renders the current page's Main Subject with the named Layout
 ```
+
+### Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `subjectId` (positional) | Subject ID to render. Defaults to the current page's Main Subject. Trimmed; not validated server-side (the frontend handles missing/invalid Subjects). |
+| `layoutName` (positional) | Layout to apply. Without one, all properties are shown in schema order. Trimmed. |
 
 ### Behavior
 
 - With no `subjectId`, renders the current page's Main Subject. Returns an empty string if the
   page has no Main Subject.
 - With a `layoutName`, applies the Layout's display rules and view type. Without one, falls back
-  to showing all properties in schema-defined order.
-- Output is rendered client-side by the NeoWiki frontend (the parser function emits a placeholder).
+  to showing all properties in schema-defined order. The View Type is determined by the Layout
+  (currently only `infobox` is implemented); there is no `view_type=` parameter on `{{#view}}`.
+- Output is rendered client-side by the NeoWiki frontend. The parser function emits a placeholder
+  element of the form `<div class="ext-neowiki-view" data-mw-neowiki-subject-id="..." data-mw-neowiki-layout-name="...">`
+  with `noparse` and `isHTML` set, and the frontend replaces it during page load.
 
 ### Examples
 
@@ -54,9 +64,9 @@ use in wikitext and for other extensions that need to read NeoWiki metadata via 
 
 | Parameter | Description |
 |-----------|-------------|
-| `propertyName` (positional) | The name of the property to read. Required. |
-| `page` | Read from the Main Subject of the named page. Defaults to the current page. |
-| `subject` | Read from the Subject with the given ID. Takes precedence over `page`. |
+| `propertyName` (positional) | The name of the property to read. Required. Trimmed; whitespace-only values return empty. |
+| `page` | Read from the Main Subject of the named page. Defaults to the current page. Silently ignored when `subject` is also passed. |
+| `subject` | Read from the Subject with the given ID. Takes precedence over `page`. Subject IDs are 15 characters starting with `s` (Crockford-style alphabet); invalid IDs return an empty string without erroring. |
 | `separator` | Separator for multi-valued properties. Defaults to `, `. Trimmed by MediaWiki, so trailing whitespace is not preserved. |
 
 ### Output by property type
@@ -64,19 +74,32 @@ use in wikitext and for other extensions that need to read NeoWiki metadata via 
 | Type | Output |
 |------|--------|
 | `text`, `url`, `select` | The string value. Multiple values joined with `separator`. |
-| `number` | The number as a string. |
-| `boolean` | `true` or `false`. |
-| `relation` | The target Subject's label. Multiple targets joined with `separator`. Falls back to the target Subject ID if the label cannot be looked up. |
+| `number` | The number as a string. PHP's default formatting (e.g. `19.99`); not locale-aware. |
+| `boolean` | The literal string `true` or `false`; not localized. |
+| `relation` | The target Subject's label. Multiple targets joined with `separator`. Falls back to the target Subject ID if the label cannot be looked up. Requires the graph database backend (Neo4j) to be available for label resolution. |
+
+### Output is HTML-escaped and not parsed
+
+The output is HTML-escaped before being inserted, and emitted with `noparse` and `isHTML` set.
+Consequences:
+
+- A property value of `<b>bold</b> & "quoted"` renders as the literal text `<b>bold</b> & "quoted"`,
+  not as bold HTML.
+- The output cannot contain wikitext (links, templates, transclusions are not expanded).
+- When passing the result to another parser function as an argument, the receiving function
+  receives HTML-encoded text. For example, a value of `Engineers & Designers` reaches the inner
+  function as `Engineers &amp; Designers`.
 
 ### Empty results
 
 Returns an empty string when:
 
-- The property name is empty
-- The page has no Main Subject (or the named page does not exist)
+- The `propertyName` is empty (after trimming whitespace)
+- The page has no Main Subject, the named page does not exist, or the page name is invalid
 - The Subject ID is invalid or not found
 - The Subject has no statement for the property
-- The value is empty
+- The value is "empty" — an empty collection of strings or relations. `number` and `boolean`
+  values are never empty, so `false` always renders as `"false"` and `0` as `"0"`.
 
 ### Examples
 
@@ -87,7 +110,9 @@ Process owner: {{#neowiki_value: Process owner | subject=s1abc5def6ghi78}}
 Tags: {{#neowiki_value: Tags | separator=;}}
 ```
 
-A typical integration with another extension's parser function:
+A typical integration with another extension's parser function. Note that because the output is
+HTML-escaped, the receiving function receives HTML-encoded text — fine for plain identifiers, but
+something to be aware of for values that may contain `<`, `>`, `&`, or `"`:
 
 ```
 {{#read-confirmation: audience={{#neowiki_value: Target audience}}}}
@@ -96,10 +121,10 @@ A typical integration with another extension's parser function:
 ## `{{#cypher_raw}}`
 
 Executes a read-only Cypher query against the Neo4j graph database and returns the raw results
-as JSON in a `<pre>` block. Primarily intended for development and debugging.
+as JSON. Primarily intended for development and debugging.
 
-For end-user dashboards, prefer the upcoming table rendering (or use the
-[Lua API](LuaAPI.md) with [`nw.query()`](LuaAPI.md) once Layer 3 lands) to format results.
+For end-user dashboards, formatted query result rendering and a Lua `nw.query()` function are
+planned (see [#736](https://github.com/ProfessionalWiki/NeoWiki/issues/736)).
 
 ### Syntax
 
@@ -107,13 +132,25 @@ For end-user dashboards, prefer the upcoming table rendering (or use the
 {{#cypher_raw: <cypherQuery>}}
 ```
 
+The query is trimmed before validation, so surrounding whitespace (including newlines from
+multi-line wikitext) is fine.
+
 ### Behavior
 
-- Validates the query is read-only (rejects `CREATE`, `DELETE`, `MERGE`, `SET`, `REMOVE`, etc).
-- Executes against a read-only Neo4j connection.
-- Returns formatted JSON wrapped in a code block.
-- Returns a styled error message in a `<div class="error">` for empty queries, write queries,
-  query execution failures, or JSON encoding failures.
+- Validates the query is read-only via two layers:
+  1. A keyword filter rejects queries containing any of `CREATE`, `SET`, `DELETE`, `REMOVE`,
+     `MERGE`, `DROP`, `CALL`, `LOAD`, `FOREACH`, `GRANT`, `DENY`, `REVOKE`, or `SHOW`. (Note that
+     `CALL` is rejected even for read-only procedures.)
+  2. An `EXPLAIN` of the query is run and rejected if the resulting plan contains any non-read
+     operators.
+- Executes via the Neo4j driver's `readTransaction()` on a dedicated read-only connection
+  (separate from the connection used for writes).
+- Returns formatted JSON wrapped in a `<pre><code class="json">` block. The JSON is HTML-escaped
+  before insertion, so values containing `<`, `>`, `&`, etc. are safely displayed.
+- Returns a styled error message in a `<div class="error">` for any failure. Possible causes
+  include: an empty query, a query containing a rejected write keyword, a query whose `EXPLAIN`
+  plan contains non-read operators, query execution failures (including Neo4j being unavailable
+  during validation), and JSON encoding failures.
 
 ### Examples
 

--- a/docs/ParserFunctions.md
+++ b/docs/ParserFunctions.md
@@ -2,6 +2,14 @@
 
 NeoWiki provides three parser functions for use in wikitext.
 
+| If you want to... | Use |
+|-------------------|-----|
+| Render a Subject visually on the page | [`{{#view}}`](#view) |
+| Insert one property's value inline as text | [`{{#neowiki_value}}`](#neowiki_value) |
+| Run a custom Cypher query and see the raw results | [`{{#cypher_raw}}`](#cypher_raw) |
+
+For programmatic access from Lua modules, see the [Lua API](LuaAPI.md).
+
 For definitions of terms like Subject, Schema, and Layout, see the [Glossary](Glossary.md).
 
 ## `{{#view}}`
@@ -23,19 +31,14 @@ and how.
 
 | Parameter | Description |
 |-----------|-------------|
-| `subjectId` (positional) | Subject ID to render. Defaults to the current page's Main Subject. Trimmed; not validated server-side (the frontend handles missing/invalid Subjects). |
-| `layoutName` (positional) | Layout to apply. Without one, all properties are shown in schema order. Trimmed. |
+| `subjectId` (positional) | Subject ID to render. Defaults to the current page's Main Subject. |
+| `layoutName` (positional) | Layout to apply. Without one, all properties are shown in schema order. |
 
-### Behavior
+### Notes
 
-- With no `subjectId`, renders the current page's Main Subject. Returns an empty string if the
-  page has no Main Subject.
-- With a `layoutName`, applies the Layout's display rules and view type. Without one, falls back
-  to showing all properties in schema-defined order. The View Type is determined by the Layout
-  (currently only `infobox` is implemented); there is no `view_type=` parameter on `{{#view}}`.
-- Output is rendered client-side by the NeoWiki frontend. The parser function emits a placeholder
-  element of the form `<div class="ext-neowiki-view" data-mw-neowiki-subject-id="..." data-mw-neowiki-layout-name="...">`
-  with `noparse` and `isHTML` set, and the frontend replaces it during page load.
+- Returns an empty string if the resolved Subject does not exist.
+- The View Type (e.g. `infobox`) is determined by the Layout. Only `infobox` is implemented today.
+- Rendering happens client-side, so the Subject view appears once the page's JavaScript has loaded.
 
 ### Examples
 
@@ -64,42 +67,37 @@ use in wikitext and for other extensions that need to read NeoWiki metadata via 
 
 | Parameter | Description |
 |-----------|-------------|
-| `propertyName` (positional) | The name of the property to read. Required. Trimmed; whitespace-only values return empty. |
-| `page` | Read from the Main Subject of the named page. Defaults to the current page. Silently ignored when `subject` is also passed. |
-| `subject` | Read from the Subject with the given ID. Takes precedence over `page`. Subject IDs are 15 characters starting with `s` (Crockford-style alphabet); invalid IDs return an empty string without erroring. |
-| `separator` | Separator for multi-valued properties. Defaults to `, `. Trimmed by MediaWiki, so trailing whitespace is not preserved. |
+| `propertyName` (positional) | The name of the property to read. Required. |
+| `page` | Read from the Main Subject of the named page. Defaults to the current page. Ignored when `subject` is also passed. |
+| `subject` | Read from the Subject with the given ID. Takes precedence over `page`. |
+| `separator` | Separator for multi-valued properties. Defaults to `, `. |
 
 ### Output by property type
 
 | Type | Output |
 |------|--------|
 | `text`, `url`, `select` | The string value. Multiple values joined with `separator`. |
-| `number` | The number as a string. PHP's default formatting (e.g. `19.99`); not locale-aware. |
-| `boolean` | The literal string `true` or `false`; not localized. |
-| `relation` | The target Subject's label. Multiple targets joined with `separator`. Falls back to the target Subject ID if the label cannot be looked up. Requires the graph database backend (Neo4j) to be available for label resolution. |
+| `number` | The number, e.g. `42` or `19.99`. |
+| `boolean` | `true` or `false`. |
+| `relation` | The target Subject's label. Multiple targets joined with `separator`. Falls back to the target Subject ID if the label cannot be looked up. |
 
-### Output is HTML-escaped and not parsed
+Boolean and number values are always rendered, even for `false` and `0` — these are not treated
+as "empty".
 
-The output is HTML-escaped before being inserted, and emitted with `noparse` and `isHTML` set.
-Consequences:
+### Output is plain text
 
-- A property value of `<b>bold</b> & "quoted"` renders as the literal text `<b>bold</b> & "quoted"`,
-  not as bold HTML.
-- The output cannot contain wikitext (links, templates, transclusions are not expanded).
-- When passing the result to another parser function as an argument, the receiving function
-  receives HTML-encoded text. For example, a value of `Engineers & Designers` reaches the inner
-  function as `Engineers &amp; Designers`.
+The output is HTML-escaped and not interpreted as wikitext. Links, templates, and HTML inside
+property values render as literal characters. Useful when you want exactly what the user typed;
+not useful when you want to emit links or styled markup.
 
-### Empty results
+When you pass the result to another parser function as an argument, that function also receives
+HTML-encoded text — a value of `Engineers & Designers` arrives as `Engineers &amp; Designers`.
 
-Returns an empty string when:
+### Returns empty when
 
-- The `propertyName` is empty (after trimming whitespace)
-- The page has no Main Subject, the named page does not exist, or the page name is invalid
-- The Subject ID is invalid or not found
-- The Subject has no statement for the property
-- The value is "empty" — an empty collection of strings or relations. `number` and `boolean`
-  values are never empty, so `false` always renders as `"false"` and `0` as `"0"`.
+- The Subject does not exist on the page (or named page), or the Subject ID was not found.
+- The Subject has no value for that property.
+- The value is an empty collection (e.g. a multi-valued text property with no entries).
 
 ### Examples
 
@@ -110,9 +108,7 @@ Process owner: {{#neowiki_value: Process owner | subject=s1abc5def6ghi78}}
 Tags: {{#neowiki_value: Tags | separator=;}}
 ```
 
-A typical integration with another extension's parser function. Note that because the output is
-HTML-escaped, the receiving function receives HTML-encoded text — fine for plain identifiers, but
-something to be aware of for values that may contain `<`, `>`, `&`, or `"`:
+Passing a value to another extension's parser function:
 
 ```
 {{#read-confirmation: audience={{#neowiki_value: Target audience}}}}
@@ -120,8 +116,8 @@ something to be aware of for values that may contain `<`, `>`, `&`, or `"`:
 
 ## `{{#cypher_raw}}`
 
-Executes a read-only Cypher query against the Neo4j graph database and returns the raw results
-as JSON. Primarily intended for development and debugging.
+Executes a read-only Cypher query and returns the raw results as JSON in a code block. Mainly
+useful for development and debugging.
 
 For end-user dashboards, formatted query result rendering and a Lua `nw.query()` function are
 planned (see [#736](https://github.com/ProfessionalWiki/NeoWiki/issues/736)).
@@ -132,25 +128,15 @@ planned (see [#736](https://github.com/ProfessionalWiki/NeoWiki/issues/736)).
 {{#cypher_raw: <cypherQuery>}}
 ```
 
-The query is trimmed before validation, so surrounding whitespace (including newlines from
-multi-line wikitext) is fine.
+### Notes
 
-### Behavior
-
-- Validates the query is read-only via two layers:
-  1. A keyword filter rejects queries containing any of `CREATE`, `SET`, `DELETE`, `REMOVE`,
-     `MERGE`, `DROP`, `CALL`, `LOAD`, `FOREACH`, `GRANT`, `DENY`, `REVOKE`, or `SHOW`. (Note that
-     `CALL` is rejected even for read-only procedures.)
-  2. An `EXPLAIN` of the query is run and rejected if the resulting plan contains any non-read
-     operators.
-- Executes via the Neo4j driver's `readTransaction()` on a dedicated read-only connection
-  (separate from the connection used for writes).
-- Returns formatted JSON wrapped in a `<pre><code class="json">` block. The JSON is HTML-escaped
-  before insertion, so values containing `<`, `>`, `&`, etc. are safely displayed.
-- Returns a styled error message in a `<div class="error">` for any failure. Possible causes
-  include: an empty query, a query containing a rejected write keyword, a query whose `EXPLAIN`
-  plan contains non-read operators, query execution failures (including Neo4j being unavailable
-  during validation), and JSON encoding failures.
+- Only read queries are allowed. Anything that creates, modifies, or deletes data is rejected,
+  including `CALL` (even for read-only procedures).
+- Errors (rejected queries, syntax errors, the database being unavailable, etc.) render as a
+  styled error message in place of the result.
+- Output is HTML-escaped, so query results containing `<`, `>`, `&`, etc. display safely.
+- The output is wrapped in `<pre><code class="json">` and the error message in
+  `<div class="error">`, so you can target either with CSS.
 
 ### Examples
 

--- a/docs/ParserFunctions.md
+++ b/docs/ParserFunctions.md
@@ -1,0 +1,133 @@
+# Parser Functions
+
+NeoWiki provides three parser functions for use in wikitext.
+
+For definitions of terms like Subject, Schema, and Layout, see the [Glossary](Glossary.md).
+
+## `{{#view}}`
+
+Renders a Subject as HTML on the page using a [View Type](Glossary.md#view-type) (currently
+`infobox`). Optionally uses a [Layout](Glossary.md#layout) to control which properties are shown
+and how.
+
+### Syntax
+
+```
+{{#view: }}                         renders the current page's Main Subject
+{{#view: <subjectId>}}              renders the specified Subject
+{{#view: <subjectId> | <layout>}}   renders the specified Subject with the named Layout
+{{#view:  | <layout>}}              renders the current page's Main Subject with the named Layout
+```
+
+### Behavior
+
+- With no `subjectId`, renders the current page's Main Subject. Returns an empty string if the
+  page has no Main Subject.
+- With a `layoutName`, applies the Layout's display rules and view type. Without one, falls back
+  to showing all properties in schema-defined order.
+- Output is rendered client-side by the NeoWiki frontend (the parser function emits a placeholder).
+
+### Examples
+
+```
+{{#view: }}
+{{#view: s1abc5def6ghi78}}
+{{#view: s1abc5def6ghi78 | CompanyOverview}}
+{{#view:  | CompanyOverview}}
+```
+
+## `{{#neowiki_value}}`
+
+Returns the value of a single property from a Subject, formatted as a string. Designed for inline
+use in wikitext and for other extensions that need to read NeoWiki metadata via parser functions.
+
+### Syntax
+
+```
+{{#neowiki_value: <propertyName> }}
+{{#neowiki_value: <propertyName> | page=<pageName> }}
+{{#neowiki_value: <propertyName> | subject=<subjectId> }}
+{{#neowiki_value: <propertyName> | separator=<separator> }}
+```
+
+### Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `propertyName` (positional) | The name of the property to read. Required. |
+| `page` | Read from the Main Subject of the named page. Defaults to the current page. |
+| `subject` | Read from the Subject with the given ID. Takes precedence over `page`. |
+| `separator` | Separator for multi-valued properties. Defaults to `, `. Trimmed by MediaWiki, so trailing whitespace is not preserved. |
+
+### Output by property type
+
+| Type | Output |
+|------|--------|
+| `text`, `url`, `select` | The string value. Multiple values joined with `separator`. |
+| `number` | The number as a string. |
+| `boolean` | `true` or `false`. |
+| `relation` | The target Subject's label. Multiple targets joined with `separator`. Falls back to the target Subject ID if the label cannot be looked up. |
+
+### Empty results
+
+Returns an empty string when:
+
+- The property name is empty
+- The page has no Main Subject (or the named page does not exist)
+- The Subject ID is invalid or not found
+- The Subject has no statement for the property
+- The value is empty
+
+### Examples
+
+```
+Founded: {{#neowiki_value: Founded at}}
+Status: {{#neowiki_value: Status | page=ACME Inc}}
+Process owner: {{#neowiki_value: Process owner | subject=s1abc5def6ghi78}}
+Tags: {{#neowiki_value: Tags | separator=;}}
+```
+
+A typical integration with another extension's parser function:
+
+```
+{{#read-confirmation: audience={{#neowiki_value: Target audience}}}}
+```
+
+## `{{#cypher_raw}}`
+
+Executes a read-only Cypher query against the Neo4j graph database and returns the raw results
+as JSON in a `<pre>` block. Primarily intended for development and debugging.
+
+For end-user dashboards, prefer the upcoming table rendering (or use the
+[Lua API](LuaAPI.md) with [`nw.query()`](LuaAPI.md) once Layer 3 lands) to format results.
+
+### Syntax
+
+```
+{{#cypher_raw: <cypherQuery>}}
+```
+
+### Behavior
+
+- Validates the query is read-only (rejects `CREATE`, `DELETE`, `MERGE`, `SET`, `REMOVE`, etc).
+- Executes against a read-only Neo4j connection.
+- Returns formatted JSON wrapped in a code block.
+- Returns a styled error message in a `<div class="error">` for empty queries, write queries,
+  query execution failures, or JSON encoding failures.
+
+### Examples
+
+```
+{{#cypher_raw: MATCH (s:Subject) RETURN s.name LIMIT 10}}
+
+{{#cypher_raw: MATCH (s:Subject) WHERE 'Company' IN labels(s) RETURN s.name, s.`Founded at`}}
+```
+
+## Related Documentation
+
+- [Lua API](LuaAPI.md) — Programmatic access to the same data via `mw.neowiki`
+- [Glossary](Glossary.md) — Definitions of Subject, Schema, Layout, View, etc.
+- [SchemaFormat.md](SchemaFormat.md) — How Schemas and properties are defined
+- [SubjectFormat.md](SubjectFormat.md) — How Subject data is stored
+- [GraphModel.md](GraphModel.md) — Neo4j node and relationship structure (relevant for
+  `{{#cypher_raw}}` queries)

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,11 @@ These docs are aimed at developers working on or interfacing with NeoWiki.
 
 Key docs:
 * [Glossary](Glossary.md) - Definitions of NeoWiki concepts. We use these as Ubiquitous Language (UI, code, docs, etc)
+* [Parser Functions](ParserFunctions.md) - Reference for `{{#view}}`, `{{#neowiki_value}}`, and `{{#cypher_raw}}`
+* [Lua API](LuaAPI.md) - Reference for the `mw.neowiki` Scribunto library
+* [Schema Format](SchemaFormat.md) - JSON format for Schema definitions
+* [Subject Format](SubjectFormat.md) - JSON format for Subject data
+* [Graph Model](GraphModel.md) - Neo4j node and relationship structure
 * [Architecture Decision Records](adr/)
 * [Planning docs](planning/) - Work-in-progress exploration and discussion documents
 


### PR DESCRIPTION
## Summary

Adds canonical reference documentation in `docs/`:

- **`docs/ParserFunctions.md`** — Reference for `{{#view}}`, `{{#neowiki_value}}`, and `{{#cypher_raw}}`. Covers syntax, parameters, output by property type, empty-result behavior, and examples.
- **`docs/LuaAPI.md`** — Reference for the `mw.neowiki` Scribunto library. Covers `getValue`, `getAll`, `getMainSubject`, `getSubject`, and `getChildSubjects`. Documents the Subject table format, performance/expensive-function behavior, and links to planned Layer 3 (#736) and Layer 4 (#737).
- **`docs/README.md`** — Adds links to the new docs alongside existing format references.

Both follow the style of the existing `SchemaFormat.md` and `SubjectFormat.md` reference docs. The on-wiki demo pages (`Lua_Data_Access`, `Property_Values`) remain as live runnable examples — these new docs are the canonical reference.

## Test plan

- [x] Read accuracy — both docs were written by reading the actual implementation files (`SubjectDataLookup.php`, `ScribuntoLuaLibrary.php`, `mw.neowiki.lua`, `NeoWikiValueParserFunction.php`, `ViewParserFunction.php`, `CypherRawParserFunction.php`)
- [x] No code changes — no CI run needed beyond markdown rendering check on GitHub
