### PR TITLE
Rename Subjects tab label to Data

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -222,7 +222,7 @@
 	"neowiki-layout-delete-success": "Deleted $1 layout",
 	"neowiki-layout-delete-error": "Failed to delete $1 layout.",
 
-	"neowiki-managesubjects-tab": "Subjects",
+	"neowiki-managesubjects-tab": "Data",
 	"neowiki-managesubjects-title": "Subjects on $1",
 	"neowiki-managesubjects-not-applicable": "Subject management is not available on this page.",
 	"neowiki-managesubjects-add-button": "Add subject",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -150,7 +150,7 @@
 	"neowiki-property-type-datetime": "Label for the date and time property type in the schema editor",
 	"neowiki-select-unknown-option": "Placeholder shown in a select-property display when a stored option ID cannot be resolved to a label (e.g. the option was removed from the Schema).",
 
-	"neowiki-managesubjects-tab": "Label for the Subjects tab that appears alongside the standard action tabs (View, Edit, History) on content pages, linking to the Subject management page.",
+	"neowiki-managesubjects-tab": "Label for the Data tab that appears alongside the standard action tabs (View, Edit, History) on content pages, linking to the Subject management page.",
 	"neowiki-managesubjects-title": "Title of the Subject management page. $1 is the prefixed page title (e.g. 'Berlin').",
 	"neowiki-managesubjects-not-applicable": "Error shown when the Subject management page is opened on a page that cannot have Subjects (e.g. a Special page or a non-existent page).",
 	"neowiki-managesubjects-add-button": "Label for the button that opens the Subject creation flow from the Subject management page.",


### PR DESCRIPTION
Only the displayed tab text changes; the action name (`subjects`), the message key (`neowiki-managesubjects-tab`), and all other code remain untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)