### PR TITLE
Check for page context

### DIFF
--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -281,7 +281,7 @@ class NeoWikiHooks {
 	public static function onSidebarBeforeOutput( Skin $skin, array &$sidebar ): void {
 		$title = $skin->getTitle();
 
-		if ( $title === null ) {
+		if ( $title === null || !$title->canExist() ) {
 			return;
 		}
 


### PR DESCRIPTION
Metadata can only be assigned to actual Wikipages, not Specialpages.

Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/748