### PR TITLE
Fetch latest schema before opening subject editor

### DIFF
--- a/resources/ext.neowiki/src/components/Views/Infobox.vue
+++ b/resources/ext.neowiki/src/components/Views/Infobox.vue
@@ -98,7 +98,10 @@ const schema = computed( () => schemaStore.getSchema( subject.value.getSchemaNam
 
 async function openEditor(): Promise<void> {
 	try {
-		await subjectStore.fetchSubject( props.subjectId );
+		await Promise.all( [
+			schemaStore.fetchSchema( subject.value.getSchemaName() ),
+			subjectStore.fetchSubject( props.subjectId )
+		] );
 		isEditorOpen.value = true;
 	} catch ( error ) {
 		mw.notify(

--- a/resources/ext.neowiki/tests/components/Views/Infobox.spec.ts
+++ b/resources/ext.neowiki/tests/components/Views/Infobox.spec.ts
@@ -32,7 +32,7 @@ describe( 'Infobox', () => {
 	} );
 
 	let pinia: ReturnType<typeof createPinia>;
-	let schemaStore;
+	let schemaStore: any;
 	let subjectStore: any;
 
 	const mockSchema = new Schema(
@@ -150,7 +150,8 @@ describe( 'Infobox', () => {
 		expect( editButton.exists() ).toBe( true );
 	} );
 
-	it( 'fetches latest subject and opens dialog when edit button is clicked', async () => {
+	it( 'fetches latest schema and subject before opening dialog when edit button is clicked', async () => {
+		schemaStore.fetchSchema = vi.fn().mockResolvedValue( undefined );
 		subjectStore.fetchSubject = vi.fn().mockResolvedValue( undefined );
 
 		const wrapper = mountComponent( mockSubject, true );
@@ -162,6 +163,7 @@ describe( 'Infobox', () => {
 		await editButton.trigger( 'click' );
 		await flushPromises();
 
+		expect( schemaStore.fetchSchema ).toHaveBeenCalledWith( mockSubject.getSchemaName() );
 		expect( subjectStore.fetchSubject ).toHaveBeenCalledWith( mockSubject.getId() );
 		expect( dialog.props( 'open' ) ).toBe( true );
 	} );


### PR DESCRIPTION
Tested manually in browser.

Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/713
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/708

PR #708 made the Infobox fetch the latest subject before opening the
SubjectEditorDialog, but the editor also depends on the schema to
decide which property fields to render. If the schema was modified
in another tab, the editor still showed stale fields.

SubjectEditorDialog's watch on `props.subject` runs `loadSchema()` via
`schemaStore.getOrFetchSchema(...)` — a cache-aware read. Fetching the
schema in parallel with the subject and awaiting both before opening
the dialog keeps the cache fresh by the time the watch fires, so the
dialog renders against the latest schema.

## Manual Browser Check

- Open a subject page with an infobox in two browser tabs
- In tab 2, open the subject's schema and add a new property, then save
- In tab 1, click the edit button on the infobox
- Verify the new property field appears in the editor
- Repeat with property removal: in tab 2, delete a property from the
  schema and save; in tab 1, click edit and verify the removed field
  is gone

> Result of a clear spec follow-up to @JeroenDeDauw's PR #708.
> Context: the NeoWiki codebase and the parent PR.
> <sub>Written by Claude Code, `Opus 4.7`</sub>