### PR TITLE
Move schema-driven statement merging into Schema

### DIFF
--- a/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
@@ -91,10 +91,10 @@
 			</CdxField>
 
 			<SubjectEditor
-				v-if="schemaStatements"
+				v-if="statements"
 				ref="subjectEditorRef"
-				:schema-statements="schemaStatements"
-				:schema-properties="schemaProperties"
+				:statements="statements"
+				:schema="loadedSchema as Schema"
 				@change="markChanged"
 			/>
 		</template>
@@ -150,9 +150,7 @@ import type { ButtonGroupItem } from '@wikimedia/codex';
 import { useSubjectStore } from '@/stores/SubjectStore.ts';
 import { useSchemaStore } from '@/stores/SchemaStore.ts';
 import { Schema } from '@/domain/Schema.ts';
-import { Statement } from '@/domain/Statement.ts';
 import { StatementList } from '@/domain/StatementList.ts';
-import { PropertyDefinitionList } from '@/domain/PropertyDefinitionList.ts';
 import SubjectEditor from '@/components/SubjectEditor/SubjectEditor.vue';
 import SchemaCreator from '@/components/SchemaCreator/SchemaCreator.vue';
 import type { SchemaCreatorExposes } from '@/components/SchemaCreator/SchemaCreator.vue';
@@ -315,29 +313,9 @@ async function handleCreateSchema(): Promise<void> {
 	markChanged();
 }
 
-const schemaProperties = computed( (): PropertyDefinitionList =>
-	loadedSchema.value?.getPropertyDefinitions() ?? new PropertyDefinitionList( [] )
+const statements = computed( (): StatementList | null =>
+	loadedSchema.value?.blankStatements() ?? null
 );
-
-const schemaStatements = computed( (): StatementList | null => {
-	if ( !loadedSchema.value ) {
-		return null;
-	}
-
-	const statements: Statement[] = [];
-
-	for ( const propDef of schemaProperties.value ) {
-		statements.push(
-			new Statement(
-				propDef.name,
-				propDef.type,
-				undefined
-			)
-		);
-	}
-
-	return new StatementList( statements );
-} );
 
 watch( () => subjectStore.subjectCreatorOpen, async ( isOpen ) => {
 	if ( isOpen ) {

--- a/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditor.vue
+++ b/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditor.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="ext-neowiki-subject-editor">
 		<CdxField
-			v-for="( statement, index ) in props.schemaStatements"
+			v-for="( statement, index ) in props.statements"
 			:key="statement.propertyName.toString()"
 		>
 			<component
@@ -9,7 +9,7 @@
 				:ref="( el: any ) => { if ( el ) valueEditors[ index ] = el; }"
 				:label="statement.propertyName.toString()"
 				:model-value="statement.value"
-				:property="props.schemaProperties.get( statement.propertyName )"
+				:property="props.schema.getPropertyDefinition( statement.propertyName )"
 				@update:model-value="emit( 'change' )"
 			/>
 		</CdxField>
@@ -23,10 +23,10 @@ import { StatementList } from '@/domain/StatementList.ts';
 import { Statement } from '@/domain/Statement.ts';
 import { NeoWikiServices } from '@/NeoWikiServices.ts';
 import { ValueInputExposes } from '@/components/Value/ValueInputContract.ts';
-import { PropertyDefinitionList } from '@/domain/PropertyDefinitionList.ts';
+import { Schema } from '@/domain/Schema.ts';
 const props = defineProps<{
-	schemaStatements: StatementList;
-	schemaProperties: PropertyDefinitionList;
+	statements: StatementList;
+	schema: Schema;
 }>();
 
 const emit = defineEmits<{
@@ -40,7 +40,7 @@ onBeforeUpdate( () => {
 const valueEditors = ref<ValueInputExposes[]>( [] );
 
 const getSubjectData = (): StatementList => {
-	const newStatements = [ ...props.schemaStatements ].map( ( statement, index ) =>
+	const newStatements = [ ...props.statements ].map( ( statement, index ) =>
 		new Statement(
 			statement.propertyName,
 			statement.propertyType,

--- a/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditorDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditorDialog.vue
@@ -48,10 +48,10 @@
 			</template>
 
 			<SubjectEditor
-				v-if="schemaStatements"
+				v-if="statements"
 				ref="subjectEditorRef"
-				:schema-statements="schemaStatements"
-				:schema-properties="schemaProperties"
+				:statements="statements"
+				:schema="loadedSchema as Schema"
 				@change="markChanged"
 			/>
 			<div v-else>
@@ -97,8 +97,6 @@ import { StatementList } from '@/domain/StatementList.ts';
 import { Subject } from '@/domain/Subject.ts';
 import { useSchemaStore } from '@/stores/SchemaStore.ts';
 import { Schema } from '@/domain/Schema.ts';
-import { Statement } from '@/domain/Statement.ts';
-import { PropertyDefinitionList } from '@/domain/PropertyDefinitionList.ts';
 import SchemaEditorDialog from '@/components/SchemaEditor/SchemaEditorDialog.vue';
 import type { SchemaSaveHandler } from '@/components/SchemaEditor/SchemaEditorDialog.vue';
 import CloseConfirmationDialog from '@/components/common/CloseConfirmationDialog.vue';
@@ -166,43 +164,9 @@ async function loadSchema(): Promise<void> {
 	}
 }
 
-const schemaProperties = computed( (): PropertyDefinitionList =>
-	loadedSchema.value?.getPropertyDefinitions() ?? new PropertyDefinitionList( [] )
+const statements = computed( (): StatementList | null =>
+	loadedSchema.value?.statementsFrom( props.subject.getStatements() ) ?? null
 );
-
-const schemaStatements = computed( (): StatementList | null => {
-	if ( !schemaProperties.value ) {
-		return null;
-	}
-
-	const existingStatements = props.subject.getStatements();
-	const allStatements: Statement[] = [];
-
-	for ( const propDef of schemaProperties.value ) {
-		let existingStatement: Statement | undefined;
-		for ( const stmt of existingStatements ) {
-			if ( stmt.propertyName.toString() === propDef.name.toString() ) {
-				existingStatement = stmt;
-				break;
-			}
-		}
-
-		if ( existingStatement ) {
-			allStatements.push( existingStatement );
-		} else {
-			// Create a new empty statement based on the schema definition
-			allStatements.push(
-				new Statement(
-					propDef.name,
-					propDef.type,
-					undefined
-				)
-			);
-		}
-	}
-
-	return new StatementList( allStatements );
-} );
 
 const handleSave = async ( summary: string ): Promise<void> => {
 	await nextTick();

--- a/resources/ext.neowiki/src/domain/Schema.ts
+++ b/resources/ext.neowiki/src/domain/Schema.ts
@@ -1,6 +1,8 @@
 import type { PropertyDefinition } from '@/domain/PropertyDefinition';
 import { PropertyName } from '@/domain/PropertyDefinition';
 import { PropertyDefinitionList } from '@/domain/PropertyDefinitionList';
+import { Statement } from '@/domain/Statement';
+import { StatementList } from '@/domain/StatementList';
 
 export type SchemaName = string;
 
@@ -61,6 +63,20 @@ export class Schema {
 			this.description,
 			this.properties.withoutNames( [ propertyName ] ),
 		);
+	}
+
+	public statementsFrom( existing: StatementList ): StatementList {
+		return new StatementList(
+			[ ...this.properties ].map( ( definition ) =>
+				existing.has( definition.name ) ?
+					existing.get( definition.name ) :
+					new Statement( definition.name, definition.type, undefined ),
+			),
+		);
+	}
+
+	public blankStatements(): StatementList {
+		return this.statementsFrom( new StatementList( [] ) );
 	}
 
 }

--- a/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
@@ -43,7 +43,7 @@ const SchemaLookupStub = {
 
 const SubjectEditorStub = {
 	template: '<div class="subject-editor-stub"></div>',
-	props: [ 'schemaStatements', 'schemaProperties' ],
+	props: [ 'statements', 'schema' ],
 	emits: [ 'change' ],
 	setup() {
 		const getSubjectData = (): StatementList => new StatementList( [

--- a/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditorDialog.spec.ts
@@ -21,7 +21,7 @@ const $i18n = createI18nMock();
 
 const SubjectEditorStub = {
 	template: '<div class="subject-editor-stub"></div>',
-	props: [ 'schemaStatements', 'schemaProperties' ],
+	props: [ 'statements', 'schema' ],
 	emits: [ 'change' ],
 	setup() {
 		const getSubjectData = (): StatementList => new StatementList( [] );

--- a/resources/ext.neowiki/tests/domain/Schema.unit.spec.ts
+++ b/resources/ext.neowiki/tests/domain/Schema.unit.spec.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { PropertyDefinitionList } from '@/domain/PropertyDefinitionList';
-import { newTextProperty } from '@/domain/propertyTypes/Text';
+import { newTextProperty, TextType } from '@/domain/propertyTypes/Text';
 import { newSchema } from '@/TestHelpers';
-import { newNumberProperty } from '@/domain/propertyTypes/Number';
+import { newNumberProperty, NumberType } from '@/domain/propertyTypes/Number';
+import { Statement } from '@/domain/Statement';
+import { StatementList } from '@/domain/StatementList';
+import { PropertyName } from '@/domain/PropertyDefinition';
+import { newStringValue } from '@/domain/Value';
 
 describe( 'Schema', () => {
 
@@ -106,6 +110,120 @@ describe( 'Schema', () => {
 			expect( updatedSchema.getPropertyDefinitions().asRecord() ).toEqual( {
 				[ property2.name.toString() ]: property2,
 			} );
+		} );
+
+	} );
+
+	describe( 'statementsFrom', () => {
+
+		it( 'returns an empty StatementList when the Schema has no Property Definitions', () => {
+			const schema = newSchema();
+
+			const result = schema.statementsFrom( new StatementList( [] ) );
+
+			expect( [ ...result ] ).toEqual( [] );
+		} );
+
+		it( 'creates an empty Statement for each Property Definition when no existing Statements are given', () => {
+			const schema = newSchema( {
+				properties: new PropertyDefinitionList( [
+					newTextProperty( { name: 'foo' } ),
+					newNumberProperty( { name: 'bar' } ),
+				] ),
+			} );
+
+			const result = schema.statementsFrom( new StatementList( [] ) );
+
+			expect( [ ...result ] ).toEqual( [
+				new Statement( new PropertyName( 'foo' ), TextType.typeName, undefined ),
+				new Statement( new PropertyName( 'bar' ), NumberType.typeName, undefined ),
+			] );
+		} );
+
+		it( 'preserves an existing Statement whose Property is in the Schema', () => {
+			const fooStatement = new Statement(
+				new PropertyName( 'foo' ),
+				TextType.typeName,
+				newStringValue( 'hello' ),
+			);
+			const schema = newSchema( {
+				properties: new PropertyDefinitionList( [
+					newTextProperty( { name: 'before' } ),
+					newTextProperty( { name: 'foo' } ),
+					newTextProperty( { name: 'after' } ),
+				] ),
+			} );
+
+			const result = schema.statementsFrom( new StatementList( [ fooStatement ] ) );
+
+			expect( result.get( new PropertyName( 'foo' ) ) ).toBe( fooStatement );
+		} );
+
+		it( 'drops existing Statements whose Property is not in the Schema', () => {
+			const orphan = new Statement(
+				new PropertyName( 'orphan' ),
+				TextType.typeName,
+				newStringValue( 'x' ),
+			);
+			const schema = newSchema( {
+				properties: new PropertyDefinitionList( [ newTextProperty( { name: 'foo' } ) ] ),
+			} );
+
+			const result = schema.statementsFrom( new StatementList( [ orphan ] ) );
+
+			expect( result.has( new PropertyName( 'orphan' ) ) ).toBe( false );
+			expect( result.has( new PropertyName( 'foo' ) ) ).toBe( true );
+		} );
+
+		it( 'orders Statements by Schema order, regardless of input order', () => {
+			const aStatement = new Statement( new PropertyName( 'a' ), TextType.typeName, newStringValue( 'A' ) );
+			const cStatement = new Statement( new PropertyName( 'c' ), TextType.typeName, newStringValue( 'C' ) );
+			const schema = newSchema( {
+				properties: new PropertyDefinitionList( [
+					newTextProperty( { name: 'a' } ),
+					newTextProperty( { name: 'b' } ),
+					newTextProperty( { name: 'c' } ),
+				] ),
+			} );
+
+			const result = schema.statementsFrom( new StatementList( [ cStatement, aStatement ] ) );
+
+			expect( [ ...result ].map( ( s ) => s.propertyName.toString() ) ).toEqual( [ 'a', 'b', 'c' ] );
+		} );
+
+		it( 'preserves the writer\'s Property Type from the existing Statement, not the Schema\'s current type', () => {
+			const existing = new Statement(
+				new PropertyName( 'foo' ),
+				TextType.typeName,
+				newStringValue( 'hello' ),
+			);
+			const schema = newSchema( {
+				properties: new PropertyDefinitionList( [ newNumberProperty( { name: 'foo' } ) ] ),
+			} );
+
+			const result = schema.statementsFrom( new StatementList( [ existing ] ) );
+
+			expect( result.get( new PropertyName( 'foo' ) ).propertyType ).toBe( TextType.typeName );
+		} );
+
+	} );
+
+	describe( 'blankStatements', () => {
+
+		it( 'creates an empty Statement for each Property Definition', () => {
+			const schema = newSchema( {
+				properties: new PropertyDefinitionList( [
+					newTextProperty( { name: 'foo' } ),
+					newNumberProperty( { name: 'bar' } ),
+				] ),
+			} );
+
+			const result = schema.blankStatements();
+
+			expect( [ ...result ] ).toEqual( [
+				new Statement( new PropertyName( 'foo' ), TextType.typeName, undefined ),
+				new Statement( new PropertyName( 'bar' ), NumberType.typeName, undefined ),
+			] );
 		} );
 
 	} );

--- a/tests/RedHerb/resources/createChild/CreateChildDialog.vue
+++ b/tests/RedHerb/resources/createChild/CreateChildDialog.vue
@@ -16,10 +16,10 @@
 		</cdx-field>
 
 		<subject-editor
-			v-if="schemaStatements && schemaProperties"
+			v-if="statements"
 			ref="editorRef"
-			:schema-statements="schemaStatements"
-			:schema-properties="schemaProperties"
+			:statements="statements"
+			:schema="loadedSchema"
 		></subject-editor>
 	</cdx-dialog>
 </template>
@@ -73,24 +73,11 @@ module.exports = exports = {
 			}
 		} );
 
-		var schemaProperties = vue.computed( function () {
-			return loadedSchema.value === null
-				? null
-				: loadedSchema.value.getPropertyDefinitions();
-		} );
-
-		var schemaStatements = vue.computed( function () {
+		var statements = vue.computed( function () {
 			if ( loadedSchema.value === null ) {
 				return null;
 			}
-			var statements = [];
-			var defs = loadedSchema.value.getPropertyDefinitions();
-			for ( var def of defs ) {
-				statements.push(
-					new nw.Statement( def.name, def.type, undefined )
-				);
-			}
-			return new nw.StatementList( statements );
+			return loadedSchema.value.blankStatements();
 		} );
 
 		function onClose() {
@@ -128,8 +115,8 @@ module.exports = exports = {
 			open: open,
 			label: label,
 			editorRef: editorRef,
-			schemaStatements: schemaStatements,
-			schemaProperties: schemaProperties,
+			statements: statements,
+			loadedSchema: loadedSchema,
 			onSave: onSave,
 			onClose: onClose,
 			onOpenChange: onOpenChange,

--- a/tests/RedHerb/resources/editMainSubject/EditMainSubjectDialog.vue
+++ b/tests/RedHerb/resources/editMainSubject/EditMainSubjectDialog.vue
@@ -16,10 +16,10 @@
 		</cdx-field>
 
 		<subject-editor
-			v-if="schemaStatements && schemaProperties"
+			v-if="statements"
 			ref="editorRef"
-			:schema-statements="schemaStatements"
-			:schema-properties="schemaProperties"
+			:statements="statements"
+			:schema="loadedSchema"
 		></subject-editor>
 	</cdx-dialog>
 </template>
@@ -91,27 +91,11 @@ module.exports = exports = {
 			}
 		} );
 
-		var schemaProperties = vue.computed( function () {
-			return loadedSchema.value === null
-				? null
-				: loadedSchema.value.getPropertyDefinitions();
-		} );
-
-		var schemaStatements = vue.computed( function () {
+		var statements = vue.computed( function () {
 			if ( loadedSchema.value === null || loadedSubject.value === null ) {
 				return null;
 			}
-			var existingStatements = loadedSubject.value.getStatements();
-			var statements = [];
-			var defs = loadedSchema.value.getPropertyDefinitions();
-			for ( var def of defs ) {
-				if ( existingStatements.has( def.name ) ) {
-					statements.push( existingStatements.get( def.name ) );
-				} else {
-					statements.push( new nw.Statement( def.name, def.type, undefined ) );
-				}
-			}
-			return new nw.StatementList( statements );
+			return loadedSchema.value.statementsFrom( loadedSubject.value.getStatements() );
 		} );
 
 		function onClose() {
@@ -152,8 +136,8 @@ module.exports = exports = {
 			state: state,
 			label: label,
 			editorRef: editorRef,
-			schemaStatements: schemaStatements,
-			schemaProperties: schemaProperties,
+			statements: statements,
+			loadedSchema: loadedSchema,
 			onSave: onSave,
 			onClose: onClose,
 			onOpenChange: onOpenChange,


### PR DESCRIPTION
> Result of multi-turn discussion with @JeroenDeDauw on whether to extract a helper, where it should live, and how to name it.
> Context: the NeoWiki codebase, the `ext.neowiki` public-API barrel, and RedHerb's edit/create dialogs.
> <sub>Written by Claude Code, `Opus 4.7 (1M context)`</sub>

Adds `Schema.statementsFor( existing )` and `Schema.blankStatements()`, encapsulating the per-schema-property statement merge that was duplicated across the `SubjectEditor` dialog, `SubjectCreator` dialog, and both RedHerb example dialogs.

`SubjectEditor`'s contract becomes "edit these statements against this schema" — its `schemaProperties: PropertyDefinitionList` prop is replaced by `schema: Schema`, so the surrounding dialogs can drop their separate `schemaProperties` computeds. All four call sites now read uniformly: `schema.statementsFor( subject.getStatements() )` for editing, `schema.blankStatements()` for creation.

Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/790

## Test plan

- [ ] `make tsci` passes (TS tests, build, lint all green locally)
- [ ] Manual: edit an existing subject through the SubjectEditor dialog — existing values populate
- [ ] Manual: create a new subject through the SubjectCreator dialog — fields render empty
- [ ] Manual: RedHerb's "Edit main subject" dialog still works
- [ ] Manual: RedHerb's "Create child" dialog still works