### PR TITLE
Link to OpenAPI spec from demo Main Page

### DIFF
--- a/DemoData/Page/Main_Page.wikitext
+++ b/DemoData/Page/Main_Page.wikitext
@@ -80,11 +80,12 @@ in EUR with a value between 0 and 1000000.
 
 == REST API Endpoints ==
 
-We will have OpenAPI docs later. For now, you can find a complete and up-to-date list by looking at the
-[https://github.com/ProfessionalWiki/NeoWiki/blob/master/extension.json MediaWiki API route definitions].
-Search for "RestRoutes".
+An auto-generated OpenAPI 3.0 spec describes the REST API:
 
-Example URL: https://neowiki.dev/w/rest.php/neowiki/v0/subject/s1demo4sssssss1
+* [{{SERVER}}{{SCRIPTPATH}}/rest.php/specs/v0/module/- NeoWiki OpenAPI spec] — <code>/rest.php/specs/v0/module/-</code>
+* [{{SERVER}}{{SCRIPTPATH}}/rest.php/specs/v0/discovery Module discovery] — <code>/rest.php/specs/v0/discovery</code>
+
+Example endpoint URL: <code>{{SERVER}}{{SCRIPTPATH}}/rest.php/neowiki/v0/subject/s1demo4sssssss1</code>
 
 === Read Endpoints ===
 


### PR DESCRIPTION
Follows-up to #774

The "REST API Endpoints" section of the demo Main Page previously said "We will have OpenAPI docs later". Now that PR #774 exposes the spec endpoints in the demo Docker image, link to them directly.

Uses `{{SERVER}}{{SCRIPTPATH}}` so the links resolve on any host.

Verified locally by re-importing demo data and checking that:
* http://localhost:8484/rest.php/specs/v0/module/- returns 200
* http://localhost:8484/rest.php/specs/v0/discovery returns 200
* The Main Page renders the links with the correct hostname.

> Result of back-and-forth with @malberts.
> Context: the NeoWiki demo data and PR #774.
> <sub>Written by Claude Code, `Opus 4.7 (1M context)`</sub>