### PR TITLE
Surface violations on Subject write endpoints

### DIFF
--- a/docs/reference/validation-codes.md
+++ b/docs/reference/validation-codes.md
@@ -4,15 +4,19 @@ Constraint violations returned by NeoWiki's backend validation API use stable `c
 This document is the authoritative reference, shared between the PHP backend implementation and
 (in a future round) the TS frontend implementation.
 
-The API endpoints are:
+Violations are returned by:
 
-- `POST /neowiki/v0/subject/validate` — validates a proposed create-shape body.
-- `POST /neowiki/v0/subject/{subjectId}/validate` — validates a proposed update-shape body
-  against an existing Subject's Schema.
+- `POST /neowiki/v0/subject/validate` — dry-run validation of a proposed create-shape body.
+- `POST /neowiki/v0/subject/{subjectId}/validate` — dry-run validation of a proposed update-shape
+  body against an existing Subject's Schema.
+- `POST /neowiki/v0/subject` and `PUT /neowiki/v0/subject/{subjectId}` — the write endpoints include
+  the resulting `violations` array in their `201`/`200` success body. Validation does not block the
+  write (see [ADR 21](../adr/021-add-backend-validation.md)).
 
-Both endpoints return `200 OK` with a `{violations: [...]}` body whenever the request is
-well-formed. Violations present in the body do not change the HTTP status. `400` is reserved for
-malformed input; `404` for a missing Schema or Subject.
+The `/validate` endpoints return `200 OK` with a `{violations: [...]}` body whenever the request is
+well-formed; violations in the body do not change the HTTP status. `400` is reserved for malformed
+input, `404` for a missing Subject (update dry-run). A missing Schema is reported differently per
+endpoint — see [`schema-not-found`](#schema-not-found).
 
 Each violation in the response has this shape:
 

--- a/docs/reference/validation-codes.md
+++ b/docs/reference/validation-codes.md
@@ -166,14 +166,23 @@ A part does not match the 6-digit hex-color pattern (`/^#[0-9a-fA-F]{6}$/`).
 
 ### `schema-not-found`
 
-Emitted by `ValidateSubjectUpdateApi`.
+Emitted by `ValidateSubjectUpdateApi` and by the Subject write endpoints
+(`POST /subject`, `PUT /subject/{id}`) via `ProposedSubjectValidator`.
 `args`: `[schemaName]`.
 `valuePartIndex`: never set.
 `propertyName`: always `null` (Subject-level).
 
-The existing Subject's Schema cannot be loaded — usually because the Schema page was deleted or
-renamed since the Subject was created. Surfaced as a violation rather than a 404 because the
-Subject itself does exist; the caller can fix this by re-creating or renaming the Schema page.
+The Subject's Schema cannot be loaded — usually because the Schema page was deleted or renamed
+since the Subject was created, or because a Subject is created/imported referencing a Schema that
+does not (yet) exist. On the write endpoints it is non-blocking: the write proceeds and the
+(unvalidatable) Subject stays editable per ADR 21, but the response reports `schema-not-found`
+rather than an empty (and misleading "valid") violation list. The caller can resolve it by
+creating or renaming the Schema page.
+
+Note the create dry-run endpoint (`POST /subject/validate`) instead returns `404`
+(`SchemaNotFoundException`) for a missing Schema, because there it is the addressed resource;
+the update dry-run (`POST /subject/{id}/validate`) and both write endpoints surface the violation.
+Reconciling that asymmetry is left to the enforcement tier (ADR 21).
 
 ## Known limitations (Foundation round)
 

--- a/src/Application/Actions/CreateSubject/CreateSubjectAction.php
+++ b/src/Application/Actions/CreateSubject/CreateSubjectAction.php
@@ -10,12 +10,11 @@ use ProfessionalWiki\NeoWiki\Application\SelectStatementResolver;
 use ProfessionalWiki\NeoWiki\Application\StatementListBuilder;
 use ProfessionalWiki\NeoWiki\Application\SubjectAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\SubjectRepository;
-use ProfessionalWiki\NeoWiki\Application\Validation\SubjectValidator;
+use ProfessionalWiki\NeoWiki\Application\Validation\ProposedSubjectValidator;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
-use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
 use ProfessionalWiki\NeoWiki\Infrastructure\IdGenerator;
 use RuntimeException;
 
@@ -29,7 +28,7 @@ readonly class CreateSubjectAction {
 		private StatementListBuilder $statementListBuilder,
 		private SchemaLookup $schemaLookup,
 		private SelectStatementResolver $selectStatementResolver,
-		private SubjectValidator $subjectValidator,
+		private ProposedSubjectValidator $proposedSubjectValidator,
 	) {
 	}
 
@@ -58,7 +57,7 @@ readonly class CreateSubjectAction {
 			return;
 		}
 
-		$violations = $this->validateProposedSubject( $subject );
+		$violations = $this->proposedSubjectValidator->validate( $subject );
 
 		$this->subjectRepository->savePageSubjects( $pageSubjects, new PageId( $request->pageId ), $request->comment );
 		$this->presenter->presentCreated( $subject->id->text, $violations );
@@ -90,21 +89,6 @@ readonly class CreateSubjectAction {
 		}
 
 		return $this->selectStatementResolver->resolve( $schema, $statements );
-	}
-
-	/** @return Violation[] */
-	private function validateProposedSubject( Subject $subject ): array {
-		$schema = $this->schemaLookup->getSchema( $subject->getSchemaName() );
-
-		if ( $schema === null ) {
-			return [];
-		}
-
-		return $this->subjectValidator->validate(
-			$subject->getLabel(),
-			$subject->getStatements(),
-			$schema,
-		);
 	}
 
 }

--- a/src/Application/Actions/CreateSubject/CreateSubjectAction.php
+++ b/src/Application/Actions/CreateSubject/CreateSubjectAction.php
@@ -4,16 +4,18 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Application\Actions\CreateSubject;
 
+use InvalidArgumentException;
 use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
 use ProfessionalWiki\NeoWiki\Application\SelectStatementResolver;
 use ProfessionalWiki\NeoWiki\Application\StatementListBuilder;
 use ProfessionalWiki\NeoWiki\Application\SubjectAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\SubjectRepository;
+use ProfessionalWiki\NeoWiki\Application\Validation\SubjectValidator;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
-use InvalidArgumentException;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
 use ProfessionalWiki\NeoWiki\Infrastructure\IdGenerator;
 use RuntimeException;
 
@@ -27,6 +29,7 @@ readonly class CreateSubjectAction {
 		private StatementListBuilder $statementListBuilder,
 		private SchemaLookup $schemaLookup,
 		private SelectStatementResolver $selectStatementResolver,
+		private SubjectValidator $subjectValidator,
 	) {
 	}
 
@@ -37,7 +40,7 @@ readonly class CreateSubjectAction {
 
 		if ( ( $request->isMainSubject && !$this->subjectAuthorizer->canCreateMainSubject(
 				) ) || !$this->subjectAuthorizer->canCreateChildSubject() ) {
-			throw new \RuntimeException( 'You do not have the necessary permissions to create this subject' );
+			throw new RuntimeException( 'You do not have the necessary permissions to create this subject' );
 		}
 
 		$subject = $this->buildSubject( $request );
@@ -50,14 +53,15 @@ readonly class CreateSubjectAction {
 			} else {
 				$pageSubjects->createChildSubject( $subject );
 			}
-		}
-		catch ( RuntimeException ) {
+		} catch ( RuntimeException ) {
 			$this->presenter->presentSubjectAlreadyExists();
 			return;
 		}
 
+		$violations = $this->validateProposedSubject( $subject );
+
 		$this->subjectRepository->savePageSubjects( $pageSubjects, new PageId( $request->pageId ), $request->comment );
-		$this->presenter->presentCreated( $subject->id->text );
+		$this->presenter->presentCreated( $subject->id->text, $violations );
 	}
 
 	private function buildSubject( CreateSubjectRequest $request ): Subject {
@@ -86,6 +90,21 @@ readonly class CreateSubjectAction {
 		}
 
 		return $this->selectStatementResolver->resolve( $schema, $statements );
+	}
+
+	/** @return Violation[] */
+	private function validateProposedSubject( Subject $subject ): array {
+		$schema = $this->schemaLookup->getSchema( $subject->getSchemaName() );
+
+		if ( $schema === null ) {
+			return [];
+		}
+
+		return $this->subjectValidator->validate(
+			$subject->getLabel(),
+			$subject->getStatements(),
+			$schema,
+		);
 	}
 
 }

--- a/src/Application/Actions/CreateSubject/CreateSubjectPresenter.php
+++ b/src/Application/Actions/CreateSubject/CreateSubjectPresenter.php
@@ -4,9 +4,12 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Application\Actions\CreateSubject;
 
+use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
+
 interface CreateSubjectPresenter {
 
-	public function presentCreated( string $subjectId ): void;
+	/** @param Violation[] $violations */
+	public function presentCreated( string $subjectId, array $violations ): void;
 
 	public function presentSubjectAlreadyExists(): void;
 

--- a/src/Application/Actions/ReplaceSubject/ReplaceSubjectAction.php
+++ b/src/Application/Actions/ReplaceSubject/ReplaceSubjectAction.php
@@ -4,17 +4,19 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Application\Actions\ReplaceSubject;
 
+use InvalidArgumentException;
 use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
 use ProfessionalWiki\NeoWiki\Application\SelectStatementResolver;
 use ProfessionalWiki\NeoWiki\Application\StatementListBuilder;
-use InvalidArgumentException;
-use ProfessionalWiki\NeoWiki\Application\SubjectAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\Subject\Exception\SubjectEditNotAuthorizedException;
 use ProfessionalWiki\NeoWiki\Application\Subject\Exception\SubjectNotFoundException;
+use ProfessionalWiki\NeoWiki\Application\SubjectAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\SubjectRepository;
+use ProfessionalWiki\NeoWiki\Application\Validation\SubjectValidator;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
 
 readonly class ReplaceSubjectAction {
 
@@ -24,13 +26,15 @@ readonly class ReplaceSubjectAction {
 		private StatementListBuilder $statementListBuilder,
 		private SchemaLookup $schemaLookup,
 		private SelectStatementResolver $selectStatementResolver,
+		private SubjectValidator $subjectValidator,
 	) {
 	}
 
 	/**
 	 * @param array<string, mixed> $statements
+	 * @return Violation[]
 	 */
-	public function replace( SubjectId $subjectId, string $label, array $statements, ?string $comment ): void {
+	public function replace( SubjectId $subjectId, string $label, array $statements, ?string $comment ): array {
 		if ( trim( $label ) === '' ) {
 			throw new InvalidArgumentException( 'SubjectLabel cannot be empty' );
 		}
@@ -50,7 +54,11 @@ readonly class ReplaceSubjectAction {
 			$this->statementListBuilder->build( $this->resolveStatements( $subject, $statements ) )
 		);
 
+		$violations = $this->validateProposedSubject( $subject );
+
 		$this->subjectRepository->updateSubject( $subject, $comment );
+
+		return $violations;
 	}
 
 	/**
@@ -66,6 +74,21 @@ readonly class ReplaceSubjectAction {
 		}
 
 		return $this->selectStatementResolver->resolve( $schema, $statements );
+	}
+
+	/** @return Violation[] */
+	private function validateProposedSubject( Subject $subject ): array {
+		$schema = $this->schemaLookup->getSchema( $subject->getSchemaName() );
+
+		if ( $schema === null ) {
+			return [];
+		}
+
+		return $this->subjectValidator->validate(
+			$subject->getLabel(),
+			$subject->getStatements(),
+			$schema,
+		);
 	}
 
 }

--- a/src/Application/Actions/ReplaceSubject/ReplaceSubjectAction.php
+++ b/src/Application/Actions/ReplaceSubject/ReplaceSubjectAction.php
@@ -12,7 +12,7 @@ use ProfessionalWiki\NeoWiki\Application\Subject\Exception\SubjectEditNotAuthori
 use ProfessionalWiki\NeoWiki\Application\Subject\Exception\SubjectNotFoundException;
 use ProfessionalWiki\NeoWiki\Application\SubjectAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\SubjectRepository;
-use ProfessionalWiki\NeoWiki\Application\Validation\SubjectValidator;
+use ProfessionalWiki\NeoWiki\Application\Validation\ProposedSubjectValidator;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
@@ -26,7 +26,7 @@ readonly class ReplaceSubjectAction {
 		private StatementListBuilder $statementListBuilder,
 		private SchemaLookup $schemaLookup,
 		private SelectStatementResolver $selectStatementResolver,
-		private SubjectValidator $subjectValidator,
+		private ProposedSubjectValidator $proposedSubjectValidator,
 	) {
 	}
 
@@ -54,7 +54,7 @@ readonly class ReplaceSubjectAction {
 			$this->statementListBuilder->build( $this->resolveStatements( $subject, $statements ) )
 		);
 
-		$violations = $this->validateProposedSubject( $subject );
+		$violations = $this->proposedSubjectValidator->validate( $subject );
 
 		$this->subjectRepository->updateSubject( $subject, $comment );
 
@@ -74,21 +74,6 @@ readonly class ReplaceSubjectAction {
 		}
 
 		return $this->selectStatementResolver->resolve( $schema, $statements );
-	}
-
-	/** @return Violation[] */
-	private function validateProposedSubject( Subject $subject ): array {
-		$schema = $this->schemaLookup->getSchema( $subject->getSchemaName() );
-
-		if ( $schema === null ) {
-			return [];
-		}
-
-		return $this->subjectValidator->validate(
-			$subject->getLabel(),
-			$subject->getStatements(),
-			$schema,
-		);
 	}
 
 }

--- a/src/Application/Validation/ProposedSubjectValidator.php
+++ b/src/Application/Validation/ProposedSubjectValidator.php
@@ -16,9 +16,10 @@ use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
  * violation is returned and the write still proceeds: the Subject stays
  * editable (ADR 21), but the response reports that it could not be validated
  * rather than implying it is valid. This matches the update-validate endpoint,
- * which emits the same violation. Centralising the decision here keeps the
- * write paths (CreateSubjectAction, ReplaceSubjectAction) from each repeating
- * it and gives the future enforcement tier one place to reason about it.
+ * which emits the same violation. Centralising the decision keeps the two write
+ * paths (CreateSubjectAction, ReplaceSubjectAction) from repeating it, and is
+ * where the enforcement tier will hook in. ValidateSubjectUpdateQuery still has
+ * its own copy until the validate and write flows are unified.
  */
 readonly class ProposedSubjectValidator {
 

--- a/src/Application/Validation/ProposedSubjectValidator.php
+++ b/src/Application/Validation/ProposedSubjectValidator.php
@@ -15,7 +15,9 @@ use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
  * When the Schema cannot be found, no violations are returned: the Subject is
  * left unvalidated so the write can still proceed and the Subject stays
  * editable (ADR 21). Centralising that decision here keeps the write paths
- * (CreateSubjectAction, ReplaceSubjectAction) from each repeating it.
+ * (CreateSubjectAction, ReplaceSubjectAction) from each repeating it, and
+ * gives the enforcement tier one place to revisit it, e.g. to align with the
+ * dedicated validate endpoints, which report a missing Schema differently.
  */
 readonly class ProposedSubjectValidator {
 

--- a/src/Application/Validation/ProposedSubjectValidator.php
+++ b/src/Application/Validation/ProposedSubjectValidator.php
@@ -12,12 +12,13 @@ use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
  * Validates a proposed Subject against its current Schema, looking the Schema
  * up by the Subject's Schema name and delegating to {@see SubjectValidator}.
  *
- * When the Schema cannot be found, no violations are returned: the Subject is
- * left unvalidated so the write can still proceed and the Subject stays
- * editable (ADR 21). Centralising that decision here keeps the write paths
- * (CreateSubjectAction, ReplaceSubjectAction) from each repeating it, and
- * gives the enforcement tier one place to revisit it, e.g. to align with the
- * dedicated validate endpoints, which report a missing Schema differently.
+ * When the Schema cannot be found, a single non-blocking `schema-not-found`
+ * violation is returned and the write still proceeds: the Subject stays
+ * editable (ADR 21), but the response reports that it could not be validated
+ * rather than implying it is valid. This matches the update-validate endpoint,
+ * which emits the same violation. Centralising the decision here keeps the
+ * write paths (CreateSubjectAction, ReplaceSubjectAction) from each repeating
+ * it and gives the future enforcement tier one place to reason about it.
  */
 readonly class ProposedSubjectValidator {
 
@@ -34,7 +35,13 @@ readonly class ProposedSubjectValidator {
 		$schema = $this->schemaLookup->getSchema( $subject->getSchemaName() );
 
 		if ( $schema === null ) {
-			return [];
+			return [
+				new Violation(
+					propertyName: null,
+					code: 'schema-not-found',
+					args: [ $subject->getSchemaName()->getText() ],
+				),
+			];
 		}
 
 		return $this->subjectValidator->validate(

--- a/src/Application/Validation/ProposedSubjectValidator.php
+++ b/src/Application/Validation/ProposedSubjectValidator.php
@@ -1,0 +1,45 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application\Validation;
+
+use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
+use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
+
+/**
+ * Validates a proposed Subject against its current Schema, looking the Schema
+ * up by the Subject's Schema name and delegating to {@see SubjectValidator}.
+ *
+ * When the Schema cannot be found, no violations are returned: the Subject is
+ * left unvalidated so the write can still proceed and the Subject stays
+ * editable (ADR 21). Centralising that decision here keeps the write paths
+ * (CreateSubjectAction, ReplaceSubjectAction) from each repeating it.
+ */
+readonly class ProposedSubjectValidator {
+
+	public function __construct(
+		private SchemaLookup $schemaLookup,
+		private SubjectValidator $subjectValidator,
+	) {
+	}
+
+	/**
+	 * @return Violation[]
+	 */
+	public function validate( Subject $subject ): array {
+		$schema = $this->schemaLookup->getSchema( $subject->getSchemaName() );
+
+		if ( $schema === null ) {
+			return [];
+		}
+
+		return $this->subjectValidator->validate(
+			$subject->getLabel(),
+			$subject->getStatements(),
+			$schema,
+		);
+	}
+
+}

--- a/src/EntryPoints/REST/CreateSubjectApi.php
+++ b/src/EntryPoints/REST/CreateSubjectApi.php
@@ -10,6 +10,7 @@ use ProfessionalWiki\NeoWiki\Application\Actions\CreateSubject\CreateSubjectPres
 use ProfessionalWiki\NeoWiki\Application\Actions\CreateSubject\CreateSubjectRequest;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Presentation\CsrfValidator;
+use ProfessionalWiki\NeoWiki\Presentation\ViolationSerializer;
 use Wikimedia\ParamValidator\ParamValidator;
 
 class CreateSubjectApi extends SimpleHandler implements CreateSubjectPresenter {
@@ -99,10 +100,11 @@ class CreateSubjectApi extends SimpleHandler implements CreateSubjectPresenter {
 		];
 	}
 
-	public function presentCreated( string $subjectId ): void {
+	public function presentCreated( string $subjectId, array $violations ): void {
 		$this->apiResponse = [
 			'status' => 'created',
 			'subjectId' => $subjectId,
+			'violations' => ViolationSerializer::serializeMany( $violations ),
 		];
 	}
 

--- a/src/EntryPoints/REST/ReplaceSubjectApi.php
+++ b/src/EntryPoints/REST/ReplaceSubjectApi.php
@@ -13,6 +13,7 @@ use ProfessionalWiki\NeoWiki\Application\Subject\Exception\SubjectNotFoundExcept
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Presentation\CsrfValidator;
+use ProfessionalWiki\NeoWiki\Presentation\ViolationSerializer;
 use Wikimedia\ParamValidator\ParamValidator;
 
 class ReplaceSubjectApi extends SimpleHandler {
@@ -31,7 +32,7 @@ class ReplaceSubjectApi extends SimpleHandler {
 		$body = $this->getValidatedBody();
 
 		try {
-			NeoWikiExtension::getInstance()->newReplaceSubjectAction( $this->getAuthority() )->replace(
+			$violations = NeoWikiExtension::getInstance()->newReplaceSubjectAction( $this->getAuthority() )->replace(
 				new SubjectId( $subjectId ),
 				$body['label'],
 				$body['statements'],
@@ -57,6 +58,7 @@ class ReplaceSubjectApi extends SimpleHandler {
 		return $this->getResponseFactory()->createJson( [
 			'status' => 'updated',
 			'subjectId' => $subjectId,
+			'violations' => ViolationSerializer::serializeMany( $violations ),
 		] );
 	}
 

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -25,6 +25,7 @@ use ProfessionalWiki\NeoWiki\Application\Actions\SetMainSubject\SetMainSubjectAc
 use ProfessionalWiki\NeoWiki\Application\Actions\SetMainSubject\SetMainSubjectPresenter;
 use ProfessionalWiki\NeoWiki\Application\Actions\ReplaceSubject\ReplaceSubjectAction;
 use ProfessionalWiki\NeoWiki\Application\StatementListBuilder;
+use ProfessionalWiki\NeoWiki\Application\Validation\ProposedSubjectValidator;
 use ProfessionalWiki\NeoWiki\Application\Validation\SubjectValidator;
 use ProfessionalWiki\NeoWiki\Application\PageIdentifiersLookup;
 use ProfessionalWiki\NeoWiki\Application\PageSubjectsLookup;
@@ -334,7 +335,7 @@ class NeoWikiExtension {
 			statementListBuilder: $this->getStatementListBuilder(),
 			schemaLookup: $this->getSchemaLookup(),
 			selectStatementResolver: $this->getSelectStatementResolver(),
-			subjectValidator: $this->getSubjectValidator(),
+			proposedSubjectValidator: $this->getProposedSubjectValidator(),
 		);
 	}
 
@@ -506,13 +507,20 @@ class NeoWikiExtension {
 			statementListBuilder: $this->getStatementListBuilder(),
 			schemaLookup: $this->getSchemaLookup(),
 			selectStatementResolver: $this->getSelectStatementResolver(),
-			subjectValidator: $this->getSubjectValidator(),
+			proposedSubjectValidator: $this->getProposedSubjectValidator(),
 		);
 	}
 
 	public function getSubjectValidator(): SubjectValidator {
 		return new SubjectValidator(
 			propertyTypeLookup: $this->getPropertyTypeLookup(),
+		);
+	}
+
+	public function getProposedSubjectValidator(): ProposedSubjectValidator {
+		return new ProposedSubjectValidator(
+			schemaLookup: $this->getSchemaLookup(),
+			subjectValidator: $this->getSubjectValidator(),
 		);
 	}
 

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -334,6 +334,7 @@ class NeoWikiExtension {
 			statementListBuilder: $this->getStatementListBuilder(),
 			schemaLookup: $this->getSchemaLookup(),
 			selectStatementResolver: $this->getSelectStatementResolver(),
+			subjectValidator: $this->getSubjectValidator(),
 		);
 	}
 

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -505,6 +505,7 @@ class NeoWikiExtension {
 			statementListBuilder: $this->getStatementListBuilder(),
 			schemaLookup: $this->getSchemaLookup(),
 			selectStatementResolver: $this->getSelectStatementResolver(),
+			subjectValidator: $this->getSubjectValidator(),
 		);
 	}
 

--- a/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
@@ -145,6 +145,7 @@ class CreateSubjectActionTest extends TestCase {
 			'presentSubjectAlreadyExists',
 			$this->presenterSpy->result
 		);
+		$this->assertSame( [], $this->presenterSpy->violations );
 	}
 
 	public function testUserIsNotAllowedToCreateSubject(): void {

--- a/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
@@ -379,7 +379,7 @@ class CreateSubjectActionTest extends TestCase {
 		$this->assertSame( 'Status', $this->presenterSpy->violations[0]->propertyName?->text );
 	}
 
-	public function testCreateWithMissingSchemaProducesEmptyViolations(): void {
+	public function testCreateWithMissingSchemaSurfacesSchemaNotFoundButStillPersists(): void {
 		$this->subjectRepository->savePageSubjects( PageSubjects::newEmpty(), new PageId( 1 ) );
 
 		$this->newCreateSubjectAction()->createSubject(
@@ -393,7 +393,9 @@ class CreateSubjectActionTest extends TestCase {
 		);
 
 		$this->assertSame( 's' . self::STUB_ID, $this->presenterSpy->result );
-		$this->assertSame( [], $this->presenterSpy->violations );
+		$this->assertCount( 1, $this->presenterSpy->violations );
+		$this->assertSame( 'schema-not-found', $this->presenterSpy->violations[0]->code );
+		$this->assertSame( [ 'NonexistentSchema' ], $this->presenterSpy->violations[0]->args );
 	}
 
 	public function testCreateWithViolationsStillPersistsTheSubject(): void {

--- a/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
@@ -10,6 +10,7 @@ use ProfessionalWiki\NeoWiki\Application\Actions\CreateSubject\CreateSubjectRequ
 use ProfessionalWiki\NeoWiki\Application\SelectStatementResolver;
 use ProfessionalWiki\NeoWiki\Application\SelectValueResolver;
 use ProfessionalWiki\NeoWiki\Application\StatementListBuilder;
+use ProfessionalWiki\NeoWiki\Application\Validation\ProposedSubjectValidator;
 use ProfessionalWiki\NeoWiki\Application\Validation\SubjectValidator;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
@@ -72,7 +73,10 @@ class CreateSubjectActionTest extends TestCase {
 			),
 			$this->schemaLookup,
 			new SelectStatementResolver( new SelectValueResolver() ),
-			new SubjectValidator( propertyTypeLookup: $registry ),
+			new ProposedSubjectValidator(
+				schemaLookup: $this->schemaLookup,
+				subjectValidator: new SubjectValidator( propertyTypeLookup: $registry ),
+			),
 		);
 	}
 

--- a/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
@@ -10,6 +10,7 @@ use ProfessionalWiki\NeoWiki\Application\Actions\CreateSubject\CreateSubjectRequ
 use ProfessionalWiki\NeoWiki\Application\SelectStatementResolver;
 use ProfessionalWiki\NeoWiki\Application\SelectValueResolver;
 use ProfessionalWiki\NeoWiki\Application\StatementListBuilder;
+use ProfessionalWiki\NeoWiki\Application\Validation\SubjectValidator;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\SelectOption;
@@ -59,17 +60,19 @@ class CreateSubjectActionTest extends TestCase {
 	}
 
 	private function newCreateSubjectAction(): CreateSubjectAction {
+		$registry = PropertyTypeRegistry::withCoreTypes();
 		return new CreateSubjectAction(
 			$this->presenterSpy,
 			$this->subjectRepository,
 			$this->idGenerator,
 			$this->authorizer,
 			new StatementListBuilder(
-				new PropertyTypeToValueType( PropertyTypeRegistry::withCoreTypes() ),
+				new PropertyTypeToValueType( $registry ),
 				$this->idGenerator
 			),
 			$this->schemaLookup,
 			new SelectStatementResolver( new SelectValueResolver() ),
+			new SubjectValidator( propertyTypeLookup: $registry ),
 		);
 	}
 
@@ -314,6 +317,98 @@ class CreateSubjectActionTest extends TestCase {
 		);
 
 		$this->assertSame( [ 'opt_draft' ], $this->getStatusValueForCreatedSubject()->strings );
+	}
+
+	private function registerSchemaWithRequiredStatus(): void {
+		$this->schemaLookup->updateSchema( new Schema(
+			name: new SchemaName( self::SELECT_SCHEMA_NAME ),
+			description: '',
+			properties: new PropertyDefinitions( [
+				'Status' => new SelectProperty(
+					core: new PropertyCore( description: '', required: true, default: null ),
+					options: [
+						new SelectOption( id: 'opt_draft', label: 'Draft' ),
+						new SelectOption( id: 'opt_approved', label: 'Approved' ),
+					],
+					multiple: false,
+				),
+			] )
+		) );
+	}
+
+	public function testCreateProducesEmptyViolationsForCleanInput(): void {
+		$this->registerSelectSchema();
+		$this->subjectRepository->savePageSubjects( PageSubjects::newEmpty(), new PageId( 1 ) );
+
+		$this->newCreateSubjectAction()->createSubject(
+			new CreateSubjectRequest(
+				pageId: 1,
+				isMainSubject: true,
+				label: 'Some Label',
+				schemaName: self::SELECT_SCHEMA_NAME,
+				statements: [],
+			)
+		);
+
+		$this->assertSame( 's' . self::STUB_ID, $this->presenterSpy->result );
+		$this->assertSame( [], $this->presenterSpy->violations );
+	}
+
+	public function testCreateProducesViolationForRequiredPropertyMissing(): void {
+		$this->registerSchemaWithRequiredStatus();
+		$this->subjectRepository->savePageSubjects( PageSubjects::newEmpty(), new PageId( 1 ) );
+
+		$this->newCreateSubjectAction()->createSubject(
+			new CreateSubjectRequest(
+				pageId: 1,
+				isMainSubject: true,
+				label: 'Some Label',
+				schemaName: self::SELECT_SCHEMA_NAME,
+				statements: [],
+			)
+		);
+
+		$this->assertSame( 's' . self::STUB_ID, $this->presenterSpy->result );
+		$this->assertCount( 1, $this->presenterSpy->violations );
+		$this->assertSame( 'required', $this->presenterSpy->violations[0]->code );
+		$this->assertSame( 'Status', $this->presenterSpy->violations[0]->propertyName?->text );
+	}
+
+	public function testCreateWithMissingSchemaProducesEmptyViolations(): void {
+		$this->subjectRepository->savePageSubjects( PageSubjects::newEmpty(), new PageId( 1 ) );
+
+		$this->newCreateSubjectAction()->createSubject(
+			new CreateSubjectRequest(
+				pageId: 1,
+				isMainSubject: true,
+				label: 'Some Label',
+				schemaName: 'NonexistentSchema',
+				statements: [],
+			)
+		);
+
+		$this->assertSame( 's' . self::STUB_ID, $this->presenterSpy->result );
+		$this->assertSame( [], $this->presenterSpy->violations );
+	}
+
+	public function testCreateWithViolationsStillPersistsTheSubject(): void {
+		$this->registerSchemaWithRequiredStatus();
+		$this->subjectRepository->savePageSubjects( PageSubjects::newEmpty(), new PageId( 1 ) );
+
+		$this->newCreateSubjectAction()->createSubject(
+			new CreateSubjectRequest(
+				pageId: 1,
+				isMainSubject: true,
+				label: 'Some Label',
+				schemaName: self::SELECT_SCHEMA_NAME,
+				statements: [],
+			)
+		);
+
+		$this->assertSame( 's' . self::STUB_ID, $this->presenterSpy->result );
+		$this->assertNotEmpty(
+			$this->subjectRepository->getSubject( new SubjectId( 's' . self::STUB_ID ) )
+		);
 	}
 
 	public function testNewRelationGetsGuidAssigned(): void {

--- a/tests/phpunit/Application/Actions/CreateSubjectPresenterSpy.php
+++ b/tests/phpunit/Application/Actions/CreateSubjectPresenterSpy.php
@@ -5,13 +5,18 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Tests\Application\Actions;
 
 use ProfessionalWiki\NeoWiki\Application\Actions\CreateSubject\CreateSubjectPresenter;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
 
 class CreateSubjectPresenterSpy implements CreateSubjectPresenter {
 
 	public string $result = '';
 
-	public function presentCreated( string $subjectId ): void {
+	/** @var Violation[] */
+	public array $violations = [];
+
+	public function presentCreated( string $subjectId, array $violations ): void {
 		$this->result = $subjectId;
+		$this->violations = $violations;
 	}
 
 	public function presentSubjectAlreadyExists(): void {

--- a/tests/phpunit/Application/Actions/ReplaceSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/ReplaceSubjectActionTest.php
@@ -11,6 +11,7 @@ use ProfessionalWiki\NeoWiki\Application\SelectValueResolver;
 use ProfessionalWiki\NeoWiki\Application\StatementListBuilder;
 use ProfessionalWiki\NeoWiki\Application\Subject\Exception\SubjectEditNotAuthorizedException;
 use ProfessionalWiki\NeoWiki\Application\Subject\Exception\SubjectNotFoundException;
+use ProfessionalWiki\NeoWiki\Application\Validation\SubjectValidator;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeRegistry;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeToValueType;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\SelectOption;
@@ -48,8 +49,9 @@ class ReplaceSubjectActionTest extends TestCase {
 	}
 
 	private function newAction( ?SubjectAuthorizer $authorizer = null ): ReplaceSubjectAction {
+		$registry = PropertyTypeRegistry::withCoreTypes();
 		$builder = new StatementListBuilder(
-			propertyTypeToValueType: new PropertyTypeToValueType( PropertyTypeRegistry::withCoreTypes() ),
+			propertyTypeToValueType: new PropertyTypeToValueType( $registry ),
 			idGenerator: new StubIdGenerator( '11111111111127' )
 		);
 		return new ReplaceSubjectAction(
@@ -58,6 +60,7 @@ class ReplaceSubjectActionTest extends TestCase {
 			statementListBuilder: $builder,
 			schemaLookup: $this->schemaLookup,
 			selectStatementResolver: new SelectStatementResolver( new SelectValueResolver() ),
+			subjectValidator: new SubjectValidator( propertyTypeLookup: $registry ),
 		);
 	}
 
@@ -203,6 +206,96 @@ class ReplaceSubjectActionTest extends TestCase {
 		);
 
 		$this->assertSame( [ 'opt_draft' ], $this->getStatusValue( new SubjectId( self::SUBJECT_ID ) )->strings );
+	}
+
+	private function registerSchemaWithRequiredStatus(): void {
+		$this->schemaLookup->updateSchema( new Schema(
+			name: new SchemaName( self::SCHEMA_NAME ),
+			description: '',
+			properties: new PropertyDefinitions( [
+				'Status' => new SelectProperty(
+					core: new PropertyCore( description: '', required: true, default: null ),
+					options: [
+						new SelectOption( id: 'opt_draft', label: 'Draft' ),
+						new SelectOption( id: 'opt_approved', label: 'Approved' ),
+					],
+					multiple: false,
+				),
+			] )
+		) );
+	}
+
+	public function testReplaceReturnsEmptyViolationsForCleanInput(): void {
+		$this->registerSchemaWithSelect();
+		$subject = TestSubject::build(
+			id: new SubjectId( self::SUBJECT_ID ),
+			label: new SubjectLabel( 'Original Label' ),
+			schemaName: new SchemaName( self::SCHEMA_NAME ),
+		);
+		$this->subjectRepository->updateSubject( $subject );
+
+		$violations = $this->newAction()->replace(
+			new SubjectId( self::SUBJECT_ID ),
+			'New Label',
+			[ 'Status' => [ 'propertyType' => 'select', 'value' => 'Approved' ] ],
+			null
+		);
+
+		$this->assertSame( [], $violations );
+	}
+
+	public function testReplaceReturnsViolationForRequiredPropertyMissing(): void {
+		$this->registerSchemaWithRequiredStatus();
+		$subject = TestSubject::build(
+			id: new SubjectId( self::SUBJECT_ID ),
+			label: new SubjectLabel( 'Before' ),
+			schemaName: new SchemaName( self::SCHEMA_NAME ),
+		);
+		$this->subjectRepository->updateSubject( $subject );
+
+		$violations = $this->newAction()->replace(
+			new SubjectId( self::SUBJECT_ID ),
+			'After',
+			[],
+			null
+		);
+
+		$this->assertCount( 1, $violations );
+		$this->assertSame( 'required', $violations[0]->code );
+		$this->assertSame( 'Status', $violations[0]->propertyName?->text );
+	}
+
+	public function testReplaceWithMissingSchemaReturnsEmptyViolations(): void {
+		$subject = TestSubject::build(
+			id: new SubjectId( self::SUBJECT_ID ),
+			label: new SubjectLabel( 'Orphan' ),
+			schemaName: new SchemaName( 'NonexistentSchema' ),
+		);
+		$this->subjectRepository->updateSubject( $subject );
+
+		$violations = $this->newAction()->replace(
+			new SubjectId( self::SUBJECT_ID ),
+			'Still Orphan',
+			[],
+			null
+		);
+
+		$this->assertSame( [], $violations );
+	}
+
+	public function testReplaceWithViolationsStillPersistsTheSubject(): void {
+		$this->registerSchemaWithRequiredStatus();
+		$subject = TestSubject::build(
+			id: new SubjectId( self::SUBJECT_ID ),
+			label: new SubjectLabel( 'Before' ),
+			schemaName: new SchemaName( self::SCHEMA_NAME ),
+		);
+		$this->subjectRepository->updateSubject( $subject );
+
+		$this->newAction()->replace( new SubjectId( self::SUBJECT_ID ), 'After', [], null );
+
+		$stored = $this->subjectRepository->getSubject( new SubjectId( self::SUBJECT_ID ) );
+		$this->assertSame( 'After', $stored->getLabel()->text );
 	}
 
 }

--- a/tests/phpunit/Application/Actions/ReplaceSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/ReplaceSubjectActionTest.php
@@ -11,6 +11,7 @@ use ProfessionalWiki\NeoWiki\Application\SelectValueResolver;
 use ProfessionalWiki\NeoWiki\Application\StatementListBuilder;
 use ProfessionalWiki\NeoWiki\Application\Subject\Exception\SubjectEditNotAuthorizedException;
 use ProfessionalWiki\NeoWiki\Application\Subject\Exception\SubjectNotFoundException;
+use ProfessionalWiki\NeoWiki\Application\Validation\ProposedSubjectValidator;
 use ProfessionalWiki\NeoWiki\Application\Validation\SubjectValidator;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeRegistry;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeToValueType;
@@ -60,7 +61,10 @@ class ReplaceSubjectActionTest extends TestCase {
 			statementListBuilder: $builder,
 			schemaLookup: $this->schemaLookup,
 			selectStatementResolver: new SelectStatementResolver( new SelectValueResolver() ),
-			subjectValidator: new SubjectValidator( propertyTypeLookup: $registry ),
+			proposedSubjectValidator: new ProposedSubjectValidator(
+				schemaLookup: $this->schemaLookup,
+				subjectValidator: new SubjectValidator( propertyTypeLookup: $registry ),
+			),
 		);
 	}
 

--- a/tests/phpunit/Application/Actions/ReplaceSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/ReplaceSubjectActionTest.php
@@ -269,7 +269,7 @@ class ReplaceSubjectActionTest extends TestCase {
 		$this->assertSame( 'Status', $violations[0]->propertyName?->text );
 	}
 
-	public function testReplaceWithMissingSchemaReturnsEmptyViolations(): void {
+	public function testReplaceWithMissingSchemaReturnsSchemaNotFound(): void {
 		$subject = TestSubject::build(
 			id: new SubjectId( self::SUBJECT_ID ),
 			label: new SubjectLabel( 'Orphan' ),
@@ -284,7 +284,9 @@ class ReplaceSubjectActionTest extends TestCase {
 			null
 		);
 
-		$this->assertSame( [], $violations );
+		$this->assertCount( 1, $violations );
+		$this->assertSame( 'schema-not-found', $violations[0]->code );
+		$this->assertSame( [ 'NonexistentSchema' ], $violations[0]->args );
 	}
 
 	public function testReplaceWithViolationsStillPersistsTheSubject(): void {

--- a/tests/phpunit/Application/Validation/ProposedSubjectValidatorTest.php
+++ b/tests/phpunit/Application/Validation/ProposedSubjectValidatorTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Application\Validation;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\Validation\ProposedSubjectValidator;
+use ProfessionalWiki\NeoWiki\Application\Validation\SubjectValidator;
+use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeRegistry;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Property\NumberProperty;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinitions;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySchemaLookup;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Application\Validation\ProposedSubjectValidator
+ */
+class ProposedSubjectValidatorTest extends TestCase {
+
+	private const string SCHEMA_NAME = 'Person';
+
+	private InMemorySchemaLookup $schemaLookup;
+
+	protected function setUp(): void {
+		$this->schemaLookup = new InMemorySchemaLookup();
+	}
+
+	private function newValidator(): ProposedSubjectValidator {
+		return new ProposedSubjectValidator(
+			schemaLookup: $this->schemaLookup,
+			subjectValidator: new SubjectValidator( propertyTypeLookup: PropertyTypeRegistry::withCoreTypes() ),
+		);
+	}
+
+	private function registerSchemaWithAge( bool $required ): void {
+		$this->schemaLookup->updateSchema( new Schema(
+			name: new SchemaName( self::SCHEMA_NAME ),
+			description: '',
+			properties: new PropertyDefinitions( [
+				'Age' => NumberProperty::fromPartialJson(
+					new PropertyCore( description: '', required: $required, default: null ),
+					[ 'minimum' => null, 'maximum' => null, 'precision' => null ],
+				),
+			] ),
+		) );
+	}
+
+	private function newSubject( string $schemaName = self::SCHEMA_NAME ): Subject {
+		return TestSubject::build(
+			label: 'John Doe',
+			schemaName: new SchemaName( $schemaName ),
+		);
+	}
+
+	public function testReturnsNoViolationsForValidSubject(): void {
+		$this->registerSchemaWithAge( required: false );
+
+		$this->assertSame( [], $this->newValidator()->validate( $this->newSubject() ) );
+	}
+
+	public function testReturnsViolationFromSchemaForMissingRequiredProperty(): void {
+		$this->registerSchemaWithAge( required: true );
+
+		$violations = $this->newValidator()->validate( $this->newSubject() );
+
+		$this->assertCount( 1, $violations );
+		$this->assertSame( 'required', $violations[0]->code );
+		$this->assertSame( 'Age', $violations[0]->propertyName?->text );
+	}
+
+	public function testReturnsNoViolationsWhenSchemaNotFound(): void {
+		$this->registerSchemaWithAge( required: true );
+
+		$this->assertSame( [], $this->newValidator()->validate( $this->newSubject( 'UnregisteredSchema' ) ) );
+	}
+
+}

--- a/tests/phpunit/Application/Validation/ProposedSubjectValidatorTest.php
+++ b/tests/phpunit/Application/Validation/ProposedSubjectValidatorTest.php
@@ -73,10 +73,15 @@ class ProposedSubjectValidatorTest extends TestCase {
 		$this->assertSame( 'Age', $violations[0]->propertyName?->text );
 	}
 
-	public function testReturnsNoViolationsWhenSchemaNotFound(): void {
+	public function testReturnsSchemaNotFoundViolationWhenSchemaIsMissing(): void {
 		$this->registerSchemaWithAge( required: true );
 
-		$this->assertSame( [], $this->newValidator()->validate( $this->newSubject( 'UnregisteredSchema' ) ) );
+		$violations = $this->newValidator()->validate( $this->newSubject( 'UnregisteredSchema' ) );
+
+		$this->assertCount( 1, $violations );
+		$this->assertSame( 'schema-not-found', $violations[0]->code );
+		$this->assertNull( $violations[0]->propertyName );
+		$this->assertSame( [ 'UnregisteredSchema' ], $violations[0]->args );
 	}
 
 }

--- a/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
@@ -152,6 +152,28 @@ class CreateSubjectApiTest extends NeoWikiIntegrationTestCase {
 		$this->assertSame( 'Status', $responseData['violations'][0]['propertyName'] );
 	}
 
+	public function testResponseIncludesSchemaNotFoundWhenSchemaMissing(): void {
+		$body = [
+			'label' => 'Subject with missing schema',
+			'schema' => 'NeverCreatedSchema',
+			'statements' => [],
+		];
+
+		$response = $this->executeHandler(
+			$this->newCreateSubjectApi(),
+			$this->createRequestData( $body )
+		);
+
+		$responseData = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertSame( 201, $response->getStatusCode() );
+		$this->assertSame( 'created', $responseData['status'] );
+		$this->assertCount( 1, $responseData['violations'] );
+		$this->assertSame( 'schema-not-found', $responseData['violations'][0]['code'] );
+		$this->assertNull( $responseData['violations'][0]['propertyName'] );
+		$this->assertSame( [ 'NeverCreatedSchema' ], $responseData['violations'][0]['args'] );
+	}
+
 	public function testAlreadyExistingMainSubjectResponseOmitsViolations(): void {
 		$this->createSchema( 'Employee' );
 

--- a/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
@@ -11,11 +11,13 @@ use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
 use MediaWiki\Tests\Unit\Permissions\MockAuthorityTrait;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
 use ProfessionalWiki\NeoWiki\Domain\Value\NumberValue;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\CreateSubjectApi;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Presentation\CsrfValidator;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestStatement;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
 use MediaWiki\Title\Title;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
 
@@ -148,6 +150,37 @@ class CreateSubjectApiTest extends NeoWikiIntegrationTestCase {
 		$this->assertNotEmpty( $responseData['violations'] );
 		$this->assertSame( 'required', $responseData['violations'][0]['code'] );
 		$this->assertSame( 'Status', $responseData['violations'][0]['propertyName'] );
+	}
+
+	public function testAlreadyExistingMainSubjectResponseOmitsViolations(): void {
+		$this->createSchema( 'Employee' );
+
+		$pageTitle = 'CreateSubjectApiTestAlreadyExists';
+		$this->createPageWithSubjects(
+			$pageTitle,
+			mainSubject: TestSubject::build(
+				id: 'sTestCSA11111A1',
+				label: new SubjectLabel( 'First main subject' ),
+			)
+		);
+		$pageId = MediaWikiServices::getInstance()->getWikiPageFactory()
+			->newFromTitle( Title::newFromText( $pageTitle ) )->getId();
+
+		$response = $this->executeHandler(
+			$this->newCreateSubjectApi(),
+			new RequestData( [
+				'method' => 'POST',
+				'pathParams' => [ 'pageId' => $pageId ],
+				'bodyContents' => json_encode( $this->validBody() ),
+				'headers' => [ 'Content-Type' => 'application/json' ],
+			] )
+		);
+
+		$responseData = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertSame( 'error', $responseData['status'] );
+		$this->assertSame( 'Subject already exists', $responseData['message'] );
+		$this->assertArrayNotHasKey( 'violations', $responseData );
 	}
 
 	public function testRejectsBodyMissingLabel(): void {

--- a/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
@@ -40,6 +40,8 @@ class CreateSubjectApiTest extends NeoWikiIntegrationTestCase {
 
 		$this->assertSame( 201, $response->getStatusCode() );
 		$this->assertSame( 'created', $responseData['status'] );
+		$this->assertArrayHasKey( 'violations', $responseData );
+		$this->assertSame( [], $responseData['violations'] );
 
 		$subject = NeoWikiExtension::getInstance()->newSubjectRepository()->getSubject( new SubjectId( $responseData['subjectId'] ) );
 
@@ -119,6 +121,33 @@ class CreateSubjectApiTest extends NeoWikiIntegrationTestCase {
 		$this->assertSame( 403, $response->getStatusCode() );
 		$this->assertSame( 'error', $responseData['status'] );
 		$this->assertSame( 'You do not have the necessary permissions to create this subject', $responseData['message'] );
+		$this->assertArrayNotHasKey( 'violations', $responseData );
+	}
+
+	public function testResponseIncludesViolationsWhenRequiredPropertyMissing(): void {
+		$this->createSchema(
+			'CreateViolationSchema',
+			'{"title":"CreateViolationSchema","propertyDefinitions":{"Status":{"type":"text","required":true}}}'
+		);
+
+		$body = [
+			'label' => 'Subject with missing required',
+			'schema' => 'CreateViolationSchema',
+			'statements' => [],
+		];
+
+		$response = $this->executeHandler(
+			$this->newCreateSubjectApi(),
+			$this->createRequestData( $body )
+		);
+
+		$responseData = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertSame( 201, $response->getStatusCode() );
+		$this->assertSame( 'created', $responseData['status'] );
+		$this->assertNotEmpty( $responseData['violations'] );
+		$this->assertSame( 'required', $responseData['violations'][0]['code'] );
+		$this->assertSame( 'Status', $responseData['violations'][0]['propertyName'] );
 	}
 
 	public function testRejectsBodyMissingLabel(): void {

--- a/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
@@ -125,6 +125,48 @@ class ReplaceSubjectApiTest extends NeoWikiIntegrationTestCase {
 		$this->assertSame( [], $subject->getStatements()->asArray() );
 	}
 
+	public function testResponseIncludesMultipleViolations(): void {
+		$this->createSchema(
+			'ReplaceMultiViolationSchema',
+			'{"title":"ReplaceMultiViolationSchema","propertyDefinitions":{"Alpha":{"type":"text","required":true},"Beta":{"type":"text","required":true}}}'
+		);
+		$this->createPageWithSubjects(
+			'ReplaceSubjectApiMultiViolationTest',
+			mainSubject: TestSubject::build(
+				id: 'sTestSA11111133',
+				label: new SubjectLabel( 'Subject with two required properties' ),
+				schemaName: new SchemaName( 'ReplaceMultiViolationSchema' ),
+			)
+		);
+
+		$response = $this->executeHandler(
+			$this->newReplaceSubjectApi(),
+			new RequestData( [
+				'method' => 'PUT',
+				'pathParams' => [ 'subjectId' => 'sTestSA11111133' ],
+				'bodyContents' => json_encode( [
+					'label' => 'Still missing both',
+					'statements' => [],
+				] ),
+				'headers' => [ 'Content-Type' => 'application/json' ],
+			] )
+		);
+
+		$responseData = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertSame( 200, $response->getStatusCode() );
+		$this->assertCount( 2, $responseData['violations'] );
+		$propertyNames = array_map(
+			static fn ( array $v ): string => $v['propertyName'],
+			$responseData['violations']
+		);
+		$this->assertSame( [ 'Alpha', 'Beta' ], $propertyNames );
+		foreach ( $responseData['violations'] as $violation ) {
+			$this->assertSame( 'required', $violation['code'] );
+			$this->assertSame( [], $violation['args'] );
+		}
+	}
+
 	public function testNonExistentSubjectReturns404(): void {
 		$body = $this->validBody();
 

--- a/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
@@ -8,6 +8,7 @@ use MediaWiki\Rest\HttpException;
 use MediaWiki\Rest\RequestData;
 use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
 use MediaWiki\Tests\Unit\Permissions\MockAuthorityTrait;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\ReplaceSubjectApi;
 use ProfessionalWiki\NeoWiki\Presentation\CsrfValidator;
@@ -39,6 +40,44 @@ class ReplaceSubjectApiTest extends NeoWikiIntegrationTestCase {
 		$this->assertSame( 200, $response->getStatusCode() );
 		$this->assertSame( 'updated', $responseData['status'] );
 		$this->assertSame( 'sTestSA11111111', $responseData['subjectId'] );
+		$this->assertArrayHasKey( 'violations', $responseData );
+		$this->assertSame( [], $responseData['violations'] );
+	}
+
+	public function testResponseIncludesViolationsWhenRequiredPropertyMissing(): void {
+		$this->createSchema(
+			'ReplaceViolationSchema',
+			'{"title":"ReplaceViolationSchema","propertyDefinitions":{"Status":{"type":"text","required":true}}}'
+		);
+		$this->createPageWithSubjects(
+			'ReplaceSubjectApiViolationTest',
+			mainSubject: TestSubject::build(
+				id: 'sTestSA11111122',
+				label: new SubjectLabel( 'Subject with required Status' ),
+				schemaName: new SchemaName( 'ReplaceViolationSchema' ),
+			)
+		);
+
+		$response = $this->executeHandler(
+			$this->newReplaceSubjectApi(),
+			new RequestData( [
+				'method' => 'PUT',
+				'pathParams' => [ 'subjectId' => 'sTestSA11111122' ],
+				'bodyContents' => json_encode( [
+					'label' => 'Still missing Status',
+					'statements' => [],
+				] ),
+				'headers' => [ 'Content-Type' => 'application/json' ],
+			] )
+		);
+
+		$responseData = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertSame( 200, $response->getStatusCode() );
+		$this->assertSame( 'updated', $responseData['status'] );
+		$this->assertNotEmpty( $responseData['violations'] );
+		$this->assertSame( 'required', $responseData['violations'][0]['code'] );
+		$this->assertSame( 'Status', $responseData['violations'][0]['propertyName'] );
 	}
 
 	public function testOmittedStatementKeyIsDeleted(): void {
@@ -104,6 +143,7 @@ class ReplaceSubjectApiTest extends NeoWikiIntegrationTestCase {
 		$this->assertSame( 404, $response->getStatusCode() );
 		$this->assertSame( 'error', $responseData['status'] );
 		$this->assertStringContainsString( 'not found', $responseData['message'] );
+		$this->assertArrayNotHasKey( 'violations', $responseData );
 	}
 
 	public function testMissingLabelReturns400(): void {

--- a/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
@@ -8,6 +8,7 @@ use MediaWiki\Rest\HttpException;
 use MediaWiki\Rest\RequestData;
 use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
 use MediaWiki\Tests\Unit\Permissions\MockAuthorityTrait;
+use MediaWiki\Title\Title;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\ReplaceSubjectApi;
@@ -165,6 +166,47 @@ class ReplaceSubjectApiTest extends NeoWikiIntegrationTestCase {
 			$this->assertSame( 'required', $violation['code'] );
 			$this->assertSame( [], $violation['args'] );
 		}
+	}
+
+	public function testResponseIncludesSchemaNotFoundWhenSchemaMissing(): void {
+		// Reproduce the canonical orphan: the Schema existed when the Subject was
+		// created, then its page was deleted, leaving the Subject un-validatable.
+		$this->createSchema( 'OrphanSchema' );
+		$this->createPageWithSubjects(
+			'ReplaceSubjectApiMissingSchemaTest',
+			mainSubject: TestSubject::build(
+				id: 'sTestSA11111155',
+				label: new SubjectLabel( 'Orphaned subject' ),
+				schemaName: new SchemaName( 'OrphanSchema' ),
+			)
+		);
+		$this->deletePage(
+			$this->getServiceContainer()->getWikiPageFactory()->newFromTitle(
+				Title::newFromText( 'OrphanSchema', NeoWikiExtension::NS_SCHEMA )
+			)
+		);
+
+		$response = $this->executeHandler(
+			$this->newReplaceSubjectApi(),
+			new RequestData( [
+				'method' => 'PUT',
+				'pathParams' => [ 'subjectId' => 'sTestSA11111155' ],
+				'bodyContents' => json_encode( [
+					'label' => 'Still orphaned',
+					'statements' => [],
+				] ),
+				'headers' => [ 'Content-Type' => 'application/json' ],
+			] )
+		);
+
+		$responseData = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertSame( 200, $response->getStatusCode() );
+		$this->assertSame( 'updated', $responseData['status'] );
+		$this->assertCount( 1, $responseData['violations'] );
+		$this->assertSame( 'schema-not-found', $responseData['violations'][0]['code'] );
+		$this->assertNull( $responseData['violations'][0]['propertyName'] );
+		$this->assertSame( [ 'OrphanSchema' ], $responseData['violations'][0]['args'] );
 	}
 
 	public function testNonExistentSubjectReturns404(): void {


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/822.

Implements step 1 of [ADR 21 backend validation](../tree/master/docs/adr/021-add-backend-validation.md): the two write endpoints — `POST /subject` and `PUT /subject/{id}` — now run `SubjectValidator` against the proposed Subject before persisting and include the resulting `Violation[]` in the success response body. Validation does not block the write; enforcement is a future round.

## What changed

- `CreateSubjectAction` and `ReplaceSubjectAction` each gain a `SubjectValidator` constructor dependency and run validation immediately before the repository write.
- `CreateSubjectPresenter::presentCreated` signature extends to `presentCreated(string $subjectId, array $violations)`.
- `ReplaceSubjectAction::replace` returns `Violation[]` instead of `void`.
- Both REST handlers emit `violations` (top-level array) in their `201`/`200` response bodies.
- Missing schema returns empty violations and proceeds with the write — preserves ADR 21's "invalid Subjects must stay editable" requirement.
- Create's `subject-already-exists` branch omits the `violations` key entirely (validation never ran).
- 14 new PHPUnit tests across Action and REST integration levels.

## Out of scope (future rounds)

- Enforcement / `$wgNeoWikiValidationEnforced` config.
- Pre-existing-vs-newly-introduced violation differentiation.
- TS `SubjectValidator` upgrade to return `Violation[]` at the top level.
- Frontend consumption.

## Test plan

- [x] `make phpunit filter=ReplaceSubject` — 23/23 green.
- [x] `make phpunit filter=CreateSubject` — 23/23 green (Action + REST).
- [x] `make phpunit filter=Application` — 270/270 green (no Application-layer regressions).
- [x] `make cs` — phpcs 392 files + phpstan 187 files, no errors.
- [x] Four Playwright smoke tests against the live demo wiki (POST + PUT × clean/violating). Raw response bodies captured during development — all four returned the expected shape:
  - `PUT /subject/s1demo1aaaaaaa1` (Status omitted): `200 {"status":"updated","subjectId":"s1demo1aaaaaaa1","violations":[{"propertyName":"Status","code":"required","args":[]}]}`
  - `PUT /subject/s1demo1aaaaaaa1` (Status set): `200 {"status":"updated","subjectId":"s1demo1aaaaaaa1","violations":[]}`
  - `POST /page/{id}/mainSubject` (Status omitted): `201 {"status":"created","subjectId":"...","violations":[{"propertyName":"Status","code":"required","args":[]}]}`
  - `POST /page/{id}/mainSubject` (Status set): `201 {"status":"created","subjectId":"...","violations":[]}`