### PR TITLE
Add InMemorySubjectContentRepository test double

### DIFF
--- a/src/Application/SubjectContentRepository.php
+++ b/src/Application/SubjectContentRepository.php
@@ -1,0 +1,25 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application;
+
+use MediaWiki\Page\PageIdentity;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+use ProfessionalWiki\NeoWiki\EntryPoints\Content\SubjectContent;
+
+interface SubjectContentRepository {
+
+	public function getSubjectContentByPageId( PageId $pageId ): ?SubjectContent;
+
+	public function getSubjectContentByPageTitle( PageIdentity $pageIdentity ): ?SubjectContent;
+
+	public function getSubjectContentByRevisionId( int $revisionId ): ?SubjectContent;
+
+	public function editSubjectContent(
+		SubjectContent $subjectContent,
+		PageId $pageId,
+		string $editSummary
+	): void;
+
+}

--- a/src/Application/SubjectResolver.php
+++ b/src/Application/SubjectResolver.php
@@ -9,7 +9,6 @@ use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
 use ProfessionalWiki\NeoWiki\Domain\Relation\Relation;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
-use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\SubjectContentRepository;
 
 class SubjectResolver {
 

--- a/src/EntryPoints/ViewParserFunction.php
+++ b/src/EntryPoints/ViewParserFunction.php
@@ -5,7 +5,7 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\EntryPoints;
 
 use MediaWiki\Parser\Parser;
-use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\SubjectContentRepository;
+use ProfessionalWiki\NeoWiki\Application\SubjectContentRepository;
 use ProfessionalWiki\NeoWiki\Presentation\ViewHtmlBuilder;
 
 class ViewParserFunction {

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -27,6 +27,7 @@ use ProfessionalWiki\NeoWiki\Application\Actions\ReplaceSubject\ReplaceSubjectAc
 use ProfessionalWiki\NeoWiki\Application\StatementListBuilder;
 use ProfessionalWiki\NeoWiki\Application\PageIdentifiersLookup;
 use ProfessionalWiki\NeoWiki\Application\PageSubjectsLookup;
+use ProfessionalWiki\NeoWiki\Application\SubjectContentRepository;
 use ProfessionalWiki\NeoWiki\Application\Queries\GetSchema\GetSchemaPresenter;
 use ProfessionalWiki\NeoWiki\Application\Queries\GetSchema\GetSchemaQuery;
 use ProfessionalWiki\NeoWiki\Application\Queries\GetLayout\GetLayoutPresenter;
@@ -71,11 +72,11 @@ use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\DatabaseSchemaNameLookup;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\PageContentFetcher;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\PageContentSaver;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\SchemaPersistenceDeserializer;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\MediaWikiSubjectContentRepository;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\MediaWikiSubjectRepository;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\PointInTimeSubjectLookup;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\StatementDeserializer;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\SubjectContentDataDeserializer;
-use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\SubjectContentRepository;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\LayoutPersistenceDeserializer;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\WikiPageSchemaLookup;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\WikiPageLayoutLookup;
@@ -311,7 +312,7 @@ class NeoWikiExtension {
 	}
 
 	public function newSubjectContentRepository(): SubjectContentRepository {
-		return new SubjectContentRepository(
+		return new MediaWikiSubjectContentRepository(
 			wikiPageFactory: MediaWikiServices::getInstance()->getWikiPageFactory(),
 			authority: RequestContext::getMain()->getUser(),
 			pageContentSaver: $this->getPageContentSaver(),

--- a/src/Persistence/MediaWiki/Subject/MediaWikiSubjectContentRepository.php
+++ b/src/Persistence/MediaWiki/Subject/MediaWikiSubjectContentRepository.php
@@ -11,13 +11,14 @@ use MediaWiki\Permissions\Authority;
 use MediaWiki\Revision\RevisionAccessException;
 use MediaWiki\Revision\RevisionLookup;
 use MediaWiki\Revision\RevisionRecord;
+use ProfessionalWiki\NeoWiki\Application\SubjectContentRepository;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\EntryPoints\Content\SubjectContent;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\PageContentSaver;
 use RuntimeException;
 use WikiPage;
 
-class SubjectContentRepository {
+class MediaWikiSubjectContentRepository implements SubjectContentRepository {
 
 	public function __construct(
 		private readonly WikiPageFactory $wikiPageFactory,

--- a/src/Presentation/ViewHtmlBuilder.php
+++ b/src/Presentation/ViewHtmlBuilder.php
@@ -6,8 +6,8 @@ namespace ProfessionalWiki\NeoWiki\Presentation;
 
 use MediaWiki\Html\Html;
 use MediaWiki\Title\Title;
+use ProfessionalWiki\NeoWiki\Application\SubjectContentRepository;
 use ProfessionalWiki\NeoWiki\EntryPoints\Content\SubjectContent;
-use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\SubjectContentRepository;
 
 class ViewHtmlBuilder {
 

--- a/tests/phpunit/Application/SubjectResolverTest.php
+++ b/tests/phpunit/Application/SubjectResolverTest.php
@@ -18,8 +18,7 @@ use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectMap;
-use ProfessionalWiki\NeoWiki\EntryPoints\Content\SubjectContent;
-use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\SubjectContentRepository;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectContentRepository;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\Application\SubjectResolver
@@ -38,23 +37,8 @@ class SubjectResolverTest extends TestCase {
 		);
 	}
 
-	private function createRepositoryWithMainSubject( Subject $subject ): SubjectContentRepository {
-		$pageSubjects = new PageSubjects( $subject, new SubjectMap() );
-
-		$subjectContent = $this->createStub( SubjectContent::class );
-		$subjectContent->method( 'getPageSubjects' )->willReturn( $pageSubjects );
-
-		$repo = $this->createStub( SubjectContentRepository::class );
-		$repo->method( 'getSubjectContentByPageTitle' )->willReturn( $subjectContent );
-
-		return $repo;
-	}
-
-	private function createEmptyRepository(): SubjectContentRepository {
-		$repo = $this->createStub( SubjectContentRepository::class );
-		$repo->method( 'getSubjectContentByPageTitle' )->willReturn( null );
-
-		return $repo;
+	private function repositoryWithMainSubject( Subject $subject ): InMemorySubjectContentRepository {
+		return new InMemorySubjectContentRepository( new PageSubjects( $subject, new SubjectMap() ) );
 	}
 
 	public function testResolveByIdReturnsSubject(): void {
@@ -63,14 +47,14 @@ class SubjectResolverTest extends TestCase {
 		$lookup = $this->createStub( SubjectLookup::class );
 		$lookup->method( 'getSubject' )->willReturn( $subject );
 
-		$resolver = new SubjectResolver( $this->createEmptyRepository(), $lookup );
+		$resolver = new SubjectResolver( new InMemorySubjectContentRepository(), $lookup );
 
 		$this->assertSame( $subject, $resolver->resolveById( self::SUBJECT_ID ) );
 	}
 
 	public function testResolveByIdReturnsNullForInvalidId(): void {
 		$resolver = new SubjectResolver(
-			$this->createEmptyRepository(),
+			new InMemorySubjectContentRepository(),
 			$this->createStub( SubjectLookup::class )
 		);
 
@@ -81,7 +65,7 @@ class SubjectResolverTest extends TestCase {
 		$lookup = $this->createStub( SubjectLookup::class );
 		$lookup->method( 'getSubject' )->willReturn( null );
 
-		$resolver = new SubjectResolver( $this->createEmptyRepository(), $lookup );
+		$resolver = new SubjectResolver( new InMemorySubjectContentRepository(), $lookup );
 
 		$this->assertNull( $resolver->resolveById( self::SUBJECT_ID ) );
 	}
@@ -90,7 +74,7 @@ class SubjectResolverTest extends TestCase {
 		$lookup = $this->createStub( SubjectLookup::class );
 		$lookup->method( 'getSubject' )->willThrowException( new \RuntimeException( 'db error' ) );
 
-		$resolver = new SubjectResolver( $this->createEmptyRepository(), $lookup );
+		$resolver = new SubjectResolver( new InMemorySubjectContentRepository(), $lookup );
 
 		$this->assertNull( $resolver->resolveById( self::SUBJECT_ID ) );
 	}
@@ -99,7 +83,7 @@ class SubjectResolverTest extends TestCase {
 		$subject = $this->createSubject();
 
 		$resolver = new SubjectResolver(
-			$this->createRepositoryWithMainSubject( $subject ),
+			$this->repositoryWithMainSubject( $subject ),
 			$this->createStub( SubjectLookup::class )
 		);
 
@@ -108,7 +92,7 @@ class SubjectResolverTest extends TestCase {
 
 	public function testResolveMainByTitleReturnsNullWhenNoContent(): void {
 		$resolver = new SubjectResolver(
-			$this->createEmptyRepository(),
+			new InMemorySubjectContentRepository(),
 			$this->createStub( SubjectLookup::class )
 		);
 
@@ -117,9 +101,11 @@ class SubjectResolverTest extends TestCase {
 
 	public function testGetPageSubjectsByTitleReturnsPageSubjects(): void {
 		$subject = $this->createSubject();
-		$repo = $this->createRepositoryWithMainSubject( $subject );
 
-		$resolver = new SubjectResolver( $repo, $this->createStub( SubjectLookup::class ) );
+		$resolver = new SubjectResolver(
+			$this->repositoryWithMainSubject( $subject ),
+			$this->createStub( SubjectLookup::class )
+		);
 
 		$pageSubjects = $resolver->getPageSubjectsByTitle( $this->createStub( Title::class ) );
 
@@ -129,7 +115,7 @@ class SubjectResolverTest extends TestCase {
 
 	public function testGetPageSubjectsByTitleReturnsNullWhenNoContent(): void {
 		$resolver = new SubjectResolver(
-			$this->createEmptyRepository(),
+			new InMemorySubjectContentRepository(),
 			$this->createStub( SubjectLookup::class )
 		);
 
@@ -142,7 +128,7 @@ class SubjectResolverTest extends TestCase {
 		$lookup = $this->createStub( SubjectLookup::class );
 		$lookup->method( 'getSubject' )->willReturn( $target );
 
-		$resolver = new SubjectResolver( $this->createEmptyRepository(), $lookup );
+		$resolver = new SubjectResolver( new InMemorySubjectContentRepository(), $lookup );
 
 		$relation = new Relation(
 			id: new RelationId( 'r1test5cccccccc' ),
@@ -157,7 +143,7 @@ class SubjectResolverTest extends TestCase {
 		$lookup = $this->createStub( SubjectLookup::class );
 		$lookup->method( 'getSubject' )->willReturn( null );
 
-		$resolver = new SubjectResolver( $this->createEmptyRepository(), $lookup );
+		$resolver = new SubjectResolver( new InMemorySubjectContentRepository(), $lookup );
 
 		$relation = new Relation(
 			id: new RelationId( 'r1test5cccccccc' ),
@@ -172,7 +158,7 @@ class SubjectResolverTest extends TestCase {
 		$lookup = $this->createStub( SubjectLookup::class );
 		$lookup->method( 'getSubject' )->willThrowException( new \RuntimeException( 'db error' ) );
 
-		$resolver = new SubjectResolver( $this->createEmptyRepository(), $lookup );
+		$resolver = new SubjectResolver( new InMemorySubjectContentRepository(), $lookup );
 
 		$relation = new Relation(
 			id: new RelationId( 'r1test5cccccccc' ),

--- a/tests/phpunit/EntryPoints/NeoWikiValueParserFunctionTest.php
+++ b/tests/phpunit/EntryPoints/NeoWikiValueParserFunctionTest.php
@@ -7,6 +7,7 @@ namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Title\Title;
 use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\SubjectContentRepository;
 use ProfessionalWiki\NeoWiki\Application\SubjectLookup;
 use ProfessionalWiki\NeoWiki\Application\SubjectResolver;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
@@ -25,9 +26,8 @@ use ProfessionalWiki\NeoWiki\Domain\Value\BooleanValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\NumberValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\RelationValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
-use ProfessionalWiki\NeoWiki\EntryPoints\Content\SubjectContent;
 use ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiValueParserFunction;
-use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\SubjectContentRepository;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectContentRepository;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiValueParserFunction
@@ -55,23 +55,8 @@ class NeoWikiValueParserFunctionTest extends TestCase {
 		);
 	}
 
-	private function createRepositoryWithSubject( Subject $subject ): SubjectContentRepository {
-		$pageSubjects = new PageSubjects( $subject, new SubjectMap() );
-
-		$subjectContent = $this->createStub( SubjectContent::class );
-		$subjectContent->method( 'getPageSubjects' )->willReturn( $pageSubjects );
-
-		$repo = $this->createStub( SubjectContentRepository::class );
-		$repo->method( 'getSubjectContentByPageTitle' )->willReturn( $subjectContent );
-
-		return $repo;
-	}
-
-	private function createEmptyRepository(): SubjectContentRepository {
-		$repo = $this->createStub( SubjectContentRepository::class );
-		$repo->method( 'getSubjectContentByPageTitle' )->willReturn( null );
-
-		return $repo;
+	private function repositoryWithSubject( Subject $subject ): InMemorySubjectContentRepository {
+		return new InMemorySubjectContentRepository( new PageSubjects( $subject, new SubjectMap() ) );
 	}
 
 	private function createDummyLookup(): SubjectLookup {
@@ -105,7 +90,7 @@ class NeoWikiValueParserFunctionTest extends TestCase {
 			new Statement( new PropertyName( 'City' ), 'text', new StringValue( 'Berlin' ) )
 		);
 
-		$result = $this->createPF( $this->createRepositoryWithSubject( $subject ) )
+		$result = $this->createPF( $this->repositoryWithSubject( $subject ) )
 			->handle( $this->createMockParser(), 'City' );
 
 		$this->assertNoParseHtml( 'Berlin', $result );
@@ -116,7 +101,7 @@ class NeoWikiValueParserFunctionTest extends TestCase {
 			new Statement( new PropertyName( 'Tags' ), 'text', new StringValue( 'alpha', 'beta', 'gamma' ) )
 		);
 
-		$result = $this->createPF( $this->createRepositoryWithSubject( $subject ) )
+		$result = $this->createPF( $this->repositoryWithSubject( $subject ) )
 			->handle( $this->createMockParser(), 'Tags' );
 
 		$this->assertNoParseHtml( 'alpha, beta, gamma', $result );
@@ -127,7 +112,7 @@ class NeoWikiValueParserFunctionTest extends TestCase {
 			new Statement( new PropertyName( 'Tags' ), 'text', new StringValue( 'alpha', 'beta' ) )
 		);
 
-		$result = $this->createPF( $this->createRepositoryWithSubject( $subject ) )
+		$result = $this->createPF( $this->repositoryWithSubject( $subject ) )
 			->handle( $this->createMockParser(), 'Tags', 'separator=;' );
 
 		$this->assertNoParseHtml( 'alpha;beta', $result );
@@ -138,7 +123,7 @@ class NeoWikiValueParserFunctionTest extends TestCase {
 			new Statement( new PropertyName( 'Tags' ), 'text', new StringValue( 'alpha', 'beta' ) )
 		);
 
-		$result = $this->createPF( $this->createRepositoryWithSubject( $subject ) )
+		$result = $this->createPF( $this->repositoryWithSubject( $subject ) )
 			->handle( $this->createMockParser(), 'Tags', ' separator = ; ' );
 
 		$this->assertNoParseHtml( 'alpha;beta', $result );
@@ -149,7 +134,7 @@ class NeoWikiValueParserFunctionTest extends TestCase {
 			new Statement( new PropertyName( 'Tags' ), 'text', new StringValue( 'a', 'b', 'c' ) )
 		);
 
-		$result = $this->createPF( $this->createRepositoryWithSubject( $subject ) )
+		$result = $this->createPF( $this->repositoryWithSubject( $subject ) )
 			->handle( $this->createMockParser(), 'Tags', 'separator=' );
 
 		$this->assertNoParseHtml( 'abc', $result );
@@ -162,7 +147,7 @@ class NeoWikiValueParserFunctionTest extends TestCase {
 			new Statement( new PropertyName( 'Age' ), 'number', new NumberValue( 42 ) )
 		);
 
-		$result = $this->createPF( $this->createRepositoryWithSubject( $subject ) )
+		$result = $this->createPF( $this->repositoryWithSubject( $subject ) )
 			->handle( $this->createMockParser(), 'Age' );
 
 		$this->assertNoParseHtml( '42', $result );
@@ -173,7 +158,7 @@ class NeoWikiValueParserFunctionTest extends TestCase {
 			new Statement( new PropertyName( 'Price' ), 'number', new NumberValue( 19.99 ) )
 		);
 
-		$result = $this->createPF( $this->createRepositoryWithSubject( $subject ) )
+		$result = $this->createPF( $this->repositoryWithSubject( $subject ) )
 			->handle( $this->createMockParser(), 'Price' );
 
 		$this->assertNoParseHtml( '19.99', $result );
@@ -186,7 +171,7 @@ class NeoWikiValueParserFunctionTest extends TestCase {
 			new Statement( new PropertyName( 'Active' ), 'boolean', new BooleanValue( true ) )
 		);
 
-		$result = $this->createPF( $this->createRepositoryWithSubject( $subject ) )
+		$result = $this->createPF( $this->repositoryWithSubject( $subject ) )
 			->handle( $this->createMockParser(), 'Active' );
 
 		$this->assertNoParseHtml( 'true', $result );
@@ -197,7 +182,7 @@ class NeoWikiValueParserFunctionTest extends TestCase {
 			new Statement( new PropertyName( 'Active' ), 'boolean', new BooleanValue( false ) )
 		);
 
-		$result = $this->createPF( $this->createRepositoryWithSubject( $subject ) )
+		$result = $this->createPF( $this->repositoryWithSubject( $subject ) )
 			->handle( $this->createMockParser(), 'Active' );
 
 		$this->assertNoParseHtml( 'false', $result );
@@ -228,7 +213,7 @@ class NeoWikiValueParserFunctionTest extends TestCase {
 		);
 
 		$result = $this->createPF(
-			$this->createRepositoryWithSubject( $subject ),
+			$this->repositoryWithSubject( $subject ),
 			$this->createLookupReturning( $targetSubject )
 		)->handle( $this->createMockParser(), 'Process owner' );
 
@@ -250,7 +235,7 @@ class NeoWikiValueParserFunctionTest extends TestCase {
 			)
 		);
 
-		$result = $this->createPF( $this->createRepositoryWithSubject( $subject ) )
+		$result = $this->createPF( $this->repositoryWithSubject( $subject ) )
 			->handle( $this->createMockParser(), 'Process owner' );
 
 		$this->assertNoParseHtml( self::TARGET_SUBJECT_ID, $result );
@@ -297,7 +282,7 @@ class NeoWikiValueParserFunctionTest extends TestCase {
 			)
 		);
 
-		$result = $this->createPF( $this->createRepositoryWithSubject( $subject ), $lookup )
+		$result = $this->createPF( $this->repositoryWithSubject( $subject ), $lookup )
 			->handle( $this->createMockParser(), 'Members' );
 
 		$this->assertNoParseHtml( 'Alice, Bob', $result );
@@ -308,7 +293,7 @@ class NeoWikiValueParserFunctionTest extends TestCase {
 			new Statement( new PropertyName( 'Members' ), 'relation', new RelationValue() )
 		);
 
-		$result = $this->createPF( $this->createRepositoryWithSubject( $subject ) )
+		$result = $this->createPF( $this->repositoryWithSubject( $subject ) )
 			->handle( $this->createMockParser(), 'Members' );
 
 		$this->assertSame( '', $result );
@@ -321,14 +306,14 @@ class NeoWikiValueParserFunctionTest extends TestCase {
 			new Statement( new PropertyName( 'City' ), 'text', new StringValue( 'Berlin' ) )
 		);
 
-		$result = $this->createPF( $this->createRepositoryWithSubject( $subject ) )
+		$result = $this->createPF( $this->repositoryWithSubject( $subject ) )
 			->handle( $this->createMockParser(), 'Nonexistent' );
 
 		$this->assertSame( '', $result );
 	}
 
 	public function testReturnsEmptyStringWhenNoSubjectOnPage(): void {
-		$result = $this->createPF( $this->createEmptyRepository() )
+		$result = $this->createPF( new InMemorySubjectContentRepository() )
 			->handle( $this->createMockParser(), 'City' );
 
 		$this->assertSame( '', $result );
@@ -339,7 +324,7 @@ class NeoWikiValueParserFunctionTest extends TestCase {
 			new Statement( new PropertyName( 'City' ), 'text', new StringValue( 'Berlin' ) )
 		);
 
-		$result = $this->createPF( $this->createRepositoryWithSubject( $subject ) )
+		$result = $this->createPF( $this->repositoryWithSubject( $subject ) )
 			->handle( $this->createMockParser(), '' );
 
 		$this->assertSame( '', $result );
@@ -350,7 +335,7 @@ class NeoWikiValueParserFunctionTest extends TestCase {
 			new Statement( new PropertyName( 'City' ), 'text', new StringValue( 'Berlin' ) )
 		);
 
-		$result = $this->createPF( $this->createRepositoryWithSubject( $subject ) )
+		$result = $this->createPF( $this->repositoryWithSubject( $subject ) )
 			->handle( $this->createMockParser() );
 
 		$this->assertSame( '', $result );
@@ -361,7 +346,7 @@ class NeoWikiValueParserFunctionTest extends TestCase {
 			new Statement( new PropertyName( 'City' ), 'text', new StringValue() )
 		);
 
-		$result = $this->createPF( $this->createRepositoryWithSubject( $subject ) )
+		$result = $this->createPF( $this->repositoryWithSubject( $subject ) )
 			->handle( $this->createMockParser(), 'City' );
 
 		$this->assertSame( '', $result );
@@ -374,7 +359,7 @@ class NeoWikiValueParserFunctionTest extends TestCase {
 			new Statement( new PropertyName( 'City' ), 'text', new StringValue( 'Berlin' ) )
 		);
 
-		$result = $this->createPF( $this->createRepositoryWithSubject( $subject ) )
+		$result = $this->createPF( $this->repositoryWithSubject( $subject ) )
 			->handle( $this->createMockParser(), '  City  ' );
 
 		$this->assertNoParseHtml( 'Berlin', $result );
@@ -391,7 +376,7 @@ class NeoWikiValueParserFunctionTest extends TestCase {
 		);
 
 		$pf = $this->createPF(
-			$this->createEmptyRepository(),
+			new InMemorySubjectContentRepository(),
 			$this->createLookupReturning( $targetSubject )
 		);
 
@@ -401,7 +386,7 @@ class NeoWikiValueParserFunctionTest extends TestCase {
 	}
 
 	public function testInvalidSubjectIdReturnsEmptyString(): void {
-		$result = $this->createPF( $this->createEmptyRepository() )
+		$result = $this->createPF( new InMemorySubjectContentRepository() )
 			->handle( $this->createMockParser(), 'City', 'subject=invalid' );
 
 		$this->assertSame( '', $result );
@@ -412,18 +397,8 @@ class NeoWikiValueParserFunctionTest extends TestCase {
 			new Statement( new PropertyName( 'City' ), 'text', new StringValue( 'Hamburg' ) )
 		);
 
-		$repo = $this->createStub( SubjectContentRepository::class );
-		$repo->method( 'getSubjectContentByPageTitle' )->willReturnCallback(
-			function ( $title ) use ( $subject ) {
-				if ( $title->getText() === 'Other Page' ) {
-					$pageSubjects = new PageSubjects( $subject, new SubjectMap() );
-					$subjectContent = $this->createStub( SubjectContent::class );
-					$subjectContent->method( 'getPageSubjects' )->willReturn( $pageSubjects );
-					return $subjectContent;
-				}
-				return null;
-			}
-		);
+		$repo = new InMemorySubjectContentRepository();
+		$repo->setContentForPage( 'Other_Page', new PageSubjects( $subject, new SubjectMap() ) );
 
 		$result = $this->createPF( $repo )
 			->handle( $this->createMockParser(), 'City', 'page=Other Page' );
@@ -446,7 +421,7 @@ class NeoWikiValueParserFunctionTest extends TestCase {
 		);
 
 		$result = $this->createPF(
-			$this->createRepositoryWithSubject( $subjectViaPage ),
+			$this->repositoryWithSubject( $subjectViaPage ),
 			$this->createLookupReturning( $subjectViaId )
 		)->handle(
 			$this->createMockParser(),
@@ -465,7 +440,7 @@ class NeoWikiValueParserFunctionTest extends TestCase {
 			new Statement( new PropertyName( 'Population' ), 'number', new NumberValue( 3_700_000 ) ),
 		);
 
-		$result = $this->createPF( $this->createRepositoryWithSubject( $subject ) )
+		$result = $this->createPF( $this->repositoryWithSubject( $subject ) )
 			->handle( $this->createMockParser(), 'Country' );
 
 		$this->assertNoParseHtml( 'Germany', $result );
@@ -478,7 +453,7 @@ class NeoWikiValueParserFunctionTest extends TestCase {
 			new Statement( new PropertyName( 'Name' ), 'text', new StringValue( '<b>bold</b> & "quoted"' ) )
 		);
 
-		$result = $this->createPF( $this->createRepositoryWithSubject( $subject ) )
+		$result = $this->createPF( $this->repositoryWithSubject( $subject ) )
 			->handle( $this->createMockParser(), 'Name' );
 
 		$this->assertIsArray( $result );

--- a/tests/phpunit/EntryPoints/Scribunto/SubjectDataLookupTest.php
+++ b/tests/phpunit/EntryPoints/Scribunto/SubjectDataLookupTest.php
@@ -24,9 +24,8 @@ use ProfessionalWiki\NeoWiki\Domain\Value\BooleanValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\NumberValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\RelationValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
-use ProfessionalWiki\NeoWiki\EntryPoints\Content\SubjectContent;
 use ProfessionalWiki\NeoWiki\EntryPoints\Scribunto\SubjectDataLookup;
-use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\SubjectContentRepository;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectContentRepository;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\EntryPoints\Scribunto\SubjectDataLookup
@@ -50,33 +49,19 @@ class SubjectDataLookupTest extends TestCase {
 		);
 	}
 
-	private function createResolverWithMainSubject( Subject $subject, ?SubjectLookup $subjectLookup = null ): SubjectResolver {
-		$pageSubjects = new PageSubjects( $subject, new SubjectMap() );
-
-		$subjectContent = $this->createStub( SubjectContent::class );
-		$subjectContent->method( 'getPageSubjects' )->willReturn( $pageSubjects );
-
-		$repo = $this->createStub( SubjectContentRepository::class );
-		$repo->method( 'getSubjectContentByPageTitle' )->willReturn( $subjectContent );
-
-		return new SubjectResolver( $repo, $subjectLookup ?? $this->createStub( SubjectLookup::class ) );
+	private function resolverWithMainSubject( Subject $subject, ?SubjectLookup $subjectLookup = null ): SubjectResolver {
+		return $this->resolverWithPageSubjects( new PageSubjects( $subject, new SubjectMap() ), $subjectLookup );
 	}
 
-	private function createResolverWithPageSubjects( PageSubjects $pageSubjects, ?SubjectLookup $subjectLookup = null ): SubjectResolver {
-		$subjectContent = $this->createStub( SubjectContent::class );
-		$subjectContent->method( 'getPageSubjects' )->willReturn( $pageSubjects );
-
-		$repo = $this->createStub( SubjectContentRepository::class );
-		$repo->method( 'getSubjectContentByPageTitle' )->willReturn( $subjectContent );
-
-		return new SubjectResolver( $repo, $subjectLookup ?? $this->createStub( SubjectLookup::class ) );
+	private function resolverWithPageSubjects( ?PageSubjects $pageSubjects, ?SubjectLookup $subjectLookup = null ): SubjectResolver {
+		return new SubjectResolver(
+			new InMemorySubjectContentRepository( $pageSubjects ),
+			$subjectLookup ?? $this->createStub( SubjectLookup::class )
+		);
 	}
 
-	private function createEmptyResolver( ?SubjectLookup $subjectLookup = null ): SubjectResolver {
-		$repo = $this->createStub( SubjectContentRepository::class );
-		$repo->method( 'getSubjectContentByPageTitle' )->willReturn( null );
-
-		return new SubjectResolver( $repo, $subjectLookup ?? $this->createStub( SubjectLookup::class ) );
+	private function emptyResolver( ?SubjectLookup $subjectLookup = null ): SubjectResolver {
+		return $this->resolverWithPageSubjects( null, $subjectLookup );
 	}
 
 	private function createSubjectLookupReturning( Subject ...$subjects ): SubjectLookup {
@@ -103,7 +88,7 @@ class SubjectDataLookupTest extends TestCase {
 			new Statement( new PropertyName( 'City' ), 'text', new StringValue( 'Berlin' ) )
 		);
 
-		$lookup = new SubjectDataLookup( $this->createResolverWithMainSubject( $subject ) );
+		$lookup = new SubjectDataLookup( $this->resolverWithMainSubject( $subject ) );
 
 		$this->assertSame( [ 'Berlin' ], $lookup->getValue( $this->createTitle(), 'City' ) );
 	}
@@ -113,7 +98,7 @@ class SubjectDataLookupTest extends TestCase {
 			new Statement( new PropertyName( 'Tags' ), 'text', new StringValue( 'alpha', 'beta', 'gamma' ) )
 		);
 
-		$lookup = new SubjectDataLookup( $this->createResolverWithMainSubject( $subject ) );
+		$lookup = new SubjectDataLookup( $this->resolverWithMainSubject( $subject ) );
 
 		$this->assertSame( [ 'alpha' ], $lookup->getValue( $this->createTitle(), 'Tags' ) );
 	}
@@ -123,7 +108,7 @@ class SubjectDataLookupTest extends TestCase {
 			new Statement( new PropertyName( 'Age' ), 'number', new NumberValue( 42 ) )
 		);
 
-		$lookup = new SubjectDataLookup( $this->createResolverWithMainSubject( $subject ) );
+		$lookup = new SubjectDataLookup( $this->resolverWithMainSubject( $subject ) );
 
 		$this->assertSame( [ 42 ], $lookup->getValue( $this->createTitle(), 'Age' ) );
 	}
@@ -133,7 +118,7 @@ class SubjectDataLookupTest extends TestCase {
 			new Statement( new PropertyName( 'Price' ), 'number', new NumberValue( 19.99 ) )
 		);
 
-		$lookup = new SubjectDataLookup( $this->createResolverWithMainSubject( $subject ) );
+		$lookup = new SubjectDataLookup( $this->resolverWithMainSubject( $subject ) );
 
 		$this->assertSame( [ 19.99 ], $lookup->getValue( $this->createTitle(), 'Price' ) );
 	}
@@ -143,7 +128,7 @@ class SubjectDataLookupTest extends TestCase {
 			new Statement( new PropertyName( 'Active' ), 'boolean', new BooleanValue( true ) )
 		);
 
-		$lookup = new SubjectDataLookup( $this->createResolverWithMainSubject( $subject ) );
+		$lookup = new SubjectDataLookup( $this->resolverWithMainSubject( $subject ) );
 
 		$this->assertSame( [ true ], $lookup->getValue( $this->createTitle(), 'Active' ) );
 	}
@@ -153,7 +138,7 @@ class SubjectDataLookupTest extends TestCase {
 			new Statement( new PropertyName( 'Active' ), 'boolean', new BooleanValue( false ) )
 		);
 
-		$lookup = new SubjectDataLookup( $this->createResolverWithMainSubject( $subject ) );
+		$lookup = new SubjectDataLookup( $this->resolverWithMainSubject( $subject ) );
 
 		$this->assertSame( [ false ], $lookup->getValue( $this->createTitle(), 'Active' ) );
 	}
@@ -181,7 +166,7 @@ class SubjectDataLookupTest extends TestCase {
 		);
 
 		$subjectLookup = $this->createSubjectLookupReturning( $targetSubject );
-		$lookup = new SubjectDataLookup( $this->createResolverWithMainSubject( $subject, $subjectLookup ) );
+		$lookup = new SubjectDataLookup( $this->resolverWithMainSubject( $subject, $subjectLookup ) );
 
 		$this->assertSame(
 			[ 'Sarah Naumann' ],
@@ -217,7 +202,7 @@ class SubjectDataLookupTest extends TestCase {
 		);
 
 		$subjectLookup = $this->createSubjectLookupReturning( $target1 );
-		$lookup = new SubjectDataLookup( $this->createResolverWithMainSubject( $subject, $subjectLookup ) );
+		$lookup = new SubjectDataLookup( $this->resolverWithMainSubject( $subject, $subjectLookup ) );
 
 		$this->assertSame(
 			[ 'Alice' ],
@@ -240,7 +225,7 @@ class SubjectDataLookupTest extends TestCase {
 			)
 		);
 
-		$lookup = new SubjectDataLookup( $this->createResolverWithMainSubject( $subject ) );
+		$lookup = new SubjectDataLookup( $this->resolverWithMainSubject( $subject ) );
 
 		$this->assertSame(
 			[ self::TARGET_SUBJECT_ID ],
@@ -253,19 +238,19 @@ class SubjectDataLookupTest extends TestCase {
 			new Statement( new PropertyName( 'City' ), 'text', new StringValue( 'Berlin' ) )
 		);
 
-		$lookup = new SubjectDataLookup( $this->createResolverWithMainSubject( $subject ) );
+		$lookup = new SubjectDataLookup( $this->resolverWithMainSubject( $subject ) );
 
 		$this->assertSame( [ null ], $lookup->getValue( $this->createTitle(), 'Nonexistent' ) );
 	}
 
 	public function testGetValueReturnsNullWhenNoSubjectOnPage(): void {
-		$lookup = new SubjectDataLookup( $this->createEmptyResolver() );
+		$lookup = new SubjectDataLookup( $this->emptyResolver() );
 
 		$this->assertSame( [ null ], $lookup->getValue( $this->createTitle(), 'City' ) );
 	}
 
 	public function testGetValueReturnsNullForEmptyPropertyName(): void {
-		$lookup = new SubjectDataLookup( $this->createEmptyResolver() );
+		$lookup = new SubjectDataLookup( $this->emptyResolver() );
 
 		$this->assertSame( [ null ], $lookup->getValue( $this->createTitle(), '' ) );
 	}
@@ -275,7 +260,7 @@ class SubjectDataLookupTest extends TestCase {
 			new Statement( new PropertyName( 'City' ), 'text', new StringValue() )
 		);
 
-		$lookup = new SubjectDataLookup( $this->createResolverWithMainSubject( $subject ) );
+		$lookup = new SubjectDataLookup( $this->resolverWithMainSubject( $subject ) );
 
 		$this->assertSame( [ null ], $lookup->getValue( $this->createTitle(), 'City' ) );
 	}
@@ -291,7 +276,7 @@ class SubjectDataLookupTest extends TestCase {
 		);
 
 		$subjectLookup = $this->createSubjectLookupReturning( $targetSubject );
-		$lookup = new SubjectDataLookup( $this->createEmptyResolver( $subjectLookup ) );
+		$lookup = new SubjectDataLookup( $this->emptyResolver( $subjectLookup ) );
 
 		$this->assertSame(
 			[ 'Munich' ],
@@ -300,7 +285,7 @@ class SubjectDataLookupTest extends TestCase {
 	}
 
 	public function testGetValueWithInvalidSubjectOptionReturnsNull(): void {
-		$lookup = new SubjectDataLookup( $this->createEmptyResolver() );
+		$lookup = new SubjectDataLookup( $this->emptyResolver() );
 
 		$this->assertSame(
 			[ null ],
@@ -313,7 +298,7 @@ class SubjectDataLookupTest extends TestCase {
 			new Statement( new PropertyName( 'City' ), 'text', new StringValue( 'Berlin' ) )
 		);
 
-		$lookup = new SubjectDataLookup( $this->createResolverWithMainSubject( $subject ) );
+		$lookup = new SubjectDataLookup( $this->resolverWithMainSubject( $subject ) );
 
 		$this->assertSame( [ 'Berlin' ], $lookup->getValue( $this->createTitle(), '  City  ' ) );
 	}
@@ -325,7 +310,7 @@ class SubjectDataLookupTest extends TestCase {
 			new Statement( new PropertyName( 'City' ), 'text', new StringValue( 'Berlin' ) )
 		);
 
-		$lookup = new SubjectDataLookup( $this->createResolverWithMainSubject( $subject ) );
+		$lookup = new SubjectDataLookup( $this->resolverWithMainSubject( $subject ) );
 
 		$this->assertSame( [ [ 1 => 'Berlin' ] ], $lookup->getAll( $this->createTitle(), 'City' ) );
 	}
@@ -335,7 +320,7 @@ class SubjectDataLookupTest extends TestCase {
 			new Statement( new PropertyName( 'Tags' ), 'text', new StringValue( 'alpha', 'beta', 'gamma' ) )
 		);
 
-		$lookup = new SubjectDataLookup( $this->createResolverWithMainSubject( $subject ) );
+		$lookup = new SubjectDataLookup( $this->resolverWithMainSubject( $subject ) );
 
 		$this->assertSame(
 			[ [ 1 => 'alpha', 2 => 'beta', 3 => 'gamma' ] ],
@@ -348,7 +333,7 @@ class SubjectDataLookupTest extends TestCase {
 			new Statement( new PropertyName( 'Age' ), 'number', new NumberValue( 42 ) )
 		);
 
-		$lookup = new SubjectDataLookup( $this->createResolverWithMainSubject( $subject ) );
+		$lookup = new SubjectDataLookup( $this->resolverWithMainSubject( $subject ) );
 
 		$this->assertSame( [ [ 1 => 42 ] ], $lookup->getAll( $this->createTitle(), 'Age' ) );
 	}
@@ -358,7 +343,7 @@ class SubjectDataLookupTest extends TestCase {
 			new Statement( new PropertyName( 'Active' ), 'boolean', new BooleanValue( true ) )
 		);
 
-		$lookup = new SubjectDataLookup( $this->createResolverWithMainSubject( $subject ) );
+		$lookup = new SubjectDataLookup( $this->resolverWithMainSubject( $subject ) );
 
 		$this->assertSame( [ [ 1 => true ] ], $lookup->getAll( $this->createTitle(), 'Active' ) );
 	}
@@ -397,7 +382,7 @@ class SubjectDataLookupTest extends TestCase {
 		);
 
 		$subjectLookup = $this->createSubjectLookupReturning( $target1, $target2 );
-		$lookup = new SubjectDataLookup( $this->createResolverWithMainSubject( $subject, $subjectLookup ) );
+		$lookup = new SubjectDataLookup( $this->resolverWithMainSubject( $subject, $subjectLookup ) );
 
 		$this->assertSame(
 			[ [ 1 => 'Alice', 2 => 'Bob' ] ],
@@ -410,7 +395,7 @@ class SubjectDataLookupTest extends TestCase {
 			new Statement( new PropertyName( 'City' ), 'text', new StringValue( 'Berlin' ) )
 		);
 
-		$lookup = new SubjectDataLookup( $this->createResolverWithMainSubject( $subject ) );
+		$lookup = new SubjectDataLookup( $this->resolverWithMainSubject( $subject ) );
 
 		$this->assertSame( [ null ], $lookup->getAll( $this->createTitle(), 'Nonexistent' ) );
 	}
@@ -420,7 +405,7 @@ class SubjectDataLookupTest extends TestCase {
 			new Statement( new PropertyName( 'City' ), 'text', new StringValue() )
 		);
 
-		$lookup = new SubjectDataLookup( $this->createResolverWithMainSubject( $subject ) );
+		$lookup = new SubjectDataLookup( $this->resolverWithMainSubject( $subject ) );
 
 		$this->assertSame( [ null ], $lookup->getAll( $this->createTitle(), 'City' ) );
 	}
@@ -433,7 +418,7 @@ class SubjectDataLookupTest extends TestCase {
 			new Statement( new PropertyName( 'Population' ), 'number', new NumberValue( 3645000 ) ),
 		);
 
-		$lookup = new SubjectDataLookup( $this->createResolverWithMainSubject( $subject ) );
+		$lookup = new SubjectDataLookup( $this->resolverWithMainSubject( $subject ) );
 
 		$result = $lookup->getMainSubjectData( $this->createTitle() );
 
@@ -447,7 +432,7 @@ class SubjectDataLookupTest extends TestCase {
 	}
 
 	public function testGetMainSubjectReturnsNullWhenNoSubject(): void {
-		$lookup = new SubjectDataLookup( $this->createEmptyResolver() );
+		$lookup = new SubjectDataLookup( $this->emptyResolver() );
 
 		$this->assertSame( [ null ], $lookup->getMainSubjectData( $this->createTitle() ) );
 	}
@@ -455,7 +440,7 @@ class SubjectDataLookupTest extends TestCase {
 	public function testGetMainSubjectReturnsNullWhenPageHasNoMainSubject(): void {
 		$pageSubjects = new PageSubjects( null, new SubjectMap() );
 
-		$lookup = new SubjectDataLookup( $this->createResolverWithPageSubjects( $pageSubjects ) );
+		$lookup = new SubjectDataLookup( $this->resolverWithPageSubjects( $pageSubjects ) );
 
 		$this->assertSame( [ null ], $lookup->getMainSubjectData( $this->createTitle() ) );
 	}
@@ -473,7 +458,7 @@ class SubjectDataLookupTest extends TestCase {
 		);
 
 		$subjectLookup = $this->createSubjectLookupReturning( $subject );
-		$lookup = new SubjectDataLookup( $this->createEmptyResolver( $subjectLookup ) );
+		$lookup = new SubjectDataLookup( $this->emptyResolver( $subjectLookup ) );
 
 		$result = $lookup->getSubjectData( self::TARGET_SUBJECT_ID );
 
@@ -484,13 +469,13 @@ class SubjectDataLookupTest extends TestCase {
 	}
 
 	public function testGetSubjectReturnsNullForInvalidId(): void {
-		$lookup = new SubjectDataLookup( $this->createEmptyResolver() );
+		$lookup = new SubjectDataLookup( $this->emptyResolver() );
 
 		$this->assertSame( [ null ], $lookup->getSubjectData( 'invalid' ) );
 	}
 
 	public function testGetSubjectReturnsNullForUnknownId(): void {
-		$lookup = new SubjectDataLookup( $this->createEmptyResolver() );
+		$lookup = new SubjectDataLookup( $this->emptyResolver() );
 
 		$this->assertSame( [ null ], $lookup->getSubjectData( self::TARGET_SUBJECT_ID ) );
 	}
@@ -523,7 +508,7 @@ class SubjectDataLookupTest extends TestCase {
 		);
 
 		$subjectLookup = $this->createSubjectLookupReturning( $subject, $targetSubject );
-		$lookup = new SubjectDataLookup( $this->createEmptyResolver( $subjectLookup ) );
+		$lookup = new SubjectDataLookup( $this->emptyResolver( $subjectLookup ) );
 
 		$result = $lookup->getSubjectData( self::SUBJECT_ID );
 
@@ -556,7 +541,7 @@ class SubjectDataLookupTest extends TestCase {
 			new SubjectMap( $child1, $child2 )
 		);
 
-		$lookup = new SubjectDataLookup( $this->createResolverWithPageSubjects( $pageSubjects ) );
+		$lookup = new SubjectDataLookup( $this->resolverWithPageSubjects( $pageSubjects ) );
 
 		$result = $lookup->getChildSubjectsData( $this->createTitle() );
 
@@ -572,13 +557,13 @@ class SubjectDataLookupTest extends TestCase {
 
 		$pageSubjects = new PageSubjects( $mainSubject, new SubjectMap() );
 
-		$lookup = new SubjectDataLookup( $this->createResolverWithPageSubjects( $pageSubjects ) );
+		$lookup = new SubjectDataLookup( $this->resolverWithPageSubjects( $pageSubjects ) );
 
 		$this->assertSame( [ [] ], $lookup->getChildSubjectsData( $this->createTitle() ) );
 	}
 
 	public function testGetChildSubjectsReturnsEmptyArrayWhenNoContent(): void {
-		$lookup = new SubjectDataLookup( $this->createEmptyResolver() );
+		$lookup = new SubjectDataLookup( $this->emptyResolver() );
 
 		$this->assertSame( [ [] ], $lookup->getChildSubjectsData( $this->createTitle() ) );
 	}
@@ -588,7 +573,7 @@ class SubjectDataLookupTest extends TestCase {
 			new Statement( new PropertyName( 'Active' ), 'boolean', new BooleanValue( true ) ),
 		);
 
-		$lookup = new SubjectDataLookup( $this->createResolverWithMainSubject( $subject ) );
+		$lookup = new SubjectDataLookup( $this->resolverWithMainSubject( $subject ) );
 
 		$result = $lookup->getMainSubjectData( $this->createTitle() );
 

--- a/tests/phpunit/EntryPoints/ViewParserFunctionTest.php
+++ b/tests/phpunit/EntryPoints/ViewParserFunctionTest.php
@@ -9,11 +9,14 @@ use MediaWiki\Parser\Parser;
 use MediaWiki\Title\Title;
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
-use ProfessionalWiki\NeoWiki\EntryPoints\Content\SubjectContent;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectMap;
 use ProfessionalWiki\NeoWiki\EntryPoints\ViewParserFunction;
-use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\SubjectContentRepository;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectContentRepository;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\EntryPoints\ViewParserFunction
@@ -79,7 +82,7 @@ class ViewParserFunctionTest extends TestCase {
 	}
 
 	public function testReturnsEmptyStringWhenNoSubjectAvailable(): void {
-		$parserFunction = new ViewParserFunction( $this->createRepositoryWithNoContent() );
+		$parserFunction = new ViewParserFunction( new InMemorySubjectContentRepository() );
 
 		$result = $parserFunction->handle( $this->createMockParser() );
 
@@ -87,7 +90,9 @@ class ViewParserFunctionTest extends TestCase {
 	}
 
 	public function testReturnsEmptyStringWhenPageHasNoMainSubject(): void {
-		$parserFunction = new ViewParserFunction( $this->createRepositoryWithNoMainSubject() );
+		$parserFunction = new ViewParserFunction(
+			new InMemorySubjectContentRepository( new PageSubjects( null, new SubjectMap() ) )
+		);
 
 		$result = $parserFunction->handle( $this->createMockParser() );
 
@@ -125,12 +130,19 @@ class ViewParserFunctionTest extends TestCase {
 	}
 
 	private function callView( string ...$args ): string|array {
-		return $this->newParserFunction( self::MAIN_SUBJECT_ID )
+		return ( new ViewParserFunction( $this->repositoryWithMainSubject() ) )
 			->handle( $this->createMockParser(), ...$args );
 	}
 
-	private function newParserFunction( string $mainSubjectId ): ViewParserFunction {
-		return new ViewParserFunction( $this->createRepositoryWithMainSubjectId( $mainSubjectId ) );
+	private function repositoryWithMainSubject(): InMemorySubjectContentRepository {
+		$mainSubject = new Subject(
+			id: new SubjectId( self::MAIN_SUBJECT_ID ),
+			label: new SubjectLabel( 'Main' ),
+			schemaName: new SchemaName( 'TestSchema' ),
+			statements: new StatementList(),
+		);
+
+		return new InMemorySubjectContentRepository( new PageSubjects( $mainSubject, new SubjectMap() ) );
 	}
 
 	private function createMockParser(): Parser {
@@ -143,37 +155,6 @@ class ViewParserFunctionTest extends TestCase {
 		);
 
 		return $parser;
-	}
-
-	private function createRepositoryWithMainSubjectId( string $subjectId ): SubjectContentRepository {
-		$subject = $this->createStub( Subject::class );
-		$subject->method( 'getId' )->willReturn( new SubjectId( $subjectId ) );
-
-		return $this->createRepositoryWithMainSubject( $subject );
-	}
-
-	private function createRepositoryWithNoMainSubject(): SubjectContentRepository {
-		return $this->createRepositoryWithMainSubject( null );
-	}
-
-	private function createRepositoryWithMainSubject( ?Subject $mainSubject ): SubjectContentRepository {
-		$pageSubjects = $this->createStub( PageSubjects::class );
-		$pageSubjects->method( 'getMainSubject' )->willReturn( $mainSubject );
-
-		$subjectContent = $this->createStub( SubjectContent::class );
-		$subjectContent->method( 'getPageSubjects' )->willReturn( $pageSubjects );
-
-		$repo = $this->createStub( SubjectContentRepository::class );
-		$repo->method( 'getSubjectContentByPageTitle' )->willReturn( $subjectContent );
-
-		return $repo;
-	}
-
-	private function createRepositoryWithNoContent(): SubjectContentRepository {
-		$repo = $this->createStub( SubjectContentRepository::class );
-		$repo->method( 'getSubjectContentByPageTitle' )->willReturn( null );
-
-		return $repo;
 	}
 
 	/**

--- a/tests/phpunit/Presentation/ViewHtmlBuilderTest.php
+++ b/tests/phpunit/Presentation/ViewHtmlBuilderTest.php
@@ -4,15 +4,13 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Tests\Presentation;
 
-use MediaWiki\Page\PageIdentity;
 use MediaWiki\Title\Title;
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectMap;
-use ProfessionalWiki\NeoWiki\EntryPoints\Content\SubjectContent;
-use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\SubjectContentRepository;
 use ProfessionalWiki\NeoWiki\Presentation\ViewHtmlBuilder;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectContentRepository;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\Presentation\ViewHtmlBuilder
@@ -20,9 +18,7 @@ use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
 class ViewHtmlBuilderTest extends TestCase {
 
 	public function testReturnsEmptyStringWhenNoContentExists(): void {
-		$builder = new ViewHtmlBuilder(
-			$this->stubRepository( byTitle: null, byRevision: null )
-		);
+		$builder = new ViewHtmlBuilder( new InMemorySubjectContentRepository() );
 
 		$html = $builder->mainSubjectHtml( Title::newFromText( 'NoContent' ), null );
 
@@ -30,10 +26,8 @@ class ViewHtmlBuilderTest extends TestCase {
 	}
 
 	public function testReturnsEmptyStringWhenContentHasNoMainSubject(): void {
-		$content = SubjectContent::newFromData( PageSubjects::newEmpty() );
-
 		$builder = new ViewHtmlBuilder(
-			$this->stubRepository( byTitle: $content )
+			new InMemorySubjectContentRepository( PageSubjects::newEmpty() )
 		);
 
 		$html = $builder->mainSubjectHtml( Title::newFromText( 'Empty' ), null );
@@ -43,10 +37,9 @@ class ViewHtmlBuilderTest extends TestCase {
 
 	public function testReturnsDivWithSubjectIdAttribute(): void {
 		$subject = TestSubject::build( id: 's1zz1111111azz1' );
-		$content = SubjectContent::newFromData( new PageSubjects( $subject, new SubjectMap() ) );
 
 		$builder = new ViewHtmlBuilder(
-			$this->stubRepository( byTitle: $content )
+			new InMemorySubjectContentRepository( new PageSubjects( $subject, new SubjectMap() ) )
 		);
 
 		$html = $builder->mainSubjectHtml( Title::newFromText( 'HasSubject' ), null );
@@ -57,11 +50,11 @@ class ViewHtmlBuilderTest extends TestCase {
 
 	public function testDoesNotIncludeRevisionIdInHtml(): void {
 		$subject = TestSubject::build( id: 's1zz1111111azz2' );
-		$content = SubjectContent::newFromData( new PageSubjects( $subject, new SubjectMap() ) );
 
-		$builder = new ViewHtmlBuilder(
-			$this->stubRepository( byRevision: $content )
-		);
+		$repo = new InMemorySubjectContentRepository();
+		$repo->setContentForRevision( 42, new PageSubjects( $subject, new SubjectMap() ) );
+
+		$builder = new ViewHtmlBuilder( $repo );
 
 		$html = $builder->mainSubjectHtml( Title::newFromText( 'WithRevision' ), 42 );
 
@@ -70,38 +63,15 @@ class ViewHtmlBuilderTest extends TestCase {
 
 	public function testUsesRevisionIdToLookUpContent(): void {
 		$subject = TestSubject::build( id: 's1zz1111111azz3' );
-		$revisionContent = SubjectContent::newFromData( new PageSubjects( $subject, new SubjectMap() ) );
 
-		$builder = new ViewHtmlBuilder(
-			$this->stubRepository( byTitle: null, byRevision: $revisionContent )
-		);
+		$repo = new InMemorySubjectContentRepository();
+		$repo->setContentForRevision( 42, new PageSubjects( $subject, new SubjectMap() ) );
+
+		$builder = new ViewHtmlBuilder( $repo );
 
 		$html = $builder->mainSubjectHtml( Title::newFromText( 'RevisionLookup' ), 42 );
 
 		$this->assertStringContainsString( 'data-mw-neowiki-subject-id="s1zz1111111azz3"', $html );
-	}
-
-	private function stubRepository(
-		?SubjectContent $byTitle = null,
-		?SubjectContent $byRevision = null,
-	): SubjectContentRepository {
-		return new class( $byTitle, $byRevision ) extends SubjectContentRepository {
-
-			public function __construct(
-				private readonly ?SubjectContent $titleContent,
-				private readonly ?SubjectContent $revisionContent,
-			) {
-			}
-
-			public function getSubjectContentByPageTitle( PageIdentity $pageIdentity ): ?SubjectContent {
-				return $this->titleContent;
-			}
-
-			public function getSubjectContentByRevisionId( int $revisionId ): ?SubjectContent {
-				return $this->revisionContent;
-			}
-
-		};
 	}
 
 }

--- a/tests/phpunit/TestDoubles/InMemorySubjectContent.php
+++ b/tests/phpunit/TestDoubles/InMemorySubjectContent.php
@@ -1,0 +1,20 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\TestDoubles;
+
+use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
+use ProfessionalWiki\NeoWiki\EntryPoints\Content\SubjectContent;
+
+class InMemorySubjectContent extends SubjectContent {
+
+	public function __construct( private readonly PageSubjects $pageSubjects ) {
+		parent::__construct( '{}' );
+	}
+
+	public function getPageSubjects(): PageSubjects {
+		return $this->pageSubjects;
+	}
+
+}

--- a/tests/phpunit/TestDoubles/InMemorySubjectContentRepository.php
+++ b/tests/phpunit/TestDoubles/InMemorySubjectContentRepository.php
@@ -1,0 +1,62 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\TestDoubles;
+
+use LogicException;
+use MediaWiki\Page\PageIdentity;
+use ProfessionalWiki\NeoWiki\Application\SubjectContentRepository;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
+use ProfessionalWiki\NeoWiki\EntryPoints\Content\SubjectContent;
+
+class InMemorySubjectContentRepository implements SubjectContentRepository {
+
+	private ?SubjectContent $defaultContent = null;
+
+	/** @var array<string, ?SubjectContent> */
+	private array $contentByPageDbKey = [];
+
+	/** @var array<int, ?SubjectContent> */
+	private array $contentByRevisionId = [];
+
+	public function __construct( ?PageSubjects $defaultPageSubjects = null ) {
+		if ( $defaultPageSubjects !== null ) {
+			$this->defaultContent = new InMemorySubjectContent( $defaultPageSubjects );
+		}
+	}
+
+	public function setContentForPage( string $pageDbKey, ?PageSubjects $pageSubjects ): void {
+		$this->contentByPageDbKey[$pageDbKey] = $pageSubjects === null
+			? null
+			: new InMemorySubjectContent( $pageSubjects );
+	}
+
+	public function setContentForRevision( int $revisionId, ?PageSubjects $pageSubjects ): void {
+		$this->contentByRevisionId[$revisionId] = $pageSubjects === null
+			? null
+			: new InMemorySubjectContent( $pageSubjects );
+	}
+
+	public function getSubjectContentByPageId( PageId $pageId ): ?SubjectContent {
+		throw new LogicException( 'Not implemented. Wire up per-PageId storage when a test needs it.' );
+	}
+
+	public function getSubjectContentByPageTitle( PageIdentity $pageIdentity ): ?SubjectContent {
+		return $this->contentByPageDbKey[$pageIdentity->getDBkey()] ?? $this->defaultContent;
+	}
+
+	public function getSubjectContentByRevisionId( int $revisionId ): ?SubjectContent {
+		return $this->contentByRevisionId[$revisionId] ?? $this->defaultContent;
+	}
+
+	public function editSubjectContent(
+		SubjectContent $subjectContent,
+		PageId $pageId,
+		string $editSummary
+	): void {
+		throw new LogicException( 'Not implemented. Wire up edit storage when a test needs it.' );
+	}
+
+}


### PR DESCRIPTION
> Result of back-and-forth with @alistair3149 (interactive brainstorming, sectioned design, reviewer-loop fix-ups).
> Context: the NeoWiki extension codebase, issue #847 thread, the existing `InMemorySubjectLookup` / `InMemorySchemaLookup` / `InMemorySubjectRepository` patterns, and the five test files swept.
> <sub>Written by Claude Code, `Opus 4.7`</sub>

Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/847

Five PHPUnit test files duplicated a `pageSubjects -> subjectContent -> repo`
stub chain to fake `SubjectContentRepository`:

* `tests/phpunit/Application/SubjectResolverTest.php`
* `tests/phpunit/EntryPoints/NeoWikiValueParserFunctionTest.php`
* `tests/phpunit/EntryPoints/Scribunto/SubjectDataLookupTest.php`
* `tests/phpunit/EntryPoints/ViewParserFunctionTest.php`
* `tests/phpunit/Presentation/ViewHtmlBuilderTest.php` (anonymous-class subclass)

To follow the established `InMemorySubjectLookup` / `InMemorySchemaLookup` /
`InMemorySubjectRepository` pattern, this:

* Extracts a `SubjectContentRepository` interface in `Application/`.
* Renames the concrete class to `MediaWikiSubjectContentRepository`, matching
  the sibling `MediaWikiSubjectRepository` convention. Updates DI wiring and
  three consumer type-hints (`SubjectResolver`, `ViewParserFunction`,
  `ViewHtmlBuilder`).
* Adds `InMemorySubjectContent` (extends `SubjectContent` and overrides
  `getPageSubjects()` to bypass the `NeoWikiExtension::getInstance()`
  dependency that breaks pure unit tests).
* Adds `InMemorySubjectContentRepository` (default content + per-page /
  per-revision overrides, keyed by `getDBkey()` / revision id).
  `getSubjectContentByPageId` and `editSubjectContent` throw `LogicException`
  rather than silently returning the wrong content; wire them up when a real
  test needs them.
* Sweeps all five test files to use the new doubles, deleting the per-file
  `createRepositoryWith*` factories.

The `Application/` interface references `SubjectContent` from
`EntryPoints/Content/` (same dependency the existing concrete and several
`Application/` services already have). Cleaning up that pre-existing layer
violation belongs in a separate issue.