### PR TITLE
Add nw.getSchema() Lua API for schema introspection

### DIFF
--- a/DemoData/Module/NeoWikiDemo.lua
+++ b/DemoData/Module/NeoWikiDemo.lua
@@ -84,4 +84,60 @@ function p.children( frame )
 	return table.concat( parts, ', ' )
 end
 
+function p.schema( frame )
+	local schemaName = frame.args[1]
+	local schema = nw.getSchema( schemaName )
+
+	if not schema then
+		return 'Schema not found'
+	end
+
+	local rows = {}
+	rows[#rows + 1] = '{| class="wikitable"'
+	rows[#rows + 1] = '! Name !! Type !! Required !! Details'
+
+	for _, prop in ipairs( schema.properties ) do
+		local required = prop.required and 'Yes' or 'No'
+		local details = {}
+
+		if prop.type == 'select' and prop.options then
+			local opts = {}
+			for _, o in ipairs( prop.options ) do
+				opts[#opts + 1] = o
+			end
+			details[#details + 1] = 'options: ' .. table.concat( opts, ', ' )
+		elseif prop.type == 'number' then
+			if prop.minimum ~= nil then
+				details[#details + 1] = 'min: ' .. tostring( prop.minimum )
+			end
+			if prop.maximum ~= nil then
+				details[#details + 1] = 'max: ' .. tostring( prop.maximum )
+			end
+			if prop.precision ~= nil then
+				details[#details + 1] = 'precision: ' .. tostring( prop.precision )
+			end
+		elseif prop.type == 'relation' then
+			if prop.targetSchema then
+				details[#details + 1] = 'targetSchema: ' .. prop.targetSchema
+			end
+			if prop.relation then
+				details[#details + 1] = 'relation: ' .. prop.relation
+			end
+		elseif prop.type == 'text' or prop.type == 'url' then
+			if prop.multiple then
+				details[#details + 1] = 'multiple: true'
+			end
+			if prop.uniqueItems then
+				details[#details + 1] = 'uniqueItems: true'
+			end
+		end
+
+		rows[#rows + 1] = '|-'
+		rows[#rows + 1] = '| ' .. prop.name .. ' || ' .. prop.type .. ' || ' .. required .. ' || ' .. table.concat( details, ', ' )
+	end
+
+	rows[#rows + 1] = '|}'
+	return table.concat( rows, '\n' )
+end
+
 return p

--- a/DemoData/Module/NeoWikiDemo.lua
+++ b/DemoData/Module/NeoWikiDemo.lua
@@ -100,12 +100,8 @@ function p.schema( frame )
 		local required = prop.required and 'Yes' or 'No'
 		local details = {}
 
-		if prop.type == 'select' and prop.options then
-			local opts = {}
-			for _, o in ipairs( prop.options ) do
-				opts[#opts + 1] = o
-			end
-			details[#details + 1] = 'options: ' .. table.concat( opts, ', ' )
+		if prop.type == 'select' then
+			details[#details + 1] = 'options: ' .. table.concat( prop.options, ', ' )
 		elseif prop.type == 'number' then
 			if prop.minimum ~= nil then
 				details[#details + 1] = 'min: ' .. tostring( prop.minimum )
@@ -117,12 +113,8 @@ function p.schema( frame )
 				details[#details + 1] = 'precision: ' .. tostring( prop.precision )
 			end
 		elseif prop.type == 'relation' then
-			if prop.targetSchema then
-				details[#details + 1] = 'targetSchema: ' .. prop.targetSchema
-			end
-			if prop.relation then
-				details[#details + 1] = 'relation: ' .. prop.relation
-			end
+			details[#details + 1] = 'targetSchema: ' .. prop.targetSchema
+			details[#details + 1] = 'relation: ' .. prop.relation
 		elseif prop.type == 'text' or prop.type == 'url' then
 			if prop.multiple then
 				details[#details + 1] = 'multiple: true'

--- a/DemoData/Page/Lua_Data_Access.wikitext
+++ b/DemoData/Page/Lua_Data_Access.wikitext
@@ -34,6 +34,18 @@ The examples use [[Module:NeoWikiDemo]], a demo module included with NeoWiki.
 
 Child subjects on [[ACME Inc]]: {{#invoke:NeoWikiDemo|children|ACME Inc}}
 
+== Inspecting a Schema ==
+
+<code>mw.neowiki.getSchema()</code> returns a Schema definition as a Lua table, including all property names, types, and type-specific attributes. This enables templates to render or validate any schema without hardcoding property names.
+
+=== Company ===
+
+{{#invoke:NeoWikiDemo|schema|Company}}
+
+=== Employee ===
+
+{{#invoke:NeoWikiDemo|schema|Employee}}
+
 == Module Source ==
 
 The demo module uses these <code>mw.neowiki</code> functions:

--- a/docs/LuaAPI.md
+++ b/docs/LuaAPI.md
@@ -12,6 +12,7 @@ enough.
 | Get a page's Main Subject (label, schema, all properties) | [`nw.getMainSubject`](#nwgetmainsubjectpagename) |
 | Get a Subject by its ID, regardless of which page it's on | [`nw.getSubject`](#nwgetsubjectsubjectid) |
 | List all Child Subjects on a page | [`nw.getChildSubjects`](#nwgetchildsubjectspagename) |
+| Inspect a Schema | [`nw.getSchema`](#nwgetschemaname) |
 
 For definitions of terms like Subject, Schema, and Statement, see the [Glossary](Glossary.md).
 
@@ -157,6 +158,68 @@ for _, child in ipairs(children) do
 end
 ```
 
+### `nw.getSchema(name)`
+
+Returns the definition of a Schema as a Lua table, including all its Property Definitions.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | Required. The name of the Schema (e.g. `'Company'`). |
+
+#### Returns
+
+A table with the following fields, or `nil` if the Schema does not exist:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | The Schema name. |
+| `description` | string | Present only when the description is non-empty. |
+| `properties` | table | 1-indexed list of property tables, in schema-defined order. |
+
+Each entry in `properties` always contains `name`, `type`, and `required`. Additional fields depend
+on the property type:
+
+| Type | Always present | Present when set |
+|------|----------------|------------------|
+| `text` | `name`, `type`, `required`, `multiple`, `uniqueItems` | `description`, `default` |
+| `url` | `name`, `type`, `required`, `multiple`, `uniqueItems` | `description`, `default` |
+| `number` | `name`, `type`, `required` | `description`, `default`, `precision`, `minimum`, `maximum` |
+| `select` | `name`, `type`, `required`, `multiple`, `options` (1-indexed list) | `description`, `default` |
+| `relation` | `name`, `type`, `required`, `multiple`, `relation`, `targetSchema` | `description`, `default` |
+
+Optional fields are **omitted** from the returned table when empty or unset. Check for presence
+before using them: `if prop.description then ... end`.
+
+#### Error behaviour
+
+| Case | Behaviour |
+|------|-----------|
+| `name` missing or not a string | Raises a Lua error |
+| Schema does not exist | Returns `nil` |
+
+#### Performance note
+
+Always counts as an expensive parser function (against the page's expensive function limit).
+
+#### Examples
+
+```lua
+-- Basic: fetch a schema and read its first property name
+local schema = nw.getSchema('Company')
+-- schema.name             --> "Company"
+-- schema.properties[1].name  --> first property name
+```
+
+```lua
+-- Generic: list all properties of this page's main subject schema
+local subject = nw.getMainSubject()
+local schema = nw.getSchema(subject.schema)
+
+for _, prop in ipairs(schema.properties) do
+    mw.log(prop.name .. ' (' .. prop.type .. ')')
+end
+```
+
 ## Subject table format
 
 Subject tables returned by `getMainSubject`, `getSubject`, and `getChildSubjects` have this
@@ -206,8 +269,6 @@ The following are not yet implemented:
 
 - `nw.query(cypher, params)` — Execute Cypher queries from Lua. Tracked in
   [#736](https://github.com/ProfessionalWiki/NeoWiki/issues/736).
-- `nw.getSchema(name)` — Schema introspection for generic templates. Tracked in
-  [#737](https://github.com/ProfessionalWiki/NeoWiki/issues/737).
 
 ## Related Documentation
 

--- a/docs/LuaAPI.md
+++ b/docs/LuaAPI.md
@@ -188,7 +188,12 @@ on the property type:
 | `relation` | `name`, `type`, `required`, `multiple`, `relation`, `targetSchema` | `description`, `default` |
 
 Optional fields are **omitted** from the returned table when empty or unset. Check for presence
-before using them: `if prop.description then ... end`.
+before using them: `if prop.description then ... end`. Boolean fields in the "always present"
+column (such as `required`, `multiple`, `uniqueItems`) are always emitted, including when
+`false` — compare the value directly, don't check for presence.
+
+The `Schema does not exist` case also covers an empty/whitespace-only name or a reserved name
+(`page`, `subject`); all of these return `nil` rather than erroring.
 
 #### Error behaviour
 

--- a/src/Domain/Schema/Property/SelectProperty.php
+++ b/src/Domain/Schema/Property/SelectProperty.php
@@ -57,7 +57,7 @@ class SelectProperty extends PropertyDefinition {
 		);
 	}
 
-	protected function nonCoreToJson(): array {
+	public function nonCoreToJson(): array {
 		return [
 			'options' => $this->getOptions(),
 			'multiple' => $this->allowsMultipleValues(),

--- a/src/Domain/Schema/PropertyDefinition.php
+++ b/src/Domain/Schema/PropertyDefinition.php
@@ -48,7 +48,7 @@ abstract class PropertyDefinition {
 		);
 	}
 
-	abstract protected function nonCoreToJson(): array;
+	abstract public function nonCoreToJson(): array;
 
 	/**
 	 * @throws InvalidArgumentException

--- a/src/Domain/Schema/PropertyDefinition.php
+++ b/src/Domain/Schema/PropertyDefinition.php
@@ -48,6 +48,13 @@ abstract class PropertyDefinition {
 		);
 	}
 
+	/**
+	 * Type-specific fields beyond the common core (type/description/required/default).
+	 *
+	 * @internal Public only so that PHP-side serializers (REST `toJson`, the Lua
+	 * `SchemaLuaSerializer`, and persistence) can share one extension point per type.
+	 * Not intended as a general UI-layer API.
+	 */
 	abstract public function nonCoreToJson(): array;
 
 	/**

--- a/src/EntryPoints/Scribunto/SchemaLuaSerializer.php
+++ b/src/EntryPoints/Scribunto/SchemaLuaSerializer.php
@@ -1,0 +1,77 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\EntryPoints\Scribunto;
+
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinition;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
+
+class SchemaLuaSerializer {
+
+	public function toLuaTable( Schema $schema ): array {
+		$result = [ 'name' => $schema->getName()->getText() ];
+
+		$description = $schema->getDescription();
+		if ( $description !== '' ) {
+			$result['description'] = $description;
+		}
+
+		$result['properties'] = $this->propertiesToLuaList( $schema );
+		return $result;
+	}
+
+	private function propertiesToLuaList( Schema $schema ): array {
+		$properties = [];
+		$index = 1;
+		foreach ( $schema->getAllProperties()->asMap() as $name => $property ) {
+			$properties[$index] = $this->propertyToLuaTable( $name, $property );
+			$index++;
+		}
+		return $properties;
+	}
+
+	private function propertyToLuaTable( string $name, PropertyDefinition $property ): array {
+		$entry = [
+			'name' => $name,
+			'type' => $property->getPropertyType(),
+			'required' => $property->isRequired(),
+		];
+
+		$description = $property->getDescription();
+		if ( $description !== '' ) {
+			$entry['description'] = $description;
+		}
+
+		if ( $property->hasDefault() ) {
+			$entry['default'] = $property->getDefault();
+		}
+
+		return $entry + $this->normalise( $property->nonCoreToJson() );
+	}
+
+	private function normalise( array $values ): array {
+		$result = [];
+		foreach ( $values as $key => $value ) {
+			if ( $value === null || $value === '' ) {
+				continue;
+			}
+			if ( is_array( $value ) ) {
+				$value = $this->normalise( $value );
+				if ( $this->isZeroIndexedList( $value ) ) {
+					$value = array_combine( range( 1, count( $value ) ), array_values( $value ) );
+				}
+			}
+			$result[$key] = $value;
+		}
+		return $result;
+	}
+
+	private function isZeroIndexedList( array $value ): bool {
+		if ( $value === [] ) {
+			return false;
+		}
+		return array_is_list( $value );
+	}
+
+}

--- a/src/EntryPoints/Scribunto/SchemaLuaSerializer.php
+++ b/src/EntryPoints/Scribunto/SchemaLuaSerializer.php
@@ -51,6 +51,10 @@ class SchemaLuaSerializer {
 	}
 
 	private function normalise( array $values ): array {
+		// If the input is a 0-indexed PHP list, filtering may leave holes; compact
+		// and re-index to 1-based at the end so Lua's ipairs() works.
+		$inputWasList = $values !== [] && array_is_list( $values );
+
 		$result = [];
 		foreach ( $values as $key => $value ) {
 			if ( $value === null || $value === '' ) {
@@ -58,20 +62,16 @@ class SchemaLuaSerializer {
 			}
 			if ( is_array( $value ) ) {
 				$value = $this->normalise( $value );
-				if ( $this->isZeroIndexedList( $value ) ) {
-					$value = array_combine( range( 1, count( $value ) ), array_values( $value ) );
-				}
 			}
 			$result[$key] = $value;
 		}
-		return $result;
-	}
 
-	private function isZeroIndexedList( array $value ): bool {
-		if ( $value === [] ) {
-			return false;
+		if ( $inputWasList && $result !== [] ) {
+			$compact = array_values( $result );
+			return array_combine( range( 1, count( $compact ) ), $compact );
 		}
-		return array_is_list( $value );
+
+		return $result;
 	}
 
 }

--- a/src/EntryPoints/Scribunto/ScribuntoLuaLibrary.php
+++ b/src/EntryPoints/Scribunto/ScribuntoLuaLibrary.php
@@ -6,11 +6,13 @@ namespace ProfessionalWiki\NeoWiki\EntryPoints\Scribunto;
 
 use MediaWiki\Extension\Scribunto\Engines\LuaCommon\LibraryBase;
 use ProfessionalWiki\NeoWiki\Application\SubjectResolver;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 
 class ScribuntoLuaLibrary extends LibraryBase {
 
 	private ?SubjectDataLookup $subjectDataLookup = null;
+	private ?SchemaLuaSerializer $schemaLuaSerializer = null;
 
 	private function getSubjectDataLookup(): SubjectDataLookup {
 		if ( $this->subjectDataLookup === null ) {
@@ -27,6 +29,13 @@ class ScribuntoLuaLibrary extends LibraryBase {
 		return $this->subjectDataLookup;
 	}
 
+	private function getSchemaLuaSerializer(): SchemaLuaSerializer {
+		if ( $this->schemaLuaSerializer === null ) {
+			$this->schemaLuaSerializer = new SchemaLuaSerializer();
+		}
+		return $this->schemaLuaSerializer;
+	}
+
 	public function register(): array {
 		$lib = [
 			'getValue' => [ $this, 'getValue' ],
@@ -34,6 +43,7 @@ class ScribuntoLuaLibrary extends LibraryBase {
 			'getMainSubject' => [ $this, 'getMainSubject' ],
 			'getSubject' => [ $this, 'getSubject' ],
 			'getChildSubjects' => [ $this, 'getChildSubjects' ],
+			'getSchema' => [ $this, 'getSchema' ],
 		];
 
 		return $this->getEngine()->registerInterface(
@@ -86,6 +96,21 @@ class ScribuntoLuaLibrary extends LibraryBase {
 		}
 
 		return $this->getSubjectDataLookup()->getChildSubjectsData( $this->getTitle(), $pageName );
+	}
+
+	public function getSchema( ?string $schemaName = null ): array {
+		$this->checkType( 'mw.neowiki.getSchema', 1, $schemaName, 'string' );
+		$this->incrementExpensiveFunctionCount();
+
+		$schema = NeoWikiExtension::getInstance()
+			->getSchemaLookup()
+			->getSchema( new SchemaName( $schemaName ) );
+
+		if ( $schema === null ) {
+			return [ null ];
+		}
+
+		return [ $this->getSchemaLuaSerializer()->toLuaTable( $schema ) ];
 	}
 
 }

--- a/src/EntryPoints/Scribunto/ScribuntoLuaLibrary.php
+++ b/src/EntryPoints/Scribunto/ScribuntoLuaLibrary.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\EntryPoints\Scribunto;
 
+use InvalidArgumentException;
 use MediaWiki\Extension\Scribunto\Engines\LuaCommon\LibraryBase;
 use ProfessionalWiki\NeoWiki\Application\SubjectResolver;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
@@ -102,9 +103,13 @@ class ScribuntoLuaLibrary extends LibraryBase {
 		$this->checkType( 'mw.neowiki.getSchema', 1, $schemaName, 'string' );
 		$this->incrementExpensiveFunctionCount();
 
-		$schema = NeoWikiExtension::getInstance()
-			->getSchemaLookup()
-			->getSchema( new SchemaName( $schemaName ) );
+		try {
+			$name = new SchemaName( $schemaName );
+		} catch ( InvalidArgumentException ) {
+			return [ null ];
+		}
+
+		$schema = NeoWikiExtension::getInstance()->getSchemaLookup()->getSchema( $name );
 
 		if ( $schema === null ) {
 			return [ null ];

--- a/src/EntryPoints/Scribunto/mw.neowiki.lua
+++ b/src/EntryPoints/Scribunto/mw.neowiki.lua
@@ -32,4 +32,8 @@ function neowiki.getChildSubjects( pageName )
 	return php.getChildSubjects( pageName )
 end
 
+function neowiki.getSchema( name )
+	return php.getSchema( name )
+end
+
 return neowiki

--- a/tests/RedHerb/src/ColorProperty.php
+++ b/tests/RedHerb/src/ColorProperty.php
@@ -21,7 +21,7 @@ class ColorProperty extends PropertyDefinition {
 		return new self( core: $core );
 	}
 
-	protected function nonCoreToJson(): array {
+	public function nonCoreToJson(): array {
 		return [];
 	}
 

--- a/tests/RedHerb/src/DateTimeProperty.php
+++ b/tests/RedHerb/src/DateTimeProperty.php
@@ -45,7 +45,7 @@ class DateTimeProperty extends PropertyDefinition {
 		);
 	}
 
-	protected function nonCoreToJson(): array {
+	public function nonCoreToJson(): array {
 		return [
 			'minimum' => $this->getMinimum(),
 			'maximum' => $this->getMaximum(),

--- a/tests/phpunit/EntryPoints/Scribunto/NeoWikiLibraryTestBase.php
+++ b/tests/phpunit/EntryPoints/Scribunto/NeoWikiLibraryTestBase.php
@@ -24,7 +24,9 @@ use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectMap;
 use ProfessionalWiki\NeoWiki\Domain\Value\NumberValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
+use ProfessionalWiki\NeoWiki\EntryPoints\Content\SchemaContent;
 use ProfessionalWiki\NeoWiki\EntryPoints\Content\SubjectContent;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\MediaWikiSubjectRepository;
 
 /**
@@ -56,6 +58,29 @@ abstract class NeoWikiLibraryTestBase extends LuaEngineTestBase {
 	}
 
 	private function createTestData(): void {
+		$this->createSchemaPage( 'Employee', json_encode( [
+			'description' => 'A person employed by a company',
+			'propertyDefinitions' => [
+				'LegalName' => [ 'type' => 'text', 'required' => true ],
+				'EmploymentFte' => [
+					'type' => 'number',
+					'minimum' => 0,
+					'maximum' => 100,
+					'default' => 100,
+				],
+				'Status' => [
+					'type' => 'select',
+					'required' => true,
+					'options' => [ 'Active', 'Inactive', 'On leave' ],
+				],
+				'Employer' => [
+					'type' => 'relation',
+					'relation' => 'Works for',
+					'targetSchema' => 'Company',
+				],
+			],
+		] ) );
+
 		$this->createPageWithSubjects(
 			'NeoWikiLuaTestPage',
 			mainSubject: new Subject(
@@ -89,6 +114,16 @@ abstract class NeoWikiLibraryTestBase extends LuaEngineTestBase {
 				),
 			),
 		);
+	}
+
+	private function createSchemaPage( string $name, string $json ): void {
+		$wikiPage = MediaWikiServices::getInstance()->getWikiPageFactory()->newFromTitle(
+			Title::newFromText( $name, NeoWikiExtension::NS_SCHEMA )
+		);
+
+		$updater = $wikiPage->newPageUpdater( $this->getTestSysop()->getUser() );
+		$updater->setContent( 'main', new SchemaContent( $json ) );
+		$updater->saveRevision( CommentStoreComment::newUnsavedComment( 'Lua test data' ) );
 	}
 
 	private function createPageWithSubjects(

--- a/tests/phpunit/EntryPoints/Scribunto/NeoWikiLibraryTests.lua
+++ b/tests/phpunit/EntryPoints/Scribunto/NeoWikiLibraryTests.lua
@@ -115,6 +115,36 @@ local function testGetSchemaReturnsNilForMissingSchema()
 	return nw.getSchema( 'NopeDoesNotExist' )
 end
 
+local function testGetSchemaReturnsNilForEmptyString()
+	return nw.getSchema( '' )
+end
+
+local function testGetSchemaReturnsNilForReservedName()
+	return nw.getSchema( 'page' )
+end
+
+local function testGetSchemaNumberPropertyBoundsAndDefault()
+	local s = nw.getSchema( 'Employee' )
+	if not s then return 'nil' end
+	for _, p in ipairs( s.properties ) do
+		if p.name == 'EmploymentFte' then
+			return p.type, p.minimum, p.maximum, p.default
+		end
+	end
+	return 'not-found'
+end
+
+local function testGetSchemaRelationPropertyTargetSchema()
+	local s = nw.getSchema( 'Employee' )
+	if not s then return 'nil' end
+	for _, p in ipairs( s.properties ) do
+		if p.name == 'Employer' then
+			return p.type, p.relation, p.targetSchema
+		end
+	end
+	return 'not-found'
+end
+
 local tests = {
 	-- getValue
 	{ name = 'getValue returns string value',
@@ -165,6 +195,14 @@ local tests = {
 	  func = testGetSchemaSelectOptionsAreOneIndexed, expect = { 'Active', 'On leave' } },
 	{ name = 'getSchema returns nil for missing schema',
 	  func = testGetSchemaReturnsNilForMissingSchema, expect = { nil } },
+	{ name = 'getSchema returns nil for empty string',
+	  func = testGetSchemaReturnsNilForEmptyString, expect = { nil } },
+	{ name = 'getSchema returns nil for reserved name',
+	  func = testGetSchemaReturnsNilForReservedName, expect = { nil } },
+	{ name = 'getSchema number property exposes bounds and default',
+	  func = testGetSchemaNumberPropertyBoundsAndDefault, expect = { 'number', 0, 100, 100 } },
+	{ name = 'getSchema relation property exposes relation and targetSchema',
+	  func = testGetSchemaRelationPropertyTargetSchema, expect = { 'relation', 'Works for', 'Company' } },
 
 }
 

--- a/tests/phpunit/EntryPoints/Scribunto/NeoWikiLibraryTests.lua
+++ b/tests/phpunit/EntryPoints/Scribunto/NeoWikiLibraryTests.lua
@@ -85,6 +85,36 @@ local function testGetChildSubjectsEmptyForPageWithoutChildren()
 	return #children
 end
 
+-- getSchema tests
+
+local function testGetSchemaReturnsNameAndPropertyCount()
+	local s = nw.getSchema( 'Employee' )
+	if not s then return 'nil' end
+	return s.name, #s.properties
+end
+
+local function testGetSchemaPropertyShape()
+	local s = nw.getSchema( 'Employee' )
+	if not s then return 'nil' end
+	local p = s.properties[1]
+	return p.name, p.type, p.required
+end
+
+local function testGetSchemaSelectOptionsAreOneIndexed()
+	local s = nw.getSchema( 'Employee' )
+	if not s then return 'nil' end
+	for _, p in ipairs( s.properties ) do
+		if p.name == 'Status' then
+			return p.options[1], p.options[3]
+		end
+	end
+	return 'not-found'
+end
+
+local function testGetSchemaReturnsNilForMissingSchema()
+	return nw.getSchema( 'NopeDoesNotExist' )
+end
+
 local tests = {
 	-- getValue
 	{ name = 'getValue returns string value',
@@ -125,6 +155,16 @@ local tests = {
 	  func = testGetChildSubjectsHasLabels, expect = { 'Child Entry', 'Entry' } },
 	{ name = 'getChildSubjects returns empty for page without children',
 	  func = testGetChildSubjectsEmptyForPageWithoutChildren, expect = { 0 } },
+
+	-- getSchema
+	{ name = 'getSchema returns name and property count',
+	  func = testGetSchemaReturnsNameAndPropertyCount, expect = { 'Employee', 4 } },
+	{ name = 'getSchema first property shape',
+	  func = testGetSchemaPropertyShape, expect = { 'LegalName', 'text', true } },
+	{ name = 'getSchema select options are one-indexed',
+	  func = testGetSchemaSelectOptionsAreOneIndexed, expect = { 'Active', 'On leave' } },
+	{ name = 'getSchema returns nil for missing schema',
+	  func = testGetSchemaReturnsNilForMissingSchema, expect = { nil } },
 
 }
 

--- a/tests/phpunit/EntryPoints/Scribunto/SchemaLuaSerializerTest.php
+++ b/tests/phpunit/EntryPoints/Scribunto/SchemaLuaSerializerTest.php
@@ -1,0 +1,213 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\Scribunto;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinitions;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Property\NumberProperty;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Property\RelationProperty;
+use ProfessionalWiki\NeoWiki\Domain\Relation\RelationType;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Property\SelectProperty;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Property\TextProperty;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Property\UrlProperty;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\EntryPoints\Scribunto\SchemaLuaSerializer;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\Scribunto\SchemaLuaSerializer
+ */
+class SchemaLuaSerializerTest extends TestCase {
+
+	private function newSerializer(): SchemaLuaSerializer {
+		return new SchemaLuaSerializer();
+	}
+
+	private function coreRequired(): PropertyCore {
+		return new PropertyCore( description: '', required: true, default: null );
+	}
+
+	private function coreOptional(): PropertyCore {
+		return new PropertyCore( description: '', required: false, default: null );
+	}
+
+	public function testEmptySchema(): void {
+		$schema = new Schema(
+			new SchemaName( 'Empty' ),
+			'',
+			new PropertyDefinitions( [] )
+		);
+
+		$this->assertSame(
+			[ 'name' => 'Empty', 'properties' => [] ],
+			$this->newSerializer()->toLuaTable( $schema )
+		);
+	}
+
+	public function testSchemaWithDescription(): void {
+		$schema = new Schema(
+			new SchemaName( 'Doc' ),
+			'Describes a document',
+			new PropertyDefinitions( [] )
+		);
+
+		$result = $this->newSerializer()->toLuaTable( $schema );
+
+		$this->assertSame( 'Describes a document', $result['description'] );
+	}
+
+	public function testTextPropertyMinimal(): void {
+		$schema = $this->schemaWith( [
+			'LegalName' => new TextProperty( $this->coreRequired(), multiple: false, uniqueItems: false ),
+		] );
+
+		$this->assertSame(
+			[
+				1 => [
+					'name' => 'LegalName',
+					'type' => 'text',
+					'required' => true,
+					'multiple' => false,
+					'uniqueItems' => false,
+				],
+			],
+			$this->newSerializer()->toLuaTable( $schema )['properties']
+		);
+	}
+
+	public function testTextPropertyWithDescriptionAndDefault(): void {
+		$core = new PropertyCore( description: 'City of residence', required: false, default: 'Berlin' );
+		$schema = $this->schemaWith( [
+			'City' => new TextProperty( $core, multiple: false, uniqueItems: false ),
+		] );
+
+		$prop = $this->newSerializer()->toLuaTable( $schema )['properties'][1];
+
+		$this->assertSame( 'City of residence', $prop['description'] );
+		$this->assertSame( 'Berlin', $prop['default'] );
+	}
+
+	public function testTextPropertyMultipleAndUniqueItems(): void {
+		$schema = $this->schemaWith( [
+			'Skills' => new TextProperty( $this->coreOptional(), multiple: true, uniqueItems: true ),
+		] );
+
+		$prop = $this->newSerializer()->toLuaTable( $schema )['properties'][1];
+
+		$this->assertTrue( $prop['multiple'] );
+		$this->assertTrue( $prop['uniqueItems'] );
+	}
+
+	public function testUrlProperty(): void {
+		$schema = $this->schemaWith( [
+			'Homepage' => new UrlProperty( $this->coreOptional(), multiple: false, uniqueItems: false ),
+		] );
+
+		$prop = $this->newSerializer()->toLuaTable( $schema )['properties'][1];
+
+		$this->assertSame( 'url', $prop['type'] );
+		$this->assertArrayNotHasKey( 'description', $prop );
+		$this->assertArrayNotHasKey( 'default', $prop );
+	}
+
+	public function testNumberPropertyWithBounds(): void {
+		$schema = $this->schemaWith( [
+			'Score' => new NumberProperty(
+				$this->coreOptional(), precision: 2, minimum: 0, maximum: 100
+			),
+		] );
+
+		$this->assertSame(
+			[
+				1 => [
+					'name' => 'Score',
+					'type' => 'number',
+					'required' => false,
+					'precision' => 2,
+					'minimum' => 0,
+					'maximum' => 100,
+				],
+			],
+			$this->newSerializer()->toLuaTable( $schema )['properties']
+		);
+	}
+
+	public function testNumberPropertyWithoutBoundsOmitsKeys(): void {
+		$schema = $this->schemaWith( [
+			'Year' => new NumberProperty(
+				$this->coreOptional(), precision: null, minimum: null, maximum: null
+			),
+		] );
+
+		$prop = $this->newSerializer()->toLuaTable( $schema )['properties'][1];
+
+		$this->assertArrayNotHasKey( 'precision', $prop );
+		$this->assertArrayNotHasKey( 'minimum', $prop );
+		$this->assertArrayNotHasKey( 'maximum', $prop );
+	}
+
+	public function testSelectPropertyOptionsAreOneIndexed(): void {
+		$schema = $this->schemaWith( [
+			'Status' => new SelectProperty(
+				$this->coreRequired(),
+				options: [ 'Active', 'Inactive', 'Archived' ],
+				multiple: false
+			),
+		] );
+
+		$prop = $this->newSerializer()->toLuaTable( $schema )['properties'][1];
+
+		$this->assertSame(
+			[ 1 => 'Active', 2 => 'Inactive', 3 => 'Archived' ],
+			$prop['options']
+		);
+	}
+
+	public function testRelationProperty(): void {
+		$schema = $this->schemaWith( [
+			'Employer' => new RelationProperty(
+				$this->coreOptional(),
+				new RelationType( 'Works for' ),
+				new SchemaName( 'Company' ),
+				multiple: false
+			),
+		] );
+
+		$prop = $this->newSerializer()->toLuaTable( $schema )['properties'][1];
+
+		$this->assertSame( 'relation', $prop['type'] );
+		$this->assertSame( 'Works for', $prop['relation'] );
+		$this->assertSame( 'Company', $prop['targetSchema'] );
+		$this->assertFalse( $prop['multiple'] );
+	}
+
+	public function testPropertyOrderMatchesDefinitionOrder(): void {
+		$schema = $this->schemaWith( [
+			'Zeta'  => new TextProperty( $this->coreOptional(), multiple: false, uniqueItems: false ),
+			'Alpha' => new TextProperty( $this->coreOptional(), multiple: false, uniqueItems: false ),
+			'Mu'    => new TextProperty( $this->coreOptional(), multiple: false, uniqueItems: false ),
+		] );
+
+		$names = array_column(
+			$this->newSerializer()->toLuaTable( $schema )['properties'],
+			'name'
+		);
+
+		$this->assertSame( [ 'Zeta', 'Alpha', 'Mu' ], $names );
+	}
+
+	/**
+	 * @param array<string, \ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinition> $props
+	 */
+	private function schemaWith( array $props ): Schema {
+		return new Schema(
+			new SchemaName( 'Test' ),
+			'',
+			new PropertyDefinitions( $props )
+		);
+	}
+
+}

--- a/tests/phpunit/EntryPoints/Scribunto/SchemaLuaSerializerTest.php
+++ b/tests/phpunit/EntryPoints/Scribunto/SchemaLuaSerializerTest.php
@@ -6,6 +6,7 @@ namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\Scribunto;
 
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinition;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinitions;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\NumberProperty;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\RelationProperty;
@@ -182,6 +183,28 @@ class SchemaLuaSerializerTest extends TestCase {
 		$this->assertSame( 'Works for', $prop['relation'] );
 		$this->assertSame( 'Company', $prop['targetSchema'] );
 		$this->assertFalse( $prop['multiple'] );
+	}
+
+	public function testListWithNullGapIsCompactedAndOneIndexed(): void {
+		$property = new class( $this->coreOptional() ) extends PropertyDefinition {
+
+			public function getPropertyType(): string {
+				return 'fake';
+			}
+
+			public function nonCoreToJson(): array {
+				return [ 'items' => [ 'a', null, 'b', '', 'c' ] ];
+			}
+
+		};
+		$schema = $this->schemaWith( [ 'Fake' => $property ] );
+
+		$prop = $this->newSerializer()->toLuaTable( $schema )['properties'][1];
+
+		$this->assertSame(
+			[ 1 => 'a', 2 => 'b', 3 => 'c' ],
+			$prop['items']
+		);
 	}
 
 	public function testPropertyOrderMatchesDefinitionOrder(): void {


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/737

## Summary

Adds `mw.neowiki.getSchema(name)` — returns a Schema definition as a plain Lua table, enabling generic templates that render or validate any schema without hardcoding property names.

```lua
local schema = nw.getSchema('Employee')
-- schema.name                       = "Employee"
-- schema.properties[1].name         = "LegalName"
-- schema.properties[1].type         = "text"
-- schema.properties[1].required     = true
-- schema.properties[4].targetSchema = "Company"

for _, prop in ipairs(schema.properties) do
    mw.log(prop.name .. ' (' .. prop.type .. ')')
end
```

- Properties returned in schema-defined order as a 1-indexed list.
- Per-type attributes emitted from each `PropertyDefinition::nonCoreToJson()`, then filtered (policy B: `description = ''` / nullable type-specific fields dropped; `default` present only when `hasDefault()`).
- Returns `nil` for missing, empty, or reserved schema names.
- Always counts as an expensive parser function.

## What's inside

- New `SchemaLuaSerializer` with a recursive `normalise()` helper that applies policy B and re-indexes 0-indexed numeric arrays (so select `options` work with Lua's `ipairs`). Dispatch via `nonCoreToJson()` instead of `instanceof` — extension-added property types serialise automatically.
- `PropertyDefinition::nonCoreToJson()` visibility widened from `protected` to `public` and marked `@internal`.
- `ScribuntoLuaLibrary::getSchema(?string)` + lazy serializer getter + `neowiki.getSchema(name)` Lua wrapper.
- `SchemaLuaSerializerTest` — 12 unit tests covering each property type, policy B omissions, 1-indexing, ordering, and the list-with-null-hole case.
- Lua integration tests: seed an `Employee` schema, then 8 test cases (success path, missing/empty/reserved name, relation + number property shapes, select option indexing).
- Full `### nw.getSchema(name)` section in `docs/LuaAPI.md`.
- Demo: `p.schema` in `DemoData/Module/NeoWikiDemo.lua` + "Inspecting a Schema" section on `DemoData/Page/Lua_Data_Access.wikitext` rendering `Company` and `Employee`.

## Test plan

- [x] `make cs` green
- [x] `make phpunit filter=SchemaLuaSerializerTest` (12/12, 21 assertions)
- [x] `make phpunit` full suite

## Manual Browser Check

For human reviewers — confirm the demo renders correctly on the wiki:

1. From the repo root, run `make import-demo-data`.
2. If you just pulled fresh code, also restart MediaWiki to flush OPcache:
   `docker compose restart mediawiki`.
3. Open http://localhost:8484/index.php/Lua_Data_Access in a browser.
4. Scroll to the **Inspecting a Schema** section.
5. Verify the *Company* schema table shows rows for `Founded at`, `Websites`, `Main product`, `Products`, `Status`, `World domination progress` with the appropriate `Type`, `Required`, and `Details` columns — for example:
   - `Status` → `select`, `Yes`, `options: Active, Inactive, Acquired, Dissolved`
   - `Products` → `relation`, `No`, `targetSchema: Product, relation: Has product`
6. Verify the *Employee* schema table shows at least `LegalName`, `WorkEmail`, `EmploymentFte`, `Skills`, `Employer` with relation/number/text details.
7. Confirm no `Script error` boxes appear anywhere on the page.