### PR TITLE
Harmonize Subject write-endpoint contracts and return 409 for already-existing Subject

### DIFF
--- a/docs/reference/validation-codes.md
+++ b/docs/reference/validation-codes.md
@@ -16,7 +16,8 @@ Violations are returned by:
 The `/validate` endpoints return `200 OK` with a `{violations: [...]}` body whenever the request is
 well-formed; violations in the body do not change the HTTP status. `400` is reserved for malformed
 input, `404` for a missing Subject (update dry-run). A missing Schema is reported differently per
-endpoint — see [`schema-not-found`](#schema-not-found).
+endpoint — see [`schema-not-found`](#schema-not-found). `POST /subject` returns `409` when the page
+already has the requested Subject (the create did not run, so the body carries no `violations`).
 
 Each violation in the response has this shape:
 

--- a/src/Application/Actions/ReplaceSubject/ReplaceSubjectAction.php
+++ b/src/Application/Actions/ReplaceSubject/ReplaceSubjectAction.php
@@ -16,7 +16,6 @@ use ProfessionalWiki\NeoWiki\Application\Validation\ProposedSubjectValidator;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
-use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
 
 readonly class ReplaceSubjectAction {
 
@@ -27,14 +26,14 @@ readonly class ReplaceSubjectAction {
 		private SchemaLookup $schemaLookup,
 		private SelectStatementResolver $selectStatementResolver,
 		private ProposedSubjectValidator $proposedSubjectValidator,
+		private ReplaceSubjectPresenter $presenter,
 	) {
 	}
 
 	/**
 	 * @param array<string, mixed> $statements
-	 * @return Violation[]
 	 */
-	public function replace( SubjectId $subjectId, string $label, array $statements, ?string $comment ): array {
+	public function replace( SubjectId $subjectId, string $label, array $statements, ?string $comment ): void {
 		if ( trim( $label ) === '' ) {
 			throw new InvalidArgumentException( 'SubjectLabel cannot be empty' );
 		}
@@ -58,7 +57,7 @@ readonly class ReplaceSubjectAction {
 
 		$this->subjectRepository->updateSubject( $subject, $comment );
 
-		return $violations;
+		$this->presenter->presentUpdated( $subjectId->text, $violations );
 	}
 
 	/**

--- a/src/Application/Actions/ReplaceSubject/ReplaceSubjectPresenter.php
+++ b/src/Application/Actions/ReplaceSubject/ReplaceSubjectPresenter.php
@@ -1,0 +1,16 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application\Actions\ReplaceSubject;
+
+use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
+
+interface ReplaceSubjectPresenter {
+
+	/**
+	 * @param Violation[] $violations
+	 */
+	public function presentUpdated( string $subjectId, array $violations ): void;
+
+}

--- a/src/EntryPoints/REST/CreateSubjectApi.php
+++ b/src/EntryPoints/REST/CreateSubjectApi.php
@@ -6,16 +6,13 @@ namespace ProfessionalWiki\NeoWiki\EntryPoints\REST;
 
 use MediaWiki\Rest\Response;
 use MediaWiki\Rest\SimpleHandler;
-use ProfessionalWiki\NeoWiki\Application\Actions\CreateSubject\CreateSubjectPresenter;
 use ProfessionalWiki\NeoWiki\Application\Actions\CreateSubject\CreateSubjectRequest;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Presentation\CsrfValidator;
-use ProfessionalWiki\NeoWiki\Presentation\ViolationSerializer;
+use ProfessionalWiki\NeoWiki\Presentation\RestCreateSubjectPresenter;
 use Wikimedia\ParamValidator\ParamValidator;
 
-class CreateSubjectApi extends SimpleHandler implements CreateSubjectPresenter {
-
-	private array $apiResponse = [];
+class CreateSubjectApi extends SimpleHandler {
 
 	public function __construct(
 		private readonly bool $isMainSubject,
@@ -28,8 +25,10 @@ class CreateSubjectApi extends SimpleHandler implements CreateSubjectPresenter {
 
 		$body = $this->getValidatedBody();
 
+		$presenter = new RestCreateSubjectPresenter();
+
 		try {
-			NeoWikiExtension::getInstance()->newCreateSubjectAction( $this, $this->getAuthority() )->createSubject(
+			NeoWikiExtension::getInstance()->newCreateSubjectAction( $presenter, $this->getAuthority() )->createSubject(
 				new CreateSubjectRequest(
 					pageId: $pageId,
 					isMainSubject: $this->isMainSubject,
@@ -39,8 +38,6 @@ class CreateSubjectApi extends SimpleHandler implements CreateSubjectPresenter {
 					comment: $body['comment'] ?? null,
 				)
 			);
-
-			return $this->buildResponseObject();
 		} catch ( \InvalidArgumentException $e ) {
 			return $this->getResponseFactory()->createHttpError( 400, [
 				'status' => 'error',
@@ -52,11 +49,9 @@ class CreateSubjectApi extends SimpleHandler implements CreateSubjectPresenter {
 				'message' => $e->getMessage(),
 			] );
 		}
-	}
 
-	private function buildResponseObject(): Response {
-		$response = $this->getResponseFactory()->createJson( $this->apiResponse );
-		$response->setStatus( 201 );
+		$response = $this->getResponseFactory()->createJson( $presenter->getJsonArray() );
+		$response->setStatus( $presenter->getStatusCode() );
 		return $response;
 	}
 
@@ -100,18 +95,4 @@ class CreateSubjectApi extends SimpleHandler implements CreateSubjectPresenter {
 		];
 	}
 
-	public function presentCreated( string $subjectId, array $violations ): void {
-		$this->apiResponse = [
-			'status' => 'created',
-			'subjectId' => $subjectId,
-			'violations' => ViolationSerializer::serializeMany( $violations ),
-		];
-	}
-
-	public function presentSubjectAlreadyExists(): void {
-		$this->apiResponse = [
-			'status' => 'error',
-			'message' => 'Subject already exists',
-		];
-	}
 }

--- a/src/EntryPoints/REST/ReplaceSubjectApi.php
+++ b/src/EntryPoints/REST/ReplaceSubjectApi.php
@@ -13,7 +13,7 @@ use ProfessionalWiki\NeoWiki\Application\Subject\Exception\SubjectNotFoundExcept
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Presentation\CsrfValidator;
-use ProfessionalWiki\NeoWiki\Presentation\ViolationSerializer;
+use ProfessionalWiki\NeoWiki\Presentation\RestReplaceSubjectPresenter;
 use Wikimedia\ParamValidator\ParamValidator;
 
 class ReplaceSubjectApi extends SimpleHandler {
@@ -31,8 +31,10 @@ class ReplaceSubjectApi extends SimpleHandler {
 
 		$body = $this->getValidatedBody();
 
+		$presenter = new RestReplaceSubjectPresenter();
+
 		try {
-			$violations = NeoWikiExtension::getInstance()->newReplaceSubjectAction( $this->getAuthority() )->replace(
+			NeoWikiExtension::getInstance()->newReplaceSubjectAction( $presenter, $this->getAuthority() )->replace(
 				new SubjectId( $subjectId ),
 				$body['label'],
 				$body['statements'],
@@ -55,11 +57,9 @@ class ReplaceSubjectApi extends SimpleHandler {
 			] );
 		}
 
-		return $this->getResponseFactory()->createJson( [
-			'status' => 'updated',
-			'subjectId' => $subjectId,
-			'violations' => ViolationSerializer::serializeMany( $violations ),
-		] );
+		$response = $this->getResponseFactory()->createJson( $presenter->getJsonArray() );
+		$response->setStatus( $presenter->getStatusCode() );
+		return $response;
 	}
 
 	public function getParamSettings(): array {

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -24,6 +24,7 @@ use ProfessionalWiki\NeoWiki\Application\Actions\DeleteSubject\DeleteSubjectActi
 use ProfessionalWiki\NeoWiki\Application\Actions\SetMainSubject\SetMainSubjectAction;
 use ProfessionalWiki\NeoWiki\Application\Actions\SetMainSubject\SetMainSubjectPresenter;
 use ProfessionalWiki\NeoWiki\Application\Actions\ReplaceSubject\ReplaceSubjectAction;
+use ProfessionalWiki\NeoWiki\Application\Actions\ReplaceSubject\ReplaceSubjectPresenter;
 use ProfessionalWiki\NeoWiki\Application\StatementListBuilder;
 use ProfessionalWiki\NeoWiki\Application\Validation\ProposedSubjectValidator;
 use ProfessionalWiki\NeoWiki\Application\Validation\SubjectValidator;
@@ -500,7 +501,7 @@ class NeoWikiExtension {
 		);
 	}
 
-	public function newReplaceSubjectAction( Authority $authority ): ReplaceSubjectAction {
+	public function newReplaceSubjectAction( ReplaceSubjectPresenter $presenter, Authority $authority ): ReplaceSubjectAction {
 		return new ReplaceSubjectAction(
 			subjectRepository: $this->getSubjectRepository(),
 			subjectAuthorizer: $this->newSubjectAuthorizer( $authority ),
@@ -508,6 +509,7 @@ class NeoWikiExtension {
 			schemaLookup: $this->getSchemaLookup(),
 			selectStatementResolver: $this->getSelectStatementResolver(),
 			proposedSubjectValidator: $this->getProposedSubjectValidator(),
+			presenter: $presenter,
 		);
 	}
 

--- a/src/Presentation/RestCreateSubjectPresenter.php
+++ b/src/Presentation/RestCreateSubjectPresenter.php
@@ -1,0 +1,43 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Presentation;
+
+use ProfessionalWiki\NeoWiki\Application\Actions\CreateSubject\CreateSubjectPresenter;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
+
+class RestCreateSubjectPresenter implements CreateSubjectPresenter {
+
+	private array $apiResponse = [];
+	private int $statusCode = 201;
+
+	public function getJsonArray(): array {
+		return $this->apiResponse;
+	}
+
+	public function getStatusCode(): int {
+		return $this->statusCode;
+	}
+
+	/**
+	 * @param Violation[] $violations
+	 */
+	public function presentCreated( string $subjectId, array $violations ): void {
+		$this->apiResponse = [
+			'status' => 'created',
+			'subjectId' => $subjectId,
+			'violations' => ViolationSerializer::serializeMany( $violations ),
+		];
+		$this->statusCode = 201;
+	}
+
+	public function presentSubjectAlreadyExists(): void {
+		$this->apiResponse = [
+			'status' => 'error',
+			'message' => 'Subject already exists',
+		];
+		$this->statusCode = 409;
+	}
+
+}

--- a/src/Presentation/RestReplaceSubjectPresenter.php
+++ b/src/Presentation/RestReplaceSubjectPresenter.php
@@ -1,0 +1,35 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Presentation;
+
+use ProfessionalWiki\NeoWiki\Application\Actions\ReplaceSubject\ReplaceSubjectPresenter;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
+
+class RestReplaceSubjectPresenter implements ReplaceSubjectPresenter {
+
+	private array $apiResponse = [];
+	private int $statusCode = 200;
+
+	public function getJsonArray(): array {
+		return $this->apiResponse;
+	}
+
+	public function getStatusCode(): int {
+		return $this->statusCode;
+	}
+
+	/**
+	 * @param Violation[] $violations
+	 */
+	public function presentUpdated( string $subjectId, array $violations ): void {
+		$this->apiResponse = [
+			'status' => 'updated',
+			'subjectId' => $subjectId,
+			'violations' => ViolationSerializer::serializeMany( $violations ),
+		];
+		$this->statusCode = 200;
+	}
+
+}

--- a/tests/phpunit/Application/Actions/ReplaceSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/ReplaceSubjectActionTest.php
@@ -43,10 +43,12 @@ class ReplaceSubjectActionTest extends TestCase {
 
 	private InMemorySubjectRepository $subjectRepository;
 	private InMemorySchemaLookup $schemaLookup;
+	private ReplaceSubjectPresenterSpy $presenterSpy;
 
 	public function setUp(): void {
 		$this->subjectRepository = new InMemorySubjectRepository();
 		$this->schemaLookup = new InMemorySchemaLookup();
+		$this->presenterSpy = new ReplaceSubjectPresenterSpy();
 	}
 
 	private function newAction( ?SubjectAuthorizer $authorizer = null ): ReplaceSubjectAction {
@@ -65,6 +67,7 @@ class ReplaceSubjectActionTest extends TestCase {
 				schemaLookup: $this->schemaLookup,
 				subjectValidator: new SubjectValidator( propertyTypeLookup: $registry ),
 			),
+			presenter: $this->presenterSpy,
 		);
 	}
 
@@ -238,14 +241,14 @@ class ReplaceSubjectActionTest extends TestCase {
 		);
 		$this->subjectRepository->updateSubject( $subject );
 
-		$violations = $this->newAction()->replace(
+		$this->newAction()->replace(
 			new SubjectId( self::SUBJECT_ID ),
 			'New Label',
 			[ 'Status' => [ 'propertyType' => 'select', 'value' => 'Approved' ] ],
 			null
 		);
 
-		$this->assertSame( [], $violations );
+		$this->assertSame( [], $this->presenterSpy->violations );
 	}
 
 	public function testReplaceReturnsViolationForRequiredPropertyMissing(): void {
@@ -257,13 +260,14 @@ class ReplaceSubjectActionTest extends TestCase {
 		);
 		$this->subjectRepository->updateSubject( $subject );
 
-		$violations = $this->newAction()->replace(
+		$this->newAction()->replace(
 			new SubjectId( self::SUBJECT_ID ),
 			'After',
 			[],
 			null
 		);
 
+		$violations = $this->presenterSpy->violations;
 		$this->assertCount( 1, $violations );
 		$this->assertSame( 'required', $violations[0]->code );
 		$this->assertSame( 'Status', $violations[0]->propertyName?->text );
@@ -277,13 +281,14 @@ class ReplaceSubjectActionTest extends TestCase {
 		);
 		$this->subjectRepository->updateSubject( $subject );
 
-		$violations = $this->newAction()->replace(
+		$this->newAction()->replace(
 			new SubjectId( self::SUBJECT_ID ),
 			'Still Orphan',
 			[],
 			null
 		);
 
+		$violations = $this->presenterSpy->violations;
 		$this->assertCount( 1, $violations );
 		$this->assertSame( 'schema-not-found', $violations[0]->code );
 		$this->assertSame( [ 'NonexistentSchema' ], $violations[0]->args );

--- a/tests/phpunit/Application/Actions/ReplaceSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/ReplaceSubjectActionTest.php
@@ -232,7 +232,7 @@ class ReplaceSubjectActionTest extends TestCase {
 		) );
 	}
 
-	public function testReplaceReturnsEmptyViolationsForCleanInput(): void {
+	public function testReplacePresentsEmptyViolationsForCleanInput(): void {
 		$this->registerSchemaWithSelect();
 		$subject = TestSubject::build(
 			id: new SubjectId( self::SUBJECT_ID ),
@@ -249,9 +249,10 @@ class ReplaceSubjectActionTest extends TestCase {
 		);
 
 		$this->assertSame( [], $this->presenterSpy->violations );
+		$this->assertSame( self::SUBJECT_ID, $this->presenterSpy->subjectId );
 	}
 
-	public function testReplaceReturnsViolationForRequiredPropertyMissing(): void {
+	public function testReplacePresentsViolationForRequiredPropertyMissing(): void {
 		$this->registerSchemaWithRequiredStatus();
 		$subject = TestSubject::build(
 			id: new SubjectId( self::SUBJECT_ID ),
@@ -273,7 +274,7 @@ class ReplaceSubjectActionTest extends TestCase {
 		$this->assertSame( 'Status', $violations[0]->propertyName?->text );
 	}
 
-	public function testReplaceWithMissingSchemaReturnsSchemaNotFound(): void {
+	public function testReplaceWithMissingSchemaPresentsSchemaNotFound(): void {
 		$subject = TestSubject::build(
 			id: new SubjectId( self::SUBJECT_ID ),
 			label: new SubjectLabel( 'Orphan' ),

--- a/tests/phpunit/Application/Actions/ReplaceSubjectPresenterSpy.php
+++ b/tests/phpunit/Application/Actions/ReplaceSubjectPresenterSpy.php
@@ -1,0 +1,22 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Application\Actions;
+
+use ProfessionalWiki\NeoWiki\Application\Actions\ReplaceSubject\ReplaceSubjectPresenter;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
+
+class ReplaceSubjectPresenterSpy implements ReplaceSubjectPresenter {
+
+	public string $subjectId = '';
+
+	/** @var Violation[] */
+	public array $violations = [];
+
+	public function presentUpdated( string $subjectId, array $violations ): void {
+		$this->subjectId = $subjectId;
+		$this->violations = $violations;
+	}
+
+}

--- a/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
@@ -200,6 +200,7 @@ class CreateSubjectApiTest extends NeoWikiIntegrationTestCase {
 
 		$responseData = json_decode( $response->getBody()->getContents(), true );
 
+		$this->assertSame( 409, $response->getStatusCode() );
 		$this->assertSame( 'error', $responseData['status'] );
 		$this->assertSame( 'Subject already exists', $responseData['message'] );
 		$this->assertArrayNotHasKey( 'violations', $responseData );

--- a/tests/phpunit/Presentation/RestCreateSubjectPresenterTest.php
+++ b/tests/phpunit/Presentation/RestCreateSubjectPresenterTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Presentation;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyName;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
+use ProfessionalWiki\NeoWiki\Presentation\RestCreateSubjectPresenter;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Presentation\RestCreateSubjectPresenter
+ */
+class RestCreateSubjectPresenterTest extends TestCase {
+
+	public function testPresentCreatedYields201WithSerializedViolations(): void {
+		$presenter = new RestCreateSubjectPresenter();
+
+		$presenter->presentCreated( 's1demo1aaaaaaa1', [
+			new Violation( propertyName: new PropertyName( 'Status' ), code: 'required' ),
+		] );
+
+		$this->assertSame( 201, $presenter->getStatusCode() );
+		$this->assertSame(
+			[
+				'status' => 'created',
+				'subjectId' => 's1demo1aaaaaaa1',
+				'violations' => [
+					[ 'propertyName' => 'Status', 'code' => 'required', 'args' => [] ],
+				],
+			],
+			$presenter->getJsonArray()
+		);
+	}
+
+	public function testPresentCreatedWithNoViolationsYieldsEmptyViolationsArray(): void {
+		$presenter = new RestCreateSubjectPresenter();
+
+		$presenter->presentCreated( 's1demo1aaaaaaa1', [] );
+
+		$this->assertSame( 201, $presenter->getStatusCode() );
+		$this->assertSame( [], $presenter->getJsonArray()['violations'] );
+	}
+
+	public function testPresentSubjectAlreadyExistsYields409ErrorWithoutViolations(): void {
+		$presenter = new RestCreateSubjectPresenter();
+
+		$presenter->presentSubjectAlreadyExists();
+
+		$this->assertSame( 409, $presenter->getStatusCode() );
+		$this->assertSame(
+			[ 'status' => 'error', 'message' => 'Subject already exists' ],
+			$presenter->getJsonArray()
+		);
+	}
+
+}

--- a/tests/phpunit/Presentation/RestReplaceSubjectPresenterTest.php
+++ b/tests/phpunit/Presentation/RestReplaceSubjectPresenterTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Presentation;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyName;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
+use ProfessionalWiki\NeoWiki\Presentation\RestReplaceSubjectPresenter;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Presentation\RestReplaceSubjectPresenter
+ */
+class RestReplaceSubjectPresenterTest extends TestCase {
+
+	public function testPresentUpdatedYields200WithSerializedViolations(): void {
+		$presenter = new RestReplaceSubjectPresenter();
+
+		$presenter->presentUpdated( 's1demo1aaaaaaa1', [
+			new Violation( propertyName: new PropertyName( 'Status' ), code: 'required' ),
+			new Violation( propertyName: null, code: 'schema-not-found', args: [ 'Person' ] ),
+		] );
+
+		$this->assertSame( 200, $presenter->getStatusCode() );
+		$this->assertSame(
+			[
+				'status' => 'updated',
+				'subjectId' => 's1demo1aaaaaaa1',
+				'violations' => [
+					[ 'propertyName' => 'Status', 'code' => 'required', 'args' => [] ],
+					[ 'propertyName' => null, 'code' => 'schema-not-found', 'args' => [ 'Person' ] ],
+				],
+			],
+			$presenter->getJsonArray()
+		);
+	}
+
+	public function testPresentUpdatedWithNoViolationsYieldsEmptyViolationsArray(): void {
+		$presenter = new RestReplaceSubjectPresenter();
+
+		$presenter->presentUpdated( 's1demo1aaaaaaa1', [] );
+
+		$this->assertSame( 200, $presenter->getStatusCode() );
+		$this->assertSame( [], $presenter->getJsonArray()['violations'] );
+	}
+
+}


### PR DESCRIPTION
> Result of a back-and-forth with @alistair3149: reviewing #855 surfaced the 201-on-already-exists smell, and they
> directed the approach — harmonizing all write endpoints onto the presenter pattern over a returns-based alternative —
> and the feature-branch execution.
> Context: the NeoWiki codebase, PR #855 and its review thread, and [ADR 21](../tree/master/docs/adr/021-add-backend-validation.md).
> <sub>Written by Claude Code, `Opus 4.8`</sub>

Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/855.

## What & why

Two coupled changes on the Subject write endpoints:

1. **Fix `POST /subject` returning `201` for an already-existing Subject.** The handler hardcoded `setStatus( 201 )`,
   so the `subject-already-exists` branch returned `201 Created` with an *error* body. It now returns
   **`409 Conflict`**.

2. **Harmonize the three mutation endpoints onto one contract.** `SetMainSubject` already used a Presentation-layer
   presenter that owns both the JSON body and the HTTP status. `Create` (handler-as-presenter, hardcoded 201) and
   `Replace` (action returned `Violation[]`) now follow the same pattern: the Action is transport-agnostic and reports
   outcomes through a presenter interface; a `Rest*Presenter` maps each outcome to a body + status; the handler applies
   `setStatus( $presenter->getStatusCode() )`. This resolves both open questions #855 deliberately deferred.

Error conditions (400/403/404) remain exceptions caught by the handlers — only expected business outcomes go through
the presenter.

## Changes

- New `RestCreateSubjectPresenter` (created → 201, already-exists → 409); `CreateSubjectApi` no longer implements the
  presenter or hardcodes the status.
- New `ReplaceSubjectPresenter` interface + `RestReplaceSubjectPresenter`; `ReplaceSubjectAction::replace()` returns
  `void` and calls `presentUpdated()`; `newReplaceSubjectAction` injects the presenter.
- `Delete` left as-is (single outcome, no violations); `SetMainSubject` unchanged (it is the template).

## Breaking change

`POST /subject` on a page that already has the Subject now returns `409` instead of `201`. NeoWiki is pre-production,
so no compatibility shim is provided.

## Test plan

- [x] `RestCreateSubjectPresenterTest` 3/3, `RestReplaceSubjectPresenterTest` 2/2 — new unit tests for
  outcome → status + body.
- [x] `CreateSubject*` 28/28, `ReplaceSubject*` 27/27 — incl. REST integration through the full handler path; the
  create already-exists case now asserts `409`, replace asserts `200`.
- [x] `make cs` — phpcs clean (400 files), phpstan no errors (191 files).
- [x] Did **not** run the full `filter=Subject` set in one go (it triggers the known Neo4j bolt-connection-accumulation
  hang); all changed code is covered via narrow filters + phpstan instead.
