### PR TITLE
Port TS-only validation rules into PHP

### DIFF
--- a/DemoData/Page/Validation_Demo.wikitext
+++ b/DemoData/Page/Validation_Demo.wikitext
@@ -14,18 +14,34 @@ With this flag on, writes that introduce new violations are rejected with HTTP 4
 
 * [[Validation Clean]] — a Subject with every property filled in correctly. Use it as the starting point for the recipes below.
 
-The [[Schema:Validation Demo|Validation Demo]] schema has four properties spanning the validation surface:
+The [[Schema:Validation Demo|Validation Demo]] schema has one or more properties for every validatable Property Type, so you can trigger each rule by typing a bad value in the editor:
 
 {| class="wikitable"
-! Property !! Type !! Notes
+! Property !! Type !! What to try
 |-
-| Title || text, required || A simple required text field.
+| Title || text, required || Clear it and save to see a "required" error.
+|-
+| Summary || text, minLength 10 / maxLength 100 || Type fewer than 10 or more than 100 characters to trigger a length violation. (This length rule was just added to the backend.)
+|-
+| Aliases || text, multi, unique || Add two identical entries to trigger a duplicate violation.
 |-
 | Homepage || url, required || A single required URL. Empty triggers a "required" error inline.
 |-
-| Tags || url, multi || Optional list of URLs. Changing one entry to a non-http(s) URL triggers a per-entry <code>invalid-url</code> violation under enforcement; only the offending sub-input is decorated.
+| Tags || url, multi || Change one entry to a non-http(s) URL to trigger a per-entry <code>invalid-url</code> violation; only the offending sub-input is decorated.
+|-
+| Score || number, 0–100, precision 2 || Enter a value below 0 or above 100 to trigger a bounds violation.
 |-
 | Status || select, required || A required choice between three options.
+|-
+| Topics || select, multi || Pick any combination of options.
+|-
+| Featured || boolean || A simple on/off flag.
+|-
+| Release date || date, 2020-01-01 – 2030-12-31 || Pick a date outside the range to trigger a bounds violation.
+|-
+| Last reviewed || dateTime, 2020-01-01 – 2030-12-31 (UTC) || Pick a moment outside the range to trigger a bounds violation.
+|-
+| Related product || relation to Product || Points at a Product subject.
 |}
 
 == Recipes ==

--- a/DemoData/Schema/Validation_Demo.json
+++ b/DemoData/Schema/Validation_Demo.json
@@ -1,30 +1,82 @@
 {
-	"description": "A demo schema for trying out backend validation. Use it together with the Validation Demo hub page to see how the editor surfaces server-side errors next to each field.",
+	"description": "A demo schema that exercises every validatable Property Type and its constraints. Open the paired Validation Clean subject in the editor and type bad values into each field to trigger the matching server-side violation. See the Validation Demo hub page for what to try.",
 	"propertyDefinitions": {
 		"Title": {
 			"type": "text",
 			"required": true,
-			"description": "Required. Save with this empty to see an inline error."
+			"description": "text, required. Clear it and save to see a required error."
+		},
+		"Summary": {
+			"type": "text",
+			"minLength": 10,
+			"maxLength": 100,
+			"description": "text, minLength 10 / maxLength 100. Type fewer than 10 or more than 100 characters to trigger a length violation."
+		},
+		"Aliases": {
+			"type": "text",
+			"multiple": true,
+			"uniqueItems": true,
+			"description": "text, multiple with uniqueItems. Add two identical entries to trigger a duplicate violation."
 		},
 		"Homepage": {
 			"type": "url",
 			"required": true,
-			"description": "Required. Must be a valid http or https URL."
+			"description": "url, required. Must be a valid http or https URL."
 		},
 		"Tags": {
 			"type": "url",
 			"multiple": true,
-			"description": "Optional list of URLs. Each entry must be a valid http or https URL."
+			"description": "url, multiple. Change one entry to a non-http(s) URL to trigger a per-entry invalid-url violation."
+		},
+		"Score": {
+			"type": "number",
+			"minimum": 0,
+			"maximum": 100,
+			"precision": 2,
+			"description": "number, minimum 0 / maximum 100, precision 2. Enter a value below 0 or above 100 to trigger a bounds violation."
 		},
 		"Status": {
 			"type": "select",
 			"required": true,
 			"options": [
-				{ "id": "o1valida1aaaaaa", "label": "Draft" },
-				{ "id": "o1valida2aaaaaa", "label": "Approved" },
-				{ "id": "o1valida3aaaaaa", "label": "Archived" }
+				{ "id": "oVgd1htUPMmGZYT", "label": "Draft" },
+				{ "id": "oVgd1CpH9LzBa3z", "label": "Review" },
+				{ "id": "oVgd1j5JPWsa8uw", "label": "Published" }
 			],
-			"description": "Required. Pick one of the three statuses."
+			"description": "select, single, required. Pick one of the three statuses."
+		},
+		"Topics": {
+			"type": "select",
+			"multiple": true,
+			"options": [
+				{ "id": "oVgd1Fzq3xfLnxJ", "label": "Red" },
+				{ "id": "oVgd1SGKB2LjGDQ", "label": "Green" },
+				{ "id": "oVgd1LjchzFUcLg", "label": "Blue" },
+				{ "id": "oVgd1UDq6CSaEHK", "label": "Yellow" }
+			],
+			"description": "select, multiple. Pick any combination of topics."
+		},
+		"Featured": {
+			"type": "boolean",
+			"description": "boolean. A simple on/off flag."
+		},
+		"Release date": {
+			"type": "date",
+			"minimum": "2020-01-01",
+			"maximum": "2030-12-31",
+			"description": "date, minimum 2020-01-01 / maximum 2030-12-31. Pick a date outside the range to trigger a bounds violation."
+		},
+		"Last reviewed": {
+			"type": "dateTime",
+			"minimum": "2020-01-01T00:00:00Z",
+			"maximum": "2030-12-31T23:59:59Z",
+			"description": "dateTime, minimum 2020-01-01T00:00:00Z / maximum 2030-12-31T23:59:59Z. Pick a moment outside the range to trigger a bounds violation."
+		},
+		"Related product": {
+			"type": "relation",
+			"relation": "Related product",
+			"targetSchema": "Product",
+			"description": "relation to a Product subject."
 		}
 	}
 }

--- a/DemoData/Subject/Validation_Clean.json
+++ b/DemoData/Subject/Validation_Clean.json
@@ -1,13 +1,21 @@
 {
-	"mainSubject": "sVdemo1aaaaaaaa",
+	"mainSubject": "sVgd1VWVmdUSMp6",
 	"subjects": {
-		"sVdemo1aaaaaaaa": {
+		"sVgd1VWVmdUSMp6": {
 			"label": "Validation Clean",
 			"schema": "Validation Demo",
 			"statements": {
 				"Title": {
 					"type": "text",
 					"value": [ "All properties filled in" ]
+				},
+				"Summary": {
+					"type": "text",
+					"value": [ "A valid summary that is comfortably between ten and one hundred characters long." ]
+				},
+				"Aliases": {
+					"type": "text",
+					"value": [ "Clean sample", "Reference subject" ]
 				},
 				"Homepage": {
 					"type": "url",
@@ -20,9 +28,38 @@
 						"https://example.com/b"
 					]
 				},
+				"Score": {
+					"type": "number",
+					"value": 42.5
+				},
 				"Status": {
 					"type": "select",
-					"value": [ "o1valida1aaaaaa" ]
+					"value": [ "oVgd1htUPMmGZYT" ]
+				},
+				"Topics": {
+					"type": "select",
+					"value": [ "oVgd1Fzq3xfLnxJ", "oVgd1LjchzFUcLg" ]
+				},
+				"Featured": {
+					"type": "boolean",
+					"value": true
+				},
+				"Release date": {
+					"type": "date",
+					"value": [ "2024-06-15" ]
+				},
+				"Last reviewed": {
+					"type": "dateTime",
+					"value": [ "2024-06-15T09:30:00Z" ]
+				},
+				"Related product": {
+					"type": "relation",
+					"value": [
+						{
+							"id": "rVgd1keRxJzQR6e",
+							"target": "s1demo1aaaaaaa2"
+						}
+					]
 				}
 			}
 		}

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -145,6 +145,8 @@
 	"neowiki-field-single-value-only": "Validation error shown when multiple values are selected for a single-select property.",
 	"neowiki-field-type-mismatch": "Validation error shown when a Statement's stored type no longer matches the property's current type (e.g. the Schema changed after the value was saved). $1 is the type the value was written as; $2 is the type the property now expects.",
 	"neowiki-field-schema-not-found": "Form-level error shown when the backend reports the Subject's Schema page is missing. $1 is the schema name.",
+	"neowiki-field-min-length": "Validation error shown when a text value is shorter than the property's minimum length. $1 is the minimum number of characters.",
+	"neowiki-field-max-length": "Validation error shown when a text value is longer than the property's maximum length. $1 is the maximum number of characters.",
 	"neowiki-select-placeholder": "Placeholder text shown in the select dropdown before any option is chosen.",
 	"neowiki-select-no-results": "Message shown in the multi-select dropdown when the typed text does not match any available option.",
 	"neowiki-field-invalid-datetime": "Validation error shown when the entered date and time value cannot be parsed. DateTime values must be strict ISO 8601 / xsd:dateTime strings with an explicit timezone offset or 'Z' (for example, '2025-06-15T12:00:00Z' or '2025-06-15T12:00:00+02:00'). Partial values such as year-only or date-only are rejected, and min/max bounds are inclusive.",

--- a/resources/ext.neowiki/src/domain/propertyTypes/Text.ts
+++ b/resources/ext.neowiki/src/domain/propertyTypes/Text.ts
@@ -28,9 +28,9 @@ export class TextType extends BasePropertyType<TextProperty, StringValue> {
 		return {
 			...base,
 			multiple: json.multiple ?? false,
-			uniqueItems: json.uniqueItems ?? true,
-			minLength: json.minLength,
-			maxLength: json.maxLength,
+			uniqueItems: json.uniqueItems ?? false,
+			minLength: json.minLength ?? undefined,
+			maxLength: json.maxLength ?? undefined,
 		} as TextProperty;
 	}
 
@@ -46,7 +46,13 @@ export class TextType extends BasePropertyType<TextProperty, StringValue> {
 		// TODO: check property.multiple
 
 		for ( const part of value.parts ) {
-			if ( property.minLength !== undefined && part.trim().length < property.minLength ) {
+			const trimmedLength = part.trim().length;
+
+			if ( trimmedLength === 0 ) {
+				continue;
+			}
+
+			if ( property.minLength !== undefined && trimmedLength < property.minLength ) {
 				errors.push( {
 					code: 'min-length',
 					args: [ property.minLength ],
@@ -54,7 +60,7 @@ export class TextType extends BasePropertyType<TextProperty, StringValue> {
 				} );
 			}
 
-			if ( property.maxLength !== undefined && part.trim().length > property.maxLength ) {
+			if ( property.maxLength !== undefined && trimmedLength > property.maxLength ) {
 				errors.push( {
 					code: 'max-length',
 					args: [ property.maxLength ],

--- a/resources/ext.neowiki/src/domain/propertyTypes/Url.ts
+++ b/resources/ext.neowiki/src/domain/propertyTypes/Url.ts
@@ -26,7 +26,7 @@ export class UrlType extends BasePropertyType<UrlProperty, StringValue> {
 		return {
 			...base,
 			multiple: json.multiple ?? false,
-			uniqueItems: json.uniqueItems ?? true,
+			uniqueItems: json.uniqueItems ?? false,
 		} as UrlProperty;
 	}
 

--- a/resources/ext.neowiki/tests/domain/propertyTypes/Text.spec.ts
+++ b/resources/ext.neowiki/tests/domain/propertyTypes/Text.spec.ts
@@ -96,6 +96,28 @@ describe( 'newTextProperty', () => {
 	} );
 } );
 
+describe( 'createPropertyDefinitionFromJson', () => {
+	const type = new TextType();
+
+	it( 'defaults uniqueItems to false when omitted, matching the backend', () => {
+		const property = type.createPropertyDefinitionFromJson(
+			{ name: new PropertyName( 'Tags' ), type: 'text', description: '', required: false },
+			{ type: 'text' },
+		);
+
+		expect( property.uniqueItems ).toBe( false );
+	} );
+
+	it( 'preserves an explicit uniqueItems value', () => {
+		const property = type.createPropertyDefinitionFromJson(
+			{ name: new PropertyName( 'Tags' ), type: 'text', description: '', required: false },
+			{ type: 'text', uniqueItems: true },
+		);
+
+		expect( property.uniqueItems ).toBe( true );
+	} );
+} );
+
 describe( 'validate', () => {
 	const textType = new TextType();
 
@@ -188,6 +210,18 @@ describe( 'validate', () => {
 		} );
 
 		const errors = textType.validate( newStringValue( [ '123' ] ), property );
+
+		expect( errors ).toEqual( [] );
+	} );
+
+	it( 'treats null length bounds from backend serialization as unset', () => {
+		// The PHP serializer emits minLength/maxLength as null when unset; null must not act as a bound.
+		const property = textType.createPropertyDefinitionFromJson(
+			{ name: new PropertyName( 'Notes' ), type: 'text', description: '', required: false },
+			{ type: 'text', minLength: null, maxLength: null },
+		);
+
+		const errors = textType.validate( newStringValue( [ 'any non-empty value' ] ), property );
 
 		expect( errors ).toEqual( [] );
 	} );

--- a/resources/ext.neowiki/tests/domain/propertyTypes/Url.spec.ts
+++ b/resources/ext.neowiki/tests/domain/propertyTypes/Url.spec.ts
@@ -190,6 +190,28 @@ describe( 'newUrlProperty', () => {
 	} );
 } );
 
+describe( 'createPropertyDefinitionFromJson', () => {
+	const type = new UrlType();
+
+	it( 'defaults uniqueItems to false when omitted, matching the backend', () => {
+		const property = type.createPropertyDefinitionFromJson(
+			{ name: new PropertyName( 'Links' ), type: 'url', description: '', required: false },
+			{ type: 'url' },
+		);
+
+		expect( property.uniqueItems ).toBe( false );
+	} );
+
+	it( 'preserves an explicit uniqueItems value', () => {
+		const property = type.createPropertyDefinitionFromJson(
+			{ name: new PropertyName( 'Links' ), type: 'url', description: '', required: false },
+			{ type: 'url', uniqueItems: true },
+		);
+
+		expect( property.uniqueItems ).toBe( true );
+	} );
+} );
+
 describe( 'validate', () => {
 	const urlType = new UrlType();
 

--- a/resources/ext.neowiki/tests/persistence/RestSchemaRepository.neo4j.spec.ts
+++ b/resources/ext.neowiki/tests/persistence/RestSchemaRepository.neo4j.spec.ts
@@ -62,7 +62,7 @@ describe( 'RestSchemaRepository', () => {
 					description: '',
 					required: true,
 					multiple: false,
-					uniqueItems: true,
+					uniqueItems: false,
 				},
 			} );
 		} );

--- a/resources/ext.neowiki/tests/persistence/SchemaDeserializer.spec.ts
+++ b/resources/ext.neowiki/tests/persistence/SchemaDeserializer.spec.ts
@@ -24,7 +24,7 @@ describe( 'SchemaDeserializer', () => {
 				description: '',
 				required: true,
 				multiple: false,
-				uniqueItems: true,
+				uniqueItems: false,
 			},
 			Age: {
 				name: new PropertyName( 'Age' ),

--- a/src/Domain/PropertyType/Types/TextType.php
+++ b/src/Domain/PropertyType/Types/TextType.php
@@ -59,10 +59,51 @@ class TextType implements PropertyType {
 			$violations[] = new Violation( propertyName: null, code: 'required' );
 		}
 
+		$violations = array_merge( $violations, $this->validateLengths( $value, $definition ) );
+
 		if ( $definition->enforcesUniqueValues()
 			&& count( array_unique( $value->strings ) ) !== count( $value->strings )
 		) {
 			$violations[] = new Violation( propertyName: null, code: 'unique' );
+		}
+
+		return $violations;
+	}
+
+	/**
+	 * @return Violation[]
+	 */
+	private function validateLengths( StringValue $value, TextProperty $definition ): array {
+		if ( !$definition->hasMinLength() && !$definition->hasMaxLength() ) {
+			return [];
+		}
+
+		$violations = [];
+
+		foreach ( $value->strings as $index => $part ) {
+			$length = mb_strlen( trim( $part ) );
+
+			if ( $length === 0 ) {
+				continue;
+			}
+
+			if ( $definition->hasMinLength() && $length < $definition->getMinLength() ) {
+				$violations[] = new Violation(
+					propertyName: null,
+					code: 'min-length',
+					args: [ $definition->getMinLength() ],
+					valuePartIndex: $index,
+				);
+			}
+
+			if ( $definition->hasMaxLength() && $length > $definition->getMaxLength() ) {
+				$violations[] = new Violation(
+					propertyName: null,
+					code: 'max-length',
+					args: [ $definition->getMaxLength() ],
+					valuePartIndex: $index,
+				);
+			}
 		}
 
 		return $violations;

--- a/src/Domain/Schema/Property/TextProperty.php
+++ b/src/Domain/Schema/Property/TextProperty.php
@@ -14,6 +14,8 @@ class TextProperty extends PropertyDefinition {
 		PropertyCore $core,
 		private readonly bool $multiple,
 		private readonly bool $uniqueItems,
+		private readonly ?int $minLength,
+		private readonly ?int $maxLength,
 	) {
 		parent::__construct( $core );
 	}
@@ -30,11 +32,29 @@ class TextProperty extends PropertyDefinition {
 		return $this->uniqueItems;
 	}
 
+	public function getMinLength(): ?int {
+		return $this->minLength;
+	}
+
+	public function hasMinLength(): bool {
+		return $this->minLength !== null;
+	}
+
+	public function getMaxLength(): ?int {
+		return $this->maxLength;
+	}
+
+	public function hasMaxLength(): bool {
+		return $this->maxLength !== null;
+	}
+
 	public static function fromPartialJson( PropertyCore $core, array $property ): self {
 		return new self(
 			core: $core,
 			multiple: $property['multiple'] ?? false,
 			uniqueItems: $property['uniqueItems'] ?? false,
+			minLength: $property['minLength'] ?? null,
+			maxLength: $property['maxLength'] ?? null,
 		);
 	}
 
@@ -42,6 +62,8 @@ class TextProperty extends PropertyDefinition {
 		return [
 			'multiple' => $this->allowsMultipleValues(),
 			'uniqueItems' => $this->enforcesUniqueValues(),
+			'minLength' => $this->getMinLength(),
+			'maxLength' => $this->getMaxLength(),
 		];
 	}
 

--- a/src/Domain/Schema/PropertyName.php
+++ b/src/Domain/Schema/PropertyName.php
@@ -4,14 +4,20 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Domain\Schema;
 
+use InvalidArgumentException;
+
 readonly class PropertyName {
 
-	public function __construct(
-		public string $text
-	) {
-		if ( $text === '' ) {
-			throw new \InvalidArgumentException( 'Property name cannot be empty' );
+	public string $text;
+
+	public function __construct( string $text ) {
+		$trimmed = trim( $text );
+
+		if ( $trimmed === '' ) {
+			throw new InvalidArgumentException( 'Property name cannot be empty' );
 		}
+
+		$this->text = $trimmed;
 	}
 
 	public function __toString(): string {

--- a/tests/phpunit/Application/Queries/GetSchema/GetSchemaQueryTest.php
+++ b/tests/phpunit/Application/Queries/GetSchema/GetSchemaQueryTest.php
@@ -71,7 +71,9 @@ class GetSchemaQueryTest extends TestCase {
             "required": false,
             "default": null,
             "multiple": false,
-            "uniqueItems": false
+            "uniqueItems": false,
+            "minLength": null,
+            "maxLength": null
         }
     }
 }

--- a/tests/phpunit/Data/TestProperty.php
+++ b/tests/phpunit/Data/TestProperty.php
@@ -29,7 +29,9 @@ class TestProperty {
 				default: $default
 			),
 			multiple: $multiple,
-			uniqueItems: false
+			uniqueItems: false,
+			minLength: null,
+			maxLength: null
 		);
 	}
 

--- a/tests/phpunit/Domain/PropertyType/Types/TextTypeValidateTest.php
+++ b/tests/phpunit/Domain/PropertyType/Types/TextTypeValidateTest.php
@@ -102,13 +102,93 @@ class TextTypeValidateTest extends TestCase {
 		$this->assertContains( 'unique', $codes );
 	}
 
+	public function testPartShorterThanMinLengthProducesMinLengthViolation(): void {
+		$violations = $this->type->validate(
+			new StringValue( 'abc', 'ab' ),
+			$this->newProperty( required: false, minLength: 3 )
+		);
+
+		$this->assertCount( 1, $violations );
+		$this->assertSame( 'min-length', $violations[0]->code );
+		$this->assertSame( [ 3 ], $violations[0]->args );
+		$this->assertSame( 1, $violations[0]->valuePartIndex );
+	}
+
+	public function testPartLongerThanMaxLengthProducesMaxLengthViolation(): void {
+		$violations = $this->type->validate(
+			new StringValue( 'ok', 'toolong' ),
+			$this->newProperty( required: false, maxLength: 4 )
+		);
+
+		$this->assertCount( 1, $violations );
+		$this->assertSame( 'max-length', $violations[0]->code );
+		$this->assertSame( [ 4 ], $violations[0]->args );
+		$this->assertSame( 1, $violations[0]->valuePartIndex );
+	}
+
+	public function testTrimmedLengthBelowMinimumProducesViolation(): void {
+		// Trimmed 'ab' has length 2 (< 3); the raw 6-character value would not.
+		$violations = $this->type->validate(
+			new StringValue( '  ab  ' ),
+			$this->newProperty( required: false, minLength: 3 )
+		);
+
+		$this->assertCount( 1, $violations );
+		$this->assertSame( 'min-length', $violations[0]->code );
+	}
+
+	public function testTrimmedLengthWithinMaximumProducesNoViolation(): void {
+		// Trimmed 'abcdef' has length 6 (<= 6); the raw 10-character value would exceed it.
+		$violations = $this->type->validate(
+			new StringValue( '  abcdef  ' ),
+			$this->newProperty( required: false, maxLength: 6 )
+		);
+
+		$this->assertSame( [], $violations );
+	}
+
+	public function testValueWithinLengthBoundsProducesNoViolation(): void {
+		$violations = $this->type->validate(
+			new StringValue( 'abcd' ),
+			$this->newProperty( required: false, minLength: 2, maxLength: 5 )
+		);
+
+		$this->assertSame( [], $violations );
+	}
+
+	public function testEmptyPartsAreSkippedForLengthValidation(): void {
+		$violations = $this->type->validate(
+			new StringValue( 'abc', '' ),
+			$this->newProperty( required: false, minLength: 3 )
+		);
+
+		$this->assertSame( [], $violations );
+	}
+
+	public function testRequiredEmptyValueDoesNotAlsoReportLengthViolation(): void {
+		$violations = $this->type->validate(
+			new StringValue( '' ),
+			$this->newProperty( required: true, minLength: 3 )
+		);
+
+		$this->assertCount( 1, $violations );
+		$this->assertSame( 'required', $violations[0]->code );
+	}
+
 	private function newProperty(
 		bool $required,
 		bool $uniqueItems = false,
+		?int $minLength = null,
+		?int $maxLength = null,
 	): TextProperty {
 		return TextProperty::fromPartialJson(
 			new PropertyCore( description: '', required: $required, default: null ),
-			[ 'multiple' => true, 'uniqueItems' => $uniqueItems ],
+			[
+				'multiple' => true,
+				'uniqueItems' => $uniqueItems,
+				'minLength' => $minLength,
+				'maxLength' => $maxLength,
+			],
 		);
 	}
 

--- a/tests/phpunit/Domain/Schema/Property/TextPropertyTest.php
+++ b/tests/phpunit/Domain/Schema/Property/TextPropertyTest.php
@@ -21,7 +21,9 @@ class TextPropertyTest extends PropertyTestCase {
 	"required": false,
 	"default": null,
 	"multiple": false,
-	"uniqueItems": false
+	"uniqueItems": false,
+	"minLength": null,
+	"maxLength": null
 }
 JSON,
 			$this->deserializeAndReserialize(
@@ -43,7 +45,9 @@ JSON
 	"required": true,
 	"default": 42,
 	"multiple": true,
-	"uniqueItems": true
+	"uniqueItems": true,
+	"minLength": 2,
+	"maxLength": 40
 }
 JSON
 		);
@@ -58,7 +62,9 @@ JSON
 	"required": false,
 	"default": null,
 	"multiple": false,
-	"uniqueItems": false
+	"uniqueItems": false,
+	"minLength": null,
+	"maxLength": null
 }
 JSON
 		);
@@ -86,6 +92,11 @@ JSON
 }
 JSON
 		);
+	}
+
+	public function testExceptionOnInvalidMinLength(): void {
+		$this->expectException( InvalidArgumentException::class );
+		$this->fromJson( '{ "type": "text", "minLength": "yes" }' );
 	}
 
 }

--- a/tests/phpunit/Domain/Schema/PropertyNameTest.php
+++ b/tests/phpunit/Domain/Schema/PropertyNameTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Domain\Schema;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyName;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Domain\Schema\PropertyName
+ */
+class PropertyNameTest extends TestCase {
+
+	public function testTrimsSurroundingWhitespace(): void {
+		$this->assertSame( 'Age', ( new PropertyName( '  Age  ' ) )->text );
+	}
+
+	public function testRejectsWhitespaceOnlyName(): void {
+		$this->expectException( InvalidArgumentException::class );
+		new PropertyName( '   ' );
+	}
+
+	public function testRejectsEmptyName(): void {
+		$this->expectException( InvalidArgumentException::class );
+		new PropertyName( '' );
+	}
+
+}

--- a/tests/phpunit/EntryPoints/Scribunto/SchemaLuaSerializerTest.php
+++ b/tests/phpunit/EntryPoints/Scribunto/SchemaLuaSerializerTest.php
@@ -63,7 +63,7 @@ class SchemaLuaSerializerTest extends TestCase {
 
 	public function testTextPropertyMinimal(): void {
 		$schema = $this->schemaWith( [
-			'LegalName' => new TextProperty( $this->coreRequired(), multiple: false, uniqueItems: false ),
+			'LegalName' => new TextProperty( $this->coreRequired(), multiple: false, uniqueItems: false, minLength: null, maxLength: null ),
 		] );
 
 		$this->assertSame(
@@ -83,7 +83,7 @@ class SchemaLuaSerializerTest extends TestCase {
 	public function testTextPropertyWithDescriptionAndDefault(): void {
 		$core = new PropertyCore( description: 'City of residence', required: false, default: 'Berlin' );
 		$schema = $this->schemaWith( [
-			'City' => new TextProperty( $core, multiple: false, uniqueItems: false ),
+			'City' => new TextProperty( $core, multiple: false, uniqueItems: false, minLength: null, maxLength: null ),
 		] );
 
 		$prop = $this->newSerializer()->toLuaTable( $schema )['properties'][1];
@@ -94,7 +94,7 @@ class SchemaLuaSerializerTest extends TestCase {
 
 	public function testTextPropertyMultipleAndUniqueItems(): void {
 		$schema = $this->schemaWith( [
-			'Skills' => new TextProperty( $this->coreOptional(), multiple: true, uniqueItems: true ),
+			'Skills' => new TextProperty( $this->coreOptional(), multiple: true, uniqueItems: true, minLength: null, maxLength: null ),
 		] );
 
 		$prop = $this->newSerializer()->toLuaTable( $schema )['properties'][1];
@@ -218,9 +218,9 @@ class SchemaLuaSerializerTest extends TestCase {
 
 	public function testPropertyOrderMatchesDefinitionOrder(): void {
 		$schema = $this->schemaWith( [
-			'Zeta'  => new TextProperty( $this->coreOptional(), multiple: false, uniqueItems: false ),
-			'Alpha' => new TextProperty( $this->coreOptional(), multiple: false, uniqueItems: false ),
-			'Mu'    => new TextProperty( $this->coreOptional(), multiple: false, uniqueItems: false ),
+			'Zeta'  => new TextProperty( $this->coreOptional(), multiple: false, uniqueItems: false, minLength: null, maxLength: null ),
+			'Alpha' => new TextProperty( $this->coreOptional(), multiple: false, uniqueItems: false, minLength: null, maxLength: null ),
+			'Mu'    => new TextProperty( $this->coreOptional(), multiple: false, uniqueItems: false, minLength: null, maxLength: null ),
 		] );
 
 		$names = array_column(

--- a/tests/phpunit/Presentation/SchemaPresentationSerializerTest.php
+++ b/tests/phpunit/Presentation/SchemaPresentationSerializerTest.php
@@ -55,6 +55,8 @@ class SchemaPresentationSerializerTest extends TestCase {
 					'multiple' => false,
 					'default' => 'foo',
 					'uniqueItems' => false,
+					'minLength' => null,
+					'maxLength' => null,
 					'type' => TextType::NAME,
 				]
 			]
@@ -154,6 +156,8 @@ class SchemaPresentationSerializerTest extends TestCase {
 					'type' => 'text',
 					'multiple' => false,
 					'uniqueItems' => false,
+					'minLength' => null,
+					'maxLength' => null,
 				]
 			]
 		] );


### PR DESCRIPTION
> Result of an extensive design collaboration with @alistair3149, who chose the server-assisted validation direction and steered the scope; this is the first, ships-regardless increment.
> Context: the NeoWiki codebase, the validation-sync design doc, and web research on client/server validation UX.
> <sub>Written by Claude Code, `Fable 5`</sub>

Aligns three points where the frontend and backend validators had drifted, moving the authoritative rule into PHP (or aligning a default) so a schema validates identically on both sides.

- **minLength/maxLength on the text Property Type.** `TextProperty` gains the two nullable fields (parsed and serialized like `NumberProperty`'s bounds); `TextType` emits per-part `min-length`/`max-length` violations mirroring the TypeScript validator. Empty parts are skipped on both sides, matching the frontend's empties-filtered behaviour.
- **uniqueItems default.** The frontend deserialization default is aligned to `false`, matching the backend and `docs/reference/schema-format.md`. Null length bounds emitted by the backend serializer are coerced to `undefined` on deserialization so they are never mistaken for a real bound (otherwise a `null` `maxLength` would spuriously flag every value in the editor).
- **Property name trimming.** The backend `PropertyName` now trims and rejects whitespace-only names, matching the frontend.

Existing schema-serialization fixtures are updated for the two new text keys.

This is step 1 of a staged validation-sync effort; it is independently valuable as a set of drift bug-fixes and does not depend on the later steps.

## Manual Browser Check

The Validation Demo schema is extended (in this branch) to exercise the new rules. After `make load-test-data` and `make ts-build`:

1. Open the **Validation Demo** subject and edit it.
2. In a text field with a min/max length, type a too-short then a too-long value — confirm `Minimum length is N characters` / `Maximum length is N characters` appear inline as you type, and clear when the value is valid.
3. Confirm a text/url field *without* `uniqueItems` no longer flags duplicate entries live (default is now off, matching the backend).
4. Confirm no spurious "Maximum length is null characters" error ever appears on a property that has no max length.

🤖 Generated with [Claude Code](https://claude.com/claude-code)