### PR TITLE
Schema Editor: replace toggle switches with checkboxes

### DIFF
--- a/resources/ext.neowiki/src/components/SchemaEditor/Property/SelectAttributesEditor.vue
+++ b/resources/ext.neowiki/src/components/SchemaEditor/Property/SelectAttributesEditor.vue
@@ -2,14 +2,12 @@
 	<!-- cdx-field class is used for spacing -->
 	<div class="select-attributes cdx-field">
 		<CdxField :hide-label="true">
-			<CdxToggleSwitch
+			<CdxCheckbox
 				:model-value="property.multiple"
-				:align-switch="true"
-				:label="$i18n( 'neowiki-property-editor-multiple' ).text()"
 				@update:model-value="updateMultiple"
 			>
 				{{ $i18n( 'neowiki-property-editor-multiple' ).text() }}
-			</CdxToggleSwitch>
+			</CdxCheckbox>
 		</CdxField>
 
 		<CdxField>
@@ -33,7 +31,7 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue';
-import { CdxChipInput, CdxField, CdxToggleSwitch } from '@wikimedia/codex';
+import { CdxCheckbox, CdxChipInput, CdxField } from '@wikimedia/codex';
 import type { ChipInputItem } from '@wikimedia/codex';
 import { SelectOption, SelectProperty } from '@/domain/propertyTypes/Select.ts';
 import { AttributesEditorEmits, AttributesEditorProps } from '@/components/SchemaEditor/Property/AttributesEditorContract.ts';

--- a/resources/ext.neowiki/src/components/SchemaEditor/Property/TextAttributesEditor.vue
+++ b/resources/ext.neowiki/src/components/SchemaEditor/Property/TextAttributesEditor.vue
@@ -2,28 +2,24 @@
 	<!-- cdx-field class is used for spacing -->
 	<div class="text-attributes cdx-field">
 		<CdxField :hide-label="true">
-			<CdxToggleSwitch
+			<CdxCheckbox
 				:model-value="property.multiple"
-				:align-switch="true"
-				:label="$i18n( 'neowiki-property-editor-multiple' ).text()"
 				@update:model-value="updateMultiple"
 			>
 				{{ $i18n( 'neowiki-property-editor-multiple' ).text() }}
-			</CdxToggleSwitch>
+			</CdxCheckbox>
 		</CdxField>
 
 		<CdxField
 			v-if="property.multiple"
 			:hide-label="true"
 		>
-			<CdxToggleSwitch
+			<CdxCheckbox
 				:model-value="property.uniqueItems"
-				:align-switch="true"
-				:label="$i18n( 'neowiki-property-editor-unique-items' ).text()"
 				@update:model-value="updateUniqueItems"
 			>
 				{{ $i18n( 'neowiki-property-editor-unique-items' ).text() }}
-			</CdxToggleSwitch>
+			</CdxCheckbox>
 		</CdxField>
 
 		<NeoNestedField :optional="true">
@@ -70,7 +66,7 @@
 import { ref, watch } from 'vue';
 import { TextProperty } from '@/domain/propertyTypes/Text.ts';
 import { AttributesEditorEmits, AttributesEditorProps } from '@/components/SchemaEditor/Property/AttributesEditorContract.ts';
-import { CdxToggleSwitch, CdxField, CdxTextInput } from '@wikimedia/codex';
+import { CdxCheckbox, CdxField, CdxTextInput } from '@wikimedia/codex';
 import { minExceedsMax } from '@/components/SchemaEditor/Property/minExceedsMax.ts';
 import NeoNestedField from '@/components/common/NeoNestedField.vue';
 

--- a/resources/ext.neowiki/src/components/SchemaEditor/Property/UrlAttributesEditor.vue
+++ b/resources/ext.neowiki/src/components/SchemaEditor/Property/UrlAttributesEditor.vue
@@ -2,28 +2,24 @@
 	<!-- cdx-field class is used for spacing -->
 	<div class="url-attributes cdx-field">
 		<CdxField :hide-label="true">
-			<CdxToggleSwitch
+			<CdxCheckbox
 				:model-value="property.multiple"
-				:align-switch="true"
-				:label="$i18n( 'neowiki-property-editor-multiple' ).text()"
 				@update:model-value="updateMultiple"
 			>
 				{{ $i18n( 'neowiki-property-editor-multiple' ).text() }}
-			</CdxToggleSwitch>
+			</CdxCheckbox>
 		</CdxField>
 
 		<CdxField
 			v-if="property.multiple"
 			:hide-label="true"
 		>
-			<CdxToggleSwitch
+			<CdxCheckbox
 				:model-value="property.uniqueItems"
-				:align-switch="true"
-				:label="$i18n( 'neowiki-property-editor-unique-items' ).text()"
 				@update:model-value="updateUniqueItems"
 			>
 				{{ $i18n( 'neowiki-property-editor-unique-items' ).text() }}
-			</CdxToggleSwitch>
+			</CdxCheckbox>
 		</CdxField>
 	</div>
 </template>
@@ -31,7 +27,7 @@
 <script setup lang="ts">
 import { UrlProperty } from '@/domain/propertyTypes/Url.ts';
 import { AttributesEditorEmits, AttributesEditorProps } from '@/components/SchemaEditor/Property/AttributesEditorContract.ts';
-import { CdxToggleSwitch, CdxField } from '@wikimedia/codex';
+import { CdxCheckbox, CdxField } from '@wikimedia/codex';
 
 defineProps<AttributesEditorProps<UrlProperty>>();
 const emit = defineEmits<AttributesEditorEmits<UrlProperty>>();

--- a/resources/ext.neowiki/src/components/SchemaEditor/PropertyDefinitionEditor.vue
+++ b/resources/ext.neowiki/src/components/SchemaEditor/PropertyDefinitionEditor.vue
@@ -32,12 +32,9 @@
 		</CdxField>
 
 		<CdxField :hide-label="true">
-			<CdxToggleSwitch
-				v-model="localProperty.required"
-				:align-switch="true"
-			>
+			<CdxCheckbox v-model="localProperty.required">
 				{{ $i18n( 'neowiki-property-editor-required' ).text() }}
-			</CdxToggleSwitch>
+			</CdxCheckbox>
 		</CdxField>
 
 		<component
@@ -57,7 +54,7 @@
 
 <script setup lang="ts">
 import { PropertyDefinition, PropertyName } from '@/domain/PropertyDefinition.ts';
-import { CdxField, CdxSelect, CdxTextArea, CdxTextInput, CdxToggleSwitch } from '@wikimedia/codex';
+import { CdxCheckbox, CdxField, CdxSelect, CdxTextArea, CdxTextInput } from '@wikimedia/codex';
 import { NeoWikiServices } from '@/NeoWikiServices.ts';
 import { nextTick, onMounted, ref, watch } from 'vue';
 

--- a/resources/ext.neowiki/tests/components/SchemaEditor/Property/TextAttributesEditor.spec.ts
+++ b/resources/ext.neowiki/tests/components/SchemaEditor/Property/TextAttributesEditor.spec.ts
@@ -49,10 +49,10 @@ describe( 'TextAttributesEditor', () => {
 			const wrapper = newWrapper( {
 				property: newTextProperty( { multiple: true, uniqueItems: false } ),
 			} );
-			const toggles = wrapper.findAll( 'input[type="checkbox"]' );
+			const checkboxes = wrapper.findAll( 'input[type="checkbox"]' );
 
-			expect( ( toggles[ 0 ].element as HTMLInputElement ).checked ).toBe( true );
-			expect( ( toggles[ 1 ].element as HTMLInputElement ).checked ).toBe( false );
+			expect( ( checkboxes[ 0 ].element as HTMLInputElement ).checked ).toBe( true );
+			expect( ( checkboxes[ 1 ].element as HTMLInputElement ).checked ).toBe( false );
 		} );
 	} );
 

--- a/resources/ext.neowiki/tests/components/SchemaEditor/Property/UrlAttributesEditor.spec.ts
+++ b/resources/ext.neowiki/tests/components/SchemaEditor/Property/UrlAttributesEditor.spec.ts
@@ -19,30 +19,30 @@ describe( 'UrlAttributesEditor', () => {
 			const wrapper = newWrapper( {
 				property: newUrlProperty( { multiple: true, uniqueItems: false } ),
 			} );
-			const toggles = wrapper.findAll( 'input[type="checkbox"]' );
+			const checkboxes = wrapper.findAll( 'input[type="checkbox"]' );
 
-			expect( ( toggles[ 0 ].element as HTMLInputElement ).checked ).toBe( true );
-			expect( ( toggles[ 1 ].element as HTMLInputElement ).checked ).toBe( false );
+			expect( ( checkboxes[ 0 ].element as HTMLInputElement ).checked ).toBe( true );
+			expect( ( checkboxes[ 1 ].element as HTMLInputElement ).checked ).toBe( false );
 		} );
 	} );
 
 	describe( 'conditional display', () => {
-		it( 'hides uniqueItems toggle when multiple is false', () => {
+		it( 'hides uniqueItems checkbox when multiple is false', () => {
 			const wrapper = newWrapper( {
 				property: newUrlProperty( { multiple: false } ),
 			} );
-			const toggles = wrapper.findAll( 'input[type="checkbox"]' );
+			const checkboxes = wrapper.findAll( 'input[type="checkbox"]' );
 
-			expect( toggles ).toHaveLength( 1 );
+			expect( checkboxes ).toHaveLength( 1 );
 		} );
 
-		it( 'shows uniqueItems toggle when multiple is true', () => {
+		it( 'shows uniqueItems checkbox when multiple is true', () => {
 			const wrapper = newWrapper( {
 				property: newUrlProperty( { multiple: true } ),
 			} );
-			const toggles = wrapper.findAll( 'input[type="checkbox"]' );
+			const checkboxes = wrapper.findAll( 'input[type="checkbox"]' );
 
-			expect( toggles ).toHaveLength( 2 );
+			expect( checkboxes ).toHaveLength( 2 );
 		} );
 	} );
 
@@ -60,9 +60,9 @@ describe( 'UrlAttributesEditor', () => {
 			const wrapper = newWrapper( {
 				property: newUrlProperty( { multiple: true, uniqueItems: true } ),
 			} );
-			const toggles = wrapper.findAll( 'input[type="checkbox"]' );
+			const checkboxes = wrapper.findAll( 'input[type="checkbox"]' );
 
-			await toggles[ 1 ].setValue( false );
+			await checkboxes[ 1 ].setValue( false );
 
 			expect( wrapper.emitted( 'update:property' ) ).toBeTruthy();
 			expect( wrapper.emitted( 'update:property' )?.[ 0 ] ).toEqual( [ { uniqueItems: false } ] );


### PR DESCRIPTION
Closes #851. Follow-up to #850 (which covered the Boolean property value widget).

## Context

Codex's [ToggleSwitch usage guideline](https://doc.wikimedia.org/codex/latest/components/demos/toggle-switch.html#when-to-use-toggleswitch):

> Use the ToggleSwitch component only where an instant change in the user-interface based on their assigned action is intended. For non-instant selections and selection groups, use Checkbox instead.

#849 / #850 applied this to `BooleanInput`. The Schema Editor's property-definition dialog still used `CdxToggleSwitch` for its remaining boolean controls, even though the dialog is Save-gated and none of these are instant-change. They are the same "non-instant selection" case and should also be Checkbox.

## Change

Swap `CdxToggleSwitch` for `CdxCheckbox` in:

- `SchemaEditor/PropertyDefinitionEditor.vue`: "Require a value".
- `SchemaEditor/Property/TextAttributesEditor.vue`: "Multiple values", "Unique items".
- `SchemaEditor/Property/UrlAttributesEditor.vue`: "Multiple values", "Unique items".
- `SchemaEditor/Property/SelectAttributesEditor.vue`: "Multiple values".

Existing `:model-value` / `@update:model-value` wiring is preserved. The `align-switch` attribute and the redundant `:label` prop (the slot already carries the visible text) are dropped because `CdxCheckbox` always renders `[ ] Label`. The `<CdxField :hide-label="true">` spacing wrappers stay, matching the post-#850 shape used by `BooleanInput`.

`v-if="property.multiple"` on the "Unique items" rows is preserved.

## Why the controls don't need extra CdxField heading machinery

`BooleanInput` (in #850) needed a conditional CdxField `#label` because it lives in two contexts: the subject editor (inline checkbox label = property name, no heading) vs. the schema editor's "Initial value" field (heading + inline label differ). The toggles in this PR have always been `:hide-label="true"` with the descriptive text living on the control itself. `CdxCheckbox` carries that slot text directly as its label, so no headings are needed and the row visually rhymes with the Initial-value checkbox added in #850.

## Test changes

In `TextAttributesEditor.spec.ts` and `UrlAttributesEditor.spec.ts` the local `toggles` variable is renamed to `checkboxes` to match the new reality. The behavioural assertions (DOM-checkbox selection, value reflection, emit on change, conditional rendering of "Unique items") are framework-agnostic and were already in place; they continue to pin the relevant contract on both the pre-swap and post-swap code.

## Out of scope

- The `BooleanInput` value widget (already done in #850).
- Any visual redesign of the Schema Editor beyond the toggle/checkbox swap.
- Filling the pre-existing unit-test gap for `SelectAttributesEditor` and `PropertyDefinitionEditor` (neither had a spec before this PR; both gaps pre-date the swap and are left for a follow-up).

## Test plan

- [x] Existing TS unit tests still pass; the rename in Text/Url specs does not change any assertion.
- [x] Full TS suite passes.
- [x] Build clean (`vue-tsc -b && vite build`).
- [x] Lint clean (eslint + stylelint).
- [x] UI (Playwright), schema editor: Text, URL, and Select property editors render `CdxCheckbox` (zero `CdxToggleSwitch` elements). The required checkbox renders on all property types via `PropertyDefinitionEditor`. Toggling "Allow multiple values" on a Text property shows/hides the "Values must be unique" checkbox correctly.
- [x] UI (Playwright), end-to-end Save chain: toggled the required, multiple, and uniqueItems controls on a Text property and the multiple control on a Select property; Save + page reload preserves each new value. Toggled them all back to false and verified the down-path persists symmetrically. Zero console errors during interaction.

## Screenshots

| | |
|---|---|
| **Text property: multiple checked.** Required + multiple + uniqueItems all render as checkboxes. | <img width="574" height="696" alt="text-property-editor-with-multiple" src="https://github.com/user-attachments/assets/6f324755-ca43-49a2-a975-67b756269454" /> |
| **Text property: multiple unchecked.** Same editor with multiple off; uniqueItems is hidden as expected. | <img width="574" height="696" alt="text-property-editor-no-multiple" src="https://github.com/user-attachments/assets/2e2b0b68-b942-4b6f-ac4f-9fa420820847" /> |
| **URL property: multiple checked.** Required + multiple + uniqueItems all render as checkboxes. | <img width="574" height="696" alt="url-property-editor-with-multiple" src="https://github.com/user-attachments/assets/5c36677c-59d9-401c-aa4e-6af98882b53c" /> |
| **Select property: multiple checked.** Required + multiple render as checkboxes (uniqueItems is not a Select attribute). | <img width="574" height="696" alt="select-property-editor-with-multiple" src="https://github.com/user-attachments/assets/66566841-8769-4b67-9143-c0cbb149b37a" /> |






