### PR TITLE
Localize Cypher error messages on wikitext surfaces

### DIFF
--- a/docs/reference/query-api.md
+++ b/docs/reference/query-api.md
@@ -103,7 +103,10 @@ Temporal and spatial values (e.g. `datetime()`, `point()`) are not supported. Ca
 | `internalError` | 500 | Anything else. |
 
 `errorType` strings are stable across releases. Clients and LLMs should branch on `errorType`, not on `message`
-text — `message` is translated and may change.
+text. The REST `message` is always English and may change between releases; it is intended for logging and
+debugging, not display. User-facing localization applies only to the wikitext surfaces — the `{{#cypher_raw}}`
+parser function and `nw.query()` in Lua — which render translated messages derived from the same `errorType`
+classification.
 
 ## Example walkthrough
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -115,6 +115,14 @@
 
 	"neowiki-cypher-raw-error-json-encode": "Failed to encode query result as JSON",
 
+	"neowiki-cypher-error-empty-query": "The Cypher query must not be empty.",
+	"neowiki-cypher-error-write-query": "Only read-only Cypher queries are allowed.",
+	"neowiki-cypher-error-syntax": "The Cypher query has a syntax error: $1",
+	"neowiki-cypher-error-parameter-missing": "The Cypher query is missing a required parameter: $1",
+	"neowiki-cypher-error-timeout": "The Cypher query exceeded the allowed time limit: $1",
+	"neowiki-cypher-error-backend-unavailable": "The graph database is currently unavailable.",
+	"neowiki-cypher-error-internal": "The Cypher query could not be completed: $1",
+
 	"neowiki-view-error-extra-positional": "Unexpected extra positional argument: $1",
 	"neowiki-view-error-conflicting-subject": "Subject specified both positionally and as a named subject argument.",
 	"neowiki-view-error-unknown-arg": "Unknown argument: $1",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -14,6 +14,14 @@
 	"neowiki-schema-label": "Label used to identify the schema. $1 is the schema name or link.",
 	"neowiki-cypher-raw-error-json-encode": "Error message shown when JSON encoding of query results fails.",
 
+	"neowiki-cypher-error-empty-query": "Error shown on the <code>{{#cypher_raw}}</code> parser function and the <code>nw.query()</code> Lua function when the supplied Cypher query is empty or only whitespace.",
+	"neowiki-cypher-error-write-query": "Error shown on the <code>{{#cypher_raw}}</code> parser function and the <code>nw.query()</code> Lua function when the query contains a write operation. Cypher queries from wikitext are restricted to read-only.",
+	"neowiki-cypher-error-syntax": "Error shown when Neo4j reports a syntax error for a Cypher query run from wikitext. $1 is the verbatim Neo4j-supplied syntax detail and is not translatable.",
+	"neowiki-cypher-error-parameter-missing": "Error shown when a Cypher query run from wikitext references a parameter that was not supplied. $1 is the verbatim Neo4j-supplied detail and is not translatable.",
+	"neowiki-cypher-error-timeout": "Error shown when a Cypher query run from wikitext exceeds the allowed time limit. $1 is the verbatim Neo4j-supplied detail and is not translatable.",
+	"neowiki-cypher-error-backend-unavailable": "Error shown when the graph database backend cannot be reached for a Cypher query run from wikitext. The underlying connection detail is intentionally omitted.",
+	"neowiki-cypher-error-internal": "Generic fallback error shown for a Cypher query run from wikitext that fails for a reason not covered by the more specific cases. $1 is the verbatim underlying detail and is not translatable.",
+
 	"neowiki-view-error-extra-positional": "Error shown when {{#view}} is called with more than one positional argument. $1 is the offending extra argument value.",
 	"neowiki-view-error-conflicting-subject": "Error shown when {{#view}} receives a Subject ID as both a positional argument and a named <code>subject=</code> argument.",
 	"neowiki-view-error-unknown-arg": "Error shown when {{#view}} receives an unrecognized named argument. $1 is the offending argument name.",

--- a/src/EntryPoints/Scribunto/ScribuntoLuaLibrary.php
+++ b/src/EntryPoints/Scribunto/ScribuntoLuaLibrary.php
@@ -10,6 +10,8 @@ use MediaWiki\Extension\Scribunto\Engines\LuaCommon\LibraryBase;
 use MediaWiki\Extension\Scribunto\Engines\LuaCommon\LuaError;
 use ProfessionalWiki\NeoWiki\Application\SubjectResolver;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\QueryException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\CypherErrorMessage;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\Lua\CypherQueryRunner;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 
@@ -121,6 +123,9 @@ class ScribuntoLuaLibrary extends LibraryBase {
 
 		try {
 			$rows = $this->getCypherQueryRunner()->run( $cypher, $params ?? [] );
+		} catch ( QueryException $e ) {
+			$message = CypherErrorMessage::for( $e );
+			throw new LuaError( $this->getParser()->msg( $message->key, ...$message->params )->text() );
 		} catch ( Exception $e ) {
 			throw new LuaError( $e->getMessage() );
 		}

--- a/src/GraphDatabasePlugins/Neo4j/EntryPoints/CypherErrorMessage.php
+++ b/src/GraphDatabasePlugins/Neo4j/EntryPoints/CypherErrorMessage.php
@@ -1,0 +1,38 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints;
+
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\QueryException;
+
+/**
+ * Maps a QueryException to the localized message that wikitext-facing surfaces
+ * ({{#cypher_raw}} and nw.query()) show to users. Returns the message key and its
+ * parameters rather than rendered text, so each surface can render it in its own
+ * language context.
+ */
+readonly class CypherErrorMessage {
+
+	/**
+	 * @param string[] $params
+	 */
+	public function __construct(
+		public string $key,
+		public array $params,
+	) {
+	}
+
+	public static function for( QueryException $error ): self {
+		return match ( $error->errorType() ) {
+			'emptyQuery' => new self( 'neowiki-cypher-error-empty-query', [] ),
+			'writeQueryRejected' => new self( 'neowiki-cypher-error-write-query', [] ),
+			'backendUnavailable' => new self( 'neowiki-cypher-error-backend-unavailable', [] ),
+			'cypherSyntaxError' => new self( 'neowiki-cypher-error-syntax', [ $error->getMessage() ] ),
+			'parameterMissing' => new self( 'neowiki-cypher-error-parameter-missing', [ $error->getMessage() ] ),
+			'queryTimeout' => new self( 'neowiki-cypher-error-timeout', [ $error->getMessage() ] ),
+			default => new self( 'neowiki-cypher-error-internal', [ $error->getMessage() ] ),
+		};
+	}
+
+}

--- a/src/GraphDatabasePlugins/Neo4j/EntryPoints/Lua/CypherQueryRunner.php
+++ b/src/GraphDatabasePlugins/Neo4j/EntryPoints/Lua/CypherQueryRunner.php
@@ -5,11 +5,9 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\Lua;
 
 use MediaWiki\Context\RequestContext;
-use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\QueryException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jQueryLimits;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jQueryRequest;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jQueryService;
-use RuntimeException;
 
 class CypherQueryRunner {
 
@@ -19,17 +17,13 @@ class CypherQueryRunner {
 	}
 
 	public function run( string $cypher, array $params ): array {
-		try {
-			$result = $this->queryService->execute(
-				new Neo4jQueryRequest(
-					cypher: $cypher,
-					parameters: $params,
-					limits: Neo4jQueryLimits::forUser( RequestContext::getMain()->getUser() ),
-				)
-			);
-		} catch ( QueryException $e ) {
-			throw new RuntimeException( $e->getMessage(), 0, $e );
-		}
+		$result = $this->queryService->execute(
+			new Neo4jQueryRequest(
+				cypher: $cypher,
+				parameters: $params,
+				limits: Neo4jQueryLimits::forUser( RequestContext::getMain()->getUser() ),
+			)
+		);
 
 		// Lua expects 1-indexed tables; Neo4jQueryResult::$rows is a 0-indexed list.
 		$indexed = [];

--- a/src/GraphDatabasePlugins/Neo4j/EntryPoints/ParserFunction/CypherRawParserFunction.php
+++ b/src/GraphDatabasePlugins/Neo4j/EntryPoints/ParserFunction/CypherRawParserFunction.php
@@ -10,6 +10,7 @@ use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\Qu
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jQueryLimits;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jQueryRequest;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jQueryService;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\CypherErrorMessage;
 
 class CypherRawParserFunction {
 
@@ -28,7 +29,8 @@ class CypherRawParserFunction {
 				)
 			);
 		} catch ( QueryException $e ) {
-			return $this->formatError( $e->getMessage() );
+			$message = CypherErrorMessage::for( $e );
+			return $this->formatError( $parser->msg( $message->key, ...$message->params )->text() );
 		}
 
 		$json = json_encode( $result->rows, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );

--- a/tests/phpunit/EntryPoints/Scribunto/NeoWikiLibraryTests.lua
+++ b/tests/phpunit/EntryPoints/Scribunto/NeoWikiLibraryTests.lua
@@ -88,23 +88,23 @@ end
 -- query tests
 
 local function testQueryRejectsEmptyString()
-	local ok = pcall( function()
+	local ok, err = pcall( function()
 		return nw.query( '' )
 	end )
 	if ok then
 		return 'unexpected success'
 	end
-	return 'error'
+	return type( err ) == 'string' and string.find( err, 'must not be empty', 1, true ) ~= nil
 end
 
 local function testQueryRejectsWriteQuery()
-	local ok = pcall( function()
+	local ok, err = pcall( function()
 		return nw.query( 'CREATE (n:Foo) RETURN n' )
 	end )
 	if ok then
 		return 'unexpected success'
 	end
-	return 'error'
+	return type( err ) == 'string' and string.find( err, 'read-only Cypher queries are allowed', 1, true ) ~= nil
 end
 
 -- getSchema tests
@@ -209,10 +209,10 @@ local tests = {
 	  func = testGetChildSubjectsEmptyForPageWithoutChildren, expect = { 0 } },
 
 	-- query
-	{ name = 'query rejects empty string',
-	  func = testQueryRejectsEmptyString, expect = { 'error' } },
-	{ name = 'query rejects write query',
-	  func = testQueryRejectsWriteQuery, expect = { 'error' } },
+	{ name = 'query rejects empty string with localized message',
+	  func = testQueryRejectsEmptyString, expect = { true } },
+	{ name = 'query rejects write query with localized message',
+	  func = testQueryRejectsWriteQuery, expect = { true } },
 
 	-- getSchema
 	{ name = 'getSchema returns name and property count',

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/EntryPoints/CypherErrorMessageTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/EntryPoints/CypherErrorMessageTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\GraphDatabasePlugins\Neo4j\EntryPoints;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\BackendUnavailableException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\CypherSyntaxException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\EmptyQueryException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\InternalQueryException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\ParameterMissingException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\QueryException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\QueryTimeoutException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\WriteQueryRejectedException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\CypherErrorMessage;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\CypherErrorMessage
+ */
+class CypherErrorMessageTest extends TestCase {
+
+	public function testEmptyQueryMapsToParamlessKey(): void {
+		$this->assertEquals(
+			new CypherErrorMessage( 'neowiki-cypher-error-empty-query', [] ),
+			CypherErrorMessage::for( new EmptyQueryException( 'Query is empty.' ) )
+		);
+	}
+
+	public function testWriteQueryRejectedMapsToParamlessKey(): void {
+		$this->assertEquals(
+			new CypherErrorMessage( 'neowiki-cypher-error-write-query', [] ),
+			CypherErrorMessage::for( new WriteQueryRejectedException( 'Query is not read-only.' ) )
+		);
+	}
+
+	public function testBackendUnavailableMapsToParamlessKey(): void {
+		$this->assertEquals(
+			new CypherErrorMessage( 'neowiki-cypher-error-backend-unavailable', [] ),
+			CypherErrorMessage::for( new BackendUnavailableException( 'Connection to bolt://neo4j:7687 refused' ) )
+		);
+	}
+
+	public function testSyntaxErrorEmbedsNeo4jDetail(): void {
+		$this->assertEquals(
+			new CypherErrorMessage( 'neowiki-cypher-error-syntax', [ "Invalid input 'X': expected an expression" ] ),
+			CypherErrorMessage::for( new CypherSyntaxException( "Invalid input 'X': expected an expression" ) )
+		);
+	}
+
+	public function testParameterMissingEmbedsNeo4jDetail(): void {
+		$this->assertEquals(
+			new CypherErrorMessage( 'neowiki-cypher-error-parameter-missing', [ 'Expected parameter(s): minYear' ] ),
+			CypherErrorMessage::for( new ParameterMissingException( 'Expected parameter(s): minYear' ) )
+		);
+	}
+
+	public function testTimeoutEmbedsNeo4jDetail(): void {
+		$this->assertEquals(
+			new CypherErrorMessage( 'neowiki-cypher-error-timeout', [ 'The transaction has been terminated.' ] ),
+			CypherErrorMessage::for( new QueryTimeoutException( 'The transaction has been terminated.' ) )
+		);
+	}
+
+	public function testInternalErrorEmbedsNeo4jDetail(): void {
+		$this->assertEquals(
+			new CypherErrorMessage( 'neowiki-cypher-error-internal', [ 'Unexpected server failure' ] ),
+			CypherErrorMessage::for( new InternalQueryException( 'Unexpected server failure' ) )
+		);
+	}
+
+	public function testUnmappedErrorTypeFallsBackToInternalKey(): void {
+		$unknown = new class( 'Some new failure' ) extends QueryException {
+			public function errorType(): string {
+				return 'someFutureErrorType';
+			}
+		};
+
+		$this->assertEquals(
+			new CypherErrorMessage( 'neowiki-cypher-error-internal', [ 'Some new failure' ] ),
+			CypherErrorMessage::for( $unknown )
+		);
+	}
+
+}

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/EntryPoints/Lua/CypherQueryRunnerTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/EntryPoints/Lua/CypherQueryRunnerTest.php
@@ -9,6 +9,9 @@ use Laudis\Neo4j\Types\CypherList;
 use Laudis\Neo4j\Types\CypherMap;
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\CypherQueryValidator;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\BackendUnavailableException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\EmptyQueryException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\WriteQueryRejectedException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jResultNormalizer;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jQueryService;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\Lua\CypherQueryRunner;
@@ -88,15 +91,14 @@ class CypherQueryRunnerTest extends TestCase {
 		);
 	}
 
-	public function testEmptyQueryThrowsWithEmptyQueryMessage(): void {
+	public function testEmptyQueryPropagatesEmptyQueryException(): void {
 		$runner = $this->newRunner( $this->stubEngine( $this->emptyResult() ) );
 
-		$this->expectException( RuntimeException::class );
-		$this->expectExceptionMessageMatches( '/empty/i' );
+		$this->expectException( EmptyQueryException::class );
 		$runner->run( '   ', [] );
 	}
 
-	public function testDisallowedQueryThrowsWithReadOnlyMessage(): void {
+	public function testWriteQueryPropagatesWriteQueryRejectedException(): void {
 		$engine = new class implements Neo4jQueryEngine {
 			public function runReadQuery( string $cypher, array $parameters = [], ?int $timeoutSeconds = null ): SummarizedResult {
 				throw new \LogicException( 'engine must not be called for a rejected query' );
@@ -116,8 +118,7 @@ class CypherQueryRunnerTest extends TestCase {
 			)
 		);
 
-		$this->expectException( RuntimeException::class );
-		$this->expectExceptionMessageMatches( '/read-only/i' );
+		$this->expectException( WriteQueryRejectedException::class );
 		$runner->run( 'CREATE (n)', [] );
 	}
 
@@ -139,7 +140,7 @@ class CypherQueryRunnerTest extends TestCase {
 		$this->assertSame( [ 'x' => 42, 'y' => 'foo' ], $engine->lastParams );
 	}
 
-	public function testEngineExceptionsPropagate(): void {
+	public function testEngineFailurePropagatesAsBackendUnavailableException(): void {
 		$engine = new class implements Neo4jQueryEngine {
 			public function runReadQuery( string $cypher, array $parameters = [], ?int $timeoutSeconds = null ): SummarizedResult {
 				throw new RuntimeException( 'connection refused' );
@@ -147,7 +148,7 @@ class CypherQueryRunnerTest extends TestCase {
 		};
 		$runner = $this->newRunner( $engine );
 
-		$this->expectException( RuntimeException::class );
+		$this->expectException( BackendUnavailableException::class );
 		$this->expectExceptionMessage( 'connection refused' );
 		$runner->run( 'MATCH (n) RETURN n', [] );
 	}

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/EntryPoints/ParserFunction/CypherRawParserFunctionTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/EntryPoints/ParserFunction/CypherRawParserFunctionTest.php
@@ -5,8 +5,11 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Tests\GraphDatabasePlugins\Neo4j\EntryPoints\ParserFunction;
 
 use Exception;
+use Laudis\Neo4j\Databags\Neo4jError;
 use Laudis\Neo4j\Databags\SummarizedResult;
+use Laudis\Neo4j\Exception\Neo4jException;
 use Laudis\Neo4j\Types\CypherMap;
+use MediaWiki\Message\Message;
 use MediaWiki\Parser\Parser;
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\CypherQueryValidator;
@@ -22,8 +25,22 @@ use RuntimeException;
  */
 class CypherRawParserFunctionTest extends TestCase {
 
-	private function createMockParser(): Parser {
-		return $this->createMock( Parser::class );
+	/**
+	 * Returns a Parser whose msg() renders any key as "[key]" (params appended as
+	 * "[key|p1|p2]"). This lets a test assert which message key the production code
+	 * selected without a full MediaWiki message-resolution context.
+	 */
+	private function createParser(): Parser {
+		$parser = $this->createMock( Parser::class );
+		$parser->method( 'msg' )->willReturnCallback(
+			function ( string $key, ...$params ): Message {
+				$rendered = $params === [] ? "[$key]" : '[' . $key . '|' . implode( '|', $params ) . ']';
+				$message = $this->createMock( Message::class );
+				$message->method( 'text' )->willReturn( $rendered );
+				return $message;
+			}
+		);
+		return $parser;
 	}
 
 	private function createDummyQueryEngine(): Neo4jQueryEngine {
@@ -71,20 +88,59 @@ class CypherRawParserFunctionTest extends TestCase {
 		);
 	}
 
-	public function testEmptyQueryReturnsError(): void {
+	public function testEmptyQueryShowsLocalizedError(): void {
 		$parserFunction = $this->createParserFunction( $this->createDummyQueryEngine() );
 
-		$result = $parserFunction->handle( $this->createMockParser(), '' );
+		$result = $parserFunction->handle( $this->createParser(), '' );
 
-		$this->assertStringContainsString( 'error', $result );
+		$this->assertStringContainsString( '[neowiki-cypher-error-empty-query]', $result );
 	}
 
-	public function testWriteQueryIsRejected(): void {
+	public function testWriteQueryShowsLocalizedError(): void {
 		$parserFunction = $this->createParserFunction( $this->createDummyQueryEngine() );
 
-		$result = $parserFunction->handle( $this->createMockParser(), "CREATE (n:Person {name: 'Alice'})" );
+		$result = $parserFunction->handle( $this->createParser(), "CREATE (n:Person {name: 'Alice'})" );
 
-		$this->assertStringContainsString( 'error', $result );
+		$this->assertStringContainsString( '[neowiki-cypher-error-write-query]', $result );
+	}
+
+	public function testEngineFailureShowsLocalizedBackendError(): void {
+		$parserFunction = $this->createParserFunction(
+			$this->createQueryEngineWithException( new Exception( 'Connection failed' ) )
+		);
+
+		$result = $parserFunction->handle( $this->createParser(), 'MATCH (n) RETURN n' );
+
+		$this->assertStringContainsString( '[neowiki-cypher-error-backend-unavailable]', $result );
+	}
+
+	public function testSyntaxErrorForwardsNeo4jDetailToLocalizedMessage(): void {
+		$neo4jException = new Neo4jException( [
+			Neo4jError::fromMessageAndCode( 'Neo.ClientError.Statement.SyntaxError', 'Invalid input near RETURN' ),
+		] );
+
+		$parserFunction = $this->createParserFunction(
+			$this->createQueryEngineWithException( $neo4jException )
+		);
+
+		$result = $parserFunction->handle( $this->createParser(), 'MATCH (n) RETURN x' );
+
+		$this->assertStringContainsString( '[neowiki-cypher-error-syntax|', $result );
+		$this->assertStringContainsString( 'Invalid input near RETURN', $result );
+	}
+
+	public function testValidatorFailureShowsLocalizedBackendError(): void {
+		$throwingValidator = new class implements CypherQueryValidator {
+			public function queryIsAllowed( string $cypher ): bool {
+				throw new RuntimeException( 'Neo4j connection refused' );
+			}
+		};
+
+		$parserFunction = $this->createParserFunction( $this->createDummyQueryEngine(), $throwingValidator );
+
+		$result = $parserFunction->handle( $this->createParser(), 'MATCH (n) RETURN n' );
+
+		$this->assertStringContainsString( '[neowiki-cypher-error-backend-unavailable]', $result );
 	}
 
 	public function testValidReadQueryReturnsFormattedResult(): void {
@@ -95,43 +151,19 @@ class CypherRawParserFunctionTest extends TestCase {
 
 		$parserFunction = $this->createParserFunction( $this->createQueryEngineWithData( $testData ) );
 
-		$result = $parserFunction->handle( $this->createMockParser(), 'MATCH (n:Person) RETURN n' );
+		$result = $parserFunction->handle( $this->createParser(), 'MATCH (n:Person) RETURN n' );
 
 		$this->assertStringContainsString( '<div class="mw-neowiki-cypher-result"><pre>', $result );
 		$this->assertStringContainsString( 'Alice', $result );
 		$this->assertStringContainsString( 'Bob', $result );
 	}
 
-	public function testQueryExecutionExceptionReturnsError(): void {
-		$parserFunction = $this->createParserFunction(
-			$this->createQueryEngineWithException( new Exception( 'Connection failed' ) )
-		);
-
-		$result = $parserFunction->handle( $this->createMockParser(), 'MATCH (n) RETURN n' );
-
-		$this->assertStringContainsString( 'error', $result );
-	}
-
 	public function testTrimWhitespaceFromQuery(): void {
 		$parserFunction = $this->createParserFunction( $this->createQueryEngineWithData( [] ) );
 
-		$result = $parserFunction->handle( $this->createMockParser(), '  MATCH (n) RETURN n  ' );
+		$result = $parserFunction->handle( $this->createParser(), '  MATCH (n) RETURN n  ' );
 
 		$this->assertStringContainsString( '<div class="mw-neowiki-cypher-result"><pre>', $result );
-	}
-
-	public function testValidatorExceptionReturnsError(): void {
-		$throwingValidator = new class implements CypherQueryValidator {
-			public function queryIsAllowed( string $cypher ): bool {
-				throw new RuntimeException( 'Neo4j connection refused' );
-			}
-		};
-
-		$parserFunction = $this->createParserFunction( $this->createDummyQueryEngine(), $throwingValidator );
-
-		$result = $parserFunction->handle( $this->createMockParser(), 'MATCH (n) RETURN n' );
-
-		$this->assertStringContainsString( 'error', $result );
 	}
 
 	public function testOutputIsHTMLEscaped(): void {
@@ -141,7 +173,7 @@ class CypherRawParserFunctionTest extends TestCase {
 
 		$parserFunction = $this->createParserFunction( $this->createQueryEngineWithData( $testData ) );
 
-		$result = $parserFunction->handle( $this->createMockParser(), 'MATCH (n) RETURN n' );
+		$result = $parserFunction->handle( $this->createParser(), 'MATCH (n) RETURN n' );
 
 		$this->assertStringNotContainsString( '<script>alert', $result );
 		$this->assertStringContainsString( '&lt;script&gt;', $result );


### PR DESCRIPTION
> Direction and the key architecture decision — a shared mapper in the EntryPoints layer rather than carrying message keys on the exception — by @alistair3149.
> Context: the NeoWiki codebase, issue #858, the post-#817 Cypher query code paths, and MediaWiki/Scribunto message-handling internals.
> <sub>Written by Claude Code, `Opus 4.8 (1M context)`</sub>

Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/858

## Screenshots

<img width="1052" height="456" alt="00-overview" src="https://github.com/user-attachments/assets/2527bcc0-e076-4693-98f5-e9a56ce67254" />

<details>
<summary>Per case</summary>

| Surface / input | Screenshot |
|---|---|
| `{{#cypher_raw:}}` (empty) | <img width="1052" height="27" alt="01-empty" src="https://github.com/user-attachments/assets/d06da46e-3a4f-4ff5-aee5-d197c46a365e" /> |
| `{{#cypher_raw:CREATE (n) RETURN n}}` (write) | <img width="1052" height="27" alt="02-write" src="https://github.com/user-attachments/assets/0c89aed1-d339-4fd0-9b89-fa3ce0245366" /> |
| `{{#cypher_raw:MATCH (n) RETURN}}` (syntax - Neo4j detail forwarded as `$1`) | <img width="1052" height="106" alt="03-syntax" src="https://github.com/user-attachments/assets/7776ac5d-0386-413b-8808-b1d29d139f71" /> |
| `nw.query( "" )` (Lua) | <img width="389" height="20" alt="04-lua" src="https://github.com/user-attachments/assets/222b3f69-eb70-43ca-b943-11b8a1bbe6f4" /> |

</details>


#817 replaced the localized i18n error messages on the wikitext-facing Cypher surfaces (`{{#cypher_raw}}` and `nw.query()`) with hardcoded English thrown from exceptions, so non-English wikis saw English error text.

A shared `CypherErrorMessage` mapper in the Neo4j EntryPoints layer turns a `QueryException` into a message key plus parameters (not rendered text), so each surface renders it in its own content-language context (parser-cache safe). The four Neo4j-diagnostic error types embed the verbatim, untranslatable Neo4j detail as `$1`; the semantic types (empty, write-rejected, backend-unavailable) are fully localized. `CypherQueryRunner` no longer flattens `QueryException` into a bare `RuntimeException`, letting the typed exception reach the Lua surface for localization. The seven `cypher-raw`/`lua` error keys are unified into one `neowiki-cypher-error-*` family so both surfaces show identical wording.

The REST API keeps its English message plus stable `errorType` by design; only the inaccurate "message is translated" claim in `docs/reference/query-api.md` is corrected.

## Manual Browser Check

These surfaces render server-side, so no TypeScript build is needed. The wiki runs at http://localhost:8484.

1. **Empty query** — create a page containing `{{#cypher_raw: }}` and view it. The error box should read *"The Cypher query must not be empty."* (previously the hardcoded *"Query is empty."*).
2. **Write query** — `{{#cypher_raw: CREATE (n) RETURN n}}` → *"Only read-only Cypher queries are allowed."*
3. **Syntax error** (Neo4j must be running) — `{{#cypher_raw: MATCH (n) RETURN }}` → *"The Cypher query has a syntax error: &lt;verbatim Neo4j detail&gt;"* — a localized frame wrapping the untranslatable Neo4j text.
4. **Proves it goes through i18n, not a hardcoded string** — edit `MediaWiki:Neowiki-cypher-error-empty-query` to any custom text, then reload the page from step 1; the error should now show your custom text. Revert afterwards.
5. **Lua surface** — create a module with `return mw.neowiki.query( '' )` (or call it from a template) and invoke it; the Lua error should carry the same *"The Cypher query must not be empty."* message instead of the old raw string.
