### PR TITLE
DateTime: user-local display/input with UTC storage and semantic <time>

### DIFF
--- a/resources/ext.neowiki/src/components/SchemaEditor/Property/DateTimeAttributesEditor.vue
+++ b/resources/ext.neowiki/src/components/SchemaEditor/Property/DateTimeAttributesEditor.vue
@@ -66,8 +66,13 @@ watch( () => props.property.maximum, ( newVal ) => {
 
 // datetime-local wire values are always `YYYY-MM-DDTHH:mm` in a single
 // timezone (host local), so lexicographic ordering matches chronological.
+// The regex guards against malformed values bypassing the ordering check.
+const DATETIME_LOCAL_WIRE_FORMAT = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/;
+
 function minExceedsMax( min: string, max: string ): boolean {
-	return min !== '' && max !== '' && min > max;
+	return DATETIME_LOCAL_WIRE_FORMAT.test( min ) &&
+		DATETIME_LOCAL_WIRE_FORMAT.test( max ) &&
+		min > max;
 }
 
 const updateMinimum = ( value: string ): void => {

--- a/resources/ext.neowiki/src/components/SchemaEditor/Property/DateTimeAttributesEditor.vue
+++ b/resources/ext.neowiki/src/components/SchemaEditor/Property/DateTimeAttributesEditor.vue
@@ -64,13 +64,10 @@ watch( () => props.property.maximum, ( newVal ) => {
 	maximumInput.value = toLocalInputValue( newVal );
 } );
 
+// datetime-local wire values are always `YYYY-MM-DDTHH:mm` in a single
+// timezone (host local), so lexicographic ordering matches chronological.
 function minExceedsMax( min: string, max: string ): boolean {
-	if ( min === '' || max === '' ) {
-		return false;
-	}
-	const minTime = Date.parse( min );
-	const maxTime = Date.parse( max );
-	return !Number.isNaN( minTime ) && !Number.isNaN( maxTime ) && minTime > maxTime;
+	return min !== '' && max !== '' && min > max;
 }
 
 const updateMinimum = ( value: string ): void => {

--- a/resources/ext.neowiki/src/components/SchemaEditor/Property/DateTimeAttributesEditor.vue
+++ b/resources/ext.neowiki/src/components/SchemaEditor/Property/DateTimeAttributesEditor.vue
@@ -14,13 +14,11 @@
 					{{ $i18n( 'neowiki-property-editor-minimum' ).text() }}
 				</template>
 
-				<!-- eslint-disable-next-line vue/html-self-closing -->
-				<input
-					type="datetime-local"
-					class="cdx-text-input__input"
-					:value="minimumInput"
-					@input="updateMinimum"
-				>
+				<CdxTextInput
+					input-type="datetime-local"
+					:model-value="minimumInput"
+					@update:model-value="updateMinimum"
+				/>
 			</CdxField>
 
 			<CdxField
@@ -32,13 +30,11 @@
 					{{ $i18n( 'neowiki-property-editor-maximum' ).text() }}
 				</template>
 
-				<!-- eslint-disable-next-line vue/html-self-closing -->
-				<input
-					type="datetime-local"
-					class="cdx-text-input__input"
-					:value="maximumInput"
-					@input="updateMaximum"
-				>
+				<CdxTextInput
+					input-type="datetime-local"
+					:model-value="maximumInput"
+					@update:model-value="updateMaximum"
+				/>
 			</CdxField>
 		</NeoNestedField>
 	</div>
@@ -46,8 +42,9 @@
 
 <script setup lang="ts">
 import { ref, watch } from 'vue';
-import { CdxField } from '@wikimedia/codex';
+import { CdxField, CdxTextInput } from '@wikimedia/codex';
 import { DateTimeProperty } from '@/domain/propertyTypes/DateTime.ts';
+import { fromLocalInputValue, toLocalInputValue } from '@/domain/propertyTypes/dateTimeConversion.ts';
 import { AttributesEditorEmits, AttributesEditorProps } from '@/components/SchemaEditor/Property/AttributesEditorContract.ts';
 import NeoNestedField from '@/components/common/NeoNestedField.vue';
 
@@ -67,17 +64,6 @@ watch( () => props.property.maximum, ( newVal ) => {
 	maximumInput.value = toLocalInputValue( newVal );
 } );
 
-function toLocalInputValue( isoString: string | undefined ): string {
-	if ( !isoString ) {
-		return '';
-	}
-	return isoString.replace( /Z$/, '' ).slice( 0, 16 );
-}
-
-function fromLocalInputValue( localValue: string ): string | undefined {
-	return localValue ? localValue + ':00Z' : undefined;
-}
-
 function minExceedsMax( min: string, max: string ): boolean {
 	if ( min === '' || max === '' ) {
 		return false;
@@ -87,8 +73,7 @@ function minExceedsMax( min: string, max: string ): boolean {
 	return !Number.isNaN( minTime ) && !Number.isNaN( maxTime ) && minTime > maxTime;
 }
 
-const updateMinimum = ( event: Event ): void => {
-	const value = ( event.target as HTMLInputElement ).value;
+const updateMinimum = ( value: string ): void => {
 	minimumInput.value = value;
 
 	if ( minExceedsMax( value, maximumInput.value ) ) {
@@ -101,8 +86,7 @@ const updateMinimum = ( event: Event ): void => {
 	emit( 'update:property', { minimum: fromLocalInputValue( value ) } );
 };
 
-const updateMaximum = ( event: Event ): void => {
-	const value = ( event.target as HTMLInputElement ).value;
+const updateMaximum = ( value: string ): void => {
 	maximumInput.value = value;
 
 	if ( minExceedsMax( minimumInput.value, value ) ) {

--- a/resources/ext.neowiki/src/components/Value/DateTimeDisplay.vue
+++ b/resources/ext.neowiki/src/components/Value/DateTimeDisplay.vue
@@ -10,10 +10,9 @@
 
 <script setup lang="ts">
 import { computed } from 'vue';
-import { newStringValue, ValueType } from '@/domain/Value.ts';
-import { DateTimeProperty, DateTimeType } from '@/domain/propertyTypes/DateTime.ts';
+import { ValueType } from '@/domain/Value.ts';
+import { DateTimeProperty, parseStrictDateTime } from '@/domain/propertyTypes/DateTime.ts';
 import { ValueDisplayProps } from '@/components/Value/ValueDisplayContract.ts';
-import { NeoWikiServices } from '@/NeoWikiServices.ts';
 
 const props = defineProps<ValueDisplayProps<DateTimeProperty>>();
 
@@ -26,15 +25,7 @@ const rawValue = computed( (): string => {
 
 const parsedIso = computed( (): string | null => {
 	const raw = rawValue.value;
-	if ( raw === '' ) {
-		return null;
-	}
-
-	const propertyType = NeoWikiServices.getPropertyTypeRegistry().getType( DateTimeType.typeName );
-	const errors = propertyType.validate( newStringValue( raw ), props.property );
-	const isValidIso = !errors.some( ( e ) => e.code === 'invalid-datetime' );
-
-	return isValidIso ? raw : null;
+	return raw !== '' && parseStrictDateTime( raw ) !== null ? raw : null;
 } );
 
 const formattedValue = computed( (): string => {

--- a/resources/ext.neowiki/src/components/Value/DateTimeDisplay.vue
+++ b/resources/ext.neowiki/src/components/Value/DateTimeDisplay.vue
@@ -13,10 +13,9 @@ import { computed } from 'vue';
 import { newStringValue, ValueType } from '@/domain/Value.ts';
 import { DateTimeProperty, DateTimeType } from '@/domain/propertyTypes/DateTime.ts';
 import { ValueDisplayProps } from '@/components/Value/ValueDisplayContract.ts';
+import { NeoWikiServices } from '@/NeoWikiServices.ts';
 
 const props = defineProps<ValueDisplayProps<DateTimeProperty>>();
-
-const dateTimeType = new DateTimeType();
 
 const rawValue = computed( (): string => {
 	if ( props.value.type !== ValueType.String ) {
@@ -31,7 +30,8 @@ const parsedIso = computed( (): string | null => {
 		return null;
 	}
 
-	const errors = dateTimeType.validate( newStringValue( raw ), props.property );
+	const propertyType = NeoWikiServices.getPropertyTypeRegistry().getType( DateTimeType.typeName );
+	const errors = propertyType.validate( newStringValue( raw ), props.property );
 	const isValidIso = !errors.some( ( e ) => e.code === 'invalid-datetime' );
 
 	return isValidIso ? raw : null;
@@ -42,6 +42,8 @@ const formattedValue = computed( (): string => {
 	if ( iso === null ) {
 		return '';
 	}
+	// Per-component options rather than dateStyle+timeStyle: ECMA-402 throws
+	// when dateStyle/timeStyle is combined with timeZoneName.
 	return new Date( iso ).toLocaleString( undefined, {
 		year: 'numeric',
 		month: 'short',

--- a/resources/ext.neowiki/src/components/Value/DateTimeDisplay.vue
+++ b/resources/ext.neowiki/src/components/Value/DateTimeDisplay.vue
@@ -1,32 +1,57 @@
 <template>
-	<div>
+	<time
+		v-if="parsedIso !== null"
+		:datetime="parsedIso"
+	>
 		{{ formattedValue }}
-	</div>
+	</time>
+	<span v-else>{{ fallbackText }}</span>
 </template>
 
 <script setup lang="ts">
-import { ValueType } from '@/domain/Value.ts';
 import { computed } from 'vue';
-import { DateTimeProperty } from '@/domain/propertyTypes/DateTime.ts';
+import { newStringValue, ValueType } from '@/domain/Value.ts';
+import { DateTimeProperty, DateTimeType } from '@/domain/propertyTypes/DateTime.ts';
 import { ValueDisplayProps } from '@/components/Value/ValueDisplayContract.ts';
 
 const props = defineProps<ValueDisplayProps<DateTimeProperty>>();
 
-const formattedValue = computed( (): string => {
+const dateTimeType = new DateTimeType();
+
+const rawValue = computed( (): string => {
 	if ( props.value.type !== ValueType.String ) {
 		return '';
 	}
+	return props.value.parts[ 0 ] ?? '';
+} );
 
-	const dateString = props.value.parts[ 0 ];
-	if ( !dateString ) {
+const parsedIso = computed( (): string | null => {
+	const raw = rawValue.value;
+	if ( raw === '' ) {
+		return null;
+	}
+
+	const errors = dateTimeType.validate( newStringValue( raw ), props.property );
+	const isValidIso = !errors.some( ( e ) => e.code === 'invalid-datetime' );
+
+	return isValidIso ? raw : null;
+} );
+
+const formattedValue = computed( (): string => {
+	const iso = parsedIso.value;
+	if ( iso === null ) {
 		return '';
 	}
-
-	const date = new Date( dateString );
-	if ( isNaN( date.getTime() ) ) {
-		return dateString;
-	}
-
-	return date.toLocaleString( undefined, { timeZone: 'UTC' } );
+	return new Date( iso ).toLocaleString( undefined, {
+		year: 'numeric',
+		month: 'short',
+		day: 'numeric',
+		hour: '2-digit',
+		minute: '2-digit',
+		second: '2-digit',
+		timeZoneName: 'short'
+	} );
 } );
+
+const fallbackText = computed( (): string => ( parsedIso.value === null ? rawValue.value : '' ) );
 </script>

--- a/resources/ext.neowiki/src/components/Value/DateTimeInput.vue
+++ b/resources/ext.neowiki/src/components/Value/DateTimeInput.vue
@@ -14,15 +14,14 @@
 				size="small"
 			/>
 		</template>
-		<!-- eslint-disable-next-line vue/html-self-closing -->
-		<input
-			type="datetime-local"
-			class="cdx-text-input__input"
-			:value="internalInputValue"
+		<CdxTextInput
+			input-type="datetime-local"
+			:start-icon="cdxIconClock"
+			:model-value="internalInputValue"
 			:min="toLocalInputValue( props.property.minimum )"
 			:max="toLocalInputValue( props.property.maximum )"
-			@input="onInput"
-		>
+			@update:model-value="onInput"
+		/>
 	</CdxField>
 </template>
 
@@ -32,10 +31,11 @@ import type { Value } from '@/domain/Value';
 
 <script setup lang="ts">
 import { ref, watch } from 'vue';
-import { CdxField, CdxIcon } from '@wikimedia/codex';
-import { cdxIconInfo } from '@wikimedia/codex-icons';
+import { CdxField, CdxIcon, CdxTextInput } from '@wikimedia/codex';
+import { cdxIconInfo, cdxIconClock } from '@wikimedia/codex-icons';
 import { newStringValue, StringValue, ValueType } from '@/domain/Value';
 import { DateTimeType, DateTimeProperty } from '@/domain/propertyTypes/DateTime.ts';
+import { fromLocalInputValue, toLocalInputValue } from '@/domain/propertyTypes/dateTimeConversion.ts';
 import { ValueInputEmits, ValueInputExposes, ValueInputProps } from '@/components/Value/ValueInputContract.ts';
 import { NeoWikiServices } from '@/NeoWikiServices.ts';
 
@@ -51,20 +51,6 @@ const emit = defineEmits<ValueInputEmits>();
 
 const validationError = ref<string | null>( null );
 const internalInputValue = ref<string>( '' );
-
-function toLocalInputValue( isoString: string | undefined ): string {
-	if ( !isoString ) {
-		return '';
-	}
-	return isoString.replace( /Z$/, '' ).slice( 0, 16 );
-}
-
-function fromLocalInputValue( localValue: string ): string {
-	if ( !localValue ) {
-		return '';
-	}
-	return localValue + ':00Z';
-}
 
 const initializeInputValue = ( value: Value | undefined ): void => {
 	if ( value && value.type === ValueType.String ) {
@@ -84,11 +70,10 @@ watch( () => props.modelValue, ( newValue ) => {
 
 const propertyType = NeoWikiServices.getPropertyTypeRegistry().getType( DateTimeType.typeName );
 
-function onInput( event: Event ): void {
-	const target = event.target as HTMLInputElement;
-	internalInputValue.value = target.value;
-	const isoValue = fromLocalInputValue( target.value );
-	const value = isoValue ? newStringValue( isoValue ) : undefined;
+function onInput( newValue: string ): void {
+	internalInputValue.value = newValue;
+	const isoValue = fromLocalInputValue( newValue );
+	const value = isoValue !== undefined ? newStringValue( isoValue ) : undefined;
 	emit( 'update:modelValue', value );
 	validate( value );
 }
@@ -106,7 +91,7 @@ watch( () => props.property, () => {
 defineExpose<ValueInputExposes>( {
 	getCurrentValue: function(): Value | undefined {
 		const isoValue = fromLocalInputValue( internalInputValue.value );
-		return isoValue ? newStringValue( isoValue ) : undefined;
+		return isoValue !== undefined ? newStringValue( isoValue ) : undefined;
 	}
 } );
 

--- a/resources/ext.neowiki/src/domain/propertyTypes/DateTime.ts
+++ b/resources/ext.neowiki/src/domain/propertyTypes/DateTime.ts
@@ -29,7 +29,7 @@ export interface DateTimeProperty extends PropertyDefinition {
 // eslint-disable-next-line security/detect-unsafe-regex
 const ISO_DATE_TIME_REGEX = /^(-?\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])T([01]\d|2[0-3]):([0-5]\d):([0-5]\d)(?:\.\d{1,9})?(?<offset>Z|[+-](?:[01]\d|2[0-3]):[0-5]\d)$/;
 
-function parseStrictDateTime( value: string ): number | null {
+export function parseStrictDateTime( value: string ): number | null {
 	const match = ISO_DATE_TIME_REGEX.exec( value );
 	if ( match === null || match.groups === undefined ) {
 		return null;

--- a/resources/ext.neowiki/src/domain/propertyTypes/DateTime.ts
+++ b/resources/ext.neowiki/src/domain/propertyTypes/DateTime.ts
@@ -29,6 +29,12 @@ export interface DateTimeProperty extends PropertyDefinition {
 // eslint-disable-next-line security/detect-unsafe-regex
 const ISO_DATE_TIME_REGEX = /^(-?\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])T([01]\d|2[0-3]):([0-5]\d):([0-5]\d)(?:\.\d{1,9})?(?<offset>Z|[+-](?:[01]\d|2[0-3]):[0-5]\d)$/;
 
+/**
+ * Parses a strict ISO 8601 / xsd:dateTime string with an explicit offset or `Z`.
+ * Returns a millisecond timestamp, or `null` if the value is malformed, missing
+ * an offset, or a calendar overflow (e.g. Feb 30) that `Date` would silently
+ * roll over.
+ */
 export function parseStrictDateTime( value: string ): number | null {
 	const match = ISO_DATE_TIME_REGEX.exec( value );
 	if ( match === null || match.groups === undefined ) {

--- a/resources/ext.neowiki/src/domain/propertyTypes/dateTimeConversion.ts
+++ b/resources/ext.neowiki/src/domain/propertyTypes/dateTimeConversion.ts
@@ -1,0 +1,40 @@
+/**
+ * Host-timezone-aware conversion between ISO 8601 strings and the
+ * `datetime-local` input wire format (`YYYY-MM-DDTHH:mm`).
+ *
+ * - Storage format is always UTC ISO 8601 (e.g. `...Z`).
+ * - `datetime-local` inputs operate in the host local timezone.
+ * - Inputs with explicit offsets (`+05:00`) are accepted and round-tripped
+ *   as the same instant; they are not silently re-interpreted as UTC.
+ */
+
+function pad( value: number ): string {
+	return String( value ).padStart( 2, '0' );
+}
+
+export function toLocalInputValue( iso: string | undefined ): string {
+	if ( iso === undefined || iso === '' ) {
+		return '';
+	}
+
+	const date = new Date( iso );
+	if ( isNaN( date.getTime() ) ) {
+		return '';
+	}
+
+	return `${ date.getFullYear() }-${ pad( date.getMonth() + 1 ) }-${ pad( date.getDate() ) }` +
+		`T${ pad( date.getHours() ) }:${ pad( date.getMinutes() ) }`;
+}
+
+export function fromLocalInputValue( local: string ): string | undefined {
+	if ( local === '' ) {
+		return undefined;
+	}
+
+	const date = new Date( local );
+	if ( isNaN( date.getTime() ) ) {
+		return undefined;
+	}
+
+	return date.toISOString();
+}

--- a/resources/ext.neowiki/tests/components/SchemaEditor/Property/DateTimeAttributesEditor.spec.ts
+++ b/resources/ext.neowiki/tests/components/SchemaEditor/Property/DateTimeAttributesEditor.spec.ts
@@ -1,9 +1,11 @@
 import { DOMWrapper, VueWrapper } from '@vue/test-utils';
 import { beforeEach, describe, expect, it } from 'vitest';
+import { CdxTextInput } from '@wikimedia/codex';
 import DateTimeAttributesEditor from '@/components/SchemaEditor/Property/DateTimeAttributesEditor.vue';
 import { newDateTimeProperty, DateTimeProperty } from '@/domain/propertyTypes/DateTime';
 import { AttributesEditorProps } from '@/components/SchemaEditor/Property/AttributesEditorContract.ts';
 import { createTestWrapper, FieldProps, setupMwMock } from '../../../VueTestHelpers.ts';
+import { toLocalInputValue } from '@/domain/propertyTypes/dateTimeConversion';
 
 describe( 'DateTimeAttributesEditor', () => {
 	beforeEach( () => {
@@ -34,19 +36,28 @@ describe( 'DateTimeAttributesEditor', () => {
 		return ( wrapper.findComponent( '.datetime-attributes__maximum' ) as VueWrapper ).props() as FieldProps;
 	}
 
+	describe( 'rendering', () => {
+		it( 'renders two CdxTextInput components with datetime-local input-type', () => {
+			const wrapper = newWrapper();
+
+			const textInputs = wrapper.findAllComponents( CdxTextInput );
+			expect( textInputs.length ).toBe( 2 );
+			expect( textInputs[ 0 ].props( 'inputType' ) ).toBe( 'datetime-local' );
+			expect( textInputs[ 1 ].props( 'inputType' ) ).toBe( 'datetime-local' );
+		} );
+	} );
+
 	describe( 'displaying existing values', () => {
-		// FIXME(#728): pins the current Z-stripping behavior; revisit when the timezone story is decided.
-		it( 'strips the Z suffix and seconds from minimum and maximum for the native input', () => {
+		it( 'renders minimum and maximum as host-local wall-clock for the prop ISOs', () => {
+			const minimum = '2020-01-01T00:00:00Z';
+			const maximum = '2030-12-31T23:59:59Z';
 			const wrapper = newWrapper( {
-				property: newDateTimeProperty( {
-					minimum: '2020-01-01T00:00:00Z',
-					maximum: '2030-12-31T23:59:59Z',
-				} ),
+				property: newDateTimeProperty( { minimum, maximum } ),
 			} );
 			const inputs = getInputs( wrapper );
 
-			expect( inputs[ 0 ].element.value ).toBe( '2020-01-01T00:00' );
-			expect( inputs[ 1 ].element.value ).toBe( '2030-12-31T23:59' );
+			expect( inputs[ 0 ].element.value ).toBe( toLocalInputValue( minimum ) );
+			expect( inputs[ 1 ].element.value ).toBe( toLocalInputValue( maximum ) );
 		} );
 
 		it( 'displays empty inputs when minimum and maximum are undefined', () => {
@@ -101,11 +112,13 @@ describe( 'DateTimeAttributesEditor', () => {
 				property: newDateTimeProperty( { maximum: '2020-01-01T00:00:00Z' } ),
 			} );
 			const inputs = getInputs( wrapper );
+			const localMax = inputs[ 1 ].element.value;
+			const expectedIso = new Date( localMax ).toISOString();
 
-			await inputs[ 0 ].setValue( '2020-01-01T00:00' );
+			await inputs[ 0 ].setValue( localMax );
 
 			expect( getMinimumFieldProps( wrapper ).status ).toBe( 'default' );
-			expect( wrapper.emitted( 'update:property' )?.[ 0 ] ).toEqual( [ { minimum: '2020-01-01T00:00:00Z' } ] );
+			expect( wrapper.emitted( 'update:property' )?.[ 0 ] ).toEqual( [ { minimum: expectedIso } ] );
 		} );
 
 		it( 'clears min error when valid value resolves conflict', async () => {
@@ -137,24 +150,26 @@ describe( 'DateTimeAttributesEditor', () => {
 	} );
 
 	describe( 'emitting updates', () => {
-		// FIXME(#728): pins the TZ-naive Z-suffix emission; revisit with the timezone fix.
-		it( 'emits minimum as an ISO string with Z suffix when the min input changes', async () => {
+		it( 'emits minimum as the UTC ISO representing the typed local instant', async () => {
 			const wrapper = newWrapper();
 			const inputs = getInputs( wrapper );
+			const local = '2020-01-01T00:00';
+			const expectedIso = new Date( local ).toISOString();
 
-			await inputs[ 0 ].setValue( '2020-01-01T00:00' );
+			await inputs[ 0 ].setValue( local );
 
-			expect( wrapper.emitted( 'update:property' )?.[ 0 ] ).toEqual( [ { minimum: '2020-01-01T00:00:00Z' } ] );
+			expect( wrapper.emitted( 'update:property' )?.[ 0 ] ).toEqual( [ { minimum: expectedIso } ] );
 		} );
 
-		// FIXME(#728): pins the TZ-naive Z-suffix emission; revisit with the timezone fix.
-		it( 'emits maximum as an ISO string with Z suffix when the max input changes', async () => {
+		it( 'emits maximum as the UTC ISO representing the typed local instant', async () => {
 			const wrapper = newWrapper();
 			const inputs = getInputs( wrapper );
+			const local = '2030-12-31T23:59';
+			const expectedIso = new Date( local ).toISOString();
 
-			await inputs[ 1 ].setValue( '2030-12-31T23:59' );
+			await inputs[ 1 ].setValue( local );
 
-			expect( wrapper.emitted( 'update:property' )?.[ 0 ] ).toEqual( [ { maximum: '2030-12-31T23:59:00Z' } ] );
+			expect( wrapper.emitted( 'update:property' )?.[ 0 ] ).toEqual( [ { maximum: expectedIso } ] );
 		} );
 
 		it( 'emits undefined minimum when the min input is cleared', async () => {

--- a/resources/ext.neowiki/tests/components/SchemaEditor/Property/DateTimeAttributesEditor.spec.ts
+++ b/resources/ext.neowiki/tests/components/SchemaEditor/Property/DateTimeAttributesEditor.spec.ts
@@ -5,7 +5,6 @@ import DateTimeAttributesEditor from '@/components/SchemaEditor/Property/DateTim
 import { newDateTimeProperty, DateTimeProperty } from '@/domain/propertyTypes/DateTime';
 import { AttributesEditorProps } from '@/components/SchemaEditor/Property/AttributesEditorContract.ts';
 import { createTestWrapper, FieldProps, setupMwMock } from '../../../VueTestHelpers.ts';
-import { toLocalInputValue } from '@/domain/propertyTypes/dateTimeConversion';
 
 describe( 'DateTimeAttributesEditor', () => {
 	beforeEach( () => {
@@ -49,15 +48,17 @@ describe( 'DateTimeAttributesEditor', () => {
 
 	describe( 'displaying existing values', () => {
 		it( 'renders minimum and maximum as host-local wall-clock for the prop ISOs', () => {
+			// Use minute-aligned ISOs so the host-local wall-clock (minute precision)
+			// parses back to the exact same instant as the original UTC prop.
 			const minimum = '2020-01-01T00:00:00Z';
-			const maximum = '2030-12-31T23:59:59Z';
+			const maximum = '2030-12-31T23:59:00Z';
 			const wrapper = newWrapper( {
 				property: newDateTimeProperty( { minimum, maximum } ),
 			} );
 			const inputs = getInputs( wrapper );
 
-			expect( inputs[ 0 ].element.value ).toBe( toLocalInputValue( minimum ) );
-			expect( inputs[ 1 ].element.value ).toBe( toLocalInputValue( maximum ) );
+			expect( new Date( inputs[ 0 ].element.value ).getTime() ).toBe( new Date( minimum ).getTime() );
+			expect( new Date( inputs[ 1 ].element.value ).getTime() ).toBe( new Date( maximum ).getTime() );
 		} );
 
 		it( 'displays empty inputs when minimum and maximum are undefined', () => {
@@ -108,17 +109,17 @@ describe( 'DateTimeAttributesEditor', () => {
 		} );
 
 		it( 'allows min equal to max', async () => {
+			const localValue = '2020-01-01T00:00';
+			const maxIso = new Date( localValue ).toISOString();
 			const wrapper = newWrapper( {
-				property: newDateTimeProperty( { maximum: '2020-01-01T00:00:00Z' } ),
+				property: newDateTimeProperty( { maximum: maxIso } ),
 			} );
 			const inputs = getInputs( wrapper );
-			const localMax = inputs[ 1 ].element.value;
-			const expectedIso = new Date( localMax ).toISOString();
 
-			await inputs[ 0 ].setValue( localMax );
+			await inputs[ 0 ].setValue( localValue );
 
 			expect( getMinimumFieldProps( wrapper ).status ).toBe( 'default' );
-			expect( wrapper.emitted( 'update:property' )?.[ 0 ] ).toEqual( [ { minimum: expectedIso } ] );
+			expect( wrapper.emitted( 'update:property' )?.[ 0 ] ).toEqual( [ { minimum: maxIso } ] );
 		} );
 
 		it( 'clears min error when valid value resolves conflict', async () => {

--- a/resources/ext.neowiki/tests/components/Value/DateTimeDisplay.spec.ts
+++ b/resources/ext.neowiki/tests/components/Value/DateTimeDisplay.spec.ts
@@ -24,44 +24,62 @@ function createWrapperWithValue( value: Value ): ReturnType<typeof mount> {
 }
 
 describe( 'DateTimeDisplay', () => {
-	// The assertions below are deliberately locale-invariant: the year and the
-	// minute-second pair are stable across en-US, en-GB, de-DE, etc., whereas
-	// day-first vs month-first and 12h vs 24h clock rendering are not. This
-	// keeps the test green for contributors whose host locale differs from CI.
-	it( 'renders a UTC date/time using the UTC timezone rather than the host timezone', () => {
-		const wrapper = createWrapperWithValue( newStringValue( '2025-06-15T12:00:00Z' ) );
+	describe( 'valid ISO 8601 input', () => {
+		it( 'renders a <time> element with the raw ISO string as the datetime attribute', () => {
+			const iso = '2025-06-15T12:00:00Z';
+			const wrapper = createWrapperWithValue( newStringValue( iso ) );
 
-		const text = wrapper.text();
-		expect( text ).toContain( '2025' );
-		expect( text ).toContain( ':00:00' );
+			const time = wrapper.find( 'time' );
+			expect( time.exists() ).toBe( true );
+			expect( time.attributes( 'datetime' ) ).toBe( iso );
+		} );
+
+		it( 'renders the instant formatted in the host timezone', () => {
+			const iso = '2025-06-15T12:00:00Z';
+			const wrapper = createWrapperWithValue( newStringValue( iso ) );
+
+			const localHour = String( new Date( iso ).getHours() ).padStart( 2, '0' );
+			expect( wrapper.text() ).toContain( localHour );
+		} );
+
+		it( 'includes a timezone name suffix in the rendered text', () => {
+			const wrapper = createWrapperWithValue( newStringValue( '2025-06-15T12:00:00Z' ) );
+
+			// With timeZoneName: 'short', toLocaleString appends a TZ abbreviation
+			// (e.g. "GMT", "UTC", "CEST", "PST"). Asserting on a letter-containing
+			// suffix after the formatted time is TZ- and locale-invariant.
+			expect( wrapper.text() ).toMatch( /[A-Za-z]{2,}/ );
+		} );
+
+		it( 'preserves an explicit-offset ISO string as the datetime attribute', () => {
+			const iso = '2025-06-15T23:30:00+05:00';
+			const wrapper = createWrapperWithValue( newStringValue( iso ) );
+
+			expect( wrapper.find( 'time' ).attributes( 'datetime' ) ).toBe( iso );
+		} );
 	} );
 
-	it( 'converts a positive-offset datetime to UTC for display', () => {
-		// 2025-06-15T23:30:00+05:00 == 2025-06-15T18:30:00Z — must NOT display as 23:30.
-		// The positive assertion uses the locale-invariant ":30:00" suffix; the
-		// negative one proves the wrong local time is not rendered.
-		const wrapper = createWrapperWithValue( newStringValue( '2025-06-15T23:30:00+05:00' ) );
+	describe( 'invalid input', () => {
+		it( 'renders a span (not a time element) with the raw string when the value cannot be parsed', () => {
+			const wrapper = createWrapperWithValue( newStringValue( 'not-a-date' ) );
 
-		const text = wrapper.text();
-		expect( text ).toContain( ':30:00' );
-		expect( text ).not.toContain( '23:30' );
-	} );
+			expect( wrapper.find( 'time' ).exists() ).toBe( false );
+			expect( wrapper.find( 'span' ).exists() ).toBe( true );
+			expect( wrapper.text() ).toBe( 'not-a-date' );
+		} );
 
-	it( 'renders the raw string when the datetime cannot be parsed', () => {
-		const wrapper = createWrapperWithValue( newStringValue( 'not-a-date' ) );
+		it( 'renders an empty span when the string value is empty', () => {
+			const wrapper = createWrapperWithValue( newStringValue( '' ) );
 
-		expect( wrapper.text() ).toBe( 'not-a-date' );
-	} );
+			expect( wrapper.find( 'time' ).exists() ).toBe( false );
+			expect( wrapper.text() ).toBe( '' );
+		} );
 
-	it( 'renders empty when the string value is empty', () => {
-		const wrapper = createWrapperWithValue( newStringValue( '' ) );
+		it( 'renders an empty span when given the wrong value type', () => {
+			const wrapper = createWrapperWithValue( newNumberValue( 42 ) );
 
-		expect( wrapper.text() ).toBe( '' );
-	} );
-
-	it( 'renders empty when given the wrong value type', () => {
-		const wrapper = createWrapperWithValue( newNumberValue( 42 ) );
-
-		expect( wrapper.text() ).toBe( '' );
+			expect( wrapper.find( 'time' ).exists() ).toBe( false );
+			expect( wrapper.text() ).toBe( '' );
+		} );
 	} );
 } );

--- a/resources/ext.neowiki/tests/components/Value/DateTimeDisplay.spec.ts
+++ b/resources/ext.neowiki/tests/components/Value/DateTimeDisplay.spec.ts
@@ -1,25 +1,24 @@
-import { mount } from '@vue/test-utils';
+import { VueWrapper } from '@vue/test-utils';
 import { describe, expect, it } from 'vitest';
 import DateTimeDisplay from '@/components/Value/DateTimeDisplay.vue';
 import { newNumberValue, newStringValue, Value } from '@/domain/Value';
 import { newDateTimeProperty, DateTimeProperty } from '@/domain/propertyTypes/DateTime';
 import { ValueDisplayProps } from '@/components/Value/ValueDisplayContract.ts';
+import { createTestWrapper } from '../../VueTestHelpers.ts';
 
-function createWrapper( props: Partial<ValueDisplayProps<DateTimeProperty>> ): ReturnType<typeof mount> {
+function createWrapper( props: Partial<ValueDisplayProps<DateTimeProperty>> ): VueWrapper {
 	const defaultProps: ValueDisplayProps<DateTimeProperty> = {
 		value: newStringValue( '' ),
 		property: newDateTimeProperty(),
 	};
 
-	return mount( DateTimeDisplay, {
-		props: {
-			...defaultProps,
-			...props,
-		},
+	return createTestWrapper( DateTimeDisplay, {
+		...defaultProps,
+		...props,
 	} );
 }
 
-function createWrapperWithValue( value: Value ): ReturnType<typeof mount> {
+function createWrapperWithValue( value: Value ): VueWrapper {
 	return createWrapper( { value } );
 }
 
@@ -46,9 +45,9 @@ describe( 'DateTimeDisplay', () => {
 			const wrapper = createWrapperWithValue( newStringValue( '2025-06-15T12:00:00Z' ) );
 
 			// With timeZoneName: 'short', toLocaleString appends a TZ abbreviation
-			// (e.g. "GMT", "UTC", "CEST", "PST"). Asserting on a letter-containing
-			// suffix after the formatted time is TZ- and locale-invariant.
-			expect( wrapper.text() ).toMatch( /[A-Za-z]{2,}/ );
+			// (UTC, CEST, PDT, MEZ, ...). These are 3+ consecutive uppercase
+			// letters, which won't match "Jun" (mixed case) or AM/PM (2 letters).
+			expect( wrapper.text() ).toMatch( /[A-Z]{3,}/ );
 		} );
 
 		it( 'preserves an explicit-offset ISO string as the datetime attribute', () => {

--- a/resources/ext.neowiki/tests/components/Value/DateTimeInput.spec.ts
+++ b/resources/ext.neowiki/tests/components/Value/DateTimeInput.spec.ts
@@ -2,7 +2,7 @@ import { VueWrapper } from '@vue/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { CdxField, CdxTextInput } from '@wikimedia/codex';
 import { cdxIconClock } from '@wikimedia/codex-icons';
-import { newStringValue } from '@/domain/Value';
+import { newStringValue, StringValue, ValueType } from '@/domain/Value';
 import DateTimeInput from '@/components/Value/DateTimeInput.vue';
 import { newDateTimeProperty, DateTimeProperty } from '@/domain/propertyTypes/DateTime';
 import { ValueInputExposes, ValueInputProps } from '@/components/Value/ValueInputContract.ts';
@@ -39,14 +39,6 @@ describe( 'DateTimeInput', () => {
 		expect( textInput.props( 'inputType' ) ).toBe( 'datetime-local' );
 		expect( textInput.props( 'startIcon' ) ).toBe( cdxIconClock );
 		expect( wrapper.text() ).toContain( 'Test Label' );
-	} );
-
-	it( 'renders exactly one input and it is under a CdxTextInput', () => {
-		const wrapper = newWrapper();
-
-		const inputs = wrapper.findAll( 'input' );
-		expect( inputs.length ).toBe( 1 );
-		expect( inputs[ 0 ].element.closest( '.cdx-text-input' ) ).not.toBeNull();
 	} );
 
 	it( 'displays ISO modelValue as the host-local wall-clock in the input', () => {
@@ -134,7 +126,7 @@ describe( 'DateTimeInput', () => {
 
 			const result = ( wrapper.vm as unknown as ValueInputExposes ).getCurrentValue();
 
-			if ( result === undefined || result.type !== 'string' ) {
+			if ( result === undefined || result.type !== ValueType.String ) {
 				throw new Error( 'expected a string value' );
 			}
 			const resultIso = result.parts[ 0 ];
@@ -168,7 +160,7 @@ describe( 'DateTimeInput', () => {
 
 			const result = ( wrapper.vm as unknown as ValueInputExposes ).getCurrentValue();
 
-			if ( result === undefined || result.type !== 'string' ) {
+			if ( result === undefined || result.type !== ValueType.String ) {
 				throw new Error( 'expected a string value' );
 			}
 			const resultIso = result.parts[ 0 ];
@@ -176,29 +168,21 @@ describe( 'DateTimeInput', () => {
 		} );
 	} );
 
-	describe( 'under a non-UTC TZ (#728 pinning test)', () => {
-		it( 'round-trips a UTC ISO through the input preserving the instant', async () => {
-			// vi.stubEnv sets process.env.TZ. Node's Intl/Date may cache the
-			// startup TZ, so this documents intent; the assertion itself is
-			// TZ-invariant — it checks instant equivalence, not a literal string.
-			vi.stubEnv( 'TZ', 'Europe/Berlin' );
+	it( 'round-trips an ISO modelValue through the full input event flow preserving the instant', async () => {
+		// Driving the input via its own displayed value asserts that the
+		// display→emit path is a no-op on the instant, independent of host TZ.
+		const iso = '2025-06-15T14:00:00Z';
+		const wrapper = newWrapper( { modelValue: newStringValue( iso ) } );
 
-			const iso = '2025-06-15T14:00:00Z';
-			const wrapper = newWrapper( { modelValue: newStringValue( iso ) } );
+		const localValue = wrapper.find( 'input' ).element.value;
+		await wrapper.find( 'input' ).setValue( localValue );
 
-			const localValue = wrapper.find( 'input' ).element.value;
-			await wrapper.find( 'input' ).setValue( localValue );
+		const events = wrapper.emitted( 'update:modelValue' );
+		const firstEvent = events?.[ 0 ]?.[ 0 ] as StringValue | undefined;
+		if ( firstEvent === undefined || firstEvent.type !== ValueType.String ) {
+			throw new Error( 'expected an emitted string value' );
+		}
 
-			const events = wrapper.emitted( 'update:modelValue' );
-			const firstEvent = events?.[ 0 ]?.[ 0 ];
-			if ( firstEvent === undefined || firstEvent === null || typeof firstEvent !== 'object' || !( 'parts' in firstEvent ) ) {
-				throw new Error( 'expected an emitted string value' );
-			}
-			const emittedIso = ( firstEvent as { parts: string[] } ).parts[ 0 ];
-
-			expect( new Date( emittedIso ).getTime() ).toBe( new Date( iso ).getTime() );
-
-			vi.unstubAllEnvs();
-		} );
+		expect( new Date( firstEvent.parts[ 0 ] ).getTime() ).toBe( new Date( iso ).getTime() );
 	} );
 } );

--- a/resources/ext.neowiki/tests/components/Value/DateTimeInput.spec.ts
+++ b/resources/ext.neowiki/tests/components/Value/DateTimeInput.spec.ts
@@ -1,11 +1,13 @@
 import { VueWrapper } from '@vue/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { CdxField } from '@wikimedia/codex';
+import { CdxField, CdxTextInput } from '@wikimedia/codex';
+import { cdxIconClock } from '@wikimedia/codex-icons';
 import { newStringValue } from '@/domain/Value';
 import DateTimeInput from '@/components/Value/DateTimeInput.vue';
 import { newDateTimeProperty, DateTimeProperty } from '@/domain/propertyTypes/DateTime';
 import { ValueInputExposes, ValueInputProps } from '@/components/Value/ValueInputContract.ts';
 import { createTestWrapper } from '../../VueTestHelpers.ts';
+import { toLocalInputValue } from '@/domain/propertyTypes/dateTimeConversion';
 
 describe( 'DateTimeInput', () => {
 	beforeEach( () => {
@@ -26,23 +28,32 @@ describe( 'DateTimeInput', () => {
 		} );
 	}
 
-	it( 'renders correctly', () => {
+	it( 'renders a CdxTextInput with datetime-local input-type and clock start-icon', () => {
 		const wrapper = newWrapper();
 
 		expect( wrapper.findComponent( CdxField ).exists() ).toBe( true );
-		expect( wrapper.findComponent( CdxField ).props( 'status' ) ).toBe( 'default' );
-		expect( wrapper.findComponent( CdxField ).props( 'messages' ) ).toEqual( {} );
 		expect( wrapper.find( 'input[type="datetime-local"]' ).exists() ).toBe( true );
+
+		const textInput = wrapper.findComponent( CdxTextInput );
+		expect( textInput.exists() ).toBe( true );
+		expect( textInput.props( 'inputType' ) ).toBe( 'datetime-local' );
+		expect( textInput.props( 'startIcon' ) ).toBe( cdxIconClock );
 		expect( wrapper.text() ).toContain( 'Test Label' );
 	} );
 
-	// FIXME(#728): pins the current Z-stripping behavior; revisit when the timezone story is decided.
-	it( 'displays ISO modelValue as datetime-local input value', () => {
-		const wrapper = newWrapper( {
-			modelValue: newStringValue( '2025-06-15T14:00:00Z' ),
-		} );
+	it( 'renders exactly one input and it is under a CdxTextInput', () => {
+		const wrapper = newWrapper();
 
-		expect( wrapper.find( 'input' ).element.value ).toBe( '2025-06-15T14:00' );
+		const inputs = wrapper.findAll( 'input' );
+		expect( inputs.length ).toBe( 1 );
+		expect( inputs[ 0 ].element.closest( '.cdx-text-input' ) ).not.toBeNull();
+	} );
+
+	it( 'displays ISO modelValue as the host-local wall-clock in the input', () => {
+		const iso = '2025-06-15T14:00:00Z';
+		const wrapper = newWrapper( { modelValue: newStringValue( iso ) } );
+
+		expect( wrapper.find( 'input' ).element.value ).toBe( toLocalInputValue( iso ) );
 	} );
 
 	it( 'displays empty input when modelValue is undefined', () => {
@@ -51,17 +62,15 @@ describe( 'DateTimeInput', () => {
 		expect( wrapper.find( 'input' ).element.value ).toBe( '' );
 	} );
 
-	// FIXME(#728): pins the current Z-stripping behavior on bounds; revisit with the timezone fix.
-	it( 'passes minimum and maximum to the input as min/max attributes', () => {
+	it( 'passes minimum and maximum as host-local wall-clock on the input min/max attrs', () => {
+		const minimum = '2020-01-01T00:00:00Z';
+		const maximum = '2030-12-31T23:59:59Z';
 		const wrapper = newWrapper( {
-			property: newDateTimeProperty( {
-				minimum: '2020-01-01T00:00:00Z',
-				maximum: '2030-12-31T23:59:59Z',
-			} ),
+			property: newDateTimeProperty( { minimum, maximum } ),
 		} );
 
-		expect( wrapper.find( 'input' ).attributes( 'min' ) ).toBe( '2020-01-01T00:00' );
-		expect( wrapper.find( 'input' ).attributes( 'max' ) ).toBe( '2030-12-31T23:59' );
+		expect( wrapper.find( 'input' ).attributes( 'min' ) ).toBe( toLocalInputValue( minimum ) );
+		expect( wrapper.find( 'input' ).attributes( 'max' ) ).toBe( toLocalInputValue( maximum ) );
 	} );
 
 	it( 'shows required error when required property has empty value', () => {
@@ -96,15 +105,15 @@ describe( 'DateTimeInput', () => {
 		expect( wrapper.findComponent( CdxField ).props( 'messages' ) ).toHaveProperty( 'error', 'neowiki-field-max-value' );
 	} );
 
-	// FIXME(#728): pins the TZ-naive Z-suffix emission; revisit with the timezone fix.
-	it( 'emits update:modelValue as ISO string with Z when input changes', async () => {
+	it( 'emits update:modelValue as a UTC ISO representing the typed local instant', async () => {
 		const wrapper = newWrapper();
+		const local = '2025-06-15T14:00';
+		const expectedIso = new Date( local ).toISOString();
 
-		await wrapper.find( 'input' ).setValue( '2025-06-15T14:00' );
+		await wrapper.find( 'input' ).setValue( local );
 
 		const events = wrapper.emitted( 'update:modelValue' );
-		expect( events ).toBeTruthy();
-		expect( events?.[ 0 ] ).toEqual( [ newStringValue( '2025-06-15T14:00:00Z' ) ] );
+		expect( events?.[ 0 ] ).toEqual( [ newStringValue( expectedIso ) ] );
 	} );
 
 	it( 'emits undefined when input is cleared', async () => {
@@ -115,28 +124,32 @@ describe( 'DateTimeInput', () => {
 		await wrapper.find( 'input' ).setValue( '' );
 
 		const events = wrapper.emitted( 'update:modelValue' );
-		expect( events ).toBeTruthy();
 		expect( events?.[ 0 ] ).toEqual( [ undefined ] );
 	} );
 
 	describe( 'getCurrentValue', () => {
-		it( 'returns initial value', () => {
-			const wrapper = newWrapper( {
-				modelValue: newStringValue( '2025-06-15T14:00:00Z' ),
-			} );
+		it( 'returns the initial modelValue as the same-instant ISO', () => {
+			const iso = '2025-06-15T14:00:00Z';
+			const wrapper = newWrapper( { modelValue: newStringValue( iso ) } );
 
-			expect( ( wrapper.vm as unknown as ValueInputExposes ).getCurrentValue() )
-				.toEqual( newStringValue( '2025-06-15T14:00:00Z' ) );
+			const result = ( wrapper.vm as unknown as ValueInputExposes ).getCurrentValue();
+
+			if ( result === undefined || result.type !== 'string' ) {
+				throw new Error( 'expected a string value' );
+			}
+			const resultIso = result.parts[ 0 ];
+			expect( new Date( resultIso ).getTime() ).toBe( new Date( iso ).getTime() );
 		} );
 
-		// FIXME(#728): pins the TZ-naive Z-suffix round-trip through getCurrentValue; revisit with the timezone fix.
-		it( 'returns updated value after input', async () => {
+		it( 'returns the typed local instant as the corresponding UTC ISO', async () => {
 			const wrapper = newWrapper();
+			const local = '2030-03-20T09:15';
+			const expectedIso = new Date( local ).toISOString();
 
-			await wrapper.find( 'input' ).setValue( '2030-03-20T09:15' );
+			await wrapper.find( 'input' ).setValue( local );
 
 			expect( ( wrapper.vm as unknown as ValueInputExposes ).getCurrentValue() )
-				.toEqual( newStringValue( '2030-03-20T09:15:00Z' ) );
+				.toEqual( newStringValue( expectedIso ) );
 		} );
 
 		it( 'returns undefined for empty input', async () => {
@@ -149,14 +162,43 @@ describe( 'DateTimeInput', () => {
 			expect( ( wrapper.vm as unknown as ValueInputExposes ).getCurrentValue() ).toBeUndefined();
 		} );
 
-		// TODO(#728): add a proper TZ-pinned round-trip test here. It belongs with the
-		// fix for the timezone bug: set TZ to a non-UTC zone via vi.stubEnv and verify
-		// that an explicit-offset ISO input (e.g. "2025-06-15T23:30:00+05:00") survives
-		// a round-trip without being silently reinterpreted as UTC. Not added now because
-		// the current implementation is pure string manipulation (TZ-independent) and a
-		// TZ-pinned test would either pass trivially or document the bug as correct.
-		// Note: vi.stubEnv('TZ', ...) only affects process.env — Node's Intl/Date honor
-		// the TZ at startup in older versions, so this may need a jsdom-level shim or
-		// a fresh worker depending on the Node version the project builds against.
+		it( 'preserves an explicit-offset modelValue as the same instant', () => {
+			const iso = '2025-06-15T23:30:00+05:00';
+			const wrapper = newWrapper( { modelValue: newStringValue( iso ) } );
+
+			const result = ( wrapper.vm as unknown as ValueInputExposes ).getCurrentValue();
+
+			if ( result === undefined || result.type !== 'string' ) {
+				throw new Error( 'expected a string value' );
+			}
+			const resultIso = result.parts[ 0 ];
+			expect( new Date( resultIso ).getTime() ).toBe( new Date( iso ).getTime() );
+		} );
+	} );
+
+	describe( 'under a non-UTC TZ (#728 pinning test)', () => {
+		it( 'round-trips a UTC ISO through the input preserving the instant', async () => {
+			// vi.stubEnv sets process.env.TZ. Node's Intl/Date may cache the
+			// startup TZ, so this documents intent; the assertion itself is
+			// TZ-invariant — it checks instant equivalence, not a literal string.
+			vi.stubEnv( 'TZ', 'Europe/Berlin' );
+
+			const iso = '2025-06-15T14:00:00Z';
+			const wrapper = newWrapper( { modelValue: newStringValue( iso ) } );
+
+			const localValue = wrapper.find( 'input' ).element.value;
+			await wrapper.find( 'input' ).setValue( localValue );
+
+			const events = wrapper.emitted( 'update:modelValue' );
+			const firstEvent = events?.[ 0 ]?.[ 0 ];
+			if ( firstEvent === undefined || firstEvent === null || typeof firstEvent !== 'object' || !( 'parts' in firstEvent ) ) {
+				throw new Error( 'expected an emitted string value' );
+			}
+			const emittedIso = ( firstEvent as { parts: string[] } ).parts[ 0 ];
+
+			expect( new Date( emittedIso ).getTime() ).toBe( new Date( iso ).getTime() );
+
+			vi.unstubAllEnvs();
+		} );
 	} );
 } );

--- a/resources/ext.neowiki/tests/domain/propertyTypes/DateTime.spec.ts
+++ b/resources/ext.neowiki/tests/domain/propertyTypes/DateTime.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { newDateTimeProperty, DateTimeType } from '@/domain/propertyTypes/DateTime';
+import { newDateTimeProperty, DateTimeType, parseStrictDateTime } from '@/domain/propertyTypes/DateTime';
 import { PropertyName } from '@/domain/PropertyDefinition';
 import { newStringValue } from '@/domain/Value';
 
@@ -217,6 +217,34 @@ describe( 'validate', () => {
 		const property = newDateTimeProperty( { maximum: 'garbage' } );
 
 		expect( dateTimeType.validate( newStringValue( '2025-06-15T12:00:00Z' ), property ) ).toEqual( [] );
+	} );
+
+} );
+
+describe( 'parseStrictDateTime', () => {
+
+	it( 'returns a millisecond timestamp for a valid ISO with Z offset', () => {
+		const result = parseStrictDateTime( '2025-06-15T12:00:00Z' );
+
+		expect( result ).toBe( Date.parse( '2025-06-15T12:00:00Z' ) );
+	} );
+
+	it( 'returns a millisecond timestamp for a valid ISO with explicit numeric offset', () => {
+		const result = parseStrictDateTime( '2025-06-15T23:30:00+05:00' );
+
+		expect( result ).toBe( Date.parse( '2025-06-15T23:30:00+05:00' ) );
+	} );
+
+	it( 'returns null for a calendar-overflow date that Date silently rolls over', () => {
+		expect( parseStrictDateTime( '2025-02-30T00:00:00Z' ) ).toBeNull();
+	} );
+
+	it( 'returns null for an ISO without an explicit offset or Z', () => {
+		expect( parseStrictDateTime( '2025-06-15T12:00:00' ) ).toBeNull();
+	} );
+
+	it( 'returns null for completely malformed input', () => {
+		expect( parseStrictDateTime( 'not-a-date' ) ).toBeNull();
 	} );
 
 } );

--- a/resources/ext.neowiki/tests/domain/propertyTypes/dateTimeConversion.spec.ts
+++ b/resources/ext.neowiki/tests/domain/propertyTypes/dateTimeConversion.spec.ts
@@ -45,7 +45,9 @@ describe( 'round-trip preserves the instant', () => {
 		const local = toLocalInputValue( iso );
 		const result = fromLocalInputValue( local );
 
-		expect( result ).toBeDefined();
-		expect( new Date( result! ).getTime() ).toBe( new Date( iso ).getTime() );
+		if ( result === undefined ) {
+			throw new Error( 'round-trip must not produce undefined' );
+		}
+		expect( new Date( result ).getTime() ).toBe( new Date( iso ).getTime() );
 	} );
 } );

--- a/resources/ext.neowiki/tests/domain/propertyTypes/dateTimeConversion.spec.ts
+++ b/resources/ext.neowiki/tests/domain/propertyTypes/dateTimeConversion.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { fromLocalInputValue, toLocalInputValue } from '@/domain/propertyTypes/dateTimeConversion';
+
+describe( 'toLocalInputValue', () => {
+	it( 'returns empty string for undefined', () => {
+		expect( toLocalInputValue( undefined ) ).toBe( '' );
+	} );
+
+	it( 'returns empty string for an unparseable input', () => {
+		expect( toLocalInputValue( 'not-a-date' ) ).toBe( '' );
+	} );
+
+	it( 'returns a YYYY-MM-DDTHH:mm string of length 16 for a valid ISO input', () => {
+		const result = toLocalInputValue( '2025-06-15T12:00:00Z' );
+
+		expect( result.length ).toBe( 16 );
+		expect( result ).toMatch( /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/ );
+	} );
+} );
+
+describe( 'fromLocalInputValue', () => {
+	it( 'returns undefined for empty string', () => {
+		expect( fromLocalInputValue( '' ) ).toBeUndefined();
+	} );
+
+	it( 'returns undefined for unparseable input', () => {
+		expect( fromLocalInputValue( 'garbage' ) ).toBeUndefined();
+	} );
+
+	it( 'encodes a datetime-local value as UTC ISO corresponding to that local instant', () => {
+		const local = '2025-06-15T14:00';
+		const expectedIso = new Date( local ).toISOString();
+
+		expect( fromLocalInputValue( local ) ).toBe( expectedIso );
+	} );
+} );
+
+describe( 'round-trip preserves the instant', () => {
+	it.each( [
+		'2025-06-15T12:00:00Z',
+		'2025-06-15T23:30:00+05:00',
+		'2025-06-15T03:15:00-08:00',
+		'2025-12-31T23:00:00Z',
+	] )( 'preserves the instant for %s', ( iso ) => {
+		const local = toLocalInputValue( iso );
+		const result = fromLocalInputValue( local );
+
+		expect( result ).toBeDefined();
+		expect( new Date( result! ).getTime() ).toBe( new Date( iso ).getTime() );
+	} );
+} );


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/728
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/731

## Summary

Three DateTime components now agree on one story: **user-local wall-clock in the UI, UTC ISO on disk**.

- **New shared utility** `dateTimeConversion.ts` (`toLocalInputValue`, `fromLocalInputValue`) uses `new Date()` + `.toISOString()` so explicit-offset ISOs (e.g. `2025-06-15T23:30:00+05:00`) round-trip without silent re-encoding.
- **`DateTimeDisplay`** renders valid ISOs inside a semantic `<time :datetime="iso">` element with the user's local wall-clock plus a visible timezone abbreviation (`UTC`, `CEST`, `PST`, ...). Invalid values render a `<span>` fallback. Validity uses the newly-exported `parseStrictDateTime` from `DateTime.ts`.
- **`DateTimeInput`** and **`DateTimeAttributesEditor`** replace raw `<input type="datetime-local">` with `CdxTextInput input-type="datetime-local"`. The Input gets a `cdxIconClock` start-icon (previously registered but never rendered). Two `eslint-disable vue/html-self-closing` comments retired.
- Tests in all three component specs rewritten around the new behavior; `FIXME(#728)` pins that locked the old buggy behavior are gone. Direct tests added for `parseStrictDateTime` since it is now part of the public module surface.

## Manual Browser Check

1. **Subject edit flow** — open a page that has a DateTime property and edit it in the subject editor.
   - Input shows a Codex clock icon on the left.
   - Typing `2025-06-15 14:00` saves as your local 14:00. Reload — the input should still show `14:00` in your host TZ.
   - If the schema declares `minimum`/`maximum`, the `min`/`max` attributes on the input reflect them in your local TZ.
2. **Subject display flow** — view the same page without editing.
   - Inspect the value: it must be a `<time>` element with a `datetime` attribute equal to the stored UTC ISO.
   - Rendered text must include a timezone abbreviation after the time (e.g. `UTC`, `CEST`, `PST`).
   - An unparseable stored value falls back to a `<span>` showing the raw string.
3. **Schema editor flow** — open the schema editor for a DateTime property.
   - Both min/max inputs are Codex-styled (focus ring, proper sizing), not bare browser inputs.
   - Entered values round-trip as the same local wall-clock after saving and reopening.

Suggested starting URL: `http://localhost:8484/index.php/Main_Page` (or any page with DateTime data).