### PR TITLE
Extract ProposedSubjectValidator and surface schema-not-found on writes

### DIFF
--- a/docs/reference/validation-codes.md
+++ b/docs/reference/validation-codes.md
@@ -4,15 +4,19 @@ Constraint violations returned by NeoWiki's backend validation API use stable `c
 This document is the authoritative reference, shared between the PHP backend implementation and
 (in a future round) the TS frontend implementation.
 
-The API endpoints are:
+Violations are returned by:
 
-- `POST /neowiki/v0/subject/validate` — validates a proposed create-shape body.
-- `POST /neowiki/v0/subject/{subjectId}/validate` — validates a proposed update-shape body
-  against an existing Subject's Schema.
+- `POST /neowiki/v0/subject/validate` — dry-run validation of a proposed create-shape body.
+- `POST /neowiki/v0/subject/{subjectId}/validate` — dry-run validation of a proposed update-shape
+  body against an existing Subject's Schema.
+- `POST /neowiki/v0/subject` and `PUT /neowiki/v0/subject/{subjectId}` — the write endpoints include
+  the resulting `violations` array in their `201`/`200` success body. Validation does not block the
+  write (see [ADR 21](../adr/021-add-backend-validation.md)).
 
-Both endpoints return `200 OK` with a `{violations: [...]}` body whenever the request is
-well-formed. Violations present in the body do not change the HTTP status. `400` is reserved for
-malformed input; `404` for a missing Schema or Subject.
+The `/validate` endpoints return `200 OK` with a `{violations: [...]}` body whenever the request is
+well-formed; violations in the body do not change the HTTP status. `400` is reserved for malformed
+input, `404` for a missing Subject (update dry-run). A missing Schema is reported differently per
+endpoint — see [`schema-not-found`](#schema-not-found).
 
 Each violation in the response has this shape:
 

--- a/docs/reference/validation-codes.md
+++ b/docs/reference/validation-codes.md
@@ -166,14 +166,23 @@ A part does not match the 6-digit hex-color pattern (`/^#[0-9a-fA-F]{6}$/`).
 
 ### `schema-not-found`
 
-Emitted by `ValidateSubjectUpdateApi`.
+Emitted by `ValidateSubjectUpdateApi` and by the Subject write endpoints
+(`POST /subject`, `PUT /subject/{id}`) via `ProposedSubjectValidator`.
 `args`: `[schemaName]`.
 `valuePartIndex`: never set.
 `propertyName`: always `null` (Subject-level).
 
-The existing Subject's Schema cannot be loaded — usually because the Schema page was deleted or
-renamed since the Subject was created. Surfaced as a violation rather than a 404 because the
-Subject itself does exist; the caller can fix this by re-creating or renaming the Schema page.
+The Subject's Schema cannot be loaded — usually because the Schema page was deleted or renamed
+since the Subject was created, or because a Subject is created/imported referencing a Schema that
+does not (yet) exist. On the write endpoints it is non-blocking: the write proceeds and the
+(unvalidatable) Subject stays editable per ADR 21, but the response reports `schema-not-found`
+rather than an empty (and misleading "valid") violation list. The caller can resolve it by
+creating or renaming the Schema page.
+
+Note the create dry-run endpoint (`POST /subject/validate`) instead returns `404`
+(`SchemaNotFoundException`) for a missing Schema, because there it is the addressed resource;
+the update dry-run (`POST /subject/{id}/validate`) and both write endpoints surface the violation.
+Reconciling that asymmetry is left to the enforcement tier (ADR 21).
 
 ## Known limitations (Foundation round)
 

--- a/src/Application/Actions/CreateSubject/CreateSubjectAction.php
+++ b/src/Application/Actions/CreateSubject/CreateSubjectAction.php
@@ -10,12 +10,11 @@ use ProfessionalWiki\NeoWiki\Application\SelectStatementResolver;
 use ProfessionalWiki\NeoWiki\Application\StatementListBuilder;
 use ProfessionalWiki\NeoWiki\Application\SubjectAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\SubjectRepository;
-use ProfessionalWiki\NeoWiki\Application\Validation\SubjectValidator;
+use ProfessionalWiki\NeoWiki\Application\Validation\ProposedSubjectValidator;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
-use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
 use ProfessionalWiki\NeoWiki\Infrastructure\IdGenerator;
 use RuntimeException;
 
@@ -29,7 +28,7 @@ readonly class CreateSubjectAction {
 		private StatementListBuilder $statementListBuilder,
 		private SchemaLookup $schemaLookup,
 		private SelectStatementResolver $selectStatementResolver,
-		private SubjectValidator $subjectValidator,
+		private ProposedSubjectValidator $proposedSubjectValidator,
 	) {
 	}
 
@@ -58,7 +57,7 @@ readonly class CreateSubjectAction {
 			return;
 		}
 
-		$violations = $this->validateProposedSubject( $subject );
+		$violations = $this->proposedSubjectValidator->validate( $subject );
 
 		$this->subjectRepository->savePageSubjects( $pageSubjects, new PageId( $request->pageId ), $request->comment );
 		$this->presenter->presentCreated( $subject->id->text, $violations );
@@ -90,21 +89,6 @@ readonly class CreateSubjectAction {
 		}
 
 		return $this->selectStatementResolver->resolve( $schema, $statements );
-	}
-
-	/** @return Violation[] */
-	private function validateProposedSubject( Subject $subject ): array {
-		$schema = $this->schemaLookup->getSchema( $subject->getSchemaName() );
-
-		if ( $schema === null ) {
-			return [];
-		}
-
-		return $this->subjectValidator->validate(
-			$subject->getLabel(),
-			$subject->getStatements(),
-			$schema,
-		);
 	}
 
 }

--- a/src/Application/Actions/ReplaceSubject/ReplaceSubjectAction.php
+++ b/src/Application/Actions/ReplaceSubject/ReplaceSubjectAction.php
@@ -12,7 +12,7 @@ use ProfessionalWiki\NeoWiki\Application\Subject\Exception\SubjectEditNotAuthori
 use ProfessionalWiki\NeoWiki\Application\Subject\Exception\SubjectNotFoundException;
 use ProfessionalWiki\NeoWiki\Application\SubjectAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\SubjectRepository;
-use ProfessionalWiki\NeoWiki\Application\Validation\SubjectValidator;
+use ProfessionalWiki\NeoWiki\Application\Validation\ProposedSubjectValidator;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
@@ -26,7 +26,7 @@ readonly class ReplaceSubjectAction {
 		private StatementListBuilder $statementListBuilder,
 		private SchemaLookup $schemaLookup,
 		private SelectStatementResolver $selectStatementResolver,
-		private SubjectValidator $subjectValidator,
+		private ProposedSubjectValidator $proposedSubjectValidator,
 	) {
 	}
 
@@ -54,7 +54,7 @@ readonly class ReplaceSubjectAction {
 			$this->statementListBuilder->build( $this->resolveStatements( $subject, $statements ) )
 		);
 
-		$violations = $this->validateProposedSubject( $subject );
+		$violations = $this->proposedSubjectValidator->validate( $subject );
 
 		$this->subjectRepository->updateSubject( $subject, $comment );
 
@@ -74,21 +74,6 @@ readonly class ReplaceSubjectAction {
 		}
 
 		return $this->selectStatementResolver->resolve( $schema, $statements );
-	}
-
-	/** @return Violation[] */
-	private function validateProposedSubject( Subject $subject ): array {
-		$schema = $this->schemaLookup->getSchema( $subject->getSchemaName() );
-
-		if ( $schema === null ) {
-			return [];
-		}
-
-		return $this->subjectValidator->validate(
-			$subject->getLabel(),
-			$subject->getStatements(),
-			$schema,
-		);
 	}
 
 }

--- a/src/Application/Validation/ProposedSubjectValidator.php
+++ b/src/Application/Validation/ProposedSubjectValidator.php
@@ -16,9 +16,10 @@ use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
  * violation is returned and the write still proceeds: the Subject stays
  * editable (ADR 21), but the response reports that it could not be validated
  * rather than implying it is valid. This matches the update-validate endpoint,
- * which emits the same violation. Centralising the decision here keeps the
- * write paths (CreateSubjectAction, ReplaceSubjectAction) from each repeating
- * it and gives the future enforcement tier one place to reason about it.
+ * which emits the same violation. Centralising the decision keeps the two write
+ * paths (CreateSubjectAction, ReplaceSubjectAction) from repeating it, and is
+ * where the enforcement tier will hook in. ValidateSubjectUpdateQuery still has
+ * its own copy until the validate and write flows are unified.
  */
 readonly class ProposedSubjectValidator {
 

--- a/src/Application/Validation/ProposedSubjectValidator.php
+++ b/src/Application/Validation/ProposedSubjectValidator.php
@@ -15,7 +15,9 @@ use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
  * When the Schema cannot be found, no violations are returned: the Subject is
  * left unvalidated so the write can still proceed and the Subject stays
  * editable (ADR 21). Centralising that decision here keeps the write paths
- * (CreateSubjectAction, ReplaceSubjectAction) from each repeating it.
+ * (CreateSubjectAction, ReplaceSubjectAction) from each repeating it, and
+ * gives the enforcement tier one place to revisit it, e.g. to align with the
+ * dedicated validate endpoints, which report a missing Schema differently.
  */
 readonly class ProposedSubjectValidator {
 

--- a/src/Application/Validation/ProposedSubjectValidator.php
+++ b/src/Application/Validation/ProposedSubjectValidator.php
@@ -12,12 +12,13 @@ use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
  * Validates a proposed Subject against its current Schema, looking the Schema
  * up by the Subject's Schema name and delegating to {@see SubjectValidator}.
  *
- * When the Schema cannot be found, no violations are returned: the Subject is
- * left unvalidated so the write can still proceed and the Subject stays
- * editable (ADR 21). Centralising that decision here keeps the write paths
- * (CreateSubjectAction, ReplaceSubjectAction) from each repeating it, and
- * gives the enforcement tier one place to revisit it, e.g. to align with the
- * dedicated validate endpoints, which report a missing Schema differently.
+ * When the Schema cannot be found, a single non-blocking `schema-not-found`
+ * violation is returned and the write still proceeds: the Subject stays
+ * editable (ADR 21), but the response reports that it could not be validated
+ * rather than implying it is valid. This matches the update-validate endpoint,
+ * which emits the same violation. Centralising the decision here keeps the
+ * write paths (CreateSubjectAction, ReplaceSubjectAction) from each repeating
+ * it and gives the future enforcement tier one place to reason about it.
  */
 readonly class ProposedSubjectValidator {
 
@@ -34,7 +35,13 @@ readonly class ProposedSubjectValidator {
 		$schema = $this->schemaLookup->getSchema( $subject->getSchemaName() );
 
 		if ( $schema === null ) {
-			return [];
+			return [
+				new Violation(
+					propertyName: null,
+					code: 'schema-not-found',
+					args: [ $subject->getSchemaName()->getText() ],
+				),
+			];
 		}
 
 		return $this->subjectValidator->validate(

--- a/src/Application/Validation/ProposedSubjectValidator.php
+++ b/src/Application/Validation/ProposedSubjectValidator.php
@@ -1,0 +1,45 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application\Validation;
+
+use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
+use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
+
+/**
+ * Validates a proposed Subject against its current Schema, looking the Schema
+ * up by the Subject's Schema name and delegating to {@see SubjectValidator}.
+ *
+ * When the Schema cannot be found, no violations are returned: the Subject is
+ * left unvalidated so the write can still proceed and the Subject stays
+ * editable (ADR 21). Centralising that decision here keeps the write paths
+ * (CreateSubjectAction, ReplaceSubjectAction) from each repeating it.
+ */
+readonly class ProposedSubjectValidator {
+
+	public function __construct(
+		private SchemaLookup $schemaLookup,
+		private SubjectValidator $subjectValidator,
+	) {
+	}
+
+	/**
+	 * @return Violation[]
+	 */
+	public function validate( Subject $subject ): array {
+		$schema = $this->schemaLookup->getSchema( $subject->getSchemaName() );
+
+		if ( $schema === null ) {
+			return [];
+		}
+
+		return $this->subjectValidator->validate(
+			$subject->getLabel(),
+			$subject->getStatements(),
+			$schema,
+		);
+	}
+
+}

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -25,6 +25,7 @@ use ProfessionalWiki\NeoWiki\Application\Actions\SetMainSubject\SetMainSubjectAc
 use ProfessionalWiki\NeoWiki\Application\Actions\SetMainSubject\SetMainSubjectPresenter;
 use ProfessionalWiki\NeoWiki\Application\Actions\ReplaceSubject\ReplaceSubjectAction;
 use ProfessionalWiki\NeoWiki\Application\StatementListBuilder;
+use ProfessionalWiki\NeoWiki\Application\Validation\ProposedSubjectValidator;
 use ProfessionalWiki\NeoWiki\Application\Validation\SubjectValidator;
 use ProfessionalWiki\NeoWiki\Application\PageIdentifiersLookup;
 use ProfessionalWiki\NeoWiki\Application\PageSubjectsLookup;
@@ -334,7 +335,7 @@ class NeoWikiExtension {
 			statementListBuilder: $this->getStatementListBuilder(),
 			schemaLookup: $this->getSchemaLookup(),
 			selectStatementResolver: $this->getSelectStatementResolver(),
-			subjectValidator: $this->getSubjectValidator(),
+			proposedSubjectValidator: $this->getProposedSubjectValidator(),
 		);
 	}
 
@@ -506,13 +507,20 @@ class NeoWikiExtension {
 			statementListBuilder: $this->getStatementListBuilder(),
 			schemaLookup: $this->getSchemaLookup(),
 			selectStatementResolver: $this->getSelectStatementResolver(),
-			subjectValidator: $this->getSubjectValidator(),
+			proposedSubjectValidator: $this->getProposedSubjectValidator(),
 		);
 	}
 
 	public function getSubjectValidator(): SubjectValidator {
 		return new SubjectValidator(
 			propertyTypeLookup: $this->getPropertyTypeLookup(),
+		);
+	}
+
+	public function getProposedSubjectValidator(): ProposedSubjectValidator {
+		return new ProposedSubjectValidator(
+			schemaLookup: $this->getSchemaLookup(),
+			subjectValidator: $this->getSubjectValidator(),
 		);
 	}
 

--- a/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
@@ -379,7 +379,7 @@ class CreateSubjectActionTest extends TestCase {
 		$this->assertSame( 'Status', $this->presenterSpy->violations[0]->propertyName?->text );
 	}
 
-	public function testCreateWithMissingSchemaProducesEmptyViolations(): void {
+	public function testCreateWithMissingSchemaSurfacesSchemaNotFoundButStillPersists(): void {
 		$this->subjectRepository->savePageSubjects( PageSubjects::newEmpty(), new PageId( 1 ) );
 
 		$this->newCreateSubjectAction()->createSubject(
@@ -393,7 +393,9 @@ class CreateSubjectActionTest extends TestCase {
 		);
 
 		$this->assertSame( 's' . self::STUB_ID, $this->presenterSpy->result );
-		$this->assertSame( [], $this->presenterSpy->violations );
+		$this->assertCount( 1, $this->presenterSpy->violations );
+		$this->assertSame( 'schema-not-found', $this->presenterSpy->violations[0]->code );
+		$this->assertSame( [ 'NonexistentSchema' ], $this->presenterSpy->violations[0]->args );
 	}
 
 	public function testCreateWithViolationsStillPersistsTheSubject(): void {

--- a/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
@@ -10,6 +10,7 @@ use ProfessionalWiki\NeoWiki\Application\Actions\CreateSubject\CreateSubjectRequ
 use ProfessionalWiki\NeoWiki\Application\SelectStatementResolver;
 use ProfessionalWiki\NeoWiki\Application\SelectValueResolver;
 use ProfessionalWiki\NeoWiki\Application\StatementListBuilder;
+use ProfessionalWiki\NeoWiki\Application\Validation\ProposedSubjectValidator;
 use ProfessionalWiki\NeoWiki\Application\Validation\SubjectValidator;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
@@ -72,7 +73,10 @@ class CreateSubjectActionTest extends TestCase {
 			),
 			$this->schemaLookup,
 			new SelectStatementResolver( new SelectValueResolver() ),
-			new SubjectValidator( propertyTypeLookup: $registry ),
+			new ProposedSubjectValidator(
+				schemaLookup: $this->schemaLookup,
+				subjectValidator: new SubjectValidator( propertyTypeLookup: $registry ),
+			),
 		);
 	}
 

--- a/tests/phpunit/Application/Actions/ReplaceSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/ReplaceSubjectActionTest.php
@@ -11,6 +11,7 @@ use ProfessionalWiki\NeoWiki\Application\SelectValueResolver;
 use ProfessionalWiki\NeoWiki\Application\StatementListBuilder;
 use ProfessionalWiki\NeoWiki\Application\Subject\Exception\SubjectEditNotAuthorizedException;
 use ProfessionalWiki\NeoWiki\Application\Subject\Exception\SubjectNotFoundException;
+use ProfessionalWiki\NeoWiki\Application\Validation\ProposedSubjectValidator;
 use ProfessionalWiki\NeoWiki\Application\Validation\SubjectValidator;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeRegistry;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeToValueType;
@@ -60,7 +61,10 @@ class ReplaceSubjectActionTest extends TestCase {
 			statementListBuilder: $builder,
 			schemaLookup: $this->schemaLookup,
 			selectStatementResolver: new SelectStatementResolver( new SelectValueResolver() ),
-			subjectValidator: new SubjectValidator( propertyTypeLookup: $registry ),
+			proposedSubjectValidator: new ProposedSubjectValidator(
+				schemaLookup: $this->schemaLookup,
+				subjectValidator: new SubjectValidator( propertyTypeLookup: $registry ),
+			),
 		);
 	}
 

--- a/tests/phpunit/Application/Actions/ReplaceSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/ReplaceSubjectActionTest.php
@@ -269,7 +269,7 @@ class ReplaceSubjectActionTest extends TestCase {
 		$this->assertSame( 'Status', $violations[0]->propertyName?->text );
 	}
 
-	public function testReplaceWithMissingSchemaReturnsEmptyViolations(): void {
+	public function testReplaceWithMissingSchemaReturnsSchemaNotFound(): void {
 		$subject = TestSubject::build(
 			id: new SubjectId( self::SUBJECT_ID ),
 			label: new SubjectLabel( 'Orphan' ),
@@ -284,7 +284,9 @@ class ReplaceSubjectActionTest extends TestCase {
 			null
 		);
 
-		$this->assertSame( [], $violations );
+		$this->assertCount( 1, $violations );
+		$this->assertSame( 'schema-not-found', $violations[0]->code );
+		$this->assertSame( [ 'NonexistentSchema' ], $violations[0]->args );
 	}
 
 	public function testReplaceWithViolationsStillPersistsTheSubject(): void {

--- a/tests/phpunit/Application/Validation/ProposedSubjectValidatorTest.php
+++ b/tests/phpunit/Application/Validation/ProposedSubjectValidatorTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Application\Validation;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\Validation\ProposedSubjectValidator;
+use ProfessionalWiki\NeoWiki\Application\Validation\SubjectValidator;
+use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeRegistry;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Property\NumberProperty;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinitions;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySchemaLookup;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Application\Validation\ProposedSubjectValidator
+ */
+class ProposedSubjectValidatorTest extends TestCase {
+
+	private const string SCHEMA_NAME = 'Person';
+
+	private InMemorySchemaLookup $schemaLookup;
+
+	protected function setUp(): void {
+		$this->schemaLookup = new InMemorySchemaLookup();
+	}
+
+	private function newValidator(): ProposedSubjectValidator {
+		return new ProposedSubjectValidator(
+			schemaLookup: $this->schemaLookup,
+			subjectValidator: new SubjectValidator( propertyTypeLookup: PropertyTypeRegistry::withCoreTypes() ),
+		);
+	}
+
+	private function registerSchemaWithAge( bool $required ): void {
+		$this->schemaLookup->updateSchema( new Schema(
+			name: new SchemaName( self::SCHEMA_NAME ),
+			description: '',
+			properties: new PropertyDefinitions( [
+				'Age' => NumberProperty::fromPartialJson(
+					new PropertyCore( description: '', required: $required, default: null ),
+					[ 'minimum' => null, 'maximum' => null, 'precision' => null ],
+				),
+			] ),
+		) );
+	}
+
+	private function newSubject( string $schemaName = self::SCHEMA_NAME ): Subject {
+		return TestSubject::build(
+			label: 'John Doe',
+			schemaName: new SchemaName( $schemaName ),
+		);
+	}
+
+	public function testReturnsNoViolationsForValidSubject(): void {
+		$this->registerSchemaWithAge( required: false );
+
+		$this->assertSame( [], $this->newValidator()->validate( $this->newSubject() ) );
+	}
+
+	public function testReturnsViolationFromSchemaForMissingRequiredProperty(): void {
+		$this->registerSchemaWithAge( required: true );
+
+		$violations = $this->newValidator()->validate( $this->newSubject() );
+
+		$this->assertCount( 1, $violations );
+		$this->assertSame( 'required', $violations[0]->code );
+		$this->assertSame( 'Age', $violations[0]->propertyName?->text );
+	}
+
+	public function testReturnsNoViolationsWhenSchemaNotFound(): void {
+		$this->registerSchemaWithAge( required: true );
+
+		$this->assertSame( [], $this->newValidator()->validate( $this->newSubject( 'UnregisteredSchema' ) ) );
+	}
+
+}

--- a/tests/phpunit/Application/Validation/ProposedSubjectValidatorTest.php
+++ b/tests/phpunit/Application/Validation/ProposedSubjectValidatorTest.php
@@ -73,10 +73,15 @@ class ProposedSubjectValidatorTest extends TestCase {
 		$this->assertSame( 'Age', $violations[0]->propertyName?->text );
 	}
 
-	public function testReturnsNoViolationsWhenSchemaNotFound(): void {
+	public function testReturnsSchemaNotFoundViolationWhenSchemaIsMissing(): void {
 		$this->registerSchemaWithAge( required: true );
 
-		$this->assertSame( [], $this->newValidator()->validate( $this->newSubject( 'UnregisteredSchema' ) ) );
+		$violations = $this->newValidator()->validate( $this->newSubject( 'UnregisteredSchema' ) );
+
+		$this->assertCount( 1, $violations );
+		$this->assertSame( 'schema-not-found', $violations[0]->code );
+		$this->assertNull( $violations[0]->propertyName );
+		$this->assertSame( [ 'UnregisteredSchema' ], $violations[0]->args );
 	}
 
 }

--- a/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
@@ -152,6 +152,28 @@ class CreateSubjectApiTest extends NeoWikiIntegrationTestCase {
 		$this->assertSame( 'Status', $responseData['violations'][0]['propertyName'] );
 	}
 
+	public function testResponseIncludesSchemaNotFoundWhenSchemaMissing(): void {
+		$body = [
+			'label' => 'Subject with missing schema',
+			'schema' => 'NeverCreatedSchema',
+			'statements' => [],
+		];
+
+		$response = $this->executeHandler(
+			$this->newCreateSubjectApi(),
+			$this->createRequestData( $body )
+		);
+
+		$responseData = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertSame( 201, $response->getStatusCode() );
+		$this->assertSame( 'created', $responseData['status'] );
+		$this->assertCount( 1, $responseData['violations'] );
+		$this->assertSame( 'schema-not-found', $responseData['violations'][0]['code'] );
+		$this->assertNull( $responseData['violations'][0]['propertyName'] );
+		$this->assertSame( [ 'NeverCreatedSchema' ], $responseData['violations'][0]['args'] );
+	}
+
 	public function testAlreadyExistingMainSubjectResponseOmitsViolations(): void {
 		$this->createSchema( 'Employee' );
 

--- a/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
@@ -8,6 +8,7 @@ use MediaWiki\Rest\HttpException;
 use MediaWiki\Rest\RequestData;
 use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
 use MediaWiki\Tests\Unit\Permissions\MockAuthorityTrait;
+use MediaWiki\Title\Title;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\ReplaceSubjectApi;
@@ -165,6 +166,47 @@ class ReplaceSubjectApiTest extends NeoWikiIntegrationTestCase {
 			$this->assertSame( 'required', $violation['code'] );
 			$this->assertSame( [], $violation['args'] );
 		}
+	}
+
+	public function testResponseIncludesSchemaNotFoundWhenSchemaMissing(): void {
+		// Reproduce the canonical orphan: the Schema existed when the Subject was
+		// created, then its page was deleted, leaving the Subject un-validatable.
+		$this->createSchema( 'OrphanSchema' );
+		$this->createPageWithSubjects(
+			'ReplaceSubjectApiMissingSchemaTest',
+			mainSubject: TestSubject::build(
+				id: 'sTestSA11111155',
+				label: new SubjectLabel( 'Orphaned subject' ),
+				schemaName: new SchemaName( 'OrphanSchema' ),
+			)
+		);
+		$this->deletePage(
+			$this->getServiceContainer()->getWikiPageFactory()->newFromTitle(
+				Title::newFromText( 'OrphanSchema', NeoWikiExtension::NS_SCHEMA )
+			)
+		);
+
+		$response = $this->executeHandler(
+			$this->newReplaceSubjectApi(),
+			new RequestData( [
+				'method' => 'PUT',
+				'pathParams' => [ 'subjectId' => 'sTestSA11111155' ],
+				'bodyContents' => json_encode( [
+					'label' => 'Still orphaned',
+					'statements' => [],
+				] ),
+				'headers' => [ 'Content-Type' => 'application/json' ],
+			] )
+		);
+
+		$responseData = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertSame( 200, $response->getStatusCode() );
+		$this->assertSame( 'updated', $responseData['status'] );
+		$this->assertCount( 1, $responseData['violations'] );
+		$this->assertSame( 'schema-not-found', $responseData['violations'][0]['code'] );
+		$this->assertNull( $responseData['violations'][0]['propertyName'] );
+		$this->assertSame( [ 'OrphanSchema' ], $responseData['violations'][0]['args'] );
 	}
 
 	public function testNonExistentSubjectReturns404(): void {


### PR DESCRIPTION
> Posted at @JeroenDeDauw's direction: after a review of #855 he asked me to land the changes I had high confidence were net-positive, then we discussed the missing-Schema behaviour and agreed to fix it here.
> Context: the NeoWiki codebase and `docs/` (ADRs, especially ADR 21), PR #855 and its existing review thread.
> <sub>Written by Claude Code, `Opus 4.8`</sub>

Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/855, and targets its branch (`step1-surface-violations`) rather than master.

## What & why

Two related changes on the Subject write paths:

1. **Extract `ProposedSubjectValidator`.** `CreateSubjectAction` and `ReplaceSubjectAction` each held a byte-identical "look up the Schema, return `[]` if missing, else run `SubjectValidator`" method. That logic now lives in one collaborator both actions depend on — the cleanup both the #855 review and the existing PR comment independently called for, and the single seam the enforcement tier will hook into.

2. **Surface `schema-not-found` on writes instead of swallowing it.** Previously a missing Schema produced an empty violation list — indistinguishable from "valid" to the API/AI consumers ADR 21 targets. The collaborator now returns a single **non-blocking** `schema-not-found` violation: the write still proceeds (the Subject stays editable per ADR 21), but the response reports it could not be validated. This aligns the replace endpoint with the update-validate endpoint (which already emits it) and is forward-compatible with enforcement — a deleted-Schema orphan is a *pre-existing* violation, which the "block only newly-introduced violations" rule never traps.

## Scope / still deferred

Behaviour decisions left to the enforcement tier, deliberately **not** changed here:

- The create dry-run (`POST /subject/validate`) still returns `404` for a missing Schema, while create-write now returns `201` + a `schema-not-found` violation. Reconciling that asymmetry — and whether structural violations like `schema-not-found` should ever *block* — belongs with enforcement.
- The `SelectStatementResolver::resolve()` (`400`) vs `resolveOrLeave()` (`invalid-option`) divergence raised in the #855 review.

## Test plan

- [x] `ProposedSubjectValidatorTest` — valid → `[]`, missing-required → violation, missing-Schema → `schema-not-found`.
- [x] `CreateSubjectActionTest` / `ReplaceSubjectActionTest` missing-Schema cases assert `schema-not-found` and that the Subject still persists.
- [x] REST tests for both endpoints; the replace test reproduces the canonical orphan (Schema deleted after the Subject was created) and is the first end-to-end coverage of a violation with non-empty `args`.
- [x] phpunit 31/31 (unit) + 21/21 (REST) + `Application` 277/277 (1 pre-existing skip); `phpcs` clean (394 files); `phpstan` clean (188 files).
- [x] `docs/reference/validation-codes.md` updated for the write-endpoint emission and the remaining create dry-run `404` asymmetry.
