### PR TITLE
Fix port auto-allocation on host conflict

### DIFF
--- a/Docker/scripts/set-port.sh
+++ b/Docker/scripts/set-port.sh
@@ -39,6 +39,8 @@ get_env_var() {
 
 # Allocate or reuse a port for $key in [$start..$end]. If the existing value
 # in .env is still free on the host, reuse it; otherwise pick the first free.
+# A held value outside [$start..$end] is treated as a deliberate user override
+# and surfaces as an error rather than being silently replaced.
 allocate() {
     local key=$1 start=$2 end=$3
     local existing
@@ -46,6 +48,11 @@ allocate() {
     if [ -n "$existing" ] && is_port_free "$existing"; then
         echo "$existing"
         return 0
+    fi
+    if [ -n "$existing" ] && { [ "$existing" -lt "$start" ] || [ "$existing" -gt "$end" ]; }; then
+        echo "Error: configured $key=$existing is in use and outside the auto-allocation range $start-$end." >&2
+        echo "Edit Docker/.env or stop the conflicting service." >&2
+        return 1
     fi
     for p in $(seq "$start" "$end"); do
         if is_port_free "$p"; then
@@ -64,6 +71,11 @@ exec 200>"$LOCK_FILE"
 flock -x 200
 
 if [ -n "$REQUESTED" ]; then
+    if ! is_port_free "$REQUESTED"; then
+        echo "Error: requested MW_SERVER_PORT=$REQUESTED is already in use." >&2
+        echo "Pick a different port or stop the conflicting service." >&2
+        exit 1
+    fi
     set_env_var MW_SERVER_PORT "$REQUESTED"
     mw_port="$REQUESTED"
 else

--- a/Docker/tests/smoke.sh
+++ b/Docker/tests/smoke.sh
@@ -2,7 +2,8 @@
 
 STATUS=0
 
-. ./.env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/../.env"
 
 function echoGood {
     echo -e "\e[32mSuccess: $1\e[0m"

--- a/Docker/tests/test-set-port.sh
+++ b/Docker/tests/test-set-port.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# Exercise Docker/scripts/set-port.sh against the port-allocation behaviour
+# matrix. Each case runs in an isolated ENV_FILE; ports are held with
+# in-process python TCP listeners that are torn down after each case.
+#
+# Uses a high-numbered MW range (PORT_RANGE_START / PORT_RANGE_END) so a busy
+# 8484-8499 on the host does not perturb assertions. Mailcatcher range is not
+# parameterised by set-port.sh, so MC allocation just happens silently and we
+# do not assert on it.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SUT="$SCRIPT_DIR/../scripts/set-port.sh"
+
+# Pick a high range we don't expect anything else to bind on a dev machine.
+TEST_RANGE_START=38484
+TEST_RANGE_END=38499
+OUT_OF_RANGE_PORT=39999
+
+WORK="$(mktemp -d)"
+ENV_FILE="$WORK/.env"
+HOLDERS=()
+
+PASSES=0
+FAILS=0
+
+color() {
+    local code=$1; shift
+    printf '\033[%sm%s\033[0m\n' "$code" "$*"
+}
+ok()   { color '32' "PASS: $*"; PASSES=$((PASSES + 1)); }
+fail() { color '31' "FAIL: $*"; FAILS=$((FAILS + 1)); }
+
+hold_port() {
+    local p=$1
+    # Backlog must be large enough AND we must keep accepting to avoid the
+    # accept queue filling up and the kernel RSTing subsequent SYNs — which
+    # would make is_port_free wrongly report the port as free.
+    python3 -c "
+import socket, time, sys, threading
+s = socket.socket()
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(('127.0.0.1', $p))
+s.listen(128)
+def accept_loop():
+    while True:
+        try:
+            conn, _ = s.accept()
+            conn.close()
+        except Exception:
+            break
+threading.Thread(target=accept_loop, daemon=True).start()
+sys.stdout.write('ready\n'); sys.stdout.flush()
+time.sleep(600)
+" &
+    local pid=$!
+    HOLDERS+=("$pid")
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+        if ! kill -0 "$pid" 2>/dev/null; then
+            return 1
+        fi
+        if (echo > /dev/tcp/127.0.0.1/"$p") 2>/dev/null; then
+            return 0
+        fi
+        sleep 0.1
+    done
+    echo "hold_port: gave up waiting for port $p to bind" >&2
+    return 1
+}
+
+release_all() {
+    for pid in "${HOLDERS[@]:-}"; do
+        kill "$pid" 2>/dev/null || true
+        wait "$pid" 2>/dev/null || true
+    done
+    HOLDERS=()
+}
+
+cleanup() {
+    release_all
+    rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+run_sut() {
+    local arg=${1:-}
+    ENV_FILE="$ENV_FILE" \
+    PORT_RANGE_START="$TEST_RANGE_START" \
+    PORT_RANGE_END="$TEST_RANGE_END" \
+        bash "$SUT" "$arg"
+}
+
+reset_env() {
+    : > "$ENV_FILE"
+    if [ -n "${1:-}" ]; then
+        echo "MW_SERVER_PORT=$1" >> "$ENV_FILE"
+    fi
+}
+
+env_value() {
+    grep -E "^$1=" "$ENV_FILE" 2>/dev/null | head -1 | cut -d= -f2-
+}
+
+assert_eq() {
+    local label=$1 actual=$2 expected=$3
+    if [ "$actual" = "$expected" ]; then
+        ok "$label (got $actual)"
+    else
+        fail "$label (expected $expected, got $actual)"
+    fi
+}
+
+assert_in_range() {
+    local label=$1 actual=$2 lo=$3 hi=$4
+    if [ -n "$actual" ] && [ "$actual" -ge "$lo" ] && [ "$actual" -le "$hi" ]; then
+        ok "$label (got $actual in [$lo..$hi])"
+    else
+        fail "$label (expected in [$lo..$hi], got '$actual')"
+    fi
+}
+
+assert_exit_nonzero() {
+    local label=$1 rc=$2
+    if [ "$rc" -ne 0 ]; then
+        ok "$label (exit $rc)"
+    else
+        fail "$label (expected non-zero exit, got 0)"
+    fi
+}
+
+# ---- Cases -------------------------------------------------------------------
+
+echo
+color '36' "Case 1: empty .env, nothing held -> allocates in-range"
+reset_env ""
+run_sut "" >/dev/null
+assert_in_range "MW port" "$(env_value MW_SERVER_PORT)" "$TEST_RANGE_START" "$TEST_RANGE_END"
+
+echo
+color '36' "Case 2: .env=$TEST_RANGE_START baked, that port held by other -> reallocates next free"
+reset_env "$TEST_RANGE_START"
+hold_port "$TEST_RANGE_START"
+run_sut "" >/dev/null
+got=$(env_value MW_SERVER_PORT)
+if [ "$got" != "$TEST_RANGE_START" ] && [ "$got" -ge "$TEST_RANGE_START" ] && [ "$got" -le "$TEST_RANGE_END" ]; then
+    ok "MW port reassigned (got $got)"
+else
+    fail "MW port should differ from baked $TEST_RANGE_START and stay in range (got '$got')"
+fi
+release_all
+
+echo
+color '36' "Case 3: .env=$((TEST_RANGE_START + 1)) free -> reuses it (no reallocation)"
+reset_env "$((TEST_RANGE_START + 1))"
+run_sut "" >/dev/null
+assert_eq "MW port preserved" "$(env_value MW_SERVER_PORT)" "$((TEST_RANGE_START + 1))"
+
+echo
+color '36' "Case 4: .env=$OUT_OF_RANGE_PORT (out-of-range), free -> preserved (deliberate override)"
+reset_env "$OUT_OF_RANGE_PORT"
+run_sut "" >/dev/null
+assert_eq "Out-of-range value preserved" "$(env_value MW_SERVER_PORT)" "$OUT_OF_RANGE_PORT"
+
+echo
+color '36' "Case 5: .env=$OUT_OF_RANGE_PORT, held -> exits non-zero, does not overwrite"
+reset_env "$OUT_OF_RANGE_PORT"
+hold_port "$OUT_OF_RANGE_PORT"
+set +e
+err_output=$(run_sut "" 2>&1)
+rc=$?
+set -e
+assert_exit_nonzero "Held out-of-range value errors" "$rc"
+assert_eq "Out-of-range value untouched on error" "$(env_value MW_SERVER_PORT)" "$OUT_OF_RANGE_PORT"
+if echo "$err_output" | grep -q "outside the auto-allocation range"; then
+    ok "Error message mentions auto-allocation range"
+else
+    fail "Error message should mention range. Got: $err_output"
+fi
+release_all
+
+echo
+color '36' "Case 6: explicit port=$((TEST_RANGE_START + 5)) free -> writes it"
+reset_env ""
+run_sut "$((TEST_RANGE_START + 5))" >/dev/null
+assert_eq "Explicit port written" "$(env_value MW_SERVER_PORT)" "$((TEST_RANGE_START + 5))"
+
+echo
+color '36' "Case 7: explicit port=$((TEST_RANGE_START + 6)) held -> exits non-zero, does not overwrite"
+reset_env ""
+hold_port "$((TEST_RANGE_START + 6))"
+set +e
+err_output=$(run_sut "$((TEST_RANGE_START + 6))" 2>&1)
+rc=$?
+set -e
+assert_exit_nonzero "Held explicit port errors" "$rc"
+assert_eq "No .env write on explicit error" "$(env_value MW_SERVER_PORT)" ""
+if echo "$err_output" | grep -q "already in use"; then
+    ok "Error message mentions in-use"
+else
+    fail "Error message should mention in-use. Got: $err_output"
+fi
+release_all
+
+# ---- Summary -----------------------------------------------------------------
+
+echo
+if [ "$FAILS" -eq 0 ]; then
+    color '32' "All $PASSES checks passed."
+    exit 0
+else
+    color '31' "$FAILS check(s) failed ($PASSES passed)."
+    exit 1
+fi

--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,15 @@ else
 	fi
 endif
 
+# ---- Shell-script tests ------------------------------------------------------
+
+# Runs the bash test suites for Docker/scripts/. Requires python3 on the host;
+# does not need docker. Kept out of the default PHP/TS test targets so the host
+# can opt in.
+.PHONY: test-scripts
+test-scripts: ## Run shell-script tests (set-port.sh, etc.)
+	@./Docker/tests/test-set-port.sh
+
 # ---- Health gate -------------------------------------------------------------
 
 .PHONY: _wait-mw

--- a/Makefile
+++ b/Makefile
@@ -111,14 +111,20 @@ bash: ## Shell into the mediawiki container
 
 # ---- Port allocation ---------------------------------------------------------
 
-# Set MW_SERVER_PORT in Docker/.env if not already set.
-# Precedence: port=<flag> > MW_SERVER_PORT env > existing .env > auto-allocate.
+# Allocate host ports into Docker/.env.
+# Precedence: port=<flag> > existing .env value (reused if still free) > range scan.
+# Skipped when our compose stack is already up, so re-running `make dev` does not
+# trigger a port change and force-recreate the running mediawiki container.
 .PHONY: ensure-port
 ensure-port:
 ifdef port
 	@./Docker/scripts/set-port.sh $(port)
 else
-	@./Docker/scripts/set-port.sh "$${MW_SERVER_PORT:-}"
+	@if $(DC_DEV) ps -q mediawiki 2>/dev/null | grep -q .; then \
+		echo "Stack already up; reusing MW_SERVER_PORT=$$MW_SERVER_PORT MAILCATCHER_PORT=$$MAILCATCHER_PORT"; \
+	else \
+		./Docker/scripts/set-port.sh ""; \
+	fi
 endif
 
 # ---- Health gate -------------------------------------------------------------


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/811

The promise of `make dev` "just works" across worktrees was not being kept:
since `.env.dist` ships `MW_SERVER_PORT=8484`, every fresh clone hit the
"explicit request" branch in `set-port.sh` on first run and skipped the
host-port-free check, so a busy 8484 (or any second worktree) failed at
`docker compose up` with a cryptic bind error.

## Commits

### 1. Fix port auto-allocation on host conflict

Three fixes, scoped to the same code path:

* `Makefile` `ensure-port`: skip allocation when our compose stack is
  already running, so an idempotent `make dev` re-run does not silently
  reallocate and force-recreate the live mediawiki container. When the
  stack is down and no `port=` override is given, pass empty string to
  `set-port.sh` so the existing `allocate()` logic (reuse if free, else
  range-scan) actually runs.
* `set-port.sh` explicit-request branch: validate that the requested
  port is free and exit with a clear error if not, rather than writing
  it back and letting docker bind fail later with an opaque message.
* `set-port.sh` `allocate()`: when the existing `.env` value is held
  AND outside the configured range, treat it as a deliberate user
  override and error out instead of silently swapping it for an
  in-range port.

### 2. Add Docker/tests/ with smoke test rename and set-port regression suite

Establishes `Docker/tests/` as the home for shell-script tests at the
Docker layer, keeping the top-level `tests/` subtree PHP-only.

* `Docker/test.sh` → `Docker/tests/smoke.sh`. Renamed (was an ambiguous
  "test.sh") and now resolves `.env` relative to the script so it can
  be invoked from anywhere.
* `Docker/tests/test-set-port.sh` locks in the coverage matrix as an
  executable regression suite. Uses python3 to hold contested ports
  (backlog 128 + accept-and-close loop), allocates into a high MW range
  (38484-38499) so a busy 8484-8499 on the host does not perturb
  assertions.
* `make test-scripts` runs the regression suite. Kept out of
  `make test` / `make ci` so it does not become a CI gate on the first
  iteration. Promote to CI after a few sprints once stability is
  confirmed.

**Heads-up:** PR #818 references `Docker/test.sh` in its planned
`smoke-test` target — that path becomes `Docker/tests/smoke.sh` after
this PR lands. (Will leave a note on #818.)

## Coverage matrix

| Scenario | Before | After |
|---|---|---|
| Fresh clone, 8484 free | works | works |
| Fresh clone, 8484 held by other | fails at docker bind | auto-picks next free in range |
| Second worktree, baked `.env=8484`, A holds it | fails at docker bind | auto-picks next free in range |
| Re-run while stack up | works | works (gate skips allocator, no recreate) |
| `port=N`, N free | works | works |
| `port=N`, N held by other | fails at docker bind | clear error, exits 1 |
| Manual `.env=9999`, 9999 free | works | works (preserved) |
| Manual `.env=9999`, 9999 held | fails at docker bind | clear error, exits 1 |

## Test plan

- [x] All 11 checks in `make test-scripts` pass.
- [x] Coverage matrix above verified against a sandboxed `.env` with python TCP listeners holding the contested port for each row.