### PR TITLE
Boolean property type fixups: false default round-trip + Vue exports + specs

### DIFF
--- a/resources/ext.neowiki/src/domain/PropertyDefinition.ts
+++ b/resources/ext.neowiki/src/domain/PropertyDefinition.ts
@@ -68,7 +68,9 @@ export class PropertyDefinitionDeserializer {
 				type: json.type as string,
 				description: json.description ?? '',
 				required: json.required ?? false,
-				default: json.default ? this.valueDeserializer.deserialize( json.default, json.type ) : undefined,
+				default: json.default !== undefined && json.default !== null ?
+					this.valueDeserializer.deserialize( json.default, json.type ) :
+					undefined,
 			} as PropertyDefinition,
 			json,
 		);

--- a/resources/ext.neowiki/src/public-api.ts
+++ b/resources/ext.neowiki/src/public-api.ts
@@ -108,6 +108,7 @@ export { default as NeoWikiApp } from './components/NeoWikiApp.vue';
 export { default as SchemaCreator } from './components/SchemaCreator/SchemaCreator.vue';
 export { default as SchemaDisplay } from './components/SchemaDisplay/SchemaDisplay.vue';
 export { default as SchemaDisplayHeader } from './components/SchemaDisplay/SchemaDisplayHeader.vue';
+export { default as BooleanAttributesEditor } from './components/SchemaEditor/Property/BooleanAttributesEditor.vue';
 export { default as DateTimeAttributesEditor } from './components/SchemaEditor/Property/DateTimeAttributesEditor.vue';
 export { default as DateAttributesEditor } from './components/SchemaEditor/Property/DateAttributesEditor.vue';
 export { default as NumberAttributesEditor } from './components/SchemaEditor/Property/NumberAttributesEditor.vue';
@@ -128,6 +129,8 @@ export { default as SubjectEditor } from './components/SubjectEditor/SubjectEdit
 export { default as SubjectEditorDialog } from './components/SubjectEditor/SubjectEditorDialog.vue';
 export { default as SubjectStatementsView } from './components/SubjectsManager/SubjectStatementsView.vue';
 export { default as SubjectsManagerPage } from './components/SubjectsManager/SubjectsManagerPage.vue';
+export { default as BooleanDisplay } from './components/Value/BooleanDisplay.vue';
+export { default as BooleanInput } from './components/Value/BooleanInput.vue';
 export { default as DateTimeDisplay } from './components/Value/DateTimeDisplay.vue';
 export { default as DateTimeInput } from './components/Value/DateTimeInput.vue';
 export { default as DateDisplay } from './components/Value/DateDisplay.vue';

--- a/resources/ext.neowiki/tests/components/SchemaEditor/Property/BooleanAttributesEditor.spec.ts
+++ b/resources/ext.neowiki/tests/components/SchemaEditor/Property/BooleanAttributesEditor.spec.ts
@@ -1,0 +1,35 @@
+import { VueWrapper } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import BooleanAttributesEditor from '@/components/SchemaEditor/Property/BooleanAttributesEditor.vue';
+import { newBooleanProperty, BooleanProperty } from '@/domain/propertyTypes/Boolean';
+import { AttributesEditorProps } from '@/components/SchemaEditor/Property/AttributesEditorContract.ts';
+import { createTestWrapper } from '../../../VueTestHelpers.ts';
+
+describe( 'BooleanAttributesEditor', () => {
+	function newWrapper( props: Partial<AttributesEditorProps<BooleanProperty>> = {} ): VueWrapper {
+		return createTestWrapper( BooleanAttributesEditor, {
+			property: newBooleanProperty(),
+			...props,
+		} );
+	}
+
+	it( 'mounts without error for a Boolean property', () => {
+		const wrapper = newWrapper();
+
+		expect( wrapper.exists() ).toBe( true );
+	} );
+
+	it( 'renders no type-specific input fields', () => {
+		const wrapper = newWrapper();
+
+		expect( wrapper.findAll( 'input' ).length ).toBe( 0 );
+		expect( wrapper.findAll( 'select' ).length ).toBe( 0 );
+		expect( wrapper.findAll( 'textarea' ).length ).toBe( 0 );
+	} );
+
+	it( 'does not emit update:property on mount', () => {
+		const wrapper = newWrapper();
+
+		expect( wrapper.emitted( 'update:property' ) ).toBeFalsy();
+	} );
+} );

--- a/resources/ext.neowiki/tests/components/Value/BooleanDisplay.spec.ts
+++ b/resources/ext.neowiki/tests/components/Value/BooleanDisplay.spec.ts
@@ -1,0 +1,59 @@
+import { VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import BooleanDisplay from '@/components/Value/BooleanDisplay.vue';
+import { newBooleanValue, newNumberValue, newStringValue, Value } from '@/domain/Value';
+import { newBooleanProperty, BooleanProperty } from '@/domain/propertyTypes/Boolean';
+import { ValueDisplayProps } from '@/components/Value/ValueDisplayContract.ts';
+import { createTestWrapper } from '../../VueTestHelpers.ts';
+
+describe( 'BooleanDisplay', () => {
+	beforeEach( () => {
+		vi.stubGlobal( 'mw', {
+			message: vi.fn( ( key: string ) => ( {
+				text: () => key === 'neowiki-boolean-true' ? 'Yes' : 'No',
+				parse: () => key,
+			} ) ),
+		} );
+	} );
+
+	function createWrapper( value: Value, property: BooleanProperty = newBooleanProperty() ): VueWrapper {
+		const props: ValueDisplayProps<BooleanProperty> = { value, property };
+		return createTestWrapper( BooleanDisplay, props );
+	}
+
+	it( 'renders the configured "true" label for BooleanValue(true)', () => {
+		const wrapper = createWrapper( newBooleanValue( true ) );
+
+		expect( wrapper.text() ).toBe( 'Yes' );
+	} );
+
+	it( 'renders the configured "false" label for BooleanValue(false)', () => {
+		const wrapper = createWrapper( newBooleanValue( false ) );
+
+		expect( wrapper.text() ).toBe( 'No' );
+	} );
+
+	it( 'renders empty when given a string Value', () => {
+		const wrapper = createWrapper( newStringValue( 'not a boolean' ) );
+
+		expect( wrapper.text() ).toBe( '' );
+	} );
+
+	it( 'renders empty when given a number Value', () => {
+		const wrapper = createWrapper( newNumberValue( 1 ) );
+
+		expect( wrapper.text() ).toBe( '' );
+	} );
+
+	it( 'uses the i18n key neowiki-boolean-true for the true label', () => {
+		createWrapper( newBooleanValue( true ) );
+
+		expect( mw.message ).toHaveBeenCalledWith( 'neowiki-boolean-true' );
+	} );
+
+	it( 'uses the i18n key neowiki-boolean-false for the false label', () => {
+		createWrapper( newBooleanValue( false ) );
+
+		expect( mw.message ).toHaveBeenCalledWith( 'neowiki-boolean-false' );
+	} );
+} );

--- a/resources/ext.neowiki/tests/components/Value/BooleanInput.spec.ts
+++ b/resources/ext.neowiki/tests/components/Value/BooleanInput.spec.ts
@@ -1,0 +1,129 @@
+import { VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CdxField, CdxToggleSwitch } from '@wikimedia/codex';
+import { newBooleanValue, newStringValue, ValueType } from '@/domain/Value';
+import BooleanInput from '@/components/Value/BooleanInput.vue';
+import { newBooleanProperty, BooleanProperty } from '@/domain/propertyTypes/Boolean';
+import { ValueInputExposes, ValueInputProps } from '@/components/Value/ValueInputContract.ts';
+import { createTestWrapper } from '../../VueTestHelpers.ts';
+
+describe( 'BooleanInput', () => {
+	beforeEach( () => {
+		vi.stubGlobal( 'mw', {
+			message: vi.fn( ( str: string ) => ( {
+				text: () => str,
+				parse: () => str,
+			} ) ),
+		} );
+	} );
+
+	function newWrapper( props: Partial<ValueInputProps<BooleanProperty>> = {} ): VueWrapper {
+		return createTestWrapper( BooleanInput, {
+			modelValue: undefined,
+			label: 'Test Label',
+			property: newBooleanProperty( {} ),
+			...props,
+		} );
+	}
+
+	function getCurrentValue( wrapper: VueWrapper ): unknown {
+		return ( wrapper.vm as unknown as ValueInputExposes ).getCurrentValue();
+	}
+
+	it( 'renders a CdxToggleSwitch wrapped in a CdxField', () => {
+		const wrapper = newWrapper();
+
+		expect( wrapper.findComponent( CdxField ).exists() ).toBe( true );
+		expect( wrapper.findComponent( CdxToggleSwitch ).exists() ).toBe( true );
+		expect( wrapper.text() ).toContain( 'Test Label' );
+	} );
+
+	it( 'renders the toggle in the off position when modelValue is BooleanValue(false)', () => {
+		const wrapper = newWrapper( { modelValue: newBooleanValue( false ) } );
+
+		expect( wrapper.findComponent( CdxToggleSwitch ).props( 'modelValue' ) ).toBe( false );
+	} );
+
+	it( 'renders the toggle in the on position when modelValue is BooleanValue(true)', () => {
+		const wrapper = newWrapper( { modelValue: newBooleanValue( true ) } );
+
+		expect( wrapper.findComponent( CdxToggleSwitch ).props( 'modelValue' ) ).toBe( true );
+	} );
+
+	it( 'renders the toggle in the off position when modelValue is undefined', () => {
+		const wrapper = newWrapper( { modelValue: undefined } );
+
+		expect( wrapper.findComponent( CdxToggleSwitch ).props( 'modelValue' ) ).toBe( false );
+	} );
+
+	it( 'falls back to the off position when modelValue is the wrong value type', () => {
+		const wrapper = newWrapper( { modelValue: newStringValue( 'not a boolean' ) } );
+
+		expect( wrapper.findComponent( CdxToggleSwitch ).props( 'modelValue' ) ).toBe( false );
+	} );
+
+	it( 'emits BooleanValue(true) when the toggle is switched on', async () => {
+		const wrapper = newWrapper();
+
+		await wrapper.findComponent( CdxToggleSwitch ).vm.$emit( 'update:modelValue', true );
+
+		expect( wrapper.emitted( 'update:modelValue' )?.[ 0 ] ).toEqual( [ newBooleanValue( true ) ] );
+	} );
+
+	it( 'emits BooleanValue(false) when the toggle is switched off', async () => {
+		const wrapper = newWrapper( { modelValue: newBooleanValue( true ) } );
+
+		await wrapper.findComponent( CdxToggleSwitch ).vm.$emit( 'update:modelValue', false );
+
+		expect( wrapper.emitted( 'update:modelValue' )?.[ 0 ] ).toEqual( [ newBooleanValue( false ) ] );
+	} );
+
+	it( 'reacts to an external modelValue change', async () => {
+		const wrapper = newWrapper( { modelValue: newBooleanValue( false ) } );
+
+		await wrapper.setProps( { modelValue: newBooleanValue( true ) } );
+
+		expect( wrapper.findComponent( CdxToggleSwitch ).props( 'modelValue' ) ).toBe( true );
+	} );
+
+	describe( 'getCurrentValue', () => {
+		it( 'returns the initial BooleanValue(true) when modelValue is true', () => {
+			const wrapper = newWrapper( { modelValue: newBooleanValue( true ) } );
+
+			expect( getCurrentValue( wrapper ) ).toEqual( newBooleanValue( true ) );
+		} );
+
+		it( 'returns the initial BooleanValue(false) when modelValue is false', () => {
+			const wrapper = newWrapper( { modelValue: newBooleanValue( false ) } );
+
+			expect( getCurrentValue( wrapper ) ).toEqual( newBooleanValue( false ) );
+		} );
+
+		it( 'returns BooleanValue(false) for an untouched input with undefined modelValue', () => {
+			// Documents the "Boolean is never unset" design choice from PR #837:
+			// the input always emits a defined BooleanValue, defaulting to false
+			// when there is no model value yet.
+			const wrapper = newWrapper( { modelValue: undefined } );
+
+			expect( getCurrentValue( wrapper ) ).toEqual( newBooleanValue( false ) );
+		} );
+
+		it( 'returns the toggled value after the user switches the toggle on', async () => {
+			const wrapper = newWrapper( { modelValue: newBooleanValue( false ) } );
+
+			await wrapper.findComponent( CdxToggleSwitch ).vm.$emit( 'update:modelValue', true );
+
+			expect( getCurrentValue( wrapper ) ).toEqual( newBooleanValue( true ) );
+		} );
+	} );
+
+	it( 'emits a Value of type Boolean (not String or Number)', async () => {
+		const wrapper = newWrapper();
+
+		await wrapper.findComponent( CdxToggleSwitch ).vm.$emit( 'update:modelValue', true );
+
+		const events = wrapper.emitted( 'update:modelValue' );
+		const emitted = events?.[ 0 ]?.[ 0 ] as { type: ValueType } | undefined;
+		expect( emitted?.type ).toBe( ValueType.Boolean );
+	} );
+} );

--- a/resources/ext.neowiki/tests/domain/PropertyDefinitionDeserializer.unit.spec.ts
+++ b/resources/ext.neowiki/tests/domain/PropertyDefinitionDeserializer.unit.spec.ts
@@ -1,6 +1,6 @@
 import { expect, it } from 'vitest';
 import { PropertyDefinitionDeserializer } from '@/domain/PropertyDefinition';
-import { newStringValue } from '@/domain/Value';
+import { newBooleanValue, newNumberValue, newStringValue } from '@/domain/Value';
 import { TextProperty, TextType } from '@/domain/propertyTypes/Text';
 import { NumberProperty, NumberType } from '@/domain/propertyTypes/Number';
 import { RelationProperty, RelationType } from '@/domain/propertyTypes/Relation';
@@ -147,6 +147,54 @@ it( 'creates definitions with explicitly undefined default value', () => {
 		{
 			type: 'text',
 			default: undefined,
+		},
+	);
+
+	expect( property.default ).toBeUndefined();
+} );
+
+it( 'preserves default: false for a boolean property', () => {
+	const property = serializer.propertyDefinitionFromJson(
+		'test',
+		{
+			type: 'boolean',
+			default: false,
+		},
+	);
+
+	expect( property.default ).toEqual( newBooleanValue( false ) );
+} );
+
+it( 'preserves default: true for a boolean property', () => {
+	const property = serializer.propertyDefinitionFromJson(
+		'test',
+		{
+			type: 'boolean',
+			default: true,
+		},
+	);
+
+	expect( property.default ).toEqual( newBooleanValue( true ) );
+} );
+
+it( 'preserves default: 0 for a number property', () => {
+	const property = serializer.propertyDefinitionFromJson(
+		'test',
+		{
+			type: 'number',
+			default: 0,
+		},
+	);
+
+	expect( property.default ).toEqual( newNumberValue( 0 ) );
+} );
+
+it( 'treats default: null as no default', () => {
+	const property = serializer.propertyDefinitionFromJson(
+		'test',
+		{
+			type: 'boolean',
+			default: null,
 		},
 	);
 


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/837

Three follow-ups surfaced during code review of #837:

- `PropertyDefinitionDeserializer` was dropping `default: false`. The truthy check in `propertyDefinitionFromJson` discarded any falsy default (`false`, `0`). Pre-existing, but #837 was the first PR with demo data that exercises it (`Everything.json` ships `boolean (default false)`). Replaced with an explicit `undefined`/`null` guard and added regression tests for the false boolean, zero number, and null cases.
- `public-api.ts` was missing the three Boolean Vue components while every other property type re-exports its `*Display`, `*Input`, and `*AttributesEditor`. Added them for parity.
- Added specs for `BooleanInput`, `BooleanDisplay`, and `BooleanAttributesEditor` to lock down the current behavior of these components against future regressions.

## Surfaced but not changed

Two design concerns from the review are deliberately left as-is because they conflict with #837's explicit "a boolean is never 'unset'" choice and the deferred "hide `Require a value` for Boolean" follow-up referenced in the #837 description:

- `BooleanInput.getCurrentValue()` returns `BooleanValue(false)` for an untouched input with `modelValue === undefined`. Combined with `Schema.blankStatements()` not applying schema defaults, an untouched Boolean field in a new subject is persisted as `false`, overriding any schema `default: true`.
- `BooleanType.validate()` has an unreachable `required && value === undefined` branch.

Raising these properly should pair with the "hide `Require a value` for Boolean" follow-up since both touch the same per-type opt-out hook.

## Test plan

- [x] `make ts-test` — 87 files, 901 tests, all green
- [x] `make ts-lint` — clean
- [x] `make ts-build` — clean
- [x] `make cs` — phpcs + phpstan clean
- [x] `make phpunit` — 1032 tests, 1964 assertions, exit 0
- [x] New deserializer tests fail without the fix (verified: 2 RED before the one-line fix, 15 GREEN after)
- [x] `BooleanInput.spec.ts` catches a mutation in `toBoolean()` (verified: 5/13 fail when the boolean is inverted, then revert)

## Manual Browser Check

1. Open the Schema editor for the `Everything` demo schema (the one shipped in `DemoData/Schema/Everything.json`).
2. Find the `boolean/boolean (default false)` property; before this PR the Initial-value cell rendered empty because `default: false` was deserialized as `undefined`. After this PR it should render **No** (the `BooleanDisplay` "false" label).
3. Open the property in the editor, save without changes, and confirm the on-disk schema JSON still carries `"default": false` (no silent strip).
4. Reopen the schema in the editor afterwards and confirm the Initial-value control reflects the `false` state.