### PR TITLE
Document validation enforcement (422) in validation-codes.md

### DIFF
--- a/docs/reference/validation-codes.md
+++ b/docs/reference/validation-codes.md
@@ -10,8 +10,14 @@ Violations are returned by:
 - `POST /neowiki/v0/subject/{subjectId}/validate` — dry-run validation of a proposed update-shape
   body against an existing Subject's Schema.
 - `POST /neowiki/v0/subject` and `PUT /neowiki/v0/subject/{subjectId}` — the write endpoints include
-  the resulting `violations` array in their `201`/`200` success body. Validation does not block the
-  write (see [ADR 21](../adr/021-add-backend-validation.md)).
+  the resulting `violations` array in their `201`/`200` success body. By default
+  (`$wgNeoWikiEnforceValidation = false`) the write always persists. When an admin enables
+  enforcement (`$wgNeoWikiEnforceValidation = true`), a write that introduces *new* blocking
+  violations is rejected with `422 Unprocessable Entity` and an `{ status, message, violations }`
+  body; `violations` carries the full proposed list, not just the newly-introduced subset.
+  Pre-existing violations (already present on the stored Subject under the current Schema) and
+  non-blocking codes such as [`schema-not-found`](#schema-not-found) never block, so editing an
+  already-invalid Subject stays possible. See [ADR 21](../adr/021-add-backend-validation.md).
 
 The `/validate` endpoints return `200 OK` with a `{violations: [...]}` body whenever the request is
 well-formed; violations in the body do not change the HTTP status. `400` is reserved for malformed


### PR DESCRIPTION
> Doc-accuracy follow-up from a review of #856, directed by @JeroenDeDauw.
> Context: the NeoWiki validation/enforcement code (CreateSubject/ReplaceSubject actions, `ViolationDiff`, the REST presenters), `validation-codes.md`, and ADR 21.
> <sub>Written by Claude Code, `Opus 4.8 (1M context)`</sub>

Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/856

The write-endpoint section of `validation-codes.md` stated "Validation does not block the write", which held for step 1 but not under the enforcement flag added in #856.

This documents that with enforcement on, a write introducing *new* blocking violations is rejected with `422` (body `{ status, message, violations }`, carrying the full proposed list), while pre-existing violations and `schema-not-found` stay non-blocking.

Note: uses the `$wgNeoWikiEnforceValidation` config name introduced by #868 — merge #868 first (or together). The two PRs touch disjoint files, so there is no merge conflict either way.