### PR TITLE
Add nw.query() Lua API for running Cypher queries

### DIFF
--- a/DemoData/Module/NeoWikiDemo.lua
+++ b/DemoData/Module/NeoWikiDemo.lua
@@ -112,34 +112,17 @@ local function renderRowsAsTable( rows )
 end
 
 function p.query( frame )
-	local cypher = frame.args[1] or frame.args.query
-	if not cypher or cypher == '' then
-		return 'No query provided'
-	end
-
-	local ok, result = pcall( nw.query, cypher )
-	if not ok then
-		return 'Query failed: ' .. tostring( result )
-	end
-
-	return renderRowsAsTable( result )
+	return renderRowsAsTable( nw.query( frame.args[1] ) )
 end
 
 function p.productsFoundedSince( frame )
 	local year = tonumber( frame.args[1] ) or 2000
 
-	local ok, result = pcall(
-		nw.query,
+	return renderRowsAsTable( nw.query(
 		'MATCH (n:Product) WHERE n.`Available since` >= $year ' ..
 			'RETURN n.name AS name, n.`Available since` AS year ORDER BY year',
 		{ year = year }
-	)
-
-	if not ok then
-		return 'Query failed: ' .. tostring( result )
-	end
-
-	return renderRowsAsTable( result )
+	) )
 end
 
 return p

--- a/DemoData/Module/NeoWikiDemo.lua
+++ b/DemoData/Module/NeoWikiDemo.lua
@@ -84,4 +84,62 @@ function p.children( frame )
 	return table.concat( parts, ', ' )
 end
 
+local function renderRowsAsTable( rows )
+	if #rows == 0 then
+		return 'No results'
+	end
+
+	local columns = {}
+	for k in pairs( rows[1] ) do
+		columns[#columns + 1] = k
+	end
+	table.sort( columns )
+
+	local out = { '{| class="wikitable"', '! ' .. table.concat( columns, ' !! ' ) }
+
+	for _, row in ipairs( rows ) do
+		local cells = {}
+		for _, col in ipairs( columns ) do
+			local v = row[col]
+			cells[#cells + 1] = v == nil and '' or tostring( v )
+		end
+		out[#out + 1] = '|-'
+		out[#out + 1] = '| ' .. table.concat( cells, ' || ' )
+	end
+
+	out[#out + 1] = '|}'
+	return table.concat( out, '\n' )
+end
+
+function p.query( frame )
+	local cypher = frame.args[1] or frame.args.query
+	if not cypher or cypher == '' then
+		return 'No query provided'
+	end
+
+	local ok, result = pcall( nw.query, cypher )
+	if not ok then
+		return 'Query failed: ' .. tostring( result )
+	end
+
+	return renderRowsAsTable( result )
+end
+
+function p.productsFoundedSince( frame )
+	local year = tonumber( frame.args[1] ) or 2000
+
+	local ok, result = pcall(
+		nw.query,
+		'MATCH (n:Product) WHERE n.`Available since` >= $year ' ..
+			'RETURN n.name AS name, n.`Available since` AS year ORDER BY year',
+		{ year = year }
+	)
+
+	if not ok then
+		return 'Query failed: ' .. tostring( result )
+	end
+
+	return renderRowsAsTable( result )
+end
+
 return p

--- a/DemoData/Page/Lua_Data_Access.wikitext
+++ b/DemoData/Page/Lua_Data_Access.wikitext
@@ -34,6 +34,34 @@ The examples use [[Module:NeoWikiDemo]], a demo module included with NeoWiki.
 
 Child subjects on [[ACME Inc]]: {{#invoke:NeoWikiDemo|children|ACME Inc}}
 
+== Running Cypher Queries ==
+
+<code>mw.neowiki.query()</code> runs a read-only Cypher query and returns each row as a Lua table keyed
+by the <code>RETURN</code> aliases. Use it when a single-property lookup is not enough — for example
+to join Subjects, sort results, or list all Subjects of a given type.
+
+=== Listing all Companies ===
+
+<syntaxhighlight lang="cypher">
+MATCH (n:Company) RETURN n.name, n.id
+</syntaxhighlight>
+
+{{#invoke:NeoWikiDemo|query|MATCH (n:Company) RETURN n.name, n.id}}
+
+=== Parameterised query: Products available since a given year ===
+
+Templates should always pass values via the <code>params</code> table instead of concatenating into the query string.
+
+<syntaxhighlight lang="lua">
+nw.query(
+    'MATCH (n:Product) WHERE n.`Available since` >= $year ' ..
+        'RETURN n.name AS name, n.`Available since` AS year ORDER BY year',
+    { year = 2010 }
+)
+</syntaxhighlight>
+
+Products available since 2010: {{#invoke:NeoWikiDemo|productsFoundedSince|2010}}
+
 == Module Source ==
 
 The demo module uses these <code>mw.neowiki</code> functions:
@@ -54,6 +82,12 @@ s.id, s.label, s.schema, s.statements
 
 -- Get child subjects
 local children = nw.getChildSubjects( 'ACME Inc' )
+
+-- Run a read-only Cypher query
+local rows = nw.query(
+    'MATCH (n:Product) WHERE n.`Available since` >= $year RETURN n.name, n.`Available since`',
+    { year = 2010 }
+)
 </syntaxhighlight>
 
 See [[Module:NeoWikiDemo]] for the full source.

--- a/docs/LuaAPI.md
+++ b/docs/LuaAPI.md
@@ -11,6 +11,7 @@ enough.
 | Read every value from a multi-valued property | [`nw.getAll`](#nwgetallpropertyname-options) |
 | Get a page's Main Subject (label, schema, all properties) | [`nw.getMainSubject`](#nwgetmainsubjectpagename) |
 | Get a Subject by its ID, regardless of which page it's on | [`nw.getSubject`](#nwgetsubjectsubjectid) |
+| Run a read-only Cypher query | [`nw.query`](#nwquerycypher-params) |
 | List all Child Subjects on a page | [`nw.getChildSubjects`](#nwgetchildsubjectspagename) |
 
 For definitions of terms like Subject, Schema, and Statement, see the [Glossary](Glossary.md).
@@ -157,6 +158,71 @@ for _, child in ipairs(children) do
 end
 ```
 
+### `nw.query(cypher, params)`
+
+Runs a read-only Cypher query against the graph database and returns each row as a Lua table. Use
+this when a single property lookup is not enough — for example, to join multiple Subjects, filter
+or sort in the query, or build a custom table.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `cypher` | string | Required. A Cypher query. Must be read-only (no `CREATE`, `SET`, `DELETE`, etc.). |
+| `params` | table | Optional. Parameter name → value. Use `$name` in the query to reference them. |
+
+#### Returns
+
+A 1-indexed Lua table of rows. Each row is a string-keyed table where the keys are the Cypher
+`RETURN` aliases. An empty result is returned as `{}`, so it is safe to iterate with `ipairs`
+without a `nil` check.
+
+Scalar values come back as strings, numbers, booleans, or `nil`. Nested Cypher lists become
+1-indexed tables; Cypher maps become string-keyed tables. Neo4j-specific types convert as follows
+(matching the JSON shape of `{{#cypher_raw}}`):
+
+| Cypher type | Lua shape |
+|-------------|-----------|
+| Node | `{ id, labels, properties }` |
+| Relationship | `{ id, type, startNodeId, endNodeId, properties }` |
+| Path | `{ nodes, relationships }` |
+| Temporal types | Structured table; fields vary by type (`days`, `seconds`, `nanoseconds`, `tzOffsetSeconds`, `tzId`) |
+| Duration | `{ months, days, seconds, nanoseconds }` |
+| Point | `{ srid, x, y }` (plus `z` for 3D points) |
+
+#### Errors
+
+Always throws on failure; wrap in `pcall` if you need graceful degradation.
+
+- Empty or whitespace-only `cypher`.
+- Write or non-read-only queries (rejected by the validator).
+- Cypher syntax errors, missing parameters, or database errors (surfaced with the underlying
+  message).
+
+#### Expensive
+
+Every call counts as an expensive parser function. Keep an eye on your page's expensive function
+limit if a template calls `nw.query` in a loop.
+
+#### Examples
+
+```lua
+local rows = nw.query( 'MATCH (s:Subject) RETURN s.name LIMIT 5' )
+
+for _, row in ipairs( rows ) do
+    mw.log( row['s.name'] )
+end
+```
+
+```lua
+-- Parameterised — always prefer this over concatenating values into the query.
+local rows = nw.query(
+    'MATCH (s:Subject {schema: $schema}) WHERE s.`Valid` = $valid RETURN s.name, s.`Expiry date`',
+    { schema = 'ISMS Document', valid = 'Yes' }
+)
+```
+
+Lua numbers are all floats in PHP. If a typed comparison fails, cast in the query — for example
+`WHERE s.year = toInteger($year)`.
+
 ## Subject table format
 
 Subject tables returned by `getMainSubject`, `getSubject`, and `getChildSubjects` have this
@@ -204,8 +270,6 @@ Calls that look up another page or a specific Subject ID count as expensive pars
 
 The following are not yet implemented:
 
-- `nw.query(cypher, params)` — Execute Cypher queries from Lua. Tracked in
-  [#736](https://github.com/ProfessionalWiki/NeoWiki/issues/736).
 - `nw.getSchema(name)` — Schema introspection for generic templates. Tracked in
   [#737](https://github.com/ProfessionalWiki/NeoWiki/issues/737).
 

--- a/docs/LuaAPI.md
+++ b/docs/LuaAPI.md
@@ -176,8 +176,7 @@ A 1-indexed Lua table of rows. Each row is a string-keyed table where the keys a
 without a `nil` check.
 
 Scalar values come back as strings, numbers, booleans, or `nil`. Nested Cypher lists become
-1-indexed tables; Cypher maps become string-keyed tables. Neo4j-specific types convert as follows
-(matching the JSON shape of `{{#cypher_raw}}`):
+1-indexed tables; Cypher maps become string-keyed tables. Neo4j-specific types convert as follows:
 
 | Cypher type | Lua shape |
 |-------------|-----------|

--- a/docs/LuaAPI.md
+++ b/docs/LuaAPI.md
@@ -183,9 +183,9 @@ Scalar values come back as strings, numbers, booleans, or `nil`. Nested Cypher l
 | Node | `{ id, labels, properties }` |
 | Relationship | `{ id, type, startNodeId, endNodeId, properties }` |
 | Path | `{ nodes, relationships }` |
-| Temporal types | Structured table; fields vary by type (`days`, `seconds`, `nanoseconds`, `tzOffsetSeconds`, `tzId`) |
-| Duration | `{ months, days, seconds, nanoseconds }` |
-| Point | `{ srid, x, y }` (plus `z` for 3D points) |
+
+Temporal and spatial values (from Cypher functions like `datetime()` or `point()`) are not
+supported. Cast to a scalar in the query — e.g. `toString(datetime())` or `point.x(p)`.
 
 #### Errors
 

--- a/docs/LuaAPI.md
+++ b/docs/LuaAPI.md
@@ -176,7 +176,7 @@ A 1-indexed Lua table of rows. Each row is a string-keyed table where the keys a
 without a `nil` check.
 
 Scalar values come back as strings, numbers, booleans, or `nil`. Nested Cypher lists become
-1-indexed tables; Cypher maps become string-keyed tables. Neo4j-specific types convert as follows:
+1-indexed tables; Cypher maps become string-keyed tables. Graph types convert as follows:
 
 | Cypher type | Lua shape |
 |-------------|-----------|
@@ -192,9 +192,8 @@ supported. Cast to a scalar in the query — e.g. `toString(datetime())` or `poi
 Always throws on failure; wrap in `pcall` if you need graceful degradation.
 
 - Empty or whitespace-only `cypher`.
-- Write or non-read-only queries (rejected by the validator).
-- Cypher syntax errors, missing parameters, or database errors (surfaced with the underlying
-  message).
+- Write or non-read-only queries.
+- Cypher syntax errors, missing parameters, or database errors.
 
 #### Expensive
 
@@ -219,8 +218,7 @@ local rows = nw.query(
 )
 ```
 
-Lua numbers are all floats in PHP. If a typed comparison fails, cast in the query — for example
-`WHERE s.year = toInteger($year)`.
+Integer comparisons need an explicit cast in the query — e.g. `WHERE s.year = toInteger($year)`.
 
 ## Subject table format
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -108,6 +108,9 @@
 	"neowiki-cypher-raw-error-query-failed": "Query execution failed: $1",
 	"neowiki-cypher-raw-error-json-encode": "Failed to encode query result as JSON",
 
+	"neowiki-lua-query-error-empty-query": "nw.query: the Cypher query must not be empty.",
+	"neowiki-lua-query-error-write-query": "nw.query: only read-only Cypher queries are allowed.",
+
 	"neowiki-schema-editor-summary-default": "Update schema via NeoWiki UI",
 	"neowiki-schema-editor-success": "Updated $1 schema",
 	"neowiki-schema-editor-error": "Failed to update $1 schema.",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -16,6 +16,9 @@
 	"neowiki-cypher-raw-error-write-query": "Error message shown when a write query is rejected by the cypher_raw parser function.",
 	"neowiki-cypher-raw-error-query-failed": "Error message shown when Cypher query execution fails. $1 is the exception message.",
 	"neowiki-cypher-raw-error-json-encode": "Error message shown when JSON encoding of query results fails.",
+
+	"neowiki-lua-query-error-empty-query": "Error raised by the nw.query() Lua function when called with an empty Cypher query.",
+	"neowiki-lua-query-error-write-query": "Error raised by the nw.query() Lua function when the Cypher query contains write or non-read-only operations.",
 	"neowiki-subject-creator-creating-schema": "Subtitle shown in the subject creator dialog header when the user is creating a new schema.",
 	"neowiki-subject-creator-create-schema": "Label for the button that creates a new schema in the subject creator dialog.",
 	"neowiki-subject-creator-continue": "Label for the button that continues from schema creation to subject editing in the subject creator dialog.",

--- a/src/EntryPoints/Scribunto/CypherQueryRunner.php
+++ b/src/EntryPoints/Scribunto/CypherQueryRunner.php
@@ -1,0 +1,40 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\EntryPoints\Scribunto;
+
+use ProfessionalWiki\NeoWiki\Application\CypherQueryValidator;
+use ProfessionalWiki\NeoWiki\Persistence\Neo4j\QueryEngine;
+use RuntimeException;
+
+class CypherQueryRunner {
+
+	public function __construct(
+		private readonly QueryEngine $queryEngine,
+		private readonly CypherQueryValidator $validator,
+		private readonly CypherResultConverter $converter,
+	) {
+	}
+
+	public function run( string $cypher, array $params ): array {
+		$cypher = trim( $cypher );
+
+		if ( $cypher === '' ) {
+			throw new RuntimeException(
+				wfMessage( 'neowiki-lua-query-error-empty-query' )->text()
+			);
+		}
+
+		if ( !$this->validator->queryIsAllowed( $cypher ) ) {
+			throw new RuntimeException(
+				wfMessage( 'neowiki-lua-query-error-write-query' )->text()
+			);
+		}
+
+		return $this->converter->convertRows(
+			$this->queryEngine->runReadQuery( $cypher, $params )
+		);
+	}
+
+}

--- a/src/EntryPoints/Scribunto/CypherResultConverter.php
+++ b/src/EntryPoints/Scribunto/CypherResultConverter.php
@@ -29,14 +29,14 @@ class CypherResultConverter {
 		}
 
 		if ( $value instanceof CypherMap ) {
-			return $this->convertMap( $value );
+			return $this->convertAssociative( $value );
 		}
 
 		if ( $value instanceof Node ) {
 			return [
 				'id' => $value->getId(),
 				'labels' => $this->convertList( $value->getLabels() ),
-				'properties' => $this->convertMap( $value->getProperties() ),
+				'properties' => $this->convertAssociative( $value->getProperties() ),
 			];
 		}
 
@@ -46,7 +46,7 @@ class CypherResultConverter {
 				'type' => $value->getType(),
 				'startNodeId' => $value->getStartNodeId(),
 				'endNodeId' => $value->getEndNodeId(),
-				'properties' => $this->convertMap( $value->getProperties() ),
+				'properties' => $this->convertAssociative( $value->getProperties() ),
 			];
 		}
 
@@ -54,7 +54,7 @@ class CypherResultConverter {
 			return [
 				'id' => $value->getId(),
 				'type' => $value->getType(),
-				'properties' => $this->convertMap( $value->getProperties() ),
+				'properties' => $this->convertAssociative( $value->getProperties() ),
 			];
 		}
 
@@ -66,7 +66,7 @@ class CypherResultConverter {
 		}
 
 		if ( $value instanceof AbstractCypherObject ) {
-			return $this->convertPlainArray( $value->toArray() );
+			return $this->convertAssociative( $value->toArray() );
 		}
 
 		throw new RuntimeException(
@@ -84,17 +84,9 @@ class CypherResultConverter {
 		return $values;
 	}
 
-	private function convertMap( CypherMap $map ): array {
-		$values = [];
-		foreach ( $map as $key => $value ) {
-			$values[$key] = $this->convert( $value );
-		}
-		return $values;
-	}
-
-	private function convertPlainArray( array $array ): array {
+	private function convertAssociative( iterable $entries ): array {
 		$result = [];
-		foreach ( $array as $key => $value ) {
+		foreach ( $entries as $key => $value ) {
 			$result[$key] = $this->convert( $value );
 		}
 		return $result;

--- a/src/EntryPoints/Scribunto/CypherResultConverter.php
+++ b/src/EntryPoints/Scribunto/CypherResultConverter.php
@@ -1,0 +1,103 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\EntryPoints\Scribunto;
+
+use Laudis\Neo4j\Types\AbstractCypherObject;
+use Laudis\Neo4j\Types\CypherList;
+use Laudis\Neo4j\Types\CypherMap;
+use Laudis\Neo4j\Types\Node;
+use Laudis\Neo4j\Types\Path;
+use Laudis\Neo4j\Types\Relationship;
+use Laudis\Neo4j\Types\UnboundRelationship;
+use RuntimeException;
+
+class CypherResultConverter {
+
+	public function convertRows( CypherList $rows ): array {
+		return $this->convertList( $rows );
+	}
+
+	private function convert( mixed $value ): mixed {
+		if ( is_scalar( $value ) || $value === null ) {
+			return $value;
+		}
+
+		if ( $value instanceof CypherList ) {
+			return $this->convertList( $value );
+		}
+
+		if ( $value instanceof CypherMap ) {
+			return $this->convertMap( $value );
+		}
+
+		if ( $value instanceof Node ) {
+			return [
+				'id' => $value->getId(),
+				'labels' => $this->convertList( $value->getLabels() ),
+				'properties' => $this->convertMap( $value->getProperties() ),
+			];
+		}
+
+		if ( $value instanceof Relationship ) {
+			return [
+				'id' => $value->getId(),
+				'type' => $value->getType(),
+				'startNodeId' => $value->getStartNodeId(),
+				'endNodeId' => $value->getEndNodeId(),
+				'properties' => $this->convertMap( $value->getProperties() ),
+			];
+		}
+
+		if ( $value instanceof UnboundRelationship ) {
+			return [
+				'id' => $value->getId(),
+				'type' => $value->getType(),
+				'properties' => $this->convertMap( $value->getProperties() ),
+			];
+		}
+
+		if ( $value instanceof Path ) {
+			return [
+				'nodes' => $this->convertList( $value->getNodes() ),
+				'relationships' => $this->convertList( $value->getRelationships() ),
+			];
+		}
+
+		if ( $value instanceof AbstractCypherObject ) {
+			return $this->convertPlainArray( $value->toArray() );
+		}
+
+		throw new RuntimeException(
+			sprintf( 'Unsupported Cypher value type: %s', get_debug_type( $value ) )
+		);
+	}
+
+	private function convertList( CypherList $list ): array {
+		$values = [];
+		$index = 1;
+		foreach ( $list as $value ) {
+			$values[$index] = $this->convert( $value );
+			$index++;
+		}
+		return $values;
+	}
+
+	private function convertMap( CypherMap $map ): array {
+		$values = [];
+		foreach ( $map as $key => $value ) {
+			$values[$key] = $this->convert( $value );
+		}
+		return $values;
+	}
+
+	private function convertPlainArray( array $array ): array {
+		$result = [];
+		foreach ( $array as $key => $value ) {
+			$result[$key] = $this->convert( $value );
+		}
+		return $result;
+	}
+
+}

--- a/src/EntryPoints/Scribunto/CypherResultConverter.php
+++ b/src/EntryPoints/Scribunto/CypherResultConverter.php
@@ -4,7 +4,6 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\EntryPoints\Scribunto;
 
-use Laudis\Neo4j\Types\AbstractCypherObject;
 use Laudis\Neo4j\Types\CypherList;
 use Laudis\Neo4j\Types\CypherMap;
 use Laudis\Neo4j\Types\Node;
@@ -63,10 +62,6 @@ class CypherResultConverter {
 				'nodes' => $this->convertList( $value->getNodes() ),
 				'relationships' => $this->convertList( $value->getRelationships() ),
 			];
-		}
-
-		if ( $value instanceof AbstractCypherObject ) {
-			return $this->convertAssociative( $value->toArray() );
 		}
 
 		throw new RuntimeException(

--- a/src/EntryPoints/Scribunto/ScribuntoLuaLibrary.php
+++ b/src/EntryPoints/Scribunto/ScribuntoLuaLibrary.php
@@ -4,13 +4,16 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\EntryPoints\Scribunto;
 
+use Exception;
 use MediaWiki\Extension\Scribunto\Engines\LuaCommon\LibraryBase;
+use MediaWiki\Extension\Scribunto\Engines\LuaCommon\LuaError;
 use ProfessionalWiki\NeoWiki\Application\SubjectResolver;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 
 class ScribuntoLuaLibrary extends LibraryBase {
 
 	private ?SubjectDataLookup $subjectDataLookup = null;
+	private ?CypherQueryRunner $cypherQueryRunner = null;
 
 	private function getSubjectDataLookup(): SubjectDataLookup {
 		if ( $this->subjectDataLookup === null ) {
@@ -27,6 +30,20 @@ class ScribuntoLuaLibrary extends LibraryBase {
 		return $this->subjectDataLookup;
 	}
 
+	private function getCypherQueryRunner(): CypherQueryRunner {
+		if ( $this->cypherQueryRunner === null ) {
+			$extension = NeoWikiExtension::getInstance();
+
+			$this->cypherQueryRunner = new CypherQueryRunner(
+				$extension->getNeo4jPlugin(),
+				$extension->getCypherQueryValidator(),
+				new CypherResultConverter(),
+			);
+		}
+
+		return $this->cypherQueryRunner;
+	}
+
 	public function register(): array {
 		$lib = [
 			'getValue' => [ $this, 'getValue' ],
@@ -34,6 +51,7 @@ class ScribuntoLuaLibrary extends LibraryBase {
 			'getMainSubject' => [ $this, 'getMainSubject' ],
 			'getSubject' => [ $this, 'getSubject' ],
 			'getChildSubjects' => [ $this, 'getChildSubjects' ],
+			'query' => [ $this, 'query' ],
 		];
 
 		return $this->getEngine()->registerInterface(
@@ -86,6 +104,20 @@ class ScribuntoLuaLibrary extends LibraryBase {
 		}
 
 		return $this->getSubjectDataLookup()->getChildSubjectsData( $this->getTitle(), $pageName );
+	}
+
+	public function query( ?string $cypher = null, ?array $params = null ): array {
+		$this->checkType( 'mw.neowiki.query', 1, $cypher, 'string' );
+		$this->checkTypeOptional( 'mw.neowiki.query', 2, $params, 'table', null );
+		$this->incrementExpensiveFunctionCount();
+
+		try {
+			$rows = $this->getCypherQueryRunner()->run( $cypher, $params ?? [] );
+		} catch ( Exception $e ) {
+			throw new LuaError( $e->getMessage() );
+		}
+
+		return [ $rows ];
 	}
 
 }

--- a/src/EntryPoints/Scribunto/mw.neowiki.lua
+++ b/src/EntryPoints/Scribunto/mw.neowiki.lua
@@ -32,4 +32,8 @@ function neowiki.getChildSubjects( pageName )
 	return php.getChildSubjects( pageName )
 end
 
+function neowiki.query( cypher, params )
+	return php.query( cypher, params )
+end
+
 return neowiki

--- a/src/Persistence/Neo4j/Neo4jQueryStore.php
+++ b/src/Persistence/Neo4j/Neo4jQueryStore.php
@@ -201,10 +201,10 @@ readonly class Neo4jQueryStore implements GraphDatabasePlugin, QueryEngine, Writ
 		)->isEmpty() === false;
 	}
 
-	public function runReadQuery( string $cypher ): SummarizedResult {
+	public function runReadQuery( string $cypher, array $parameters = [] ): SummarizedResult {
 		return $this->readOnlyClient->readTransaction(
-			function ( TransactionInterface $transaction ) use ( $cypher ): SummarizedResult {
-				return $transaction->run( $cypher );
+			function ( TransactionInterface $transaction ) use ( $cypher, $parameters ): SummarizedResult {
+				return $transaction->run( $cypher, $parameters );
 			}
 		);
 	}

--- a/src/Persistence/Neo4j/QueryEngine.php
+++ b/src/Persistence/Neo4j/QueryEngine.php
@@ -8,6 +8,6 @@ use Laudis\Neo4j\Databags\SummarizedResult;
 
 interface QueryEngine {
 
-	public function runReadQuery( string $cypher ): SummarizedResult;
+	public function runReadQuery( string $cypher, array $parameters = [] ): SummarizedResult;
 
 }

--- a/tests/phpunit/EntryPoints/Scribunto/CypherQueryRunnerTest.php
+++ b/tests/phpunit/EntryPoints/Scribunto/CypherQueryRunnerTest.php
@@ -80,16 +80,21 @@ class CypherQueryRunnerTest extends TestCase {
 		);
 	}
 
-	public function testEmptyQueryThrows(): void {
+	public function testEmptyQueryThrowsWithEmptyQueryMessage(): void {
 		$runner = $this->newRunner( $this->stubEngine( $this->emptyResult() ) );
 
 		$this->expectException( RuntimeException::class );
+		$this->expectExceptionMessageMatches( '/empty/i' );
 		$runner->run( '   ', [] );
 	}
 
-	public function testDisallowedQueryThrowsAndSkipsEngine(): void {
-		$engine = $this->stubEngine( $this->emptyResult() );
-		$runner = $this->newRunner(
+	public function testDisallowedQueryThrowsWithReadOnlyMessage(): void {
+		$engine = new class implements QueryEngine {
+			public function runReadQuery( string $cypher, array $parameters = [] ): SummarizedResult {
+				throw new \LogicException( 'engine must not be called for a rejected query' );
+			}
+		};
+		$runner = new CypherQueryRunner(
 			$engine,
 			new class implements CypherQueryValidator {
 
@@ -97,15 +102,13 @@ class CypherQueryRunnerTest extends TestCase {
 					return false;
 				}
 
-			}
+			},
+			new CypherResultConverter()
 		);
 
-		try {
-			$runner->run( 'CREATE (n)', [] );
-			$this->fail( 'Expected RuntimeException' );
-		} catch ( RuntimeException $e ) {
-			$this->assertSame( '', $engine->lastCypher, 'engine must not be called for a rejected query' );
-		}
+		$this->expectException( RuntimeException::class );
+		$this->expectExceptionMessageMatches( '/read-only/i' );
+		$runner->run( 'CREATE (n)', [] );
 	}
 
 	public function testTrimsCypherBeforeValidationAndExecution(): void {

--- a/tests/phpunit/EntryPoints/Scribunto/CypherQueryRunnerTest.php
+++ b/tests/phpunit/EntryPoints/Scribunto/CypherQueryRunnerTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\Scribunto;
+
+use Laudis\Neo4j\Databags\SummarizedResult;
+use Laudis\Neo4j\Types\CypherList;
+use Laudis\Neo4j\Types\CypherMap;
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\CypherQueryValidator;
+use ProfessionalWiki\NeoWiki\EntryPoints\Scribunto\CypherQueryRunner;
+use ProfessionalWiki\NeoWiki\EntryPoints\Scribunto\CypherResultConverter;
+use ProfessionalWiki\NeoWiki\Persistence\Neo4j\QueryEngine;
+use RuntimeException;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\Scribunto\CypherQueryRunner
+ */
+class CypherQueryRunnerTest extends TestCase {
+
+	private function newRunner(
+		QueryEngine $engine,
+		?CypherQueryValidator $validator = null
+	): CypherQueryRunner {
+		$validator ??= new class implements CypherQueryValidator {
+
+			public function queryIsAllowed( string $cypher ): bool {
+				return true;
+			}
+
+		};
+		return new CypherQueryRunner( $engine, $validator, new CypherResultConverter() );
+	}
+
+	private function stubEngine( SummarizedResult $result ): QueryEngine {
+		return new class( $result ) implements QueryEngine {
+			public string $lastCypher = '';
+			public array $lastParams = [];
+
+			public function __construct( private readonly SummarizedResult $result ) {
+			}
+
+			public function runReadQuery( string $cypher, array $parameters = [] ): SummarizedResult {
+				$this->lastCypher = $cypher;
+				$this->lastParams = $parameters;
+				return $this->result;
+			}
+		};
+	}
+
+	private function emptyResult(): SummarizedResult {
+		$summary = null;
+		return new SummarizedResult( $summary, new CypherList( [] ) );
+	}
+
+	private function resultWithRows( array $rows ): SummarizedResult {
+		$summary = null;
+		$cypherMaps = new CypherList( array_map(
+			fn( array $row ) => new CypherMap( $row ),
+			$rows
+		) );
+		return new SummarizedResult( $summary, $cypherMaps );
+	}
+
+	public function testReturnsConvertedRows(): void {
+		$engine = $this->stubEngine(
+			$this->resultWithRows( [
+				[ 'name' => 'Ada' ],
+				[ 'name' => 'Grace' ],
+			] )
+		);
+
+		$this->assertSame(
+			[
+				1 => [ 'name' => 'Ada' ],
+				2 => [ 'name' => 'Grace' ],
+			],
+			$this->newRunner( $engine )->run( 'MATCH (n) RETURN n.name', [] )
+		);
+	}
+
+	public function testEmptyQueryThrows(): void {
+		$runner = $this->newRunner( $this->stubEngine( $this->emptyResult() ) );
+
+		$this->expectException( RuntimeException::class );
+		$runner->run( '   ', [] );
+	}
+
+	public function testDisallowedQueryThrowsAndSkipsEngine(): void {
+		$engine = $this->stubEngine( $this->emptyResult() );
+		$runner = $this->newRunner(
+			$engine,
+			new class implements CypherQueryValidator {
+
+				public function queryIsAllowed( string $cypher ): bool {
+					return false;
+				}
+
+			}
+		);
+
+		try {
+			$runner->run( 'CREATE (n)', [] );
+			$this->fail( 'Expected RuntimeException' );
+		} catch ( RuntimeException $e ) {
+			$this->assertSame( '', $engine->lastCypher, 'engine must not be called for a rejected query' );
+		}
+	}
+
+	public function testTrimsCypherBeforeValidationAndExecution(): void {
+		$engine = $this->stubEngine( $this->emptyResult() );
+		$runner = $this->newRunner( $engine );
+
+		$runner->run( "  MATCH (n) RETURN n  \n", [] );
+
+		$this->assertSame( 'MATCH (n) RETURN n', $engine->lastCypher );
+	}
+
+	public function testPassesParametersThrough(): void {
+		$engine = $this->stubEngine( $this->emptyResult() );
+		$runner = $this->newRunner( $engine );
+
+		$runner->run( 'RETURN $x', [ 'x' => 42, 'y' => 'foo' ] );
+
+		$this->assertSame( [ 'x' => 42, 'y' => 'foo' ], $engine->lastParams );
+	}
+
+	public function testEngineExceptionsPropagate(): void {
+		$engine = new class implements QueryEngine {
+			public function runReadQuery( string $cypher, array $parameters = [] ): SummarizedResult {
+				throw new RuntimeException( 'connection refused' );
+			}
+		};
+		$runner = $this->newRunner( $engine );
+
+		$this->expectException( RuntimeException::class );
+		$this->expectExceptionMessage( 'connection refused' );
+		$runner->run( 'MATCH (n) RETURN n', [] );
+	}
+
+}

--- a/tests/phpunit/EntryPoints/Scribunto/CypherResultConverterTest.php
+++ b/tests/phpunit/EntryPoints/Scribunto/CypherResultConverterTest.php
@@ -4,14 +4,8 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\Scribunto;
 
-use Laudis\Neo4j\Types\Cartesian3DPoint;
-use Laudis\Neo4j\Types\CartesianPoint;
 use Laudis\Neo4j\Types\CypherList;
 use Laudis\Neo4j\Types\CypherMap;
-use Laudis\Neo4j\Types\Date;
-use Laudis\Neo4j\Types\DateTime as Neo4jDateTime;
-use Laudis\Neo4j\Types\Duration;
-use Laudis\Neo4j\Types\LocalDateTime;
 use Laudis\Neo4j\Types\Node;
 use Laudis\Neo4j\Types\Path;
 use Laudis\Neo4j\Types\Relationship;
@@ -174,95 +168,6 @@ class CypherResultConverterTest extends TestCase {
 			$converted[1]['p']['nodes']
 		);
 		$this->assertSame( 9, $converted[1]['p']['relationships'][1]['id'] );
-	}
-
-	public function testDateBecomesToArrayShape(): void {
-		$result = new CypherList( [
-			new CypherMap( [ 'd' => new Date( 19500 ) ] ),
-		] );
-
-		$this->assertSame(
-			[ 1 => [ 'd' => [ 'days' => 19500 ] ] ],
-			$this->newConverter()->convertRows( $result )
-		);
-	}
-
-	public function testDateTimeBecomesToArrayShape(): void {
-		$result = new CypherList( [
-			new CypherMap( [ 'dt' => new Neo4jDateTime( 1700000000, 123456789, 3600, false ) ] ),
-		] );
-
-		$this->assertSame(
-			[ 1 => [ 'dt' => [
-				'seconds' => 1700000000,
-				'nanoseconds' => 123456789,
-				'tzOffsetSeconds' => 3600,
-			] ] ],
-			$this->newConverter()->convertRows( $result )
-		);
-	}
-
-	public function testDurationBecomesToArrayShape(): void {
-		$result = new CypherList( [
-			new CypherMap( [ 'dur' => new Duration( 2, 15, 30, 0 ) ] ),
-		] );
-
-		$this->assertSame(
-			[ 1 => [ 'dur' => [
-				'months' => 2,
-				'days' => 15,
-				'seconds' => 30,
-				'nanoseconds' => 0,
-			] ] ],
-			$this->newConverter()->convertRows( $result )
-		);
-	}
-
-	public function testCartesianPointBecomesToArrayShape(): void {
-		$result = new CypherList( [
-			new CypherMap( [ 'p' => new CartesianPoint( 1.0, 2.0 ) ] ),
-		] );
-
-		$this->assertSame(
-			[ 1 => [ 'p' => [
-				'x' => 1.0,
-				'y' => 2.0,
-				'crs' => 'cartesian',
-				'srid' => 7203,
-			] ] ],
-			$this->newConverter()->convertRows( $result )
-		);
-	}
-
-	public function testCartesian3DPointIncludesZ(): void {
-		$result = new CypherList( [
-			new CypherMap( [ 'p' => new Cartesian3DPoint( 1.0, 2.0, 3.0 ) ] ),
-		] );
-
-		$this->assertSame(
-			[ 1 => [ 'p' => [
-				'x' => 1.0,
-				'y' => 2.0,
-				'crs' => 'cartesian-3d',
-				'srid' => 9157,
-				'z' => 3.0,
-			] ] ],
-			$this->newConverter()->convertRows( $result )
-		);
-	}
-
-	public function testLocalDateTimeBecomesToArrayShape(): void {
-		$result = new CypherList( [
-			new CypherMap( [ 'ldt' => new LocalDateTime( 1700000000, 123456789 ) ] ),
-		] );
-
-		$this->assertSame(
-			[ 1 => [ 'ldt' => [
-				'seconds' => 1700000000,
-				'nanoseconds' => 123456789,
-			] ] ],
-			$this->newConverter()->convertRows( $result )
-		);
 	}
 
 	public function testUnknownObjectTypeThrows(): void {

--- a/tests/phpunit/EntryPoints/Scribunto/CypherResultConverterTest.php
+++ b/tests/phpunit/EntryPoints/Scribunto/CypherResultConverterTest.php
@@ -4,12 +4,14 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\Scribunto;
 
+use Laudis\Neo4j\Types\Cartesian3DPoint;
 use Laudis\Neo4j\Types\CartesianPoint;
 use Laudis\Neo4j\Types\CypherList;
 use Laudis\Neo4j\Types\CypherMap;
 use Laudis\Neo4j\Types\Date;
 use Laudis\Neo4j\Types\DateTime as Neo4jDateTime;
 use Laudis\Neo4j\Types\Duration;
+use Laudis\Neo4j\Types\LocalDateTime;
 use Laudis\Neo4j\Types\Node;
 use Laudis\Neo4j\Types\Path;
 use Laudis\Neo4j\Types\Relationship;
@@ -218,14 +220,49 @@ class CypherResultConverterTest extends TestCase {
 
 	public function testCartesianPointBecomesToArrayShape(): void {
 		$result = new CypherList( [
-			new CypherMap( [ 'p' => new CartesianPoint( 1.0, 2.0, 7203 ) ] ),
+			new CypherMap( [ 'p' => new CartesianPoint( 1.0, 2.0 ) ] ),
 		] );
 
-		$converted = $this->newConverter()->convertRows( $result );
+		$this->assertSame(
+			[ 1 => [ 'p' => [
+				'x' => 1.0,
+				'y' => 2.0,
+				'crs' => 'cartesian',
+				'srid' => 7203,
+			] ] ],
+			$this->newConverter()->convertRows( $result )
+		);
+	}
 
-		$this->assertSame( 7203, $converted[1]['p']['srid'] );
-		$this->assertSame( 1.0, $converted[1]['p']['x'] );
-		$this->assertSame( 2.0, $converted[1]['p']['y'] );
+	public function testCartesian3DPointIncludesZ(): void {
+		$result = new CypherList( [
+			new CypherMap( [ 'p' => new Cartesian3DPoint( 1.0, 2.0, 3.0 ) ] ),
+		] );
+
+		$this->assertSame(
+			[ 1 => [ 'p' => [
+				'x' => 1.0,
+				'y' => 2.0,
+				'crs' => 'cartesian-3d',
+				'srid' => 9157,
+				'z' => 3.0,
+			] ] ],
+			$this->newConverter()->convertRows( $result )
+		);
+	}
+
+	public function testLocalDateTimeBecomesToArrayShape(): void {
+		$result = new CypherList( [
+			new CypherMap( [ 'ldt' => new LocalDateTime( 1700000000, 123456789 ) ] ),
+		] );
+
+		$this->assertSame(
+			[ 1 => [ 'ldt' => [
+				'seconds' => 1700000000,
+				'nanoseconds' => 123456789,
+			] ] ],
+			$this->newConverter()->convertRows( $result )
+		);
 	}
 
 	public function testUnknownObjectTypeThrows(): void {

--- a/tests/phpunit/EntryPoints/Scribunto/CypherResultConverterTest.php
+++ b/tests/phpunit/EntryPoints/Scribunto/CypherResultConverterTest.php
@@ -1,0 +1,238 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\Scribunto;
+
+use Laudis\Neo4j\Types\CartesianPoint;
+use Laudis\Neo4j\Types\CypherList;
+use Laudis\Neo4j\Types\CypherMap;
+use Laudis\Neo4j\Types\Date;
+use Laudis\Neo4j\Types\DateTime as Neo4jDateTime;
+use Laudis\Neo4j\Types\Duration;
+use Laudis\Neo4j\Types\Node;
+use Laudis\Neo4j\Types\Path;
+use Laudis\Neo4j\Types\Relationship;
+use Laudis\Neo4j\Types\UnboundRelationship;
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\EntryPoints\Scribunto\CypherResultConverter;
+use RuntimeException;
+use stdClass;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\Scribunto\CypherResultConverter
+ */
+class CypherResultConverterTest extends TestCase {
+
+	private function newConverter(): CypherResultConverter {
+		return new CypherResultConverter();
+	}
+
+	public function testEmptyResultReturnsEmptyArray(): void {
+		$this->assertSame(
+			[],
+			$this->newConverter()->convertRows( new CypherList( [] ) )
+		);
+	}
+
+	public function testScalarRowsAreReturnedOneIndexed(): void {
+		$result = new CypherList( [
+			new CypherMap( [ 'name' => 'Ada', 'age' => 36, 'active' => true ] ),
+			new CypherMap( [ 'name' => 'Grace', 'age' => 85, 'active' => false ] ),
+		] );
+
+		$this->assertSame(
+			[
+				1 => [ 'name' => 'Ada', 'age' => 36, 'active' => true ],
+				2 => [ 'name' => 'Grace', 'age' => 85, 'active' => false ],
+			],
+			$this->newConverter()->convertRows( $result )
+		);
+	}
+
+	public function testNullsArePreserved(): void {
+		$result = new CypherList( [ new CypherMap( [ 'name' => null ] ) ] );
+
+		$this->assertSame(
+			[ 1 => [ 'name' => null ] ],
+			$this->newConverter()->convertRows( $result )
+		);
+	}
+
+	public function testNestedCypherListBecomesOneIndexedArray(): void {
+		$result = new CypherList( [
+			new CypherMap( [
+				'tags' => new CypherList( [ 'alpha', 'beta', 'gamma' ] ),
+			] ),
+		] );
+
+		$this->assertSame(
+			[ 1 => [ 'tags' => [ 1 => 'alpha', 2 => 'beta', 3 => 'gamma' ] ] ],
+			$this->newConverter()->convertRows( $result )
+		);
+	}
+
+	public function testNestedCypherMapBecomesStringKeyedArray(): void {
+		$result = new CypherList( [
+			new CypherMap( [
+				'props' => new CypherMap( [ 'city' => 'Berlin', 'founded' => 2019 ] ),
+			] ),
+		] );
+
+		$this->assertSame(
+			[ 1 => [ 'props' => [ 'city' => 'Berlin', 'founded' => 2019 ] ] ],
+			$this->newConverter()->convertRows( $result )
+		);
+	}
+
+	public function testNodeIsConvertedWithIdLabelsAndProperties(): void {
+		$node = new Node(
+			42,
+			new CypherList( [ 'Person', 'Employee' ] ),
+			new CypherMap( [ 'name' => 'Ada', 'age' => 36 ] ),
+			null
+		);
+
+		$this->assertSame(
+			[ 1 => [ 'node' => [
+				'id' => 42,
+				'labels' => [ 1 => 'Person', 2 => 'Employee' ],
+				'properties' => [ 'name' => 'Ada', 'age' => 36 ],
+			] ] ],
+			$this->newConverter()->convertRows(
+				new CypherList( [ new CypherMap( [ 'node' => $node ] ) ] )
+			)
+		);
+	}
+
+	public function testRelationshipIsConvertedWithEndpointsAndType(): void {
+		$rel = new Relationship(
+			7,
+			1,
+			2,
+			'KNOWS',
+			new CypherMap( [ 'since' => 2020 ] ),
+			null
+		);
+
+		$this->assertSame(
+			[ 1 => [ 'r' => [
+				'id' => 7,
+				'type' => 'KNOWS',
+				'startNodeId' => 1,
+				'endNodeId' => 2,
+				'properties' => [ 'since' => 2020 ],
+			] ] ],
+			$this->newConverter()->convertRows(
+				new CypherList( [ new CypherMap( [ 'r' => $rel ] ) ] )
+			)
+		);
+	}
+
+	public function testUnboundRelationshipHasNoEndpoints(): void {
+		$rel = new UnboundRelationship(
+			3,
+			'TAGGED',
+			new CypherMap( [ 'weight' => 0.5 ] ),
+			null
+		);
+
+		$this->assertSame(
+			[ 1 => [ 'r' => [
+				'id' => 3,
+				'type' => 'TAGGED',
+				'properties' => [ 'weight' => 0.5 ],
+			] ] ],
+			$this->newConverter()->convertRows(
+				new CypherList( [ new CypherMap( [ 'r' => $rel ] ) ] )
+			)
+		);
+	}
+
+	public function testPathBecomesNodesAndRelationships(): void {
+		$nodeA = new Node( 1, new CypherList( [ 'A' ] ), new CypherMap( [] ), null );
+		$nodeB = new Node( 2, new CypherList( [ 'B' ] ), new CypherMap( [] ), null );
+		$rel = new UnboundRelationship( 9, 'R', new CypherMap( [] ), null );
+
+		$path = new Path(
+			new CypherList( [ $nodeA, $nodeB ] ),
+			new CypherList( [ $rel ] ),
+			new CypherList( [] ),
+		);
+
+		$converted = $this->newConverter()->convertRows(
+			new CypherList( [ new CypherMap( [ 'p' => $path ] ) ] )
+		);
+
+		$this->assertSame(
+			[
+				1 => [ 'id' => 1, 'labels' => [ 1 => 'A' ], 'properties' => [] ],
+				2 => [ 'id' => 2, 'labels' => [ 1 => 'B' ], 'properties' => [] ],
+			],
+			$converted[1]['p']['nodes']
+		);
+		$this->assertSame( 9, $converted[1]['p']['relationships'][1]['id'] );
+	}
+
+	public function testDateBecomesToArrayShape(): void {
+		$result = new CypherList( [
+			new CypherMap( [ 'd' => new Date( 19500 ) ] ),
+		] );
+
+		$this->assertSame(
+			[ 1 => [ 'd' => [ 'days' => 19500 ] ] ],
+			$this->newConverter()->convertRows( $result )
+		);
+	}
+
+	public function testDateTimeBecomesToArrayShape(): void {
+		$result = new CypherList( [
+			new CypherMap( [ 'dt' => new Neo4jDateTime( 1700000000, 123456789, 3600, false ) ] ),
+		] );
+
+		$this->assertSame(
+			[ 1 => [ 'dt' => [
+				'seconds' => 1700000000,
+				'nanoseconds' => 123456789,
+				'tzOffsetSeconds' => 3600,
+			] ] ],
+			$this->newConverter()->convertRows( $result )
+		);
+	}
+
+	public function testDurationBecomesToArrayShape(): void {
+		$result = new CypherList( [
+			new CypherMap( [ 'dur' => new Duration( 2, 15, 30, 0 ) ] ),
+		] );
+
+		$this->assertSame(
+			[ 1 => [ 'dur' => [
+				'months' => 2,
+				'days' => 15,
+				'seconds' => 30,
+				'nanoseconds' => 0,
+			] ] ],
+			$this->newConverter()->convertRows( $result )
+		);
+	}
+
+	public function testCartesianPointBecomesToArrayShape(): void {
+		$result = new CypherList( [
+			new CypherMap( [ 'p' => new CartesianPoint( 1.0, 2.0, 7203 ) ] ),
+		] );
+
+		$converted = $this->newConverter()->convertRows( $result );
+
+		$this->assertSame( 7203, $converted[1]['p']['srid'] );
+		$this->assertSame( 1.0, $converted[1]['p']['x'] );
+		$this->assertSame( 2.0, $converted[1]['p']['y'] );
+	}
+
+	public function testUnknownObjectTypeThrows(): void {
+		$result = new CypherList( [ new CypherMap( [ 'mystery' => new stdClass() ] ) ] );
+
+		$this->expectException( RuntimeException::class );
+		$this->newConverter()->convertRows( $result );
+	}
+
+}

--- a/tests/phpunit/EntryPoints/Scribunto/NeoWikiLibraryTests.lua
+++ b/tests/phpunit/EntryPoints/Scribunto/NeoWikiLibraryTests.lua
@@ -85,6 +85,28 @@ local function testGetChildSubjectsEmptyForPageWithoutChildren()
 	return #children
 end
 
+-- query tests
+
+local function testQueryRejectsEmptyString()
+	local ok = pcall( function()
+		return nw.query( '' )
+	end )
+	if ok then
+		return 'unexpected success'
+	end
+	return 'error'
+end
+
+local function testQueryRejectsWriteQuery()
+	local ok = pcall( function()
+		return nw.query( 'CREATE (n:Foo) RETURN n' )
+	end )
+	if ok then
+		return 'unexpected success'
+	end
+	return 'error'
+end
+
 local tests = {
 	-- getValue
 	{ name = 'getValue returns string value',
@@ -125,6 +147,12 @@ local tests = {
 	  func = testGetChildSubjectsHasLabels, expect = { 'Child Entry', 'Entry' } },
 	{ name = 'getChildSubjects returns empty for page without children',
 	  func = testGetChildSubjectsEmptyForPageWithoutChildren, expect = { 0 } },
+
+	-- query
+	{ name = 'query rejects empty string',
+	  func = testQueryRejectsEmptyString, expect = { 'error' } },
+	{ name = 'query rejects write query',
+	  func = testQueryRejectsWriteQuery, expect = { 'error' } },
 
 }
 


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/736

## Summary

Adds `mw.neowiki.query(cypher, params)` — a read-only Cypher query function for Lua templates. Each row comes back as a Lua table keyed by the Cypher `RETURN` aliases.

```lua
local rows = nw.query(
    'MATCH (s:Subject {schema: $schema}) WHERE s.`Valid` = $valid RETURN s.name, s.`Expiry date`',
    { schema = 'ISMS Document', valid = 'Yes' }
)
```

- Parameterised queries (no string concatenation).
- Read-only: write/non-read-only queries rejected via the existing `CypherQueryValidator`.
- Always counts as an expensive parser function.
- Errors throw — wrap in `pcall` for graceful degradation.

## What's inside

- Extends `QueryEngine::runReadQuery()` to accept `array $parameters = []`.
- New `CypherResultConverter` that walks Laudis result types (Node, Relationship, Path, temporal, point) into Lua-ready PHP arrays.
- New `CypherQueryRunner` to orchestrate validation → execution → conversion.
- Wires `nw.query` into `ScribuntoLuaLibrary` and `mw.neowiki.lua`.
- Unit tests for converter (16) and runner (6); Lua-side error-path integration tests.
- Full `nw.query` section in `docs/LuaAPI.md`.
- Demo additions in `DemoData/Module/NeoWikiDemo.lua` + `DemoData/Page/Lua_Data_Access.wikitext`.

## Test plan

- [x] `make cs` green
- [x] `make phpunit filter=CypherResultConverterTest` (16/16)
- [x] `make phpunit filter=CypherQueryRunnerTest` (6/6)
- [x] `make phpunit` full suite

## Manual Browser Check

For human reviewers — confirm the demo renders correctly on the wiki:

1. From the repo root, run `make import-demo-data` to load the updated `Module:NeoWikiDemo` and the new `Lua_Data_Access` page content.
2. Open http://localhost:8484/index.php/Lua_Data_Access in a browser.
3. Scroll to the **Running Cypher Queries** section.
4. Verify the *Listing all Companies* sub-section shows a wikitable with two rows (`ACME Inc.` and `Professional Wiki GmbH`) and columns `n.id` and `n.name`.
5. Verify the *Parameterised query: Products available since a given year* sub-section shows a wikitable with four rows (`Bar 2010`, `Baz 2015`, `ProWiki 2022`, `NeoWiki 2023`) and columns `name` and `year`.
6. Confirm no `Script error` boxes appear anywhere on the page.