### PR TITLE
Load RedHerb on demo Docker image

### DIFF
--- a/Docker/SettingsTemplate.php
+++ b/Docker/SettingsTemplate.php
@@ -195,6 +195,7 @@ if ( getenv( 'MW_PASSWORD_SENDER' ) !== false ) {
 }
 
 wfLoadExtension( 'NeoWiki' );
+wfLoadExtension( 'RedHerb', "$IP/extensions/NeoWiki/tests/RedHerb/extension.json" );
 
 $wgNeoWikiEnableDevelopmentUI = true;
 


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/764

The demo image baked from Docker/SettingsTemplate.php runs neowiki.dev without RedHerb, so the dateTime property type (registered only by RedHerb via the NeoWikiRegistration hook) is absent. Creating or updating a Subject with a dateTime statement then triggers "Unknown property type: dateTime" from PropertyTypeRegistry, which the REST handlers currently return as HTTP 403.

Also exposes the color property type and the StaticPagePropertyProvider on the demo; acceptable since RedHerb and its artifacts are already visible in the public codebase that the demo showcases.