### PR TITLE
Switch #view to named-args with single positional Subject

### DIFF
--- a/DemoData/AGENTS.md
+++ b/DemoData/AGENTS.md
@@ -54,8 +54,9 @@ Subject, relation, and option IDs:
    `NeoWikiHooks::handleContentPage` (`BeforePageDisplay`). Don't `{{#view}}` the same subject in
    the page's wikitext, or you get two infoboxes. Use `{{#view}}` only on plain `Page/` hubs (which
    have no Main Subject) or to embed a different subject.
-4. **`{{#view}}` uses named args for Layout.** Write `{{#view:id|layout=LayoutName}}`. The
-   old positional form `{{#view:id|LayoutName}}` is gone and now renders a visible parser error.
+4. **`{{#view}}` takes one positional Subject ID plus named args.** Write
+   `{{#view:id|layout=LayoutName}}` or `{{#view:subject=id|layout=LayoutName}}`. The old
+   positional form `{{#view:id|LayoutName}}` is gone and now renders a visible parser error.
 
 ## Cypher gotchas
 

--- a/DemoData/AGENTS.md
+++ b/DemoData/AGENTS.md
@@ -54,8 +54,8 @@ Subject, relation, and option IDs:
    `NeoWikiHooks::handleContentPage` (`BeforePageDisplay`). Don't `{{#view}}` the same subject in
    the page's wikitext, or you get two infoboxes. Use `{{#view}}` only on plain `Page/` hubs (which
    have no Main Subject) or to embed a different subject.
-4. **`{{#view:id|LayoutName}}` is positional.** The named form `{{#view:id|layout=LayoutName}}` is
-   silently ignored.
+4. **`{{#view}}` uses named args for Layout.** Write `{{#view:id|layout=LayoutName}}`. The
+   old positional form `{{#view:id|LayoutName}}` is gone and now renders a visible parser error.
 
 ## Cypher gotchas
 

--- a/DemoData/Module/SubjectRow.lua
+++ b/DemoData/Module/SubjectRow.lua
@@ -33,7 +33,7 @@ function p.render( frame )
 
 		local view
 		if viewLayout and viewLayout ~= '' then
-			view = frame:preprocess( '{{#view:' .. id .. '|' .. viewLayout .. '}}' )
+			view = frame:preprocess( '{{#view:' .. id .. '|layout=' .. viewLayout .. '}}' )
 		else
 			view = frame:preprocess( '{{#view:' .. id .. '}}' )
 		end

--- a/docs/adr/018-views.md
+++ b/docs/adr/018-views.md
@@ -102,9 +102,11 @@ referenced Layout no longer exists. Usage sites (parser functions, Page Schemas,
 
 A View is what users see on a page — a rendered Subject. The `{{#view}}` parser function places a View:
 
-* `{{#view: SubjectId}}` — renders a Subject with the default infobox (no Layout)
-* `{{#view: SubjectId | layout=LayoutName}}` — renders using the specified Layout's Display Rules
+* `{{#view: }}` — renders the current page's Main Subject with the default infobox (no Layout)
+* `{{#view: SubjectId}}` — renders the specified Subject with the default infobox (no Layout)
 * `{{#view: layout=LayoutName}}` — renders the current page's Main Subject with the specified Layout
+* `{{#view: SubjectId | layout=LayoutName}}` — renders the specified Subject using the Layout's Display Rules
+* `{{#view: subject=SubjectId | layout=LayoutName}}` — same, with the Subject specified as a named argument
 
 Views are not stored entities. They exist as HTML placeholders that the frontend hydrates with Vue components.
 

--- a/docs/adr/018-views.md
+++ b/docs/adr/018-views.md
@@ -104,6 +104,7 @@ A View is what users see on a page — a rendered Subject. The `{{#view}}` parse
 
 * `{{#view: }}` — renders the current page's Main Subject with the default infobox (no Layout)
 * `{{#view: SubjectId}}` — renders the specified Subject with the default infobox (no Layout)
+* `{{#view: subject=SubjectId}}` — same, with the Subject specified as a named argument
 * `{{#view: layout=LayoutName}}` — renders the current page's Main Subject with the specified Layout
 * `{{#view: SubjectId | layout=LayoutName}}` — renders the specified Subject using the Layout's Display Rules
 * `{{#view: subject=SubjectId | layout=LayoutName}}` — same, with the Subject specified as a named argument

--- a/docs/adr/018-views.md
+++ b/docs/adr/018-views.md
@@ -103,7 +103,8 @@ referenced Layout no longer exists. Usage sites (parser functions, Page Schemas,
 A View is what users see on a page — a rendered Subject. The `{{#view}}` parser function places a View:
 
 * `{{#view: SubjectId}}` — renders a Subject with the default infobox (no Layout)
-* `{{#view: SubjectId | LayoutName}}` — renders using the specified Layout's Display Rules
+* `{{#view: SubjectId | layout=LayoutName}}` — renders using the specified Layout's Display Rules
+* `{{#view: layout=LayoutName}}` — renders the current page's Main Subject with the specified Layout
 
 Views are not stored entities. They exist as HTML placeholders that the frontend hydrates with Vue components.
 

--- a/docs/reference/parser-functions.md
+++ b/docs/reference/parser-functions.md
@@ -25,18 +25,20 @@ and how.
 ### Syntax
 
 ```
-{{#view: }}                              renders the current page's Main Subject
-{{#view: <subjectId>}}                   renders the specified Subject
-{{#view: <subjectId> | <layoutName>}}    renders the specified Subject with the named Layout
-{{#view:  | <layoutName>}}               renders the current page's Main Subject with the named Layout
+{{#view: }}                                           renders the current page's Main Subject
+{{#view: <subjectId>}}                                renders the specified Subject
+{{#view: layout=<layoutName>}}                        renders the current page's Main Subject with the named Layout
+{{#view: <subjectId> | layout=<layoutName>}}          renders the specified Subject with the named Layout
+{{#view: subject=<subjectId> | layout=<layoutName>}}  same, with the Subject specified as a named argument
 ```
 
 ### Parameters
 
 | Parameter | Description |
 |-----------|-------------|
-| `subjectId` (positional) | Subject ID to render. Defaults to the current page's Main Subject. |
-| `layoutName` (positional) | Layout to apply. Without one, all properties are shown in schema order. |
+| `<subjectId>` (positional) | Subject ID to render. Defaults to the current page's Main Subject. |
+| `subject=<subjectId>` | Named alternative to the positional form. Cannot be combined with the positional form. |
+| `layout=<layoutName>` | Layout to apply. Without one, all properties are shown in schema order. |
 
 ### Notes
 
@@ -49,9 +51,13 @@ and how.
 ```
 {{#view: }}
 {{#view: s1abc5def6ghi78}}
-{{#view: s1abc5def6ghi78 | CompanyOverview}}
-{{#view:  | CompanyOverview}}
+{{#view: layout=CompanyOverview}}
+{{#view: s1abc5def6ghi78 | layout=CompanyOverview}}
+{{#view: subject=s1abc5def6ghi78 | layout=CompanyOverview}}
 ```
+
+Unknown named arguments, more than one positional argument, or specifying the
+Subject both positionally and as `subject=` produce a visible parser error.
 
 ## `{{#neowiki_value}}`
 

--- a/docs/reference/parser-functions.md
+++ b/docs/reference/parser-functions.md
@@ -27,6 +27,7 @@ and how.
 ```
 {{#view: }}                                           renders the current page's Main Subject
 {{#view: <subjectId>}}                                renders the specified Subject
+{{#view: subject=<subjectId>}}                        same, with the Subject specified as a named argument
 {{#view: layout=<layoutName>}}                        renders the current page's Main Subject with the named Layout
 {{#view: <subjectId> | layout=<layoutName>}}          renders the specified Subject with the named Layout
 {{#view: subject=<subjectId> | layout=<layoutName>}}  same, with the Subject specified as a named argument

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -110,9 +110,9 @@
 
 	"neowiki-cypher-raw-error-json-encode": "Failed to encode query result as JSON",
 
-	"neowiki-view-error-extra-positional": "Unexpected extra positional argument: <code>$1</code>",
-	"neowiki-view-error-conflicting-subject": "Subject specified both positionally and as <code>subject=</code> named argument.",
-	"neowiki-view-error-unknown-arg": "Unknown argument: <code>$1</code>",
+	"neowiki-view-error-extra-positional": "Unexpected extra positional argument: $1",
+	"neowiki-view-error-conflicting-subject": "Subject specified both positionally and as a named subject argument.",
+	"neowiki-view-error-unknown-arg": "Unknown argument: $1",
 
 	"neowiki-schema-editor-summary-default": "Update schema via NeoWiki UI",
 	"neowiki-schema-editor-success": "Updated $1 schema",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -110,6 +110,10 @@
 
 	"neowiki-cypher-raw-error-json-encode": "Failed to encode query result as JSON",
 
+	"neowiki-view-error-extra-positional": "Unexpected extra positional argument: <code>$1</code>",
+	"neowiki-view-error-conflicting-subject": "Subject specified both positionally and as <code>subject=</code> named argument.",
+	"neowiki-view-error-unknown-arg": "Unknown argument: <code>$1</code>",
+
 	"neowiki-schema-editor-summary-default": "Update schema via NeoWiki UI",
 	"neowiki-schema-editor-success": "Updated $1 schema",
 	"neowiki-schema-editor-error": "Failed to update $1 schema.",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -14,6 +14,10 @@
 	"neowiki-schema-label": "Label used to identify the schema. $1 is the schema name or link.",
 	"neowiki-cypher-raw-error-json-encode": "Error message shown when JSON encoding of query results fails.",
 
+	"neowiki-view-error-extra-positional": "Error shown when {{#view}} is called with more than one positional argument. $1 is the offending extra argument value.",
+	"neowiki-view-error-conflicting-subject": "Error shown when {{#view}} receives both a positional Subject ID and a named subject= argument.",
+	"neowiki-view-error-unknown-arg": "Error shown when {{#view}} receives an unrecognized named argument. $1 is the offending argument name.",
+
 	"neowiki-page-tools-label": "Heading for the NeoWiki section in the MediaWiki sidebar (shown as a group label in legacy skins and inside the page tools menu in modern Vector).",
 	"neowiki-page-tools-create-subject": "Label for the sidebar link that opens the 'create subject' dialog. The dialog creates a main subject if the page has none, or a child subject otherwise.",
 	"neowiki-page-tools-edit-json": "Label for the sidebar link that navigates to Special:NeoJson for the current page. Only visible when development UIs are enabled.",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -15,7 +15,7 @@
 	"neowiki-cypher-raw-error-json-encode": "Error message shown when JSON encoding of query results fails.",
 
 	"neowiki-view-error-extra-positional": "Error shown when {{#view}} is called with more than one positional argument. $1 is the offending extra argument value.",
-	"neowiki-view-error-conflicting-subject": "Error shown when {{#view}} receives both a positional Subject ID and a named subject= argument.",
+	"neowiki-view-error-conflicting-subject": "Error shown when {{#view}} receives a Subject ID as both a positional argument and a named <code>subject=</code> argument.",
 	"neowiki-view-error-unknown-arg": "Error shown when {{#view}} receives an unrecognized named argument. $1 is the offending argument name.",
 
 	"neowiki-page-tools-label": "Heading for the NeoWiki section in the MediaWiki sidebar (shown as a group label in legacy skins and inside the page tools menu in modern Vector).",

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -141,7 +141,7 @@ class NeoWikiHooks {
 				$parserFunction = new ViewParserFunction(
 					NeoWikiExtension::getInstance()->newSubjectContentRepository()
 				);
-				return $parserFunction->handle( $parser, $args[0] ?? '', $args[1] ?? '' );
+				return $parserFunction->handle( $parser, ...$args );
 			}
 		);
 

--- a/src/EntryPoints/ViewParserFunction.php
+++ b/src/EntryPoints/ViewParserFunction.php
@@ -10,6 +10,9 @@ use ProfessionalWiki\NeoWiki\Presentation\ViewHtmlBuilder;
 
 class ViewParserFunction {
 
+	private const string ARG_SUBJECT = 'subject';
+	private const string ARG_LAYOUT = 'layout';
+
 	public function __construct(
 		private readonly SubjectContentRepository $subjectContentRepository
 	) {
@@ -18,21 +21,96 @@ class ViewParserFunction {
 	/**
 	 * @return string|array{0: string, noparse: true, isHTML: true}
 	 */
-	public function handle( Parser $parser, string $subjectId = '', string $layoutName = '' ): string|array {
-		$subjectId = trim( $subjectId );
-		$layoutName = trim( $layoutName );
+	public function handle( Parser $parser, string ...$args ): string|array {
+		$parsed = $this->parseArgs( $parser, $args );
 
-		$resolvedSubjectId = $subjectId !== '' ? $subjectId : $this->resolveMainSubjectId( $parser );
+		if ( is_string( $parsed ) ) {
+			return $parsed;
+		}
+
+		[ $explicitSubjectId, $layoutName ] = $parsed;
+
+		$resolvedSubjectId = $explicitSubjectId ?? $this->resolveMainSubjectId( $parser );
 
 		if ( $resolvedSubjectId === null ) {
 			return '';
 		}
 
 		return [
-			ViewHtmlBuilder::viewPlaceholderHtml( $resolvedSubjectId, $layoutName !== '' ? $layoutName : null ),
+			ViewHtmlBuilder::viewPlaceholderHtml( $resolvedSubjectId, $layoutName ),
 			'noparse' => true,
 			'isHTML' => true,
 		];
+	}
+
+	/**
+	 * @param string[] $args
+	 * @return array{0: ?string, 1: ?string}|string
+	 */
+	private function parseArgs( Parser $parser, array $args ): array|string {
+		$classified = $this->classifyArgs( $parser, $args );
+
+		if ( is_string( $classified ) ) {
+			return $classified;
+		}
+
+		[ $positional, $named ] = $classified;
+
+		if ( count( $positional ) > 1 ) {
+			return $this->renderError( $parser, 'neowiki-view-error-extra-positional', $positional[1] );
+		}
+
+		return $this->resolveSubjectAndLayout( $parser, $positional[0] ?? '', $named );
+	}
+
+	/**
+	 * @param string[] $args
+	 * @return array{0: string[], 1: array<string, string>}|string
+	 */
+	private function classifyArgs( Parser $parser, array $args ): array|string {
+		$positional = [];
+		$named = [];
+
+		foreach ( $args as $arg ) {
+			if ( !str_contains( $arg, '=' ) ) {
+				$positional[] = trim( $arg );
+				continue;
+			}
+
+			[ $key, $value ] = explode( '=', $arg, 2 );
+			$key = trim( $key );
+
+			if ( $key !== self::ARG_SUBJECT && $key !== self::ARG_LAYOUT ) {
+				return $this->renderError( $parser, 'neowiki-view-error-unknown-arg', $key );
+			}
+
+			$named[$key] = trim( $value );
+		}
+
+		return [ $positional, $named ];
+	}
+
+	/**
+	 * @param array<string, string> $named
+	 * @return array{0: ?string, 1: ?string}|string
+	 */
+	private function resolveSubjectAndLayout( Parser $parser, string $positionalSubject, array $named ): array|string {
+		$namedSubject = $named[self::ARG_SUBJECT] ?? '';
+
+		if ( $positionalSubject !== '' && $namedSubject !== '' ) {
+			return $this->renderError( $parser, 'neowiki-view-error-conflicting-subject', '' );
+		}
+
+		$subjectId = $positionalSubject !== '' ? $positionalSubject : ( $namedSubject !== '' ? $namedSubject : null );
+		$layoutName = ( $named[self::ARG_LAYOUT] ?? '' ) !== '' ? $named[self::ARG_LAYOUT] : null;
+
+		return [ $subjectId, $layoutName ];
+	}
+
+	private function renderError( Parser $parser, string $messageKey, string $insertion ): string {
+		return '<div class="error">'
+			. $parser->msg( $messageKey, $insertion )->escaped()
+			. '</div>';
 	}
 
 	private function resolveMainSubjectId( Parser $parser ): ?string {

--- a/src/EntryPoints/ViewParserFunction.php
+++ b/src/EntryPoints/ViewParserFunction.php
@@ -81,7 +81,11 @@ class ViewParserFunction {
 			$key = trim( $key );
 
 			if ( $key !== self::ARG_SUBJECT && $key !== self::ARG_LAYOUT ) {
-				return $this->renderError( $parser, 'neowiki-view-error-unknown-arg', $key );
+				return $this->renderError(
+					$parser,
+					'neowiki-view-error-unknown-arg',
+					$key !== '' ? $key : $arg
+				);
 			}
 
 			$named[$key] = trim( $value );
@@ -101,10 +105,22 @@ class ViewParserFunction {
 			return $this->renderError( $parser, 'neowiki-view-error-conflicting-subject', '' );
 		}
 
-		$subjectId = $positionalSubject !== '' ? $positionalSubject : ( $namedSubject !== '' ? $namedSubject : null );
+		$subjectId = $this->pickSubjectId( $positionalSubject, $namedSubject );
 		$layoutName = ( $named[self::ARG_LAYOUT] ?? '' ) !== '' ? $named[self::ARG_LAYOUT] : null;
 
 		return [ $subjectId, $layoutName ];
+	}
+
+	private function pickSubjectId( string $positional, string $named ): ?string {
+		if ( $positional !== '' ) {
+			return $positional;
+		}
+
+		if ( $named !== '' ) {
+			return $named;
+		}
+
+		return null;
 	}
 
 	private function renderError( Parser $parser, string $messageKey, string $insertion ): string {

--- a/src/EntryPoints/ViewParserFunction.php
+++ b/src/EntryPoints/ViewParserFunction.php
@@ -102,7 +102,7 @@ class ViewParserFunction {
 		$namedSubject = $named[self::ARG_SUBJECT] ?? '';
 
 		if ( $positionalSubject !== '' && $namedSubject !== '' ) {
-			return $this->renderError( $parser, 'neowiki-view-error-conflicting-subject', '' );
+			return $this->renderError( $parser, 'neowiki-view-error-conflicting-subject' );
 		}
 
 		$subjectId = $this->pickSubjectId( $positionalSubject, $namedSubject );
@@ -123,10 +123,12 @@ class ViewParserFunction {
 		return null;
 	}
 
-	private function renderError( Parser $parser, string $messageKey, string $insertion ): string {
-		return '<div class="error">'
-			. $parser->msg( $messageKey, $insertion )->escaped()
-			. '</div>';
+	private function renderError( Parser $parser, string $messageKey, ?string $insertion = null ): string {
+		$message = $insertion === null
+			? $parser->msg( $messageKey )
+			: $parser->msg( $messageKey, $insertion );
+
+		return '<div class="error">' . $message->escaped() . '</div>';
 	}
 
 	private function resolveMainSubjectId( Parser $parser ): ?string {

--- a/tests/phpunit/EntryPoints/ViewParserFunctionI18nTest.php
+++ b/tests/phpunit/EntryPoints/ViewParserFunctionI18nTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\ViewParserFunction
+ */
+class ViewParserFunctionI18nTest extends TestCase {
+
+	/**
+	 * Error messages are rendered via Message::escaped(), which HTML-escapes
+	 * the full message text. HTML markup inside the message would surface in
+	 * the page as literal &lt;tag&gt; entities. ViewParserFunctionTest cannot
+	 * catch this because it mocks Parser::msg() with a marker-free RawMessage.
+	 */
+	public function testViewErrorMessagesContainNoHtmlMarkup(): void {
+		$messages = $this->loadEnMessages();
+
+		foreach ( $messages as $key => $value ) {
+			if ( !str_starts_with( $key, 'neowiki-view-error-' ) ) {
+				continue;
+			}
+
+			$this->assertStringNotContainsString(
+				'<',
+				$value,
+				"Message $key contains HTML markup; Message::escaped() will leak entity references into rendered HTML."
+			);
+		}
+	}
+
+	/**
+	 * @return array<string, string>
+	 */
+	private function loadEnMessages(): array {
+		$path = __DIR__ . '/../../../i18n/en.json';
+		$contents = file_get_contents( $path );
+
+		$this->assertNotFalse( $contents, "Failed to read $path" );
+
+		$messages = json_decode( $contents, associative: true, flags: JSON_THROW_ON_ERROR );
+
+		$this->assertIsArray( $messages );
+
+		return $messages;
+	}
+
+}

--- a/tests/phpunit/EntryPoints/ViewParserFunctionTest.php
+++ b/tests/phpunit/EntryPoints/ViewParserFunctionTest.php
@@ -149,8 +149,16 @@ class ViewParserFunctionTest extends TestCase {
 		$subject = $this->createStub( Subject::class );
 		$subject->method( 'getId' )->willReturn( new SubjectId( $subjectId ) );
 
+		return $this->createRepositoryWithMainSubject( $subject );
+	}
+
+	private function createRepositoryWithNoMainSubject(): SubjectContentRepository {
+		return $this->createRepositoryWithMainSubject( null );
+	}
+
+	private function createRepositoryWithMainSubject( ?Subject $mainSubject ): SubjectContentRepository {
 		$pageSubjects = $this->createStub( PageSubjects::class );
-		$pageSubjects->method( 'getMainSubject' )->willReturn( $subject );
+		$pageSubjects->method( 'getMainSubject' )->willReturn( $mainSubject );
 
 		$subjectContent = $this->createStub( SubjectContent::class );
 		$subjectContent->method( 'getPageSubjects' )->willReturn( $pageSubjects );
@@ -164,19 +172,6 @@ class ViewParserFunctionTest extends TestCase {
 	private function createRepositoryWithNoContent(): SubjectContentRepository {
 		$repo = $this->createStub( SubjectContentRepository::class );
 		$repo->method( 'getSubjectContentByPageTitle' )->willReturn( null );
-
-		return $repo;
-	}
-
-	private function createRepositoryWithNoMainSubject(): SubjectContentRepository {
-		$pageSubjects = $this->createStub( PageSubjects::class );
-		$pageSubjects->method( 'getMainSubject' )->willReturn( null );
-
-		$subjectContent = $this->createStub( SubjectContent::class );
-		$subjectContent->method( 'getPageSubjects' )->willReturn( $pageSubjects );
-
-		$repo = $this->createStub( SubjectContentRepository::class );
-		$repo->method( 'getSubjectContentByPageTitle' )->willReturn( $subjectContent );
 
 		return $repo;
 	}

--- a/tests/phpunit/EntryPoints/ViewParserFunctionTest.php
+++ b/tests/phpunit/EntryPoints/ViewParserFunctionTest.php
@@ -20,6 +20,119 @@ use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\SubjectContentReposit
  */
 class ViewParserFunctionTest extends TestCase {
 
+	private const string MAIN_SUBJECT_ID = 's11111111111111';
+	private const string EXPLICIT_SUBJECT_ID = 's22222222222222';
+	private const string OTHER_SUBJECT_ID = 's33333333333333';
+
+	public function testEmitsPlaceholderWithExplicitPositionalSubject(): void {
+		$result = $this->callView( self::EXPLICIT_SUBJECT_ID );
+
+		$this->assertRendersSubject( $result, self::EXPLICIT_SUBJECT_ID );
+	}
+
+	public function testEmitsPlaceholderWithLayoutAsNamedArg(): void {
+		$result = $this->callView( 'layout=Finances' );
+
+		$this->assertRendersSubject( $result, self::MAIN_SUBJECT_ID, 'Finances' );
+	}
+
+	public function testEmitsPlaceholderWithSubjectAsNamedArg(): void {
+		$result = $this->callView( 'subject=' . self::EXPLICIT_SUBJECT_ID );
+
+		$this->assertRendersSubject( $result, self::EXPLICIT_SUBJECT_ID );
+	}
+
+	public function testEmitsPlaceholderWithSubjectAndLayoutNamedArgs(): void {
+		$result = $this->callView( 'subject=' . self::EXPLICIT_SUBJECT_ID, 'layout=Finances' );
+
+		$this->assertRendersSubject( $result, self::EXPLICIT_SUBJECT_ID, 'Finances' );
+	}
+
+	public function testEmitsPlaceholderWithMixedPositionalAndNamed(): void {
+		$result = $this->callView( self::EXPLICIT_SUBJECT_ID, 'layout=Finances' );
+
+		$this->assertRendersSubject( $result, self::EXPLICIT_SUBJECT_ID, 'Finances' );
+	}
+
+	public function testEmitsPlaceholderWhenNamedArgComesBeforePositional(): void {
+		$result = $this->callView( 'layout=Finances', self::EXPLICIT_SUBJECT_ID );
+
+		$this->assertRendersSubject( $result, self::EXPLICIT_SUBJECT_ID, 'Finances' );
+	}
+
+	public function testTreatsEmptyNamedSubjectAsFallbackToMainSubject(): void {
+		$result = $this->callView( 'subject=', 'layout=Finances' );
+
+		$this->assertRendersSubject( $result, self::MAIN_SUBJECT_ID, 'Finances' );
+	}
+
+	public function testTreatsEmptyNamedLayoutAsUnset(): void {
+		$result = $this->callView( self::EXPLICIT_SUBJECT_ID, 'layout=' );
+
+		$this->assertRendersSubject( $result, self::EXPLICIT_SUBJECT_ID );
+	}
+
+	public function testFallsBackToMainSubjectWhenNoArgs(): void {
+		$result = $this->callView();
+
+		$this->assertRendersSubject( $result, self::MAIN_SUBJECT_ID );
+	}
+
+	public function testReturnsEmptyStringWhenNoSubjectAvailable(): void {
+		$parserFunction = new ViewParserFunction( $this->createRepositoryWithNoContent() );
+
+		$result = $parserFunction->handle( $this->createMockParser() );
+
+		$this->assertSame( '', $result );
+	}
+
+	public function testReturnsEmptyStringWhenPageHasNoMainSubject(): void {
+		$parserFunction = new ViewParserFunction( $this->createRepositoryWithNoMainSubject() );
+
+		$result = $parserFunction->handle( $this->createMockParser() );
+
+		$this->assertSame( '', $result );
+	}
+
+	public function testRendersErrorOnExtraPositional(): void {
+		$result = $this->callView( self::EXPLICIT_SUBJECT_ID, self::OTHER_SUBJECT_ID );
+
+		$this->assertRendersError( $result, 'neowiki-view-error-extra-positional', self::OTHER_SUBJECT_ID );
+	}
+
+	public function testOldPositionalLayoutFormProducesExtraPositionalError(): void {
+		$result = $this->callView( self::EXPLICIT_SUBJECT_ID, 'Finances' );
+
+		$this->assertRendersError( $result, 'neowiki-view-error-extra-positional', 'Finances' );
+	}
+
+	public function testRendersErrorOnConflictingSubject(): void {
+		$result = $this->callView( self::EXPLICIT_SUBJECT_ID, 'subject=' . self::OTHER_SUBJECT_ID );
+
+		$this->assertRendersError( $result, 'neowiki-view-error-conflicting-subject' );
+	}
+
+	public function testRendersErrorOnUnknownNamedArg(): void {
+		$result = $this->callView( 'layuot=Finances' );
+
+		$this->assertRendersError( $result, 'neowiki-view-error-unknown-arg', 'layuot' );
+	}
+
+	public function testRendersErrorOnArgWithEmptyName(): void {
+		$result = $this->callView( '=Finances' );
+
+		$this->assertRendersError( $result, 'neowiki-view-error-unknown-arg', '=Finances' );
+	}
+
+	private function callView( string ...$args ): string|array {
+		return $this->newParserFunction( self::MAIN_SUBJECT_ID )
+			->handle( $this->createMockParser(), ...$args );
+	}
+
+	private function newParserFunction( string $mainSubjectId ): ViewParserFunction {
+		return new ViewParserFunction( $this->createRepositoryWithMainSubjectId( $mainSubjectId ) );
+	}
+
 	private function createMockParser(): Parser {
 		$title = $this->createStub( Title::class );
 
@@ -68,201 +181,35 @@ class ViewParserFunctionTest extends TestCase {
 		return $repo;
 	}
 
-	private function newParserFunction( string $mainSubjectId ): ViewParserFunction {
-		return new ViewParserFunction( $this->createRepositoryWithMainSubjectId( $mainSubjectId ) );
-	}
-
-	public function testEmitsPlaceholderWithExplicitPositionalSubject(): void {
-		$parserFunction = $this->newParserFunction( 's11111111111111' );
-
-		$result = $parserFunction->handle( $this->createMockParser(), 's22222222222222' );
-
-		$this->assertIsArray( $result );
+	/**
+	 * @param string|array{0: string, noparse: true, isHTML: true} $result
+	 */
+	private function assertRendersSubject( string|array $result, string $subjectId, ?string $layoutName = null ): void {
+		$this->assertIsArray( $result, 'Expected a placeholder array; got an error string or empty string.' );
 		$this->assertTrue( $result['isHTML'] );
 		$this->assertTrue( $result['noparse'] );
-		$this->assertStringContainsString( 'data-mw-neowiki-subject-id="s22222222222222"', $result[0] );
-		$this->assertStringNotContainsString( 'data-mw-neowiki-layout-name', $result[0] );
+
+		$html = $result[0];
+		$this->assertStringContainsString( 'data-mw-neowiki-subject-id="' . $subjectId . '"', $html );
+
+		if ( $layoutName === null ) {
+			$this->assertStringNotContainsString( 'data-mw-neowiki-layout-name', $html );
+		} else {
+			$this->assertStringContainsString( 'data-mw-neowiki-layout-name="' . $layoutName . '"', $html );
+		}
 	}
 
-	public function testEmitsPlaceholderWithLayoutAsNamedArg(): void {
-		$parserFunction = $this->newParserFunction( 's11111111111111' );
-
-		$result = $parserFunction->handle( $this->createMockParser(), 'layout=Finances' );
-
-		$this->assertIsArray( $result );
-		$this->assertStringContainsString( 'data-mw-neowiki-subject-id="s11111111111111"', $result[0] );
-		$this->assertStringContainsString( 'data-mw-neowiki-layout-name="Finances"', $result[0] );
-	}
-
-	public function testEmitsPlaceholderWithSubjectAsNamedArg(): void {
-		$parserFunction = $this->newParserFunction( 's11111111111111' );
-
-		$result = $parserFunction->handle( $this->createMockParser(), 'subject=s22222222222222' );
-
-		$this->assertIsArray( $result );
-		$this->assertStringContainsString( 'data-mw-neowiki-subject-id="s22222222222222"', $result[0] );
-		$this->assertStringNotContainsString( 'data-mw-neowiki-layout-name', $result[0] );
-	}
-
-	public function testEmitsPlaceholderWithSubjectAndLayoutNamedArgs(): void {
-		$parserFunction = $this->newParserFunction( 's11111111111111' );
-
-		$result = $parserFunction->handle(
-			$this->createMockParser(),
-			'subject=s22222222222222',
-			'layout=Finances'
-		);
-
-		$this->assertIsArray( $result );
-		$this->assertStringContainsString( 'data-mw-neowiki-subject-id="s22222222222222"', $result[0] );
-		$this->assertStringContainsString( 'data-mw-neowiki-layout-name="Finances"', $result[0] );
-	}
-
-	public function testEmitsPlaceholderWithMixedPositionalAndNamed(): void {
-		$parserFunction = $this->newParserFunction( 's11111111111111' );
-
-		$result = $parserFunction->handle(
-			$this->createMockParser(),
-			's22222222222222',
-			'layout=Finances'
-		);
-
-		$this->assertIsArray( $result );
-		$this->assertStringContainsString( 'data-mw-neowiki-subject-id="s22222222222222"', $result[0] );
-		$this->assertStringContainsString( 'data-mw-neowiki-layout-name="Finances"', $result[0] );
-	}
-
-	public function testEmitsPlaceholderWhenNamedArgComesBeforePositional(): void {
-		$parserFunction = $this->newParserFunction( 's11111111111111' );
-
-		$result = $parserFunction->handle(
-			$this->createMockParser(),
-			'layout=Finances',
-			's22222222222222'
-		);
-
-		$this->assertIsArray( $result );
-		$this->assertStringContainsString( 'data-mw-neowiki-subject-id="s22222222222222"', $result[0] );
-		$this->assertStringContainsString( 'data-mw-neowiki-layout-name="Finances"', $result[0] );
-	}
-
-	public function testTreatsEmptyNamedSubjectAsFallbackToMainSubject(): void {
-		$parserFunction = $this->newParserFunction( 's11111111111111' );
-
-		$result = $parserFunction->handle(
-			$this->createMockParser(),
-			'subject=',
-			'layout=Finances'
-		);
-
-		$this->assertIsArray( $result );
-		$this->assertStringContainsString( 'data-mw-neowiki-subject-id="s11111111111111"', $result[0] );
-		$this->assertStringContainsString( 'data-mw-neowiki-layout-name="Finances"', $result[0] );
-	}
-
-	public function testTreatsEmptyNamedLayoutAsUnset(): void {
-		$parserFunction = $this->newParserFunction( 's11111111111111' );
-
-		$result = $parserFunction->handle(
-			$this->createMockParser(),
-			's22222222222222',
-			'layout='
-		);
-
-		$this->assertIsArray( $result );
-		$this->assertStringContainsString( 'data-mw-neowiki-subject-id="s22222222222222"', $result[0] );
-		$this->assertStringNotContainsString( 'data-mw-neowiki-layout-name', $result[0] );
-	}
-
-	public function testFallsBackToMainSubjectWhenNoArgs(): void {
-		$parserFunction = $this->newParserFunction( 's11111111111111' );
-
-		$result = $parserFunction->handle( $this->createMockParser() );
-
-		$this->assertIsArray( $result );
-		$this->assertStringContainsString( 'data-mw-neowiki-subject-id="s11111111111111"', $result[0] );
-	}
-
-	public function testReturnsEmptyStringWhenNoSubjectAvailable(): void {
-		$parserFunction = new ViewParserFunction( $this->createRepositoryWithNoContent() );
-
-		$result = $parserFunction->handle( $this->createMockParser() );
-
-		$this->assertSame( '', $result );
-	}
-
-	public function testReturnsEmptyStringWhenPageHasNoMainSubject(): void {
-		$parserFunction = new ViewParserFunction( $this->createRepositoryWithNoMainSubject() );
-
-		$result = $parserFunction->handle( $this->createMockParser() );
-
-		$this->assertSame( '', $result );
-	}
-
-	public function testRendersErrorOnExtraPositional(): void {
-		$parserFunction = $this->newParserFunction( 's11111111111111' );
-
-		$result = $parserFunction->handle(
-			$this->createMockParser(),
-			's22222222222222',
-			's33333333333333'
-		);
-
-		$this->assertIsString( $result );
+	/**
+	 * @param string|array{0: string, noparse: true, isHTML: true} $result
+	 */
+	private function assertRendersError( string|array $result, string $messageKey, ?string $insertion = null ): void {
+		$this->assertIsString( $result, 'Expected an error HTML string; got a placeholder array.' );
 		$this->assertStringContainsString( 'class="error"', $result );
-		$this->assertStringContainsString( 'neowiki-view-error-extra-positional', $result );
-		$this->assertStringContainsString( 's33333333333333', $result );
-	}
+		$this->assertStringContainsString( $messageKey, $result );
 
-	public function testOldPositionalLayoutFormProducesExtraPositionalError(): void {
-		$parserFunction = $this->newParserFunction( 's11111111111111' );
-
-		$result = $parserFunction->handle(
-			$this->createMockParser(),
-			's22222222222222',
-			'Finances'
-		);
-
-		$this->assertIsString( $result );
-		$this->assertStringContainsString( 'class="error"', $result );
-		$this->assertStringContainsString( 'neowiki-view-error-extra-positional', $result );
-		$this->assertStringContainsString( 'Finances', $result );
-	}
-
-	public function testRendersErrorOnConflictingSubject(): void {
-		$parserFunction = $this->newParserFunction( 's11111111111111' );
-
-		$result = $parserFunction->handle(
-			$this->createMockParser(),
-			's22222222222222',
-			'subject=s33333333333333'
-		);
-
-		$this->assertIsString( $result );
-		$this->assertStringContainsString( 'class="error"', $result );
-		$this->assertStringContainsString( 'neowiki-view-error-conflicting-subject', $result );
-	}
-
-	public function testRendersErrorOnUnknownNamedArg(): void {
-		$parserFunction = $this->newParserFunction( 's11111111111111' );
-
-		$result = $parserFunction->handle( $this->createMockParser(), 'layuot=Finances' );
-
-		$this->assertIsString( $result );
-		$this->assertStringContainsString( 'class="error"', $result );
-		$this->assertStringContainsString( 'neowiki-view-error-unknown-arg', $result );
-		$this->assertStringContainsString( 'layuot', $result );
-	}
-
-	public function testRendersErrorOnArgWithEmptyName(): void {
-		$parserFunction = $this->newParserFunction( 's11111111111111' );
-
-		$result = $parserFunction->handle( $this->createMockParser(), '=Finances' );
-
-		$this->assertIsString( $result );
-		$this->assertStringContainsString( 'class="error"', $result );
-		$this->assertStringContainsString( 'neowiki-view-error-unknown-arg', $result );
-		$this->assertStringContainsString( '=Finances', $result );
+		if ( $insertion !== null ) {
+			$this->assertStringContainsString( $insertion, $result );
+		}
 	}
 
 }

--- a/tests/phpunit/EntryPoints/ViewParserFunctionTest.php
+++ b/tests/phpunit/EntryPoints/ViewParserFunctionTest.php
@@ -210,6 +210,7 @@ class ViewParserFunctionTest extends TestCase {
 
 		$this->assertIsString( $result );
 		$this->assertStringContainsString( 'class="error"', $result );
+		$this->assertStringContainsString( 'neowiki-view-error-extra-positional', $result );
 		$this->assertStringContainsString( 's33333333333333', $result );
 	}
 
@@ -224,6 +225,7 @@ class ViewParserFunctionTest extends TestCase {
 
 		$this->assertIsString( $result );
 		$this->assertStringContainsString( 'class="error"', $result );
+		$this->assertStringContainsString( 'neowiki-view-error-extra-positional', $result );
 		$this->assertStringContainsString( 'Finances', $result );
 	}
 
@@ -238,6 +240,7 @@ class ViewParserFunctionTest extends TestCase {
 
 		$this->assertIsString( $result );
 		$this->assertStringContainsString( 'class="error"', $result );
+		$this->assertStringContainsString( 'neowiki-view-error-conflicting-subject', $result );
 	}
 
 	public function testRendersErrorOnUnknownNamedArg(): void {
@@ -247,7 +250,19 @@ class ViewParserFunctionTest extends TestCase {
 
 		$this->assertIsString( $result );
 		$this->assertStringContainsString( 'class="error"', $result );
+		$this->assertStringContainsString( 'neowiki-view-error-unknown-arg', $result );
 		$this->assertStringContainsString( 'layuot', $result );
+	}
+
+	public function testRendersErrorOnArgWithEmptyName(): void {
+		$parserFunction = $this->newParserFunction( 's11111111111111' );
+
+		$result = $parserFunction->handle( $this->createMockParser(), '=Finances' );
+
+		$this->assertIsString( $result );
+		$this->assertStringContainsString( 'class="error"', $result );
+		$this->assertStringContainsString( 'neowiki-view-error-unknown-arg', $result );
+		$this->assertStringContainsString( '=Finances', $result );
 	}
 
 }

--- a/tests/phpunit/EntryPoints/ViewParserFunctionTest.php
+++ b/tests/phpunit/EntryPoints/ViewParserFunctionTest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints;
 
+use MediaWiki\Language\RawMessage;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Title\Title;
 use PHPUnit\Framework\TestCase;
@@ -24,6 +25,9 @@ class ViewParserFunctionTest extends TestCase {
 
 		$parser = $this->createStub( Parser::class );
 		$parser->method( 'getTitle' )->willReturn( $title );
+		$parser->method( 'msg' )->willReturnCallback(
+			static fn ( string $key, ...$params ) => new RawMessage( $key . ': $1', $params )
+		);
 
 		return $parser;
 	}
@@ -64,50 +68,123 @@ class ViewParserFunctionTest extends TestCase {
 		return $repo;
 	}
 
-	public function testEmitsPlaceholderWithExplicitSubjectIdAndLayoutName(): void {
-		$parserFunction = new ViewParserFunction(
-			$this->createRepositoryWithMainSubjectId( 's11111111111111' )
-		);
+	private function newParserFunction( string $mainSubjectId ): ViewParserFunction {
+		return new ViewParserFunction( $this->createRepositoryWithMainSubjectId( $mainSubjectId ) );
+	}
 
-		$result = $parserFunction->handle( $this->createMockParser(), 's22222222222222', 'Finances' );
+	public function testEmitsPlaceholderWithExplicitPositionalSubject(): void {
+		$parserFunction = $this->newParserFunction( 's11111111111111' );
+
+		$result = $parserFunction->handle( $this->createMockParser(), 's22222222222222' );
 
 		$this->assertIsArray( $result );
 		$this->assertTrue( $result['isHTML'] );
 		$this->assertTrue( $result['noparse'] );
-
-		$html = $result[0];
-		$this->assertStringContainsString( 'data-mw-neowiki-subject-id="s22222222222222"', $html );
-		$this->assertStringContainsString( 'data-mw-neowiki-layout-name="Finances"', $html );
+		$this->assertStringContainsString( 'data-mw-neowiki-subject-id="s22222222222222"', $result[0] );
+		$this->assertStringNotContainsString( 'data-mw-neowiki-layout-name', $result[0] );
 	}
 
-	public function testEmitsPlaceholderWithExplicitSubjectIdAndNoLayoutName(): void {
-		$parserFunction = new ViewParserFunction(
-			$this->createRepositoryWithMainSubjectId( 's11111111111111' )
-		);
+	public function testEmitsPlaceholderWithLayoutAsNamedArg(): void {
+		$parserFunction = $this->newParserFunction( 's11111111111111' );
 
-		$result = $parserFunction->handle( $this->createMockParser(), 's22222222222222' );
+		$result = $parserFunction->handle( $this->createMockParser(), 'layout=Finances' );
 
-		$html = $result[0];
-		$this->assertStringContainsString( 'data-mw-neowiki-subject-id="s22222222222222"', $html );
-		$this->assertStringNotContainsString( 'data-mw-neowiki-layout-name', $html );
+		$this->assertIsArray( $result );
+		$this->assertStringContainsString( 'data-mw-neowiki-subject-id="s11111111111111"', $result[0] );
+		$this->assertStringContainsString( 'data-mw-neowiki-layout-name="Finances"', $result[0] );
 	}
 
-	public function testFallsBackToMainSubjectWhenSubjectIdIsEmpty(): void {
-		$parserFunction = new ViewParserFunction(
-			$this->createRepositoryWithMainSubjectId( 's11111111111111' )
+	public function testEmitsPlaceholderWithSubjectAsNamedArg(): void {
+		$parserFunction = $this->newParserFunction( 's11111111111111' );
+
+		$result = $parserFunction->handle( $this->createMockParser(), 'subject=s22222222222222' );
+
+		$this->assertIsArray( $result );
+		$this->assertStringContainsString( 'data-mw-neowiki-subject-id="s22222222222222"', $result[0] );
+		$this->assertStringNotContainsString( 'data-mw-neowiki-layout-name', $result[0] );
+	}
+
+	public function testEmitsPlaceholderWithSubjectAndLayoutNamedArgs(): void {
+		$parserFunction = $this->newParserFunction( 's11111111111111' );
+
+		$result = $parserFunction->handle(
+			$this->createMockParser(),
+			'subject=s22222222222222',
+			'layout=Finances'
 		);
 
-		$result = $parserFunction->handle( $this->createMockParser(), '', 'Finances' );
+		$this->assertIsArray( $result );
+		$this->assertStringContainsString( 'data-mw-neowiki-subject-id="s22222222222222"', $result[0] );
+		$this->assertStringContainsString( 'data-mw-neowiki-layout-name="Finances"', $result[0] );
+	}
 
-		$html = $result[0];
-		$this->assertStringContainsString( 'data-mw-neowiki-subject-id="s11111111111111"', $html );
-		$this->assertStringContainsString( 'data-mw-neowiki-layout-name="Finances"', $html );
+	public function testEmitsPlaceholderWithMixedPositionalAndNamed(): void {
+		$parserFunction = $this->newParserFunction( 's11111111111111' );
+
+		$result = $parserFunction->handle(
+			$this->createMockParser(),
+			's22222222222222',
+			'layout=Finances'
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertStringContainsString( 'data-mw-neowiki-subject-id="s22222222222222"', $result[0] );
+		$this->assertStringContainsString( 'data-mw-neowiki-layout-name="Finances"', $result[0] );
+	}
+
+	public function testEmitsPlaceholderWhenNamedArgComesBeforePositional(): void {
+		$parserFunction = $this->newParserFunction( 's11111111111111' );
+
+		$result = $parserFunction->handle(
+			$this->createMockParser(),
+			'layout=Finances',
+			's22222222222222'
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertStringContainsString( 'data-mw-neowiki-subject-id="s22222222222222"', $result[0] );
+		$this->assertStringContainsString( 'data-mw-neowiki-layout-name="Finances"', $result[0] );
+	}
+
+	public function testTreatsEmptyNamedSubjectAsFallbackToMainSubject(): void {
+		$parserFunction = $this->newParserFunction( 's11111111111111' );
+
+		$result = $parserFunction->handle(
+			$this->createMockParser(),
+			'subject=',
+			'layout=Finances'
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertStringContainsString( 'data-mw-neowiki-subject-id="s11111111111111"', $result[0] );
+		$this->assertStringContainsString( 'data-mw-neowiki-layout-name="Finances"', $result[0] );
+	}
+
+	public function testTreatsEmptyNamedLayoutAsUnset(): void {
+		$parserFunction = $this->newParserFunction( 's11111111111111' );
+
+		$result = $parserFunction->handle(
+			$this->createMockParser(),
+			's22222222222222',
+			'layout='
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertStringContainsString( 'data-mw-neowiki-subject-id="s22222222222222"', $result[0] );
+		$this->assertStringNotContainsString( 'data-mw-neowiki-layout-name', $result[0] );
+	}
+
+	public function testFallsBackToMainSubjectWhenNoArgs(): void {
+		$parserFunction = $this->newParserFunction( 's11111111111111' );
+
+		$result = $parserFunction->handle( $this->createMockParser() );
+
+		$this->assertIsArray( $result );
+		$this->assertStringContainsString( 'data-mw-neowiki-subject-id="s11111111111111"', $result[0] );
 	}
 
 	public function testReturnsEmptyStringWhenNoSubjectAvailable(): void {
-		$parserFunction = new ViewParserFunction(
-			$this->createRepositoryWithNoContent()
-		);
+		$parserFunction = new ViewParserFunction( $this->createRepositoryWithNoContent() );
 
 		$result = $parserFunction->handle( $this->createMockParser() );
 
@@ -115,13 +192,62 @@ class ViewParserFunctionTest extends TestCase {
 	}
 
 	public function testReturnsEmptyStringWhenPageHasNoMainSubject(): void {
-		$parserFunction = new ViewParserFunction(
-			$this->createRepositoryWithNoMainSubject()
-		);
+		$parserFunction = new ViewParserFunction( $this->createRepositoryWithNoMainSubject() );
 
 		$result = $parserFunction->handle( $this->createMockParser() );
 
 		$this->assertSame( '', $result );
+	}
+
+	public function testRendersErrorOnExtraPositional(): void {
+		$parserFunction = $this->newParserFunction( 's11111111111111' );
+
+		$result = $parserFunction->handle(
+			$this->createMockParser(),
+			's22222222222222',
+			's33333333333333'
+		);
+
+		$this->assertIsString( $result );
+		$this->assertStringContainsString( 'class="error"', $result );
+		$this->assertStringContainsString( 's33333333333333', $result );
+	}
+
+	public function testOldPositionalLayoutFormProducesExtraPositionalError(): void {
+		$parserFunction = $this->newParserFunction( 's11111111111111' );
+
+		$result = $parserFunction->handle(
+			$this->createMockParser(),
+			's22222222222222',
+			'Finances'
+		);
+
+		$this->assertIsString( $result );
+		$this->assertStringContainsString( 'class="error"', $result );
+		$this->assertStringContainsString( 'Finances', $result );
+	}
+
+	public function testRendersErrorOnConflictingSubject(): void {
+		$parserFunction = $this->newParserFunction( 's11111111111111' );
+
+		$result = $parserFunction->handle(
+			$this->createMockParser(),
+			's22222222222222',
+			'subject=s33333333333333'
+		);
+
+		$this->assertIsString( $result );
+		$this->assertStringContainsString( 'class="error"', $result );
+	}
+
+	public function testRendersErrorOnUnknownNamedArg(): void {
+		$parserFunction = $this->newParserFunction( 's11111111111111' );
+
+		$result = $parserFunction->handle( $this->createMockParser(), 'layuot=Finances' );
+
+		$this->assertIsString( $result );
+		$this->assertStringContainsString( 'class="error"', $result );
+		$this->assertStringContainsString( 'layuot', $result );
 	}
 
 }


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/739


https://github.com/user-attachments/assets/8467d953-a678-4bdc-86c2-2b49f389d734


`{{#view}}` now takes one positional Subject ID plus named arguments
(`subject=`, `layout=`). The old `{{#view: id | LayoutName}}` positional-Layout
form is hard-broken and renders a visible parser error, as do unknown named
arguments, conflicting subject specifications (positional + `subject=`),
and extra positional args.

## Accepted forms

| Wikitext | Result |
|---|---|
| `{{#view:}}` | Main Subject of page (existing) |
| `{{#view: s123}}` | explicit Subject, positional (existing) |
| `{{#view: subject=s123}}` | explicit Subject, named |
| `{{#view: layout=Finances}}` | Main Subject + Layout |
| `{{#view: s123 \| layout=Finances}}` | explicit + Layout |
| `{{#view: subject=s123 \| layout=Finances}}` | fully named |
| `{{#view: layout=Finances \| s123}}` | order-free |

Errors (rendered as `<div class="error">…</div>`):
* Two or more positional args (also catches the old positional-Layout form).
* Subject specified both positionally and via `subject=`.
* Unknown named arg (e.g. `layuot=Finances`).
* Argument with empty name (e.g. `=Finances`).

## Hard break

NeoWiki is pre-release; the only in-tree caller of the old positional-Layout
form was `DemoData/Module/SubjectRow.lua`, updated in the same PR. Once the
wiki re-imports that module, demo pages using it (e.g. `Research_catalog`,
`Subject_views`) will render correctly; until then those pages will display
the new parser errors for any subject-with-Layout entry.

## Notes for review

* Live smoke testing through `action=parse` against a running dev wiki
  surfaced one production bug the unit tests had missed: `<code>...</code>`
  markup in error message text was HTML-escaped by `Message::escaped()`,
  leaking literal `&lt;code&gt;` to users. Fixed by going plain-text-only
  (commit `6650c530`), matching the precedent in `CypherRawParserFunction`.
* New `ViewParserFunctionI18nTest` (commit `19650fbb`) locks this down:
  it asserts every `neowiki-view-error-*` message contains no `<`.
  Sanity-checked: temporarily reintroducing `<code>` makes it fail.
* `make cs` green (phpcs 359/359, phpstan 176/176 [OK]),
  `make phpunit filter=ViewParserFunction` green (17 tests, 54 assertions).