### PR TITLE
Keep NeoWiki REST dependencies compatible with MW 1.43

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -47,6 +47,19 @@ To deploy on a server with automatic HTTPS via Caddy:
 
 4. Access your wiki at the configured `MW_SERVER` URL.
 
+## Composer dependency loading
+
+NeoWiki's PHP dependencies must be available through MediaWiki's root Composer
+autoload setup. The bundled Docker images do this by merging
+`extensions/NeoWiki/composer.json` into the MediaWiki root Composer install with
+`composer-merge-plugin`.
+
+Do not load `extensions/NeoWiki/vendor/autoload.php` directly from
+`LocalSettings.php`. Registering the extension's standalone Composer autoloader
+ahead of MediaWiki's autoloader can make shared interfaces resolve to versions
+that are incompatible with MediaWiki core. In particular, MediaWiki 1.43 REST
+classes expect `psr/http-message` 1.x interfaces.
+
 ## Reserved host ports
 
 `make dev` allocates host ports from these ranges. Auto-allocation skips ports that

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
 		"composer/installers": "^2|^1.0.1",
 		"opis/json-schema": "^2.3.0",
 		"laudis/neo4j-php-client": "^3.1.2",
+		"psr/http-message": "^1.1",
 		"jeroen/psr-log-test-doubles": "^3.0.0",
 		"jeroen/file-fetcher": "^6.1.0",
 		"ext-json": "*",


### PR DESCRIPTION
## Summary
- require `psr/http-message` 1.x while NeoWiki targets MediaWiki 1.43
- document that NeoWiki dependencies should be loaded through MediaWiki root Composer autoloading, not by prepending the extension vendor autoloader from `LocalSettings.php`

## Context
MediaWiki 1.43 REST classes implement the PSR-7 v1 method signatures. If a manual deployment loads `extensions/NeoWiki/vendor/autoload.php` ahead of MediaWiki core, Composer can resolve `psr/http-message` 2.x from NeoWiki standalone vendor directory and REST endpoints can fatal with a `StringStream::close()` signature mismatch.

The bundled Docker setup already merges NeoWiki dependencies into MediaWiki root Composer install via `composer-merge-plugin`; this change hardens standalone dependency resolution and documents the expected deployment pattern.

## Checks
- `composer validate --no-check-lock`
- `composer update psr/http-message --with-dependencies --no-interaction` resolved `psr/http-message 1.1` locally
- PHP reflection check confirmed `MediaWiki\Rest\StringStream::close` and loaded `Psr\Http\Message\StreamInterface::close` both have no return type
- `vendor/bin/phpcs -p -s --standard=phpcs.xml`
- `git diff --check`