### PR TITLE
Fix stale QueryLimits class reference in query API docs

### DIFF
--- a/docs/reference/query-api.md
+++ b/docs/reference/query-api.md
@@ -263,7 +263,7 @@ $wgGroupPermissions['researcher']['neowiki-query'] = true;
 
 ## Deployment notes
 
-NeoWiki enforces a transaction timeout in-process via `QueryLimits::$timeoutSeconds`. This is the primary
+NeoWiki enforces a transaction timeout in-process via `Neo4jQueryLimits::$timeoutSeconds`. This is the primary
 protection against long-running queries. For defense-in-depth, configure Neo4j itself with matching server-side
 limits so that a bug or misconfiguration in the application layer does not leave the database exposed:
 


### PR DESCRIPTION
## Summary

`docs/reference/query-api.md` referenced `QueryLimits::$timeoutSeconds`, but that class was renamed to `Neo4jQueryLimits` when the Neo4j-bound code moved into `src/GraphDatabasePlugins/Neo4j/` (#817). There is no `QueryLimits` class anymore, so the reference was dangling. Updated it to `Neo4jQueryLimits::$timeoutSeconds`.

The `$wgNeoWikiQueryLimits` config variable mentioned elsewhere in the same doc is unchanged and correct — only the class reference was stale.

## Test plan

- [x] `grep` confirms no `QueryLimits` class exists in `src/`; only `Neo4jQueryLimits` (with `public int $timeoutSeconds`)
- [x] Docs-only change, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)