### PR TITLE
Remove hardcoded contributor path from DemoData/AGENTS.md

### DIFF
--- a/DemoData/AGENTS.md
+++ b/DemoData/AGENTS.md
@@ -134,7 +134,7 @@ the content.
 
 ## Verifying changes
 
-From the repo root (`/home/alistair/unix-projects/professionalwiki/NeoWiki-Docker`):
+From the repo root:
 
 ```sh
 # Incremental import (does not delete removed pages).


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/814

The "Verifying changes" section pointed to a specific contributor's local checkout path. Drop the parenthetical; the surrounding instructions already establish that the commands run from the repo root.

> Spotted by @malberts during a review of #814.
> Context: the NeoWiki extension codebase and PR #814.
> <sub>Written by Claude Code, `Opus 4.7 (1M context)`</sub>