### PR TITLE
Gate RedHerb subject sidebar links on subject permissions

### DIFF
--- a/tests/RedHerb/src/RedHerbSidebarHook.php
+++ b/tests/RedHerb/src/RedHerbSidebarHook.php
@@ -51,12 +51,14 @@ class RedHerbSidebarHook implements SidebarBeforeOutputHook {
 		if ( $title !== null && $title->exists() ) {
 			$authorizer = ( $this->newSubjectAuthorizer )( $skin->getAuthority() );
 
-			$links[] = [
-				'id' => 'redherb-sidebar-create-child-company',
-				'text' => $skin->msg( 'redherb-sidebar-create-child-company' )->text(),
-				'href' => '#',
-				'class' => 'ext-redherb-create-child-company-trigger',
-			];
+			if ( $authorizer->canCreateChildSubject() ) {
+				$links[] = [
+					'id' => 'redherb-sidebar-create-child-company',
+					'text' => $skin->msg( 'redherb-sidebar-create-child-company' )->text(),
+					'href' => '#',
+					'class' => 'ext-redherb-create-child-company-trigger',
+				];
+			}
 
 			if ( ( $this->pageHasMainSubject )( $title ) && $authorizer->canEditSubject() ) {
 				$links[] = [

--- a/tests/RedHerb/src/RedHerbSidebarHook.php
+++ b/tests/RedHerb/src/RedHerbSidebarHook.php
@@ -6,7 +6,9 @@ namespace ProfessionalWiki\RedHerb;
 
 use Closure;
 use MediaWiki\Hook\SidebarBeforeOutputHook;
+use MediaWiki\Permissions\Authority;
 use MediaWiki\Title\Title;
+use ProfessionalWiki\NeoWiki\Application\SubjectAuthorizer;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use Skin;
@@ -15,10 +17,25 @@ class RedHerbSidebarHook implements SidebarBeforeOutputHook {
 
 	private Closure $pageHasMainSubject;
 
-	public function __construct( ?Closure $pageHasMainSubject = null ) {
+	/**
+	 * @var Closure(Authority): SubjectAuthorizer
+	 */
+	private Closure $newSubjectAuthorizer;
+
+	/**
+	 * @param ?Closure(Title): bool $pageHasMainSubject
+	 * @param ?Closure(Authority): SubjectAuthorizer $newSubjectAuthorizer
+	 */
+	public function __construct(
+		?Closure $pageHasMainSubject = null,
+		?Closure $newSubjectAuthorizer = null
+	) {
 		$this->pageHasMainSubject = $pageHasMainSubject ?? static fn ( Title $title ): bool =>
 			NeoWikiExtension::getInstance()->newPageSubjectsLookup()
 				->pageHasMainSubject( new PageId( $title->getArticleID() ) );
+
+		$this->newSubjectAuthorizer = $newSubjectAuthorizer ?? static fn ( Authority $authority ): SubjectAuthorizer =>
+			NeoWikiExtension::getInstance()->newSubjectAuthorizer( $authority );
 	}
 
 	public function onSidebarBeforeOutput( $skin, &$sidebar ): void {
@@ -32,6 +49,8 @@ class RedHerbSidebarHook implements SidebarBeforeOutputHook {
 
 		$title = $skin->getTitle();
 		if ( $title !== null && $title->exists() ) {
+			$authorizer = ( $this->newSubjectAuthorizer )( $skin->getAuthority() );
+
 			$links[] = [
 				'id' => 'redherb-sidebar-create-child-company',
 				'text' => $skin->msg( 'redherb-sidebar-create-child-company' )->text(),
@@ -39,7 +58,7 @@ class RedHerbSidebarHook implements SidebarBeforeOutputHook {
 				'class' => 'ext-redherb-create-child-company-trigger',
 			];
 
-			if ( ( $this->pageHasMainSubject )( $title ) ) {
+			if ( ( $this->pageHasMainSubject )( $title ) && $authorizer->canEditSubject() ) {
 				$links[] = [
 					'id' => 'redherb-sidebar-edit-main-subject',
 					'text' => $skin->msg( 'redherb-sidebar-edit-main-subject' )->text(),

--- a/tests/phpunit/RedHerb/RedHerbSidebarHookTest.php
+++ b/tests/phpunit/RedHerb/RedHerbSidebarHookTest.php
@@ -9,6 +9,7 @@ use MediaWiki\Language\RawMessage;
 use MediaWiki\Message\Message;
 use MediaWiki\Title\Title;
 use MediaWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Application\SubjectAuthorizer;
 use ProfessionalWiki\RedHerb\RedHerbSidebarHook;
 use Skin;
 
@@ -20,7 +21,7 @@ class RedHerbSidebarHookTest extends MediaWikiIntegrationTestCase {
 
 	public function testAddsCreateChildLinkOnAnyExistingPage(): void {
 		$sidebar = [];
-		$hook = new RedHerbSidebarHook( self::pageHasMainSubjectStub( false ) );
+		$hook = $this->newHook( pageHasMainSubject: false );
 
 		$hook->onSidebarBeforeOutput( $this->newSkinForExistingPage(), $sidebar );
 
@@ -32,7 +33,7 @@ class RedHerbSidebarHookTest extends MediaWikiIntegrationTestCase {
 
 	public function testAddsEditLinkOnPageWithMainSubject(): void {
 		$sidebar = [];
-		$hook = new RedHerbSidebarHook( self::pageHasMainSubjectStub( true ) );
+		$hook = $this->newHook( pageHasMainSubject: true );
 
 		$hook->onSidebarBeforeOutput( $this->newSkinForExistingPage(), $sidebar );
 
@@ -41,13 +42,28 @@ class RedHerbSidebarHookTest extends MediaWikiIntegrationTestCase {
 		$this->assertSame( 'ext-redherb-edit-main-subject-trigger', $sidebar['redherb-sidebar'][2]['class'] );
 	}
 
+	public function testDoesNotAddEditLinkWhenUserCannotEditSubject(): void {
+		$sidebar = [];
+		$hook = $this->newHook( pageHasMainSubject: true, canEditSubject: false );
+
+		$hook->onSidebarBeforeOutput( $this->newSkinForExistingPage(), $sidebar );
+
+		$this->assertSame(
+			[ 'redherb-sidebar-subject-finder', 'redherb-sidebar-create-child-company' ],
+			array_column( $sidebar['redherb-sidebar'], 'id' )
+		);
+	}
+
 	public function testOnlyAddsSubjectFinderLinkOnNonExistentPages(): void {
 		$sidebar = [];
 		$predicateInvoked = false;
-		$hook = new RedHerbSidebarHook( static function () use ( &$predicateInvoked ): bool {
-			$predicateInvoked = true;
-			return true;
-		} );
+		$hook = new RedHerbSidebarHook(
+			static function () use ( &$predicateInvoked ): bool {
+				$predicateInvoked = true;
+				return true;
+			},
+			$this->newSubjectAuthorizerStub()
+		);
 
 		$hook->onSidebarBeforeOutput(
 			$this->newSkinStub( Title::newFromText( 'NonExistentPage_' . uniqid() ) ),
@@ -61,10 +77,13 @@ class RedHerbSidebarHookTest extends MediaWikiIntegrationTestCase {
 	public function testDoesNotCheckMainSubjectForNonExistingTitles(): void {
 		$sidebar = [];
 		$predicateInvoked = false;
-		$hook = new RedHerbSidebarHook( static function () use ( &$predicateInvoked ): bool {
-			$predicateInvoked = true;
-			return true;
-		} );
+		$hook = new RedHerbSidebarHook(
+			static function () use ( &$predicateInvoked ): bool {
+				$predicateInvoked = true;
+				return true;
+			},
+			$this->newSubjectAuthorizerStub()
+		);
 
 		$hook->onSidebarBeforeOutput(
 			$this->newSkinStub( Title::newFromText( 'UserLogin', NS_SPECIAL ) ),
@@ -77,7 +96,7 @@ class RedHerbSidebarHookTest extends MediaWikiIntegrationTestCase {
 
 	public function testDoesNotOverwriteExistingSidebarSections(): void {
 		$sidebar = [ 'navigation' => [ [ 'id' => 'preexisting' ] ] ];
-		$hook = new RedHerbSidebarHook( self::pageHasMainSubjectStub( false ) );
+		$hook = $this->newHook( pageHasMainSubject: false );
 
 		$hook->onSidebarBeforeOutput( $this->newSkin(), $sidebar );
 
@@ -86,8 +105,25 @@ class RedHerbSidebarHookTest extends MediaWikiIntegrationTestCase {
 		$this->assertArrayHasKey( 'redherb-sidebar', $sidebar );
 	}
 
-	private static function pageHasMainSubjectStub( bool $value ): Closure {
-		return static fn ( Title $title ): bool => $value;
+	private function newHook(
+		bool $pageHasMainSubject,
+		bool $canEditSubject = true,
+		bool $canCreateChildSubject = true
+	): RedHerbSidebarHook {
+		return new RedHerbSidebarHook(
+			static fn ( Title $title ): bool => $pageHasMainSubject,
+			$this->newSubjectAuthorizerStub( $canEditSubject, $canCreateChildSubject )
+		);
+	}
+
+	private function newSubjectAuthorizerStub(
+		bool $canEditSubject = true,
+		bool $canCreateChildSubject = true
+	): Closure {
+		$authorizer = $this->createStub( SubjectAuthorizer::class );
+		$authorizer->method( 'canEditSubject' )->willReturn( $canEditSubject );
+		$authorizer->method( 'canCreateChildSubject' )->willReturn( $canCreateChildSubject );
+		return static fn (): SubjectAuthorizer => $authorizer;
 	}
 
 	private function newSkin(): Skin {

--- a/tests/phpunit/RedHerb/RedHerbSidebarHookTest.php
+++ b/tests/phpunit/RedHerb/RedHerbSidebarHookTest.php
@@ -54,6 +54,18 @@ class RedHerbSidebarHookTest extends MediaWikiIntegrationTestCase {
 		);
 	}
 
+	public function testDoesNotAddCreateChildLinkWhenUserCannotCreateChildSubject(): void {
+		$sidebar = [];
+		$hook = $this->newHook( pageHasMainSubject: true, canCreateChildSubject: false );
+
+		$hook->onSidebarBeforeOutput( $this->newSkinForExistingPage(), $sidebar );
+
+		$this->assertSame(
+			[ 'redherb-sidebar-subject-finder', 'redherb-sidebar-edit-main-subject' ],
+			array_column( $sidebar['redherb-sidebar'], 'id' )
+		);
+	}
+
 	public function testOnlyAddsSubjectFinderLinkOnNonExistentPages(): void {
 		$sidebar = [];
 		$predicateInvoked = false;


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/821
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/824

The RedHerb sidebar's "Edit main subject" and "Create child Company"
links were rendered without checking whether the current user could
perform the action. On wikis where anonymous editing is disabled,
anonymous users saw tools they could not use. RedHerb is the canonical
example extension demonstrating NeoWiki extension points, so it should
model correct permission handling rather than the bug.

## Changes

Two separate commits, one per issue:

1. **#821** — Inject a `SubjectAuthorizer` factory into `RedHerbSidebarHook`
   and gate the "Edit main subject" link on `SubjectAuthorizer::canEditSubject()`,
   mirroring how `NeoWikiHooks` gates `canCreateMainSubject`.
2. **#824** — Gate the "Create child Company" link on
   `SubjectAuthorizer::canCreateChildSubject()`, reusing the authorizer
   already resolved in the hook.

The authorizer is resolved per-request from `$skin->getAuthority()` via an
injected closure (defaulting to `NeoWikiExtension::newSubjectAuthorizer()`),
consistent with the existing `pageHasMainSubject` closure-injection pattern
used for testability.

## Testing

- Added `testDoesNotAddEditLinkWhenUserCannotEditSubject` (#821) and
  `testDoesNotAddCreateChildLinkWhenUserCannotCreateChildSubject` (#824).
  Both verified to fail without their respective gate and pass with it.
- Existing `RedHerbSidebarHookTest` cases updated to inject an authorizer stub.
- Full PHPUnit suite green (922 tests). PHPCS and PHPStan clean.
- Mutation testing: 5 mutations (gate removal, condition inversion, `&&`→`||`,
  forced-true) all caught by the new tests.
- **Browser verification** on the dev wiki (anonymous editing disabled, page
  with a main subject):
  - Anonymous user (no edit perm): only the ungated "Find a subject" link
    shows — "Edit main subject" and "Create child Company" correctly hidden.
  - Logged-in user with edit permission: all three links show (confirms the
    gating is real permission handling, not blanket hiding).
  - With the gates removed, the links reappear for the anonymous user
    (confirms the bug is genuinely reproduced and the fix resolves it).

Note: this branch is an independent from-scratch reimplementation requested
for comparison against the existing PR #823.

🤖 Generated with [Claude Code](https://claude.com/claude-code)