### PR TITLE
Expose OpenAPI spec routes in demo Docker image

### DIFF
--- a/Docker/SettingsTemplate.php
+++ b/Docker/SettingsTemplate.php
@@ -207,6 +207,11 @@ $wgCrossSiteAJAXdomains = [
 	'*'
 ];
 
+// Expose MediaWiki core's OpenAPI spec endpoints (T365753) so the
+// auto-generated NeoWiki REST spec is reachable at
+// /rest.php/specs/v0/module/- and /rest.php/specs/v0/discovery.
+$wgRestAPIAdditionalRouteFiles[] = 'includes/Rest/specs.v0.json';
+
 $wgEmailConfirmToEdit = false;
 
 $wgGroupPermissions['*']['edit'] = false;


### PR DESCRIPTION
> Result of back-and-forth with @malberts after manual-testing PR #766.
> Context: the NeoWiki demo Docker image's `SettingsTemplate.php`, PR #766, MediaWiki core's `ModuleSpecHandler` / `specs/v0` routes.
> <sub>Written by Claude Code, `Opus 4.7 (1M context)`</sub>

MediaWiki core's `specs/v0` routes (OpenAPI 3.0 emission and discovery) are not registered by default ([T365753](https://phabricator.wikimedia.org/T365753)). Enable them in the demo Docker image so the auto-generated NeoWiki REST spec is reachable at `/rest.php/specs/v0/module/-` and `/rest.php/specs/v0/discovery` without any further configuration.

Follows-up to #766