### PR TITLE
Add RebuildGraphDatabases maintenance script (MVP)

### DIFF
--- a/maintenance/RebuildGraphDatabases.php
+++ b/maintenance/RebuildGraphDatabases.php
@@ -1,0 +1,104 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Maintenance;
+
+use Maintenance;
+use MediaWiki\MediaWikiServices;
+use MediaWiki\Page\WikiPageFactory;
+use MediaWiki\Title\Title;
+use MediaWiki\User\UserIdentity;
+use ProfessionalWiki\NeoWiki\EntryPoints\OnRevisionCreatedHandler;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\MediaWikiSubjectRepository;
+use User;
+
+$basePath = getenv( 'MW_INSTALL_PATH' ) !== false ? getenv( 'MW_INSTALL_PATH' ) : __DIR__ . '/../../..';
+
+require_once $basePath . '/maintenance/Maintenance.php';
+
+class RebuildGraphDatabases extends Maintenance {
+
+	public function __construct() {
+		parent::__construct();
+
+		$this->requireExtension( 'NeoWiki' );
+		$this->addDescription(
+			'Rebuilds the graph databases by re-saving every Subject from the latest revision of its page. ' .
+			'Useful after a graph database has been wiped or has otherwise drifted from the MediaWiki source of truth.'
+		);
+	}
+
+	public function execute(): void {
+		$pageIds = $this->getSubjectPageIds();
+
+		$this->outputChanneled( 'Rebuilding graph databases for ' . count( $pageIds ) . ' subject pages...' );
+
+		$handler = NeoWikiExtension::getInstance()->getStoreContentUC();
+		$wikiPageFactory = MediaWikiServices::getInstance()->getWikiPageFactory();
+		$user = $this->getMaintenanceUser();
+
+		$rebuilt = 0;
+
+		foreach ( $pageIds as $pageId ) {
+			if ( $this->rebuildPage( $pageId, $handler, $wikiPageFactory, $user ) ) {
+				$rebuilt++;
+			}
+		}
+
+		$this->outputChanneled( "Rebuild finished. Rebuilt $rebuilt of " . count( $pageIds ) . ' pages.' );
+	}
+
+	private function rebuildPage(
+		int $pageId,
+		OnRevisionCreatedHandler $handler,
+		WikiPageFactory $wikiPageFactory,
+		UserIdentity $user
+	): bool {
+		$title = Title::newFromID( $pageId );
+
+		if ( $title === null ) {
+			$this->outputChanneled( "Skipped page $pageId: title not found" );
+			return false;
+		}
+
+		$revision = $wikiPageFactory->newFromTitle( $title )->getRevisionRecord();
+
+		if ( $revision === null ) {
+			$this->outputChanneled( 'Skipped ' . $title->getPrefixedText() . ': no current revision' );
+			return false;
+		}
+
+		$handler->onRevisionCreated( $revision, $user );
+		$this->outputChanneled( 'Rebuilt ' . $title->getPrefixedText() );
+		return true;
+	}
+
+	/**
+	 * @return int[] Page IDs of every page whose latest revision carries the NeoWiki subject slot.
+	 */
+	private function getSubjectPageIds(): array {
+		$services = MediaWikiServices::getInstance();
+		$roleId = $services->getSlotRoleStore()->getId( MediaWikiSubjectRepository::SLOT_NAME );
+
+		$rows = $this->getReplicaDB()->newSelectQueryBuilder()
+			->select( 'page_id' )
+			->from( 'page' )
+			->join( 'slots', null, 'slot_revision_id = page_latest' )
+			->where( [ 'slot_role_id' => $roleId ] )
+			->orderBy( 'page_id' )
+			->caller( __METHOD__ )
+			->fetchFieldValues();
+
+		return array_map( 'intval', $rows );
+	}
+
+	private function getMaintenanceUser(): User {
+		return User::newSystemUser( 'NeoWiki', [ 'steal' => true ] );
+	}
+
+}
+
+$maintClass = RebuildGraphDatabases::class;
+require_once RUN_MAINTENANCE_IF_MAIN;

--- a/maintenance/RebuildGraphDatabases.php
+++ b/maintenance/RebuildGraphDatabases.php
@@ -6,13 +6,10 @@ namespace ProfessionalWiki\NeoWiki\Maintenance;
 
 use Maintenance;
 use MediaWiki\MediaWikiServices;
-use MediaWiki\Page\WikiPageFactory;
 use MediaWiki\Title\Title;
-use MediaWiki\User\UserIdentity;
-use ProfessionalWiki\NeoWiki\EntryPoints\OnRevisionCreatedHandler;
+use ProfessionalWiki\NeoWiki\Application\SubjectPageRebuilder;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\MediaWikiSubjectRepository;
-use User;
 
 $basePath = getenv( 'MW_INSTALL_PATH' ) !== false ? getenv( 'MW_INSTALL_PATH' ) : __DIR__ . '/../../..';
 
@@ -35,14 +32,15 @@ class RebuildGraphDatabases extends Maintenance {
 
 		$this->outputChanneled( 'Rebuilding graph databases for ' . count( $pageIds ) . ' subject pages...' );
 
-		$handler = NeoWikiExtension::getInstance()->getStoreContentUC();
-		$wikiPageFactory = MediaWikiServices::getInstance()->getWikiPageFactory();
-		$user = $this->getMaintenanceUser();
+		$rebuilder = new SubjectPageRebuilder(
+			NeoWikiExtension::getInstance()->getStoreContentUC(),
+			MediaWikiServices::getInstance()->getWikiPageFactory()
+		);
 
 		$rebuilt = 0;
 
 		foreach ( $pageIds as $pageId ) {
-			if ( $this->rebuildPage( $pageId, $handler, $wikiPageFactory, $user ) ) {
+			if ( $this->rebuildPage( $pageId, $rebuilder ) ) {
 				$rebuilt++;
 			}
 		}
@@ -50,12 +48,7 @@ class RebuildGraphDatabases extends Maintenance {
 		$this->outputChanneled( "Rebuild finished. Rebuilt $rebuilt of " . count( $pageIds ) . ' pages.' );
 	}
 
-	private function rebuildPage(
-		int $pageId,
-		OnRevisionCreatedHandler $handler,
-		WikiPageFactory $wikiPageFactory,
-		UserIdentity $user
-	): bool {
+	private function rebuildPage( int $pageId, SubjectPageRebuilder $rebuilder ): bool {
 		$title = Title::newFromID( $pageId );
 
 		if ( $title === null ) {
@@ -63,14 +56,11 @@ class RebuildGraphDatabases extends Maintenance {
 			return false;
 		}
 
-		$revision = $wikiPageFactory->newFromTitle( $title )->getRevisionRecord();
-
-		if ( $revision === null ) {
+		if ( !$rebuilder->rebuild( $title ) ) {
 			$this->outputChanneled( 'Skipped ' . $title->getPrefixedText() . ': no current revision' );
 			return false;
 		}
 
-		$handler->onRevisionCreated( $revision, $user );
 		$this->outputChanneled( 'Rebuilt ' . $title->getPrefixedText() );
 		return true;
 	}
@@ -92,10 +82,6 @@ class RebuildGraphDatabases extends Maintenance {
 			->fetchFieldValues();
 
 		return array_map( 'intval', $rows );
-	}
-
-	private function getMaintenanceUser(): User {
-		return User::newSystemUser( 'NeoWiki', [ 'steal' => true ] );
 	}
 
 }

--- a/src/Application/SubjectPageRebuilder.php
+++ b/src/Application/SubjectPageRebuilder.php
@@ -1,0 +1,36 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application;
+
+use MediaWiki\Page\WikiPageFactory;
+use MediaWiki\Title\Title;
+use ProfessionalWiki\NeoWiki\EntryPoints\OnRevisionCreatedHandler;
+
+class SubjectPageRebuilder {
+
+	public function __construct(
+		private readonly OnRevisionCreatedHandler $handler,
+		private readonly WikiPageFactory $wikiPageFactory,
+	) {
+	}
+
+	public function rebuild( Title $title ): bool {
+		$revision = $this->wikiPageFactory->newFromTitle( $title )->getRevisionRecord();
+
+		if ( $revision === null ) {
+			return false;
+		}
+
+		$user = $revision->getUser();
+
+		if ( $user === null ) {
+			return false;
+		}
+
+		$this->handler->onRevisionCreated( $revision, $user );
+		return true;
+	}
+
+}

--- a/tests/phpunit/Application/SubjectPageRebuilderTest.php
+++ b/tests/phpunit/Application/SubjectPageRebuilderTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Application;
+
+use MediaWiki\Page\WikiPageFactory;
+use MediaWiki\Revision\RevisionRecord;
+use MediaWiki\Title\Title;
+use MediaWiki\User\UserIdentity;
+use MediaWiki\User\UserIdentityValue;
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\SubjectPageRebuilder;
+use ProfessionalWiki\NeoWiki\EntryPoints\OnRevisionCreatedHandler;
+use WikiPage;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Application\SubjectPageRebuilder
+ */
+class SubjectPageRebuilderTest extends TestCase {
+
+	public function testPassesRevisionAuthorToHandler(): void {
+		$revisionAuthor = new UserIdentityValue( 42, 'RevisionAuthor' );
+		$revision = $this->newRevisionWithUser( $revisionAuthor );
+
+		$capturedUser = null;
+		$handler = $this->newHandlerCapturingUser( $capturedUser );
+
+		$rebuilder = new SubjectPageRebuilder(
+			$handler,
+			$this->newWikiPageFactoryWithRevision( $revision )
+		);
+
+		$rebuilder->rebuild( Title::makeTitle( NS_MAIN, 'TestPage' ) );
+
+		$this->assertSame( $revisionAuthor, $capturedUser );
+	}
+
+	public function testPassesGivenRevisionToHandler(): void {
+		$revisionAuthor = new UserIdentityValue( 42, 'RevisionAuthor' );
+		$revision = $this->newRevisionWithUser( $revisionAuthor );
+
+		$capturedRevision = null;
+		$handler = $this->createMock( OnRevisionCreatedHandler::class );
+		$handler->expects( $this->once() )
+			->method( 'onRevisionCreated' )
+			->willReturnCallback(
+				function ( RevisionRecord $r ) use ( &$capturedRevision ): void {
+					$capturedRevision = $r;
+				}
+			);
+
+		$rebuilder = new SubjectPageRebuilder(
+			$handler,
+			$this->newWikiPageFactoryWithRevision( $revision )
+		);
+
+		$rebuilder->rebuild( Title::makeTitle( NS_MAIN, 'TestPage' ) );
+
+		$this->assertSame( $revision, $capturedRevision );
+	}
+
+	public function testReturnsTrueWhenRebuilt(): void {
+		$revision = $this->newRevisionWithUser( new UserIdentityValue( 1, 'Someone' ) );
+
+		$rebuilder = new SubjectPageRebuilder(
+			$this->createMock( OnRevisionCreatedHandler::class ),
+			$this->newWikiPageFactoryWithRevision( $revision )
+		);
+
+		$this->assertTrue( $rebuilder->rebuild( Title::makeTitle( NS_MAIN, 'TestPage' ) ) );
+	}
+
+	public function testSkipsPageWithoutCurrentRevision(): void {
+		$handler = $this->createMock( OnRevisionCreatedHandler::class );
+		$handler->expects( $this->never() )->method( 'onRevisionCreated' );
+
+		$rebuilder = new SubjectPageRebuilder(
+			$handler,
+			$this->newWikiPageFactoryWithRevision( null )
+		);
+
+		$this->assertFalse( $rebuilder->rebuild( Title::makeTitle( NS_MAIN, 'Missing' ) ) );
+	}
+
+	private function newRevisionWithUser( UserIdentity $user ): RevisionRecord {
+		$revision = $this->createMock( RevisionRecord::class );
+		$revision->method( 'getUser' )->willReturn( $user );
+		return $revision;
+	}
+
+	private function newWikiPageFactoryWithRevision( ?RevisionRecord $revision ): WikiPageFactory {
+		$wikiPage = $this->createMock( WikiPage::class );
+		$wikiPage->method( 'getRevisionRecord' )->willReturn( $revision );
+
+		$factory = $this->createMock( WikiPageFactory::class );
+		$factory->method( 'newFromTitle' )->willReturn( $wikiPage );
+
+		return $factory;
+	}
+
+	private function newHandlerCapturingUser( ?UserIdentity &$capturedUser ): OnRevisionCreatedHandler {
+		$handler = $this->createMock( OnRevisionCreatedHandler::class );
+		$handler->expects( $this->once() )
+			->method( 'onRevisionCreated' )
+			->willReturnCallback(
+				function ( RevisionRecord $r, UserIdentity $user ) use ( &$capturedUser ): void {
+					$capturedUser = $user;
+				}
+			);
+		return $handler;
+	}
+
+}

--- a/tests/phpunit/Application/SubjectPageRebuilderTest.php
+++ b/tests/phpunit/Application/SubjectPageRebuilderTest.php
@@ -11,7 +11,7 @@ use MediaWiki\User\UserIdentity;
 use MediaWiki\User\UserIdentityValue;
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Application\SubjectPageRebuilder;
-use ProfessionalWiki\NeoWiki\EntryPoints\OnRevisionCreatedHandler;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpyOnRevisionCreatedHandler;
 use WikiPage;
 
 /**
@@ -19,96 +19,42 @@ use WikiPage;
  */
 class SubjectPageRebuilderTest extends TestCase {
 
+	private SpyOnRevisionCreatedHandler $handler;
+
+	protected function setUp(): void {
+		$this->handler = new SpyOnRevisionCreatedHandler();
+	}
+
 	public function testPassesRevisionAuthorToHandler(): void {
-		$revisionAuthor = new UserIdentityValue( 42, 'RevisionAuthor' );
-		$revision = $this->newRevisionWithUser( $revisionAuthor );
+		$author = new UserIdentityValue( 42, 'RevisionAuthor' );
 
-		$capturedUser = null;
-		$handler = $this->newHandlerCapturingUser( $capturedUser );
+		$this->newRebuilder( $this->newRevisionByUser( $author ) )
+			->rebuild( Title::makeTitle( NS_MAIN, 'AnyPage' ) );
 
-		$rebuilder = new SubjectPageRebuilder(
-			$handler,
-			$this->newWikiPageFactoryWithRevision( $revision )
-		);
-
-		$rebuilder->rebuild( Title::makeTitle( NS_MAIN, 'TestPage' ) );
-
-		$this->assertSame( $revisionAuthor, $capturedUser );
-	}
-
-	public function testPassesGivenRevisionToHandler(): void {
-		$revisionAuthor = new UserIdentityValue( 42, 'RevisionAuthor' );
-		$revision = $this->newRevisionWithUser( $revisionAuthor );
-
-		$capturedRevision = null;
-		$handler = $this->createMock( OnRevisionCreatedHandler::class );
-		$handler->expects( $this->once() )
-			->method( 'onRevisionCreated' )
-			->willReturnCallback(
-				function ( RevisionRecord $r ) use ( &$capturedRevision ): void {
-					$capturedRevision = $r;
-				}
-			);
-
-		$rebuilder = new SubjectPageRebuilder(
-			$handler,
-			$this->newWikiPageFactoryWithRevision( $revision )
-		);
-
-		$rebuilder->rebuild( Title::makeTitle( NS_MAIN, 'TestPage' ) );
-
-		$this->assertSame( $revision, $capturedRevision );
-	}
-
-	public function testReturnsTrueWhenRebuilt(): void {
-		$revision = $this->newRevisionWithUser( new UserIdentityValue( 1, 'Someone' ) );
-
-		$rebuilder = new SubjectPageRebuilder(
-			$this->createMock( OnRevisionCreatedHandler::class ),
-			$this->newWikiPageFactoryWithRevision( $revision )
-		);
-
-		$this->assertTrue( $rebuilder->rebuild( Title::makeTitle( NS_MAIN, 'TestPage' ) ) );
+		$this->assertSame( $author, $this->handler->calls[0]['user'] );
 	}
 
 	public function testSkipsPageWithoutCurrentRevision(): void {
-		$handler = $this->createMock( OnRevisionCreatedHandler::class );
-		$handler->expects( $this->never() )->method( 'onRevisionCreated' );
+		$rebuilt = $this->newRebuilder( null )->rebuild( Title::makeTitle( NS_MAIN, 'Missing' ) );
 
-		$rebuilder = new SubjectPageRebuilder(
-			$handler,
-			$this->newWikiPageFactoryWithRevision( null )
-		);
-
-		$this->assertFalse( $rebuilder->rebuild( Title::makeTitle( NS_MAIN, 'Missing' ) ) );
+		$this->assertFalse( $rebuilt );
+		$this->assertSame( [], $this->handler->calls );
 	}
 
-	private function newRevisionWithUser( UserIdentity $user ): RevisionRecord {
-		$revision = $this->createMock( RevisionRecord::class );
+	private function newRebuilder( ?RevisionRecord $revision ): SubjectPageRebuilder {
+		$page = $this->createStub( WikiPage::class );
+		$page->method( 'getRevisionRecord' )->willReturn( $revision );
+
+		$factory = $this->createStub( WikiPageFactory::class );
+		$factory->method( 'newFromTitle' )->willReturn( $page );
+
+		return new SubjectPageRebuilder( $this->handler, $factory );
+	}
+
+	private function newRevisionByUser( UserIdentity $user ): RevisionRecord {
+		$revision = $this->createStub( RevisionRecord::class );
 		$revision->method( 'getUser' )->willReturn( $user );
 		return $revision;
-	}
-
-	private function newWikiPageFactoryWithRevision( ?RevisionRecord $revision ): WikiPageFactory {
-		$wikiPage = $this->createMock( WikiPage::class );
-		$wikiPage->method( 'getRevisionRecord' )->willReturn( $revision );
-
-		$factory = $this->createMock( WikiPageFactory::class );
-		$factory->method( 'newFromTitle' )->willReturn( $wikiPage );
-
-		return $factory;
-	}
-
-	private function newHandlerCapturingUser( ?UserIdentity &$capturedUser ): OnRevisionCreatedHandler {
-		$handler = $this->createMock( OnRevisionCreatedHandler::class );
-		$handler->expects( $this->once() )
-			->method( 'onRevisionCreated' )
-			->willReturnCallback(
-				function ( RevisionRecord $r, UserIdentity $user ) use ( &$capturedUser ): void {
-					$capturedUser = $user;
-				}
-			);
-		return $handler;
 	}
 
 }

--- a/tests/phpunit/TestDoubles/SpyOnRevisionCreatedHandler.php
+++ b/tests/phpunit/TestDoubles/SpyOnRevisionCreatedHandler.php
@@ -1,0 +1,23 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\TestDoubles;
+
+use MediaWiki\Revision\RevisionRecord;
+use MediaWiki\User\UserIdentity;
+use ProfessionalWiki\NeoWiki\EntryPoints\OnRevisionCreatedHandler;
+
+class SpyOnRevisionCreatedHandler extends OnRevisionCreatedHandler {
+
+	/** @var list<array{revision: RevisionRecord, user: UserIdentity}> */
+	public array $calls = [];
+
+	public function __construct() {
+	}
+
+	public function onRevisionCreated( RevisionRecord $revisionRecord, UserIdentity $user ): void {
+		$this->calls[] = [ 'revision' => $revisionRecord, 'user' => $user ];
+	}
+
+}


### PR DESCRIPTION
My idea, as an alternative fix to 
* https://github.com/ProfessionalWiki/NeoWiki/pull/744

First part of
* https://github.com/ProfessionalWiki/NeoWiki/issues/647

Manually tested

> Result of debugging session with @JeroenDeDauw after stub Neo4j nodes broke
> relation rendering on the local dev wiki. Context: NeoWiki codebase, ADR 019
> (Graph Database Architecture), Neo4j cypher inspection.
> <sub>Written by Claude Code, \`Opus 4.7\`</sub>

## Summary

Adds a `RebuildGraphDatabases` maintenance script that re-saves every Subject
from the latest revision of its page through the `GraphDatabasePlugin` chain.
Useful after a graph database has been wiped or otherwise drifted from the
MediaWiki source of truth.

## Scope

This is an **MVP for #647**. It satisfies the first AC (script exists and saves
all Subjects to the graph DB) and provides per-page progress output. It deliberately
does **not** implement:

- `--resume-from` parameter
- Ctrl+C handling with resume instructions
- Cleanup of stale entries / `--delete-first` flag
- `SubjectIterator` abstraction
- Use case + presenter decoupling

Those are deferred. Issue #647 stays open for them.

## Why now

`make import-demo-data` re-runs after a Neo4j wipe leave subjects on unchanged
pages unindexed (the `RevisionFromEditComplete` hook only fires when a new
revision is actually created). Inbound relations from re-saved pages then
create unlabeled stub nodes via `MERGE (target {id: \$targetId})` in
`SubjectRelationUpdater`, which the API can't resolve. The companion
NeoWiki-Docker PR chains this script into `make import-demo-data` so the dev
flow self-heals.

## How it works

1. Queries `slots` for every page whose latest revision carries the NeoWiki
   subject slot (`slot_role_id = id of "neo"`), ordered by `page_id`.
2. For each, loads the current revision and fires
   `OnRevisionCreatedHandler::onRevisionCreated()` — the same path the hook
   takes on a real edit.
3. Outputs `Rebuilt <Title>` per page, plus a totals line at the end.

The handler is idempotent: pages already in sync get the same write, no harm.

## Test plan

- [x] `make cs` — PHPCS clean, PHPStan no errors
- [x] Manually deleted `s1demo4sssssss1` and `s1demo6sssssss1` stub nodes from
      Neo4j, ran the script directly, confirmed both subjects resolve via the
      REST API and the `Professional_Wiki` infobox shows linked product names.
- [x] Re-ran with state already in sync; script reports `Rebuilt 26 of 26`
      with no errors.
- [x] Verified via the NeoWiki-Docker companion PR that
      `make import-demo-data` now chains the rebuild and self-heals.
- [x] CI green