### PR TITLE
Cover CypherQueryApi rate-limit gate with a regression test

### DIFF
--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/EntryPoints/REST/CypherQueryApiTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/EntryPoints/REST/CypherQueryApiTest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Tests\GraphDatabasePlugins\Neo4j\EntryPoints\REST;
 
+use MediaWiki\MainConfigNames;
 use MediaWiki\Permissions\Authority;
 use MediaWiki\Rest\RequestData;
 use MediaWiki\Rest\ResponseInterface;
@@ -142,10 +143,23 @@ class CypherQueryApiTest extends MediaWikiIntegrationTestCase {
 	}
 
 	public function testRateLimitedReturns429(): void {
-		// Rate-limit triggering requires PingLimiter setup that is too entangled
-		// with the MW session/request infrastructure to test in unit/integration style.
-		// Covered by manual testing or future end-to-end integration coverage.
-		$this->markTestIncomplete( 'Rate-limit gate is tested manually; PingLimiter is not easily triggered in integration tests.' );
+		$this->overrideConfigValue(
+			MainConfigNames::RateLimits,
+			[ 'neowiki-query' => [ 'user' => [ 0, 60 ] ] ]
+		);
+
+		$response = $this->executeRequest(
+			$this->stubServiceReturning( $this->emptyResult() ),
+			[ 'cypher' => 'MATCH (n) RETURN n' ],
+			authority: $this->mockUserAuthorityWithPermissions(
+				$this->getTestUser()->getUser(),
+				[ 'neowiki-query' ]
+			)
+		);
+		$body = $this->decodeBody( $response );
+
+		$this->assertSame( 429, $response->getStatusCode() );
+		$this->assertSame( 'rateLimitExceeded', $body['errorType'] );
 	}
 
 	private function executeRequest(


### PR DESCRIPTION
> Result of a brainstorm with @alistair3149, who weighed the options and chose the integration-test approach over a mocked limiter, an injected collaborator, or a handler refactor.
> Context: the NeoWiki codebase, issue #859, and exploration of MediaWiki's `RateLimiter` / `pingLimiter` internals.
> <sub>Written by Claude Code, `Opus 4.8`</sub>

Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/859

Replace the `markTestIncomplete` stub on `testRateLimitedReturns429` with a real integration test. The original skip
reason — that `pingLimiter` is too entangled with MW session/request infrastructure to test — is outdated: since MW
1.39 it delegates to the `RateLimiter` service, backed by an in-memory `HashBagOStuff` in tests, so the 429 /
`rateLimitExceeded` branch can be driven deterministically by overriding `$wgRateLimits` and firing one request as a
registered user.

Test-only change; no production code touched.

The test was verified to genuinely guard the branch: it goes red (`200 != 429`) when the `pingLimiter` gate is removed
from the handler, and green with it in place.

---

Follow-up (not in this PR): the handler still reaches into `MediaWikiServices::getInstance()->getUserFactory()` inside
`run()`. `Neo4jQueryLimits::forUser()` only needs an `Authority`, so that global reach-in could be dropped — a separate
de-globalization change worth its own discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
