### PR TITLE
Move page-subject predicates off ViewHtmlBuilder

### DIFF
--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -75,7 +75,7 @@ class NeoWikiHooks {
 		if ( self::shouldShowSubjectCreator( $out ) ) {
 			$attrs['data-mw-neowiki-create-subject'] = 'true';
 			$attrs['data-mw-neowiki-page-has-main-subject'] =
-				NeoWikiExtension::getInstance()->newViewHtmlBuilder()->pageHasMainSubject( $out->getTitle() )
+				NeoWikiExtension::getInstance()->newSubjectContentRepository()->pageHasMainSubject( $out->getTitle() )
 					? 'true'
 					: 'false';
 		}

--- a/src/Persistence/MediaWiki/Subject/SubjectContentRepository.php
+++ b/src/Persistence/MediaWiki/Subject/SubjectContentRepository.php
@@ -35,6 +35,16 @@ class SubjectContentRepository {
 		return $this->getSubjectContentFromWikiPage( $this->wikiPageFactory->newFromTitle( $pageIdentity ) );
 	}
 
+	public function pageHasSubjects( PageIdentity $pageIdentity ): bool {
+		return $this->getSubjectContentByPageTitle( $pageIdentity )?->hasSubjects() === true;
+	}
+
+	public function pageHasMainSubject( PageIdentity $pageIdentity ): bool {
+		return $this->getSubjectContentByPageTitle( $pageIdentity )
+			?->getPageSubjects()
+			->getMainSubject() !== null;
+	}
+
 	public function getSubjectContentByRevisionId( int $revisionId ): ?SubjectContent {
 		$revision = $this->revisionLookup->getRevisionById( $revisionId );
 

--- a/src/Presentation/ViewHtmlBuilder.php
+++ b/src/Presentation/ViewHtmlBuilder.php
@@ -40,19 +40,6 @@ class ViewHtmlBuilder {
 		return Html::element( 'div', $attributes );
 	}
 
-	public function pageHasSubjects( Title $title ): bool {
-		return $this->subjectContentRepository
-			->getSubjectContentByPageTitle( $title )
-			?->hasSubjects() === true;
-	}
-
-	public function pageHasMainSubject( Title $title ): bool {
-		return $this->subjectContentRepository
-			->getSubjectContentByPageTitle( $title )
-			?->getPageSubjects()
-			->getMainSubject() !== null;
-	}
-
 	private function getSubjectContent( Title $title, ?int $revisionId ): ?SubjectContent {
 		if ( $revisionId === null ) {
 			return $this->subjectContentRepository->getSubjectContentByPageTitle( $title );

--- a/tests/phpunit/Persistence/MediaWiki/Subject/SubjectContentRepositoryTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/Subject/SubjectContentRepositoryTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Persistence\MediaWiki\Subject;
+
+use MediaWiki\Page\PageIdentity;
+use MediaWiki\Title\Title;
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectMap;
+use ProfessionalWiki\NeoWiki\EntryPoints\Content\SubjectContent;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\SubjectContentRepository;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\SubjectContentRepository
+ */
+class SubjectContentRepositoryTest extends TestCase {
+
+	public function testPageHasSubjectsReturnsTrueWhenSubjectsExist(): void {
+		$repository = $this->repositoryWithContent(
+			SubjectContent::newFromData( new PageSubjects( TestSubject::build(), new SubjectMap() ) )
+		);
+
+		$this->assertTrue( $repository->pageHasSubjects( Title::newFromText( 'HasSubjects' ) ) );
+	}
+
+	public function testPageHasSubjectsReturnsFalseWhenNoContent(): void {
+		$repository = $this->repositoryWithContent( null );
+
+		$this->assertFalse( $repository->pageHasSubjects( Title::newFromText( 'NoContent' ) ) );
+	}
+
+	public function testPageHasSubjectsReturnsFalseWhenContentIsEmpty(): void {
+		$repository = $this->repositoryWithContent(
+			SubjectContent::newFromData( PageSubjects::newEmpty() )
+		);
+
+		$this->assertFalse( $repository->pageHasSubjects( Title::newFromText( 'EmptyContent' ) ) );
+	}
+
+	public function testPageHasMainSubjectReturnsTrueWhenMainSubjectExists(): void {
+		$repository = $this->repositoryWithContent(
+			SubjectContent::newFromData( new PageSubjects( TestSubject::build(), new SubjectMap() ) )
+		);
+
+		$this->assertTrue( $repository->pageHasMainSubject( Title::newFromText( 'HasMain' ) ) );
+	}
+
+	public function testPageHasMainSubjectReturnsFalseWhenNoContent(): void {
+		$repository = $this->repositoryWithContent( null );
+
+		$this->assertFalse( $repository->pageHasMainSubject( Title::newFromText( 'NoContent' ) ) );
+	}
+
+	public function testPageHasMainSubjectReturnsFalseWhenOnlyChildrenExist(): void {
+		$child = TestSubject::build( id: 's1zz1111111ccc1' );
+		$repository = $this->repositoryWithContent(
+			SubjectContent::newFromData( new PageSubjects( null, new SubjectMap( $child ) ) )
+		);
+
+		$this->assertFalse( $repository->pageHasMainSubject( Title::newFromText( 'OnlyChildren' ) ) );
+	}
+
+	private function repositoryWithContent( ?SubjectContent $content ): SubjectContentRepository {
+		return new class( $content ) extends SubjectContentRepository {
+
+			public function __construct(
+				private readonly ?SubjectContent $content,
+			) {
+			}
+
+			public function getSubjectContentByPageTitle( PageIdentity $pageIdentity ): ?SubjectContent {
+				return $this->content;
+			}
+
+		};
+	}
+
+}

--- a/tests/phpunit/Presentation/ViewHtmlBuilderTest.php
+++ b/tests/phpunit/Presentation/ViewHtmlBuilderTest.php
@@ -81,67 +81,6 @@ class ViewHtmlBuilderTest extends TestCase {
 		$this->assertStringContainsString( 'data-mw-neowiki-subject-id="s1zz1111111azz3"', $html );
 	}
 
-	public function testPageHasSubjectsReturnsTrueWhenSubjectsExist(): void {
-		$content = SubjectContent::newFromData(
-			new PageSubjects( TestSubject::build(), new SubjectMap() )
-		);
-
-		$builder = new ViewHtmlBuilder(
-			$this->stubRepository( byTitle: $content )
-		);
-
-		$this->assertTrue( $builder->pageHasSubjects( Title::newFromText( 'HasSubjects' ) ) );
-	}
-
-	public function testPageHasSubjectsReturnsFalseWhenNoContent(): void {
-		$builder = new ViewHtmlBuilder(
-			$this->stubRepository( byTitle: null )
-		);
-
-		$this->assertFalse( $builder->pageHasSubjects( Title::newFromText( 'NoContent' ) ) );
-	}
-
-	public function testPageHasSubjectsReturnsFalseWhenContentIsEmpty(): void {
-		$content = SubjectContent::newFromData( PageSubjects::newEmpty() );
-
-		$builder = new ViewHtmlBuilder(
-			$this->stubRepository( byTitle: $content )
-		);
-
-		$this->assertFalse( $builder->pageHasSubjects( Title::newFromText( 'EmptyContent' ) ) );
-	}
-
-	public function testPageHasMainSubjectReturnsTrueWhenMainSubjectExists(): void {
-		$content = SubjectContent::newFromData(
-			new PageSubjects( TestSubject::build(), new SubjectMap() )
-		);
-
-		$builder = new ViewHtmlBuilder(
-			$this->stubRepository( byTitle: $content )
-		);
-
-		$this->assertTrue( $builder->pageHasMainSubject( Title::newFromText( 'HasMain' ) ) );
-	}
-
-	public function testPageHasMainSubjectReturnsFalseWhenNoContent(): void {
-		$builder = new ViewHtmlBuilder(
-			$this->stubRepository( byTitle: null )
-		);
-
-		$this->assertFalse( $builder->pageHasMainSubject( Title::newFromText( 'NoContent' ) ) );
-	}
-
-	public function testPageHasMainSubjectReturnsFalseWhenOnlyChildrenExist(): void {
-		$child = TestSubject::build( id: 's1zz1111111ccc1' );
-		$content = SubjectContent::newFromData( new PageSubjects( null, new SubjectMap( $child ) ) );
-
-		$builder = new ViewHtmlBuilder(
-			$this->stubRepository( byTitle: $content )
-		);
-
-		$this->assertFalse( $builder->pageHasMainSubject( Title::newFromText( 'OnlyChildren' ) ) );
-	}
-
 	private function stubRepository(
 		?SubjectContent $byTitle = null,
 		?SubjectContent $byRevision = null,


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/NeoWiki/issues/789

`pageHasMainSubject` and `pageHasSubjects` are pure subject lookups that don't render any HTML. Reaching them via `newViewHtmlBuilder()` forced consumers (internal hook code; #781 RedHerb sidebar) to traverse a factory named after view-HTML construction to ask a domain question.

Move both predicates to `SubjectContentRepository`, where the underlying `getSubjectContentByPageTitle` lookup already lives. `ViewHtmlBuilder` now only renders HTML.

Addresses one of the two breach points raised in #789. The other (`NeoWikiHooks::addNeoWikiModules` called from a foreign extension's SpecialPage) lives on the `frontend-extensibility` branch and will follow up after #754 lands.

Doesn't claim to close #789 — that issue's broader question of whether NeoWiki should commit to a documented PHP API surface is unresolved on the issue thread.