### PR TITLE
Restore Subjects tab in skin navigation

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -54,6 +54,7 @@
 		"ContentModelCanBeUsedOn": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onContentModelCanBeUsedOn",
 
 		"SidebarBeforeOutput": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onSidebarBeforeOutput",
+		"SkinTemplateNavigation::Universal": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onSkinTemplateNavigationUniversal",
 		"ScribuntoExternalLibraries": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onScribuntoExternalLibraries"
 	},
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -222,6 +222,7 @@
 	"neowiki-layout-delete-success": "Deleted $1 layout",
 	"neowiki-layout-delete-error": "Failed to delete $1 layout.",
 
+	"neowiki-managesubjects-tab": "Subjects",
 	"neowiki-managesubjects-title": "Subjects on $1",
 	"neowiki-managesubjects-not-applicable": "Subject management is not available on this page.",
 	"neowiki-managesubjects-add-button": "Add subject",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -150,6 +150,7 @@
 	"neowiki-property-type-datetime": "Label for the date and time property type in the schema editor",
 	"neowiki-select-unknown-option": "Placeholder shown in a select-property display when a stored option ID cannot be resolved to a label (e.g. the option was removed from the Schema).",
 
+	"neowiki-managesubjects-tab": "Label for the Subjects tab that appears alongside the standard action tabs (View, Edit, History) on content pages, linking to the Subject management page.",
 	"neowiki-managesubjects-title": "Title of the Subject management page. $1 is the prefixed page title (e.g. 'Berlin').",
 	"neowiki-managesubjects-not-applicable": "Error shown when the Subject management page is opened on a page that cannot have Subjects (e.g. a Special page or a non-existent page).",
 	"neowiki-managesubjects-add-button": "Label for the button that opens the Subject creation flow from the Subject management page.",

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -23,6 +23,7 @@ use ProfessionalWiki\NeoWiki\EntryPoints\Content\SchemaContent;
 use ProfessionalWiki\NeoWiki\EntryPoints\Content\SubjectContent;
 use ProfessionalWiki\NeoWiki\EntryPoints\Content\LayoutContent;
 use ProfessionalWiki\NeoWiki\Application\SubjectResolver;
+use ProfessionalWiki\NeoWiki\EntryPoints\Actions\SubjectsAction;
 use ProfessionalWiki\NeoWiki\EntryPoints\Scribunto\ScribuntoLuaLibrary;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\SchemaContentValidator;
@@ -32,6 +33,7 @@ use ProfessionalWiki\NeoWiki\Presentation\JsonSchemaErrorFormatter;
 use ProfessionalWiki\NeoWiki\Presentation\PageToolsBuilder;
 use MediaWiki\SpecialPage\SpecialPage;
 use Skin;
+use SkinTemplate;
 use WikiPage;
 
 class NeoWikiHooks {
@@ -317,6 +319,22 @@ class NeoWikiHooks {
 			// the section heading, so it must match an existing message name.
 			$sidebar['neowiki-page-tools-label'] = $pageToolsItems;
 		}
+	}
+
+	public static function onSkinTemplateNavigationUniversal( SkinTemplate $sktemplate, array &$links ): void {
+		$title = $sktemplate->getTitle();
+
+		if ( !SubjectsAction::isEligibleTitle( $title ) ) {
+			return;
+		}
+
+		$action = $sktemplate->getRequest()->getRawVal( 'action' );
+
+		$links['views']['neowiki-subjects'] = [
+			'class' => $action === SubjectsAction::ACTION_NAME ? 'selected' : false,
+			'text' => $sktemplate->msg( 'neowiki-managesubjects-tab' )->text(),
+			'href' => $title->getLocalURL( [ 'action' => SubjectsAction::ACTION_NAME ] ),
+		];
 	}
 
 	private static function handleLayoutPage( OutputPage $out ): void {


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/755

This is somewhat obsoleting https://github.com/ProfessionalWiki/NeoWiki/pull/761, since we could just remove the sidebar link now we have the tab again. What do you think we should do with the sidebar link?

PR #755 dropped the SkinTemplateNavigation tab in favour of a
"Manage subjects" link in the NeoWiki tools-menu section. This
restores the tab (labelled "Subjects") while leaving the tools-menu
link in place, so the Subject management page is reachable from
both surfaces.

The tab is rendered only on content pages where
`SubjectsAction::isEligibleTitle()` returns true, and is marked
selected when the current request uses `?action=subjects`.

## Test plan

- [x] Visit a content page (e.g. `Main_Page`) and confirm a "Subjects" tab appears next to the standard action tabs
- [x] Click the Subjects tab → lands on `?action=subjects` and the tab is marked selected
- [x] Confirm the tab does not appear on non-content namespaces (e.g. Schema, Layout, Special pages)
- [x] Confirm the NeoWiki tools-menu still exposes the "Manage subjects" link