### PR TITLE
Add stable IDs for select options

### DIFF
--- a/DemoData/Schema/Company.json
+++ b/DemoData/Schema/Company.json
@@ -20,7 +20,12 @@
 		},
 		"Status": {
 			"type": "select",
-			"options": ["Active", "Inactive", "Acquired", "Dissolved"],
+			"options": [
+				{ "id": "o1demo1aaaaaaa1", "label": "Active" },
+				{ "id": "o1demo1aaaaaaa2", "label": "Inactive" },
+				{ "id": "o1demo1aaaaaaa3", "label": "Acquired" },
+				{ "id": "o1demo1aaaaaaa4", "label": "Dissolved" }
+			],
 			"required": true
 		},
 		"World domination progress": {

--- a/DemoData/Schema/Everything.json
+++ b/DemoData/Schema/Everything.json
@@ -42,16 +42,31 @@
 		},
 		"select/select": {
 			"type": "select",
-			"options": ["Draft", "Review", "Approved", "Archived"]
+			"options": [
+				{ "id": "o1demo1aaaaaab1", "label": "Draft" },
+				{ "id": "o1demo1aaaaaab2", "label": "Review" },
+				{ "id": "o1demo1aaaaaab3", "label": "Approved" },
+				{ "id": "o1demo1aaaaaab4", "label": "Archived" }
+			]
 		},
 		"select/select (required)": {
 			"type": "select",
-			"options": ["Low", "Medium", "High", "Critical"],
+			"options": [
+				{ "id": "o1demo1aaaaaac1", "label": "Low" },
+				{ "id": "o1demo1aaaaaac2", "label": "Medium" },
+				{ "id": "o1demo1aaaaaac3", "label": "High" },
+				{ "id": "o1demo1aaaaaac4", "label": "Critical" }
+			],
 			"required": true
 		},
 		"select/select (many)": {
 			"type": "select",
-			"options": ["Red", "Green", "Blue", "Yellow"],
+			"options": [
+				{ "id": "o1demo1aaaaaad1", "label": "Red" },
+				{ "id": "o1demo1aaaaaad2", "label": "Green" },
+				{ "id": "o1demo1aaaaaad3", "label": "Blue" },
+				{ "id": "o1demo1aaaaaad4", "label": "Yellow" }
+			],
 			"multiple": true
 		},
 		"relation/relation": {

--- a/DemoData/Subject/ACME_Inc.json
+++ b/DemoData/Subject/ACME_Inc.json
@@ -17,7 +17,7 @@
 				},
 				"Status": {
 					"type": "select",
-					"value": ["Active"]
+					"value": ["o1demo1aaaaaaa1"]
 				},
 				"World domination progress": {
 					"type": "number",

--- a/DemoData/Subject/Professional_Wiki.json
+++ b/DemoData/Subject/Professional_Wiki.json
@@ -18,7 +18,7 @@
 				},
 				"Status": {
 					"type": "select",
-					"value": ["Active"]
+					"value": ["o1demo1aaaaaaa1"]
 				},
 				"Products": {
 					"type": "relation",

--- a/docs/SchemaFormat.md
+++ b/docs/SchemaFormat.md
@@ -114,26 +114,51 @@ Example with constraints:
 
 ### Select (`select`)
 
-A fixed set of allowed options that users pick from. Stored as string values.
+A fixed set of allowed options that users pick from. Each option has a stable ID;
+stored statement values reference the ID, so renaming an option's label does not break
+existing data.
 
 ```json
 {
   "type": "select",
-  "options": ["Draft", "Review", "Approved"]
+  "options": [
+    { "id": "opt_draft",    "label": "Draft" },
+    { "id": "opt_review",   "label": "Review" },
+    { "id": "opt_approved", "label": "Approved" }
+  ]
 }
 ```
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `options` | string[] | `[]` | The allowed values to choose from |
-| `multiple` | boolean | `false` | Allow selecting multiple options |
+| `options` | `SelectOption[]` | `[]` | The allowed values to choose from. |
+| `multiple` | boolean | `false` | Allow selecting multiple options. |
+
+Each `SelectOption`:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | Yes | Stable identifier. Unique within the property. Statements store this. |
+| `label` | string | Yes | Human-readable display text. Unique (case-insensitive, trimmed) within the property. |
+
+Stored statement values for a select property are option IDs (not labels). Display and
+API reads resolve IDs to labels via the current Schema.
+
+On write (create/patch statement), the API accepts either an option `id` or a `label`
+(case-insensitive, whitespace-trimmed). A `{ "id": ..., "label": ... }` object is also
+accepted when consistent; mismatched `id`/`label` is rejected.
 
 Example with multi-select:
 
 ```json
 {
   "type": "select",
-  "options": ["Red", "Green", "Blue", "Yellow"],
+  "options": [
+    { "id": "opt_red",    "label": "Red" },
+    { "id": "opt_green",  "label": "Green" },
+    { "id": "opt_blue",   "label": "Blue" },
+    { "id": "opt_yellow", "label": "Yellow" }
+  ],
   "multiple": true,
   "required": true,
   "description": "Color tags"

--- a/docs/SchemaFormat.md
+++ b/docs/SchemaFormat.md
@@ -263,7 +263,12 @@ A "Company" schema with various property types:
     },
     "Status": {
       "type": "select",
-      "options": ["Active", "Inactive", "Acquired", "Dissolved"],
+      "options": [
+        { "id": "opt_active",    "label": "Active" },
+        { "id": "opt_inactive",  "label": "Inactive" },
+        { "id": "opt_acquired",  "label": "Acquired" },
+        { "id": "opt_dissolved", "label": "Dissolved" }
+      ],
       "required": true
     },
     "World domination progress": {

--- a/extension.json
+++ b/extension.json
@@ -278,6 +278,7 @@
 				"neowiki-field-single-value-only",
 				"neowiki-select-placeholder",
 				"neowiki-select-no-results",
+				"neowiki-select-unknown-option",
 				"neowiki-property-editor-description",
 				"neowiki-property-editor-name",
 				"neowiki-property-editor-type",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -58,6 +58,7 @@
 	"neowiki-field-single-value-only": "Only one value can be selected.",
 	"neowiki-select-placeholder": "Select an option",
 	"neowiki-select-no-results": "No matching options.",
+	"neowiki-select-unknown-option": "(unknown option)",
 
 	"neowiki-property-editor-description": "Description",
 	"neowiki-edit-schema": "Edit schema",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -139,5 +139,6 @@
 	"neowiki-select-placeholder": "Placeholder text shown in the select dropdown before any option is chosen.",
 	"neowiki-select-no-results": "Message shown in the multi-select dropdown when the typed text does not match any available option.",
 	"neowiki-field-invalid-datetime": "Validation error shown when the entered date and time value cannot be parsed.",
-	"neowiki-property-type-datetime": "Label for the date and time property type in the schema editor"
+	"neowiki-property-type-datetime": "Label for the date and time property type in the schema editor",
+	"neowiki-select-unknown-option": "Placeholder shown in a select-property display when a stored option ID cannot be resolved to a label (e.g. the option was removed from the Schema)."
 }

--- a/resources/ext.neowiki/src/components/SchemaEditor/Property/SelectAttributesEditor.vue
+++ b/resources/ext.neowiki/src/components/SchemaEditor/Property/SelectAttributesEditor.vue
@@ -35,7 +35,7 @@
 import { computed, ref } from 'vue';
 import { CdxChipInput, CdxField, CdxToggleSwitch } from '@wikimedia/codex';
 import type { ChipInputItem } from '@wikimedia/codex';
-import { SelectProperty } from '@/domain/propertyTypes/Select.ts';
+import { SelectOption, SelectProperty } from '@/domain/propertyTypes/Select.ts';
 import { AttributesEditorEmits, AttributesEditorProps } from '@/components/SchemaEditor/Property/AttributesEditorContract.ts';
 
 const props = defineProps<AttributesEditorProps<SelectProperty>>();
@@ -44,12 +44,12 @@ const emit = defineEmits<AttributesEditorEmits<SelectProperty>>();
 const optionsError = ref<string | null>( null );
 
 const optionChips = computed( (): ChipInputItem[] =>
-	props.property.options.map( ( option ) => ( { value: option } ) )
+	props.property.options.map( ( option ) => ( { value: option.label } ) )
 );
 
 const updateOptions = ( chips: ChipInputItem[] ): void => {
-	const newOptions = chips.map( ( chip ) => String( chip.value ) );
-	const hasDuplicates = new Set( newOptions ).size !== newOptions.length;
+	const newLabels = chips.map( ( chip ) => String( chip.value ) );
+	const hasDuplicates = new Set( newLabels ).size !== newLabels.length;
 
 	if ( hasDuplicates ) {
 		optionsError.value = mw.message( 'neowiki-property-editor-options-unique' ).text();
@@ -57,6 +57,7 @@ const updateOptions = ( chips: ChipInputItem[] ): void => {
 	}
 
 	optionsError.value = null;
+	const newOptions: SelectOption[] = newLabels.map( ( label ) => ( { id: label, label } ) );
 	emit( 'update:property', { options: newOptions } );
 };
 

--- a/resources/ext.neowiki/src/components/Value/SelectDisplay.vue
+++ b/resources/ext.neowiki/src/components/Value/SelectDisplay.vue
@@ -7,7 +7,7 @@
 <script setup lang="ts">
 import { ValueType } from '@/domain/Value.ts';
 import { computed } from 'vue';
-import { SelectProperty } from '@/domain/propertyTypes/Select.ts';
+import { resolveSelectLabel, SelectProperty } from '@/domain/propertyTypes/Select.ts';
 import { ValueDisplayProps } from '@/components/Value/ValueDisplayContract.ts';
 
 const props = defineProps<ValueDisplayProps<SelectProperty>>();
@@ -16,6 +16,10 @@ const displayText = computed( () => {
 	if ( props.value.type !== ValueType.String ) {
 		return '';
 	}
-	return props.value.parts.filter( ( part ) => part.trim() !== '' ).join( ', ' );
+
+	return props.value.parts
+		.filter( ( part ) => part.trim() !== '' )
+		.map( ( id ) => resolveSelectLabel( props.property, id ) ?? mw.message( 'neowiki-select-unknown-option' ).text() )
+		.join( ', ' );
 } );
 </script>

--- a/resources/ext.neowiki/src/components/Value/SelectInput.vue
+++ b/resources/ext.neowiki/src/components/Value/SelectInput.vue
@@ -69,8 +69,8 @@ const selectPlaceholder = computed( () =>
 
 const singleMenuItems = computed( (): MenuItemData[] =>
 	props.property.options.map( ( option ) => ( {
-		value: option,
-		label: option
+		value: option.id,
+		label: option.label
 	} ) )
 );
 
@@ -96,9 +96,9 @@ const propertyType = NeoWikiServices.getPropertyTypeRegistry().getType( SelectTy
 function getFilteredOptions(): MenuItemData[] {
 	const query = String( inputValue.value ).toLowerCase();
 	return props.property.options
-		.filter( ( option ) => !selection.value.includes( option ) )
-		.filter( ( option ) => query === '' || option.toLowerCase().includes( query ) )
-		.map( ( option ) => ( { value: option, label: option } ) );
+		.filter( ( option ) => !selection.value.includes( option.id ) )
+		.filter( ( option ) => query === '' || option.label.toLowerCase().includes( query ) )
+		.map( ( option ) => ( { value: option.id, label: option.label } ) );
 }
 
 function validate(): void {

--- a/resources/ext.neowiki/src/components/Value/SelectInput.vue
+++ b/resources/ext.neowiki/src/components/Value/SelectInput.vue
@@ -47,7 +47,7 @@ import { CdxField, CdxIcon, CdxMultiselectLookup, CdxSelect } from '@wikimedia/c
 import type { ChipInputItem, MenuItemData } from '@wikimedia/codex';
 import { cdxIconInfo } from '@wikimedia/codex-icons';
 import { newStringValue, StringValue, ValueType } from '@/domain/Value';
-import { SelectProperty, SelectType } from '@/domain/propertyTypes/Select.ts';
+import { resolveSelectLabel, SelectProperty, SelectType } from '@/domain/propertyTypes/Select.ts';
 import { ValueInputEmits, ValueInputExposes, ValueInputProps } from '@/components/Value/ValueInputContract.ts';
 import { NeoWikiServices } from '@/NeoWikiServices.ts';
 
@@ -81,9 +81,17 @@ function partsFromValue( value: Value | undefined ): string[] {
 	return [];
 }
 
+function chipFromId( id: string ): ChipInputItem {
+	const label = resolveSelectLabel( props.property, id );
+	return {
+		value: id,
+		label: label ?? mw.message( 'neowiki-select-unknown-option' ).text()
+	};
+}
+
 const initialParts = partsFromValue( props.modelValue );
 const selection = ref<string[]>( [ ...initialParts ] );
-const chips = ref<ChipInputItem[]>( initialParts.map( ( part ) => ( { value: part } ) ) );
+const chips = ref<ChipInputItem[]>( initialParts.map( chipFromId ) );
 const inputValue = ref<string | number>( '' );
 const menuItems = ref<MenuItemData[]>( [] );
 
@@ -150,7 +158,7 @@ watch( () => props.modelValue, ( newValue ) => {
 	const newParts = partsFromValue( newValue );
 	if ( JSON.stringify( newParts ) !== JSON.stringify( selection.value ) ) {
 		selection.value = [ ...newParts ];
-		chips.value = newParts.map( ( part ) => ( { value: part } ) );
+		chips.value = newParts.map( chipFromId );
 		validate();
 	}
 } );

--- a/resources/ext.neowiki/src/domain/propertyTypes/Select.ts
+++ b/resources/ext.neowiki/src/domain/propertyTypes/Select.ts
@@ -3,11 +3,22 @@ import { PropertyName } from '@/domain/PropertyDefinition';
 import { newStringValue, type StringValue, ValueType } from '@/domain/Value';
 import { BasePropertyType, ValueValidationError } from '@/domain/PropertyType';
 
+export interface SelectOption {
+
+	readonly id: string;
+	readonly label: string;
+
+}
+
 export interface SelectProperty extends PropertyDefinition {
 
-	readonly options: string[];
+	readonly options: SelectOption[];
 	readonly multiple: boolean;
 
+}
+
+export function resolveSelectLabel( property: SelectProperty, id: string ): string | undefined {
+	return property.options.find( ( option ) => option.id === id )?.label;
 }
 
 export class SelectType extends BasePropertyType<SelectProperty, StringValue> {
@@ -21,13 +32,13 @@ export class SelectType extends BasePropertyType<SelectProperty, StringValue> {
 	}
 
 	public getExampleValue( property: SelectProperty ): StringValue {
-		return newStringValue( property.options[ 0 ] ?? '' );
+		return newStringValue( property.options[ 0 ]?.id ?? '' );
 	}
 
 	public createPropertyDefinitionFromJson( base: PropertyDefinition, json: any ): SelectProperty {
 		return {
 			...base,
-			options: json.options ?? [],
+			options: ( json.options ?? [] ) as SelectOption[],
 			multiple: json.multiple ?? false,
 		} as SelectProperty;
 	}
@@ -41,8 +52,10 @@ export class SelectType extends BasePropertyType<SelectProperty, StringValue> {
 			return errors;
 		}
 
+		const validIds = new Set( property.options.map( ( option ) => option.id ) );
+
 		for ( const part of value.parts ) {
-			if ( !property.options.includes( part ) ) {
+			if ( !validIds.has( part ) ) {
 				errors.push( {
 					code: 'invalid-option',
 					args: [ part ],

--- a/resources/ext.neowiki/tests/domain/propertyTypes/Select.spec.ts
+++ b/resources/ext.neowiki/tests/domain/propertyTypes/Select.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { newSelectProperty, SelectType } from '@/domain/propertyTypes/Select';
+import { newSelectProperty, resolveSelectLabel, SelectType } from '@/domain/propertyTypes/Select';
 import { PropertyName } from '@/domain/PropertyDefinition';
 import { newStringValue } from '@/domain/Value';
 
@@ -56,7 +56,11 @@ describe( 'newSelectProperty', () => {
 			name: 'Status',
 			description: 'Document status',
 			required: true,
-			options: [ 'Draft', 'Review', 'Approved' ],
+			options: [
+				{ id: 'opt1', label: 'Draft' },
+				{ id: 'opt2', label: 'Review' },
+				{ id: 'opt3', label: 'Approved' },
+			],
 			multiple: true,
 		} );
 
@@ -64,7 +68,11 @@ describe( 'newSelectProperty', () => {
 		expect( property.type ).toBe( SelectType.typeName );
 		expect( property.description ).toBe( 'Document status' );
 		expect( property.required ).toBe( true );
-		expect( property.options ).toEqual( [ 'Draft', 'Review', 'Approved' ] );
+		expect( property.options ).toEqual( [
+			{ id: 'opt1', label: 'Draft' },
+			{ id: 'opt2', label: 'Review' },
+			{ id: 'opt3', label: 'Approved' },
+		] );
 		expect( property.multiple ).toBe( true );
 	} );
 } );
@@ -74,7 +82,11 @@ describe( 'validate', () => {
 
 	it( 'returns no errors for empty value when optional', () => {
 		const property = newSelectProperty( {
-			options: [ 'A', 'B', 'C' ],
+			options: [
+				{ id: 'a', label: 'A' },
+				{ id: 'b', label: 'B' },
+				{ id: 'c', label: 'C' },
+			],
 		} );
 
 		const errors = selectType.validate( newStringValue(), property );
@@ -85,7 +97,9 @@ describe( 'validate', () => {
 	it( 'returns required error for required empty value', () => {
 		const property = newSelectProperty( {
 			required: true,
-			options: [ 'A', 'B', 'C' ],
+			options: [
+				{ id: 'a', label: 'A' },
+			],
 		} );
 
 		const errors = selectType.validate( newStringValue(), property );
@@ -96,7 +110,9 @@ describe( 'validate', () => {
 	it( 'returns required error for required undefined value', () => {
 		const property = newSelectProperty( {
 			required: true,
-			options: [ 'A', 'B', 'C' ],
+			options: [
+				{ id: 'a', label: 'A' },
+			],
 		} );
 
 		const errors = selectType.validate( undefined, property );
@@ -104,63 +120,97 @@ describe( 'validate', () => {
 		expect( errors ).toEqual( [ { code: 'required' } ] );
 	} );
 
-	it( 'returns no errors for valid option', () => {
+	it( 'accepts a known option ID as valid', () => {
 		const property = newSelectProperty( {
-			options: [ 'Draft', 'Review', 'Approved' ],
+			options: [
+				{ id: 'opt1', label: 'Draft' },
+				{ id: 'opt2', label: 'Review' },
+			],
 		} );
 
-		const errors = selectType.validate( newStringValue( 'Review' ), property );
-
-		expect( errors ).toEqual( [] );
+		expect( selectType.validate( newStringValue( 'opt2' ), property ) ).toEqual( [] );
 	} );
 
-	it( 'returns invalid-option error for value not in options', () => {
+	it( 'rejects an option label as invalid since values are matched by ID', () => {
 		const property = newSelectProperty( {
-			options: [ 'Draft', 'Review', 'Approved' ],
+			options: [
+				{ id: 'opt1', label: 'Draft' },
+				{ id: 'opt2', label: 'Review' },
+			],
 		} );
 
-		const errors = selectType.validate( newStringValue( 'Rejected' ), property );
-
-		expect( errors ).toEqual( [ {
-			code: 'invalid-option',
-			args: [ 'Rejected' ],
-			source: 'Rejected',
-		} ] );
+		expect( selectType.validate( newStringValue( 'Draft' ), property ) ).toEqual( [
+			{ code: 'invalid-option', args: [ 'Draft' ], source: 'Draft' },
+		] );
 	} );
 
 	it( 'returns single-value-only error when multiple values given for single select', () => {
 		const property = newSelectProperty( {
-			options: [ 'A', 'B', 'C' ],
+			options: [
+				{ id: 'a', label: 'A' },
+				{ id: 'b', label: 'B' },
+			],
 			multiple: false,
 		} );
 
-		const errors = selectType.validate( newStringValue( [ 'A', 'B' ] ), property );
+		const errors = selectType.validate( newStringValue( [ 'a', 'b' ] ), property );
 
 		expect( errors ).toEqual( [ { code: 'single-value-only' } ] );
 	} );
 
 	it( 'returns no errors for multiple values when multiple is true', () => {
 		const property = newSelectProperty( {
-			options: [ 'A', 'B', 'C' ],
+			options: [
+				{ id: 'a', label: 'A' },
+				{ id: 'b', label: 'B' },
+				{ id: 'c', label: 'C' },
+			],
 			multiple: true,
 		} );
 
-		const errors = selectType.validate( newStringValue( [ 'A', 'C' ] ), property );
+		const errors = selectType.validate( newStringValue( [ 'a', 'c' ] ), property );
 
 		expect( errors ).toEqual( [] );
 	} );
 
 	it( 'returns invalid-option errors for each invalid value in multi-select', () => {
 		const property = newSelectProperty( {
-			options: [ 'A', 'B', 'C' ],
+			options: [
+				{ id: 'a', label: 'A' },
+				{ id: 'b', label: 'B' },
+				{ id: 'c', label: 'C' },
+			],
 			multiple: true,
 		} );
 
-		const errors = selectType.validate( newStringValue( [ 'A', 'X', 'B', 'Y' ] ), property );
+		const errors = selectType.validate( newStringValue( [ 'a', 'X', 'b', 'Y' ] ), property );
 
 		expect( errors ).toEqual( [
 			{ code: 'invalid-option', args: [ 'X' ], source: 'X' },
 			{ code: 'invalid-option', args: [ 'Y' ], source: 'Y' },
 		] );
+	} );
+} );
+
+describe( 'resolveSelectLabel', () => {
+	it( 'returns the label for a known id', () => {
+		const property = newSelectProperty( {
+			options: [
+				{ id: 'opt1', label: 'Draft' },
+				{ id: 'opt2', label: 'Review' },
+			],
+		} );
+
+		expect( resolveSelectLabel( property, 'opt2' ) ).toBe( 'Review' );
+	} );
+
+	it( 'returns undefined for an unknown id', () => {
+		const property = newSelectProperty( {
+			options: [
+				{ id: 'opt1', label: 'Draft' },
+			],
+		} );
+
+		expect( resolveSelectLabel( property, 'unknown' ) ).toBeUndefined();
 	} );
 } );

--- a/src/Application/Actions/CreateSubject/CreateSubjectAction.php
+++ b/src/Application/Actions/CreateSubject/CreateSubjectAction.php
@@ -4,6 +4,8 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Application\Actions\CreateSubject;
 
+use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
+use ProfessionalWiki\NeoWiki\Application\SelectPatchResolver;
 use ProfessionalWiki\NeoWiki\Application\StatementListPatcher;
 use ProfessionalWiki\NeoWiki\Application\SubjectRepository;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
@@ -23,6 +25,8 @@ readonly class CreateSubjectAction {
 		private IdGenerator $idGenerator,
 		private SubjectAuthorizer $subjectAuthorizer,
 		private StatementListPatcher $statementListPatcher,
+		private SchemaLookup $schemaLookup,
+		private SelectPatchResolver $selectPatchResolver,
 	) {
 	}
 
@@ -53,15 +57,32 @@ readonly class CreateSubjectAction {
 	}
 
 	private function buildSubject( CreateSubjectRequest $request ): Subject {
+		$schemaName = new SchemaName( $request->schemaName );
+
 		return Subject::createNew(
 			idGenerator: $this->idGenerator,
 			label: new SubjectLabel( $request->label ),
-			schemaName: new SchemaName( $request->schemaName ),
+			schemaName: $schemaName,
 			statements: $this->statementListPatcher->buildStatementList(
 				statements: new StatementList(),
-				patch: $request->statements
+				patch: $this->resolvePatch( $schemaName, $request->statements )
 			)
 		);
+	}
+
+	/**
+	 * @param array<string, mixed> $patch
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function resolvePatch( SchemaName $schemaName, array $patch ): array {
+		$schema = $this->schemaLookup->getSchema( $schemaName );
+
+		if ( $schema === null ) {
+			return $patch;
+		}
+
+		return $this->selectPatchResolver->resolve( $schema, $patch );
 	}
 
 }

--- a/src/Application/Actions/PatchSubject/PatchSubjectAction.php
+++ b/src/Application/Actions/PatchSubject/PatchSubjectAction.php
@@ -4,8 +4,11 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Application\Actions\PatchSubject;
 
+use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
+use ProfessionalWiki\NeoWiki\Application\SelectPatchResolver;
 use ProfessionalWiki\NeoWiki\Application\StatementListPatcher;
 use ProfessionalWiki\NeoWiki\Application\SubjectRepository;
+use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\Application\SubjectAuthorizer;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
@@ -16,7 +19,9 @@ readonly class PatchSubjectAction {
 	public function __construct(
 		private SubjectRepository $subjectRepository,
 		private SubjectAuthorizer $subjectAuthorizer,
-		private StatementListPatcher $patcher
+		private StatementListPatcher $patcher,
+		private SchemaLookup $schemaLookup,
+		private SelectPatchResolver $selectPatchResolver,
 	) {
 	}
 
@@ -43,9 +48,24 @@ readonly class PatchSubjectAction {
 			$subject->setLabel( new SubjectLabel( $label ) );
 		}
 
-		$subject->patchStatements( $this->patcher, $patch );
+		$subject->patchStatements( $this->patcher, $this->resolvePatch( $subject, $patch ) );
 
 		$this->subjectRepository->updateSubject( $subject, $comment );
+	}
+
+	/**
+	 * @param array<string, mixed> $patch
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function resolvePatch( Subject $subject, array $patch ): array {
+		$schema = $this->schemaLookup->getSchema( $subject->getSchemaName() );
+
+		if ( $schema === null ) {
+			return $patch;
+		}
+
+		return $this->selectPatchResolver->resolve( $schema, $patch );
 	}
 
 }

--- a/src/Application/SelectPatchResolver.php
+++ b/src/Application/SelectPatchResolver.php
@@ -1,0 +1,102 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application;
+
+use InvalidArgumentException;
+use ProfessionalWiki\NeoWiki\Domain\PropertyType\Types\SelectType;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Property\SelectProperty;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
+
+/**
+ * Walks a write-path patch array and resolves every select statement value
+ * (id, label, or {id, label} object) to the canonical live option ID.
+ *
+ * Leaves non-select entries, deletions (null), and properties not found
+ * on the Schema untouched.
+ */
+readonly class SelectPatchResolver {
+
+	public function __construct(
+		private SelectValueResolver $valueResolver,
+	) {
+	}
+
+	/**
+	 * @param array<string, mixed> $patch
+	 *
+	 * @return array<string, mixed>
+	 *
+	 * @throws InvalidArgumentException When a select value cannot be resolved.
+	 */
+	public function resolve( Schema $schema, array $patch ): array {
+		foreach ( $patch as $propertyName => $entry ) {
+			if ( !is_array( $entry ) ) {
+				continue;
+			}
+
+			if ( ( $entry['propertyType'] ?? null ) !== SelectType::NAME ) {
+				continue;
+			}
+
+			if ( !array_key_exists( 'value', $entry ) ) {
+				continue;
+			}
+
+			if ( !$schema->hasProperty( $propertyName ) ) {
+				continue;
+			}
+
+			$property = $schema->getProperty( $propertyName );
+
+			if ( !$property instanceof SelectProperty ) {
+				continue;
+			}
+
+			$entry['value'] = $this->resolveEntryValue(
+				(string)$propertyName,
+				$property,
+				$entry['value']
+			);
+
+			$patch[$propertyName] = $entry;
+		}
+
+		return $patch;
+	}
+
+	private function resolveEntryValue( string $propertyName, SelectProperty $property, mixed $value ): mixed {
+		if ( $this->isListOfValues( $value ) ) {
+			return array_map(
+				fn( mixed $item ): string => $this->resolveSingle( $propertyName, $property, $item ),
+				$value
+			);
+		}
+
+		return $this->resolveSingle( $propertyName, $property, $value );
+	}
+
+	private function resolveSingle( string $propertyName, SelectProperty $property, mixed $value ): string {
+		if ( !is_string( $value ) && !is_array( $value ) ) {
+			throw new InvalidArgumentException(
+				"Select value for \"{$propertyName}\" must be a string or object"
+			);
+		}
+
+		try {
+			return $this->valueResolver->resolve( $property, $value );
+		} catch ( InvalidArgumentException $e ) {
+			throw new InvalidArgumentException(
+				"Invalid select value for \"{$propertyName}\": " . $e->getMessage(),
+				0,
+				$e
+			);
+		}
+	}
+
+	private function isListOfValues( mixed $value ): bool {
+		return is_array( $value ) && array_is_list( $value );
+	}
+
+}

--- a/src/Application/SelectValueResolver.php
+++ b/src/Application/SelectValueResolver.php
@@ -65,7 +65,11 @@ readonly class SelectValueResolver {
 		}
 
 		if ( $id !== null ) {
-			return $this->resolveFromScalar( $property, $id );
+			$matched = $this->findById( $property, $id );
+			if ( $matched === null ) {
+				throw new InvalidArgumentException( "No select option matches id \"$id\"" );
+			}
+			return $matched->getId();
 		}
 
 		/** @var string $label */

--- a/src/Application/SelectValueResolver.php
+++ b/src/Application/SelectValueResolver.php
@@ -1,0 +1,84 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application;
+
+use InvalidArgumentException;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Property\SelectOption;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Property\SelectProperty;
+
+readonly class SelectValueResolver {
+
+	/**
+	 * Resolves a raw input value (id, label, or {id,label} object) to the canonical option ID.
+	 * Throws on mismatch or unknown.
+	 *
+	 * @param string|array<string,string> $raw
+	 */
+	public function resolve( SelectProperty $property, string|array $raw ): string {
+		if ( is_array( $raw ) ) {
+			return $this->resolveFromObject( $property, $raw );
+		}
+
+		return $this->resolveFromScalar( $property, $raw );
+	}
+
+	private function resolveFromScalar( SelectProperty $property, string $raw ): string {
+		$byId = $this->findById( $property, $raw );
+		if ( $byId !== null ) {
+			return $byId->getId();
+		}
+
+		return $this->resolveByLabel( $property, $raw );
+	}
+
+	private function resolveByLabel( SelectProperty $property, string $label ): string {
+		$normalized = strtolower( trim( $label ) );
+
+		foreach ( $property->getOptions() as $option ) {
+			if ( $option->normalizedLabel() === $normalized ) {
+				return $option->getId();
+			}
+		}
+
+		throw new InvalidArgumentException( "No select option matches \"$label\"" );
+	}
+
+	/**
+	 * @param array<string,string> $raw
+	 */
+	private function resolveFromObject( SelectProperty $property, array $raw ): string {
+		if ( !isset( $raw['id'] ) && !isset( $raw['label'] ) ) {
+			throw new InvalidArgumentException( 'Select value must have id or label' );
+		}
+
+		$id = $raw['id'] ?? null;
+		$label = $raw['label'] ?? null;
+
+		if ( $id !== null && $label !== null ) {
+			$matched = $this->findById( $property, $id );
+			if ( $matched === null || $matched->normalizedLabel() !== strtolower( trim( $label ) ) ) {
+				throw new InvalidArgumentException( "Select value id/label mismatch for \"$id\" / \"$label\"" );
+			}
+			return $matched->getId();
+		}
+
+		if ( $id !== null ) {
+			return $this->resolveFromScalar( $property, $id );
+		}
+
+		/** @var string $label */
+		return $this->resolveByLabel( $property, $label );
+	}
+
+	private function findById( SelectProperty $property, string $id ): ?SelectOption {
+		foreach ( $property->getOptions() as $option ) {
+			if ( $option->getId() === $id ) {
+				return $option;
+			}
+		}
+		return null;
+	}
+
+}

--- a/src/Domain/Schema/Property/SelectOption.php
+++ b/src/Domain/Schema/Property/SelectOption.php
@@ -1,0 +1,67 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\Schema\Property;
+
+use InvalidArgumentException;
+
+class SelectOption {
+
+	public function __construct(
+		private readonly string $id,
+		private readonly string $label,
+	) {
+		if ( $id === '' ) {
+			throw new InvalidArgumentException( 'Select option id must not be empty' );
+		}
+
+		if ( trim( $label ) === '' ) {
+			throw new InvalidArgumentException( 'Select option label must not be empty' );
+		}
+	}
+
+	public function getId(): string {
+		return $this->id;
+	}
+
+	public function getLabel(): string {
+		return $this->label;
+	}
+
+	public function normalizedLabel(): string {
+		return strtolower( trim( $this->label ) );
+	}
+
+	public function equals( self $other ): bool {
+		return $this->id === $other->id
+			&& $this->label === $other->label;
+	}
+
+	/**
+	 * @return array{id: string, label: string}
+	 */
+	public function toJson(): array {
+		return [
+			'id' => $this->id,
+			'label' => $this->label,
+		];
+	}
+
+	public static function fromJson( mixed $json ): self {
+		if ( !is_array( $json ) ) {
+			throw new InvalidArgumentException( 'Select option must be an object' );
+		}
+
+		if ( !isset( $json['id'] ) || !is_string( $json['id'] ) ) {
+			throw new InvalidArgumentException( 'Select option missing string id' );
+		}
+
+		if ( !isset( $json['label'] ) || !is_string( $json['label'] ) ) {
+			throw new InvalidArgumentException( 'Select option missing string label' );
+		}
+
+		return new self( $json['id'], $json['label'] );
+	}
+
+}

--- a/src/Domain/Schema/Property/SelectProperty.php
+++ b/src/Domain/Schema/Property/SelectProperty.php
@@ -12,7 +12,7 @@ use ProfessionalWiki\NeoWiki\Domain\PropertyType\Types\SelectType;
 class SelectProperty extends PropertyDefinition {
 
 	/**
-	 * @param string[] $options
+	 * @param SelectOption[] $options
 	 */
 	public function __construct(
 		PropertyCore $core,
@@ -20,6 +20,8 @@ class SelectProperty extends PropertyDefinition {
 		private readonly bool $multiple,
 	) {
 		parent::__construct( $core );
+		$this->assertUniqueIds( $options );
+		$this->assertUniqueLabels( $options );
 	}
 
 	public function getPropertyType(): string {
@@ -27,7 +29,7 @@ class SelectProperty extends PropertyDefinition {
 	}
 
 	/**
-	 * @return string[]
+	 * @return SelectOption[]
 	 */
 	public function getOptions(): array {
 		return $this->options;
@@ -38,30 +40,51 @@ class SelectProperty extends PropertyDefinition {
 	}
 
 	public static function fromPartialJson( PropertyCore $core, array $property ): self {
-		$options = $property['options'] ?? [];
+		$rawOptions = $property['options'] ?? [];
 
-		if ( !is_array( $options ) ) {
+		if ( !is_array( $rawOptions ) ) {
 			throw new InvalidArgumentException( 'Select options must be an array' );
 		}
 
-		foreach ( $options as $option ) {
-			if ( !is_string( $option ) ) {
-				throw new InvalidArgumentException( 'Each select option must be a string' );
-			}
-		}
+		$options = array_map(
+			fn( mixed $raw ): SelectOption => SelectOption::fromJson( $raw ),
+			array_values( $rawOptions )
+		);
 
 		return new self(
 			core: $core,
-			options: array_values( $options ),
+			options: $options,
 			multiple: $property['multiple'] ?? false,
 		);
 	}
 
 	protected function nonCoreToJson(): array {
 		return [
-			'options' => $this->getOptions(),
+			'options' => array_map( fn( SelectOption $o ): array => $o->toJson(), $this->options ),
 			'multiple' => $this->allowsMultipleValues(),
 		];
+	}
+
+	/**
+	 * @param SelectOption[] $options
+	 */
+	private function assertUniqueIds( array $options ): void {
+		$ids = array_map( fn( SelectOption $o ): string => $o->getId(), $options );
+
+		if ( count( $ids ) !== count( array_unique( $ids ) ) ) {
+			throw new InvalidArgumentException( 'Select option ids must be unique' );
+		}
+	}
+
+	/**
+	 * @param SelectOption[] $options
+	 */
+	private function assertUniqueLabels( array $options ): void {
+		$labels = array_map( fn( SelectOption $o ): string => $o->normalizedLabel(), $options );
+
+		if ( count( $labels ) !== count( array_unique( $labels ) ) ) {
+			throw new InvalidArgumentException( 'Select option labels must be unique' );
+		}
 	}
 
 }

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -33,6 +33,8 @@ use ProfessionalWiki\NeoWiki\Domain\Page\PagePropertyProviderRegistry;
 use ProfessionalWiki\NeoWiki\Persistence\CompositeGraphDatabasePlugin;
 use ProfessionalWiki\NeoWiki\Persistence\GraphDatabasePlugin;
 use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
+use ProfessionalWiki\NeoWiki\Application\SelectPatchResolver;
+use ProfessionalWiki\NeoWiki\Application\SelectValueResolver;
 use ProfessionalWiki\NeoWiki\Application\SubjectLabelLookup;
 use ProfessionalWiki\NeoWiki\Application\LayoutLookup;
 use ProfessionalWiki\NeoWiki\Application\StatementListPatcher;
@@ -297,8 +299,14 @@ class NeoWikiExtension {
 			subjectRepository: $this->getSubjectRepository(),
 			idGenerator: $this->getIdGenerator(),
 			subjectAuthorizer: $this->newSubjectAuthorizer( $authority ),
-			statementListPatcher: $this->getStatementListPatcher()
+			statementListPatcher: $this->getStatementListPatcher(),
+			schemaLookup: $this->getSchemaLookup(),
+			selectPatchResolver: $this->getSelectPatchResolver(),
 		);
+	}
+
+	public function getSelectPatchResolver(): SelectPatchResolver {
+		return new SelectPatchResolver( new SelectValueResolver() );
 	}
 
 	public function getSubjectRepository(): SubjectRepository {
@@ -443,7 +451,9 @@ class NeoWikiExtension {
 		return new PatchSubjectAction(
 			subjectRepository: $this->getSubjectRepository(),
 			subjectAuthorizer: $this->newSubjectAuthorizer( $authority ),
-			patcher: $this->getStatementListPatcher()
+			patcher: $this->getStatementListPatcher(),
+			schemaLookup: $this->getSchemaLookup(),
+			selectPatchResolver: $this->getSelectPatchResolver(),
 		);
 	}
 

--- a/src/Persistence/MediaWiki/schemaContentSchema.json
+++ b/src/Persistence/MediaWiki/schemaContentSchema.json
@@ -140,7 +140,22 @@
 								"options": {
 									"type": "array",
 									"items": {
-										"type": "string"
+										"type": "object",
+										"required": [
+											"id",
+											"label"
+										],
+										"properties": {
+											"id": {
+												"type": "string",
+												"minLength": 1
+											},
+											"label": {
+												"type": "string",
+												"minLength": 1
+											}
+										},
+										"additionalProperties": true
 									}
 								}
 							}

--- a/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
@@ -7,12 +7,22 @@ namespace ProfessionalWiki\NeoWiki\Tests\Application\Actions;
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Application\Actions\CreateSubject\CreateSubjectAction;
 use ProfessionalWiki\NeoWiki\Application\Actions\CreateSubject\CreateSubjectRequest;
+use ProfessionalWiki\NeoWiki\Application\SelectPatchResolver;
+use ProfessionalWiki\NeoWiki\Application\SelectValueResolver;
 use ProfessionalWiki\NeoWiki\Application\StatementListPatcher;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Property\SelectOption;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Property\SelectProperty;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinitions;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyName;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\Domain\Value\RelationValue;
+use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeToValueType;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeRegistry;
 use ProfessionalWiki\NeoWiki\Infrastructure\IdGenerator;
@@ -20,6 +30,7 @@ use ProfessionalWiki\NeoWiki\Application\SubjectAuthorizer;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestRelation;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestStatement;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\FailingSubjectAuthorizer;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySchemaLookup;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectRepository;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SucceedingSubjectAuthorizer;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubIdGenerator;
@@ -31,17 +42,20 @@ use RuntimeException;
 class CreateSubjectActionTest extends TestCase {
 
 	private const string STUB_ID = 'EVNrDCjgVpv9oC';
+	private const string SELECT_SCHEMA_NAME = 'StatusSchema';
 
 	private InMemorySubjectRepository $subjectRepository;
 	private IdGenerator $idGenerator;
 	private CreateSubjectPresenterSpy $presenterSpy;
 	private SubjectAuthorizer $authorizer;
+	private InMemorySchemaLookup $schemaLookup;
 
 	public function setUp(): void {
 		$this->subjectRepository = new InMemorySubjectRepository();
 		$this->idGenerator = new StubIdGenerator( self::STUB_ID );
 		$this->presenterSpy = new CreateSubjectPresenterSpy();
 		$this->authorizer = new SucceedingSubjectAuthorizer();
+		$this->schemaLookup = new InMemorySchemaLookup();
 	}
 
 	private function newCreateSubjectAction(): CreateSubjectAction {
@@ -53,8 +67,39 @@ class CreateSubjectActionTest extends TestCase {
 			new StatementListPatcher(
 				new PropertyTypeToValueType( PropertyTypeRegistry::withCoreTypes() ),
 				$this->idGenerator
-			)
+			),
+			$this->schemaLookup,
+			new SelectPatchResolver( new SelectValueResolver() ),
 		);
+	}
+
+	private function registerSelectSchema( bool $multiple = false ): void {
+		$this->schemaLookup->updateSchema( new Schema(
+			name: new SchemaName( self::SELECT_SCHEMA_NAME ),
+			description: '',
+			properties: new PropertyDefinitions( [
+				'Status' => new SelectProperty(
+					core: new PropertyCore( description: '', required: false, default: null ),
+					options: [
+						new SelectOption( id: 'opt_draft', label: 'Draft' ),
+						new SelectOption( id: 'opt_approved', label: 'Approved' ),
+					],
+					multiple: $multiple,
+				),
+			] )
+		) );
+	}
+
+	private function getStatusValueForCreatedSubject(): StringValue {
+		$statement = $this->subjectRepository
+			->getSubject( new SubjectId( $this->presenterSpy->result ) )
+			->getStatements()
+			->getStatement( new PropertyName( 'Status' ) );
+
+		/** @var StringValue $value */
+		$value = $statement->getValue();
+
+		return $value;
 	}
 
 	public function testCreateMainSubject(): void {
@@ -147,6 +192,128 @@ class CreateSubjectActionTest extends TestCase {
 		);
 
 		$this->assertNull( $this->subjectRepository->comments[1] );
+	}
+
+	public function testSelectValueAcceptsOptionId(): void {
+		$this->registerSelectSchema();
+
+		$this->newCreateSubjectAction()->createSubject(
+			new CreateSubjectRequest(
+				pageId: 1,
+				isMainSubject: true,
+				label: 'Some Label',
+				schemaName: self::SELECT_SCHEMA_NAME,
+				statements: [
+					'Status' => [ 'propertyType' => 'select', 'value' => 'opt_draft' ],
+				]
+			)
+		);
+
+		$this->assertSame( [ 'opt_draft' ], $this->getStatusValueForCreatedSubject()->strings );
+	}
+
+	public function testSelectValueResolvesLabelToId(): void {
+		$this->registerSelectSchema();
+
+		$this->newCreateSubjectAction()->createSubject(
+			new CreateSubjectRequest(
+				pageId: 1,
+				isMainSubject: true,
+				label: 'Some Label',
+				schemaName: self::SELECT_SCHEMA_NAME,
+				statements: [
+					'Status' => [ 'propertyType' => 'select', 'value' => '  approved  ' ],
+				]
+			)
+		);
+
+		$this->assertSame( [ 'opt_approved' ], $this->getStatusValueForCreatedSubject()->strings );
+	}
+
+	public function testSelectValueAcceptsConsistentIdLabelObject(): void {
+		$this->registerSelectSchema();
+
+		$this->newCreateSubjectAction()->createSubject(
+			new CreateSubjectRequest(
+				pageId: 1,
+				isMainSubject: true,
+				label: 'Some Label',
+				schemaName: self::SELECT_SCHEMA_NAME,
+				statements: [
+					'Status' => [
+						'propertyType' => 'select',
+						'value' => [ 'id' => 'opt_approved', 'label' => 'Approved' ],
+					],
+				]
+			)
+		);
+
+		$this->assertSame( [ 'opt_approved' ], $this->getStatusValueForCreatedSubject()->strings );
+	}
+
+	public function testSelectValueRejectsInconsistentIdLabelObject(): void {
+		$this->registerSelectSchema();
+
+		$this->expectException( \InvalidArgumentException::class );
+
+		$this->newCreateSubjectAction()->createSubject(
+			new CreateSubjectRequest(
+				pageId: 1,
+				isMainSubject: true,
+				label: 'Some Label',
+				schemaName: self::SELECT_SCHEMA_NAME,
+				statements: [
+					'Status' => [
+						'propertyType' => 'select',
+						'value' => [ 'id' => 'opt_draft', 'label' => 'WrongName' ],
+					],
+				]
+			)
+		);
+	}
+
+	public function testMultiSelectValueResolvesMixedForms(): void {
+		$this->registerSelectSchema( multiple: true );
+
+		$this->newCreateSubjectAction()->createSubject(
+			new CreateSubjectRequest(
+				pageId: 1,
+				isMainSubject: true,
+				label: 'Some Label',
+				schemaName: self::SELECT_SCHEMA_NAME,
+				statements: [
+					'Status' => [
+						'propertyType' => 'select',
+						'value' => [
+							'opt_draft',
+							'Approved',
+							[ 'id' => 'opt_draft', 'label' => 'Draft' ],
+						],
+					],
+				]
+			)
+		);
+
+		$this->assertSame(
+			[ 'opt_draft', 'opt_approved', 'opt_draft' ],
+			$this->getStatusValueForCreatedSubject()->strings
+		);
+	}
+
+	public function testSelectValuePassesThroughWhenSchemaIsMissing(): void {
+		$this->newCreateSubjectAction()->createSubject(
+			new CreateSubjectRequest(
+				pageId: 1,
+				isMainSubject: true,
+				label: 'Some Label',
+				schemaName: 'UnknownSchema',
+				statements: [
+					'Status' => [ 'propertyType' => 'select', 'value' => 'opt_draft' ],
+				]
+			)
+		);
+
+		$this->assertSame( [ 'opt_draft' ], $this->getStatusValueForCreatedSubject()->strings );
 	}
 
 	public function testNewRelationGetsGuidAssigned(): void {

--- a/tests/phpunit/Application/Actions/PatchSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/PatchSubjectActionTest.php
@@ -6,17 +6,27 @@ namespace ProfessionalWiki\NeoWiki\Tests\Application\Actions;
 
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Application\Actions\PatchSubject\PatchSubjectAction;
+use ProfessionalWiki\NeoWiki\Application\SelectPatchResolver;
+use ProfessionalWiki\NeoWiki\Application\SelectValueResolver;
 use ProfessionalWiki\NeoWiki\Application\StatementListPatcher;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Property\SelectOption;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Property\SelectProperty;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinitions;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyName;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
 use ProfessionalWiki\NeoWiki\Domain\Value\RelationValue;
+use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeToValueType;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeRegistry;
 use ProfessionalWiki\NeoWiki\Infrastructure\IdGenerator;
 use ProfessionalWiki\NeoWiki\Application\SubjectAuthorizer;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\FailingSubjectAuthorizer;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySchemaLookup;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectRepository;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SucceedingSubjectAuthorizer;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubIdGenerator;
@@ -27,13 +37,16 @@ use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubIdGenerator;
 class PatchSubjectActionTest extends TestCase {
 
 	private const string SUBJECT_ID = 's11111111111127';
+	private const string SCHEMA_NAME = 'TestSchema';
 
 	private InMemorySubjectRepository $inMemorySubjectRepository;
 	private IdGenerator $idGenerator;
+	private InMemorySchemaLookup $schemaLookup;
 
 	public function setUp(): void {
 		$this->inMemorySubjectRepository = new InMemorySubjectRepository();
 		$this->idGenerator = new StubIdGenerator( '11111111111127' );
+		$this->schemaLookup = new InMemorySchemaLookup();
 	}
 
 	private function newPatchSubjectAction( SubjectAuthorizer $authorizer = null ): PatchSubjectAction {
@@ -43,8 +56,39 @@ class PatchSubjectActionTest extends TestCase {
 			new StatementListPatcher(
 				propertyTypeToValueType: new PropertyTypeToValueType( PropertyTypeRegistry::withCoreTypes() ),
 				idGenerator: $this->idGenerator
-			)
+			),
+			$this->schemaLookup,
+			new SelectPatchResolver( new SelectValueResolver() ),
 		);
+	}
+
+	private function registerSchemaWithSelect( bool $multiple = false ): void {
+		$this->schemaLookup->updateSchema( new Schema(
+			name: new SchemaName( self::SCHEMA_NAME ),
+			description: '',
+			properties: new PropertyDefinitions( [
+				'Status' => new SelectProperty(
+					core: new PropertyCore( description: '', required: false, default: null ),
+					options: [
+						new SelectOption( id: 'opt_draft', label: 'Draft' ),
+						new SelectOption( id: 'opt_approved', label: 'Approved' ),
+					],
+					multiple: $multiple,
+				),
+			] )
+		) );
+	}
+
+	private function getStatusValue( SubjectId $subjectId ): StringValue {
+		$statement = $this->inMemorySubjectRepository
+			->getSubject( $subjectId )
+			->getStatements()
+			->getStatement( new PropertyName( 'Status' ) );
+
+		/** @var StringValue $value */
+		$value = $statement->getValue();
+
+		return $value;
 	}
 
 	public function testPatchSubjectWithPermission(): void {
@@ -116,6 +160,158 @@ class PatchSubjectActionTest extends TestCase {
 		$this->expectExceptionMessage( 'Subject not found: ' . self::SUBJECT_ID );
 
 		$patchSubjectAction->patch( new SubjectId( self::SUBJECT_ID ), null, [] );
+	}
+
+	public function testSelectValueAcceptsOptionId(): void {
+		$this->registerSchemaWithSelect();
+		$subject = TestSubject::build(
+			id: new SubjectId( self::SUBJECT_ID ),
+			schemaName: new SchemaName( self::SCHEMA_NAME ),
+		);
+		$this->inMemorySubjectRepository->updateSubject( $subject );
+
+		$this->newPatchSubjectAction()->patch(
+			$subject->getId(),
+			null,
+			[
+				'Status' => [ 'propertyType' => 'select', 'value' => 'opt_approved' ],
+			]
+		);
+
+		$this->assertSame( [ 'opt_approved' ], $this->getStatusValue( $subject->getId() )->strings );
+	}
+
+	public function testSelectValueResolvesLabelToId(): void {
+		$this->registerSchemaWithSelect();
+		$subject = TestSubject::build(
+			id: new SubjectId( self::SUBJECT_ID ),
+			schemaName: new SchemaName( self::SCHEMA_NAME ),
+		);
+		$this->inMemorySubjectRepository->updateSubject( $subject );
+
+		$this->newPatchSubjectAction()->patch(
+			$subject->getId(),
+			null,
+			[
+				'Status' => [ 'propertyType' => 'select', 'value' => '  approved  ' ],
+			]
+		);
+
+		$this->assertSame( [ 'opt_approved' ], $this->getStatusValue( $subject->getId() )->strings );
+	}
+
+	public function testSelectValueAcceptsConsistentIdLabelObject(): void {
+		$this->registerSchemaWithSelect();
+		$subject = TestSubject::build(
+			id: new SubjectId( self::SUBJECT_ID ),
+			schemaName: new SchemaName( self::SCHEMA_NAME ),
+		);
+		$this->inMemorySubjectRepository->updateSubject( $subject );
+
+		$this->newPatchSubjectAction()->patch(
+			$subject->getId(),
+			null,
+			[
+				'Status' => [
+					'propertyType' => 'select',
+					'value' => [ 'id' => 'opt_draft', 'label' => 'Draft' ],
+				],
+			]
+		);
+
+		$this->assertSame( [ 'opt_draft' ], $this->getStatusValue( $subject->getId() )->strings );
+	}
+
+	public function testSelectValueRejectsInconsistentIdLabelObject(): void {
+		$this->registerSchemaWithSelect();
+		$subject = TestSubject::build(
+			id: new SubjectId( self::SUBJECT_ID ),
+			schemaName: new SchemaName( self::SCHEMA_NAME ),
+		);
+		$this->inMemorySubjectRepository->updateSubject( $subject );
+
+		$action = $this->newPatchSubjectAction();
+
+		$this->expectException( \InvalidArgumentException::class );
+
+		$action->patch(
+			$subject->getId(),
+			null,
+			[
+				'Status' => [
+					'propertyType' => 'select',
+					'value' => [ 'id' => 'opt_draft', 'label' => 'WrongName' ],
+				],
+			]
+		);
+	}
+
+	public function testSelectValueRejectsUnknownValue(): void {
+		$this->registerSchemaWithSelect();
+		$subject = TestSubject::build(
+			id: new SubjectId( self::SUBJECT_ID ),
+			schemaName: new SchemaName( self::SCHEMA_NAME ),
+		);
+		$this->inMemorySubjectRepository->updateSubject( $subject );
+
+		$action = $this->newPatchSubjectAction();
+
+		$this->expectException( \InvalidArgumentException::class );
+
+		$action->patch(
+			$subject->getId(),
+			null,
+			[
+				'Status' => [ 'propertyType' => 'select', 'value' => 'Nonexistent' ],
+			]
+		);
+	}
+
+	public function testMultiSelectValueResolvesMixedForms(): void {
+		$this->registerSchemaWithSelect( multiple: true );
+		$subject = TestSubject::build(
+			id: new SubjectId( self::SUBJECT_ID ),
+			schemaName: new SchemaName( self::SCHEMA_NAME ),
+		);
+		$this->inMemorySubjectRepository->updateSubject( $subject );
+
+		$this->newPatchSubjectAction()->patch(
+			$subject->getId(),
+			null,
+			[
+				'Status' => [
+					'propertyType' => 'select',
+					'value' => [
+						'opt_draft',
+						'Approved',
+						[ 'id' => 'opt_draft', 'label' => 'Draft' ],
+					],
+				],
+			]
+		);
+
+		$this->assertSame(
+			[ 'opt_draft', 'opt_approved', 'opt_draft' ],
+			$this->getStatusValue( $subject->getId() )->strings
+		);
+	}
+
+	public function testSelectValuePassesThroughWhenSchemaIsMissing(): void {
+		$subject = TestSubject::build(
+			id: new SubjectId( self::SUBJECT_ID ),
+			schemaName: new SchemaName( 'UnknownSchema' ),
+		);
+		$this->inMemorySubjectRepository->updateSubject( $subject );
+
+		$this->newPatchSubjectAction()->patch(
+			$subject->getId(),
+			null,
+			[
+				'Status' => [ 'propertyType' => 'select', 'value' => 'opt_draft' ],
+			]
+		);
+
+		$this->assertSame( [ 'opt_draft' ], $this->getStatusValue( $subject->getId() )->strings );
 	}
 
 	public function testNewRelationGetsGuid(): void {

--- a/tests/phpunit/Application/SelectPatchResolverTest.php
+++ b/tests/phpunit/Application/SelectPatchResolverTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Application;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\SelectPatchResolver;
+use ProfessionalWiki\NeoWiki\Application\SelectValueResolver;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Property\SelectOption;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Property\SelectProperty;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinitions;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestProperty;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Application\SelectPatchResolver
+ */
+class SelectPatchResolverTest extends TestCase {
+
+	private function newResolver(): SelectPatchResolver {
+		return new SelectPatchResolver( new SelectValueResolver() );
+	}
+
+	private function newSchemaWithSelect( bool $multiple = false ): Schema {
+		return new Schema(
+			name: new SchemaName( 'SomeSchema' ),
+			description: '',
+			properties: new PropertyDefinitions( [
+				'Status' => new SelectProperty(
+					core: new PropertyCore( description: '', required: false, default: null ),
+					options: [
+						new SelectOption( id: 'opt1', label: 'Draft' ),
+						new SelectOption( id: 'opt2', label: 'Approved' ),
+					],
+					multiple: $multiple,
+				),
+				'Name' => TestProperty::buildText(),
+			] )
+		);
+	}
+
+	public function testResolvesScalarIdValue(): void {
+		$patch = [
+			'Status' => [ 'propertyType' => 'select', 'value' => 'opt1' ],
+		];
+
+		$resolved = $this->newResolver()->resolve( $this->newSchemaWithSelect(), $patch );
+
+		$this->assertSame( 'opt1', $resolved['Status']['value'] );
+	}
+
+	public function testResolvesScalarLabelValue(): void {
+		$patch = [
+			'Status' => [ 'propertyType' => 'select', 'value' => 'Draft' ],
+		];
+
+		$resolved = $this->newResolver()->resolve( $this->newSchemaWithSelect(), $patch );
+
+		$this->assertSame( 'opt1', $resolved['Status']['value'] );
+	}
+
+	public function testResolvesIdLabelObjectValue(): void {
+		$patch = [
+			'Status' => [
+				'propertyType' => 'select',
+				'value' => [ 'id' => 'opt2', 'label' => 'Approved' ],
+			],
+		];
+
+		$resolved = $this->newResolver()->resolve( $this->newSchemaWithSelect(), $patch );
+
+		$this->assertSame( 'opt2', $resolved['Status']['value'] );
+	}
+
+	public function testResolvesListOfIds(): void {
+		$patch = [
+			'Status' => [
+				'propertyType' => 'select',
+				'value' => [ 'opt1', 'opt2' ],
+			],
+		];
+
+		$resolved = $this->newResolver()->resolve( $this->newSchemaWithSelect( multiple: true ), $patch );
+
+		$this->assertSame( [ 'opt1', 'opt2' ], $resolved['Status']['value'] );
+	}
+
+	public function testResolvesListOfMixedForms(): void {
+		$patch = [
+			'Status' => [
+				'propertyType' => 'select',
+				'value' => [
+					'opt1',
+					'Approved',
+					[ 'id' => 'opt1', 'label' => 'Draft' ],
+				],
+			],
+		];
+
+		$resolved = $this->newResolver()->resolve( $this->newSchemaWithSelect( multiple: true ), $patch );
+
+		$this->assertSame( [ 'opt1', 'opt2', 'opt1' ], $resolved['Status']['value'] );
+	}
+
+	public function testLeavesNonSelectPropertyUntouched(): void {
+		$patch = [
+			'Name' => [ 'propertyType' => 'text', 'value' => 'Some Name' ],
+		];
+
+		$resolved = $this->newResolver()->resolve( $this->newSchemaWithSelect(), $patch );
+
+		$this->assertSame( $patch, $resolved );
+	}
+
+	public function testLeavesNullValueUntouchedForSelect(): void {
+		$patch = [
+			'Status' => null,
+		];
+
+		$resolved = $this->newResolver()->resolve( $this->newSchemaWithSelect(), $patch );
+
+		$this->assertSame( $patch, $resolved );
+	}
+
+	public function testLeavesPatchUntouchedWhenSchemaDoesNotHaveProperty(): void {
+		$patch = [
+			'Unknown' => [ 'propertyType' => 'select', 'value' => 'something' ],
+		];
+
+		$resolved = $this->newResolver()->resolve( $this->newSchemaWithSelect(), $patch );
+
+		$this->assertSame( $patch, $resolved );
+	}
+
+	public function testThrowsOnUnknownValueForKnownSelectProperty(): void {
+		$patch = [
+			'Status' => [ 'propertyType' => 'select', 'value' => 'Nonexistent' ],
+		];
+
+		$this->expectException( InvalidArgumentException::class );
+
+		$this->newResolver()->resolve( $this->newSchemaWithSelect(), $patch );
+	}
+
+	public function testIncludesPropertyNameInErrorMessage(): void {
+		$patch = [
+			'Status' => [ 'propertyType' => 'select', 'value' => 'Nonexistent' ],
+		];
+
+		$this->expectException( InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'Status' );
+
+		$this->newResolver()->resolve( $this->newSchemaWithSelect(), $patch );
+	}
+
+}

--- a/tests/phpunit/Application/SelectValueResolverTest.php
+++ b/tests/phpunit/Application/SelectValueResolverTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Application;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\SelectValueResolver;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Property\SelectOption;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Property\SelectProperty;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Application\SelectValueResolver
+ */
+class SelectValueResolverTest extends TestCase {
+
+	private function newProperty(): SelectProperty {
+		return new SelectProperty(
+			core: new PropertyCore( description: '', required: false, default: null ),
+			options: [
+				new SelectOption( id: 'opt1', label: 'Draft' ),
+				new SelectOption( id: 'opt2', label: 'In Review' ),
+				new SelectOption( id: 'opt3', label: 'Approved' ),
+			],
+			multiple: false,
+		);
+	}
+
+	private function newResolver(): SelectValueResolver {
+		return new SelectValueResolver();
+	}
+
+	public function testAcceptsOptionId(): void {
+		$id = $this->newResolver()->resolve( $this->newProperty(), 'opt2' );
+
+		$this->assertSame( 'opt2', $id );
+	}
+
+	public function testResolvesLabelToId(): void {
+		$id = $this->newResolver()->resolve( $this->newProperty(), 'In Review' );
+
+		$this->assertSame( 'opt2', $id );
+	}
+
+	public function testResolvesLabelCaseInsensitively(): void {
+		$id = $this->newResolver()->resolve( $this->newProperty(), 'draft' );
+
+		$this->assertSame( 'opt1', $id );
+	}
+
+	public function testResolvesLabelWithSurroundingWhitespace(): void {
+		$id = $this->newResolver()->resolve( $this->newProperty(), '  Approved  ' );
+
+		$this->assertSame( 'opt3', $id );
+	}
+
+	public function testAcceptsConsistentIdLabelObject(): void {
+		$id = $this->newResolver()->resolve(
+			$this->newProperty(),
+			[ 'id' => 'opt1', 'label' => 'Draft' ]
+		);
+
+		$this->assertSame( 'opt1', $id );
+	}
+
+	public function testAcceptsConsistentIdLabelObjectWithCaseInsensitiveLabel(): void {
+		$id = $this->newResolver()->resolve(
+			$this->newProperty(),
+			[ 'id' => 'opt1', 'label' => '  draft  ' ]
+		);
+
+		$this->assertSame( 'opt1', $id );
+	}
+
+	public function testRejectsInconsistentIdLabelObject(): void {
+		$this->expectException( InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'Select value id/label mismatch' );
+
+		$this->newResolver()->resolve(
+			$this->newProperty(),
+			[ 'id' => 'opt1', 'label' => 'WrongName' ]
+		);
+	}
+
+	public function testRejectsUnknownValue(): void {
+		$this->expectException( InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'Nonexistent' );
+
+		$this->newResolver()->resolve( $this->newProperty(), 'Nonexistent' );
+	}
+
+	public function testRejectsObjectWithoutIdOrLabel(): void {
+		$this->expectException( InvalidArgumentException::class );
+
+		$this->newResolver()->resolve( $this->newProperty(), [] );
+	}
+
+	public function testAcceptsObjectWithOnlyId(): void {
+		$id = $this->newResolver()->resolve(
+			$this->newProperty(),
+			[ 'id' => 'opt3' ]
+		);
+
+		$this->assertSame( 'opt3', $id );
+	}
+
+	public function testAcceptsObjectWithOnlyLabel(): void {
+		$id = $this->newResolver()->resolve(
+			$this->newProperty(),
+			[ 'label' => 'Approved' ]
+		);
+
+		$this->assertSame( 'opt3', $id );
+	}
+
+}

--- a/tests/phpunit/Application/SelectValueResolverTest.php
+++ b/tests/phpunit/Application/SelectValueResolverTest.php
@@ -106,6 +106,16 @@ class SelectValueResolverTest extends TestCase {
 		$this->assertSame( 'opt3', $id );
 	}
 
+	public function testObjectWithOnlyIdDoesNotFallBackToLabelMatch(): void {
+		$this->expectException( InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'Draft' );
+
+		$this->newResolver()->resolve(
+			$this->newProperty(),
+			[ 'id' => 'Draft' ]
+		);
+	}
+
 	public function testAcceptsObjectWithOnlyLabel(): void {
 		$id = $this->newResolver()->resolve(
 			$this->newProperty(),

--- a/tests/phpunit/Domain/Schema/Property/SelectOptionTest.php
+++ b/tests/phpunit/Domain/Schema/Property/SelectOptionTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Domain\Schema\Property;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Property\SelectOption;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Domain\Schema\Property\SelectOption
+ */
+class SelectOptionTest extends TestCase {
+
+	public function testStoresId(): void {
+		$option = new SelectOption( 'EVNrDCjgVpv9oC', 'Draft' );
+
+		$this->assertSame( 'EVNrDCjgVpv9oC', $option->getId() );
+	}
+
+	public function testStoresLabel(): void {
+		$option = new SelectOption( 'x', 'Draft' );
+
+		$this->assertSame( 'Draft', $option->getLabel() );
+	}
+
+	public function testThrowsOnEmptyId(): void {
+		$this->expectException( InvalidArgumentException::class );
+		new SelectOption( '', 'Draft' );
+	}
+
+	public function testThrowsOnEmptyLabel(): void {
+		$this->expectException( InvalidArgumentException::class );
+		new SelectOption( 'x', '' );
+	}
+
+	public function testThrowsOnWhitespaceOnlyLabel(): void {
+		$this->expectException( InvalidArgumentException::class );
+		new SelectOption( 'x', '   ' );
+	}
+
+	public function testToJsonReturnsIdAndLabel(): void {
+		$option = new SelectOption( 'abc', 'Draft' );
+
+		$this->assertSame( [ 'id' => 'abc', 'label' => 'Draft' ], $option->toJson() );
+	}
+
+	public function testFromJsonBuildsFromIdAndLabel(): void {
+		$option = SelectOption::fromJson( [ 'id' => 'abc', 'label' => 'Draft' ] );
+
+		$this->assertEquals( new SelectOption( 'abc', 'Draft' ), $option );
+	}
+
+	public function testFromJsonThrowsOnMissingId(): void {
+		$this->expectException( InvalidArgumentException::class );
+		SelectOption::fromJson( [ 'label' => 'Draft' ] );
+	}
+
+	public function testFromJsonThrowsOnMissingLabel(): void {
+		$this->expectException( InvalidArgumentException::class );
+		SelectOption::fromJson( [ 'id' => 'abc' ] );
+	}
+
+	public function testFromJsonThrowsOnLegacyStringShape(): void {
+		$this->expectException( InvalidArgumentException::class );
+		SelectOption::fromJson( 'Draft' );
+	}
+
+	public function testEqualsComparesAllFields(): void {
+		$a = new SelectOption( 'abc', 'Draft' );
+		$b = new SelectOption( 'abc', 'Draft' );
+		$c = new SelectOption( 'abc', 'Review' );
+		$d = new SelectOption( 'xyz', 'Draft' );
+
+		$this->assertTrue( $a->equals( $b ) );
+		$this->assertFalse( $a->equals( $c ) );
+		$this->assertFalse( $a->equals( $d ) );
+	}
+
+	public function testNormalizedLabelTrimsAndLowercases(): void {
+		$option = new SelectOption( 'abc', '  DrAfT  ' );
+
+		$this->assertSame( 'draft', $option->normalizedLabel() );
+	}
+
+}

--- a/tests/phpunit/Domain/Schema/Property/SelectPropertyTest.php
+++ b/tests/phpunit/Domain/Schema/Property/SelectPropertyTest.php
@@ -33,7 +33,7 @@ JSON
 		);
 	}
 
-	public function testFullSerializationWithChangedValuesIsStable(): void {
+	public function testFullSerializationIsStable(): void {
 		$this->assertSerializationDoesNotChange(
 			<<<JSON
 {
@@ -41,38 +41,24 @@ JSON
 	"description": "Document status",
 	"required": true,
 	"default": null,
-	"options": ["Draft", "Review", "Approved"],
+	"options": [
+		{ "id": "opt1", "label": "Draft" },
+		{ "id": "opt2", "label": "Review" },
+		{ "id": "opt3", "label": "Approved" }
+	],
 	"multiple": false
 }
 JSON
 		);
 	}
 
-	public function testFullSerializationWithDefaultValuesIsStable(): void {
-		$this->assertSerializationDoesNotChange(
+	public function testExceptionOnLegacyStringOption(): void {
+		$this->expectException( InvalidArgumentException::class );
+		$this->fromJson(
 			<<<JSON
 {
 	"type": "select",
-	"description": "",
-	"required": false,
-	"default": null,
-	"options": [],
-	"multiple": false
-}
-JSON
-		);
-	}
-
-	public function testMultiSelectSerialization(): void {
-		$this->assertSerializationDoesNotChange(
-			<<<JSON
-{
-	"type": "select",
-	"description": "Tags",
-	"required": false,
-	"default": null,
-	"options": ["Important", "Urgent", "Low priority"],
-	"multiple": true
+	"options": ["Draft", "Review"]
 }
 JSON
 		);
@@ -90,13 +76,46 @@ JSON
 		);
 	}
 
-	public function testExceptionOnNonStringOption(): void {
+	public function testExceptionOnDuplicateOptionId(): void {
 		$this->expectException( InvalidArgumentException::class );
 		$this->fromJson(
 			<<<JSON
 {
 	"type": "select",
-	"options": ["valid", 42]
+	"options": [
+		{ "id": "dup", "label": "A" },
+		{ "id": "dup", "label": "B" }
+	]
+}
+JSON
+		);
+	}
+
+	public function testExceptionOnDuplicateLabelCaseInsensitive(): void {
+		$this->expectException( InvalidArgumentException::class );
+		$this->fromJson(
+			<<<JSON
+{
+	"type": "select",
+	"options": [
+		{ "id": "a", "label": "Draft" },
+		{ "id": "b", "label": "draft" }
+	]
+}
+JSON
+		);
+	}
+
+	public function testExceptionOnDuplicateLabelWhitespace(): void {
+		$this->expectException( InvalidArgumentException::class );
+		$this->fromJson(
+			<<<JSON
+{
+	"type": "select",
+	"options": [
+		{ "id": "a", "label": "Draft" },
+		{ "id": "b", "label": "  Draft  " }
+	]
 }
 JSON
 		);
@@ -119,12 +138,17 @@ JSON
 			<<<JSON
 {
 	"type": "select",
-	"options": ["Zebra", "Apple", "Mango"]
+	"options": [
+		{ "id": "z", "label": "Zebra" },
+		{ "id": "a", "label": "Apple" },
+		{ "id": "m", "label": "Mango" }
+	]
 }
 JSON
 		);
 
-		$this->assertSame( [ 'Zebra', 'Apple', 'Mango' ], $property->toJson()['options'] );
+		$ids = array_map( fn( $o ) => $o->getId(), $property->getOptions() );
+		$this->assertSame( [ 'z', 'a', 'm' ], $ids );
 	}
 
 }


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/719

> Result of extensive back-and-forth with @alistair3149 — design discussion, implementation strategy,
> and a mid-PR scope reduction (tombstone feature deferred as YAGNI).
> Context: the NeoWiki codebase, issue #719, competitive comparison of Notion/Airtable/Baserow,
> browser smoke testing against the local dev wiki.
> <sub>Written by Claude Code, `Opus 4.7`</sub>

Tested modifying the existing select options in the editor.
There are no visible regression.

## Summary

Migrates select-property options from `string[]` to `{id, label}[]`. Stored statement values reference the
option `id`, so renaming a label no longer breaks existing statements. The write API accepts either an `id`
or a `label` and resolves to the canonical id server-side.

- `SelectOption` value objects in both PHP and TypeScript domain layers
- Statement values store option IDs (not labels)
- `SelectDisplay` resolves IDs to labels; unknown IDs show `(unknown option)`
- Write path accepts `id`, `label`, or `{id, label}` object; mismatched `{id, label}` rejected; object with
  `id` only requires a matching option (no label-fallback)
- No migration from the legacy string-option format: loading a legacy schema throws `InvalidArgumentException`

## Known limitation — schema editor UI

`SelectAttributesEditor.vue` is unchanged in this PR. It still rebuilds the entire options array from chip
labels on save, using the label as the id (`{id: label, label}`). That means saving a schema through the UI
editor after it was edited via the ID-aware API (or by hand through source) will rewrite every option's id
to its current label, orphaning any existing statements.

This is left intentionally out of scope because it requires some UI design work on the options input in the SchemaEditor.
When we work on anything that edits "properties" of an option (e.g. #718, #726), then we will need the UI.

## Design notes

- `StatementListPatcher` stays pure. Resolution lives in two new pure readonly services — `SelectValueResolver`
  (single value) and `SelectPatchResolver` (patch walker) — invoked from the Action layer where
  `SchemaLookup` is already in hand.
- When `SchemaLookup` returns `null` the patch passes through unresolved (lenient), matching the pre-PR
  behaviour. Follow-up-worthy for observability but not urgent.
- Label uniqueness is case-insensitive and whitespace-trimmed, global across all options. Tombstoning was
  scoped out; there is no live-only distinction.
- Translatable option labels are tracked separately in #726.

## Test plan

- [x] `make phpunit filter='Domain.*Schema'` — 49/49
- [x] `make phpunit filter='Application'` — 79/79 (1 pre-existing skip)
- [x] `make phpunit filter='SchemaContent'` — 9/9
- [x] `make cs` — PHPCS clean, PHPStan no errors
- [x] `make tsci` — lint + build + Vitest green
- [x] Browser: subject display resolves IDs to labels; `(unknown option)` fallback renders when a stored
      value doesn't match any current option
- [x] Browser: subject edit picker shows labels, writes IDs (verified the stored JSON carries IDs after save)
- [x] REST: `PATCH /rest.php/neowiki/v0/subject/{id}` with `value: "Active"` (a label) resolves to the
      option ID before storing
- [x] Full `make phpunit` on CI (Neo4j-backed integration suite doesn't reliably run in the local env)