### PR TITLE
RedHerb integration probes cleanups (PR #781 follow-up)

### DIFF
--- a/tests/RedHerb/extension.json
+++ b/tests/RedHerb/extension.json
@@ -51,7 +51,7 @@
 	},
 
 	"ResourceModules": {
-		"ext.redherb-sidebar": {
+		"ext.redherb-subject-finder": {
 			"class": "MediaWiki\\ResourceLoader\\CodexModule",
 			"localBasePath": "resources/subjectFinder",
 			"remoteExtPath": "NeoWiki/tests/RedHerb/resources/subjectFinder",

--- a/tests/RedHerb/extension.json
+++ b/tests/RedHerb/extension.json
@@ -78,7 +78,8 @@
 			"codexComponents": [ "CdxButton", "CdxDialog", "CdxField", "CdxTextInput", "CdxTooltip" ],
 			"packageFiles": [
 				"init.js",
-				"CreateChildDialog.vue"
+				"CreateChildDialog.vue",
+				"constants.js"
 			],
 			"messages": [
 				"redherb-sidebar-create-child-company",
@@ -98,7 +99,8 @@
 			"codexComponents": [ "CdxButton", "CdxDialog", "CdxField", "CdxTextInput", "CdxTooltip" ],
 			"packageFiles": [
 				"init.js",
-				"EditMainSubjectDialog.vue"
+				"EditMainSubjectDialog.vue",
+				"constants.js"
 			],
 			"messages": [
 				"redherb-sidebar-edit-main-subject",

--- a/tests/RedHerb/resources/createChild/CreateChildDialog.vue
+++ b/tests/RedHerb/resources/createChild/CreateChildDialog.vue
@@ -148,8 +148,6 @@ module.exports = exports = {
 </script>
 
 <style lang="less">
-@import 'mediawiki.skin.variables.less';
-
 .ext-redherb-create-child-mount {
 	display: contents;
 }

--- a/tests/RedHerb/resources/createChild/CreateChildDialog.vue
+++ b/tests/RedHerb/resources/createChild/CreateChildDialog.vue
@@ -30,9 +30,9 @@
 var vue = require( 'vue' );
 var codex = require( './codex.js' );
 var nw = require( 'ext.neowiki' );
+var DIALOG_OPEN_KEY = require( './constants.js' ).DIALOG_OPEN_KEY;
 
 var SCHEMA_NAME = 'Company';
-var DIALOG_OPEN_KEY = 'redHerbCreateChildOpen';
 
 module.exports = exports = {
 	components: {

--- a/tests/RedHerb/resources/createChild/CreateChildDialog.vue
+++ b/tests/RedHerb/resources/createChild/CreateChildDialog.vue
@@ -53,8 +53,14 @@ module.exports = exports = {
 		function loadSchema() {
 			schemaStore.getOrFetchSchema( SCHEMA_NAME ).then( function ( schema ) {
 				loadedSchema.value = schema;
-			} ).catch( function () {
+			} ).catch( function ( err ) {
 				loadedSchema.value = null;
+				mw.log.error( err );
+				mw.notify(
+					err instanceof Error ? err.message : String( err ),
+					{ type: 'error' }
+				);
+				open.value = false;
 			} );
 		}
 

--- a/tests/RedHerb/resources/createChild/constants.js
+++ b/tests/RedHerb/resources/createChild/constants.js
@@ -1,0 +1,3 @@
+'use strict';
+
+exports.DIALOG_OPEN_KEY = 'redHerbCreateChildOpen';

--- a/tests/RedHerb/resources/createChild/init.js
+++ b/tests/RedHerb/resources/createChild/init.js
@@ -5,9 +5,9 @@
 	var codex = require( './codex.js' );
 	var nw = require( 'ext.neowiki' );
 	var CreateChildDialog = require( './CreateChildDialog.vue' );
+	var DIALOG_OPEN_KEY = require( './constants.js' ).DIALOG_OPEN_KEY;
 
 	var TRIGGER_SELECTOR = '.ext-redherb-create-child-company-trigger';
-	var DIALOG_OPEN_KEY = 'redHerbCreateChildOpen';
 
 	var open = Vue.ref( false );
 	var mounted = false;

--- a/tests/RedHerb/resources/editMainSubject/EditMainSubjectDialog.vue
+++ b/tests/RedHerb/resources/editMainSubject/EditMainSubjectDialog.vue
@@ -172,8 +172,6 @@ module.exports = exports = {
 </script>
 
 <style lang="less">
-@import 'mediawiki.skin.variables.less';
-
 .ext-redherb-edit-main-subject-mount {
 	display: contents;
 }

--- a/tests/RedHerb/resources/editMainSubject/EditMainSubjectDialog.vue
+++ b/tests/RedHerb/resources/editMainSubject/EditMainSubjectDialog.vue
@@ -30,8 +30,7 @@
 var vue = require( 'vue' );
 var codex = require( './codex.js' );
 var nw = require( 'ext.neowiki' );
-
-var DIALOG_STATE_KEY = 'redHerbEditMainSubjectState';
+var DIALOG_STATE_KEY = require( './constants.js' ).DIALOG_STATE_KEY;
 
 module.exports = exports = {
 	components: {

--- a/tests/RedHerb/resources/editMainSubject/constants.js
+++ b/tests/RedHerb/resources/editMainSubject/constants.js
@@ -1,0 +1,3 @@
+'use strict';
+
+exports.DIALOG_STATE_KEY = 'redHerbEditMainSubjectState';

--- a/tests/RedHerb/resources/editMainSubject/init.js
+++ b/tests/RedHerb/resources/editMainSubject/init.js
@@ -5,10 +5,10 @@
 	var codex = require( './codex.js' );
 	var nw = require( 'ext.neowiki' );
 	var EditMainSubjectDialog = require( './EditMainSubjectDialog.vue' );
+	var DIALOG_STATE_KEY = require( './constants.js' ).DIALOG_STATE_KEY;
 
 	var TRIGGER_SELECTOR = '.ext-redherb-edit-main-subject-trigger';
 	var MAIN_SUBJECT_SELECTOR = '.ext-neowiki-view[data-mw-neowiki-subject-id]';
-	var DIALOG_STATE_KEY = 'redHerbEditMainSubjectState';
 
 	var dialogState = Vue.reactive( { open: false, subjectId: null } );
 	var mounted = false;

--- a/tests/RedHerb/resources/subjectFinder/SubjectFinderPanel.vue
+++ b/tests/RedHerb/resources/subjectFinder/SubjectFinderPanel.vue
@@ -73,6 +73,13 @@ module.exports = exports = {
 				.loadSubjectsAndSchemas( new Set( [ id ] ) )
 				.then( function () {
 					loadedSubjectId.value = id;
+				} )
+				.catch( function ( err ) {
+					mw.log.error( err );
+					mw.notify(
+						err instanceof Error ? err.message : String( err ),
+						{ type: 'error' }
+					);
 				} );
 		}
 

--- a/tests/RedHerb/src/RedHerbSidebarHook.php
+++ b/tests/RedHerb/src/RedHerbSidebarHook.php
@@ -23,7 +23,7 @@ class RedHerbSidebarHook implements SidebarBeforeOutputHook {
 		$links = [
 			[
 				'id' => 'redherb-sidebar-subject-finder',
-				'text' => wfMessage( 'redherb-sidebar-subject-finder' )->text(),
+				'text' => $skin->msg( 'redherb-sidebar-subject-finder' )->text(),
 				'href' => Title::makeTitle( NS_SPECIAL, 'RedHerbSubjectFinder' )->getLocalURL(),
 			],
 		];
@@ -32,7 +32,7 @@ class RedHerbSidebarHook implements SidebarBeforeOutputHook {
 		if ( $title !== null && $title->exists() ) {
 			$links[] = [
 				'id' => 'redherb-sidebar-create-child-company',
-				'text' => wfMessage( 'redherb-sidebar-create-child-company' )->text(),
+				'text' => $skin->msg( 'redherb-sidebar-create-child-company' )->text(),
 				'href' => '#',
 				'class' => 'ext-redherb-create-child-company-trigger',
 			];
@@ -40,7 +40,7 @@ class RedHerbSidebarHook implements SidebarBeforeOutputHook {
 			if ( ( $this->pageHasMainSubject )( $title ) ) {
 				$links[] = [
 					'id' => 'redherb-sidebar-edit-main-subject',
-					'text' => wfMessage( 'redherb-sidebar-edit-main-subject' )->text(),
+					'text' => $skin->msg( 'redherb-sidebar-edit-main-subject' )->text(),
 					'href' => '#',
 					'class' => 'ext-redherb-edit-main-subject-trigger',
 				];

--- a/tests/RedHerb/src/Specials/SpecialRedHerbSubjectFinder.php
+++ b/tests/RedHerb/src/Specials/SpecialRedHerbSubjectFinder.php
@@ -23,7 +23,7 @@ class SpecialRedHerbSubjectFinder extends SpecialPage {
 
 		$out = $this->getOutput();
 		NeoWikiHooks::addNeoWikiModules( $out, $this->getSkin() );
-		$out->addModules( 'ext.redherb-sidebar' );
+		$out->addModules( 'ext.redherb-subject-finder' );
 
 		$out->addHTML( Html::element( 'div', [ 'id' => 'ext-redherb-subject-finder' ] ) );
 	}

--- a/tests/phpunit/RedHerb/RedHerbFrontendModulesHookTest.php
+++ b/tests/phpunit/RedHerb/RedHerbFrontendModulesHookTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\RedHerb;
+
+use MediaWiki\Output\OutputPage;
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\RedHerb\RedHerbFrontendModulesHook;
+use Skin;
+
+/**
+ * @covers \ProfessionalWiki\RedHerb\RedHerbFrontendModulesHook
+ */
+class RedHerbFrontendModulesHookTest extends TestCase {
+
+	public function testAddsRedHerbDialogModules(): void {
+		$modules = [];
+		$hook = new RedHerbFrontendModulesHook();
+
+		$hook->onNeoWikiGetFrontendModules(
+			$modules,
+			$this->createStub( OutputPage::class ),
+			$this->createStub( Skin::class )
+		);
+
+		$this->assertSame(
+			[ 'ext.redherb-create-child', 'ext.redherb-edit-main-subject' ],
+			$modules
+		);
+	}
+
+	public function testPreservesExistingModules(): void {
+		$modules = [ 'ext.preexisting' ];
+		$hook = new RedHerbFrontendModulesHook();
+
+		$hook->onNeoWikiGetFrontendModules(
+			$modules,
+			$this->createStub( OutputPage::class ),
+			$this->createStub( Skin::class )
+		);
+
+		$this->assertSame(
+			[ 'ext.preexisting', 'ext.redherb-create-child', 'ext.redherb-edit-main-subject' ],
+			$modules
+		);
+	}
+
+}

--- a/tests/phpunit/RedHerb/RedHerbSidebarHookTest.php
+++ b/tests/phpunit/RedHerb/RedHerbSidebarHookTest.php
@@ -5,11 +5,11 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Tests\RedHerb;
 
 use Closure;
+use MediaWiki\Language\RawMessage;
 use MediaWiki\Message\Message;
 use MediaWiki\Title\Title;
 use MediaWikiIntegrationTestCase;
 use ProfessionalWiki\RedHerb\RedHerbSidebarHook;
-use RawMessage;
 use Skin;
 
 /**

--- a/tests/phpunit/RedHerb/RedHerbSidebarHookTest.php
+++ b/tests/phpunit/RedHerb/RedHerbSidebarHookTest.php
@@ -5,9 +5,11 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Tests\RedHerb;
 
 use Closure;
+use MediaWiki\Message\Message;
 use MediaWiki\Title\Title;
 use MediaWikiIntegrationTestCase;
 use ProfessionalWiki\RedHerb\RedHerbSidebarHook;
+use RawMessage;
 use Skin;
 
 /**
@@ -47,10 +49,10 @@ class RedHerbSidebarHookTest extends MediaWikiIntegrationTestCase {
 			return true;
 		} );
 
-		$skin = $this->createStub( Skin::class );
-		$skin->method( 'getTitle' )->willReturn( Title::newFromText( 'NonExistentPage_' . uniqid() ) );
-
-		$hook->onSidebarBeforeOutput( $skin, $sidebar );
+		$hook->onSidebarBeforeOutput(
+			$this->newSkinStub( Title::newFromText( 'NonExistentPage_' . uniqid() ) ),
+			$sidebar
+		);
 
 		$this->assertFalse( $predicateInvoked );
 		$this->assertCount( 1, $sidebar['redherb-sidebar'] );
@@ -64,10 +66,10 @@ class RedHerbSidebarHookTest extends MediaWikiIntegrationTestCase {
 			return true;
 		} );
 
-		$skin = $this->createStub( Skin::class );
-		$skin->method( 'getTitle' )->willReturn( Title::newFromText( 'UserLogin', NS_SPECIAL ) );
-
-		$hook->onSidebarBeforeOutput( $skin, $sidebar );
+		$hook->onSidebarBeforeOutput(
+			$this->newSkinStub( Title::newFromText( 'UserLogin', NS_SPECIAL ) ),
+			$sidebar
+		);
 
 		$this->assertFalse( $predicateInvoked );
 		$this->assertCount( 1, $sidebar['redherb-sidebar'] );
@@ -89,14 +91,19 @@ class RedHerbSidebarHookTest extends MediaWikiIntegrationTestCase {
 	}
 
 	private function newSkin(): Skin {
-		$skin = $this->createStub( Skin::class );
-		$skin->method( 'getTitle' )->willReturn( Title::newFromText( 'Test' ) );
-		return $skin;
+		return $this->newSkinStub( Title::newFromText( 'Test' ) );
 	}
 
 	private function newSkinForExistingPage(): Skin {
+		return $this->newSkinStub( $this->getExistingTestPage()->getTitle() );
+	}
+
+	private function newSkinStub( Title $title ): Skin {
 		$skin = $this->createStub( Skin::class );
-		$skin->method( 'getTitle' )->willReturn( $this->getExistingTestPage()->getTitle() );
+		$skin->method( 'getTitle' )->willReturn( $title );
+		$skin->method( 'msg' )->willReturnCallback(
+			static fn ( string $key ): Message => new RawMessage( $key )
+		);
 		return $skin;
 	}
 

--- a/tests/phpunit/RedHerb/SpecialRedHerbSubjectFinderTest.php
+++ b/tests/phpunit/RedHerb/SpecialRedHerbSubjectFinderTest.php
@@ -30,7 +30,7 @@ class SpecialRedHerbSubjectFinderTest extends SpecialPageTestBase {
 		$modules = $page->getOutput()->getModules();
 
 		$this->assertContains( 'ext.neowiki', $modules );
-		$this->assertContains( 'ext.redherb-sidebar', $modules );
+		$this->assertContains( 'ext.redherb-subject-finder', $modules );
 	}
 
 }

--- a/tests/phpunit/RedHerb/SpecialRedHerbSubjectFinderTest.php
+++ b/tests/phpunit/RedHerb/SpecialRedHerbSubjectFinderTest.php
@@ -4,6 +4,9 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Tests\RedHerb;
 
+use MediaWiki\Context\DerivativeContext;
+use MediaWiki\Context\RequestContext;
+use MediaWiki\Output\OutputPage;
 use ProfessionalWiki\RedHerb\Specials\SpecialRedHerbSubjectFinder;
 use SpecialPageTestBase;
 
@@ -25,9 +28,12 @@ class SpecialRedHerbSubjectFinderTest extends SpecialPageTestBase {
 
 	public function testRegistersResourceLoaderModules(): void {
 		$page = $this->newSpecialPage();
+		$context = new DerivativeContext( RequestContext::getMain() );
+		$context->setOutput( new OutputPage( $context ) );
+		$page->setContext( $context );
 		$page->execute( null );
 
-		$modules = $page->getOutput()->getModules();
+		$modules = $context->getOutput()->getModules();
 
 		$this->assertContains( 'ext.neowiki', $modules );
 		$this->assertContains( 'ext.redherb-subject-finder', $modules );


### PR DESCRIPTION
> Result of code review of #781 with @alistair3149.
> Context: the NeoWiki codebase, the `frontend-extensibility` branch, and live verification of which findings were worth acting on.
> <sub>Written by Claude Code, `Opus 4.7 (1M context)`</sub>

Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/781

Targets `redherb-sidebar-panel` so this lands as a stacked review fix into #781 once approved.

## Addressed

Eight commits, one per finding (read in branch order):

1. Rename `ext.redherb-sidebar` → `ext.redherb-subject-finder` — only loaded by `Special:RedHerbSubjectFinder`; old name was misleading.
2. Use fresh `DerivativeContext + OutputPage` in `testRegistersResourceLoaderModules` — was order-dependent on `RequestContext::getMain()`.
3. `SubjectFinderPanel.onSelected` — add `.catch()` so a load failure logs and notifies instead of silently half-loading.
4. `CreateChildDialog.loadSchema` — `.catch()` now logs / notifies / closes instead of silently nulling state.
5. Move `DIALOG_OPEN_KEY` / `DIALOG_STATE_KEY` into per-module `constants.js`; init.js and .vue share via `require()` instead of duplicated string literals.
6. Add `RedHerbFrontendModulesHookTest` to pin the module-name contract.
7. Drop unused `mediawiki.skin.variables.less` imports from both dialog components.
8. Replace `wfMessage(...)` with `$skin->msg(...)` in `RedHerbSidebarHook` (context-aware lookup instead of `RequestContext::getMain()`); test stubs updated to mock `Skin::msg()` via a shared `newSkinStub( Title $title )` helper that also dedupes the previous inline stubs.

## Not addressed

- `MAIN_SUBJECT_SELECTOR` matches any rendered view, not specifically the main subject — needs either a public PHP API or a DOM marker, both intersecting with #789.
- Design-level findings split out to #789 (PHP public API surface) and #790 (schema-driven statement-list helper).
- Two `RedHerbSidebarHookTest` cases (`testOnlyAddsSubjectFinderLinkOnNonExistentPages` and `testDoesNotCheckMainSubjectForNonExistingTitles`) cover the same `$title->exists() === false` path; not collapsed in this PR — judgment call left for the next pass.

## Manual Browser Check

1. Visit `Special:RedHerbSubjectFinder`. Type a schema name, select a subject from the lookup, confirm the infobox renders.
2. On a content page with a main subject, click **Create child Company** in the sidebar. Fill the dialog, save. Confirm the success notification and the new subject on `?action=subjects`.
3. Same page, click **Edit main subject**. Change the label, save. Confirm the existing infobox re-renders without reload.
4. Confirm the browser network tab on the special page loads `ext.redherb-subject-finder` (renamed), not `ext.redherb-sidebar`.
5. Optional error path: take the API offline and load the special page; pick a subject — confirm an error notification fires instead of a silent half-load.

## Verification

Local run on this branch (NeoWiki dev container, MW REL1_43, PHP 8.3):

- `make phpunit` — `OK, 858 tests, 1636 assertions, 7 skipped` (28s)
- `vendor/bin/phpcs` — clean, 328 files (5s)
- `vendor/bin/phpstan` — `[OK] No errors`, 150 files

**Browser pass** (Chrome DevTools, against the running dev wiki on this branch):

- ✅ **Step 1** — `Special:RedHerbSubjectFinder` with `Schema = Company`, picked `ACME Inc.`, the `Infobox` renders all properties (Founded at, Websites, Products, Status, World domination progress).
- ✅ **Step 2** — `Create child Company` opens the `SubjectEditor`-backed dialog; `Status = Active`, label `Test Subsidiary`, `Create` returns `201` from `POST /rest.php/neowiki/v0/page/24/childSubjects`; dialog auto-closes; `?action=subjects` shows `Test Subsidiary Company • 1 statement`.
- ✅ **Step 3** — `Edit main subject` opens pre-populated with all `ACME Inc.` statements (label, founded, websites, products, status, progress). Changed label to `ACME Incorporated`; on save the page-side `Infobox` `<h2>` reactively updates from `ACME Inc.` → `ACME Incorporated` with no reload, and `Updated main subject.` mw-notify fires. This is the cross-app shared-Pinia path #781 is meant to prove out.
- ✅ **Step 4** — network shows `load.php?...modules=ext.redherb-create-child,redherb-edit-main-subject,redherb-subject-finder...`; no stale `ext.redherb-sidebar` reference.
- Step 5 (offline error path) skipped — invasive on the dev environment; the unit-tested `.catch()` handlers in commits 3 and 4 cover the same code path.
