### PR TITLE
Fix stale test class namespaces left behind by Neo4j plugin move

### DIFF
--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Application/CompositeCypherQueryValidatorIntegrationTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Application/CompositeCypherQueryValidatorIntegrationTest.php
@@ -2,7 +2,7 @@
 
 declare( strict_types = 1 );
 
-namespace ProfessionalWiki\NeoWiki\Tests\Application;
+namespace ProfessionalWiki\NeoWiki\Tests\GraphDatabasePlugins\Neo4j\Application;
 
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\CompositeCypherQueryValidator;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Application/CompositeCypherQueryValidatorTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Application/CompositeCypherQueryValidatorTest.php
@@ -2,7 +2,7 @@
 
 declare( strict_types = 1 );
 
-namespace ProfessionalWiki\NeoWiki\Tests\Application;
+namespace ProfessionalWiki\NeoWiki\Tests\GraphDatabasePlugins\Neo4j\Application;
 
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\CompositeCypherQueryValidator;

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Application/Exception/QueryExceptionTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Application/Exception/QueryExceptionTest.php
@@ -2,7 +2,7 @@
 
 declare( strict_types = 1 );
 
-namespace ProfessionalWiki\NeoWiki\Tests\GraphDatabasePlugins\Neo4j\Application;
+namespace ProfessionalWiki\NeoWiki\Tests\GraphDatabasePlugins\Neo4j\Application\Exception;
 
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\BackendUnavailableException;

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Application/ExplainCypherQueryValidatorTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Application/ExplainCypherQueryValidatorTest.php
@@ -2,7 +2,7 @@
 
 declare( strict_types = 1 );
 
-namespace ProfessionalWiki\NeoWiki\Tests\GraphDatabasePlugins\Neo4j\Persistence;
+namespace ProfessionalWiki\NeoWiki\Tests\GraphDatabasePlugins\Neo4j\Application;
 
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\ExplainCypherQueryValidator;

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Application/KeywordCypherQueryValidatorTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Application/KeywordCypherQueryValidatorTest.php
@@ -2,7 +2,7 @@
 
 declare( strict_types = 1 );
 
-namespace ProfessionalWiki\NeoWiki\Tests\GraphDatabasePlugins\Neo4j\Persistence;
+namespace ProfessionalWiki\NeoWiki\Tests\GraphDatabasePlugins\Neo4j\Application;
 
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\KeywordCypherQueryValidator;

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jResultNormalizerTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jResultNormalizerTest.php
@@ -2,7 +2,7 @@
 
 declare( strict_types = 1 );
 
-namespace ProfessionalWiki\NeoWiki\Tests\GraphDatabasePlugins\Neo4j\Application;
+namespace ProfessionalWiki\NeoWiki\Tests\GraphDatabasePlugins\Neo4j\Persistence;
 
 use Laudis\Neo4j\Types\CypherList;
 use Laudis\Neo4j\Types\CypherMap;


### PR DESCRIPTION
Implements #842.

After #840 moved Neo4j-bound code into `src/GraphDatabasePlugins/Neo4j/` and moved the corresponding tests under `tests/phpunit/GraphDatabasePlugins/Neo4j/`, six test files were left with namespace declarations that no longer match their PSR-4 path. Composer therefore can't autoload these test classes by FQN. The matching source classes' namespaces are already correct — only the test side is stale.

## Fixes

| File | Was | Now |
| --- | --- | --- |
| `tests/phpunit/GraphDatabasePlugins/Neo4j/Application/CompositeCypherQueryValidatorTest.php` | `…\\Tests\\Application` | `…\\Tests\\GraphDatabasePlugins\\Neo4j\\Application` |
| `tests/phpunit/GraphDatabasePlugins/Neo4j/Application/CompositeCypherQueryValidatorIntegrationTest.php` | `…\\Tests\\Application` | `…\\Tests\\GraphDatabasePlugins\\Neo4j\\Application` |
| `tests/phpunit/GraphDatabasePlugins/Neo4j/Application/ExplainCypherQueryValidatorTest.php` | `…\\Tests\\GraphDatabasePlugins\\Neo4j\\Persistence` | `…\\Tests\\GraphDatabasePlugins\\Neo4j\\Application` |
| `tests/phpunit/GraphDatabasePlugins/Neo4j/Application/KeywordCypherQueryValidatorTest.php` | `…\\Tests\\GraphDatabasePlugins\\Neo4j\\Persistence` | `…\\Tests\\GraphDatabasePlugins\\Neo4j\\Application` |
| `tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jResultNormalizerTest.php` | `…\\Tests\\GraphDatabasePlugins\\Neo4j\\Application` | `…\\Tests\\GraphDatabasePlugins\\Neo4j\\Persistence` |
| `tests/phpunit/GraphDatabasePlugins/Neo4j/Application/Exception/QueryExceptionTest.php` | `…\\Tests\\GraphDatabasePlugins\\Neo4j\\Application` | `…\\Tests\\GraphDatabasePlugins\\Neo4j\\Application\\Exception` |

## Verification

A path → expected-PSR-4-namespace sweep across `tests/phpunit/` reports zero mismatches after the fix.

No cross-file references to these test classes by FQN exist, so changing the namespace declaration is the only edit required. No production code or test logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)