### PR TITLE
Add PageSubjectsLookup for page-level subject predicates

### DIFF
--- a/src/Application/PageSubjectsLookup.php
+++ b/src/Application/PageSubjectsLookup.php
@@ -1,0 +1,24 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application;
+
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+
+class PageSubjectsLookup {
+
+	public function __construct(
+		private readonly SubjectRepository $subjectRepository,
+	) {
+	}
+
+	public function pageHasSubjects( PageId $pageId ): bool {
+		return $this->subjectRepository->getSubjectsByPageId( $pageId )->hasSubjects();
+	}
+
+	public function pageHasMainSubject( PageId $pageId ): bool {
+		return $this->subjectRepository->getSubjectsByPageId( $pageId )->hasMainSubject();
+	}
+
+}

--- a/src/Domain/Page/PageSubjects.php
+++ b/src/Domain/Page/PageSubjects.php
@@ -41,6 +41,10 @@ class PageSubjects {
 			|| !$this->childSubjects->isEmpty();
 	}
 
+	public function hasMainSubject(): bool {
+		return $this->mainSubject !== null;
+	}
+
 	public function isEmpty(): bool {
 		return $this->mainSubject === null
 			&& $this->childSubjects->isEmpty();

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -17,6 +17,7 @@ use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Revision\SlotRoleRegistry;
 use MediaWiki\Title\Title;
 use MediaWiki\User\UserIdentity;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Layout\LayoutName;
 use ProfessionalWiki\NeoWiki\EntryPoints\Content\SchemaContent;
@@ -75,9 +76,10 @@ class NeoWikiHooks {
 		if ( self::shouldShowSubjectCreator( $out ) ) {
 			$attrs['data-mw-neowiki-create-subject'] = 'true';
 			$attrs['data-mw-neowiki-page-has-main-subject'] =
-				NeoWikiExtension::getInstance()->newViewHtmlBuilder()->pageHasMainSubject( $out->getTitle() )
-					? 'true'
-					: 'false';
+				NeoWikiExtension::getInstance()->newPageSubjectsLookup()
+					->pageHasMainSubject( new PageId( $out->getTitle()->getArticleID() ) )
+						? 'true'
+						: 'false';
 		}
 
 		return Html::element( 'div', $attrs );

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -23,6 +23,7 @@ use ProfessionalWiki\NeoWiki\Application\Actions\SetMainSubject\SetMainSubjectAc
 use ProfessionalWiki\NeoWiki\Application\Actions\SetMainSubject\SetMainSubjectPresenter;
 use ProfessionalWiki\NeoWiki\Application\Actions\PatchSubject\PatchSubjectAction;
 use ProfessionalWiki\NeoWiki\Application\PageIdentifiersLookup;
+use ProfessionalWiki\NeoWiki\Application\PageSubjectsLookup;
 use ProfessionalWiki\NeoWiki\Application\Queries\GetSchema\GetSchemaPresenter;
 use ProfessionalWiki\NeoWiki\Application\Queries\GetSchema\GetSchemaQuery;
 use ProfessionalWiki\NeoWiki\Application\Queries\GetLayout\GetLayoutPresenter;
@@ -281,6 +282,10 @@ class NeoWikiExtension {
 		return new ViewHtmlBuilder(
 			subjectContentRepository: $this->newSubjectContentRepository()
 		);
+	}
+
+	public function newPageSubjectsLookup(): PageSubjectsLookup {
+		return new PageSubjectsLookup( $this->getSubjectRepository() );
 	}
 
 	public function newSubjectContentRepository(): SubjectContentRepository {

--- a/src/Presentation/ViewHtmlBuilder.php
+++ b/src/Presentation/ViewHtmlBuilder.php
@@ -40,19 +40,6 @@ class ViewHtmlBuilder {
 		return Html::element( 'div', $attributes );
 	}
 
-	public function pageHasSubjects( Title $title ): bool {
-		return $this->subjectContentRepository
-			->getSubjectContentByPageTitle( $title )
-			?->hasSubjects() === true;
-	}
-
-	public function pageHasMainSubject( Title $title ): bool {
-		return $this->subjectContentRepository
-			->getSubjectContentByPageTitle( $title )
-			?->getPageSubjects()
-			->getMainSubject() !== null;
-	}
-
 	private function getSubjectContent( Title $title, ?int $revisionId ): ?SubjectContent {
 		if ( $revisionId === null ) {
 			return $this->subjectContentRepository->getSubjectContentByPageTitle( $title );

--- a/tests/phpunit/Application/PageSubjectsLookupTest.php
+++ b/tests/phpunit/Application/PageSubjectsLookupTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Application;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\PageSubjectsLookup;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectMap;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectRepository;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Application\PageSubjectsLookup
+ */
+class PageSubjectsLookupTest extends TestCase {
+
+	private const int PAGE_ID = 42;
+	private const int OTHER_PAGE_ID = 43;
+
+	public function testPageHasSubjectsIsTrueWhenMainSubjectExists(): void {
+		$lookup = $this->newLookupWithSubjects(
+			new PageSubjects( TestSubject::build(), new SubjectMap() )
+		);
+
+		$this->assertTrue( $lookup->pageHasSubjects( new PageId( self::PAGE_ID ) ) );
+	}
+
+	public function testPageHasSubjectsIsTrueWhenOnlyChildSubjectsExist(): void {
+		$lookup = $this->newLookupWithSubjects(
+			new PageSubjects( null, new SubjectMap( TestSubject::build() ) )
+		);
+
+		$this->assertTrue( $lookup->pageHasSubjects( new PageId( self::PAGE_ID ) ) );
+	}
+
+	public function testPageHasSubjectsIsFalseForOtherPage(): void {
+		$lookup = $this->newLookupWithSubjects(
+			new PageSubjects( TestSubject::build(), new SubjectMap() )
+		);
+
+		$this->assertFalse( $lookup->pageHasSubjects( new PageId( self::OTHER_PAGE_ID ) ) );
+	}
+
+	public function testPageHasMainSubjectIsTrueWhenMainSubjectExists(): void {
+		$lookup = $this->newLookupWithSubjects(
+			new PageSubjects( TestSubject::build(), new SubjectMap() )
+		);
+
+		$this->assertTrue( $lookup->pageHasMainSubject( new PageId( self::PAGE_ID ) ) );
+	}
+
+	public function testPageHasMainSubjectIsFalseWhenOnlyChildSubjectsExist(): void {
+		$lookup = $this->newLookupWithSubjects(
+			new PageSubjects( null, new SubjectMap( TestSubject::build() ) )
+		);
+
+		$this->assertFalse( $lookup->pageHasMainSubject( new PageId( self::PAGE_ID ) ) );
+	}
+
+	public function testPageHasMainSubjectIsFalseForOtherPage(): void {
+		$lookup = $this->newLookupWithSubjects(
+			new PageSubjects( TestSubject::build(), new SubjectMap() )
+		);
+
+		$this->assertFalse( $lookup->pageHasMainSubject( new PageId( self::OTHER_PAGE_ID ) ) );
+	}
+
+	private function newLookupWithSubjects( PageSubjects $subjects ): PageSubjectsLookup {
+		$repository = new InMemorySubjectRepository();
+		$repository->savePageSubjects( $subjects, new PageId( self::PAGE_ID ) );
+
+		return new PageSubjectsLookup( $repository );
+	}
+
+}

--- a/tests/phpunit/Presentation/ViewHtmlBuilderTest.php
+++ b/tests/phpunit/Presentation/ViewHtmlBuilderTest.php
@@ -81,67 +81,6 @@ class ViewHtmlBuilderTest extends TestCase {
 		$this->assertStringContainsString( 'data-mw-neowiki-subject-id="s1zz1111111azz3"', $html );
 	}
 
-	public function testPageHasSubjectsReturnsTrueWhenSubjectsExist(): void {
-		$content = SubjectContent::newFromData(
-			new PageSubjects( TestSubject::build(), new SubjectMap() )
-		);
-
-		$builder = new ViewHtmlBuilder(
-			$this->stubRepository( byTitle: $content )
-		);
-
-		$this->assertTrue( $builder->pageHasSubjects( Title::newFromText( 'HasSubjects' ) ) );
-	}
-
-	public function testPageHasSubjectsReturnsFalseWhenNoContent(): void {
-		$builder = new ViewHtmlBuilder(
-			$this->stubRepository( byTitle: null )
-		);
-
-		$this->assertFalse( $builder->pageHasSubjects( Title::newFromText( 'NoContent' ) ) );
-	}
-
-	public function testPageHasSubjectsReturnsFalseWhenContentIsEmpty(): void {
-		$content = SubjectContent::newFromData( PageSubjects::newEmpty() );
-
-		$builder = new ViewHtmlBuilder(
-			$this->stubRepository( byTitle: $content )
-		);
-
-		$this->assertFalse( $builder->pageHasSubjects( Title::newFromText( 'EmptyContent' ) ) );
-	}
-
-	public function testPageHasMainSubjectReturnsTrueWhenMainSubjectExists(): void {
-		$content = SubjectContent::newFromData(
-			new PageSubjects( TestSubject::build(), new SubjectMap() )
-		);
-
-		$builder = new ViewHtmlBuilder(
-			$this->stubRepository( byTitle: $content )
-		);
-
-		$this->assertTrue( $builder->pageHasMainSubject( Title::newFromText( 'HasMain' ) ) );
-	}
-
-	public function testPageHasMainSubjectReturnsFalseWhenNoContent(): void {
-		$builder = new ViewHtmlBuilder(
-			$this->stubRepository( byTitle: null )
-		);
-
-		$this->assertFalse( $builder->pageHasMainSubject( Title::newFromText( 'NoContent' ) ) );
-	}
-
-	public function testPageHasMainSubjectReturnsFalseWhenOnlyChildrenExist(): void {
-		$child = TestSubject::build( id: 's1zz1111111ccc1' );
-		$content = SubjectContent::newFromData( new PageSubjects( null, new SubjectMap( $child ) ) );
-
-		$builder = new ViewHtmlBuilder(
-			$this->stubRepository( byTitle: $content )
-		);
-
-		$this->assertFalse( $builder->pageHasMainSubject( Title::newFromText( 'OnlyChildren' ) ) );
-	}
-
 	private function stubRepository(
 		?SubjectContent $byTitle = null,
 		?SubjectContent $byRevision = null,


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/NeoWiki/issues/789

`pageHasMainSubject` and `pageHasSubjects` previously lived on `ViewHtmlBuilder`, even though neither rendered any HTML. Reaching them via `newViewHtmlBuilder()` forced consumers (the internal hook code, and external code such as #781's RedHerb sidebar) to traverse a factory named after view-HTML construction to ask a domain question.

`SubjectContentRepository` was rejected as a destination: `SubjectContent` is a MediaWiki `JsonContent` slot wrapper, a persistence detail not in the glossary, and the predicates take/return only domain types.

Introduce `Application/PageSubjectsLookup`, a small concrete class that depends on the existing `SubjectRepository` interface and exposes the two predicates against `PageId`. Both are one-line delegates to `PageSubjects::hasSubjects()` / `hasMainSubject()`.

Add `PageSubjects::hasMainSubject()` to mirror the existing `hasSubjects()` predicate and dedup the recurring `getMainSubject() !== null` check.

Drop the predicates from `ViewHtmlBuilder` and remove their tests; the behavior is now covered by `PageSubjectsLookupTest`.

Addresses one of the two breach points raised in #789. The other (`NeoWikiHooks::addNeoWikiModules` called from a foreign extension's SpecialPage) lives on the `frontend-extensibility` branch and will follow up after #754 lands.

Doesn't claim to close #789 — that issue's broader question of whether NeoWiki should commit to a documented PHP API surface is unresolved on the issue thread.