### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities **privately** — do not open a public
+issue or pull request for a suspected vulnerability.
+
+Use GitHub's private vulnerability reporting:
+[**Report a vulnerability**](https://github.com/ProfessionalWiki/NeoWiki/security/advisories/new).
+
+A helpful report includes:
+
+- The affected component and the commit or branch you tested against
+- Steps to reproduce, ideally with a proof of concept
+- Your assessment of the impact (what an attacker could do)
+
+## Supported Versions
+
+NeoWiki is in active pre-release development and is not yet intended for
+production use. There are no released versions with separate maintenance
+branches; security fixes are applied to the latest `master`.
+
+## Disclosure
+
+We practice coordinated disclosure. We aim to acknowledge your report within
+five business days, keep you informed of our progress, and credit you when a
+fix is published (unless you prefer to remain anonymous). We will work on a fix
+as quickly as the severity warrants. Please give us a reasonable opportunity to
+release that fix before disclosing the issue publicly.


### PR DESCRIPTION
> Result of a short back-and-forth with @alistair3149, who chose the reporting channel (GitHub private vulnerability reporting) and the five-business-day acknowledgment window.
> Context: the NeoWiki repository (pre-release, `0.0.0-alpha`, no released versions).
> <sub>Written by Claude Code, `Opus 4.8`</sub>

Add a SECURITY.md describing how to report vulnerabilities privately via
GitHub's private vulnerability reporting, the pre-release support status, and
our coordinated-disclosure expectations (acknowledgment within five business
days).

🤖 Generated with [Claude Code](https://claude.com/claude-code)