### PR TITLE
Trigger website rebuild when docs change

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,19 @@
+name: Deploy docs to website
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'docs/**'
+
+permissions:
+  contents: read
+
+jobs:
+  trigger-website-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Cloudflare Pages build
+        run: curl -fsS -X POST "$DEPLOY_HOOK"
+        env:
+          DEPLOY_HOOK: ${{ secrets.CLOUDFLARE_PAGES_DEPLOY_HOOK }}


### PR DESCRIPTION
Requires #825

Adds `.github/workflows/docs-deploy.yml`: on a push to `master` touching `docs/**`, it POSTs the Cloudflare Pages deploy hook so the VitePress site rebuilds and re-fetches the documentation.

The hook URL is read from the `CLOUDFLARE_PAGES_DEPLOY_HOOK` repository secret (provisioned separately). `curl -fsS` fails the job on a non-2xx response.

Part of a multi-repo change that publishes the extension docs on the VitePress site (companion PRs reorganize `docs/` and add the site-side sync).

> Result of brainstorming and iterative review with @alistair3149.
> Context: the NeoWiki extension and NeoWiki-Website codebases.
> <sub>Written by Claude Code, `Opus 4.7`</sub>