### PR TITLE
Simplify "no main subject" empty-state copy

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -229,7 +229,7 @@
 	"neowiki-managesubjects-empty-title": "No subjects yet",
 	"neowiki-managesubjects-empty-description": "A subject describes one thing with structured data.",
 	"neowiki-managesubjects-no-main-title": "No main subject set",
-	"neowiki-managesubjects-no-main-description": "Pin any subject below to make it the main subject, indicating it represents the same topic as this page.",
+	"neowiki-managesubjects-no-main-description": "Pin a subject to make it the main subject — the subject this page is about.",
 	"neowiki-managesubjects-count": "{{PLURAL:$1|$1 subject|$1 subjects}} in total",
 	"neowiki-managesubjects-main-subject-set": "Set \"$1\" as the main subject.",
 	"neowiki-managesubjects-main-subject-cleared": "Main subject cleared.",


### PR DESCRIPTION
This is more concise and fits on a single line. It is not quite technically correct in the sense that the page is not about the subject, they are both about the same concept, but its my read that we can ignore that distinction for this help text which is aimed at people unfaimiar with the system and unlikley to be refined enough to differentiate those things anyway. 

Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/773

Shortens the subtitle from 19 words to 15 and uses plainer English.
"Pin any subject below to make it the main subject, indicating it
represents the same topic as this page." becomes "Pin a subject to make
it the main subject — the one this page is about." — dropping "below"
(redundant when the subject list is the only place to pin from),
replacing the formal "indicating it represents the same topic as" with
an em-dash and appositive in natural English.

> Result of a back-and-forth with @JeroenDeDauw refining the wording after PR #773 shipped.
> Context: the NeoWiki codebase, the Glossary's Main Subject definition, and PR #773's final copy.
> <sub>Written by Claude Code, `Opus 4.7 (1M context)`</sub>