### PR TITLE
Hide RedHerb subject-editing sidebar links from users without permission

### DIFF
--- a/tests/RedHerb/src/RedHerbSidebarHook.php
+++ b/tests/RedHerb/src/RedHerbSidebarHook.php
@@ -6,6 +6,7 @@ namespace ProfessionalWiki\RedHerb;
 
 use Closure;
 use MediaWiki\Hook\SidebarBeforeOutputHook;
+use MediaWiki\Permissions\Authority;
 use MediaWiki\Title\Title;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
@@ -14,11 +15,21 @@ use Skin;
 class RedHerbSidebarHook implements SidebarBeforeOutputHook {
 
 	private Closure $pageHasMainSubject;
+	private Closure $canEditSubject;
+	private Closure $canCreateChildSubject;
 
-	public function __construct( ?Closure $pageHasMainSubject = null ) {
+	public function __construct(
+		?Closure $pageHasMainSubject = null,
+		?Closure $canEditSubject = null,
+		?Closure $canCreateChildSubject = null
+	) {
 		$this->pageHasMainSubject = $pageHasMainSubject ?? static fn ( Title $title ): bool =>
 			NeoWikiExtension::getInstance()->newPageSubjectsLookup()
 				->pageHasMainSubject( new PageId( $title->getArticleID() ) );
+		$this->canEditSubject = $canEditSubject ?? static fn ( Authority $authority ): bool =>
+			NeoWikiExtension::getInstance()->newSubjectAuthorizer( $authority )->canEditSubject();
+		$this->canCreateChildSubject = $canCreateChildSubject ?? static fn ( Authority $authority ): bool =>
+			NeoWikiExtension::getInstance()->newSubjectAuthorizer( $authority )->canCreateChildSubject();
 	}
 
 	public function onSidebarBeforeOutput( $skin, &$sidebar ): void {
@@ -32,14 +43,21 @@ class RedHerbSidebarHook implements SidebarBeforeOutputHook {
 
 		$title = $skin->getTitle();
 		if ( $title !== null && $title->exists() ) {
-			$links[] = [
-				'id' => 'redherb-sidebar-create-child-company',
-				'text' => $skin->msg( 'redherb-sidebar-create-child-company' )->text(),
-				'href' => '#',
-				'class' => 'ext-redherb-create-child-company-trigger',
-			];
+			$authority = $skin->getAuthority();
 
-			if ( ( $this->pageHasMainSubject )( $title ) ) {
+			if ( ( $this->canCreateChildSubject )( $authority ) ) {
+				$links[] = [
+					'id' => 'redherb-sidebar-create-child-company',
+					'text' => $skin->msg( 'redherb-sidebar-create-child-company' )->text(),
+					'href' => '#',
+					'class' => 'ext-redherb-create-child-company-trigger',
+				];
+			}
+
+			if (
+				( $this->pageHasMainSubject )( $title )
+				&& ( $this->canEditSubject )( $authority )
+			) {
 				$links[] = [
 					'id' => 'redherb-sidebar-edit-main-subject',
 					'text' => $skin->msg( 'redherb-sidebar-edit-main-subject' )->text(),

--- a/tests/phpunit/RedHerb/RedHerbSidebarHookTest.php
+++ b/tests/phpunit/RedHerb/RedHerbSidebarHookTest.php
@@ -7,6 +7,7 @@ namespace ProfessionalWiki\NeoWiki\Tests\RedHerb;
 use Closure;
 use MediaWiki\Language\RawMessage;
 use MediaWiki\Message\Message;
+use MediaWiki\Permissions\Authority;
 use MediaWiki\Title\Title;
 use MediaWikiIntegrationTestCase;
 use ProfessionalWiki\RedHerb\RedHerbSidebarHook;
@@ -18,9 +19,13 @@ use Skin;
  */
 class RedHerbSidebarHookTest extends MediaWikiIntegrationTestCase {
 
-	public function testAddsCreateChildLinkOnAnyExistingPage(): void {
+	public function testAddsCreateChildLinkWhenUserCanCreateChildSubject(): void {
 		$sidebar = [];
-		$hook = new RedHerbSidebarHook( self::pageHasMainSubjectStub( false ) );
+		$hook = new RedHerbSidebarHook(
+			self::pageHasMainSubjectStub( false ),
+			self::canEditSubjectStub( true ),
+			self::canCreateChildSubjectStub( true )
+		);
 
 		$hook->onSidebarBeforeOutput( $this->newSkinForExistingPage(), $sidebar );
 
@@ -30,15 +35,47 @@ class RedHerbSidebarHookTest extends MediaWikiIntegrationTestCase {
 		$this->assertSame( 'ext-redherb-create-child-company-trigger', $sidebar['redherb-sidebar'][1]['class'] );
 	}
 
-	public function testAddsEditLinkOnPageWithMainSubject(): void {
+	public function testOmitsCreateChildLinkWhenUserCannotCreateChildSubject(): void {
 		$sidebar = [];
-		$hook = new RedHerbSidebarHook( self::pageHasMainSubjectStub( true ) );
+		$hook = new RedHerbSidebarHook(
+			self::pageHasMainSubjectStub( false ),
+			self::canEditSubjectStub( true ),
+			self::canCreateChildSubjectStub( false )
+		);
+
+		$hook->onSidebarBeforeOutput( $this->newSkinForExistingPage(), $sidebar );
+
+		$ids = array_column( $sidebar['redherb-sidebar'], 'id' );
+		$this->assertNotContains( 'redherb-sidebar-create-child-company', $ids );
+	}
+
+	public function testAddsEditLinkWhenUserCanEditAndPageHasMainSubject(): void {
+		$sidebar = [];
+		$hook = new RedHerbSidebarHook(
+			self::pageHasMainSubjectStub( true ),
+			self::canEditSubjectStub( true ),
+			self::canCreateChildSubjectStub( true )
+		);
 
 		$hook->onSidebarBeforeOutput( $this->newSkinForExistingPage(), $sidebar );
 
 		$this->assertCount( 3, $sidebar['redherb-sidebar'] );
 		$this->assertSame( 'redherb-sidebar-edit-main-subject', $sidebar['redherb-sidebar'][2]['id'] );
 		$this->assertSame( 'ext-redherb-edit-main-subject-trigger', $sidebar['redherb-sidebar'][2]['class'] );
+	}
+
+	public function testOmitsEditLinkWhenUserCannotEditSubject(): void {
+		$sidebar = [];
+		$hook = new RedHerbSidebarHook(
+			self::pageHasMainSubjectStub( true ),
+			self::canEditSubjectStub( false ),
+			self::canCreateChildSubjectStub( true )
+		);
+
+		$hook->onSidebarBeforeOutput( $this->newSkinForExistingPage(), $sidebar );
+
+		$ids = array_column( $sidebar['redherb-sidebar'], 'id' );
+		$this->assertNotContains( 'redherb-sidebar-edit-main-subject', $ids );
 	}
 
 	public function testOnlyAddsSubjectFinderLinkOnNonExistentPages(): void {
@@ -88,6 +125,14 @@ class RedHerbSidebarHookTest extends MediaWikiIntegrationTestCase {
 
 	private static function pageHasMainSubjectStub( bool $value ): Closure {
 		return static fn ( Title $title ): bool => $value;
+	}
+
+	private static function canEditSubjectStub( bool $value ): Closure {
+		return static fn ( Authority $authority ): bool => $value;
+	}
+
+	private static function canCreateChildSubjectStub( bool $value ): Closure {
+		return static fn ( Authority $authority ): bool => $value;
 	}
 
 	private function newSkin(): Skin {


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/821
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/824

The "Edit main subject" and "Create child Company" sidebar links were
rendered without checking whether the current user could perform the
action. On wikis where anonymous editing is disabled, anonymous users
saw tools they could not use.

Gate "Edit main subject" on `SubjectAuthorizer::canEditSubject()` and
"Create child Company" on `SubjectAuthorizer::canCreateChildSubject()`,
so each link only shows when the current user can perform that action.