### PR TITLE
CI: run PHPUnit against MediaWiki master (1.47) on PHP 8.5

### DIFF
--- a/.github/workflows/ci-php.yml
+++ b/.github/workflows/ci-php.yml
@@ -21,12 +21,18 @@ jobs:
   test:
     name: "PHPUnit: MW ${{ matrix.mw }}, PHP ${{ matrix.php }}"
 
+    continue-on-error: ${{ matrix.experimental }}
+
     strategy:
       fail-fast: false
       matrix:
         include:
           - mw: 'REL1_43'
             php: '8.3'
+            experimental: false
+          - mw: 'master'
+            php: '8.5'
+            experimental: true
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci-php.yml
+++ b/.github/workflows/ci-php.yml
@@ -152,7 +152,8 @@ jobs:
           echo "QLever did not become ready in time; dumping logs:"; docker logs test_qlever; exit 1
 
       - name: Run PHPUnit
-        run: php tests/phpunit/phpunit.php -c extensions/NeoWiki/phpunit.xml.dist
+        run: composer phpunit
+        working-directory: mediawiki/extensions/NeoWiki
 
   phpcs:
     name: "PHPCS with PHP 8.3"

--- a/.github/workflows/ci-php.yml
+++ b/.github/workflows/ci-php.yml
@@ -82,7 +82,7 @@ jobs:
             mediawiki
             !mediawiki/extensions/
             !mediawiki/vendor/
-          key: mw_${{ matrix.mw }}-php${{ matrix.php }}
+          key: mw_${{ matrix.mw }}-php${{ matrix.php }}-v2
 
       - name: Cache Composer cache
         uses: actions/cache@v5
@@ -210,7 +210,7 @@ jobs:
             mediawiki
             !mediawiki/extensions/
             !mediawiki/vendor/
-          key: mw_${{ matrix.mw }}-php${{ matrix.php }}
+          key: mw_${{ matrix.mw }}-php${{ matrix.php }}-v2
 
       - name: Cache Composer cache
         uses: actions/cache@v5

--- a/.github/workflows/installMediaWiki.sh
+++ b/.github/workflows/installMediaWiki.sh
@@ -13,6 +13,16 @@ cd mediawiki
 composer install
 php maintenance/install.php --dbtype sqlite --dbuser root --dbname mw --dbpath $(pwd) --pass AdminPassword WikiName AdminUser
 
+# MediaWiki 1.46 replaced `phpunit.xml.dist` with `phpunit.xml.template`, which
+# is turned into a runnable `phpunit.xml` by `generatePHPUnitConfig.php`. The
+# extension's `composer phpunit` script invokes `-c phpunit.xml.dist`, so on
+# branches that only ship a template, generate the config and expose it under the
+# name the script expects. Generated here (after `composer install` provides the
+# autoloader, before the extension load lines are appended to LocalSettings.php).
+if [ ! -f phpunit.xml.dist ] && [ -f phpunit.xml.template ]; then
+    php tests/phpunit/generatePHPUnitConfig.php
+    cp phpunit.xml phpunit.xml.dist
+fi
 
 cat <<'EOT' >> LocalSettings.php
 error_reporting(E_ALL| E_STRICT);

--- a/.github/workflows/installMediaWiki.sh
+++ b/.github/workflows/installMediaWiki.sh
@@ -3,10 +3,9 @@
 MW_BRANCH=$1
 EXTENSION_NAME=$2
 
-wget https://github.com/wikimedia/mediawiki/archive/$MW_BRANCH.tar.gz -nv
-
-tar -zxf $MW_BRANCH.tar.gz
-mv mediawiki-$MW_BRANCH mediawiki
+# Cloned rather than fetched as a tarball: phpunit.xml.template is export-ignore'd
+# in MediaWiki's .gitattributes, and `composer phpunit:config` needs it.
+git clone --depth 1 --branch "$MW_BRANCH" https://github.com/wikimedia/mediawiki.git mediawiki
 
 cd mediawiki
 

--- a/.github/workflows/installMediaWiki.sh
+++ b/.github/workflows/installMediaWiki.sh
@@ -13,16 +13,6 @@ cd mediawiki
 composer install
 php maintenance/install.php --dbtype sqlite --dbuser root --dbname mw --dbpath $(pwd) --pass AdminPassword WikiName AdminUser
 
-# MediaWiki 1.46 replaced `phpunit.xml.dist` with `phpunit.xml.template`, which
-# is turned into a runnable `phpunit.xml` by `generatePHPUnitConfig.php`. The
-# extension's `composer phpunit` script invokes `-c phpunit.xml.dist`, so on
-# branches that only ship a template, generate the config and expose it under the
-# name the script expects. Generated here (after `composer install` provides the
-# autoloader, before the extension load lines are appended to LocalSettings.php).
-if [ ! -f phpunit.xml.dist ] && [ -f phpunit.xml.template ]; then
-    php tests/phpunit/generatePHPUnitConfig.php
-    cp phpunit.xml phpunit.xml.dist
-fi
 
 cat <<'EOT' >> LocalSettings.php
 error_reporting(E_ALL| E_STRICT);

--- a/Makefile
+++ b/Makefile
@@ -295,9 +295,9 @@ cs: phpcs stan ## Run code style checks (phpcs + phpstan)
 phpunit: ## Run PHPUnit (use filter=X for a single test)
 ifeq ($(INSIDE_CONTAINER),1)
 ifdef filter
-	php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist --filter $(filter) < /dev/null
+	composer phpunit -- --filter $(filter) < /dev/null
 else
-	php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist < /dev/null
+	composer phpunit < /dev/null
 endif
 else
 ifdef filter
@@ -309,7 +309,7 @@ endif
 
 perf: ## Run performance test group
 ifeq ($(INSIDE_CONTAINER),1)
-	php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist --group Performance < /dev/null
+	composer phpunit -- --group Performance < /dev/null
 else
 	$(EXEC_MW) bash -c 'cd extensions/NeoWiki && make perf' < /dev/null
 endif

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,9 @@
 			"ProfessionalWiki\\NeoWiki\\Tests\\": "tests/phpunit/"
 		}
 	},
+	"scripts": {
+		"phpunit": "cd ${MW_INSTALL_PATH:-../..} && (composer phpunit:config 2>/dev/null || true) && vendor/bin/phpunit -c extensions/NeoWiki/phpunit.xml.dist --bootstrap tests/phpunit/bootstrap.php"
+	},
 	"config": {
 		"allow-plugins": {
 			"composer/installers": true,


### PR DESCRIPTION
Adds a MediaWiki `master` (1.47) / PHP 8.5 row to the PHPUnit matrix, so the extension is exercised against the development branch in addition to the current LTS (`REL1_43` / PHP 8.3). The `master` row is marked `experimental` and runs `continue-on-error`, so breakage originating in MediaWiki core does not block PRs while still surfacing the failure. This follows the `continue-on-error: ${{ matrix.experimental }}` convention already used across the other ProfessionalWiki extensions (e.g. Network, WikibaseFacetedSearch, Chameleon).

Adding the row required migrating the test runner, since MediaWiki 1.46 removed the `tests/phpunit/phpunit.php` entry point the workflow invoked.

## One runner for every version

The replacement is a `phpunit` composer script in the extension, called by both CI and the Makefile so the two cannot drift. It runs unchanged on `REL1_43` and `master`: `composer phpunit:config` generates the config MediaWiki 1.46 and later require, and is tolerated as a no-op where that script does not exist. No version gate is needed, and 1.43's own entry point already printed a deprecation notice pointing at `composer phpunit`.

The script keeps `-c extensions/NeoWiki/phpunit.xml.dist` and passes core's bootstrap explicitly, which the removed entry point used to inject on its own. The alternative, selecting tests by path and inheriting core's config, would have silently adopted its `forceCoversAnnotation`, `failOnWarning`, `failOnRisky` and strictness settings, and would have dropped the `<env>` block that points the Neo4j and QLever tests at the right endpoints.

## Cloning instead of unpacking

MediaWiki is now cloned rather than fetched as an archive. `phpunit.xml.template` is `export-ignore`d in MediaWiki's `.gitattributes`, so it is absent from the tarball while the generator that reads it is present, and on `master` the bootstrap refuses to run without the generated config.

The MediaWiki cache key is bumped alongside it. That cache is keyed only by branch and PHP version, so without a new key the pre-existing tarball checkout would be restored and the install step skipped, leaving the change with no effect.

The PHPStan job stays pinned to a single MediaWiki version, matching the same org-wide convention: PHPUnit fans out across versions, static analysis does not. `phpcs` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
