### PR TITLE
RedHerb Color cleanups (PR #780 follow-up)

### DIFF
--- a/tests/RedHerb/extension.json
+++ b/tests/RedHerb/extension.json
@@ -53,6 +53,7 @@
 			],
 			"packageFiles": [
 				"init.js",
+				"hexRegex.js",
 				"ColorDisplay.vue",
 				"ColorInput.vue",
 				"ColorAttributesEditor.vue",

--- a/tests/RedHerb/resources/ColorAttributesEditor.vue
+++ b/tests/RedHerb/resources/ColorAttributesEditor.vue
@@ -70,7 +70,7 @@ var codex = require( './codex.js' );
 var icons = require( './icons.json' );
 var nw = require( 'ext.neowiki' );
 
-var HEX_REGEX = /^#[0-9a-fA-F]{6}$/;
+var HEX_REGEX = require( './hexRegex.js' );
 var nextId = 0;
 
 function wrapEntries( colors ) {

--- a/tests/RedHerb/resources/ColorDisplay.vue
+++ b/tests/RedHerb/resources/ColorDisplay.vue
@@ -26,7 +26,7 @@ var nw = require( 'ext.neowiki' );
 // constraints like allowedColors: a stored value that was valid when
 // it was saved should keep rendering as a swatch even if the schema's
 // palette has since narrowed.
-var HEX_REGEX = /^#[0-9a-fA-F]{6}$/;
+var HEX_REGEX = require( './hexRegex.js' );
 
 module.exports = exports = {
 	components: {

--- a/tests/RedHerb/resources/ColorInput.vue
+++ b/tests/RedHerb/resources/ColorInput.vue
@@ -39,7 +39,7 @@ var icons = require( './icons.json' );
 var nw = require( 'ext.neowiki' );
 
 var COLOR_TYPE_NAME = 'color';
-var HEX_PREVIEW_REGEX = /^#[0-9a-fA-F]{6}$/;
+var HEX_PREVIEW_REGEX = require( './hexRegex.js' );
 
 module.exports = exports = {
 	components: {

--- a/tests/RedHerb/resources/hexRegex.js
+++ b/tests/RedHerb/resources/hexRegex.js
@@ -1,0 +1,6 @@
+( function () {
+	'use strict';
+
+	// eslint-disable-next-line security/detect-unsafe-regex -- bounded quantifiers, no backtracking
+	module.exports = /^#[0-9a-fA-F]{6}$/;
+}() );

--- a/tests/RedHerb/resources/init.js
+++ b/tests/RedHerb/resources/init.js
@@ -15,7 +15,7 @@
 	function validate( value, property ) {
 		var errors = [];
 
-		if ( property.required && value === undefined ) {
+		if ( property.required && ( value === undefined || value.parts.length === 0 ) ) {
 			errors.push( { code: 'required' } );
 			return errors;
 		}

--- a/tests/RedHerb/resources/init.js
+++ b/tests/RedHerb/resources/init.js
@@ -3,14 +3,12 @@
 
 	var nw = require( 'ext.neowiki' );
 	var icons = require( './icons.json' );
+	var HEX_REGEX = require( './hexRegex.js' );
 	var ColorDisplay = require( './ColorDisplay.vue' );
 	var ColorInput = require( './ColorInput.vue' );
 	var ColorAttributesEditor = require( './ColorAttributesEditor.vue' );
 
 	var COLOR_TYPE_NAME = 'color';
-
-	// eslint-disable-next-line security/detect-unsafe-regex -- bounded quantifiers, no backtracking
-	var HEX_REGEX = /^#[0-9a-fA-F]{6}$/;
 
 	function validate( value, property ) {
 		var errors = [];

--- a/tests/RedHerb/src/ColorProperty.php
+++ b/tests/RedHerb/src/ColorProperty.php
@@ -27,6 +27,12 @@ class ColorProperty extends PropertyDefinition {
 			}
 		}
 
+		if ( $core->default !== null && ( !is_string( $core->default ) || preg_match( self::HEX_COLOR_REGEX, $core->default ) !== 1 ) ) {
+			throw new InvalidArgumentException(
+				'ColorProperty default must be a 6-digit hex string prefixed with #'
+			);
+		}
+
 		parent::__construct( $core );
 	}
 

--- a/tests/RedHerb/src/RedHerbFrontendHook.php
+++ b/tests/RedHerb/src/RedHerbFrontendHook.php
@@ -5,9 +5,10 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\RedHerb;
 
 use MediaWiki\Output\OutputPage;
+use ProfessionalWiki\NeoWiki\EntryPoints\Hook\NeoWikiGetFrontendModulesHook;
 use Skin;
 
-class RedHerbFrontendHook {
+class RedHerbFrontendHook implements NeoWikiGetFrontendModulesHook {
 
 	public function onNeoWikiGetFrontendModules( array &$modules, OutputPage $out, Skin $skin ): void {
 		$modules[] = 'ext.redherb';

--- a/tests/phpunit/RedHerb/ColorPropertyTest.php
+++ b/tests/phpunit/RedHerb/ColorPropertyTest.php
@@ -104,6 +104,36 @@ class ColorPropertyTest extends TestCase {
 		$this->assertSame( [ '#ABCDEF' ], $property->getAllowedColors() );
 	}
 
+	public function testConstructorAcceptsValidHexDefault(): void {
+		$property = new ColorProperty(
+			core: new PropertyCore( description: '', required: false, default: '#abcdef' ),
+			allowedColors: [],
+		);
+
+		$this->assertSame( '#abcdef', $property->getDefault() );
+	}
+
+	/**
+	 * @dataProvider malformedDefaultProvider
+	 */
+	public function testConstructorRejectsMalformedDefault( mixed $malformed ): void {
+		$this->expectException( \InvalidArgumentException::class );
+
+		new ColorProperty(
+			core: new PropertyCore( description: '', required: false, default: $malformed ),
+			allowedColors: [],
+		);
+	}
+
+	public static function malformedDefaultProvider(): iterable {
+		yield 'missing hash' => [ 'ff0000' ];
+		yield 'too short' => [ '#fff' ];
+		yield 'too long' => [ '#ff00000' ];
+		yield 'invalid char' => [ '#gggggg' ];
+		yield 'empty string' => [ '' ];
+		yield 'not a string' => [ 42 ];
+	}
+
 	private function buildProperty(): ColorProperty {
 		return new ColorProperty(
 			core: new PropertyCore( description: '', required: false, default: null ),


### PR DESCRIPTION
> Result of extensive back-and-forth code review with @alistair3149.
> Context: PR #780, the NeoWiki extension API surface, and the RedHerb-as-reference-example brief in CLAUDE.md/AGENTS.md.
> <sub>Written by Claude Code, `Opus 4.7`</sub>

Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/780. Targets that PR's branch so it can fold in before merge to `frontend-extensibility`.

Each commit is independently reviewable. Splitting them out keeps the main PR focused on the new property-type frontend and lets these polish items merge separately if needed.

## Commits

1. **Flag required for empty Color values in RedHerb** — `init.js`'s `validate()` only fired the required check when the value was `undefined`, so a defined but empty `StringValue` (zero parts) was treated as present. Mirrors core's `Url.ts:35-40` pattern.
2. **Declare `NeoWikiGetFrontendModulesHook` implementation in RedHerb** — MediaWiki's HookHandler dispatch is duck-typed, so the previous shape worked, but as a reference example for extension authors the explicit `implements` makes the contract obvious and gives static analysers the signature.
3. **Share hex regex across RedHerb resources** — `/^#[0-9a-fA-F]{6}$/` was duplicated in `init.js` and the three Color SFCs. Extracted into `hexRegex.js` as a packageFile so all four consumers share the definition.
4. **Reject invalid default values in `ColorProperty` constructor** — `allowedColors` entries were already validated as hex strings, but a non-null `default` could be any value. For symmetry, validate `default` the same way; `null` still means "no default". TDD red→green; new `malformedDefaultProvider` mirrors `malformedAllowedColorsProvider`.

## Verification

- `make phpunit filter=ColorPropertyTest` — 21 tests, 28 assertions, green.
- `make cs` — phpcs and phpstan clean.
- `make ts-test` — 773/773 vitest pass.
- `make ts-lint` — clean.
- Browser smoke test in `Special:Schemas` → Create → Color: picker, palette editor, and `ColorInput` all render and validate as expected.

## Manual Browser Check

1. Open `Special:Schemas` and click **Create**.
2. Click **Add property definition**, then change the type picker to **Color**.
3. Confirm the palette `+` button is present and the Initial value `ColorInput` renders with the highlighter start-icon and an empty striped swatch.
4. Type `#ff5733` into the Initial value — swatch should turn orange, no error.
5. Edit it to `#zzz` — bad text stays visible, swatch reverts to empty stripes, the `Please enter a 6-digit hex color like #ff5733.` error appears.