### PR TITLE
Fix stale doc links in docs/planning after the docs reorganization

### DIFF
--- a/docs/planning/ECHOLOT.md
+++ b/docs/planning/ECHOLOT.md
@@ -1,6 +1,6 @@
 # ECHOLOT
 
-If you are not familiar with the NeoWiki terminology yet, see [the glossary](../Glossary.md).
+If you are not familiar with the NeoWiki terminology yet, see [the glossary](../concepts/glossary.md).
 
 ## Open Questions
 
@@ -9,20 +9,20 @@ If you are not familiar with the NeoWiki terminology yet, see [the glossary](../
 * What will the interaction of the wiki and WP4 look like? WP4 is about import, export, reconciliation,
   image recognition and annotation, enrichment, and quality checks. Which UIs will live in the wiki?
   Which services will live in the wiki backend vs which ones will be microservices?
-* What other things do Schemas need to support? Things like Subclasses. See [Glossary](../Glossary.md) and
-  [SchemaFormat](../SchemaFormat.md) for what is already supported. (80% likely)
+* What other things do Schemas need to support? Things like Subclasses. See [Glossary](../concepts/glossary.md) and
+  [SchemaFormat](../reference/schema-format.md) for what is already supported. (80% likely)
 
 ### Medium Priority
 
 * Verify the current data model (Property-graph-like Subjects and multi-Subject support) is workable for provenance.
 * Does the [RDF mapping stwaman proposal](RdfMapping.md) go in the right direction? What needs to be adjusted?
-* Is our [Graph Model](../GraphModel.md) OK? In particular, is it OK to have non-Subject data in there, like the connected
+* Is our [Graph Model](../reference/graph-model.md) OK? In particular, is it OK to have non-Subject data in there, like the connected
   MediaWiki pages? (80% likely, briefly covered in Vienna: can filter out these values when querying)
 * How important is multilinguality for ECHOLOT? Do we need to provide anything beyond our current data model to support that?
 
 ### Low Priority
 
-* Is [one Schema per Subject](../adr/008_One_Schema_per_Subject.md) viable?
+* Is [one Schema per Subject](../adr/008-one-schema-per-subject.md) viable?
   (likely, but let's verify)
 * Do we need to have an API that provides Schemas in JSON Schema format? (50% likely, can be deferred, easy to implement)
 * ID-generation for bulk import: do we need an API for (bulk) ID gen? (local impact, easy to implement)

--- a/docs/planning/GlobalProperties.md
+++ b/docs/planning/GlobalProperties.md
@@ -4,7 +4,7 @@ Written 2026-01-31 by Jeroen De Dauw with some help from Claude Opus 4.5
 
 ## Context
 
-Currently, Property Definitions are local to their Schema ([ADR 6](../adr/006_Schemas.md)). "Name" in a Person
+Currently, Property Definitions are local to their Schema ([ADR 6](../adr/006-schemas.md)). "Name" in a Person
 Schema and "Name" in a Company Schema are independent definitions that can have different types and constraints.
 
 Both Semantic MediaWiki and Wikibase use global properties: a property is defined once and reused across types.
@@ -20,7 +20,7 @@ the same ontology term (e.g., `foaf:name`) must be mapped separately for every S
 
 **Enforced consistency.** Same-named properties cannot accidentally have different types across Schemas.
 
-**Cross-schema query semantics.** A property name on a Subject node in the [graph](../GraphModel.md) is
+**Cross-schema query semantics.** A property name on a Subject node in the [graph](../reference/graph-model.md) is
 guaranteed to mean the same thing regardless of the Subject's Schema.
 
 **Reduced redundancy.** Properties like "Name" or "Website" are defined once instead of duplicated across
@@ -30,10 +30,10 @@ every Schema that uses them.
 
 ## Cons of Global Properties
 
-**Thin abstraction.** Currently a [Property Definition](../Glossary.md#property-definition) carries its type,
+**Thin abstraction.** Currently a [Property Definition](../concepts/glossary.md#property-definition) carries its type,
 constraints (like `minimum`/`maximum`), `required`, `default`, `multiple`, and display hints (like `precision`).
 Whether a property is required, what its default is, and what constraints apply are per-Schema decisions. Display
-settings are per-[Layout](../adr/018_Views.md). Once you move all of that out, a global property is just a name
+settings are per-[Layout](../adr/018-views.md). Once you move all of that out, a global property is just a name
 and a type. It is unclear if that justifies the architectural complexity.
 
 **Schema creation UX suffers.** Instead of defining properties inline while creating a Schema, users must
@@ -52,7 +52,7 @@ local properties with extra indirection.
 a creation/editing UI, and search/browse functionality — all separate from the Schema UI.
 
 **Interaction with Layouts is unclear.** Display attributes like `precision` are currently Property Definition
-Attributes but are also listed as Layout Attributes in [ADR 18](../adr/018_Views.md). With global properties,
+Attributes but are also listed as Layout Attributes in [ADR 18](../adr/018-views.md). With global properties,
 this overlap becomes a design problem: a property has no display defaults outside of a Layout context unless we
 add yet another layer (e.g., display defaults on the Schema's property reference that Layouts can override).
 

--- a/docs/planning/RdfMapping.md
+++ b/docs/planning/RdfMapping.md
@@ -7,7 +7,7 @@ Status: Draft, incorporating feedback from ECHOLOT partners (Bilbao meeting Marc
 ## Purpose
 
 This document proposes how NeoWiki's data model maps to RDF triples for the SPARQL plugin described in
-[ADR 19](../adr/019_Graph_Database_Architecture.md). The mapping determines what RDF a triple store contains
+[ADR 19](../adr/019-graph-database-architecture.md). The mapping determines what RDF a triple store contains
 and therefore what SPARQL queries users can write. It also defines the shape of RDF exports.
 
 This is a strawman proposal. Many decisions here need input from partners with RDF and Linked Open Data expertise,
@@ -18,7 +18,7 @@ collected at the end. Discussion is tracked in [#723](https://github.com/Profess
 
 1. **Simple queries should be simple.** The most common operation — looking up a Subject's properties or finding
    Subjects by property values — should require only basic triple patterns, not navigating reification structures.
-2. **No information loss.** Everything in the [Subject format](../SubjectFormat.md) must be representable in RDF,
+2. **No information loss.** Everything in the [Subject format](../reference/subject-format.md) must be representable in RDF,
    including Relation IDs and Relation properties.
 3. **Standard RDF 1.1.** No dependency on RDF-star/RDF 1.2, which is still a Working Draft and not supported by
    QLever. Can be adopted later as an optimization.


### PR DESCRIPTION
## Problem

PR #825 ("Reorganize docs into concepts/reference/adr structure", merged as a5cbb8b3) moved the flat `docs/` layout into `concepts/`, `reference/`, and kebab-cased `adr/`, and rewrote internal cross-links. Its follow-up commit was titled "Fix stale doc paths and link text **missed** in the docs reorganization", and the PR body claimed all internal cross-links were updated — but `docs/planning/` was never in scope and still points at the old flat layout.

All **12** relative links across the three planning files are currently broken on `master`:

| File | Broken target → fixed target |
|---|---|
| `planning/ECHOLOT.md` | `../Glossary.md` → `../concepts/glossary.md` (x2); `../SchemaFormat.md` → `../reference/schema-format.md`; `../GraphModel.md` → `../reference/graph-model.md`; `../adr/008_One_Schema_per_Subject.md` → `../adr/008-one-schema-per-subject.md` |
| `planning/GlobalProperties.md` | `../adr/006_Schemas.md` → `../adr/006-schemas.md`; `../GraphModel.md` → `../reference/graph-model.md`; `../Glossary.md#property-definition` → `../concepts/glossary.md#property-definition`; `../adr/018_Views.md` → `../adr/018-views.md` (x2) |
| `planning/RdfMapping.md` | `../adr/019_Graph_Database_Architecture.md` → `../adr/019-graph-database-architecture.md`; `../SubjectFormat.md` → `../reference/subject-format.md` |

## Changes

Repoint all 12 links to their new locations. Same-directory planning links (e.g. `RdfMapping.md`, `GlobalProperties.md`) were already correct and left untouched. Every fixed target was verified to exist on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)