### PR TITLE
Fix catastrophic backtracking in URL validation regex

### DIFF
--- a/resources/ext.neowiki/src/domain/propertyTypes/Url.ts
+++ b/resources/ext.neowiki/src/domain/propertyTypes/Url.ts
@@ -168,7 +168,7 @@ export function isValidUrl( urlString: string ): boolean {
 
 	const pattern = new RegExp(
 		'^([a-z][a-z\\d+.-]*://)?' +
-		'((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' +
+		'((?:[a-z\\d](?:[a-z\\d-]*[a-z\\d])?\\.)+[a-z]{2,}|' +
 		'((\\d{1,3}\\.){3}\\d{1,3})|' +
 		'(localhost))' +
 		'(\\:\\d+)?' +

--- a/src/Domain/PropertyType/Types/UrlType.php
+++ b/src/Domain/PropertyType/Types/UrlType.php
@@ -89,7 +89,7 @@ class UrlType implements PropertyType {
 		}
 
 		$pattern = '/^([a-z][a-z\d+.-]*:\/\/)?'
-			. '((([a-z\d]([a-z\d-]*[a-z\d])*)\.)+[a-z]{2,}|'
+			. '((?:[a-z\d](?:[a-z\d-]*[a-z\d])?\.)+[a-z]{2,}|'
 			. '((\d{1,3}\.){3}\d{1,3})|'
 			. '(localhost))'
 			. '(\:\d+)?'


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/822

## Summary

`UrlType::isValidUrl()` and its TypeScript twin (`Url.ts`) validate URLs with a host sub-pattern
`(([a-z\d]([a-z\d-]*[a-z\d])*)\.)+` whose nested unbounded quantifier backtracks exponentially.
#822 added the first server-side caller — `POST /neowiki/v0/subject/validate`, which has
`needsWriteAccess() === false` and runs `isValidUrl` once per URL part on caller-controlled input —
so the cost is now reachable from an unauthenticated-read endpoint and amplifiable per value part.

This flattens the host label to an equivalent non-backtracking form,
`(?:[a-z\d](?:[a-z\d-]*[a-z\d])?\.)+`, in both PHP and TS. The matched language is unchanged; only the
catastrophic backtracking is removed.

## Impact (measured)

| adversarial input | before | after |
|---|---|---|
| `("a-" × 20) + "!"` | ~4.6 ms, exhausts `pcre.backtrack_limit` → returns false → spurious `invalid-url` | ~0.005 ms |
| `("a-" × 45) + "!"` | ~4.3 ms, backtrack-limit error | ~0.002 ms |

PHP's backtrack limit means it is not an outright hang, but each pathological part costs ~1000× a
normal match and a single request can pack many parts.

## Test plan

- [x] Behavior-preserving: old vs new regex agree on all 22 cross-check vectors (every `UrlTypeValidateTest::isValidUrlProvider` case plus extras).
- [x] `make phpunit filter=UrlTypeValidateTest` — 29/29.
- [x] Benchmark: adversarial input no longer hits the backtrack limit (table above).
- [ ] TS `Url` spec not run locally (the `node` dev service was down). The TS edit is the identical regex transformation to the verified PHP change; CI covers `ts-test` + `ts-lint`.

> Jeroen flagged this regex while reviewing #822; I confirmed it with a PHP PCRE benchmark, and he asked for this follow-up.
> Context: the NeoWiki codebase, PR #822, and a benchmark of the regex against adversarial input.
> <sub>Written by Claude Code, \`Opus 4.7\`</sub>