### PR TITLE
Extract shared field-level server-violation handling into a composable

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -339,6 +339,7 @@
 				"neowiki-field-invalid-date",
 				"neowiki-field-invalid-option",
 				"neowiki-field-single-value-only",
+				"neowiki-field-type-mismatch",
 				"neowiki-field-schema-not-found",
 				"neowiki-select-placeholder",
 				"neowiki-select-no-results",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -66,6 +66,7 @@
 	"neowiki-field-invalid-date": "Please enter a valid date.",
 	"neowiki-field-invalid-option": "\"$1\" is not a valid option.",
 	"neowiki-field-single-value-only": "Only one value can be selected.",
+	"neowiki-field-type-mismatch": "This value was saved as type \"$1\" but the property now expects \"$2\".",
 	"neowiki-field-schema-not-found": "The schema \"$1\" is missing. Restore it before saving.",
 	"neowiki-select-placeholder": "Select an option",
 	"neowiki-select-no-results": "No matching options.",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -143,6 +143,7 @@
 	"neowiki-property-editor-options-unique": "Error shown in the schema editor when duplicate option values are entered for a select property.",
 	"neowiki-field-invalid-option": "Validation error shown when a selected value is not in the allowed options list. $1 is the invalid value.",
 	"neowiki-field-single-value-only": "Validation error shown when multiple values are selected for a single-select property.",
+	"neowiki-field-type-mismatch": "Validation error shown when a Statement's stored type no longer matches the property's current type (e.g. the Schema changed after the value was saved). $1 is the type the value was written as; $2 is the type the property now expects.",
 	"neowiki-field-schema-not-found": "Form-level error shown when the backend reports the Subject's Schema page is missing. $1 is the schema name.",
 	"neowiki-select-placeholder": "Placeholder text shown in the select dropdown before any option is chosen.",
 	"neowiki-select-no-results": "Message shown in the multi-select dropdown when the typed text does not match any available option.",

--- a/resources/ext.neowiki/src/components/Value/BooleanInput.vue
+++ b/resources/ext.neowiki/src/components/Value/BooleanInput.vue
@@ -31,7 +31,7 @@ import type { Value } from '@/domain/Value';
 </script>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue';
+import { computed, ref, toRef, watch } from 'vue';
 import { CdxCheckbox, CdxField, CdxIcon } from '@wikimedia/codex';
 import { cdxIconInfo } from '@wikimedia/codex-icons';
 import { newBooleanValue, BooleanValue, ValueType } from '@/domain/Value';
@@ -53,10 +53,10 @@ const emit = defineEmits<ValueInputEmits>();
 const liveValidationError = ref<string | null>( null );
 
 const { validationError, clearServerViolation } = useFieldServerViolation(
-	() => props.property.name.toString(),
-	() => props.serverViolations,
+	toRef( props, 'property' ),
+	toRef( props, 'serverViolations' ),
 	liveValidationError,
-	( payload ) => emit( 'clear-server-violation', payload )
+	emit
 );
 
 // Hide the heading when it would duplicate the inline checkbox label

--- a/resources/ext.neowiki/src/components/Value/BooleanInput.vue
+++ b/resources/ext.neowiki/src/components/Value/BooleanInput.vue
@@ -38,6 +38,7 @@ import { newBooleanValue, BooleanValue, ValueType } from '@/domain/Value';
 import { BooleanType, BooleanProperty } from '@/domain/propertyTypes/Boolean.ts';
 import { ValueInputEmits, ValueInputExposes, ValueInputProps } from '@/components/Value/ValueInputContract.ts';
 import { NeoWikiServices } from '@/NeoWikiServices.ts';
+import { useFieldServerViolation } from '@/composables/useFieldServerViolation.ts';
 
 const props = withDefaults(
 	defineProps<ValueInputProps<BooleanProperty>>(),
@@ -51,19 +52,12 @@ const emit = defineEmits<ValueInputEmits>();
 
 const liveValidationError = ref<string | null>( null );
 
-const validationError = computed<string | null>( () => {
-	if ( liveValidationError.value !== null ) {
-		return liveValidationError.value;
-	}
-	const name = props.property.name.toString();
-	const hit = ( props.serverViolations ?? [] )
-		.find( ( v ) => v.propertyName === name &&
-			( v.valuePartIndex === null || v.valuePartIndex === undefined ) );
-	if ( hit ) {
-		return mw.message( `neowiki-field-${ hit.code }`, ...( hit.args as string[] ) ).text();
-	}
-	return null;
-} );
+const { validationError, clearServerViolation } = useFieldServerViolation(
+	() => props.property.name.toString(),
+	() => props.serverViolations,
+	liveValidationError,
+	( payload ) => emit( 'clear-server-violation', payload )
+);
 
 // Hide the heading when it would duplicate the inline checkbox label
 // (subject-editor case: the caller passes the property name as the label).
@@ -87,14 +81,7 @@ function onInput( newValue: boolean ): void {
 	const value = newBooleanValue( newValue );
 	emit( 'update:modelValue', value );
 	validate( value );
-
-	const name = props.property.name.toString();
-	const hadServerViolation = ( props.serverViolations ?? [] )
-		.some( ( v ) => v.propertyName === name &&
-			( v.valuePartIndex === null || v.valuePartIndex === undefined ) );
-	if ( hadServerViolation ) {
-		emit( 'clear-server-violation', { propertyName: name, valuePartIndex: null } );
-	}
+	clearServerViolation();
 }
 
 watch( () => props.modelValue, ( newValue ) => {

--- a/resources/ext.neowiki/src/components/Value/DateInput.vue
+++ b/resources/ext.neowiki/src/components/Value/DateInput.vue
@@ -30,7 +30,7 @@ import type { Value } from '@/domain/Value';
 </script>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue';
+import { ref, watch } from 'vue';
 import { CdxField, CdxIcon, CdxTextInput } from '@wikimedia/codex';
 import { cdxIconInfo, cdxIconCalendar } from '@wikimedia/codex-icons';
 import { newStringValue, StringValue, ValueType } from '@/domain/Value';
@@ -38,6 +38,7 @@ import { DateType, DateProperty, formatDateForDisplay } from '@/domain/propertyT
 import { fromDateInputValue, toDateInputValue } from '@/domain/propertyTypes/dateConversion.ts';
 import { ValueInputEmits, ValueInputExposes, ValueInputProps } from '@/components/Value/ValueInputContract.ts';
 import { NeoWikiServices } from '@/NeoWikiServices.ts';
+import { useFieldServerViolation } from '@/composables/useFieldServerViolation.ts';
 
 const props = withDefaults(
 	defineProps<ValueInputProps<DateProperty>>(),
@@ -51,20 +52,13 @@ const emit = defineEmits<ValueInputEmits>();
 
 const liveValidationError = ref<string | null>( null );
 
-const validationError = computed<string | null>( () => {
-	if ( liveValidationError.value !== null ) {
-		return liveValidationError.value;
-	}
-	const name = props.property.name.toString();
-	const hit = ( props.serverViolations ?? [] )
-		.find( ( v ) => v.propertyName === name &&
-			( v.valuePartIndex === null || v.valuePartIndex === undefined ) );
-	if ( hit ) {
-		const formattedArgs = ( hit.args as string[] ).map( formatDateForDisplay );
-		return mw.message( `neowiki-field-${ hit.code }`, ...formattedArgs ).text();
-	}
-	return null;
-} );
+const { validationError, clearServerViolation } = useFieldServerViolation(
+	() => props.property.name.toString(),
+	() => props.serverViolations,
+	liveValidationError,
+	( payload ) => emit( 'clear-server-violation', payload ),
+	formatDateForDisplay
+);
 
 const internalInputValue = ref<string>( '' );
 
@@ -92,14 +86,7 @@ function onInput( newValue: string ): void {
 	const value = isoValue !== undefined ? newStringValue( isoValue ) : undefined;
 	emit( 'update:modelValue', value );
 	validate( value );
-
-	const name = props.property.name.toString();
-	const hadServerViolation = ( props.serverViolations ?? [] )
-		.some( ( v ) => v.propertyName === name &&
-			( v.valuePartIndex === null || v.valuePartIndex === undefined ) );
-	if ( hadServerViolation ) {
-		emit( 'clear-server-violation', { propertyName: name, valuePartIndex: null } );
-	}
+	clearServerViolation();
 }
 
 function validate( value: StringValue | undefined ): void {

--- a/resources/ext.neowiki/src/components/Value/DateInput.vue
+++ b/resources/ext.neowiki/src/components/Value/DateInput.vue
@@ -30,7 +30,7 @@ import type { Value } from '@/domain/Value';
 </script>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue';
+import { ref, toRef, watch } from 'vue';
 import { CdxField, CdxIcon, CdxTextInput } from '@wikimedia/codex';
 import { cdxIconInfo, cdxIconCalendar } from '@wikimedia/codex-icons';
 import { newStringValue, StringValue, ValueType } from '@/domain/Value';
@@ -53,10 +53,10 @@ const emit = defineEmits<ValueInputEmits>();
 const liveValidationError = ref<string | null>( null );
 
 const { validationError, clearServerViolation } = useFieldServerViolation(
-	() => props.property.name.toString(),
-	() => props.serverViolations,
+	toRef( props, 'property' ),
+	toRef( props, 'serverViolations' ),
 	liveValidationError,
-	( payload ) => emit( 'clear-server-violation', payload ),
+	emit,
 	formatDateForDisplay
 );
 

--- a/resources/ext.neowiki/src/components/Value/DateTimeInput.vue
+++ b/resources/ext.neowiki/src/components/Value/DateTimeInput.vue
@@ -30,7 +30,7 @@ import type { Value } from '@/domain/Value';
 </script>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue';
+import { ref, toRef, watch } from 'vue';
 import { CdxField, CdxIcon, CdxTextInput } from '@wikimedia/codex';
 import { cdxIconInfo, cdxIconClock } from '@wikimedia/codex-icons';
 import { newStringValue, StringValue, ValueType } from '@/domain/Value';
@@ -53,10 +53,10 @@ const emit = defineEmits<ValueInputEmits>();
 const liveValidationError = ref<string | null>( null );
 
 const { validationError, clearServerViolation } = useFieldServerViolation(
-	() => props.property.name.toString(),
-	() => props.serverViolations,
+	toRef( props, 'property' ),
+	toRef( props, 'serverViolations' ),
 	liveValidationError,
-	( payload ) => emit( 'clear-server-violation', payload ),
+	emit,
 	formatDateTimeForDisplay
 );
 

--- a/resources/ext.neowiki/src/components/Value/DateTimeInput.vue
+++ b/resources/ext.neowiki/src/components/Value/DateTimeInput.vue
@@ -30,7 +30,7 @@ import type { Value } from '@/domain/Value';
 </script>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue';
+import { ref, watch } from 'vue';
 import { CdxField, CdxIcon, CdxTextInput } from '@wikimedia/codex';
 import { cdxIconInfo, cdxIconClock } from '@wikimedia/codex-icons';
 import { newStringValue, StringValue, ValueType } from '@/domain/Value';
@@ -38,6 +38,7 @@ import { DateTimeType, DateTimeProperty, formatDateTimeForDisplay } from '@/doma
 import { fromLocalInputValue, toLocalInputValue } from '@/domain/propertyTypes/dateTimeConversion.ts';
 import { ValueInputEmits, ValueInputExposes, ValueInputProps } from '@/components/Value/ValueInputContract.ts';
 import { NeoWikiServices } from '@/NeoWikiServices.ts';
+import { useFieldServerViolation } from '@/composables/useFieldServerViolation.ts';
 
 const props = withDefaults(
 	defineProps<ValueInputProps<DateTimeProperty>>(),
@@ -51,20 +52,13 @@ const emit = defineEmits<ValueInputEmits>();
 
 const liveValidationError = ref<string | null>( null );
 
-const validationError = computed<string | null>( () => {
-	if ( liveValidationError.value !== null ) {
-		return liveValidationError.value;
-	}
-	const name = props.property.name.toString();
-	const hit = ( props.serverViolations ?? [] )
-		.find( ( v ) => v.propertyName === name &&
-			( v.valuePartIndex === null || v.valuePartIndex === undefined ) );
-	if ( hit ) {
-		const formattedArgs = ( hit.args as string[] ).map( formatDateTimeForDisplay );
-		return mw.message( `neowiki-field-${ hit.code }`, ...formattedArgs ).text();
-	}
-	return null;
-} );
+const { validationError, clearServerViolation } = useFieldServerViolation(
+	() => props.property.name.toString(),
+	() => props.serverViolations,
+	liveValidationError,
+	( payload ) => emit( 'clear-server-violation', payload ),
+	formatDateTimeForDisplay
+);
 
 const internalInputValue = ref<string>( '' );
 
@@ -92,14 +86,7 @@ function onInput( newValue: string ): void {
 	const value = isoValue !== undefined ? newStringValue( isoValue ) : undefined;
 	emit( 'update:modelValue', value );
 	validate( value );
-
-	const name = props.property.name.toString();
-	const hadServerViolation = ( props.serverViolations ?? [] )
-		.some( ( v ) => v.propertyName === name &&
-			( v.valuePartIndex === null || v.valuePartIndex === undefined ) );
-	if ( hadServerViolation ) {
-		emit( 'clear-server-violation', { propertyName: name, valuePartIndex: null } );
-	}
+	clearServerViolation();
 }
 
 function validate( value: StringValue | undefined ): void {

--- a/resources/ext.neowiki/src/components/Value/NumberInput.vue
+++ b/resources/ext.neowiki/src/components/Value/NumberInput.vue
@@ -28,7 +28,7 @@ import type { Value } from '@/domain/Value';
 </script>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue';
+import { ref, toRef, watch } from 'vue';
 import { CdxField, CdxIcon, CdxTextInput } from '@wikimedia/codex';
 import { cdxIconInfo } from '@wikimedia/codex-icons';
 import { newNumberValue, NumberValue, ValueType } from '@/domain/Value';
@@ -52,10 +52,10 @@ const emit = defineEmits<ValueInputEmits>();
 const liveValidationError = ref<string | null>( null );
 
 const { validationError, clearServerViolation } = useFieldServerViolation(
-	() => props.property.name.toString(),
-	() => props.serverViolations,
+	toRef( props, 'property' ),
+	toRef( props, 'serverViolations' ),
 	liveValidationError,
-	( payload ) => emit( 'clear-server-violation', payload )
+	emit
 );
 
 const internalInputValue = ref<string>( '' );

--- a/resources/ext.neowiki/src/components/Value/NumberInput.vue
+++ b/resources/ext.neowiki/src/components/Value/NumberInput.vue
@@ -28,13 +28,14 @@ import type { Value } from '@/domain/Value';
 </script>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue';
+import { ref, watch } from 'vue';
 import { CdxField, CdxIcon, CdxTextInput } from '@wikimedia/codex';
 import { cdxIconInfo } from '@wikimedia/codex-icons';
 import { newNumberValue, NumberValue, ValueType } from '@/domain/Value';
 import { NumberType, NumberProperty } from '@/domain/propertyTypes/Number.ts';
 import { ValueInputEmits, ValueInputExposes, ValueInputProps } from '@/components/Value/ValueInputContract.ts';
 import { NeoWikiServices } from '@/NeoWikiServices.ts';
+import { useFieldServerViolation } from '@/composables/useFieldServerViolation.ts';
 
 const props = withDefaults(
 	defineProps<ValueInputProps<NumberProperty>>(),
@@ -50,19 +51,12 @@ const emit = defineEmits<ValueInputEmits>();
 
 const liveValidationError = ref<string | null>( null );
 
-const validationError = computed<string | null>( () => {
-	if ( liveValidationError.value !== null ) {
-		return liveValidationError.value;
-	}
-	const name = props.property.name.toString();
-	const hit = ( props.serverViolations ?? [] )
-		.find( ( v ) => v.propertyName === name &&
-			( v.valuePartIndex === null || v.valuePartIndex === undefined ) );
-	if ( hit ) {
-		return mw.message( `neowiki-field-${ hit.code }`, ...( hit.args as string[] ) ).text();
-	}
-	return null;
-} );
+const { validationError, clearServerViolation } = useFieldServerViolation(
+	() => props.property.name.toString(),
+	() => props.serverViolations,
+	liveValidationError,
+	( payload ) => emit( 'clear-server-violation', payload )
+);
 
 const internalInputValue = ref<string>( '' );
 
@@ -89,14 +83,7 @@ function onInput( newValue: string ): void {
 	const value = newValue === '' ? undefined : newNumberValue( Number( newValue ) );
 	emit( 'update:modelValue', value );
 	validate( value );
-
-	const name = props.property.name.toString();
-	const hadServerViolation = ( props.serverViolations ?? [] )
-		.some( ( v ) => v.propertyName === name &&
-			( v.valuePartIndex === null || v.valuePartIndex === undefined ) );
-	if ( hadServerViolation ) {
-		emit( 'clear-server-violation', { propertyName: name, valuePartIndex: null } );
-	}
+	clearServerViolation();
 }
 
 function validate( value: NumberValue | undefined ): void {

--- a/resources/ext.neowiki/src/composables/useFieldServerViolation.ts
+++ b/resources/ext.neowiki/src/composables/useFieldServerViolation.ts
@@ -1,0 +1,60 @@
+import { computed, ComputedRef, Ref } from 'vue';
+import { SubjectViolation } from '@/domain/SubjectViolation.ts';
+
+interface FieldServerViolation {
+	validationError: ComputedRef<string | null>;
+	clearServerViolation: () => void;
+}
+
+/**
+ * Field-level server-violation handling shared by the single-value inputs
+ * (Boolean, Number, Date, DateTime). Merges a server-sourced violation for
+ * this property into the displayed error — live client-side errors take
+ * precedence — and clears it when the user edits the field.
+ *
+ * Only field-level violations (valuePartIndex null/undefined) are handled;
+ * single-value inputs have no per-index slot. Multi-value inputs (Text and Url
+ * via useStringValueInput, plus Select and Relation) do their own per-index
+ * handling and do not use this.
+ *
+ * @param propertyName Getter for the field's property name.
+ * @param serverViolations Getter for the violations passed to this input.
+ * @param liveValidationError The component's live client-side error, if any.
+ * @param emitClear Emits clear-server-violation up to the parent.
+ * @param formatArg Per-arg formatter; Date/DateTime format their bounds for display.
+ */
+export function useFieldServerViolation(
+	propertyName: () => string,
+	serverViolations: () => readonly SubjectViolation[] | undefined,
+	liveValidationError: Ref<string | null>,
+	emitClear: ( payload: { propertyName: string; valuePartIndex: number | null } ) => void,
+	formatArg: ( arg: string ) => string = ( arg ) => arg,
+): FieldServerViolation {
+	const fieldLevelHit = (): SubjectViolation | undefined =>
+		( serverViolations() ?? [] ).find(
+			( v ) => v.propertyName === propertyName() &&
+				( v.valuePartIndex === null || v.valuePartIndex === undefined ),
+		);
+
+	const validationError = computed<string | null>( () => {
+		if ( liveValidationError.value !== null ) {
+			return liveValidationError.value;
+		}
+		const hit = fieldLevelHit();
+		if ( hit ) {
+			return mw.message(
+				`neowiki-field-${ hit.code }`,
+				...( hit.args as string[] ).map( formatArg ),
+			).text();
+		}
+		return null;
+	} );
+
+	function clearServerViolation(): void {
+		if ( fieldLevelHit() ) {
+			emitClear( { propertyName: propertyName(), valuePartIndex: null } );
+		}
+	}
+
+	return { validationError, clearServerViolation };
+}

--- a/resources/ext.neowiki/src/composables/useFieldServerViolation.ts
+++ b/resources/ext.neowiki/src/composables/useFieldServerViolation.ts
@@ -1,5 +1,7 @@
 import { computed, ComputedRef, Ref } from 'vue';
 import { SubjectViolation } from '@/domain/SubjectViolation.ts';
+import { PropertyDefinition } from '@/domain/PropertyDefinition.ts';
+import { ValueInputEmitFunction } from '@/components/Value/ValueInputContract.ts';
 
 interface FieldServerViolation {
 	validationError: ComputedRef<string | null>;
@@ -13,26 +15,27 @@ interface FieldServerViolation {
  * precedence — and clears it when the user edits the field.
  *
  * Only field-level violations (valuePartIndex null/undefined) are handled;
- * single-value inputs have no per-index slot. Multi-value inputs (Text and Url
- * via useStringValueInput, plus Select and Relation) do their own per-index
- * handling and do not use this.
+ * single-value inputs have no per-index slot. Text and Url (via
+ * useStringValueInput) merge per-index violations into their per-input slots;
+ * Select and Relation do their own inline lookup, surfacing the first
+ * violation for the property at field level.
  *
- * @param propertyName Getter for the field's property name.
- * @param serverViolations Getter for the violations passed to this input.
+ * @param property The field's Property Definition; violations are matched on its name.
+ * @param serverViolations The violations passed to this input.
  * @param liveValidationError The component's live client-side error, if any.
- * @param emitClear Emits clear-server-violation up to the parent.
+ * @param emit The component's emit function; used for clear-server-violation.
  * @param formatArg Per-arg formatter; Date/DateTime format their bounds for display.
  */
-export function useFieldServerViolation(
-	propertyName: () => string,
-	serverViolations: () => readonly SubjectViolation[] | undefined,
+export function useFieldServerViolation<P extends PropertyDefinition>(
+	property: Ref<P>,
+	serverViolations: Ref<readonly SubjectViolation[] | undefined>,
 	liveValidationError: Ref<string | null>,
-	emitClear: ( payload: { propertyName: string; valuePartIndex: number | null } ) => void,
+	emit: ValueInputEmitFunction,
 	formatArg: ( arg: string ) => string = ( arg ) => arg,
 ): FieldServerViolation {
 	const fieldLevelHit = (): SubjectViolation | undefined =>
-		( serverViolations() ?? [] ).find(
-			( v ) => v.propertyName === propertyName() &&
+		( serverViolations.value ?? [] ).find(
+			( v ) => v.propertyName === property.value.name.toString() &&
 				( v.valuePartIndex === null || v.valuePartIndex === undefined ),
 		);
 
@@ -52,7 +55,10 @@ export function useFieldServerViolation(
 
 	function clearServerViolation(): void {
 		if ( fieldLevelHit() ) {
-			emitClear( { propertyName: propertyName(), valuePartIndex: null } );
+			emit( 'clear-server-violation', {
+				propertyName: property.value.name.toString(),
+				valuePartIndex: null,
+			} );
 		}
 	}
 

--- a/resources/ext.neowiki/src/public-api.ts
+++ b/resources/ext.neowiki/src/public-api.ts
@@ -27,6 +27,7 @@ export * from './components/Value/ValueDisplayContract';
 export * from './components/Value/ValueInputContract';
 export * from './composables/useChangeDetection';
 export * from './composables/useCloseConfirmation';
+export * from './composables/useFieldServerViolation';
 export * from './composables/useLayoutPermissions';
 export * from './composables/useOverflowDetection';
 export * from './composables/useSchemaPermissions';

--- a/resources/ext.neowiki/tests/components/Value/BooleanInput.spec.ts
+++ b/resources/ext.neowiki/tests/components/Value/BooleanInput.spec.ts
@@ -141,4 +141,33 @@ describe( 'BooleanInput', () => {
 		const emitted = events?.[ 0 ]?.[ 0 ] as { type: ValueType } | undefined;
 		expect( emitted?.type ).toBe( ValueType.Boolean );
 	} );
+
+	describe( 'Server violations', () => {
+		function newWrapperWithViolationOnFoo(): VueWrapper {
+			return newWrapper( {
+				property: newBooleanProperty( { name: 'Foo' } ),
+				serverViolations: [
+					{ propertyName: 'Foo', code: 'type-mismatch', args: [ 'string', 'boolean' ], valuePartIndex: null },
+				],
+			} );
+		}
+
+		it( 'shows a field-level server violation as the field error', () => {
+			const wrapper = newWrapperWithViolationOnFoo();
+
+			const field = wrapper.findComponent( CdxField );
+			expect( field.props( 'status' ) ).toBe( 'error' );
+			expect( field.props( 'messages' ) ).toEqual( { error: 'neowiki-field-type-mismatch' } );
+		} );
+
+		it( 'emits clear-server-violation when the user edits the field', async () => {
+			const wrapper = newWrapperWithViolationOnFoo();
+
+			await wrapper.find( 'input[type="checkbox"]' ).setValue( true );
+
+			expect( wrapper.emitted( 'clear-server-violation' )![ 0 ] ).toEqual( [
+				{ propertyName: 'Foo', valuePartIndex: null },
+			] );
+		} );
+	} );
 } );

--- a/resources/ext.neowiki/tests/components/Value/DateInput.spec.ts
+++ b/resources/ext.neowiki/tests/components/Value/DateInput.spec.ts
@@ -187,4 +187,47 @@ describe( 'DateInput', () => {
 
 		expect( firstEvent.parts[ 0 ] ).toBe( date );
 	} );
+
+	describe( 'Server violations', () => {
+		it( 'shows a field-level server violation as the field error', () => {
+			const wrapper = newWrapper( {
+				property: newDateProperty( { name: 'Foo' } ),
+				serverViolations: [
+					{ propertyName: 'Foo', code: 'type-mismatch', args: [ 'date', 'number' ], valuePartIndex: null },
+				],
+			} );
+
+			expect( wrapper.findComponent( CdxField ).props( 'status' ) ).toBe( 'error' );
+			expect( wrapper.findComponent( CdxField ).props( 'messages' ) ).toHaveProperty( 'error', 'neowiki-field-type-mismatch' );
+		} );
+
+		it( 'emits clear-server-violation when the user edits the field', async () => {
+			const wrapper = newWrapper( {
+				property: newDateProperty( { name: 'Foo' } ),
+				serverViolations: [
+					{ propertyName: 'Foo', code: 'type-mismatch', args: [ 'date', 'number' ], valuePartIndex: null },
+				],
+			} );
+
+			await wrapper.find( 'input' ).setValue( '2025-06-15' );
+
+			expect( wrapper.emitted( 'clear-server-violation' )![ 0 ] ).toEqual( [
+				{ propertyName: 'Foo', valuePartIndex: null },
+			] );
+		} );
+
+		it( 'passes server-violation args to mw.message as formatted strings, not the raw ISO', () => {
+			const minimum = '2025-01-01';
+			newWrapper( {
+				property: newDateProperty( { name: 'Foo' } ),
+				serverViolations: [
+					{ propertyName: 'Foo', code: 'min-value', args: [ minimum ], valuePartIndex: null },
+				],
+			} );
+
+			const minCall = findMessageCall( 'neowiki-field-min-value' );
+			expect( minCall?.[ 1 ] ).not.toBe( minimum );
+			expect( minCall?.[ 1 ] ).not.toMatch( /^\d{4}-\d{2}-\d{2}$/ );
+		} );
+	} );
 } );

--- a/resources/ext.neowiki/tests/components/Value/DateTimeInput.spec.ts
+++ b/resources/ext.neowiki/tests/components/Value/DateTimeInput.spec.ts
@@ -212,4 +212,47 @@ describe( 'DateTimeInput', () => {
 
 		expect( new Date( firstEvent.parts[ 0 ] ).getTime() ).toBe( new Date( iso ).getTime() );
 	} );
+
+	describe( 'Server violations', () => {
+		it( 'shows a field-level server violation as the field error', () => {
+			const wrapper = newWrapper( {
+				property: newDateTimeProperty( { name: 'Foo' } ),
+				serverViolations: [
+					{ propertyName: 'Foo', code: 'type-mismatch', args: [ 'dateTime', 'string' ], valuePartIndex: null },
+				],
+			} );
+
+			expect( wrapper.findComponent( CdxField ).props( 'status' ) ).toBe( 'error' );
+			expect( wrapper.findComponent( CdxField ).props( 'messages' ) ).toHaveProperty( 'error', 'neowiki-field-type-mismatch' );
+		} );
+
+		it( 'emits clear-server-violation when the user edits the field', async () => {
+			const wrapper = newWrapper( {
+				property: newDateTimeProperty( { name: 'Foo' } ),
+				serverViolations: [
+					{ propertyName: 'Foo', code: 'type-mismatch', args: [ 'dateTime', 'string' ], valuePartIndex: null },
+				],
+			} );
+
+			await wrapper.find( 'input' ).setValue( '2025-06-15T14:00' );
+
+			expect( wrapper.emitted( 'clear-server-violation' )![ 0 ] ).toEqual( [
+				{ propertyName: 'Foo', valuePartIndex: null },
+			] );
+		} );
+
+		it( 'passes the server-violation minimum bound to mw.message as a host-local formatted string, not the raw UTC ISO', () => {
+			const minimum = '2025-01-01T00:00:00Z';
+			newWrapper( {
+				property: newDateTimeProperty( { name: 'Foo' } ),
+				serverViolations: [
+					{ propertyName: 'Foo', code: 'min-value', args: [ minimum ], valuePartIndex: null },
+				],
+			} );
+
+			const minCall = findMessageCall( 'neowiki-field-min-value' );
+			expect( minCall?.[ 1 ] ).not.toBe( minimum );
+			expect( minCall?.[ 1 ] ).not.toMatch( /Z$/ );
+		} );
+	} );
 } );

--- a/resources/ext.neowiki/tests/components/Value/NumberInput.spec.ts
+++ b/resources/ext.neowiki/tests/components/Value/NumberInput.spec.ts
@@ -86,4 +86,33 @@ describe( 'NumberInput', () => {
 			expect( ( wrapper.vm as unknown as ValueInputExposes ).getCurrentValue() ).toBeUndefined();
 		} );
 	} );
+
+	describe( 'Server violations', () => {
+		it( 'shows a field-level server violation as the field error', () => {
+			const wrapper = newWrapper( {
+				property: newNumberProperty( { name: 'Foo' } ),
+				serverViolations: [
+					{ propertyName: 'Foo', code: 'type-mismatch', args: [ 'number', 'string' ], valuePartIndex: null },
+				],
+			} );
+
+			expect( wrapper.findComponent( CdxField ).props( 'status' ) ).toBe( 'error' );
+			expect( wrapper.findComponent( CdxField ).props( 'messages' ) ).toHaveProperty( 'error', 'neowiki-field-type-mismatch' );
+		} );
+
+		it( 'emits clear-server-violation when the user edits the field', async () => {
+			const wrapper = newWrapper( {
+				property: newNumberProperty( { name: 'Foo' } ),
+				serverViolations: [
+					{ propertyName: 'Foo', code: 'type-mismatch', args: [ 'number', 'string' ], valuePartIndex: null },
+				],
+			} );
+
+			await wrapper.find( 'input' ).setValue( '12' );
+
+			expect( wrapper.emitted( 'clear-server-violation' )![ 0 ] ).toEqual( [
+				{ propertyName: 'Foo', valuePartIndex: null },
+			] );
+		} );
+	} );
 } );

--- a/resources/ext.neowiki/tests/composables/useFieldServerViolation.spec.ts
+++ b/resources/ext.neowiki/tests/composables/useFieldServerViolation.spec.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { ref, type Ref } from 'vue';
+import { useFieldServerViolation } from '@/composables/useFieldServerViolation.ts';
+import { SubjectViolation } from '@/domain/SubjectViolation.ts';
+
+type SetupResult = ReturnType<typeof useFieldServerViolation> & {
+	liveValidationError: Ref<string | null>;
+	emitClear: Mock;
+};
+
+vi.stubGlobal( 'mw', {
+	message: vi.fn( ( key: string, ...params: string[] ) => ( {
+		text: () => [ key, ...params ].join( '|' ),
+	} ) ),
+} );
+
+const PROPERTY_NAME = 'Homepage';
+
+function fieldViolation( overrides: Partial<SubjectViolation> = {} ): SubjectViolation {
+	return {
+		propertyName: PROPERTY_NAME,
+		code: 'required',
+		args: [],
+		valuePartIndex: null,
+		...overrides,
+	};
+}
+
+function setup( violations: SubjectViolation[], live: string | null = null ): SetupResult {
+	const liveValidationError = ref<string | null>( live );
+	const emitClear = vi.fn();
+	const composable = useFieldServerViolation(
+		() => PROPERTY_NAME,
+		() => violations,
+		liveValidationError,
+		emitClear,
+	);
+	return { ...composable, liveValidationError, emitClear };
+}
+
+describe( 'useFieldServerViolation', () => {
+	beforeEach( () => {
+		vi.clearAllMocks();
+	} );
+
+	describe( 'validationError', () => {
+		it( 'is null when there are no violations and no live error', () => {
+			const { validationError } = setup( [] );
+
+			expect( validationError.value ).toBeNull();
+		} );
+
+		it( 'formats the field-level server violation when there is no live error', () => {
+			const { validationError } = setup( [ fieldViolation( { code: 'type-mismatch', args: [ 'url', 'number' ] } ) ] );
+
+			expect( validationError.value ).toBe( 'neowiki-field-type-mismatch|url|number' );
+		} );
+
+		it( 'prefers the live error over a server violation on the same field', () => {
+			const { validationError } = setup( [ fieldViolation() ], 'live error' );
+
+			expect( validationError.value ).toBe( 'live error' );
+		} );
+
+		it( 'ignores violations belonging to a different property', () => {
+			const { validationError } = setup( [ fieldViolation( { propertyName: 'OtherProperty' } ) ] );
+
+			expect( validationError.value ).toBeNull();
+		} );
+
+		it( 'ignores per-index violations, since single-value inputs have no per-index slot', () => {
+			const { validationError } = setup( [ fieldViolation( { valuePartIndex: 2 } ) ] );
+
+			expect( validationError.value ).toBeNull();
+		} );
+
+		it( 'selects the field-level violation from among per-index ones for the same property', () => {
+			const { validationError } = setup( [
+				fieldViolation( { code: 'invalid-url', valuePartIndex: 0 } ),
+				fieldViolation( { code: 'required', valuePartIndex: null } ),
+				fieldViolation( { code: 'invalid-url', valuePartIndex: 1 } ),
+			] );
+
+			expect( validationError.value ).toBe( 'neowiki-field-required' );
+		} );
+
+		it( 'passes args through unchanged when no formatter is given', () => {
+			const { validationError } = setup( [ fieldViolation( { code: 'min-value', args: [ '42' ] } ) ] );
+
+			expect( validationError.value ).toBe( 'neowiki-field-min-value|42' );
+		} );
+
+		it( 'applies the arg formatter to message args', () => {
+			const { validationError } = useFieldServerViolation(
+				() => PROPERTY_NAME,
+				() => [ fieldViolation( { code: 'min-value', args: [ '2025-01-01' ] } ) ],
+				ref( null ),
+				vi.fn(),
+				( arg ) => `formatted(${ arg })`,
+			);
+
+			expect( validationError.value ).toBe( 'neowiki-field-min-value|formatted(2025-01-01)' );
+		} );
+	} );
+
+	describe( 'clearServerViolation', () => {
+		it( 'emits clear for the field when a matching field-level violation exists', () => {
+			const { clearServerViolation, emitClear } = setup( [ fieldViolation() ] );
+
+			clearServerViolation();
+
+			expect( emitClear ).toHaveBeenCalledWith( { propertyName: PROPERTY_NAME, valuePartIndex: null } );
+		} );
+
+		it( 'does not emit when there is no violation for the field', () => {
+			const { clearServerViolation, emitClear } = setup( [] );
+
+			clearServerViolation();
+
+			expect( emitClear ).not.toHaveBeenCalled();
+		} );
+
+		it( 'does not emit when the only violation is per-index', () => {
+			const { clearServerViolation, emitClear } = setup( [ fieldViolation( { valuePartIndex: 0 } ) ] );
+
+			clearServerViolation();
+
+			expect( emitClear ).not.toHaveBeenCalled();
+		} );
+	} );
+} );

--- a/resources/ext.neowiki/tests/composables/useFieldServerViolation.spec.ts
+++ b/resources/ext.neowiki/tests/composables/useFieldServerViolation.spec.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
-import { ref, type Ref } from 'vue';
+import { ref, shallowRef, type Ref } from 'vue';
 import { useFieldServerViolation } from '@/composables/useFieldServerViolation.ts';
 import { SubjectViolation } from '@/domain/SubjectViolation.ts';
+import { PropertyDefinition, PropertyName } from '@/domain/PropertyDefinition.ts';
 
 type SetupResult = ReturnType<typeof useFieldServerViolation> & {
+	serverViolations: Ref<readonly SubjectViolation[] | undefined>;
 	liveValidationError: Ref<string | null>;
-	emitClear: Mock;
+	emit: Mock;
 };
 
 vi.stubGlobal( 'mw', {
@@ -15,6 +17,15 @@ vi.stubGlobal( 'mw', {
 } );
 
 const PROPERTY_NAME = 'Homepage';
+
+function newProperty(): PropertyDefinition {
+	return {
+		name: new PropertyName( PROPERTY_NAME ),
+		type: 'text',
+		description: '',
+		required: false,
+	};
+}
 
 function fieldViolation( overrides: Partial<SubjectViolation> = {} ): SubjectViolation {
 	return {
@@ -27,15 +38,16 @@ function fieldViolation( overrides: Partial<SubjectViolation> = {} ): SubjectVio
 }
 
 function setup( violations: SubjectViolation[], live: string | null = null ): SetupResult {
+	const serverViolations = ref<readonly SubjectViolation[] | undefined>( violations );
 	const liveValidationError = ref<string | null>( live );
-	const emitClear = vi.fn();
+	const emit = vi.fn();
 	const composable = useFieldServerViolation(
-		() => PROPERTY_NAME,
-		() => violations,
+		shallowRef( newProperty() ),
+		serverViolations,
 		liveValidationError,
-		emitClear,
+		emit,
 	);
-	return { ...composable, liveValidationError, emitClear };
+	return { ...composable, serverViolations, liveValidationError, emit };
 }
 
 describe( 'useFieldServerViolation', () => {
@@ -60,6 +72,23 @@ describe( 'useFieldServerViolation', () => {
 			const { validationError } = setup( [ fieldViolation() ], 'live error' );
 
 			expect( validationError.value ).toBe( 'live error' );
+		} );
+
+		it( 'surfaces the server violation when the live error resolves', () => {
+			const { validationError, liveValidationError } = setup( [ fieldViolation() ], 'live error' );
+
+			liveValidationError.value = null;
+
+			expect( validationError.value ).toBe( 'neowiki-field-required' );
+		} );
+
+		it( 'stops surfacing the violation when the parent removes it', () => {
+			const { validationError, serverViolations } = setup( [ fieldViolation() ] );
+			expect( validationError.value ).toBe( 'neowiki-field-required' );
+
+			serverViolations.value = [];
+
+			expect( validationError.value ).toBeNull();
 		} );
 
 		it( 'ignores violations belonging to a different property', () => {
@@ -92,8 +121,8 @@ describe( 'useFieldServerViolation', () => {
 
 		it( 'applies the arg formatter to message args', () => {
 			const { validationError } = useFieldServerViolation(
-				() => PROPERTY_NAME,
-				() => [ fieldViolation( { code: 'min-value', args: [ '2025-01-01' ] } ) ],
+				shallowRef( newProperty() ),
+				ref<readonly SubjectViolation[] | undefined>( [ fieldViolation( { code: 'min-value', args: [ '2025-01-01' ] } ) ] ),
 				ref( null ),
 				vi.fn(),
 				( arg ) => `formatted(${ arg })`,
@@ -105,27 +134,38 @@ describe( 'useFieldServerViolation', () => {
 
 	describe( 'clearServerViolation', () => {
 		it( 'emits clear for the field when a matching field-level violation exists', () => {
-			const { clearServerViolation, emitClear } = setup( [ fieldViolation() ] );
+			const { clearServerViolation, emit } = setup( [ fieldViolation() ] );
 
 			clearServerViolation();
 
-			expect( emitClear ).toHaveBeenCalledWith( { propertyName: PROPERTY_NAME, valuePartIndex: null } );
+			expect( emit ).toHaveBeenCalledWith(
+				'clear-server-violation',
+				{ propertyName: PROPERTY_NAME, valuePartIndex: null },
+			);
 		} );
 
 		it( 'does not emit when there is no violation for the field', () => {
-			const { clearServerViolation, emitClear } = setup( [] );
+			const { clearServerViolation, emit } = setup( [] );
 
 			clearServerViolation();
 
-			expect( emitClear ).not.toHaveBeenCalled();
+			expect( emit ).not.toHaveBeenCalled();
+		} );
+
+		it( 'does not emit when the only violation is for a different property', () => {
+			const { clearServerViolation, emit } = setup( [ fieldViolation( { propertyName: 'OtherProperty' } ) ] );
+
+			clearServerViolation();
+
+			expect( emit ).not.toHaveBeenCalled();
 		} );
 
 		it( 'does not emit when the only violation is per-index', () => {
-			const { clearServerViolation, emitClear } = setup( [ fieldViolation( { valuePartIndex: 0 } ) ] );
+			const { clearServerViolation, emit } = setup( [ fieldViolation( { valuePartIndex: 0 } ) ] );
 
 			clearServerViolation();
 
-			expect( emitClear ).not.toHaveBeenCalled();
+			expect( emit ).not.toHaveBeenCalled();
 		} );
 	} );
 } );


### PR DESCRIPTION
> Result of a first-principles review of #879 with @JeroenDeDauw, who directed the scope (high-confidence, small, removals over additions).
> Context: the NeoWiki frontend, #879/#856/#855, and the validation-codes contract.
> <sub>Written by Claude Code, `Opus 4.8`</sub>

Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/879.

## What and why

The four single-value inputs (Boolean, Number, Date, DateTime) each carried a byte-identical copy of two pieces of server-violation handling added in #879: the `validationError` fallback (surface the field-level violation when there is no live client-side error) and the clear-on-edit emit. This extracts that into `useFieldServerViolation`, mirroring how the multi-value inputs already share `useStringValueInput`. Net **-49 lines** across the four components; behavior unchanged.

Also adds the missing **`neowiki-field-type-mismatch`** message. The frontend formats every violation code as `neowiki-field-<code>`, but `type-mismatch` had no key — so a `type-mismatch` violation (e.g. a pre-existing one riding along in an enforced-write 422 after a Schema type change) rendered as the raw `⧼neowiki-field-type-mismatch⧽` placeholder.

`label-required` is **deliberately left without a key**: it is unreachable on every current frontend path (write actions reject an empty label with a 400 before validation runs, and nothing yet renders the validate-endpoint output), so adding it now would be speculative.

## Out of scope (deliberately not done, to keep this small)

- `SelectInput`/`RelationInput` also do field-level violation lookup inline. They could share a helper too, but they have multi/per-chip concerns that don't fit this single-value composable cleanly — left as-is.
- No shared `formatViolationMessage()` helper for the `mw.message(\`neowiki-field-\${code}\`, …)` pattern that recurs across several inputs. A reasonable future cleanup, but a wider refactor than this.

## Test plan

- [x] `make tsci` green — 964/964 vitest (was 953; +11 for the new composable spec), build + lint clean.
- [x] New `useFieldServerViolation.spec.ts` directly covers the composable (the four components had no tests for this logic before): live-error precedence, field-level surfacing, per-index violations ignored, arg formatter applied (Date/DateTime) and passthrough (Boolean/Number), and clear-emit gated on a matching field-level violation. Verified the meaningful assertions fail when the composable logic is neutered.