### PR TITLE
Ignore null bounds in NumberType validation

### DIFF
--- a/resources/ext.neowiki/src/domain/propertyTypes/Number.ts
+++ b/resources/ext.neowiki/src/domain/propertyTypes/Number.ts
@@ -28,9 +28,9 @@ export class NumberType extends BasePropertyType<NumberProperty, NumberValue> {
 	public createPropertyDefinitionFromJson( base: PropertyDefinition, json: any ): NumberProperty {
 		return {
 			...base,
-			precision: json.precision,
-			minimum: json.minimum,
-			maximum: json.maximum,
+			precision: json.precision ?? undefined,
+			minimum: json.minimum ?? undefined,
+			maximum: json.maximum ?? undefined,
 		} as NumberProperty;
 	}
 

--- a/resources/ext.neowiki/tests/domain/propertyTypes/Number.spec.ts
+++ b/resources/ext.neowiki/tests/domain/propertyTypes/Number.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { newNumberProperty, NumberType } from '@/domain/propertyTypes/Number';
-import { PropertyName } from '@/domain/PropertyDefinition';
+import { newNumberProperty, NumberType, type NumberProperty } from '@/domain/propertyTypes/Number';
+import { PropertyName, type PropertyDefinition } from '@/domain/PropertyDefinition';
 import { newNumberValue } from '@/domain/Value';
 
 describe( 'NumberType', () => {
@@ -150,5 +150,22 @@ describe( 'validate', () => {
 			code: 'max-value',
 			args: [ 100 ],
 		} ] );
+	} );
+
+	it( 'ignores null bounds coming from JSON deserialization', () => {
+		const base: PropertyDefinition = {
+			name: new PropertyName( 'n' ),
+			type: NumberType.typeName,
+			description: '',
+			required: false,
+		};
+		const property = numberType.createPropertyDefinitionFromJson(
+			base,
+			{ type: NumberType.typeName, minimum: null, maximum: null, precision: null },
+		) as NumberProperty;
+
+		const errors = numberType.validate( newNumberValue( 2000 ), property );
+
+		expect( errors ).toEqual( [] );
 	} );
 } );

--- a/resources/ext.neowiki/tests/domain/propertyTypes/Number.spec.ts
+++ b/resources/ext.neowiki/tests/domain/propertyTypes/Number.spec.ts
@@ -152,19 +152,31 @@ describe( 'validate', () => {
 		} ] );
 	} );
 
-	it( 'ignores null bounds coming from JSON deserialization', () => {
+	function numberPropertyFromJson( json: Record<string, unknown> ): NumberProperty {
 		const base: PropertyDefinition = {
 			name: new PropertyName( 'n' ),
 			type: NumberType.typeName,
 			description: '',
 			required: false,
 		};
-		const property = numberType.createPropertyDefinitionFromJson(
+		return numberType.createPropertyDefinitionFromJson(
 			base,
-			{ type: NumberType.typeName, minimum: null, maximum: null, precision: null },
+			{ type: NumberType.typeName, ...json },
 		) as NumberProperty;
+	}
+
+	it( 'ignores null maximum coming from JSON deserialization', () => {
+		const property = numberPropertyFromJson( { maximum: null } );
 
 		const errors = numberType.validate( newNumberValue( 2000 ), property );
+
+		expect( errors ).toEqual( [] );
+	} );
+
+	it( 'ignores null minimum coming from JSON deserialization', () => {
+		const property = numberPropertyFromJson( { minimum: null } );
+
+		const errors = numberType.validate( newNumberValue( -2000 ), property );
 
 		expect( errors ).toEqual( [] );
 	} );


### PR DESCRIPTION
Related to https://github.com/ProfessionalWiki/NeoWiki/issues/756

## What this changes

Hardens `NumberType` validation against `null` bounds at the JSON seam. The TS type declares `minimum?: number` / `maximum?: number` — "absent" should mean `undefined`, not `null`. Today `NumberType.createPropertyDefinitionFromJson` copies the JSON values through verbatim, so if a `null` ever arrives (e.g. from PHP's `NumberProperty::nonCoreToJson`, or a hand-edited schema page), it lands on the domain object as `null` and the validator's `!== undefined` guard lets it through. JS then coerces `null` to `0` in the numeric comparison, so any non-zero input is rejected with "Maximum value is null." (or "Minimum value is null." for negatives).

Normalize `null` to `undefined` at the JSON seam so the domain type stays honest and existing validator guards do the right thing.

Two regression tests cover the maximum and minimum paths independently (value `2000` exercises only `maximum > 0`; `-2000` exercises `minimum < 0`).

## Note on #756

I could not reproduce the user-visible "Maximum value is null." error on master today. The current `RestSchemaRepository.getSchema` fetches `/v1/page/Schema:<name>` (raw wikitext source), not the PHP-serialized JSON — and schema wikitext omits unset keys, so `minimum`/`maximum` arrive as `undefined`, not `null`, and the existing guard works. So this PR is defensive rather than a fix for a currently reachable bug via the SubjectEditor flow. Leaving #756 open — the original screenshot must have come from a different path or state that we haven't identified yet.

## Follow-up

The same null-leak pattern exists at the JSON seam for `Text.ts` (`minLength`/`maxLength`) and `DateTime.ts` (`minimum`/`maximum`). Neither triggers a user-visible bug today — `TextProperty.php` does not emit those keys, and `DateTime.ts` has a `parseStrictDateTime(null)` guard that masks the coercion — but both are latent and worth tidying as a separate change.

> Result of extensive back and forth with @JeroenDeDauw and this specific refinement of his after empirical verification in the dev environment.
> Context: the NeoWiki codebase on master, browser-based reproduction attempt against the running dev wiki, inspection of the PHP serialization and TS deserialization layers.
> <sub>Written by Claude Code, \`Opus 4.7\`</sub>