### PR TITLE
Refactor frontend validation: declarative constraints + interpreter

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -284,6 +284,7 @@
 				"neowiki-property-type-datetime",
 				"neowiki-infobox-type",
 				"neowiki-infobox-edit-link",
+				"neowiki-field-label-required",
 				"neowiki-field-required",
 				"neowiki-field-unique",
 				"neowiki-field-min-length",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -50,6 +50,7 @@
 
 	"neowiki-infobox-type": "Type",
 	"neowiki-infobox-edit-link": "Edit",
+	"neowiki-field-label-required": "This subject needs a label.",
 	"neowiki-field-required": "Please provide a value.",
 	"neowiki-field-unique": "All values must be unique.",
 	"neowiki-field-min-length": "Minimum length is $1 characters.",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -147,6 +147,7 @@
 	"neowiki-select-placeholder": "Placeholder text shown in the select dropdown before any option is chosen.",
 	"neowiki-select-no-results": "Message shown in the multi-select dropdown when the typed text does not match any available option.",
 	"neowiki-field-invalid-datetime": "Validation error shown when the entered date and time value cannot be parsed. DateTime values must be strict ISO 8601 / xsd:dateTime strings with an explicit timezone offset or 'Z' (for example, '2025-06-15T12:00:00Z' or '2025-06-15T12:00:00+02:00'). Partial values such as year-only or date-only are rejected, and min/max bounds are inclusive.",
+	"neowiki-field-label-required": "Error message shown when a Subject is saved or validated with an empty label.",
 	"neowiki-property-type-datetime": "Label for the date and time property type in the schema editor",
 	"neowiki-select-unknown-option": "Placeholder shown in a select-property display when a stored option ID cannot be resolved to a label (e.g. the option was removed from the Schema).",
 

--- a/resources/ext.neowiki/src/domain/Constraint.ts
+++ b/resources/ext.neowiki/src/domain/Constraint.ts
@@ -5,5 +5,5 @@ export type Constraint =
 	| { kind: 'minLength'; value: number; severity?: Severity }
 	| { kind: 'maxLength'; value: number; severity?: Severity }
 	| { kind: 'uniqueItems'; severity?: Severity }
-	| { kind: 'cardinality'; max: number; severity?: Severity }
+	| { kind: 'cardinality'; maxItems: number; severity?: Severity }
 	| { kind: 'enum'; allowedValues: string[]; severity?: Severity };

--- a/resources/ext.neowiki/src/domain/Constraint.ts
+++ b/resources/ext.neowiki/src/domain/Constraint.ts
@@ -1,0 +1,9 @@
+export type Severity = 'error' | 'warning';
+
+export type Constraint =
+	| { kind: 'required'; severity?: Severity }
+	| { kind: 'minLength'; value: number; severity?: Severity }
+	| { kind: 'maxLength'; value: number; severity?: Severity }
+	| { kind: 'uniqueItems'; severity?: Severity }
+	| { kind: 'cardinality'; max: number; severity?: Severity }
+	| { kind: 'enum'; allowedValues: string[]; severity?: Severity };

--- a/resources/ext.neowiki/src/domain/ConstraintInterpreter.ts
+++ b/resources/ext.neowiki/src/domain/ConstraintInterpreter.ts
@@ -1,0 +1,79 @@
+import type { Constraint } from '@/domain/Constraint';
+import { isValueEmpty, type StringValue, type Value, ValueType } from '@/domain/Value';
+import type { ValueValidationError } from '@/domain/PropertyType';
+
+export function interpretConstraints(
+	constraints: Constraint[],
+	value: Value | undefined,
+): ValueValidationError[] {
+	const errors: ValueValidationError[] = [];
+	for ( const constraint of constraints ) {
+		errors.push( ...evaluate( constraint, value ) );
+	}
+	return errors;
+}
+
+function evaluate( constraint: Constraint, value: Value | undefined ): ValueValidationError[] {
+	switch ( constraint.kind ) {
+		case 'required':
+			return isValueEmpty( value ) ? [ emit( 'required', constraint ) ] : [];
+
+		case 'minLength': {
+			if ( value?.type !== ValueType.String ) return [];
+			const out: ValueValidationError[] = [];
+			for ( const part of ( value as StringValue ).parts ) {
+				if ( part.trim().length < constraint.value ) {
+					out.push( emit( 'min-length', constraint, { args: [ constraint.value ], source: part } ) );
+				}
+			}
+			return out;
+		}
+
+		case 'maxLength': {
+			if ( value?.type !== ValueType.String ) return [];
+			const out: ValueValidationError[] = [];
+			for ( const part of ( value as StringValue ).parts ) {
+				if ( part.trim().length > constraint.value ) {
+					out.push( emit( 'max-length', constraint, { args: [ constraint.value ], source: part } ) );
+				}
+			}
+			return out;
+		}
+
+		case 'uniqueItems': {
+			if ( value?.type !== ValueType.String ) return [];
+			const parts = ( value as StringValue ).parts;
+			return new Set( parts ).size !== parts.length ? [ emit( 'unique', constraint ) ] : [];
+		}
+
+		case 'cardinality': {
+			if ( value?.type !== ValueType.String ) return [];
+			const parts = ( value as StringValue ).parts;
+			return parts.length > constraint.maxItems ? [ emit( 'single-value-only', constraint ) ] : [];
+		}
+
+		case 'enum': {
+			if ( value?.type !== ValueType.String ) return [];
+			const allowed = new Set( constraint.allowedValues );
+			const out: ValueValidationError[] = [];
+			for ( const part of ( value as StringValue ).parts ) {
+				if ( !allowed.has( part ) ) {
+					out.push( emit( 'invalid-option', constraint, { args: [ part ], source: part } ) );
+				}
+			}
+			return out;
+		}
+	}
+}
+
+function emit(
+	code: string,
+	constraint: Constraint,
+	extra: Partial<Omit<ValueValidationError, 'code' | 'severity'>> = {},
+): ValueValidationError {
+	const error: ValueValidationError = { code, ...extra };
+	if ( constraint.severity !== undefined ) {
+		error.severity = constraint.severity;
+	}
+	return error;
+}

--- a/resources/ext.neowiki/src/domain/ConstraintInterpreter.ts
+++ b/resources/ext.neowiki/src/domain/ConstraintInterpreter.ts
@@ -1,5 +1,5 @@
 import type { Constraint } from '@/domain/Constraint';
-import { isValueEmpty, type StringValue, type Value, ValueType } from '@/domain/Value';
+import { isValueEmpty, type Value, ValueType } from '@/domain/Value';
 import type { ValueValidationError } from '@/domain/PropertyType';
 
 export function interpretConstraints(
@@ -23,7 +23,7 @@ function evaluate( constraint: Constraint, value: Value | undefined ): ValueVali
 				return [];
 			}
 			const out: ValueValidationError[] = [];
-			for ( const part of ( value as StringValue ).parts ) {
+			for ( const part of value.parts ) {
 				if ( part.trim().length < constraint.value ) {
 					out.push( emit( 'min-length', constraint, { args: [ constraint.value ], source: part } ) );
 				}
@@ -36,7 +36,7 @@ function evaluate( constraint: Constraint, value: Value | undefined ): ValueVali
 				return [];
 			}
 			const out: ValueValidationError[] = [];
-			for ( const part of ( value as StringValue ).parts ) {
+			for ( const part of value.parts ) {
 				if ( part.trim().length > constraint.value ) {
 					out.push( emit( 'max-length', constraint, { args: [ constraint.value ], source: part } ) );
 				}
@@ -48,7 +48,7 @@ function evaluate( constraint: Constraint, value: Value | undefined ): ValueVali
 			if ( value?.type !== ValueType.String ) {
 				return [];
 			}
-			const parts = ( value as StringValue ).parts;
+			const parts = value.parts;
 			return new Set( parts ).size !== parts.length ? [ emit( 'unique', constraint ) ] : [];
 		}
 
@@ -56,7 +56,10 @@ function evaluate( constraint: Constraint, value: Value | undefined ): ValueVali
 			if ( value?.type !== ValueType.String ) {
 				return [];
 			}
-			const parts = ( value as StringValue ).parts;
+			const parts = value.parts;
+			// The 'single-value-only' code assumes maxItems === 1 (the only value used today).
+			// When a maxItems > 1 use case lands, branch the error code (e.g. 'max-items' with
+			// args: [ maxItems ]) and add a matching i18n message.
 			return parts.length > constraint.maxItems ? [ emit( 'single-value-only', constraint ) ] : [];
 		}
 
@@ -66,7 +69,7 @@ function evaluate( constraint: Constraint, value: Value | undefined ): ValueVali
 			}
 			const allowed = new Set( constraint.allowedValues );
 			const out: ValueValidationError[] = [];
-			for ( const part of ( value as StringValue ).parts ) {
+			for ( const part of value.parts ) {
 				if ( !allowed.has( part ) ) {
 					out.push( emit( 'invalid-option', constraint, { args: [ part ], source: part } ) );
 				}

--- a/resources/ext.neowiki/src/domain/ConstraintInterpreter.ts
+++ b/resources/ext.neowiki/src/domain/ConstraintInterpreter.ts
@@ -19,7 +19,9 @@ function evaluate( constraint: Constraint, value: Value | undefined ): ValueVali
 			return isValueEmpty( value ) ? [ emit( 'required', constraint ) ] : [];
 
 		case 'minLength': {
-			if ( value?.type !== ValueType.String ) return [];
+			if ( value?.type !== ValueType.String ) {
+				return [];
+			}
 			const out: ValueValidationError[] = [];
 			for ( const part of ( value as StringValue ).parts ) {
 				if ( part.trim().length < constraint.value ) {
@@ -30,7 +32,9 @@ function evaluate( constraint: Constraint, value: Value | undefined ): ValueVali
 		}
 
 		case 'maxLength': {
-			if ( value?.type !== ValueType.String ) return [];
+			if ( value?.type !== ValueType.String ) {
+				return [];
+			}
 			const out: ValueValidationError[] = [];
 			for ( const part of ( value as StringValue ).parts ) {
 				if ( part.trim().length > constraint.value ) {
@@ -41,19 +45,25 @@ function evaluate( constraint: Constraint, value: Value | undefined ): ValueVali
 		}
 
 		case 'uniqueItems': {
-			if ( value?.type !== ValueType.String ) return [];
+			if ( value?.type !== ValueType.String ) {
+				return [];
+			}
 			const parts = ( value as StringValue ).parts;
 			return new Set( parts ).size !== parts.length ? [ emit( 'unique', constraint ) ] : [];
 		}
 
 		case 'cardinality': {
-			if ( value?.type !== ValueType.String ) return [];
+			if ( value?.type !== ValueType.String ) {
+				return [];
+			}
 			const parts = ( value as StringValue ).parts;
 			return parts.length > constraint.maxItems ? [ emit( 'single-value-only', constraint ) ] : [];
 		}
 
 		case 'enum': {
-			if ( value?.type !== ValueType.String ) return [];
+			if ( value?.type !== ValueType.String ) {
+				return [];
+			}
 			const allowed = new Set( constraint.allowedValues );
 			const out: ValueValidationError[] = [];
 			for ( const part of ( value as StringValue ).parts ) {

--- a/resources/ext.neowiki/src/domain/PropertyType.ts
+++ b/resources/ext.neowiki/src/domain/PropertyType.ts
@@ -44,6 +44,11 @@ export interface ValueValidationError {
 	 */
 	source?: unknown;
 
+	/**
+	 * Optional severity. Absent means error (default).
+	 */
+	severity?: 'error' | 'warning';
+
 }
 
 export type PropertyType = BasePropertyType<PropertyDefinition, Value>;

--- a/resources/ext.neowiki/src/domain/PropertyType.ts
+++ b/resources/ext.neowiki/src/domain/PropertyType.ts
@@ -31,9 +31,7 @@ export abstract class BasePropertyType<P extends PropertyDefinition, V extends V
 		];
 	}
 
-	public getConstraints( _property: P ): Constraint[] {
-		return [];
-	}
+	public abstract getConstraints( property: P ): Constraint[];
 
 	public validateValue( _value: V | undefined, _property: P ): ValueValidationError[] {
 		return [];

--- a/resources/ext.neowiki/src/domain/PropertyType.ts
+++ b/resources/ext.neowiki/src/domain/PropertyType.ts
@@ -1,6 +1,8 @@
 import { PropertyDefinition } from '@/domain/PropertyDefinition';
 import type { Value } from '@/domain/Value';
 import { ValueType } from '@/domain/Value';
+import type { Constraint } from '@/domain/Constraint';
+import { interpretConstraints } from '@/domain/ConstraintInterpreter';
 
 export abstract class BasePropertyType<P extends PropertyDefinition, V extends Value> {
 
@@ -22,8 +24,20 @@ export abstract class BasePropertyType<P extends PropertyDefinition, V extends V
 
 	public abstract getExampleValue( property: P ): V;
 
-	// TODO: do we need to allow undefined for value?
-	public abstract validate( value: V | undefined, property: P ): ValueValidationError[];
+	public validate( value: V | undefined, property: P ): ValueValidationError[] {
+		return [
+			...this.validateValue( value, property ),
+			...interpretConstraints( this.getConstraints( property ), value ),
+		];
+	}
+
+	public getConstraints( _property: P ): Constraint[] {
+		return [];
+	}
+
+	public validateValue( _value: V | undefined, _property: P ): ValueValidationError[] {
+		return [];
+	}
 
 }
 

--- a/resources/ext.neowiki/src/domain/SubjectValidator.ts
+++ b/resources/ext.neowiki/src/domain/SubjectValidator.ts
@@ -1,7 +1,13 @@
-import { PropertyType, PropertyTypeRegistry } from '@/domain/PropertyType';
+import { PropertyTypeRegistry } from '@/domain/PropertyType';
+import type { ValueValidationError } from '@/domain/PropertyType';
 import { Subject } from '@/domain/Subject';
 import { Schema } from '@/domain/Schema';
 import { Statement } from '@/domain/Statement';
+
+export interface SubjectValidationError {
+	readonly propertyName: string | null;
+	readonly error: ValueValidationError;
+}
 
 export class SubjectValidator {
 
@@ -9,37 +15,30 @@ export class SubjectValidator {
 		private readonly propertyTypeRegistry: PropertyTypeRegistry,
 	) {}
 
-	public validate( subject: Subject, schema: Schema ): boolean {
+	public validate( subject: Subject, schema: Schema ): SubjectValidationError[] {
+		const errors: SubjectValidationError[] = [];
+
 		if ( subject.getLabel().trim() === '' ) {
-			return false;
+			errors.push( { propertyName: null, error: { code: 'label-required' } } );
 		}
 
 		for ( const statement of subject.getStatements() ) {
-			if ( !this.statementIsValid( statement, schema ) ) {
-				return false;
-			}
+			errors.push( ...this.validateStatement( statement, schema ) );
 		}
 
-		return true;
+		return errors;
 	}
 
-	private statementIsValid( statement: Statement, schema: Schema ): boolean {
-		if ( !schema.getPropertyDefinitions().has( statement.propertyName ) ) {
-			return true; // Statements for unknown properties are considered valid
+	private validateStatement( statement: Statement, schema: Schema ): SubjectValidationError[] {
+		const propertyDef = schema.getPropertyDefinitions().get( statement.propertyName );
+		if ( propertyDef === undefined ) {
+			return [];
 		}
 
-		const errors =
-			this.getPropertyType( statement )
-				.validate(
-					statement.value,
-					schema.getPropertyDefinitions().get( statement.propertyName ),
-				);
+		const propertyType = this.propertyTypeRegistry.getType( statement.propertyType );
+		const valueErrors = propertyType.validate( statement.value, propertyDef );
 
-		return errors.length === 0;
-	}
-
-	private getPropertyType( statement: Statement ): PropertyType {
-		return this.propertyTypeRegistry.getType( statement.propertyType );
+		return valueErrors.map( ( error ) => ( { propertyName: statement.propertyName.toString(), error } ) );
 	}
 
 }

--- a/resources/ext.neowiki/src/domain/Value.ts
+++ b/resources/ext.neowiki/src/domain/Value.ts
@@ -87,7 +87,9 @@ export function newRelation( id: string | undefined, target: SubjectId | string 
 }
 
 export function isValueEmpty( value: Value | undefined ): boolean {
-	if ( value === undefined ) return true;
+	if ( value === undefined ) {
+		return true;
+	}
 	switch ( value.type ) {
 		case ValueType.String:
 			return value.parts.length === 0;

--- a/resources/ext.neowiki/src/domain/Value.ts
+++ b/resources/ext.neowiki/src/domain/Value.ts
@@ -86,6 +86,20 @@ export function newRelation( id: string | undefined, target: SubjectId | string 
 	);
 }
 
+export function isValueEmpty( value: Value | undefined ): boolean {
+	if ( value === undefined ) return true;
+	switch ( value.type ) {
+		case ValueType.String:
+			return value.parts.length === 0;
+		case ValueType.Number:
+			return false;
+		case ValueType.Boolean:
+			return false;
+		case ValueType.Relation:
+			return value.relations.length === 0;
+	}
+}
+
 export function relationValuesHaveSameTargets(
 	a: RelationValue | undefined,
 	b: RelationValue | undefined,

--- a/resources/ext.neowiki/src/domain/propertyTypes/DateTime.ts
+++ b/resources/ext.neowiki/src/domain/propertyTypes/DateTime.ts
@@ -2,6 +2,7 @@ import type { PropertyDefinition } from '@/domain/PropertyDefinition';
 import { PropertyName } from '@/domain/PropertyDefinition';
 import { newStringValue, type StringValue, ValueType } from '@/domain/Value';
 import { BasePropertyType, ValueValidationError } from '@/domain/PropertyType';
+import type { Constraint } from '@/domain/Constraint';
 
 export interface DateTimeProperty extends PropertyDefinition {
 
@@ -112,41 +113,31 @@ export class DateTimeType extends BasePropertyType<DateTimeProperty, StringValue
 		} as DateTimeProperty;
 	}
 
-	public validate( value: StringValue | undefined, property: DateTimeProperty ): ValueValidationError[] {
-		const errors: ValueValidationError[] = [];
+	public getConstraints( property: DateTimeProperty ): Constraint[] {
+		return property.required ? [ { kind: 'required' } ] : [];
+	}
 
-		if ( property.required && value === undefined ) {
-			errors.push( { code: 'required' } );
+	public validateValue(
+		value: StringValue | undefined,
+		property: DateTimeProperty,
+	): ValueValidationError[] {
+		if ( value === undefined || value.parts.length === 0 ) {
+			return [];
+		}
+		const errors: ValueValidationError[] = [];
+		const timestamp = parseStrictDateTime( value.parts[ 0 ] );
+		if ( timestamp === null ) {
+			errors.push( { code: 'invalid-datetime' } );
 			return errors;
 		}
-
-		if ( value !== undefined && value.parts.length > 0 ) {
-			const timestamp = parseStrictDateTime( value.parts[ 0 ] );
-
-			if ( timestamp === null ) {
-				errors.push( { code: 'invalid-datetime' } );
-				return errors;
-			}
-
-			const minimum = property.minimum;
-			const minimumTimestamp = minimum !== undefined ? parseStrictDateTime( minimum ) : null;
-			if ( minimum !== undefined && minimumTimestamp !== null && timestamp < minimumTimestamp ) {
-				errors.push( {
-					code: 'min-value',
-					args: [ minimum ],
-				} );
-			}
-
-			const maximum = property.maximum;
-			const maximumTimestamp = maximum !== undefined ? parseStrictDateTime( maximum ) : null;
-			if ( maximum !== undefined && maximumTimestamp !== null && timestamp > maximumTimestamp ) {
-				errors.push( {
-					code: 'max-value',
-					args: [ maximum ],
-				} );
-			}
+		const min = property.minimum !== undefined ? parseStrictDateTime( property.minimum ) : null;
+		if ( min !== null && timestamp < min ) {
+			errors.push( { code: 'min-value', args: [ property.minimum ] } );
 		}
-
+		const max = property.maximum !== undefined ? parseStrictDateTime( property.maximum ) : null;
+		if ( max !== null && timestamp > max ) {
+			errors.push( { code: 'max-value', args: [ property.maximum ] } );
+		}
 		return errors;
 	}
 

--- a/resources/ext.neowiki/src/domain/propertyTypes/Number.ts
+++ b/resources/ext.neowiki/src/domain/propertyTypes/Number.ts
@@ -1,3 +1,4 @@
+import type { Constraint } from '@/domain/Constraint';
 import type { PropertyDefinition } from '@/domain/PropertyDefinition';
 import { PropertyName } from '@/domain/PropertyDefinition';
 import { newNumberValue, type NumberValue, ValueType } from '@/domain/Value';
@@ -34,29 +35,21 @@ export class NumberType extends BasePropertyType<NumberProperty, NumberValue> {
 		} as NumberProperty;
 	}
 
-	public validate( value: NumberValue | undefined, property: NumberProperty ): ValueValidationError[] {
+	public getConstraints( property: NumberProperty ): Constraint[] {
+		return property.required ? [ { kind: 'required' } ] : [];
+	}
+
+	public validateValue( value: NumberValue | undefined, property: NumberProperty ): ValueValidationError[] {
+		if ( value === undefined ) {
+			return [];
+		}
 		const errors: ValueValidationError[] = [];
-
-		if ( property.required && value === undefined ) {
-			errors.push( { code: 'required' } );
-			return errors;
+		if ( property.minimum !== undefined && value.number < property.minimum ) {
+			errors.push( { code: 'min-value', args: [ property.minimum ] } );
 		}
-
-		if ( value !== undefined ) {
-			if ( property.minimum !== undefined && value.number < property.minimum ) {
-				errors.push( {
-					code: 'min-value',
-					args: [ property.minimum ],
-				} );
-			}
-			if ( property.maximum !== undefined && value.number > property.maximum ) {
-				errors.push( {
-					code: 'max-value',
-					args: [ property.maximum ],
-				} );
-			}
+		if ( property.maximum !== undefined && value.number > property.maximum ) {
+			errors.push( { code: 'max-value', args: [ property.maximum ] } );
 		}
-
 		return errors;
 	}
 

--- a/resources/ext.neowiki/src/domain/propertyTypes/Relation.ts
+++ b/resources/ext.neowiki/src/domain/propertyTypes/Relation.ts
@@ -3,6 +3,7 @@ import { PropertyName } from '@/domain/PropertyDefinition';
 import { newRelation, RelationValue, ValueType } from '@/domain/Value';
 import { BasePropertyType, ValueValidationError } from '@/domain/PropertyType';
 import { SubjectId } from '@/domain/SubjectId';
+import type { Constraint } from '@/domain/Constraint';
 
 export interface RelationProperty extends PropertyDefinition {
 
@@ -41,25 +42,20 @@ export class RelationType extends BasePropertyType<RelationProperty, RelationVal
 		} as RelationProperty;
 	}
 
-	public validate( value: RelationValue | undefined, property: RelationProperty ): ValueValidationError[] {
+	public getConstraints( property: RelationProperty ): Constraint[] {
+		return property.required ? [ { kind: 'required' } ] : [];
+	}
+
+	public validateValue( value: RelationValue | undefined ): ValueValidationError[] {
+		if ( value === undefined || value.relations.length === 0 ) {
+			return [];
+		}
 		const errors: ValueValidationError[] = [];
-		const valueIsEmpty = !value || value.relations.length === 0;
-
-		if ( property.required && valueIsEmpty ) {
-			errors.push( { code: 'required' } );
-			return errors;
-		}
-
-		if ( valueIsEmpty ) {
-			return errors;
-		}
-
 		for ( const relation of value.relations ) {
 			if ( !SubjectId.isValid( relation.target.text ) ) {
 				errors.push( { code: 'invalid-subject-id', args: [ relation.target.text ] } );
 			}
 		}
-
 		return errors;
 	}
 

--- a/resources/ext.neowiki/src/domain/propertyTypes/Select.ts
+++ b/resources/ext.neowiki/src/domain/propertyTypes/Select.ts
@@ -1,7 +1,8 @@
+import type { Constraint } from '@/domain/Constraint';
 import type { PropertyDefinition } from '@/domain/PropertyDefinition';
 import { PropertyName } from '@/domain/PropertyDefinition';
 import { newStringValue, type StringValue, ValueType } from '@/domain/Value';
-import { BasePropertyType, ValueValidationError } from '@/domain/PropertyType';
+import { BasePropertyType } from '@/domain/PropertyType';
 
 export interface SelectOption {
 
@@ -43,32 +44,19 @@ export class SelectType extends BasePropertyType<SelectProperty, StringValue> {
 		} as SelectProperty;
 	}
 
-	public validate( value: StringValue | undefined, property: SelectProperty ): ValueValidationError[] {
-		const errors: ValueValidationError[] = [];
-		value = value === undefined ? newStringValue() : value;
-
-		if ( property.required && value.parts.length === 0 ) {
-			errors.push( { code: 'required' } );
-			return errors;
+	public getConstraints( property: SelectProperty ): Constraint[] {
+		const constraints: Constraint[] = [];
+		if ( property.required ) {
+			constraints.push( { kind: 'required' } );
 		}
-
-		const validIds = new Set( property.options.map( ( option ) => option.id ) );
-
-		for ( const part of value.parts ) {
-			if ( !validIds.has( part ) ) {
-				errors.push( {
-					code: 'invalid-option',
-					args: [ part ],
-					source: part,
-				} );
-			}
+		constraints.push( {
+			kind: 'enum',
+			allowedValues: property.options.map( ( option ) => option.id ),
+		} );
+		if ( !property.multiple ) {
+			constraints.push( { kind: 'cardinality', maxItems: 1 } );
 		}
-
-		if ( !property.multiple && value.parts.length > 1 ) {
-			errors.push( { code: 'single-value-only' } );
-		}
-
-		return errors;
+		return constraints;
 	}
 
 }

--- a/resources/ext.neowiki/src/domain/propertyTypes/Text.ts
+++ b/resources/ext.neowiki/src/domain/propertyTypes/Text.ts
@@ -1,7 +1,8 @@
 import type { MultiStringProperty, PropertyDefinition } from '@/domain/PropertyDefinition';
 import { PropertyName } from '@/domain/PropertyDefinition';
 import { newStringValue, type StringValue, ValueType } from '@/domain/Value';
-import { BasePropertyType, ValueValidationError } from '@/domain/PropertyType';
+import { BasePropertyType } from '@/domain/PropertyType';
+import type { Constraint } from '@/domain/Constraint';
 
 export interface TextProperty extends MultiStringProperty {
 
@@ -34,40 +35,22 @@ export class TextType extends BasePropertyType<TextProperty, StringValue> {
 		} as TextProperty;
 	}
 
-	public validate( value: StringValue | undefined, property: TextProperty ): ValueValidationError[] {
-		const errors: ValueValidationError[] = [];
-		value = value === undefined ? newStringValue() : value;
-
-		if ( property.required && value.parts.length === 0 ) {
-			errors.push( { code: 'required' } );
-			return errors;
+	public getConstraints( property: TextProperty ): Constraint[] {
+		const constraints: Constraint[] = [];
+		if ( property.required ) {
+			constraints.push( { kind: 'required' } );
 		}
-
+		if ( property.minLength !== undefined ) {
+			constraints.push( { kind: 'minLength', value: property.minLength } );
+		}
+		if ( property.maxLength !== undefined ) {
+			constraints.push( { kind: 'maxLength', value: property.maxLength } );
+		}
+		if ( property.uniqueItems ) {
+			constraints.push( { kind: 'uniqueItems' } );
+		}
 		// TODO: check property.multiple
-
-		for ( const part of value.parts ) {
-			if ( property.minLength !== undefined && part.trim().length < property.minLength ) {
-				errors.push( {
-					code: 'min-length',
-					args: [ property.minLength ],
-					source: part,
-				} );
-			}
-
-			if ( property.maxLength !== undefined && part.trim().length > property.maxLength ) {
-				errors.push( {
-					code: 'max-length',
-					args: [ property.maxLength ],
-					source: part,
-				} );
-			}
-		}
-
-		if ( property.uniqueItems && new Set( value.parts ).size !== value.parts.length ) {
-			errors.push( { code: 'unique' } ); // TODO: add source
-		}
-
-		return errors;
+		return constraints;
 	}
 
 }

--- a/resources/ext.neowiki/src/domain/propertyTypes/Url.ts
+++ b/resources/ext.neowiki/src/domain/propertyTypes/Url.ts
@@ -1,6 +1,7 @@
 import { MultiStringProperty, PropertyDefinition, PropertyName } from '@/domain/PropertyDefinition';
 import { newStringValue, type StringValue, ValueType } from '@/domain/Value';
 import { BasePropertyType, ValueValidationError } from '@/domain/PropertyType';
+import type { Constraint } from '@/domain/Constraint';
 
 export interface UrlProperty extends MultiStringProperty {
 
@@ -30,29 +31,29 @@ export class UrlType extends BasePropertyType<UrlProperty, StringValue> {
 		} as UrlProperty;
 	}
 
-	public validate( value: StringValue | undefined, property: UrlProperty ): ValueValidationError[] {
-		const errors: ValueValidationError[] = [];
-		value = value === undefined ? newStringValue() : value;
-
-		if ( property.required && value.parts.length === 0 ) {
-			errors.push( { code: 'required' } );
-			return errors;
+	public getConstraints( property: UrlProperty ): Constraint[] {
+		const constraints: Constraint[] = [];
+		if ( property.required ) {
+			constraints.push( { kind: 'required' } );
 		}
-
 		// TODO: check property.multiple
+		if ( property.uniqueItems ) {
+			constraints.push( { kind: 'uniqueItems' } );
+		}
+		return constraints;
+	}
 
+	public validateValue( value: StringValue | undefined ): ValueValidationError[] {
+		if ( value === undefined ) {
+			return [];
+		}
+		const errors: ValueValidationError[] = [];
 		for ( const part of value.parts ) {
 			const url = part.trim();
-
 			if ( url !== '' && !isValidUrl( url ) ) {
 				errors.push( { code: 'invalid-url', source: part } );
 			}
 		}
-
-		if ( property.uniqueItems && new Set( value.parts ).size !== value.parts.length ) {
-			errors.push( { code: 'unique' } ); // TODO: add source
-		}
-
 		return errors;
 	}
 

--- a/resources/ext.neowiki/src/presentation/PropertyTypeAdapter.ts
+++ b/resources/ext.neowiki/src/presentation/PropertyTypeAdapter.ts
@@ -41,6 +41,8 @@ export class PropertyTypeAdapter extends BasePropertyType<PropertyDefinition, Va
 		return this.registration.getExampleValue( property );
 	}
 
+	// Unreachable: validate() below is overridden and never delegates to getConstraints.
+	// Required only to satisfy the abstract contract on BasePropertyType.
 	public getConstraints(): Constraint[] {
 		return [];
 	}

--- a/resources/ext.neowiki/src/presentation/PropertyTypeAdapter.ts
+++ b/resources/ext.neowiki/src/presentation/PropertyTypeAdapter.ts
@@ -1,5 +1,6 @@
 import { BasePropertyType } from '@/domain/PropertyType';
 import type { ValueValidationError } from '@/domain/PropertyType';
+import type { Constraint } from '@/domain/Constraint';
 import type { PropertyDefinition } from '@/domain/PropertyDefinition';
 import type { Value, ValueType } from '@/domain/Value';
 import type { PropertyTypeRegistration } from '@/domain/PropertyTypeRegistration';
@@ -38,6 +39,10 @@ export class PropertyTypeAdapter extends BasePropertyType<PropertyDefinition, Va
 
 	public getExampleValue( property: PropertyDefinition ): Value {
 		return this.registration.getExampleValue( property );
+	}
+
+	public getConstraints(): Constraint[] {
+		return [];
 	}
 
 	public validate( value: Value | undefined, property: PropertyDefinition ): ValueValidationError[] {

--- a/resources/ext.neowiki/src/public-api.ts
+++ b/resources/ext.neowiki/src/public-api.ts
@@ -34,6 +34,8 @@ export * from './composables/useSortable';
 export * from './composables/useStringValueInput';
 export * from './composables/useSubjectPermissions';
 export * from './composables/useValueValidation';
+export * from './domain/Constraint';
+export * from './domain/ConstraintInterpreter';
 export * from './domain/Layout';
 export * from './domain/PageIdentifiers';
 export * from './domain/PageSubjects';

--- a/resources/ext.neowiki/tests/domain/ConstraintInterpreter.spec.ts
+++ b/resources/ext.neowiki/tests/domain/ConstraintInterpreter.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { interpretConstraints } from '@/domain/ConstraintInterpreter';
-import { newNumberValue, newRelation, newStringValue, RelationValue } from '@/domain/Value';
+import { newNumberValue, newRelation, newStringValue, RelationValue, ValueType, type StringValue } from '@/domain/Value';
 
 describe( 'interpretConstraints', () => {
 
@@ -52,7 +52,7 @@ describe( 'interpretConstraints', () => {
 		it( 'measures trimmed length', () => {
 			// Note: newStringValue trims at construction; this confirms the interpreter ALSO trims.
 			// Construct a StringValue with an untrimmed part by hand to bypass newStringValue's trim.
-			const value = { type: 'string' as const, parts: [ '  ab  ' ] };
+			const value: StringValue = { type: ValueType.String, parts: [ '  ab  ' ] };
 			expect( interpretConstraints(
 				[ { kind: 'minLength', value: 3 } ],
 				value,

--- a/resources/ext.neowiki/tests/domain/ConstraintInterpreter.spec.ts
+++ b/resources/ext.neowiki/tests/domain/ConstraintInterpreter.spec.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from 'vitest';
+import { interpretConstraints } from '@/domain/ConstraintInterpreter';
+import { newNumberValue, newRelation, newStringValue, RelationValue } from '@/domain/Value';
+
+describe( 'interpretConstraints', () => {
+
+	describe( 'required', () => {
+
+		it( 'produces required error for empty StringValue', () => {
+			expect( interpretConstraints( [ { kind: 'required' } ], newStringValue() ) )
+				.toEqual( [ { code: 'required' } ] );
+		} );
+
+		it( 'produces required error for undefined value', () => {
+			expect( interpretConstraints( [ { kind: 'required' } ], undefined ) )
+				.toEqual( [ { code: 'required' } ] );
+		} );
+
+		it( 'produces no error for non-empty StringValue', () => {
+			expect( interpretConstraints( [ { kind: 'required' } ], newStringValue( 'a' ) ) )
+				.toEqual( [] );
+		} );
+
+		it( 'produces required error for empty RelationValue', () => {
+			expect( interpretConstraints( [ { kind: 'required' } ], new RelationValue( [] ) ) )
+				.toEqual( [ { code: 'required' } ] );
+		} );
+
+		it( 'produces no error for non-empty RelationValue', () => {
+			const value = new RelationValue( [ newRelation( undefined, 's11111111111111' ) ] );
+			expect( interpretConstraints( [ { kind: 'required' } ], value ) ).toEqual( [] );
+		} );
+
+	} );
+
+	describe( 'minLength', () => {
+
+		it( 'produces error per part below threshold', () => {
+			expect( interpretConstraints(
+				[ { kind: 'minLength', value: 3 } ],
+				newStringValue( 'ab', 'abcd' ),
+			) ).toEqual( [ { code: 'min-length', args: [ 3 ], source: 'ab' } ] );
+		} );
+
+		it( 'produces no error when all parts meet threshold', () => {
+			expect( interpretConstraints(
+				[ { kind: 'minLength', value: 3 } ],
+				newStringValue( 'abc', 'abcd' ),
+			) ).toEqual( [] );
+		} );
+
+		it( 'measures trimmed length', () => {
+			// Note: newStringValue trims at construction; this confirms the interpreter ALSO trims.
+			// Construct a StringValue with an untrimmed part by hand to bypass newStringValue's trim.
+			const value = { type: 'string' as const, parts: [ '  ab  ' ] };
+			expect( interpretConstraints(
+				[ { kind: 'minLength', value: 3 } ],
+				value,
+			) ).toEqual( [ { code: 'min-length', args: [ 3 ], source: '  ab  ' } ] );
+		} );
+
+	} );
+
+	describe( 'maxLength', () => {
+
+		it( 'produces error per part above threshold', () => {
+			expect( interpretConstraints(
+				[ { kind: 'maxLength', value: 3 } ],
+				newStringValue( 'ab', 'abcd' ),
+			) ).toEqual( [ { code: 'max-length', args: [ 3 ], source: 'abcd' } ] );
+		} );
+
+		it( 'produces no error when all parts within threshold', () => {
+			expect( interpretConstraints(
+				[ { kind: 'maxLength', value: 5 } ],
+				newStringValue( 'ab', 'abcd' ),
+			) ).toEqual( [] );
+		} );
+
+	} );
+
+	describe( 'uniqueItems', () => {
+
+		it( 'produces unique error when parts contain duplicates', () => {
+			expect( interpretConstraints(
+				[ { kind: 'uniqueItems' } ],
+				newStringValue( 'a', 'b', 'a' ),
+			) ).toEqual( [ { code: 'unique' } ] );
+		} );
+
+		it( 'produces no error when all parts are unique', () => {
+			expect( interpretConstraints(
+				[ { kind: 'uniqueItems' } ],
+				newStringValue( 'a', 'b', 'c' ),
+			) ).toEqual( [] );
+		} );
+
+	} );
+
+	describe( 'cardinality', () => {
+
+		it( 'produces single-value-only when parts exceed maxItems', () => {
+			expect( interpretConstraints(
+				[ { kind: 'cardinality', maxItems: 1 } ],
+				newStringValue( 'a', 'b' ),
+			) ).toEqual( [ { code: 'single-value-only' } ] );
+		} );
+
+		it( 'produces no error when parts at or below maxItems', () => {
+			expect( interpretConstraints(
+				[ { kind: 'cardinality', maxItems: 1 } ],
+				newStringValue( 'a' ),
+			) ).toEqual( [] );
+		} );
+
+	} );
+
+	describe( 'enum', () => {
+
+		it( 'produces invalid-option per part outside allowedValues', () => {
+			expect( interpretConstraints(
+				[ { kind: 'enum', allowedValues: [ 'a', 'b' ] } ],
+				newStringValue( 'a', 'x', 'b', 'y' ),
+			) ).toEqual( [
+				{ code: 'invalid-option', args: [ 'x' ], source: 'x' },
+				{ code: 'invalid-option', args: [ 'y' ], source: 'y' },
+			] );
+		} );
+
+		it( 'produces no error when all parts in allowedValues', () => {
+			expect( interpretConstraints(
+				[ { kind: 'enum', allowedValues: [ 'a', 'b', 'c' ] } ],
+				newStringValue( 'a', 'b' ),
+			) ).toEqual( [] );
+		} );
+
+	} );
+
+	describe( 'value-type guards', () => {
+
+		it( 'skips minLength on NumberValue silently', () => {
+			expect( interpretConstraints(
+				[ { kind: 'minLength', value: 3 } ],
+				newNumberValue( 42 ),
+			) ).toEqual( [] );
+		} );
+
+		it( 'skips uniqueItems on undefined silently', () => {
+			expect( interpretConstraints( [ { kind: 'uniqueItems' } ], undefined ) ).toEqual( [] );
+		} );
+
+		it( 'skips enum on RelationValue silently', () => {
+			const value = new RelationValue( [ newRelation( undefined, 's11111111111111' ) ] );
+			expect( interpretConstraints(
+				[ { kind: 'enum', allowedValues: [ 'a' ] } ],
+				value,
+			) ).toEqual( [] );
+		} );
+
+	} );
+
+	describe( 'severity passthrough', () => {
+
+		it( 'copies severity from constraint to error', () => {
+			expect( interpretConstraints(
+				[ { kind: 'required', severity: 'warning' } ],
+				newStringValue(),
+			) ).toEqual( [ { code: 'required', severity: 'warning' } ] );
+		} );
+
+		it( 'omits severity when not set on constraint', () => {
+			const errors = interpretConstraints( [ { kind: 'required' } ], newStringValue() );
+			expect( errors[ 0 ] ).not.toHaveProperty( 'severity' );
+		} );
+
+	} );
+
+	describe( 'multiple constraints', () => {
+
+		it( 'concatenates errors in input order', () => {
+			// minLength then maxLength: each emits independently across parts
+			expect( interpretConstraints(
+				[ { kind: 'minLength', value: 3 }, { kind: 'maxLength', value: 5 } ],
+				newStringValue( 'ab', 'abcdefgh' ),
+			) ).toEqual( [
+				{ code: 'min-length', args: [ 3 ], source: 'ab' },
+				{ code: 'max-length', args: [ 5 ], source: 'abcdefgh' },
+			] );
+		} );
+
+		it( 'returns empty array when no constraints fail', () => {
+			expect( interpretConstraints(
+				[ { kind: 'required' }, { kind: 'minLength', value: 1 } ],
+				newStringValue( 'ok' ),
+			) ).toEqual( [] );
+		} );
+
+	} );
+
+} );

--- a/resources/ext.neowiki/tests/domain/SubjectValidator.spec.ts
+++ b/resources/ext.neowiki/tests/domain/SubjectValidator.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { SubjectValidator } from '@/domain/SubjectValidator';
+import { SubjectValidator, SubjectValidationError } from '@/domain/SubjectValidator';
 import { BasePropertyType, PropertyTypeRegistry, ValueValidationError } from '@/domain/PropertyType';
 import { Subject } from '@/domain/Subject';
 import { Schema } from '@/domain/Schema';
@@ -8,6 +8,7 @@ import { Statement } from '@/domain/Statement';
 import { PropertyDefinitionList } from '@/domain/PropertyDefinitionList';
 import { PropertyDefinition, PropertyName } from '@/domain/PropertyDefinition';
 import { newStringValue, Value, ValueType } from '@/domain/Value';
+import { Constraint } from '@/domain/Constraint';
 import { newSubject } from '@/TestHelpers';
 
 describe( 'SubjectValidator', () => {
@@ -36,6 +37,10 @@ describe( 'SubjectValidator', () => {
 
 		public getExampleValue(): Value {
 			throw new Error( 'Not implemented' );
+		}
+
+		public getConstraints(): Constraint[] {
+			return [];
 		}
 
 		public validate(): ValueValidationError[] {
@@ -78,16 +83,16 @@ describe( 'SubjectValidator', () => {
 	}
 
 	describe( 'validate', () => {
-		it( 'returns true when subject has no statements', () => {
+		it( 'returns no errors when subject has no statements', () => {
 			const validator = new SubjectValidator( new PropertyTypeRegistry() );
 
 			const subject = newSubject();
 			const schema = newSchema( [] );
 
-			expect( validator.validate( subject, schema ) ).toBe( true );
+			expect( validator.validate( subject, schema ) ).toEqual( [] );
 		} );
 
-		it( 'returns true when statements are for unknown properties', () => {
+		it( 'returns no errors when statements are for unknown properties', () => {
 			const validator = new SubjectValidator(
 				getFormatRegistryWithMockPropertyType( true ),
 			);
@@ -95,10 +100,10 @@ describe( 'SubjectValidator', () => {
 			const subject = newValidSubjectWithProperty();
 			const schema = newSchema( [] ); // Property not defined in schema
 
-			expect( validator.validate( subject, schema ) ).toBe( true );
+			expect( validator.validate( subject, schema ) ).toEqual( [] );
 		} );
 
-		it( 'returns true when all statements are valid according to their property types', () => {
+		it( 'returns no errors when all statements are valid according to their property types', () => {
 			const validator = new SubjectValidator(
 				getFormatRegistryWithMockPropertyType( true ),
 			);
@@ -106,10 +111,10 @@ describe( 'SubjectValidator', () => {
 			const subject = newValidSubjectWithProperty();
 			const schema = newSchema( [ exampleProperty ] );
 
-			expect( validator.validate( subject, schema ) ).toBe( true );
+			expect( validator.validate( subject, schema ) ).toEqual( [] );
 		} );
 
-		it( 'returns false when a statement is invalid according to its property type', () => {
+		it( 'returns a statement error when a statement is invalid according to its property type', () => {
 			const validator = new SubjectValidator(
 				getFormatRegistryWithMockPropertyType( false ),
 			);
@@ -117,23 +122,30 @@ describe( 'SubjectValidator', () => {
 			const subject = newValidSubjectWithProperty();
 			const schema = newSchema( [ exampleProperty ] );
 
-			expect( validator.validate( subject, schema ) ).toBe( false );
+			expect( validator.validate( subject, schema ) ).toEqual( [
+				{ propertyName: exampleProperty, error: { code: 'mock-error' } },
+			] );
 		} );
 
-		it( 'returns false when subject label is empty', () => {
+		it( 'returns a label-required error when subject label is empty', () => {
 			const validator = new SubjectValidator( new PropertyTypeRegistry() );
 
 			const subject = newSubject( { label: '' } );
 
-			expect( validator.validate( subject, newSchema( [] ) ) ).toBe( false );
+			const expected: SubjectValidationError[] = [
+				{ propertyName: null, error: { code: 'label-required' } },
+			];
+			expect( validator.validate( subject, newSchema( [] ) ) ).toEqual( expected );
 		} );
 
-		it( 'returns false when subject label contains only whitespace', () => {
+		it( 'returns a label-required error when subject label contains only whitespace', () => {
 			const validator = new SubjectValidator( new PropertyTypeRegistry() );
 
 			const subject = newSubject( { label: '   ' } );
 
-			expect( validator.validate( subject, newSchema( [] ) ) ).toBe( false );
+			expect( validator.validate( subject, newSchema( [] ) ) ).toEqual( [
+				{ propertyName: null, error: { code: 'label-required' } },
+			] );
 		} );
 
 	} );

--- a/resources/ext.neowiki/tests/domain/Value.spec.ts
+++ b/resources/ext.neowiki/tests/domain/Value.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+	isValueEmpty,
 	newBooleanValue,
 	newNumberValue,
 	newRelation,
@@ -150,6 +151,46 @@ describe( 'relationValuesHaveSameTargets', () => {
 		] );
 
 		expect( relationValuesHaveSameTargets( a, b ) ).toBe( true );
+	} );
+
+} );
+
+describe( 'isValueEmpty', () => {
+
+	it( 'returns true for undefined', () => {
+		expect( isValueEmpty( undefined ) ).toBe( true );
+	} );
+
+	it( 'returns true for StringValue with no parts', () => {
+		expect( isValueEmpty( newStringValue() ) ).toBe( true );
+	} );
+
+	it( 'returns false for StringValue with one part', () => {
+		expect( isValueEmpty( newStringValue( 'hello' ) ) ).toBe( false );
+	} );
+
+	it( 'returns false for NumberValue with zero', () => {
+		expect( isValueEmpty( newNumberValue( 0 ) ) ).toBe( false );
+	} );
+
+	it( 'returns false for NumberValue with non-zero', () => {
+		expect( isValueEmpty( newNumberValue( 42 ) ) ).toBe( false );
+	} );
+
+	it( 'returns false for BooleanValue (true)', () => {
+		expect( isValueEmpty( newBooleanValue( true ) ) ).toBe( false );
+	} );
+
+	it( 'returns false for BooleanValue (false)', () => {
+		expect( isValueEmpty( newBooleanValue( false ) ) ).toBe( false );
+	} );
+
+	it( 'returns true for RelationValue with no relations', () => {
+		expect( isValueEmpty( new RelationValue( [] ) ) ).toBe( true );
+	} );
+
+	it( 'returns false for RelationValue with one relation', () => {
+		expect( isValueEmpty( new RelationValue( [ newRelation( undefined, 's11111111111111' ) ] ) ) ).toBe( false );
 	} );
 
 } );

--- a/resources/ext.neowiki/tests/domain/propertyTypes/DateTime.spec.ts
+++ b/resources/ext.neowiki/tests/domain/propertyTypes/DateTime.spec.ts
@@ -70,6 +70,12 @@ describe( 'validate', () => {
 		expect( dateTimeType.validate( undefined, property ) ).toEqual( [ { code: 'required' } ] );
 	} );
 
+	it( 'returns required error for required empty StringValue', () => {
+		const property = newDateTimeProperty( { required: true } );
+
+		expect( dateTimeType.validate( newStringValue(), property ) ).toEqual( [ { code: 'required' } ] );
+	} );
+
 	it( 'returns no errors for valid datetime within bounds', () => {
 		const property = newDateTimeProperty( {
 			minimum: '2020-01-01T00:00:00Z',

--- a/resources/ext.neowiki/tests/domain/propertyTypes/Relation.spec.ts
+++ b/resources/ext.neowiki/tests/domain/propertyTypes/Relation.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { newRelationProperty, RelationType } from '@/domain/propertyTypes/Relation';
 import { PropertyName } from '@/domain/PropertyDefinition';
-import { newRelation, RelationValue } from '@/domain/Value';
+import { newRelation, RelationValue, Relation } from '@/domain/Value';
 
 describe( 'RelationType', () => {
 
@@ -83,4 +83,50 @@ describe( 'newRelationProperty', () => {
 		expect( property.targetSchema ).toBe( 'MyTargetSchema' );
 		expect( property.multiple ).toBe( false );
 	} );
+} );
+
+describe( 'RelationType.validate', () => {
+
+	const type = new RelationType();
+
+	it( 'returns no errors when not required and value is undefined', () => {
+		const property = newRelationProperty();
+		expect( type.validate( undefined, property ) ).toEqual( [] );
+	} );
+
+	it( 'returns required error when required and value is undefined', () => {
+		const property = newRelationProperty( { required: true } );
+		expect( type.validate( undefined, property ) ).toEqual( [ { code: 'required' } ] );
+	} );
+
+	it( 'returns required error when required and value has empty relations', () => {
+		const property = newRelationProperty( { required: true } );
+		expect( type.validate( new RelationValue( [] ), property ) ).toEqual( [ { code: 'required' } ] );
+	} );
+
+	it( 'returns no errors when relations all have valid SubjectIds', () => {
+		const property = newRelationProperty();
+		const value = new RelationValue( [
+			newRelation( undefined, 's11111111111111' ),
+			newRelation( undefined, 's22222222222222' ),
+		] );
+		expect( type.validate( value, property ) ).toEqual( [] );
+	} );
+
+	it( 'returns one invalid-subject-id error per malformed target', () => {
+		const property = newRelationProperty();
+		// Construct Relation directly with mock SubjectId objects to bypass validation
+		// in the SubjectId constructor
+		const invalidSubjectIdMock1 = { text: 'not-a-valid-id' };
+		const invalidSubjectIdMock2 = { text: 'also-bad' };
+		const value = new RelationValue( [
+			new Relation( undefined, invalidSubjectIdMock1 as any ),
+			new Relation( undefined, invalidSubjectIdMock2 as any ),
+		] );
+		expect( type.validate( value, property ) ).toEqual( [
+			{ code: 'invalid-subject-id', args: [ 'not-a-valid-id' ] },
+			{ code: 'invalid-subject-id', args: [ 'also-bad' ] },
+		] );
+	} );
+
 } );


### PR DESCRIPTION
> Result of extensive back-and-forth with @alistair3149.
> Context: the NeoWiki codebase, `docs/planning/Validation.md`, `docs/planning/Validation-Severity.md`, and PR #631.
> <sub>Written by Claude Code, `Opus 4.7 (1M context)`</sub>

Follows-up to #631.

## Summary

- Splits per-Property-Type `validate()` into declarative constraint metadata + a generic interpreter, with a small per-type `validateValue` hook for intrinsic format checks (URL syntax, ISO-8601 parse, SubjectId validity, DateTime min/max).
- `SubjectValidator.validate` returns a structured `SubjectValidationError[]` instead of `boolean`; adds i18n message `neowiki-field-label-required`.
- Forward-compat severity: optional `severity` field on `Constraint` and `ValueValidationError`. No Property Type emits severity yet; activation is a one-line change per type when the severity-levels feature is decided.

## Details

- New `Constraint` discriminated union with six kinds: `required`, `minLength`, `maxLength`, `uniqueItems`, `cardinality` (with `maxItems: number`), `enum` (with `allowedValues: string[]`). Each variant carries optional `severity?: 'error' | 'warning'`.
- New `interpretConstraints(constraints, value)` pure function in `domain/ConstraintInterpreter.ts`. Switches on `constraint.kind`; type-mismatched constraints (e.g. `minLength` on a `NumberValue`) are skipped silently.
- New `isValueEmpty(value)` helper in `domain/Value.ts` centralizing the per-Value-Type "empty" notion.
- `BasePropertyType.validate` becomes concrete and delegates `[...validateValue(value, property), ...interpretConstraints(getConstraints(property), value)]`. The `validateValue`-first ordering preserves the existing per-type test ordering. `getConstraints` is abstract; `validateValue` defaults to `[]`.
- All six Property Types migrated. Text and Select are pure declarative (`getConstraints` only). Number, Url, Relation, DateTime each contribute a small `validateValue` hook (3-8 lines) for the type-intrinsic format check.
- `Constraint`, `ConstraintInterpreter`, `Severity` exported from `public-api.ts` so external TS extensions subclassing `BasePropertyType` can satisfy the abstract contract.
- Backfilled regression tests for `RelationType.validate` (which had none) before migrating it.
- Added DateTime regression test pinning the unified empty-value behavior — `required` now fires for empty `StringValue` (`parts.length === 0`), not only `undefined`. This matches Text and Select; the old DateTime code only flagged `undefined`. Net effect is a small correctness improvement.

## Out of scope

- PHP backend validation (deferred until a concrete external need; ADR 12 covers the current frontend-only stance).
- Vue editor unification (separate spec; this work surfaces the metadata that enables it but does not deliver editor changes).
- Severity emission, defaults, and UI surfacing.
- Plug-in registry for new constraint kinds.
- Text and Url's `// TODO: check property.multiple` gaps — preserved verbatim; closing them is a separate follow-up.

## Manual Browser Check

1. Open a Subject with the Company schema (e.g. `Professional Wiki`) and click **Edit**.
2. In one of the **Websites** fields, type `not-a-url`. Confirm:
    - The field renders the error state (red border, `cdx-text-input--status-error` class).
    - **Save changes** is disabled.
3. Replace `not-a-url` with `https://example.com`. Confirm the error state clears and **Save changes** re-enables.
4. Open a Subject with the City schema (e.g. `Berlin`) and click **Edit**.
5. Clear the **Country** field (required). Confirm **Save changes** is disabled.
6. Restore Country to `Germany`. Confirm **Save changes** re-enables.
7. Throughout, the browser JS console should remain free of errors and warnings.

Local URLs: http://localhost:8484/index.php/Professional_Wiki and http://localhost:8484/index.php/Berlin

## Test plan

- [x] `make tsci` green (build + 819 tests across 79 files + lint)
- [x] Manual browser check above passes locally
- [ ] Reviewer: run `make tsci` after pulling
- [ ] Reviewer: walk through the Manual Browser Check