### PR TITLE
Fire neowiki.registration hook in SubjectFinder init

### DIFF
--- a/tests/RedHerb/resources/subjectFinder/init.js
+++ b/tests/RedHerb/resources/subjectFinder/init.js
@@ -12,7 +12,15 @@
 			return;
 		}
 
-		var pinia = nw.NeoWikiExtension.getInstance().getPinia();
+		var ext = nw.NeoWikiExtension.getInstance();
+		mw.hook( 'neowiki.registration' ).fire(
+			new nw.FrontendRegistrar(
+				ext.getTypeSpecificComponentRegistry(),
+				ext.getPropertyTypeRegistry()
+			)
+		);
+
+		var pinia = ext.getPinia();
 		var app = Vue.createMwApp( SubjectFinderPanel )
 			.directive( 'tooltip', codex.CdxTooltip );
 		app.use( pinia );


### PR DESCRIPTION
Special:RedHerbSubjectFinder mounts at the custom DOM id
`#ext-redherb-subject-finder`, which is not one of the six
mount points handled by the initializers in `neowiki.ts` that
fire `mw.hook('neowiki.registration')`. As a result, extension-
contributed property types (RedHerb's `color` and any future
ones) were never registered when this page loaded. As soon as
the lookup tried to deserialize a Subject of a Schema using one
of those types, `PropertyTypeRegistry` threw "Unknown property
type: color", and the lookup silently returned no results.

This commit is a targeted fix: it fires the hook from the
SubjectFinder's own init before mounting, mirroring the firing
pattern in `resources/ext.neowiki/src/neowiki.ts`.

A follow-up PR will centralize the fire in `ext.neowiki` itself
so any custom mount point (RedHerb's, future BlueSpice ones)
gets the registration automatically without duplicating this
boilerplate.