### PR TITLE
Rename config to NeoWikiEnforceValidation and clarify how it's read

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -140,7 +140,7 @@
 			"description": "Whether development UIs should be enabled",
 			"value": false
 		},
-		"NeoWikiValidationEnforced": {
+		"NeoWikiEnforceValidation": {
 			"description": "Whether write endpoints reject edits that introduce new constraint violations. When false, violations are surfaced in responses but writes always persist.",
 			"value": false
 		},

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -515,14 +515,11 @@ class NeoWikiExtension {
 		);
 	}
 
-	/**
-	 * Reads the flag fresh from MainConfig rather than from $this->config because the
-	 * NeoWikiExtension singleton (and the NeoWikiConfig it holds) is built once on first
-	 * getInstance() call, so a setMwGlobals('wgNeoWikiValidationEnforced', true) in
-	 * integration tests would not be observable through the baked config.
-	 */
 	private function isValidationEnforced(): bool {
-		return MediaWikiServices::getInstance()->getMainConfig()->get( 'NeoWikiValidationEnforced' ) === true;
+		// Behavioral config is read live from MainConfig (like Neo4jQueryLimits), so the admin's
+		// LocalSettings value applies per request and tests can override it via overrideConfigValue()
+		// without rebuilding the getInstance() singleton (which bakes only bootstrap config).
+		return MediaWikiServices::getInstance()->getMainConfig()->get( 'NeoWikiEnforceValidation' ) === true;
 	}
 
 	public function getSubjectValidator(): SubjectValidator {

--- a/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
@@ -234,7 +234,7 @@ class CreateSubjectApiTest extends NeoWikiIntegrationTestCase {
 	}
 
 	public function testEnforcementBlockedReturns422(): void {
-		$this->setMwGlobals( 'wgNeoWikiValidationEnforced', true );
+		$this->setMwGlobals( 'wgNeoWikiEnforceValidation', true );
 
 		$this->createSchema(
 			'EnforcementSchema',

--- a/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
@@ -302,7 +302,7 @@ class ReplaceSubjectApiTest extends NeoWikiIntegrationTestCase {
 	}
 
 	public function testEnforcementBlockedReturns422(): void {
-		$this->setMwGlobals( 'wgNeoWikiValidationEnforced', true );
+		$this->setMwGlobals( 'wgNeoWikiEnforceValidation', true );
 
 		$this->createSchema(
 			'EnforcementSchema',


### PR DESCRIPTION
> Follow-up from a review of #856, directed by @JeroenDeDauw, who chose the verb-first `NeoWikiEnforceValidation` name and the minimal comment reframe over a larger config refactor.
> Context: the NeoWiki config wiring (`NeoWikiExtension`, `NeoWikiConfig`, `Neo4jQueryLimits`), `extension.json`, the REST integration tests, and ADR 21.
> <sub>Written by Claude Code, `Opus 4.8 (1M context)`</sub>

Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/856

Two tidy-ups to the validation-enforcement config introduced in #856:

- **Rename the config key** `NeoWikiValidationEnforced` → `NeoWikiEnforceValidation`: verb-first, matching the extension's existing `NeoWikiEnableDevelopmentUI` toggle and MediaWiki's `$wgEnable…`/`$wgAllow…` idiom. The internal `validationEnforced` flag and `isValidationEnforced()` keep their state-style names. Touches `extension.json`, the config read, and the two REST integration tests.
- **Reframe the comment** on the live read: it is the same intentional pattern as `Neo4jQueryLimits` (behavioral config read live from `MainConfig` so the admin's `LocalSettings` value applies per request and tests can override it), not a workaround for test observability.