### PR TITLE
Refine "no main subject" empty-state copy

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -229,7 +229,7 @@
 	"neowiki-managesubjects-empty-title": "No subjects yet",
 	"neowiki-managesubjects-empty-description": "A subject describes one thing with structured data.",
 	"neowiki-managesubjects-no-main-title": "No main subject set",
-	"neowiki-managesubjects-no-main-description": "Main subjects are optional. Pin a subject below to set one.",
+	"neowiki-managesubjects-no-main-description": "Pin any subject below to make it the main subject, indicating it represents the same topic as this page.",
 	"neowiki-managesubjects-count": "{{PLURAL:$1|$1 subject|$1 subjects}} in total",
 	"neowiki-managesubjects-main-subject-set": "Set \"$1\" as the main subject.",
 	"neowiki-managesubjects-main-subject-cleared": "Main subject cleared.",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -157,7 +157,7 @@
 	"neowiki-managesubjects-empty-title": "Heading of the large zero-state shown on the Subject management page when the page has neither a Main Subject nor any Child Subjects.",
 	"neowiki-managesubjects-empty-description": "Descriptive subtitle below {{msg-mw|neowiki-managesubjects-empty-title}} explaining what Subjects are and inviting the user to add one.",
 	"neowiki-managesubjects-no-main-title": "Heading of the placeholder shown in the Main Subject slot when the page has Child Subjects but no Main Subject assigned.",
-	"neowiki-managesubjects-no-main-description": "Subtitle under {{msg-mw|neowiki-managesubjects-no-main-title}} explaining how to assign a Main Subject.",
+	"neowiki-managesubjects-no-main-description": "Subtitle under {{msg-mw|neowiki-managesubjects-no-main-title}} explaining how to assign a Main Subject and what the Main Subject represents.",
 	"neowiki-managesubjects-count": "Subtle text on the Subject management toolbar showing the total number of Subjects on the page. $1 is the count.",
 	"neowiki-managesubjects-main-subject-set": "Notification confirming a Subject was promoted to Main Subject. $1 is the Subject label.",
 	"neowiki-managesubjects-main-subject-cleared": "Notification confirming the page no longer has a Main Subject.",


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/771

Replaces "Main subjects are optional. Pin a subject below to set one."
with "Pin any subject below to make it the main subject, indicating it
represents the same topic as this page."

The previous copy used the misleading plural "Main subjects" and spent a
sentence on "optional" reassurance. The new copy drops both, explains
what a Main Subject is (the subject that represents the same topic as
the page), and tells the user how to assign one — all in one sentence.

> Result of a back-and-forth with @JeroenDeDauw refining the wording.
> Context: the NeoWiki codebase, the Glossary's Main Subject definition, and PR #771.
> <sub>Written by Claude Code, `Opus 4.7 (1M context)`</sub>