### PR TITLE
Allow creating child subjects from the tools menu

### DIFF
--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -21,7 +21,7 @@
 	"neowiki-lua-query-error-write-query": "Error raised by the nw.query() Lua function when the Cypher query contains write or non-read-only operations.",
 
 	"neowiki-page-tools-label": "Heading for the NeoWiki section in the MediaWiki sidebar (shown as a group label in legacy skins and inside the page tools menu in modern Vector).",
-	"neowiki-page-tools-create-subject": "Label for the sidebar link that opens the 'create subject' dialog on pages that have no NeoWiki subject yet.",
+	"neowiki-page-tools-create-subject": "Label for the sidebar link that opens the 'create subject' dialog. The dialog creates a main subject if the page has none, or a child subject otherwise.",
 	"neowiki-page-tools-edit-json": "Label for the sidebar link that navigates to Special:NeoJson for the current page. Only visible when development UIs are enabled.",
 
 	"neowiki-subject-creator-creating-schema": "Subtitle shown in the subject creator dialog header when the user is creating a new schema.",

--- a/resources/ext.neowiki/src/components/NeoWikiApp.vue
+++ b/resources/ext.neowiki/src/components/NeoWikiApp.vue
@@ -14,7 +14,7 @@
 	</teleport>
 
 	<teleport v-if="shouldShowSubjectCreator" to="#mw-content-text">
-		<SubjectCreatorDialog />
+		<SubjectCreatorDialog :page-has-main-subject="pageHasMainSubject" />
 	</teleport>
 </template>
 
@@ -39,11 +39,13 @@ interface ViewData {
 
 const props = defineProps<{
 	showSubjectCreator: boolean;
+	pageHasMainSubject: boolean;
 }>();
 
 const viewsData = ref<ViewData[]>( [] );
 
 const shouldShowSubjectCreator = ref( props.showSubjectCreator );
+const pageHasMainSubject = ref( props.pageHasMainSubject );
 const subjectAuthorizer = NeoWikiServices.getSubjectAuthorizer();
 const viewTypeRegistry = NeoWikiServices.getViewTypeRegistry();
 

--- a/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
@@ -165,6 +165,10 @@ import { useChangeDetection } from '@/composables/useChangeDetection.ts';
 import { useCloseConfirmation } from '@/composables/useCloseConfirmation.ts';
 import { setPendingNotification } from '@/presentation/PendingNotification.ts';
 
+const props = defineProps<{
+	pageHasMainSubject: boolean;
+}>();
+
 const selectedSchemaOption = ref( 'existing' );
 const selectedSchemaName = ref<string | null>( null );
 const loadedSchema = ref<Schema | null>( null );
@@ -389,13 +393,27 @@ const handleSave = async ( summary: string ): Promise<void> => {
 		const updatedStatements = subjectEditorRef.value.getSubjectData();
 		const statementsToSave = [ ...updatedStatements ].filter( ( statement ) => statement.hasValue() );
 
-		await subjectStore.createMainSubject(
-			mw.config.get( 'wgArticleId' ),
-			label,
-			selectedSchemaName.value,
-			new StatementList( statementsToSave ),
-			summary || undefined
-		);
+		const pageId = mw.config.get( 'wgArticleId' );
+		const statementList = new StatementList( statementsToSave );
+		const commentOrUndefined = summary || undefined;
+
+		if ( props.pageHasMainSubject ) {
+			await subjectStore.createChildSubject(
+				pageId,
+				label,
+				selectedSchemaName.value,
+				statementList,
+				commentOrUndefined
+			);
+		} else {
+			await subjectStore.createMainSubject(
+				pageId,
+				label,
+				selectedSchemaName.value,
+				statementList,
+				commentOrUndefined
+			);
+		}
 		setPendingNotification( 'neowiki-subject-creator-success' );
 		window.location.reload();
 	} catch ( error ) {

--- a/resources/ext.neowiki/src/domain/SubjectRepository.ts
+++ b/resources/ext.neowiki/src/domain/SubjectRepository.ts
@@ -18,7 +18,8 @@ export interface SubjectRepository extends SubjectLookup {
 		pageId: number,
 		label: string,
 		schemaName: SchemaName,
-		statements: StatementList
+		statements: StatementList,
+		comment?: string
 	): Promise<SubjectId>;
 
 	// TODO: return something to indicate status
@@ -34,7 +35,7 @@ export class StubSubjectRepository extends InMemorySubjectLookup implements Subj
 		return Promise.resolve( new SubjectId( 's11111111111111' ) );
 	}
 
-	public createChildSubject( _pageId: number, _label: string, _schemaName: string, _statements: StatementList ): Promise<SubjectId> {
+	public createChildSubject( _pageId: number, _label: string, _schemaName: string, _statements: StatementList, _comment?: string ): Promise<SubjectId> {
 		return Promise.resolve( new SubjectId( 's11111111111112' ) );
 	}
 

--- a/resources/ext.neowiki/src/neowiki.ts
+++ b/resources/ext.neowiki/src/neowiki.ts
@@ -40,9 +40,11 @@ async function initializeNeoWikiApp(): Promise<void> {
 		showPendingNotification( 'neowiki-subject-creator-success' );
 
 		const showSubjectCreator = ( neowikiApp as HTMLElement ).dataset.mwNeowikiCreateSubject === 'true';
+		const pageHasMainSubject = ( neowikiApp as HTMLElement ).dataset.mwNeowikiPageHasMainSubject === 'true';
 
 		const app = createMwApp( NeoWikiApp, {
 			showSubjectCreator,
+			pageHasMainSubject,
 		} ).directive( 'tooltip', CdxTooltip );
 		const pinia = createPinia();
 		app.use( pinia );

--- a/resources/ext.neowiki/src/persistence/RestSubjectRepository.ts
+++ b/resources/ext.neowiki/src/persistence/RestSubjectRepository.ts
@@ -88,11 +88,13 @@ export class RestSubjectRepository implements SubjectRepository {
 		label: string,
 		schemaName: SchemaName,
 		statements: StatementList,
+		comment?: string,
 	): Promise<SubjectId> {
 		const payload = {
 			label: label,
 			schema: schemaName,
 			statements: statementsToJson( statements ),
+			comment,
 		};
 
 		const response = await this.httpClient.post(

--- a/resources/ext.neowiki/src/stores/SubjectStore.ts
+++ b/resources/ext.neowiki/src/stores/SubjectStore.ts
@@ -69,6 +69,26 @@ export const useSubjectStore = defineStore( 'subject', {
 			);
 			return subjectId;
 		},
+		async createChildSubject( pageId: number, label: string, schemaName: SchemaName, statements: StatementList, comment?: string ): Promise<SubjectId> {
+			const subjectId = await NeoWikiExtension.getInstance().getSubjectRepository().createChildSubject(
+				pageId,
+				label,
+				schemaName,
+				statements,
+				comment,
+			);
+
+			this.setSubject(
+				new SubjectWithContext(
+					subjectId,
+					label,
+					schemaName,
+					statements,
+					new PageIdentifiers( pageId, 'page-title' ),
+				),
+			);
+			return subjectId;
+		},
 
 		openSubjectCreator(): void {
 			this.subjectCreatorOpen = true;

--- a/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
@@ -119,8 +119,10 @@ describe( 'SubjectCreatorDialog', () => {
 
 	const mountComponent = (
 		stubs: Record<string, any> = {},
+		props: Record<string, any> = {},
 	): VueWrapper => (
 		mount( SubjectCreatorDialog, {
+			props: { pageHasMainSubject: false, ...props },
 			global: {
 				plugins: [ pinia ],
 				stubs: {
@@ -187,6 +189,7 @@ describe( 'SubjectCreatorDialog', () => {
 
 		subjectStore = useSubjectStore();
 		subjectStore.createMainSubject = vi.fn().mockResolvedValue( new SubjectId( 's11111111111111' ) );
+		subjectStore.createChildSubject = vi.fn().mockResolvedValue( new SubjectId( 's11111111111112' ) );
 
 		schemaStore = useSchemaStore();
 		schemaStore.getOrFetchSchema = vi.fn().mockResolvedValue( newSchema( { title: SCHEMA_NAME } ) );
@@ -313,6 +316,25 @@ describe( 'SubjectCreatorDialog', () => {
 			expect.any( StatementList ),
 			undefined,
 		);
+	} );
+
+	it( 'calls createChildSubject when the page already has a main subject', async () => {
+		const wrapper = mountComponent( {}, { pageHasMainSubject: true } );
+
+		await wrapper.findComponent( SchemaLookup ).vm.$emit( 'select', SCHEMA_NAME );
+		await flushPromises();
+
+		await wrapper.findComponent( EditSummary ).vm.$emit( 'save', 'test summary' );
+		await flushPromises();
+
+		expect( subjectStore.createChildSubject ).toHaveBeenCalledWith(
+			PAGE_ID,
+			PAGE_TITLE,
+			SCHEMA_NAME,
+			expect.any( StatementList ),
+			'test summary',
+		);
+		expect( subjectStore.createMainSubject ).not.toHaveBeenCalled();
 	} );
 
 	it( 'reloads page after successful save', async () => {

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -72,6 +72,10 @@ class NeoWikiHooks {
 
 		if ( self::shouldShowSubjectCreator( $out ) ) {
 			$attrs['data-mw-neowiki-create-subject'] = 'true';
+			$attrs['data-mw-neowiki-page-has-main-subject'] =
+				NeoWikiExtension::getInstance()->newViewHtmlBuilder()->pageHasMainSubject( $out->getTitle() )
+					? 'true'
+					: 'false';
 		}
 
 		return Html::element( 'div', $attrs );
@@ -79,8 +83,7 @@ class NeoWikiHooks {
 
 	private static function shouldShowSubjectCreator( OutputPage $out ): bool {
 		return NeoWikiExtension::getInstance()->newSubjectAuthorizer( $out->getAuthority() )->canCreateMainSubject()
-			&& self::pageIsLatestRevision( $out )
-			&& !NeoWikiExtension::getInstance()->newViewHtmlBuilder()->pageHasSubjects( $out->getTitle() );
+			&& self::pageIsLatestRevision( $out );
 	}
 
 	private static function pageIsLatestRevision( OutputPage $out ): bool {
@@ -306,7 +309,6 @@ class NeoWikiHooks {
 				->isContent( $title->getNamespace() ),
 			canCreateMainSubject: $extension->newSubjectAuthorizer( $skin->getAuthority() )->canCreateMainSubject(),
 			isLatestRevision: self::pageIsLatestRevision( $skin->getOutput() ),
-			pageHasSubjects: $extension->newViewHtmlBuilder()->pageHasSubjects( $title ),
 			devUiEnabled: $extension->isDevelopmentUIEnabled()
 		);
 

--- a/src/Presentation/PageToolsBuilder.php
+++ b/src/Presentation/PageToolsBuilder.php
@@ -17,7 +17,6 @@ class PageToolsBuilder {
 		bool $isContentNamespace,
 		bool $canCreateMainSubject,
 		bool $isLatestRevision,
-		bool $pageHasSubjects,
 		bool $devUiEnabled
 	): array {
 		if ( !$isContentNamespace ) {
@@ -26,7 +25,7 @@ class PageToolsBuilder {
 
 		$items = [];
 
-		if ( $canCreateMainSubject && $isLatestRevision && !$pageHasSubjects ) {
+		if ( $canCreateMainSubject && $isLatestRevision ) {
 			$items[] = [
 				'text' => wfMessage( 'neowiki-page-tools-create-subject' )->text(),
 				'href' => '#',

--- a/src/Presentation/ViewHtmlBuilder.php
+++ b/src/Presentation/ViewHtmlBuilder.php
@@ -46,6 +46,13 @@ class ViewHtmlBuilder {
 			?->hasSubjects() === true;
 	}
 
+	public function pageHasMainSubject( Title $title ): bool {
+		return $this->subjectContentRepository
+			->getSubjectContentByPageTitle( $title )
+			?->getPageSubjects()
+			->getMainSubject() !== null;
+	}
+
 	private function getSubjectContent( Title $title, ?int $revisionId ): ?SubjectContent {
 		if ( $revisionId === null ) {
 			return $this->subjectContentRepository->getSubjectContentByPageTitle( $title );

--- a/tests/phpunit/Presentation/PageToolsBuilderTest.php
+++ b/tests/phpunit/Presentation/PageToolsBuilderTest.php
@@ -40,13 +40,6 @@ class PageToolsBuilderTest extends MediaWikiIntegrationTestCase {
 		);
 	}
 
-	public function testShowsOnlyEditJsonWhenPageHasSubjects(): void {
-		$this->assertSame(
-			[ $this->editJsonItem() ],
-			$this->build( pageHasSubjects: true )
-		);
-	}
-
 	public function testShowsOnlyEditJsonOnOldRevision(): void {
 		$this->assertSame(
 			[ $this->editJsonItem() ],
@@ -78,7 +71,6 @@ class PageToolsBuilderTest extends MediaWikiIntegrationTestCase {
 		bool $isContentNamespace = true,
 		bool $canCreateMainSubject = true,
 		bool $isLatestRevision = true,
-		bool $pageHasSubjects = false,
 		bool $devUiEnabled = true
 	): array {
 		return ( new PageToolsBuilder() )->build(
@@ -86,7 +78,6 @@ class PageToolsBuilderTest extends MediaWikiIntegrationTestCase {
 			isContentNamespace: $isContentNamespace,
 			canCreateMainSubject: $canCreateMainSubject,
 			isLatestRevision: $isLatestRevision,
-			pageHasSubjects: $pageHasSubjects,
 			devUiEnabled: $devUiEnabled
 		);
 	}

--- a/tests/phpunit/Presentation/ViewHtmlBuilderTest.php
+++ b/tests/phpunit/Presentation/ViewHtmlBuilderTest.php
@@ -111,6 +111,37 @@ class ViewHtmlBuilderTest extends TestCase {
 		$this->assertFalse( $builder->pageHasSubjects( Title::newFromText( 'EmptyContent' ) ) );
 	}
 
+	public function testPageHasMainSubjectReturnsTrueWhenMainSubjectExists(): void {
+		$content = SubjectContent::newFromData(
+			new PageSubjects( TestSubject::build(), new SubjectMap() )
+		);
+
+		$builder = new ViewHtmlBuilder(
+			$this->stubRepository( byTitle: $content )
+		);
+
+		$this->assertTrue( $builder->pageHasMainSubject( Title::newFromText( 'HasMain' ) ) );
+	}
+
+	public function testPageHasMainSubjectReturnsFalseWhenNoContent(): void {
+		$builder = new ViewHtmlBuilder(
+			$this->stubRepository( byTitle: null )
+		);
+
+		$this->assertFalse( $builder->pageHasMainSubject( Title::newFromText( 'NoContent' ) ) );
+	}
+
+	public function testPageHasMainSubjectReturnsFalseWhenOnlyChildrenExist(): void {
+		$child = TestSubject::build( id: 's1zz1111111ccc1' );
+		$content = SubjectContent::newFromData( new PageSubjects( null, new SubjectMap( $child ) ) );
+
+		$builder = new ViewHtmlBuilder(
+			$this->stubRepository( byTitle: $content )
+		);
+
+		$this->assertFalse( $builder->pageHasMainSubject( Title::newFromText( 'OnlyChildren' ) ) );
+	}
+
 	private function stubRepository(
 		?SubjectContent $byTitle = null,
 		?SubjectContent $byRevision = null,


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/NeoWiki/issues/750

https://github.com/user-attachments/assets/10784699-46bc-49af-b2b7-e9d280b92d08

Un-gates the existing "Create subject" tools-menu entry so it remains
visible after a page has its first subject. When the page already has
a main subject, the creator dialog now targets the child-subject
endpoint instead.

## Changes

- Drop `!pageHasSubjects` from `PageToolsBuilder`'s "Create subject"
  visibility and from `NeoWikiHooks::shouldShowSubjectCreator`.
- Emit a new `data-mw-neowiki-page-has-main-subject` attribute on the
  app root, threaded through `NeoWikiApp.vue` as a required
  `pageHasMainSubject` prop to `SubjectCreatorDialog`.
- `SubjectCreatorDialog` branches on the prop to call
  `SubjectStore.createChildSubject` (new action) or `createMainSubject`.
- Add `ViewHtmlBuilder::pageHasMainSubject` (vs. the existing
  `pageHasSubjects`, which is true for either main or children).
- Wire `comment` through `RestSubjectRepository::createChildSubject`
  and the domain interface, for edit-summary parity with
  `createMainSubject`.

## Manual Browser Check

On a page that already has a main subject (e.g. `ACME_Inc`):

1. Open the NeoWiki section of the tools menu -- "Create subject" is listed.
2. Click it -- the creator modal opens.
3. Pick a schema, enter a label, save -- page reloads.
4. The new subject is stored as a child. Confirm via `Special:NeoJson/ACME_Inc`: the JSON has the original subject in the `mainSubject` slot and the new one in `childSubjects`.

On a fresh page with no subjects:

5. "Create subject" is still listed (existing behavior).
6. Click it -- the creator modal opens.
7. Save -- a main subject is created, page reloads, infobox renders (existing behavior).

Independent of #751 (can land in either order).