### PR TITLE
Hide Manage subjects sidebar link while viewing that tab

### DIFF
--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -309,7 +309,10 @@ class NeoWikiHooks {
 				->isContent( $title->getNamespace() ),
 			canCreateMainSubject: $extension->newSubjectAuthorizer( $skin->getAuthority() )->canCreateMainSubject(),
 			isLatestRevision: self::pageIsLatestRevision( $skin->getOutput() ),
-			devUiEnabled: $extension->isDevelopmentUIEnabled()
+			devUiEnabled: $extension->isDevelopmentUIEnabled(),
+			currentAction: MediaWikiServices::getInstance()
+				->getActionFactory()
+				->getActionName( $skin->getContext() )
 		);
 
 		if ( $pageToolsItems !== [] ) {

--- a/src/Presentation/PageToolsBuilder.php
+++ b/src/Presentation/PageToolsBuilder.php
@@ -18,7 +18,8 @@ class PageToolsBuilder {
 		bool $isContentNamespace,
 		bool $canCreateMainSubject,
 		bool $isLatestRevision,
-		bool $devUiEnabled
+		bool $devUiEnabled,
+		string $currentAction
 	): array {
 		if ( !$isContentNamespace ) {
 			return [];
@@ -37,7 +38,7 @@ class PageToolsBuilder {
 			];
 		}
 
-		if ( $title->canExist() ) {
+		if ( $title->canExist() && $currentAction !== SubjectsAction::ACTION_NAME ) {
 			$items[] = [
 				'text' => wfMessage( 'neowiki-page-tools-manage-subjects' )->text(),
 				'href' => $title->getLocalURL( [ 'action' => SubjectsAction::ACTION_NAME ] ),

--- a/tests/phpunit/Presentation/PageToolsBuilderTest.php
+++ b/tests/phpunit/Presentation/PageToolsBuilderTest.php
@@ -65,6 +65,24 @@ class PageToolsBuilderTest extends MediaWikiIntegrationTestCase {
 		);
 	}
 
+	public function testHidesManageSubjectsLinkWhenAlreadyViewingSubjectsAction(): void {
+		$this->assertSame(
+			[ $this->createSubjectItem(), $this->editJsonItem() ],
+			$this->build( currentAction: 'subjects' )
+		);
+	}
+
+	public function testReturnsEmptyListOnSubjectsActionWhenNothingElseQualifies(): void {
+		$this->assertSame(
+			[],
+			$this->build(
+				canCreateMainSubject: false,
+				devUiEnabled: false,
+				currentAction: 'subjects'
+			)
+		);
+	}
+
 	/**
 	 * @return list<array<string, mixed>>
 	 */
@@ -72,14 +90,16 @@ class PageToolsBuilderTest extends MediaWikiIntegrationTestCase {
 		bool $isContentNamespace = true,
 		bool $canCreateMainSubject = true,
 		bool $isLatestRevision = true,
-		bool $devUiEnabled = true
+		bool $devUiEnabled = true,
+		string $currentAction = 'view'
 	): array {
 		return ( new PageToolsBuilder() )->build(
 			title: Title::newFromText( self::PAGE_NAME ),
 			isContentNamespace: $isContentNamespace,
 			canCreateMainSubject: $canCreateMainSubject,
 			isLatestRevision: $isLatestRevision,
-			devUiEnabled: $devUiEnabled
+			devUiEnabled: $devUiEnabled,
+			currentAction: $currentAction
 		);
 	}
 


### PR DESCRIPTION
FU to https://github.com/ProfessionalWiki/NeoWiki/pull/755

## Summary

The NeoWiki sidebar shows a "Manage subjects" link that points at `?action=subjects`. When the user is already on that action, the link just reloads the page they are on — hide it in that case.

`PageToolsBuilder::build` gains an `isOnSubjectsAction` flag; `NeoWikiHooks::onSidebarBeforeOutput` derives it from `ActionFactory::getActionName`, so view/history/edit keep the link.

## Test plan

- [x] On a content page with `?action=view`, the "Manage subjects" link is still present.
- [x] On the same page with `?action=subjects`, the link is gone; "Create subject" and "Edit JSON" (when dev UI is enabled) remain.
- [x] PHPUnit green (`PageToolsBuilderTest` gains two cases: hidden on subjects action, and empty list when nothing else qualifies on subjects action).