### PR TITLE
Bump axios to ^1.15.2 for security fixes (security-only follow-up to #815)

### DIFF
--- a/resources/ext.neowiki/package-lock.json
+++ b/resources/ext.neowiki/package-lock.json
@@ -21,7 +21,7 @@
 				"@wikimedia/codex-design-tokens": "1.14.0",
 				"@wikimedia/codex-icons": "1.14.0",
 				"@wmde/eslint-config-wikimedia-typescript": "^0.2.14",
-				"axios": "^1.7.7",
+				"axios": "^1.15.2",
 				"eslint": "^8.57.0",
 				"eslint-config-wikimedia": "^0.32.3",
 				"eslint-plugin-n": "^17.10.2",
@@ -3073,15 +3073,43 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "1.14.0",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-			"integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+			"integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"follow-redirects": "^1.15.11",
+				"follow-redirects": "^1.16.0",
 				"form-data": "^4.0.5",
+				"https-proxy-agent": "^5.0.1",
 				"proxy-from-env": "^2.1.0"
+			}
+		},
+		"node_modules/axios/node_modules/agent-base": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
+			}
+		},
+		"node_modules/axios/node_modules/https-proxy-agent": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "6",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/balanced-match": {
@@ -5691,9 +5719,9 @@
 			"license": "ISC"
 		},
 		"node_modules/follow-redirects": {
-			"version": "1.15.11",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-			"integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+			"integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
 			"dev": true,
 			"funding": [
 				{

--- a/resources/ext.neowiki/package.json
+++ b/resources/ext.neowiki/package.json
@@ -30,7 +30,7 @@
 		"@wikimedia/codex-design-tokens": "1.14.0",
 		"@wikimedia/codex-icons": "1.14.0",
 		"@wmde/eslint-config-wikimedia-typescript": "^0.2.14",
-		"axios": "^1.7.7",
+		"axios": "^1.15.2",
 		"eslint": "^8.57.0",
 		"eslint-config-wikimedia": "^0.32.3",
 		"eslint-plugin-n": "^17.10.2",


### PR DESCRIPTION
Security-only follow-up to the closed grouped Dependabot PR #815.

#815 failed CI (`ERESOLVE` — `vite` 5→8 with `@vitejs/plugin-vue` pinned to v5) and bundled breaking `vite` 5→8 / `vitest` 2→4 majors that require a separate migration incompatible with the `vue@3.4.27` pin (tracks MediaWiki). This PR extracts just the security-relevant change.

## Changes

| Dependency | Before | After | Notes |
|---|---|---|---|
| `axios` (devDep) | 1.14.0 (`^1.7.7`) | 1.16.1 (`^1.15.2`) | prototype-pollution + SSRF hardening |
| `follow-redirects` | 1.15.11 | 1.16.0 | transitive, via lockfile regeneration |

No `vite` / `vitest` / `@vitejs/plugin-vue` changes — the toolchain stays on the current `master` baseline.

## Verification

Clean checkout of this branch:

- `npm ci` ✅
- `npm run build` ✅
- `npm run lint` ✅
- `npm test` ✅ under `TZ=UTC` (as CI runs). Locally the 3 host-timezone `DateTime*` tests fail only in non-UTC zones — a pre-existing test-robustness gap (no `TZ` pin in vitest config/CI), unrelated to this bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)