### PR TITLE
Enforce validation under NeoWikiValidationEnforced

### DIFF
--- a/docs/reference/validation-codes.md
+++ b/docs/reference/validation-codes.md
@@ -10,8 +10,14 @@ Violations are returned by:
 - `POST /neowiki/v0/subject/{subjectId}/validate` — dry-run validation of a proposed update-shape
   body against an existing Subject's Schema.
 - `POST /neowiki/v0/subject` and `PUT /neowiki/v0/subject/{subjectId}` — the write endpoints include
-  the resulting `violations` array in their `201`/`200` success body. Validation does not block the
-  write (see [ADR 21](../adr/021-add-backend-validation.md)).
+  the resulting `violations` array in their `201`/`200` success body. By default
+  (`$wgNeoWikiEnforceValidation = false`) the write always persists. When an admin enables
+  enforcement (`$wgNeoWikiEnforceValidation = true`), a write that introduces *new* blocking
+  violations is rejected with `422 Unprocessable Entity` and an `{ status, message, violations }`
+  body; `violations` carries the full proposed list, not just the newly-introduced subset.
+  Pre-existing violations (already present on the stored Subject under the current Schema) and
+  non-blocking codes such as [`schema-not-found`](#schema-not-found) never block, so editing an
+  already-invalid Subject stays possible. See [ADR 21](../adr/021-add-backend-validation.md).
 
 The `/validate` endpoints return `200 OK` with a `{violations: [...]}` body whenever the request is
 well-formed; violations in the body do not change the HTTP status. `400` is reserved for malformed

--- a/extension.json
+++ b/extension.json
@@ -140,6 +140,10 @@
 			"description": "Whether development UIs should be enabled",
 			"value": false
 		},
+		"NeoWikiValidationEnforced": {
+			"description": "Whether write endpoints reject edits that introduce new constraint violations. When false, violations are surfaced in responses but writes always persist.",
+			"value": false
+		},
 		"NeoWikiQueryLimits": {
 			"description": "Per-tier per-query resource caps. Keys: 'default' (users without apihighlimits) and 'expensive' (users with apihighlimits). Each value: { timeoutSeconds, maxRows }.",
 			"value": {

--- a/extension.json
+++ b/extension.json
@@ -140,7 +140,7 @@
 			"description": "Whether development UIs should be enabled",
 			"value": false
 		},
-		"NeoWikiValidationEnforced": {
+		"NeoWikiEnforceValidation": {
 			"description": "Whether write endpoints reject edits that introduce new constraint violations. When false, violations are surfaced in responses but writes always persist.",
 			"value": false
 		},

--- a/src/Application/Actions/CreateSubject/CreateSubjectAction.php
+++ b/src/Application/Actions/CreateSubject/CreateSubjectAction.php
@@ -15,6 +15,7 @@ use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
 use ProfessionalWiki\NeoWiki\Infrastructure\IdGenerator;
 use RuntimeException;
 
@@ -29,6 +30,7 @@ readonly class CreateSubjectAction {
 		private SchemaLookup $schemaLookup,
 		private SelectStatementResolver $selectStatementResolver,
 		private ProposedSubjectValidator $proposedSubjectValidator,
+		private bool $validationEnforced,
 	) {
 	}
 
@@ -59,8 +61,24 @@ readonly class CreateSubjectAction {
 
 		$violations = $this->proposedSubjectValidator->validate( $subject );
 
+		if ( $this->validationEnforced && $this->blockingViolations( $violations ) !== [] ) {
+			$this->presenter->presentValidationFailed( $violations );
+			return;
+		}
+
 		$this->subjectRepository->savePageSubjects( $pageSubjects, new PageId( $request->pageId ), $request->comment );
 		$this->presenter->presentCreated( $subject->id->text, $violations );
+	}
+
+	/**
+	 * @param Violation[] $violations
+	 * @return Violation[]
+	 */
+	private function blockingViolations( array $violations ): array {
+		return array_values( array_filter(
+			$violations,
+			static fn ( Violation $v ): bool => $v->isBlocking()
+		) );
 	}
 
 	private function buildSubject( CreateSubjectRequest $request ): Subject {

--- a/src/Application/Actions/CreateSubject/CreateSubjectPresenter.php
+++ b/src/Application/Actions/CreateSubject/CreateSubjectPresenter.php
@@ -13,4 +13,12 @@ interface CreateSubjectPresenter {
 
 	public function presentSubjectAlreadyExists(): void;
 
+	/**
+	 * Called when validation enforcement rejects a Subject the request would
+	 * have created.
+	 *
+	 * @param Violation[] $violations
+	 */
+	public function presentValidationFailed( array $violations ): void;
+
 }

--- a/src/Application/Actions/ReplaceSubject/ReplaceSubjectAction.php
+++ b/src/Application/Actions/ReplaceSubject/ReplaceSubjectAction.php
@@ -16,6 +16,8 @@ use ProfessionalWiki\NeoWiki\Application\Validation\ProposedSubjectValidator;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
+use ProfessionalWiki\NeoWiki\Domain\Validation\ViolationDiff;
 
 readonly class ReplaceSubjectAction {
 
@@ -27,6 +29,7 @@ readonly class ReplaceSubjectAction {
 		private SelectStatementResolver $selectStatementResolver,
 		private ProposedSubjectValidator $proposedSubjectValidator,
 		private ReplaceSubjectPresenter $presenter,
+		private bool $validationEnforced,
 	) {
 	}
 
@@ -48,16 +51,28 @@ readonly class ReplaceSubjectAction {
 			throw SubjectNotFoundException::forId( $subjectId );
 		}
 
+		$priorViolations = $this->proposedSubjectValidator->validate( $subject );
+
 		$subject->setLabel( new SubjectLabel( $label ) );
 		$subject->setStatements(
 			$this->statementListBuilder->build( $this->resolveStatements( $subject, $statements ) )
 		);
 
-		$violations = $this->proposedSubjectValidator->validate( $subject );
+		$proposedViolations = $this->proposedSubjectValidator->validate( $subject );
+
+		$newBlockingViolations = array_filter(
+			ViolationDiff::newViolations( $proposedViolations, $priorViolations ),
+			static fn ( Violation $v ): bool => $v->isBlocking()
+		);
+
+		if ( $this->validationEnforced && $newBlockingViolations !== [] ) {
+			$this->presenter->presentValidationFailed( $proposedViolations );
+			return;
+		}
 
 		$this->subjectRepository->updateSubject( $subject, $comment );
 
-		$this->presenter->presentUpdated( $subjectId->text, $violations );
+		$this->presenter->presentUpdated( $subjectId->text, $proposedViolations );
 	}
 
 	/**

--- a/src/Application/Actions/ReplaceSubject/ReplaceSubjectPresenter.php
+++ b/src/Application/Actions/ReplaceSubject/ReplaceSubjectPresenter.php
@@ -13,4 +13,12 @@ interface ReplaceSubjectPresenter {
 	 */
 	public function presentUpdated( string $subjectId, array $violations ): void;
 
+	/**
+	 * Called when validation enforcement rejects an edit that would introduce
+	 * new constraint violations relative to the Subject's prior state.
+	 *
+	 * @param Violation[] $violations
+	 */
+	public function presentValidationFailed( array $violations ): void;
+
 }

--- a/src/Domain/Validation/Violation.php
+++ b/src/Domain/Validation/Violation.php
@@ -25,4 +25,14 @@ readonly class Violation {
 		);
 	}
 
+	/**
+	 * Whether this Violation should block writes under enforcement.
+	 * schema-not-found is a system condition (the Schema page is missing
+	 * or has been deleted), not a user-correctable constraint, so it does
+	 * not block.
+	 */
+	public function isBlocking(): bool {
+		return $this->code !== 'schema-not-found';
+	}
+
 }

--- a/src/Domain/Validation/ViolationDiff.php
+++ b/src/Domain/Validation/ViolationDiff.php
@@ -7,9 +7,15 @@ namespace ProfessionalWiki\NeoWiki\Domain\Validation;
 class ViolationDiff {
 
 	/**
-	 * Returns violations in $proposed that are not present in $prior, identified
-	 * by (propertyName, code). Used by Replace-style writes to detect violations
-	 * introduced by an edit while ignoring pre-existing ones.
+	 * Returns violations in $proposed that are not present in $prior. Used by
+	 * Replace-style writes to detect violations introduced by an edit while
+	 * ignoring pre-existing ones.
+	 *
+	 * Identity is (propertyName, code, valuePartIndex). Including
+	 * valuePartIndex distinguishes per-value violations on multi-value
+	 * properties (e.g. url, select) so that adding a second bad value at a
+	 * new index is reported as new, even when prior already reported a
+	 * violation with the same code at a different index.
 	 *
 	 * @param Violation[] $proposed
 	 * @param Violation[] $prior
@@ -31,7 +37,9 @@ class ViolationDiff {
 	}
 
 	private static function key( Violation $violation ): string {
-		return ( $violation->propertyName?->text ?? '' ) . "\0" . $violation->code;
+		return ( $violation->propertyName?->text ?? '' )
+			. "\0" . $violation->code
+			. "\0" . ( $violation->valuePartIndex ?? '' );
 	}
 
 }

--- a/src/Domain/Validation/ViolationDiff.php
+++ b/src/Domain/Validation/ViolationDiff.php
@@ -1,0 +1,37 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\Validation;
+
+class ViolationDiff {
+
+	/**
+	 * Returns violations in $proposed that are not present in $prior, identified
+	 * by (propertyName, code). Used by Replace-style writes to detect violations
+	 * introduced by an edit while ignoring pre-existing ones.
+	 *
+	 * @param Violation[] $proposed
+	 * @param Violation[] $prior
+	 * @return Violation[]
+	 */
+	public static function newViolations( array $proposed, array $prior ): array {
+		$priorKeys = [];
+		foreach ( $prior as $violation ) {
+			$priorKeys[self::key( $violation )] = true;
+		}
+
+		$new = [];
+		foreach ( $proposed as $violation ) {
+			if ( !isset( $priorKeys[self::key( $violation )] ) ) {
+				$new[] = $violation;
+			}
+		}
+		return $new;
+	}
+
+	private static function key( Violation $violation ): string {
+		return ( $violation->propertyName?->text ?? '' ) . "\0" . $violation->code;
+	}
+
+}

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -515,14 +515,11 @@ class NeoWikiExtension {
 		);
 	}
 
-	/**
-	 * Reads the flag fresh from MainConfig rather than from $this->config because the
-	 * NeoWikiExtension singleton (and the NeoWikiConfig it holds) is built once on first
-	 * getInstance() call, so a setMwGlobals('wgNeoWikiValidationEnforced', true) in
-	 * integration tests would not be observable through the baked config.
-	 */
 	private function isValidationEnforced(): bool {
-		return MediaWikiServices::getInstance()->getMainConfig()->get( 'NeoWikiValidationEnforced' ) === true;
+		// Behavioral config is read live from MainConfig (like Neo4jQueryLimits), so the admin's
+		// LocalSettings value applies per request and tests can override it via overrideConfigValue()
+		// without rebuilding the getInstance() singleton (which bakes only bootstrap config).
+		return MediaWikiServices::getInstance()->getMainConfig()->get( 'NeoWikiEnforceValidation' ) === true;
 	}
 
 	public function getSubjectValidator(): SubjectValidator {

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -337,6 +337,7 @@ class NeoWikiExtension {
 			schemaLookup: $this->getSchemaLookup(),
 			selectStatementResolver: $this->getSelectStatementResolver(),
 			proposedSubjectValidator: $this->getProposedSubjectValidator(),
+			validationEnforced: $this->isValidationEnforced(),
 		);
 	}
 
@@ -510,7 +511,18 @@ class NeoWikiExtension {
 			selectStatementResolver: $this->getSelectStatementResolver(),
 			proposedSubjectValidator: $this->getProposedSubjectValidator(),
 			presenter: $presenter,
+			validationEnforced: $this->isValidationEnforced(),
 		);
+	}
+
+	/**
+	 * Reads the flag fresh from MainConfig rather than from $this->config because the
+	 * NeoWikiExtension singleton (and the NeoWikiConfig it holds) is built once on first
+	 * getInstance() call, so a setMwGlobals('wgNeoWikiValidationEnforced', true) in
+	 * integration tests would not be observable through the baked config.
+	 */
+	private function isValidationEnforced(): bool {
+		return MediaWikiServices::getInstance()->getMainConfig()->get( 'NeoWikiValidationEnforced' ) === true;
 	}
 
 	public function getSubjectValidator(): SubjectValidator {

--- a/src/Presentation/RestCreateSubjectPresenter.php
+++ b/src/Presentation/RestCreateSubjectPresenter.php
@@ -40,4 +40,16 @@ class RestCreateSubjectPresenter implements CreateSubjectPresenter {
 		$this->statusCode = 409;
 	}
 
+	/**
+	 * @param Violation[] $violations
+	 */
+	public function presentValidationFailed( array $violations ): void {
+		$this->apiResponse = [
+			'status' => 'error',
+			'message' => 'Validation failed',
+			'violations' => ViolationSerializer::serializeMany( $violations ),
+		];
+		$this->statusCode = 422;
+	}
+
 }

--- a/src/Presentation/RestReplaceSubjectPresenter.php
+++ b/src/Presentation/RestReplaceSubjectPresenter.php
@@ -32,4 +32,16 @@ class RestReplaceSubjectPresenter implements ReplaceSubjectPresenter {
 		$this->statusCode = 200;
 	}
 
+	/**
+	 * @param Violation[] $violations
+	 */
+	public function presentValidationFailed( array $violations ): void {
+		$this->apiResponse = [
+			'status' => 'error',
+			'message' => 'Validation failed',
+			'violations' => ViolationSerializer::serializeMany( $violations ),
+		];
+		$this->statusCode = 422;
+	}
+
 }

--- a/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
@@ -60,7 +60,7 @@ class CreateSubjectActionTest extends TestCase {
 		$this->schemaLookup = new InMemorySchemaLookup();
 	}
 
-	private function newCreateSubjectAction(): CreateSubjectAction {
+	private function newCreateSubjectAction( bool $validationEnforced = false ): CreateSubjectAction {
 		$registry = PropertyTypeRegistry::withCoreTypes();
 		return new CreateSubjectAction(
 			$this->presenterSpy,
@@ -77,6 +77,7 @@ class CreateSubjectActionTest extends TestCase {
 				schemaLookup: $this->schemaLookup,
 				subjectValidator: new SubjectValidator( propertyTypeLookup: $registry ),
 			),
+			$validationEnforced,
 		);
 	}
 
@@ -464,6 +465,118 @@ class CreateSubjectActionTest extends TestCase {
 			] ),
 			$newSubject->getStatements()
 		);
+	}
+
+	private function registerPersonSchemaWithRequiredName(): void {
+		$this->schemaLookup->updateSchema( new Schema(
+			name: new SchemaName( 'PersonSchema' ),
+			description: '',
+			properties: new PropertyDefinitions( [
+				'Name' => new SelectProperty(
+					core: new PropertyCore( description: '', required: true, default: null ),
+					options: [ new SelectOption( id: 'opt_alice', label: 'Alice' ) ],
+					multiple: false,
+				),
+			] )
+		) );
+	}
+
+	public function testEnforcementOffPersistsCreateWithViolations(): void {
+		$this->registerPersonSchemaWithRequiredName();
+		$this->subjectRepository->savePageSubjects( PageSubjects::newEmpty(), new PageId( 1 ) );
+
+		$this->newCreateSubjectAction( validationEnforced: false )->createSubject(
+			new CreateSubjectRequest(
+				pageId: 1,
+				isMainSubject: true,
+				label: 'Bob',
+				schemaName: 'PersonSchema',
+				statements: [],
+			)
+		);
+
+		$this->assertSame( 's' . self::STUB_ID, $this->presenterSpy->result );
+		$this->assertFalse( $this->presenterSpy->validationFailed );
+	}
+
+	public function testEnforcementOnRejectsCreateWithViolations(): void {
+		$this->registerPersonSchemaWithRequiredName();
+		$this->subjectRepository->savePageSubjects( PageSubjects::newEmpty(), new PageId( 1 ) );
+
+		$this->newCreateSubjectAction( validationEnforced: true )->createSubject(
+			new CreateSubjectRequest(
+				pageId: 1,
+				isMainSubject: true,
+				label: 'Bob',
+				schemaName: 'PersonSchema',
+				statements: [],
+			)
+		);
+
+		$this->assertTrue( $this->presenterSpy->validationFailed );
+		$this->assertSame( '', $this->presenterSpy->result );
+		$this->assertNull( $this->subjectRepository->getSubject( new SubjectId( 's' . self::STUB_ID ) ) );
+	}
+
+	public function testEnforcementOnAllowsCleanCreate(): void {
+		$this->registerPersonSchemaWithRequiredName();
+		$this->subjectRepository->savePageSubjects( PageSubjects::newEmpty(), new PageId( 1 ) );
+
+		$this->newCreateSubjectAction( validationEnforced: true )->createSubject(
+			new CreateSubjectRequest(
+				pageId: 1,
+				isMainSubject: true,
+				label: 'Bob',
+				schemaName: 'PersonSchema',
+				statements: [
+					'Name' => [ 'propertyType' => 'select', 'value' => 'opt_alice' ],
+				],
+			)
+		);
+
+		$this->assertSame( 's' . self::STUB_ID, $this->presenterSpy->result );
+		$this->assertFalse( $this->presenterSpy->validationFailed );
+	}
+
+	public function testEnforcementOnAllowsCreateWhenSchemaIsMissing(): void {
+		$this->subjectRepository->savePageSubjects( PageSubjects::newEmpty(), new PageId( 1 ) );
+
+		$this->newCreateSubjectAction( validationEnforced: true )->createSubject(
+			new CreateSubjectRequest(
+				pageId: 1,
+				isMainSubject: true,
+				label: 'Subject',
+				schemaName: 'NonexistentSchema',
+				statements: [],
+			)
+		);
+
+		$this->assertSame( 's' . self::STUB_ID, $this->presenterSpy->result );
+		$this->assertFalse( $this->presenterSpy->validationFailed );
+		$this->assertCount( 1, $this->presenterSpy->violations );
+		$this->assertSame( 'schema-not-found', $this->presenterSpy->violations[0]->code );
+	}
+
+	public function testEnforcementOnDoesNotInterceptAlreadyExistsBranch(): void {
+		$this->registerPersonSchemaWithRequiredName();
+		$pageSubjects = $this->createMock( PageSubjects::class );
+		$pageSubjects->method( 'createMainSubject' )->willThrowException(
+			new RuntimeException( 'Subject already exists' )
+		);
+		$this->subjectRepository->savePageSubjects( $pageSubjects, new PageId( 1 ) );
+
+		$this->newCreateSubjectAction( validationEnforced: true )->createSubject(
+			new CreateSubjectRequest(
+				pageId: 1,
+				isMainSubject: true,
+				label: 'Existing Label',
+				schemaName: 'PersonSchema',
+				statements: [],
+			)
+		);
+
+		$this->assertSame( 'presentSubjectAlreadyExists', $this->presenterSpy->result );
+		$this->assertFalse( $this->presenterSpy->validationFailed );
 	}
 
 }

--- a/tests/phpunit/Application/Actions/CreateSubjectPresenterSpy.php
+++ b/tests/phpunit/Application/Actions/CreateSubjectPresenterSpy.php
@@ -14,6 +14,8 @@ class CreateSubjectPresenterSpy implements CreateSubjectPresenter {
 	/** @var Violation[] */
 	public array $violations = [];
 
+	public bool $validationFailed = false;
+
 	public function presentCreated( string $subjectId, array $violations ): void {
 		$this->result = $subjectId;
 		$this->violations = $violations;
@@ -21,6 +23,11 @@ class CreateSubjectPresenterSpy implements CreateSubjectPresenter {
 
 	public function presentSubjectAlreadyExists(): void {
 		$this->result = 'presentSubjectAlreadyExists';
+	}
+
+	public function presentValidationFailed( array $violations ): void {
+		$this->validationFailed = true;
+		$this->violations = $violations;
 	}
 
 }

--- a/tests/phpunit/Application/Actions/ReplaceSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/ReplaceSubjectActionTest.php
@@ -17,6 +17,7 @@ use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeRegistry;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeToValueType;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\SelectOption;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\SelectProperty;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Property\UrlProperty;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinitions;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyName;
@@ -445,6 +446,41 @@ class ReplaceSubjectActionTest extends TestCase {
 		$this->assertFalse( $this->presenterSpy->validationFailed );
 		$this->assertCount( 1, $this->presenterSpy->violations );
 		$this->assertSame( 'schema-not-found', $this->presenterSpy->violations[0]->code );
+	}
+
+	public function testEnforcementOnRejectsEditThatAddsBadValueAtNewIndex(): void {
+		$this->schemaLookup->updateSchema( new Schema(
+			name: new SchemaName( self::SCHEMA_NAME ),
+			description: '',
+			properties: new PropertyDefinitions( [
+				'Website' => new UrlProperty(
+					core: new PropertyCore( description: '', required: false, default: null ),
+					multiple: true,
+					uniqueItems: false,
+				),
+			] )
+		) );
+		$subject = TestSubject::build(
+			id: new SubjectId( self::SUBJECT_ID ),
+			schemaName: new SchemaName( self::SCHEMA_NAME ),
+			statements: new StatementList( [
+				TestStatement::build(
+					property: 'Website',
+					value: new StringValue( 'not-a-url' ),
+					propertyType: 'url',
+				),
+			] ),
+		);
+		$this->subjectRepository->updateSubject( $subject );
+
+		$this->newAction( validationEnforced: true )->replace(
+			new SubjectId( self::SUBJECT_ID ),
+			'After',
+			[ 'Website' => [ 'propertyType' => 'url', 'value' => [ 'not-a-url', 'also-not-a-url' ] ] ],
+			null
+		);
+
+		$this->assertTrue( $this->presenterSpy->validationFailed );
 	}
 
 }

--- a/tests/phpunit/Application/Actions/ReplaceSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/ReplaceSubjectActionTest.php
@@ -22,10 +22,12 @@ use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinitions;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyName;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
 use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
 use ProfessionalWiki\NeoWiki\Application\SubjectAuthorizer;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestStatement;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\FailingSubjectAuthorizer;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySchemaLookup;
@@ -51,7 +53,10 @@ class ReplaceSubjectActionTest extends TestCase {
 		$this->presenterSpy = new ReplaceSubjectPresenterSpy();
 	}
 
-	private function newAction( ?SubjectAuthorizer $authorizer = null ): ReplaceSubjectAction {
+	private function newAction(
+		?SubjectAuthorizer $authorizer = null,
+		bool $validationEnforced = false,
+	): ReplaceSubjectAction {
 		$registry = PropertyTypeRegistry::withCoreTypes();
 		$builder = new StatementListBuilder(
 			propertyTypeToValueType: new PropertyTypeToValueType( $registry ),
@@ -68,6 +73,7 @@ class ReplaceSubjectActionTest extends TestCase {
 				subjectValidator: new SubjectValidator( propertyTypeLookup: $registry ),
 			),
 			presenter: $this->presenterSpy,
+			validationEnforced: $validationEnforced,
 		);
 	}
 
@@ -308,6 +314,137 @@ class ReplaceSubjectActionTest extends TestCase {
 
 		$stored = $this->subjectRepository->getSubject( new SubjectId( self::SUBJECT_ID ) );
 		$this->assertSame( 'After', $stored->getLabel()->text );
+	}
+
+	private function registerSchemaWithRequiredAlphaAndBeta(): void {
+		$this->schemaLookup->updateSchema( new Schema(
+			name: new SchemaName( self::SCHEMA_NAME ),
+			description: '',
+			properties: new PropertyDefinitions( [
+				'Alpha' => new SelectProperty(
+					core: new PropertyCore( description: '', required: true, default: null ),
+					options: [ new SelectOption( id: 'opt_a', label: 'A' ) ],
+					multiple: false,
+				),
+				'Beta' => new SelectProperty(
+					core: new PropertyCore( description: '', required: true, default: null ),
+					options: [ new SelectOption( id: 'opt_b', label: 'B' ) ],
+					multiple: false,
+				),
+			] )
+		) );
+	}
+
+	public function testEnforcementOffPersistsEditWithNewViolations(): void {
+		$this->registerSchemaWithRequiredAlphaAndBeta();
+		$subject = TestSubject::build(
+			id: new SubjectId( self::SUBJECT_ID ),
+			label: new SubjectLabel( 'Original' ),
+			schemaName: new SchemaName( self::SCHEMA_NAME ),
+			statements: new StatementList( [
+				TestStatement::build( property: 'Alpha', value: new StringValue( 'opt_a' ), propertyType: 'select' ),
+				TestStatement::build( property: 'Beta', value: new StringValue( 'opt_b' ), propertyType: 'select' ),
+			] ),
+		);
+		$this->subjectRepository->updateSubject( $subject );
+
+		$this->newAction( validationEnforced: false )->replace(
+			new SubjectId( self::SUBJECT_ID ),
+			'After',
+			[],
+			null
+		);
+
+		$stored = $this->subjectRepository->getSubject( new SubjectId( self::SUBJECT_ID ) );
+		$this->assertSame( 'After', $stored->getLabel()->text );
+		$this->assertFalse( $this->presenterSpy->validationFailed );
+	}
+
+	public function testEnforcementOnRejectsEditThatIntroducesNewViolation(): void {
+		$this->registerSchemaWithRequiredAlphaAndBeta();
+		$subject = TestSubject::build(
+			id: new SubjectId( self::SUBJECT_ID ),
+			label: new SubjectLabel( 'Original' ),
+			schemaName: new SchemaName( self::SCHEMA_NAME ),
+			statements: new StatementList( [
+				TestStatement::build( property: 'Alpha', value: new StringValue( 'opt_a' ), propertyType: 'select' ),
+				TestStatement::build( property: 'Beta', value: new StringValue( 'opt_b' ), propertyType: 'select' ),
+			] ),
+		);
+		$this->subjectRepository->updateSubject( $subject );
+		$updatesBeforeAction = $this->subjectRepository->updateSubjectCallCount;
+
+		$this->newAction( validationEnforced: true )->replace(
+			new SubjectId( self::SUBJECT_ID ),
+			'After',
+			[],
+			null
+		);
+
+		$this->assertTrue( $this->presenterSpy->validationFailed );
+		$this->assertSame( $updatesBeforeAction, $this->subjectRepository->updateSubjectCallCount );
+	}
+
+	public function testEnforcementOnAllowsEditWithOnlyPreExistingViolations(): void {
+		$this->registerSchemaWithRequiredAlphaAndBeta();
+		$subject = TestSubject::build(
+			id: new SubjectId( self::SUBJECT_ID ),
+			label: new SubjectLabel( 'Old' ),
+			schemaName: new SchemaName( self::SCHEMA_NAME ),
+		);
+		$this->subjectRepository->updateSubject( $subject );
+
+		$this->newAction( validationEnforced: true )->replace(
+			new SubjectId( self::SUBJECT_ID ),
+			'New',
+			[],
+			null
+		);
+
+		$this->assertFalse( $this->presenterSpy->validationFailed );
+		$this->assertCount( 2, $this->presenterSpy->violations );
+		$this->assertSame( 'New', $this->subjectRepository->getSubject(
+			new SubjectId( self::SUBJECT_ID )
+		)->getLabel()->text );
+	}
+
+	public function testEnforcementOnAllowsEditThatReducesViolations(): void {
+		$this->registerSchemaWithRequiredAlphaAndBeta();
+		$subject = TestSubject::build(
+			id: new SubjectId( self::SUBJECT_ID ),
+			schemaName: new SchemaName( self::SCHEMA_NAME ),
+		);
+		$this->subjectRepository->updateSubject( $subject );
+
+		$this->newAction( validationEnforced: true )->replace(
+			new SubjectId( self::SUBJECT_ID ),
+			'After',
+			[ 'Alpha' => [ 'propertyType' => 'select', 'value' => 'opt_a' ] ],
+			null
+		);
+
+		$this->assertFalse( $this->presenterSpy->validationFailed );
+		$this->assertCount( 1, $this->presenterSpy->violations );
+		$this->assertSame( 'Beta', $this->presenterSpy->violations[0]->propertyName?->text );
+	}
+
+	public function testEnforcementOnAllowsEditWhenSchemaIsMissing(): void {
+		$subject = TestSubject::build(
+			id: new SubjectId( self::SUBJECT_ID ),
+			schemaName: new SchemaName( 'NonexistentSchema' ),
+		);
+		$this->subjectRepository->updateSubject( $subject );
+
+		$this->newAction( validationEnforced: true )->replace(
+			new SubjectId( self::SUBJECT_ID ),
+			'After',
+			[],
+			null
+		);
+
+		$this->assertFalse( $this->presenterSpy->validationFailed );
+		$this->assertCount( 1, $this->presenterSpy->violations );
+		$this->assertSame( 'schema-not-found', $this->presenterSpy->violations[0]->code );
 	}
 
 }

--- a/tests/phpunit/Application/Actions/ReplaceSubjectPresenterSpy.php
+++ b/tests/phpunit/Application/Actions/ReplaceSubjectPresenterSpy.php
@@ -14,8 +14,15 @@ class ReplaceSubjectPresenterSpy implements ReplaceSubjectPresenter {
 	/** @var Violation[] */
 	public array $violations = [];
 
+	public bool $validationFailed = false;
+
 	public function presentUpdated( string $subjectId, array $violations ): void {
 		$this->subjectId = $subjectId;
+		$this->violations = $violations;
+	}
+
+	public function presentValidationFailed( array $violations ): void {
+		$this->validationFailed = true;
 		$this->violations = $violations;
 	}
 

--- a/tests/phpunit/Domain/Validation/ViolationDiffTest.php
+++ b/tests/phpunit/Domain/Validation/ViolationDiffTest.php
@@ -89,8 +89,47 @@ class ViolationDiffTest extends TestCase {
 		$this->assertSame( [], $result );
 	}
 
+	public function testAddingASecondBadValueIsReportedAsNewWhenFirstAlreadyBad(): void {
+		$urlAtIndex0 = $this->invalidUrlAt( 0 );
+		$urlAtIndex1 = $this->invalidUrlAt( 1 );
+
+		$result = ViolationDiff::newViolations(
+			proposed: [ $urlAtIndex0, $urlAtIndex1 ],
+			prior: [ $urlAtIndex0 ],
+		);
+
+		$this->assertSame( [ $urlAtIndex1 ], $result );
+	}
+
+	public function testRepeatedBadValueAtSameIndexIsNotReportedAsNew(): void {
+		$urlAtIndex0 = $this->invalidUrlAt( 0 );
+
+		$result = ViolationDiff::newViolations(
+			proposed: [ $urlAtIndex0 ],
+			prior: [ $urlAtIndex0 ],
+		);
+
+		$this->assertSame( [], $result );
+	}
+
+	public function testNullAndZeroValuePartIndexAreDistinct(): void {
+		$indexZero = new Violation( new PropertyName( 'Website' ), 'invalid-url', valuePartIndex: 0 );
+		$indexNull = new Violation( new PropertyName( 'Website' ), 'invalid-url' );
+
+		$result = ViolationDiff::newViolations(
+			proposed: [ $indexNull ],
+			prior: [ $indexZero ],
+		);
+
+		$this->assertSame( [ $indexNull ], $result );
+	}
+
 	private function required( string $property ): Violation {
 		return new Violation( new PropertyName( $property ), 'required' );
+	}
+
+	private function invalidUrlAt( int $index ): Violation {
+		return new Violation( new PropertyName( 'Website' ), 'invalid-url', valuePartIndex: $index );
 	}
 
 }

--- a/tests/phpunit/Domain/Validation/ViolationDiffTest.php
+++ b/tests/phpunit/Domain/Validation/ViolationDiffTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Domain\Validation;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyName;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
+use ProfessionalWiki\NeoWiki\Domain\Validation\ViolationDiff;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Domain\Validation\ViolationDiff
+ */
+class ViolationDiffTest extends TestCase {
+
+	public function testEmptyProposedReturnsEmpty(): void {
+		$this->assertSame( [], ViolationDiff::newViolations( [], [] ) );
+		$this->assertSame( [], ViolationDiff::newViolations( [], [ $this->required( 'Status' ) ] ) );
+	}
+
+	public function testEmptyPriorReturnsAllProposed(): void {
+		$proposed = [ $this->required( 'Status' ), $this->required( 'Name' ) ];
+		$this->assertSame( $proposed, ViolationDiff::newViolations( $proposed, [] ) );
+	}
+
+	public function testIdenticalProposedAndPriorReturnsEmpty(): void {
+		$violations = [ $this->required( 'Status' ), $this->required( 'Name' ) ];
+		$this->assertSame( [], ViolationDiff::newViolations( $violations, $violations ) );
+	}
+
+	public function testReturnsOnlyProposedNotInPrior(): void {
+		$alpha = $this->required( 'Alpha' );
+		$beta = $this->required( 'Beta' );
+		$gamma = $this->required( 'Gamma' );
+
+		$result = ViolationDiff::newViolations(
+			proposed: [ $alpha, $beta, $gamma ],
+			prior: [ $alpha ],
+		);
+
+		$this->assertSame( [ $beta, $gamma ], $result );
+	}
+
+	public function testMatchingIgnoresOrderAndExtraPrior(): void {
+		$alpha = $this->required( 'Alpha' );
+		$beta = $this->required( 'Beta' );
+
+		$result = ViolationDiff::newViolations(
+			proposed: [ $beta ],
+			prior: [ $alpha, $beta ],
+		);
+
+		$this->assertSame( [], $result );
+	}
+
+	public function testSamePropertyDifferentCodeIsConsideredNew(): void {
+		$required = $this->required( 'Status' );
+		$tooShort = new Violation( new PropertyName( 'Status' ), 'too-short' );
+
+		$result = ViolationDiff::newViolations(
+			proposed: [ $tooShort ],
+			prior: [ $required ],
+		);
+
+		$this->assertSame( [ $tooShort ], $result );
+	}
+
+	public function testSameCodeDifferentPropertyIsConsideredNew(): void {
+		$alpha = $this->required( 'Alpha' );
+		$beta = $this->required( 'Beta' );
+
+		$result = ViolationDiff::newViolations(
+			proposed: [ $beta ],
+			prior: [ $alpha ],
+		);
+
+		$this->assertSame( [ $beta ], $result );
+	}
+
+	public function testNullPropertyNameMatchesNullPropertyName(): void {
+		$schemaNotFound = new Violation( propertyName: null, code: 'schema-not-found' );
+
+		$result = ViolationDiff::newViolations(
+			proposed: [ $schemaNotFound ],
+			prior: [ $schemaNotFound ],
+		);
+
+		$this->assertSame( [], $result );
+	}
+
+	private function required( string $property ): Violation {
+		return new Violation( new PropertyName( $property ), 'required' );
+	}
+
+}

--- a/tests/phpunit/Domain/Validation/ViolationTest.php
+++ b/tests/phpunit/Domain/Validation/ViolationTest.php
@@ -66,4 +66,18 @@ class ViolationTest extends TestCase {
 		$this->assertSame( 1, $named->valuePartIndex );
 	}
 
+	public function testSchemaNotFoundIsNotBlocking(): void {
+		$violation = new Violation( propertyName: null, code: 'schema-not-found', args: [ 'Person' ] );
+
+		$this->assertFalse( $violation->isBlocking() );
+	}
+
+	public function testOtherCodesAreBlocking(): void {
+		$required = new Violation( propertyName: new PropertyName( 'Status' ), code: 'required' );
+		$invalid = new Violation( propertyName: new PropertyName( 'Website' ), code: 'invalid-url' );
+
+		$this->assertTrue( $required->isBlocking() );
+		$this->assertTrue( $invalid->isBlocking() );
+	}
+
 }

--- a/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
@@ -233,4 +233,30 @@ class CreateSubjectApiTest extends NeoWikiIntegrationTestCase {
 		$this->assertSame( 400, $response->getStatusCode() );
 	}
 
+	public function testEnforcementBlockedReturns422(): void {
+		$this->setMwGlobals( 'wgNeoWikiValidationEnforced', true );
+
+		$this->createSchema(
+			'EnforcementSchema',
+			'{"title":"EnforcementSchema","propertyDefinitions":{"Required":{"type":"text","required":true}}}'
+		);
+
+		$body = $this->validBody();
+		$body['schema'] = 'EnforcementSchema';
+		$body['statements'] = [];
+
+		$response = $this->executeHandler(
+			$this->newCreateSubjectApi(),
+			$this->createRequestData( $body )
+		);
+
+		$responseData = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertSame( 422, $response->getStatusCode() );
+		$this->assertSame( 'error', $responseData['status'] );
+		$this->assertSame( 'Validation failed', $responseData['message'] );
+		$this->assertSame( 'Required', $responseData['violations'][0]['propertyName'] );
+		$this->assertSame( 'required', $responseData['violations'][0]['code'] );
+	}
+
 }

--- a/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
@@ -234,7 +234,7 @@ class CreateSubjectApiTest extends NeoWikiIntegrationTestCase {
 	}
 
 	public function testEnforcementBlockedReturns422(): void {
-		$this->setMwGlobals( 'wgNeoWikiValidationEnforced', true );
+		$this->setMwGlobals( 'wgNeoWikiEnforceValidation', true );
 
 		$this->createSchema(
 			'EnforcementSchema',

--- a/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
@@ -10,9 +10,11 @@ use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
 use MediaWiki\Tests\Unit\Permissions\MockAuthorityTrait;
 use MediaWiki\Title\Title;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\ReplaceSubjectApi;
 use ProfessionalWiki\NeoWiki\Presentation\CsrfValidator;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestStatement;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
@@ -297,6 +299,48 @@ class ReplaceSubjectApiTest extends NeoWikiIntegrationTestCase {
 		);
 
 		$this->assertSame( 200, $response->getStatusCode() );
+	}
+
+	public function testEnforcementBlockedReturns422(): void {
+		$this->setMwGlobals( 'wgNeoWikiValidationEnforced', true );
+
+		$this->createSchema(
+			'EnforcementSchema',
+			'{"title":"EnforcementSchema","propertyDefinitions":{"Required":{"type":"text","required":true}}}'
+		);
+		$this->createPageWithSubjects(
+			'ReplaceSubjectApiEnforcementTest',
+			mainSubject: TestSubject::build(
+				id: 'sTestSA11111144',
+				label: new SubjectLabel( 'Was clean' ),
+				schemaName: new SchemaName( 'EnforcementSchema' ),
+				statements: new StatementList( [
+					TestStatement::build( property: 'Required', value: 'present' ),
+				] )
+			)
+		);
+
+		$response = $this->executeHandler(
+			$this->newReplaceSubjectApi(),
+			new RequestData( [
+				'method' => 'PUT',
+				'pathParams' => [ 'subjectId' => 'sTestSA11111144' ],
+				'bodyContents' => json_encode( [
+					'label' => 'After',
+					'statements' => [],
+				] ),
+				'headers' => [ 'Content-Type' => 'application/json' ],
+			] )
+		);
+
+		$responseData = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertSame( 422, $response->getStatusCode() );
+		$this->assertSame( 'error', $responseData['status'] );
+		$this->assertSame( 'Validation failed', $responseData['message'] );
+		$this->assertNotEmpty( $responseData['violations'] );
+		$this->assertSame( 'Required', $responseData['violations'][0]['propertyName'] );
+		$this->assertSame( 'required', $responseData['violations'][0]['code'] );
 	}
 
 	private function createPages(): void {

--- a/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
@@ -302,7 +302,7 @@ class ReplaceSubjectApiTest extends NeoWikiIntegrationTestCase {
 	}
 
 	public function testEnforcementBlockedReturns422(): void {
-		$this->setMwGlobals( 'wgNeoWikiValidationEnforced', true );
+		$this->setMwGlobals( 'wgNeoWikiEnforceValidation', true );
 
 		$this->createSchema(
 			'EnforcementSchema',

--- a/tests/phpunit/Presentation/RestCreateSubjectPresenterTest.php
+++ b/tests/phpunit/Presentation/RestCreateSubjectPresenterTest.php
@@ -55,4 +55,24 @@ class RestCreateSubjectPresenterTest extends TestCase {
 		);
 	}
 
+	public function testPresentValidationFailedYields422WithErrorBody(): void {
+		$presenter = new RestCreateSubjectPresenter();
+
+		$presenter->presentValidationFailed( [
+			new Violation( propertyName: new PropertyName( 'Required' ), code: 'required' ),
+		] );
+
+		$this->assertSame( 422, $presenter->getStatusCode() );
+		$this->assertSame(
+			[
+				'status' => 'error',
+				'message' => 'Validation failed',
+				'violations' => [
+					[ 'propertyName' => 'Required', 'code' => 'required', 'args' => [] ],
+				],
+			],
+			$presenter->getJsonArray()
+		);
+	}
+
 }

--- a/tests/phpunit/Presentation/RestReplaceSubjectPresenterTest.php
+++ b/tests/phpunit/Presentation/RestReplaceSubjectPresenterTest.php
@@ -45,4 +45,24 @@ class RestReplaceSubjectPresenterTest extends TestCase {
 		$this->assertSame( [], $presenter->getJsonArray()['violations'] );
 	}
 
+	public function testPresentValidationFailedYields422WithErrorBody(): void {
+		$presenter = new RestReplaceSubjectPresenter();
+
+		$presenter->presentValidationFailed( [
+			new Violation( propertyName: new PropertyName( 'Status' ), code: 'required' ),
+		] );
+
+		$this->assertSame( 422, $presenter->getStatusCode() );
+		$this->assertSame(
+			[
+				'status' => 'error',
+				'message' => 'Validation failed',
+				'violations' => [
+					[ 'propertyName' => 'Status', 'code' => 'required', 'args' => [] ],
+				],
+			],
+			$presenter->getJsonArray()
+		);
+	}
+
 }

--- a/tests/phpunit/TestDoubles/InMemorySubjectRepository.php
+++ b/tests/phpunit/TestDoubles/InMemorySubjectRepository.php
@@ -27,6 +27,8 @@ class InMemorySubjectRepository implements SubjectRepository {
 	 */
 	public array $comments = [];
 
+	public int $updateSubjectCallCount = 0;
+
 	public function getSubject( SubjectId $subjectId ): ?Subject {
 		return $this->subjects[$subjectId->text] ?? null;
 	}
@@ -34,6 +36,7 @@ class InMemorySubjectRepository implements SubjectRepository {
 	public function updateSubject( Subject $subject, ?string $comment = null ): void {
 		$this->subjects[$subject->id->text] = $subject;
 		$this->comments[$subject->id->text] = $comment;
+		$this->updateSubjectCallCount++;
 	}
 
 	public function deleteSubject( SubjectId $id, ?string $comment ): void {


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/855.

Blocked by #865 since that should land first.

Implements step 2 of [ADR 21 backend validation](../tree/master/docs/adr/021-add-backend-validation.md): when an admin opts in via `$wgNeoWikiValidationEnforced = true`, the two write endpoints reject edits that introduce *newly-introduced* constraint violations. Pre-existing violations remain tolerated, so editing an already-invalid Subject is still possible (per ADR 21's invalid-Subjects-must-stay-editable requirement). Default is `false`; enforcement-off behavior is unchanged from step 1.

## What changed

- New `NeoWikiValidationEnforced` boolean config (default `false`) in `extension.json`.
- New `Domain/Validation/ViolationDiff::newViolations(proposed, prior): array` helper. Identity: `(propertyName, code)`.
- New `Application/Subject/Exception/ValidationFailedException` carrying `Violation[]`.
- `ReplaceSubjectAction` validates the prior persisted Subject against the *current* Schema, validates the proposed Subject, diffs. Throws `ValidationFailedException` when enforcement is on AND new violations are non-empty.
- `CreateSubjectAction` throws when enforcement is on AND the proposed Subject has any violation (no prior on Create). The `presentSubjectAlreadyExists` branch still short-circuits first.
- Both REST handlers catch `ValidationFailedException` → HTTP 422 with `{status, message, violations}` body.
- Step 1's success-response contract (`violations: [...]` on 200/201) is preserved.

## Wire shape on enforcement block

```json
HTTP 422 Unprocessable Entity
{
  "status": "error",
  "message": "Validation failed",
  "violations": [
    { "propertyName": "Status", "code": "required", "args": [] }
  ]
}
```

`violations` carries the *full* proposed violation list, not just the newly-introduced subset — the new-vs-pre-existing split is server-internal.

## Out of scope (future rounds)

- Severity (error/warning) tiering. Wire format stays additive (a future `severity` field per violation can land without breaking step 2).
- Per-Schema or per-Property enforcement overrides (ADR 21 lists this as a possible future direction).
- TS-side validator upgrade.
- `DeleteSubject` and `SetMainSubject` — neither changes Subject data.

## Test plan

- [x] `make phpunit filter=ViolationDiff` — 10/10 green.
- [x] `make phpunit filter=Replace` — 26/26 green.
- [x] `make phpunit filter=Create` — 26/26 green.
- [x] `make phpunit filter=Application` — 276/276 green (1 expected skip).
- [x] `make cs` — phpcs (392 files) + phpstan (189 files), no errors.
- [x] Live smoke against the running wiki, raw response bodies captured:
  - `PUT /subject/s1demo1aaaaaaa1` enforcement on, no Status → `422 {"status":"error","message":"Validation failed","violations":[{"propertyName":"Status","code":"required","args":[]}]}`
  - `PUT /subject/s1demo1aaaaaaa1` enforcement on, Status set → `200 {"status":"updated","subjectId":"s1demo1aaaaaaa1","violations":[]}`
  - `POST /page/91/mainSubject` enforcement on, no Status → `422 {"status":"error","message":"Validation failed","violations":[{"propertyName":"Status","code":"required","args":[]}]}`
  - `POST /page/92/mainSubject` enforcement on, Status set → `201 {"status":"created","subjectId":"sEu8VkDNrkdFxWz","violations":[]}`
  - `PUT /subject/s1demo1aaaaaaa1` enforcement off, no Status → `200 {"status":"updated","subjectId":"s1demo1aaaaaaa1","violations":[{"propertyName":"Status","code":"required","args":[]}]}` (step 1 contract restored)