### PR TITLE
Centralize neowiki.registration fire on ext.neowiki module load

### DIFF
--- a/resources/ext.neowiki/src/neowiki.ts
+++ b/resources/ext.neowiki/src/neowiki.ts
@@ -34,6 +34,13 @@ export function registerSubjectCreatorClickHandler( pinia: Pinia, signal?: Abort
 	}, { signal } );
 }
 
+function registerExtensions(): void {
+	const ext = NeoWikiExtension.getInstance();
+	mw.hook( 'neowiki.registration' ).fire(
+		new FrontendRegistrar( ext.getTypeSpecificComponentRegistry(), ext.getPropertyTypeRegistry() ),
+	);
+}
+
 function initializeNeoWikiApp(): void {
 	queueMicrotask( () => {
 		const neowikiApp = document.querySelector( '#mw-content-text > #ext-neowiki-app' );
@@ -46,9 +53,6 @@ function initializeNeoWikiApp(): void {
 			const pageHasMainSubject = ( neowikiApp as HTMLElement ).dataset.mwNeowikiPageHasMainSubject === 'true';
 
 			const ext = NeoWikiExtension.getInstance();
-			mw.hook( 'neowiki.registration' ).fire(
-				new FrontendRegistrar( ext.getTypeSpecificComponentRegistry(), ext.getPropertyTypeRegistry() ),
-			);
 
 			const app = createMwApp( NeoWikiApp, {
 				showSubjectCreator,
@@ -69,10 +73,6 @@ function initializeSchemaView(): void {
 
 		if ( viewSchema !== null ) {
 			const ext = NeoWikiExtension.getInstance();
-
-			mw.hook( 'neowiki.registration' ).fire(
-				new FrontendRegistrar( ext.getTypeSpecificComponentRegistry(), ext.getPropertyTypeRegistry() ),
-			);
 
 			const revisionId = mw.config.get( 'wgRevisionId' );
 			const schemaName = mw.config.get( 'wgTitle' ) as SchemaName;
@@ -107,9 +107,6 @@ function initializeSchemasPage(): void {
 
 		if ( schemasPage !== null ) {
 			const ext = NeoWikiExtension.getInstance();
-			mw.hook( 'neowiki.registration' ).fire(
-				new FrontendRegistrar( ext.getTypeSpecificComponentRegistry(), ext.getPropertyTypeRegistry() ),
-			);
 
 			const app = createMwApp( SchemasPage );
 			app.use( ext.getPinia() );
@@ -125,10 +122,6 @@ function initializeLayoutView(): void {
 
 		if ( viewLayout !== null ) {
 			const ext = NeoWikiExtension.getInstance();
-
-			mw.hook( 'neowiki.registration' ).fire(
-				new FrontendRegistrar( ext.getTypeSpecificComponentRegistry(), ext.getPropertyTypeRegistry() ),
-			);
 
 			const revisionId = mw.config.get( 'wgRevisionId' );
 			const layoutName = mw.config.get( 'wgTitle' ) as LayoutName;
@@ -159,9 +152,6 @@ function initializeLayoutsPage(): void {
 
 		if ( layoutsPage !== null ) {
 			const ext = NeoWikiExtension.getInstance();
-			mw.hook( 'neowiki.registration' ).fire(
-				new FrontendRegistrar( ext.getTypeSpecificComponentRegistry(), ext.getPropertyTypeRegistry() ),
-			);
 
 			const app = createMwApp( LayoutsPage );
 			app.use( ext.getPinia() );
@@ -178,10 +168,6 @@ function initializeSubjectsManagerPage(): void {
 		if ( subjectsManager !== null ) {
 			const ext = NeoWikiExtension.getInstance();
 
-			mw.hook( 'neowiki.registration' ).fire(
-				new FrontendRegistrar( ext.getTypeSpecificComponentRegistry(), ext.getPropertyTypeRegistry() ),
-			);
-
 			const app = createMwApp( SubjectsManagerPage ).directive( 'tooltip', CdxTooltip );
 			const pinia = ext.getPinia();
 			app.use( pinia );
@@ -196,6 +182,7 @@ const isTestEnvironment = typeof window !== 'undefined' &&
 	( window as unknown as { neoWikiTestMode?: boolean } ).neoWikiTestMode === true;
 
 if ( !isTestEnvironment ) {
+	registerExtensions();
 	initializeNeoWikiApp();
 	initializeSchemaView();
 	initializeLayoutView();

--- a/resources/ext.neowiki/src/neowiki.ts
+++ b/resources/ext.neowiki/src/neowiki.ts
@@ -34,7 +34,7 @@ export function registerSubjectCreatorClickHandler( pinia: Pinia, signal?: Abort
 	}, { signal } );
 }
 
-function registerExtensions(): void {
+function fireRegistrationHook(): void {
 	const ext = NeoWikiExtension.getInstance();
 	mw.hook( 'neowiki.registration' ).fire(
 		new FrontendRegistrar( ext.getTypeSpecificComponentRegistry(), ext.getPropertyTypeRegistry() ),
@@ -182,7 +182,7 @@ const isTestEnvironment = typeof window !== 'undefined' &&
 	( window as unknown as { neoWikiTestMode?: boolean } ).neoWikiTestMode === true;
 
 if ( !isTestEnvironment ) {
-	registerExtensions();
+	fireRegistrationHook();
 	initializeNeoWikiApp();
 	initializeSchemaView();
 	initializeLayoutView();

--- a/resources/ext.neowiki/tests/integration/HookRegistration.spec.ts
+++ b/resources/ext.neowiki/tests/integration/HookRegistration.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { markRaw } from 'vue';
 import { FrontendRegistrar } from '@/presentation/FrontendRegistrar';
 import { TypeSpecificComponentRegistry } from '@/TypeSpecificComponentRegistry';
@@ -77,5 +77,32 @@ describe( 'neowiki.registration hook end-to-end', () => {
 		} );
 
 		expect( typeRegistry.getTypeNames() ).toContain( 'late' );
+	} );
+} );
+
+describe( 'ext.neowiki module load', () => {
+	beforeEach( () => setupMwHook() );
+
+	afterEach( () => {
+		( window as unknown as { neoWikiTestMode?: boolean } ).neoWikiTestMode = true;
+	} );
+
+	it( 'fires neowiki.registration with a registrar wired to the live extension registries', async () => {
+		( window as unknown as { neoWikiTestMode?: boolean } ).neoWikiTestMode = false;
+
+		vi.resetModules();
+		await import( '@/neowiki' );
+		const { NeoWikiExtension } = await import( '@/NeoWikiExtension' );
+
+		let receivedRegistrar: FrontendRegistrar | null = null;
+		( globalThis as any ).mw.hook( 'neowiki.registration' ).add( ( r: FrontendRegistrar ) => {
+			receivedRegistrar = r;
+		} );
+
+		receivedRegistrar!.registerPropertyType( fakeRegistration( 'boot-fake' ) );
+
+		const ext = NeoWikiExtension.getInstance();
+		expect( ext.getPropertyTypeRegistry().getTypeNames() ).toContain( 'boot-fake' );
+		expect( ext.getTypeSpecificComponentRegistry().getPropertyTypes() ).toContain( 'boot-fake' );
 	} );
 } );

--- a/tests/RedHerb/resources/subjectFinder/init.js
+++ b/tests/RedHerb/resources/subjectFinder/init.js
@@ -12,15 +12,7 @@
 			return;
 		}
 
-		var ext = nw.NeoWikiExtension.getInstance();
-		mw.hook( 'neowiki.registration' ).fire(
-			new nw.FrontendRegistrar(
-				ext.getTypeSpecificComponentRegistry(),
-				ext.getPropertyTypeRegistry()
-			)
-		);
-
-		var pinia = ext.getPinia();
+		var pinia = nw.NeoWikiExtension.getInstance().getPinia();
 		var app = Vue.createMwApp( SubjectFinderPanel )
 			.directive( 'tooltip', codex.CdxTooltip );
 		app.use( pinia );


### PR DESCRIPTION
> Result of extensive back and forth with @malberts.
> Context: the NeoWiki codebase, PR #803 (the just-merged targeted fix), and the project's `mw.hook` replay-on-late-subscribe semantics covered by `HookRegistration.spec.ts`.
> <sub>Written by Claude Code, `Opus 4.7`</sub>

Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/803

Related to https://github.com/ProfessionalWiki/NeoWiki/issues/686

The previous setup duplicated `mw.hook( 'neowiki.registration' ).fire()` in each of the six mount-point initializers in `neowiki.ts`, plus a seventh in RedHerb's SubjectFinder init added by PR #803. Each fire constructed a fresh `FrontendRegistrar` over the same singleton registries — pure boilerplate that any new custom mount point would have to remember to replicate or risk extension property types silently failing to register.

Extract a single `fireRegistrationHook()` and call it once at `ext.neowiki` module load, before the initializers. Subscribers that load before or after benefit equally thanks to `mw.hook`'s documented replay-on-late-subscribe behavior, already covered by `HookRegistration.spec.ts`. The seven redundant per-mount fires are removed.

A new boot-time test asserts that loading `@/neowiki` fires the hook with a registrar wired to the live `NeoWikiExtension` registries — registering a fake type via the fired registrar must be observable on the singleton's `PropertyTypeRegistry` *and* `TypeSpecificComponentRegistry`. This catches a missing fire, a fully detached registrar, and a half-detached registrar (where one registry is fresh and the other live — would only surface as broken Vue rendering in the browser).