### PR TITLE
Fix prod/CI Makefile targets and run image build on PRs

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -4,12 +4,18 @@ on:
   push:
     branches:
       - master
+  pull_request:
   workflow_dispatch:
+
+concurrency:
+  group: build-docker-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
 
   build_and_deploy_mediawiki:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       packages: write
@@ -47,15 +53,13 @@ jobs:
         run: rsync -a --exclude='Docker/' ./ Docker/mediawiki/extensions/NeoWiki/
 
       - run: make wiki-production-image
-        working-directory: Docker
 
       - name: Use CI docker-compose
         run: rm docker-compose.yml && mv docker-compose.ci.yml docker-compose.yml
         working-directory: Docker
 
       - name: Start containers
-        run: docker compose up -d
-        working-directory: Docker
+        run: make up
 
       - name: Wait for Neo4j
         uses: iFaxity/wait-on-action@v1.1.0
@@ -65,14 +69,11 @@ jobs:
 
       - name: Install MediaWiki
         run: make install-db
-        working-directory: Docker
 
       - name: Load Neo4j users
         run: make load-neo4j-users
-        working-directory: Docker
 
-      - run: make test
-        working-directory: Docker
+      - run: make smoke-test
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -7,10 +7,6 @@ on:
   pull_request:
   workflow_dispatch:
 
-concurrency:
-  group: build-docker-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
 
   build_and_deploy_mediawiki:

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -15,7 +15,6 @@ jobs:
 
   build_and_deploy_mediawiki:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
     permissions:
       contents: read
       packages: write

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -38,14 +38,25 @@ To deploy on a server with automatic HTTPS via Caddy:
 1. Copy `Docker/.env.dist` to `Docker/.env` and change all values marked with
    `# Change for production`, including `MW_SERVER` (e.g. `https://wiki.example.com`).
 
-2. Start all services including Caddy:
+2. From the extension root, bring up the stack including Caddy:
    ```bash
-   docker compose --profile server up -d
+   docker compose --profile server -p neowiki-neowiki --project-directory Docker up -d
    ```
+   (Or equivalently `cd Docker && docker compose --profile server up -d` if you do
+   not need the make-driven project name.)
 
 3. Run the install/load steps from the try-it-out section above.
 
 4. Access your wiki at the configured `MW_SERVER` URL.
+
+### Upgrading
+
+```bash
+make update
+```
+
+Pulls the latest production image, restarts the stack (including Caddy), and runs
+`maintenance/update.php`.
 
 ## Reserved host ports
 

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -40,10 +40,8 @@ To deploy on a server with automatic HTTPS via Caddy:
 
 2. From the extension root, bring up the stack including Caddy:
    ```bash
-   docker compose --profile server -p neowiki-neowiki --project-directory Docker up -d
+   make server-up
    ```
-   (Or equivalently `cd Docker && docker compose --profile server up -d` if you do
-   not need the make-driven project name.)
 
 3. Run the install/load steps from the try-it-out section above.
 

--- a/Makefile
+++ b/Makefile
@@ -367,7 +367,7 @@ update: ## Pull the latest production image, restart, and run update.php (VPS up
 	$(EXEC_MW_ROOT) php maintenance/run.php update --quick
 
 smoke-test: ## Hit the running wiki from outside and verify Main_Page/api.php respond (CI smoke test)
-	cd Docker && bash test.sh
+	bash Docker/tests/smoke.sh
 
 # ---- Production image --------------------------------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -359,6 +359,8 @@ update-dot-php: ## Run MW maintenance/update.php
 update: ## Pull the latest production image, restart, and run update.php (VPS upgrade flow)
 	$(DC) --profile server pull
 	$(DC) --profile server up -d
+	$(EXEC_MW_ROOT) bash -c '/wait-for-it.sh db:3306 -t 60'
+	$(MAKE) --no-print-directory wait-for-neo4j
 	$(EXEC_MW_ROOT) php maintenance/run.php update --quick
 
 smoke-test: ## Hit the running wiki from outside and verify Main_Page/api.php respond (CI smoke test)

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,8 @@ else
 	EXEC_USER := --user $(shell id -u):$(shell id -g)
 endif
 
-EXEC_MW := $(DC_DEV) exec -T $(EXEC_USER) mediawiki
-EXEC_MW_ROOT := $(DC_DEV) exec -T mediawiki
+EXEC_MW := $(DC) exec -T $(EXEC_USER) mediawiki
+EXEC_MW_ROOT := $(DC) exec -T mediawiki
 EXEC_NODE := $(DC_DEV) exec -T $(EXEC_USER) -e npm_config_cache=/tmp/.npm node
 
 # Detect when this Makefile is invoked from inside the mediawiki container.
@@ -159,6 +159,7 @@ _first-run-seed:
 	else \
 		$(MAKE) --no-print-directory install-db; \
 		$(MAKE) --no-print-directory load-neo4j-users; \
+		$(MAKE) --no-print-directory setup-test-neo; \
 		$(MAKE) --no-print-directory composer-install; \
 		$(MAKE) --no-print-directory import-demo-data; \
 	fi
@@ -166,9 +167,9 @@ _first-run-seed:
 
 # ---- DB and Neo4j init -------------------------------------------------------
 
-.PHONY: install-db load-neo4j-users wait-for-neo4j
+.PHONY: install-db load-neo4j-users wait-for-neo4j setup-test-neo
 
-install-db:
+install-db: ## Install MediaWiki against the running stack
 	$(EXEC_MW_ROOT) bash -c '/wait-for-it.sh db:3306 -t 60'
 	$(EXEC_MW_ROOT) mv LocalSettings.php __LocalSettings.php
 	$(EXEC_MW_ROOT) \
@@ -184,12 +185,15 @@ install-db:
 
 wait-for-neo4j:
 	$(EXEC_MW_ROOT) bash -c '/wait-for-it.sh neo:7687 -t 60'
-	$(EXEC_MW_ROOT) bash -c '/wait-for-it.sh test_neo:7689 -t 60'
 
-load-neo4j-users:
+load-neo4j-users: ## Create the read-only Neo4j user against the running stack
 	$(MAKE) --no-print-directory wait-for-neo4j
-	$(DC_DEV) exec -T neo bash -c \
+	$(DC) exec -T neo bash -c \
 		"echo \"CREATE USER $(NEO4J_USERNAME_READ) SET PASSWORD '$(NEO4J_PASSWORD_READ)' CHANGE NOT REQUIRED; GRANT ROLE reader TO $(NEO4J_USERNAME_READ);\" | cypher-shell -u neo4j -p $(NEO4J_PASSWORD) -a bolt://localhost:7687"
+
+# Dev-only: wait for and seed the test_neo instance. Not called from prod or CI flows.
+setup-test-neo:
+	$(EXEC_MW_ROOT) bash -c '/wait-for-it.sh test_neo:7689 -t 60'
 	$(DC_DEV) exec -T test_neo bash -c \
 		"echo \"CREATE USER mediawiki_read SET PASSWORD 'mediawiki_read' CHANGE NOT REQUIRED; GRANT ROLE reader TO mediawiki_read;\" | cypher-shell -u neo4j -p password -a bolt://localhost:7689"
 
@@ -332,7 +336,7 @@ ts-lint: _wait-node ## Run TS linter
 
 # ---- Maintenance -------------------------------------------------------------
 
-.PHONY: reset import-demo-data rebuild-graph-databases update-dot-php
+.PHONY: reset import-demo-data rebuild-graph-databases update-dot-php update smoke-test
 
 reset: ## Wipe DB + Neo4j volumes and reseed demo data (containers stay)
 	$(DC_DEV) down --volumes
@@ -340,6 +344,7 @@ reset: ## Wipe DB + Neo4j volumes and reseed demo data (containers stay)
 	@$(MAKE) --no-print-directory _wait-mw
 	$(MAKE) --no-print-directory install-db
 	$(MAKE) --no-print-directory load-neo4j-users
+	$(MAKE) --no-print-directory setup-test-neo
 	$(MAKE) --no-print-directory import-demo-data
 
 import-demo-data: ## Import the NeoWiki demo subjects
@@ -350,6 +355,14 @@ rebuild-graph-databases: ## Rebuild Neo4j projection from MariaDB
 
 update-dot-php: ## Run MW maintenance/update.php
 	$(EXEC_MW_ROOT) php maintenance/run.php update --quick
+
+update: ## Pull the latest production image, restart, and run update.php (VPS upgrade flow)
+	$(DC) --profile server pull
+	$(DC) --profile server up -d
+	$(EXEC_MW_ROOT) php maintenance/run.php update --quick
+
+smoke-test: ## Hit the running wiki from outside and verify Main_Page/api.php respond (CI smoke test)
+	cd Docker && bash test.sh
 
 # ---- Production image --------------------------------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -49,10 +49,13 @@ help:
 
 # ---- Lifecycle (host only) ---------------------------------------------------
 
-.PHONY: up dev dev-tools _dev-tools-impl stop down logs ps bash
+.PHONY: up server-up dev dev-tools _dev-tools-impl stop down logs ps bash
 
 up: ## Bring up try-it-out stack (no profile, prebuilt image)
 	$(DC) up -d
+
+server-up: ## Bring up production stack including Caddy (HTTPS on 80/443)
+	$(DC) --profile server up -d
 
 dev: bootstrap ensure-port ## Bring up dev stack (build image, install, seed, wait for health)
 	@$(MAKE) --no-print-directory _dev-impl

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ PORT_RANGE_END := 8499
 
 # ---- Compose invocations -----------------------------------------------------
 
-DC := docker compose -p $(PROJECT_NAME)
-DC_DEV := $(DC) -f Docker/docker-compose.yml -f Docker/docker-compose.dev.yml --profile dev
+DC := docker compose -p $(PROJECT_NAME) -f Docker/docker-compose.yml
+DC_DEV := $(DC) -f Docker/docker-compose.dev.yml --profile dev
 DC_TOOLS := $(DC_DEV) -f Docker/docker-compose.tools.yml
 
 IS_PODMAN := $(shell (docker --version 2>/dev/null | grep -qi podman || command -v podman >/dev/null 2>&1) && echo 1 || echo 0)


### PR DESCRIPTION
PR #811 made `install-db`, `load-neo4j-users`, and `wait-for-neo4j` depend on
`test_neo`, which is profile-gated to dev. Both CI (against `docker-compose.ci.yml`)
and the VPS upgrade flow (against `docker-compose.yml`) now fail at the 60s
`test_neo` wait. CI on master has been red since the merge.

Decouple `test_neo` from the shared targets:

- `wait-for-neo4j` and `load-neo4j-users` now wait/configure only `neo`.
- A new dev-only `setup-test-neo` target waits for and seeds `test_neo`. It is
  explicitly chained by `_first-run-seed` and `reset` (the only dev call sites).
- `EXEC_MW_ROOT`/`EXEC_MW` switch from `$(DC_DEV)` to `$(DC)`. `docker compose exec`
  attaches by project+service to the already-running `mediawiki` container, so
  this works in both dev and prod without overlay coupling.

Add two new targets:

- `update` for VPS upgrades: pull, up -d with `--profile server`, wait for db
  and neo readiness, then update.php.
- `smoke-test` wrapping `Docker/test.sh` for CI.

Update `build-docker.yml`: drop `working-directory: Docker` from the make steps
so they pick up the top-level Makefile, switch the start step to `make up` so
the docker compose project name matches subsequent make invocations, rename
the test step to `make smoke-test`. Add `pull_request` trigger so the build
runs (without ghcr push) on every PR and catches regressions like this one
before merge.

## Test plan

- [x] Full `make dev` cycle from a fresh `/tmp` checkout (port 8500). Wiki
      responds 200; `setup-test-neo` seeded test_neo.
- [x] Full prod sequence from a separate fresh `/tmp` checkout (port 8501):
      `make up && make install-db && make load-neo4j-users && make smoke-test
      && make import-demo-data`. Wiki responds 200.
- [x] `make reset` after a dev setup. Chain completes including the new
      `setup-test-neo` step.
- [x] `make update` end-to-end against a fresh prod stack (with Caddy ports
      remapped to 8080/8443 to avoid host conflicts on a dev machine).
      Pull + up + db/neo readiness wait + update.php all succeed.
- [ ] CI (this PR) goes green.