### PR TITLE
Reindex subject pages in Neo4j after demo data import

### DIFF
--- a/maintenance/ImportDemoData.php
+++ b/maintenance/ImportDemoData.php
@@ -7,6 +7,7 @@ namespace ProfessionalWiki\NeoWiki\Maintenance;
 use FileFetcher\SimpleFileFetcher;
 use Maintenance;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
 use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\ImportPagesAction;
 use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\ImportPresenter;
 use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\PageContentSource;
@@ -32,6 +33,7 @@ class ImportDemoData extends Maintenance {
 
 	public function execute(): void {
 		$this->newImportAction()->import();
+		$this->reindexSubjectPages();
 	}
 
 	private function newImportAction(): ImportPagesAction {
@@ -47,10 +49,7 @@ class ImportDemoData extends Maintenance {
 				NeoWikiExtension::getInstance()->getNeoWikiRootDirectory() . '/DemoData/Schema',
 				new SimpleFileFetcher()
 			),
-			subjectPageSource: new SubjectPageSource(
-				NeoWikiExtension::getInstance()->getNeoWikiRootDirectory() . '/DemoData/Subject',
-				new SimpleFileFetcher()
-			),
+			subjectPageSource: $this->newSubjectPageSource(),
 			pageContentSource: new PageContentSource(
 				[
 					NeoWikiExtension::getInstance()->getNeoWikiRootDirectory() . '/DemoData/Page',
@@ -68,6 +67,42 @@ class ImportDemoData extends Maintenance {
 				new SimpleFileFetcher()
 			)
 		);
+	}
+
+	private function newSubjectPageSource(): SubjectPageSource {
+		return new SubjectPageSource(
+			NeoWikiExtension::getInstance()->getNeoWikiRootDirectory() . '/DemoData/Subject',
+			new SimpleFileFetcher()
+		);
+	}
+
+	/**
+	 * Re-fires the revision-created handler for every subject page so that the Neo4j index
+	 * matches the imported state. The standard import path only triggers indexing when a
+	 * new revision is actually created, so re-runs after a Neo4j wipe leave subjects on
+	 * unchanged pages unindexed (and any inbound relations point at unlabeled stub nodes).
+	 */
+	private function reindexSubjectPages(): void {
+		$wikiPageFactory = MediaWikiServices::getInstance()->getWikiPageFactory();
+		$handler = NeoWikiExtension::getInstance()->getStoreContentUC();
+		$user = $this->getUser();
+
+		foreach ( $this->newSubjectPageSource()->getSubjectPages() as $subjectPageData ) {
+			$title = Title::newFromText( $subjectPageData->pageName );
+
+			if ( $title === null ) {
+				continue;
+			}
+
+			$revision = $wikiPageFactory->newFromTitle( $title )->getRevisionRecord();
+
+			if ( $revision === null ) {
+				continue;
+			}
+
+			$handler->onRevisionCreated( $revision, $user );
+			$this->outputChanneled( 'Reindexed ' . $title->getPrefixedText() );
+		}
 	}
 
 	private function getUser(): User {


### PR DESCRIPTION
> Result of investigation by @JeroenDeDauw with Claude Code, after observing that
> related-subject infobox links rendered as raw IDs after running `make import-demo-data`.
> Context: NeoWiki codebase, Neo4j cypher inspection of the local dev wiki.
> <sub>Written by Claude Code, `Opus 4.7`</sub>

## Summary

Re-fires the revision-created handler for every imported subject page so the Neo4j
index matches the imported state.

## Why

The standard import path only triggers indexing when a new revision is actually
created (the `RevisionFromEditComplete` hook). When `make import-demo-data` is
re-run after Neo4j has been wiped — common on dev environments after `docker
compose down --volumes` — pages whose content didn't change report
`done (no changes)` and Neo4j is never updated for them.

Worse: when an unrelated changed page (e.g. `Professional_Wiki`) has a relation
to one of those unchanged pages, `SubjectRelationUpdater` runs
`MERGE (target {id: \$targetId})` which creates an **unlabeled stub node** for the
target. The subject is now half-present in Neo4j: the node exists with `id` set,
but has no `:Subject` label and no `:HasSubject` edge from any Page. The
`Neo4jPageIdentifiersLookup` query (`MATCH (page:Page)-[:HasSubject]->(subject {id: \$id})`)
returns no match, so `GET /rest.php/neowiki/v0/subject/{id}` returns
\`{\"subject\":null}\` and the Vue `RelationDisplay` renders the raw ID.

Reproduced locally: `s1demo4sssssss1` (NeoWiki) and `s1demo6sssssss1` (ProWiki)
were stub nodes referenced from `Professional_Wiki`'s Products relation. After
the fix, both resolve correctly.

## Test plan

- [x] `make cs` — PHPCS clean, PHPStan no errors
- [x] Manually deleted the stub nodes from Neo4j, ran `make import-demo-data`,
      confirmed `GET /rest.php/neowiki/v0/subject/s1demo4sssssss1` and
      `s1demo6sssssss1` now return the subjects, and the `Professional_Wiki`
      page renders relation links correctly.
- [ ] CI green