### PR TITLE
Fix RedHerbSidebarHook calling removed ViewHtmlBuilder method

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,6 +5,7 @@ parameters:
 	level: 9
 	paths:
 		- src
+		- tests/RedHerb/src
 	scanDirectories:
 		- ../../includes
 		- ../../tests/phpunit

--- a/tests/RedHerb/src/RedHerbSidebarHook.php
+++ b/tests/RedHerb/src/RedHerbSidebarHook.php
@@ -7,6 +7,7 @@ namespace ProfessionalWiki\RedHerb;
 use Closure;
 use MediaWiki\Hook\SidebarBeforeOutputHook;
 use MediaWiki\Title\Title;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use Skin;
 
@@ -16,7 +17,8 @@ class RedHerbSidebarHook implements SidebarBeforeOutputHook {
 
 	public function __construct( ?Closure $pageHasMainSubject = null ) {
 		$this->pageHasMainSubject = $pageHasMainSubject ?? static fn ( Title $title ): bool =>
-			NeoWikiExtension::getInstance()->newViewHtmlBuilder()->pageHasMainSubject( $title );
+			NeoWikiExtension::getInstance()->newPageSubjectsLookup()
+				->pageHasMainSubject( new PageId( $title->getArticleID() ) );
 	}
 
 	public function onSidebarBeforeOutput( $skin, &$sidebar ): void {


### PR DESCRIPTION
Master has been red since #795 merged: every page that builds a sidebar 500s with `Call to undefined method ProfessionalWiki\NeoWiki\Presentation\ViewHtmlBuilder::pageHasMainSubject()`, fired from `RedHerbSidebarHook`. The PR-time PHPStan job did not catch this because `tests/RedHerb/` was not in its analyse paths.

Two commits, ordered so each leaves the tree green by itself when applied to pre-#795 master, but together restore master here:

1. **Include RedHerb test extension in PHPStan analysis** — adds `tests/RedHerb/src` to `phpstan.neon` `paths`. Closes the gap that let #795 land. On its own this commit fails PHPStan (intentionally — it surfaces the existing call to a removed method).
2. **Fix RedHerbSidebarHook calling removed ViewHtmlBuilder method** — switches the default closure to `PageSubjectsLookup::pageHasMainSubject()`, matching the pattern now used in `NeoWikiHooks::getNeoWikiAppHtml()`. The closure signature stays `Title -> bool`, so existing test stubs are unchanged.

Follows-up to #795

## Test plan

- [x] PHPStan: green after both commits, fails on commit 1 alone (proving the check works)
- [x] PHPUnit `RedHerbSidebarHookTest`: 6 tests, 15 assertions, all pass
- [x] PHPCS: clean
- [x] Local Docker stack: `index.php/Main_Page` and `api.php` both return 200 (were 500)