### PR TITLE
Boolean property: use CdxCheckbox instead of CdxToggleSwitch

### DIFF
--- a/resources/ext.neowiki/src/components/Value/BooleanInput.vue
+++ b/resources/ext.neowiki/src/components/Value/BooleanInput.vue
@@ -2,13 +2,19 @@
 	<CdxField
 		:status="validationError === null ? 'default' : 'error'"
 		:messages="validationError === null ? {} : { error: validationError }"
-		:hide-label="true"
+		:hide-label="!showFieldHeading"
 	>
+		<template
+			v-if="showFieldHeading"
+			#label
+		>
+			{{ props.label }}
+		</template>
 		<CdxCheckbox
 			:model-value="internalValue"
 			@update:model-value="onInput"
 		>
-			{{ props.label }}
+			{{ props.property.name.toString() }}
 			<CdxIcon
 				v-if="props.property.description"
 				v-tooltip="props.property.description"
@@ -25,7 +31,7 @@ import type { Value } from '@/domain/Value';
 </script>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { CdxCheckbox, CdxField, CdxIcon } from '@wikimedia/codex';
 import { cdxIconInfo } from '@wikimedia/codex-icons';
 import { newBooleanValue, BooleanValue, ValueType } from '@/domain/Value';
@@ -44,6 +50,10 @@ const props = withDefaults(
 const emit = defineEmits<ValueInputEmits>();
 
 const validationError = ref<string | null>( null );
+
+// Hide the heading when it would duplicate the inline checkbox label
+// (subject-editor case: the caller passes the property name as the label).
+const showFieldHeading = computed( () => props.label !== props.property.name.toString() );
 
 const toBoolean = ( value: Value | undefined ): boolean =>
 	value !== undefined && value.type === ValueType.Boolean ? ( value as BooleanValue ).boolean : false;

--- a/resources/ext.neowiki/src/components/Value/BooleanInput.vue
+++ b/resources/ext.neowiki/src/components/Value/BooleanInput.vue
@@ -4,10 +4,8 @@
 		:messages="validationError === null ? {} : { error: validationError }"
 		:hide-label="true"
 	>
-		<CdxToggleSwitch
+		<CdxCheckbox
 			:model-value="internalValue"
-			:align-switch="true"
-			:label="props.label"
 			@update:model-value="onInput"
 		>
 			{{ props.label }}
@@ -18,7 +16,7 @@
 				class="ext-neowiki-value-input__description-icon"
 				size="small"
 			/>
-		</CdxToggleSwitch>
+		</CdxCheckbox>
 	</CdxField>
 </template>
 
@@ -28,7 +26,7 @@ import type { Value } from '@/domain/Value';
 
 <script setup lang="ts">
 import { ref, watch } from 'vue';
-import { CdxField, CdxIcon, CdxToggleSwitch } from '@wikimedia/codex';
+import { CdxCheckbox, CdxField, CdxIcon } from '@wikimedia/codex';
 import { cdxIconInfo } from '@wikimedia/codex-icons';
 import { newBooleanValue, BooleanValue, ValueType } from '@/domain/Value';
 import { BooleanType, BooleanProperty } from '@/domain/propertyTypes/Boolean.ts';

--- a/resources/ext.neowiki/tests/components/Value/BooleanInput.spec.ts
+++ b/resources/ext.neowiki/tests/components/Value/BooleanInput.spec.ts
@@ -21,7 +21,7 @@ describe( 'BooleanInput', () => {
 		return createTestWrapper( BooleanInput, {
 			modelValue: undefined,
 			label: 'Test Label',
-			property: newBooleanProperty( {} ),
+			property: newBooleanProperty( { name: 'Is public' } ),
 			...props,
 		} );
 	}
@@ -30,12 +30,27 @@ describe( 'BooleanInput', () => {
 		return ( wrapper.vm as unknown as ValueInputExposes ).getCurrentValue();
 	}
 
-	it( 'renders a CdxCheckbox wrapped in a CdxField', () => {
+	it( 'renders a CdxCheckbox wrapped in a CdxField, inline-labelled with the property name', () => {
 		const wrapper = newWrapper();
 
 		expect( wrapper.findComponent( CdxField ).exists() ).toBe( true );
 		expect( wrapper.findComponent( CdxCheckbox ).exists() ).toBe( true );
-		expect( wrapper.text() ).toContain( 'Test Label' );
+		expect( wrapper.findComponent( CdxCheckbox ).text() ).toContain( 'Is public' );
+	} );
+
+	it( 'shows the caller-supplied label as the field heading when it differs from the property name (schema-editor case)', () => {
+		const wrapper = newWrapper( { label: 'Initial value' } );
+
+		expect( wrapper.findComponent( CdxField ).props( 'hideLabel' ) ).toBe( false );
+		expect( wrapper.text() ).toContain( 'Initial value' );
+		expect( wrapper.findComponent( CdxCheckbox ).text() ).toContain( 'Is public' );
+	} );
+
+	it( 'hides the field heading when the caller-supplied label equals the property name (subject-editor case)', () => {
+		const wrapper = newWrapper( { label: 'Is public' } );
+
+		expect( wrapper.findComponent( CdxField ).props( 'hideLabel' ) ).toBe( true );
+		expect( wrapper.findComponent( CdxCheckbox ).text() ).toContain( 'Is public' );
 	} );
 
 	it( 'renders the checkbox unchecked when modelValue is BooleanValue(false)', () => {

--- a/resources/ext.neowiki/tests/components/Value/BooleanInput.spec.ts
+++ b/resources/ext.neowiki/tests/components/Value/BooleanInput.spec.ts
@@ -1,6 +1,6 @@
 import { VueWrapper } from '@vue/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { CdxField, CdxToggleSwitch } from '@wikimedia/codex';
+import { CdxCheckbox, CdxField } from '@wikimedia/codex';
 import { newBooleanValue, newStringValue, ValueType } from '@/domain/Value';
 import BooleanInput from '@/components/Value/BooleanInput.vue';
 import { newBooleanProperty, BooleanProperty } from '@/domain/propertyTypes/Boolean';
@@ -30,50 +30,50 @@ describe( 'BooleanInput', () => {
 		return ( wrapper.vm as unknown as ValueInputExposes ).getCurrentValue();
 	}
 
-	it( 'renders a CdxToggleSwitch wrapped in a CdxField', () => {
+	it( 'renders a CdxCheckbox wrapped in a CdxField', () => {
 		const wrapper = newWrapper();
 
 		expect( wrapper.findComponent( CdxField ).exists() ).toBe( true );
-		expect( wrapper.findComponent( CdxToggleSwitch ).exists() ).toBe( true );
+		expect( wrapper.findComponent( CdxCheckbox ).exists() ).toBe( true );
 		expect( wrapper.text() ).toContain( 'Test Label' );
 	} );
 
-	it( 'renders the toggle in the off position when modelValue is BooleanValue(false)', () => {
+	it( 'renders the checkbox unchecked when modelValue is BooleanValue(false)', () => {
 		const wrapper = newWrapper( { modelValue: newBooleanValue( false ) } );
 
-		expect( wrapper.findComponent( CdxToggleSwitch ).props( 'modelValue' ) ).toBe( false );
+		expect( wrapper.findComponent( CdxCheckbox ).props( 'modelValue' ) ).toBe( false );
 	} );
 
-	it( 'renders the toggle in the on position when modelValue is BooleanValue(true)', () => {
+	it( 'renders the checkbox checked when modelValue is BooleanValue(true)', () => {
 		const wrapper = newWrapper( { modelValue: newBooleanValue( true ) } );
 
-		expect( wrapper.findComponent( CdxToggleSwitch ).props( 'modelValue' ) ).toBe( true );
+		expect( wrapper.findComponent( CdxCheckbox ).props( 'modelValue' ) ).toBe( true );
 	} );
 
-	it( 'renders the toggle in the off position when modelValue is undefined', () => {
+	it( 'renders the checkbox unchecked when modelValue is undefined', () => {
 		const wrapper = newWrapper( { modelValue: undefined } );
 
-		expect( wrapper.findComponent( CdxToggleSwitch ).props( 'modelValue' ) ).toBe( false );
+		expect( wrapper.findComponent( CdxCheckbox ).props( 'modelValue' ) ).toBe( false );
 	} );
 
-	it( 'falls back to the off position when modelValue is the wrong value type', () => {
+	it( 'falls back to unchecked when modelValue is the wrong value type', () => {
 		const wrapper = newWrapper( { modelValue: newStringValue( 'not a boolean' ) } );
 
-		expect( wrapper.findComponent( CdxToggleSwitch ).props( 'modelValue' ) ).toBe( false );
+		expect( wrapper.findComponent( CdxCheckbox ).props( 'modelValue' ) ).toBe( false );
 	} );
 
-	it( 'emits BooleanValue(true) when the toggle is switched on', async () => {
+	it( 'emits BooleanValue(true) when the checkbox is checked', async () => {
 		const wrapper = newWrapper();
 
-		await wrapper.findComponent( CdxToggleSwitch ).vm.$emit( 'update:modelValue', true );
+		await wrapper.findComponent( CdxCheckbox ).vm.$emit( 'update:modelValue', true );
 
 		expect( wrapper.emitted( 'update:modelValue' )?.[ 0 ] ).toEqual( [ newBooleanValue( true ) ] );
 	} );
 
-	it( 'emits BooleanValue(false) when the toggle is switched off', async () => {
+	it( 'emits BooleanValue(false) when the checkbox is unchecked', async () => {
 		const wrapper = newWrapper( { modelValue: newBooleanValue( true ) } );
 
-		await wrapper.findComponent( CdxToggleSwitch ).vm.$emit( 'update:modelValue', false );
+		await wrapper.findComponent( CdxCheckbox ).vm.$emit( 'update:modelValue', false );
 
 		expect( wrapper.emitted( 'update:modelValue' )?.[ 0 ] ).toEqual( [ newBooleanValue( false ) ] );
 	} );
@@ -83,7 +83,7 @@ describe( 'BooleanInput', () => {
 
 		await wrapper.setProps( { modelValue: newBooleanValue( true ) } );
 
-		expect( wrapper.findComponent( CdxToggleSwitch ).props( 'modelValue' ) ).toBe( true );
+		expect( wrapper.findComponent( CdxCheckbox ).props( 'modelValue' ) ).toBe( true );
 	} );
 
 	describe( 'getCurrentValue', () => {
@@ -108,10 +108,10 @@ describe( 'BooleanInput', () => {
 			expect( getCurrentValue( wrapper ) ).toEqual( newBooleanValue( false ) );
 		} );
 
-		it( 'returns the toggled value after the user switches the toggle on', async () => {
+		it( 'returns the new value after the user checks the checkbox', async () => {
 			const wrapper = newWrapper( { modelValue: newBooleanValue( false ) } );
 
-			await wrapper.findComponent( CdxToggleSwitch ).vm.$emit( 'update:modelValue', true );
+			await wrapper.findComponent( CdxCheckbox ).vm.$emit( 'update:modelValue', true );
 
 			expect( getCurrentValue( wrapper ) ).toEqual( newBooleanValue( true ) );
 		} );
@@ -120,7 +120,7 @@ describe( 'BooleanInput', () => {
 	it( 'emits a Value of type Boolean (not String or Number)', async () => {
 		const wrapper = newWrapper();
 
-		await wrapper.findComponent( CdxToggleSwitch ).vm.$emit( 'update:modelValue', true );
+		await wrapper.findComponent( CdxCheckbox ).vm.$emit( 'update:modelValue', true );
 
 		const events = wrapper.emitted( 'update:modelValue' );
 		const emitted = events?.[ 0 ]?.[ 0 ] as { type: ValueType } | undefined;


### PR DESCRIPTION
Closes #849.

## Context

PR #837 introduced the Boolean property type with `BooleanInput.vue` rendering as `CdxToggleSwitch`. Codex's [ToggleSwitch usage guideline](https://doc.wikimedia.org/codex/latest/components/demos/toggle-switch.html#when-to-use-toggleswitch) states:

> Use the ToggleSwitch component only where an instant change in the user-interface based on their assigned action is intended. For non-instant selections and selection groups, use Checkbox instead.

`BooleanInput` is used in two non-instant contexts:

- Subject editor (form gated by Save).
- Schema editor's "Initial value" control (also gated by Save inside the schema-editor dialog).

Both fit the "non-instant selection" case, so Checkbox is the guideline-correct widget.

## Change

Swap `CdxToggleSwitch` for `CdxCheckbox` in `BooleanInput.vue`. Same `:model-value` and `@update:model-value` wiring; no change to the emitted `BooleanValue(true/false)` shape, the checked-iff-`modelValue.boolean === true` rule, or the default-to-`false` behaviour for `undefined` / wrong-type input.

### Why the field labelling differs across call sites

`BooleanInput` renders in two places that semantically show different things:

- **Subject editor.** The checkbox *is* the property's value for this subject. The property name (e.g. `Is public`) is the natural label for the checkbox itself; `[ ] Is public` reads as "this subject's `Is public` is / isn't set". No separate top-of-field heading is needed.
- **Schema editor (Initial value field).** Here the Boolean isn't a value of the property; it's the *initial value* that will be used when a new subject is created. The field renders the way every other property type's initial-value widget renders: an "Initial value" heading at the top, the type's value widget (the checkbox) below.

So the same `BooleanInput` carries an inline checkbox label *always* (the property name) and a CdxField `#label` heading *conditionally*: shown when the caller-supplied `props.label` differs from the property name (the schema-editor case, where `props.label` is "Initial value"); suppressed when they match (the subject-editor case, where the caller passes the property name as the label and the heading would just repeat the inline checkbox label).

### Why CdxToggleSwitch didn't need this machinery

The toggle implementation in PR #837 had no CdxField heading. `align-switch="true"` rendered the toggle's slot content to the *left* of the switch, giving every row a `Label [O ]` shape. The schema-editor row read `Initial value [O ]` and visually rhymed with `Require a value [O ]` right above it; the widget itself handled the label-first layout, so no separate heading slot was needed.

`CdxCheckbox` has no equivalent of `align-switch`. It always renders as `[ ] Label`, box on the left and label to its right. A bare toggle→checkbox swap therefore makes the schema-editor row read `[ ] Initial value` hugging the left edge, with no top heading and no visual continuity with `Name` / `Type` / `Description` above. To restore a "heading on top, control below" rhythm in the schema editor, the `Initial value` text has to live somewhere other than the checkbox's own slot. That somewhere is the CdxField `#label` slot, conditionally shown as described above.

`:optional` is intentionally not set on the CdxField: a Boolean value is always defined ("never unset" per PR #837), so an "(optional)" affordance would be misleading.

## Screenshots

| | |
|---|---|
| **Schema editor: Boolean property editor.** The property-definition form shows the Boolean property's row with "Initial value" as a top heading (matching Name / Type / Description above) and `[ ] Is public` as the checkbox below. | <img width="574" height="696" alt="849-9-schema-editor-property-only" src="https://github.com/user-attachments/assets/6f0afef0-e2ba-438f-9635-4c5c41ddb211" /> |
| **Subject editor: full dialog.** ACME Inc edit dialog with `Is public` as the only boolean property; rendered as a checkbox. | <img width="512" height="1040" alt="849-4-subject-editor-full" src="https://github.com/user-attachments/assets/847b3c9b-32eb-4f28-abc2-391a3c502561" /> |

## Test plan

- [x] TS unit tests for `BooleanInput` updated to assert `CdxCheckbox` (not `CdxToggleSwitch`), the inline checkbox label is the property name, and the heading-shown / heading-hidden branches both behave correctly. The behavioural assertions (modelValue prop binding, emit on update, BooleanValue emission, default-to-false, type-mismatch fallback, external-modelValue reactivity, `getCurrentValue`) are unchanged.
- [x] Updated tests fail against the toggle implementation and pass against the checkbox implementation.
- [x] Full TS suite passes.
- [x] Build clean; ESLint + Stylelint clean.
- [x] UI (Playwright), schema editor: "Is public" property's Initial value renders as `CdxCheckbox`; "Require a value" still renders as `CdxToggleSwitch` (unchanged).
- [x] UI (Playwright), subject editor (ACME Inc): "Is public" renders as `CdxCheckbox`; modelValue=true → checkbox checked; 0 console errors during interaction.









