### PR TITLE
Add server-driven subject validation alongside the editor

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -147,6 +147,10 @@
 			"description": "Whether write endpoints reject edits that introduce new constraint violations. When false, violations are surfaced in responses but writes always persist.",
 			"value": false
 		},
+		"NeoWikiValidationDebounceMs": {
+			"description": "Debounce delay in milliseconds before the subject editor sends a server-side dry-run validation request. 0 disables the timer, so validation only runs on blur or pre-save.",
+			"value": 300
+		},
 		"NeoWikiQueryLimits": {
 			"description": "Per-tier per-query resource caps. Keys: 'default' (users without apihighlimits) and 'expensive' (users with apihighlimits). Each value: { timeoutSeconds, maxRows }.",
 			"value": {

--- a/extension.json
+++ b/extension.json
@@ -362,6 +362,7 @@
 				"neowiki-field-single-value-only",
 				"neowiki-field-type-mismatch",
 				"neowiki-field-schema-not-found",
+				"neowiki-field-label-required",
 				"neowiki-select-placeholder",
 				"neowiki-select-no-results",
 				"neowiki-select-unknown-option",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -72,6 +72,7 @@
 	"neowiki-field-single-value-only": "Only one value can be selected.",
 	"neowiki-field-type-mismatch": "This value was saved as type \"$1\" but the property now expects \"$2\".",
 	"neowiki-field-schema-not-found": "The schema \"$1\" is missing. Restore it before saving.",
+	"neowiki-field-label-required": "Please provide a label for the subject.",
 	"neowiki-select-placeholder": "Select an option",
 	"neowiki-select-no-results": "No matching options.",
 	"neowiki-select-unknown-option": "(unknown option)",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -155,6 +155,7 @@
 	"neowiki-field-schema-not-found": "Form-level error shown when the backend reports the Subject's Schema page is missing. $1 is the schema name.",
 	"neowiki-field-min-length": "Validation error shown when a text value is shorter than the property's minimum length. $1 is the minimum number of characters.",
 	"neowiki-field-max-length": "Validation error shown when a text value is longer than the property's maximum length. $1 is the maximum number of characters.",
+	"neowiki-field-label-required": "Form-level error shown when the backend reports the Subject is missing its required display label.",
 	"neowiki-select-placeholder": "Placeholder text shown in the select dropdown before any option is chosen.",
 	"neowiki-select-no-results": "Message shown in the multi-select dropdown when the typed text does not match any available option.",
 	"neowiki-field-invalid-datetime": "Validation error shown when the entered date and time value cannot be parsed. DateTime values must be strict ISO 8601 / xsd:dateTime strings with an explicit timezone offset or 'Z' (for example, '2025-06-15T12:00:00Z' or '2025-06-15T12:00:00+02:00'). Partial values such as year-only or date-only are rejected, and min/max bounds are inclusive.",

--- a/resources/ext.neowiki/src/NeoWikiExtension.ts
+++ b/resources/ext.neowiki/src/NeoWikiExtension.ts
@@ -255,6 +255,11 @@ export class NeoWikiExtension {
 		return Neo.getInstance();
 	}
 
+	public getValidationDebounceMs(): number {
+		const value = mw.config.get( 'wgNeoWikiValidationDebounceMs' );
+		return typeof value === 'number' ? value : 300;
+	}
+
 	public newSubjectValidator(): SubjectValidator {
 		return new SubjectValidator(
 			this.getPropertyTypeRegistry(),

--- a/resources/ext.neowiki/src/components/SchemaCreator/SchemaCreator.vue
+++ b/resources/ext.neowiki/src/components/SchemaCreator/SchemaCreator.vue
@@ -91,17 +91,15 @@ function onNameInput(): void {
 }
 
 async function checkDuplicateName( name: string, expectedSequence: number ): Promise<void> {
-	try {
-		await schemaStore.getOrFetchSchema( name );
+	const exists = await schemaStore.schemaNameExists( name );
 
-		if ( expectedSequence !== requestSequence ) {
-			return;
-		}
+	if ( expectedSequence !== requestSequence ) {
+		return;
+	}
 
+	if ( exists ) {
 		nameError.value = mw.msg( 'neowiki-schema-creator-name-taken' );
 		nameStatus.value = 'error';
-	} catch {
-		// Schema not found — name is available
 	}
 }
 
@@ -124,15 +122,13 @@ async function validate(): Promise<boolean> {
 		return false;
 	}
 
-	try {
-		await schemaStore.getOrFetchSchema( name );
+	if ( await schemaStore.schemaNameExists( name ) ) {
 		nameError.value = mw.msg( 'neowiki-schema-creator-name-taken' );
 		nameStatus.value = 'error';
 		return false;
-	} catch {
-		// Schema not found — name is available
-		return true;
 	}
+
+	return true;
 }
 
 function getSchema(): Schema | null {

--- a/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
@@ -83,7 +83,8 @@
 				<CdxTextInput
 					v-model="subjectLabel"
 					:placeholder="$i18n( 'neowiki-subject-creator-label-placeholder' ).text()"
-					@input="markChanged"
+					@input="handleEditorChange"
+					@blur="handleEditorBlur"
 				/>
 				<template #label>
 					{{ $i18n( 'neowiki-subject-creator-label-field' ).text() }}
@@ -110,7 +111,8 @@
 				:statements="statements"
 				:schema="loadedSchema as Schema"
 				:server-violations="serverViolations"
-				@change="markChanged"
+				@change="handleEditorChange"
+				@focusout="handleEditorBlur"
 				@clear-server-violation="handleClearViolation"
 			/>
 		</template>
@@ -180,6 +182,8 @@ import SchemaAbandonmentDialog from '@/components/SubjectCreator/SchemaAbandonme
 import { useSchemaPermissions } from '@/composables/useSchemaPermissions.ts';
 import { useChangeDetection } from '@/composables/useChangeDetection.ts';
 import { useCloseConfirmation } from '@/composables/useCloseConfirmation.ts';
+import { useSubjectValidation } from '@/composables/useSubjectValidation.ts';
+import { NeoWikiExtension } from '@/NeoWikiExtension.ts';
 import { setPendingNotification } from '@/presentation/PendingNotification.ts';
 
 const props = defineProps<{
@@ -249,7 +253,45 @@ interface SubjectEditorInstance {
 
 const subjectEditorRef = ref<SubjectEditorInstance | null>( null );
 
-const serverViolations = ref<SubjectViolation[]>( [] );
+const { violations: serverViolations, revalidate, flush, reset } = useSubjectValidation(
+	async () => {
+		if ( !subjectEditorRef.value || !selectedSchemaName.value ) {
+			return [];
+		}
+		const statements = [ ...subjectEditorRef.value.getSubjectData() ].filter( ( s ) => s.hasValue() );
+		try {
+			return await subjectStore.validateSubject(
+				subjectLabel.value.trim(),
+				selectedSchemaName.value,
+				new StatementList( statements )
+			);
+		} catch ( error ) {
+			// The dry-run runs alongside the live validators and must never
+			// break editing or saving; the authoritative result is the save's
+			// own 422 response.
+			console.error( 'Subject validation dry-run failed:', error );
+			return [];
+		}
+	},
+	{ debounceMs: NeoWikiExtension.getInstance().getValidationDebounceMs() }
+);
+
+let dirtySinceValidation = false;
+
+function handleEditorChange(): void {
+	markChanged();
+	dirtySinceValidation = true;
+	revalidate();
+}
+
+function handleEditorBlur(): void {
+	// focusout bubbles on every field-to-field move; only flush when something
+	// actually changed since the last validation, to avoid redundant requests.
+	if ( dirtySinceValidation ) {
+		dirtySinceValidation = false;
+		flush();
+	}
+}
 
 const anchorlessViolations = computed<SubjectViolation[]>( () => {
 	// SubjectEditor renders one field per entry in `statements`, which the
@@ -366,7 +408,7 @@ const statements = computed( (): StatementList | null =>
 
 watch( () => subjectStore.subjectCreatorOpen, async ( isOpen ) => {
 	if ( isOpen ) {
-		serverViolations.value = [];
+		reset();
 		await nextTick();
 		focusInitialInput( selectedSchemaOption.value );
 	} else {
@@ -410,7 +452,7 @@ const handleSave = async ( summary: string ): Promise<void> => {
 		return;
 	}
 
-	serverViolations.value = [];
+	await flush();
 
 	try {
 		if ( draftSchema.value ) {

--- a/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
@@ -255,7 +255,9 @@ const subjectEditorRef = ref<SubjectEditorInstance | null>( null );
 
 const { violations: serverViolations, revalidate, flush, reset } = useSubjectValidation(
 	async () => {
-		if ( !subjectEditorRef.value || !selectedSchemaName.value ) {
+		// A draft (unsaved) schema does not exist server-side yet, so a dry-run
+		// against it would only 404. Skip until the schema is saved.
+		if ( !subjectEditorRef.value || !selectedSchemaName.value || hasDraftSchema.value ) {
 			return [];
 		}
 		const statements = [ ...subjectEditorRef.value.getSubjectData() ].filter( ( s ) => s.hasValue() );

--- a/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
@@ -169,7 +169,7 @@ import { useSubjectStore } from '@/stores/SubjectStore.ts';
 import { useSchemaStore } from '@/stores/SchemaStore.ts';
 import { Schema } from '@/domain/Schema.ts';
 import { StatementList } from '@/domain/StatementList.ts';
-import { withoutRequiredViolations, type SubjectViolation } from '@/domain/SubjectViolation';
+import { withoutMissingValueViolations, type SubjectViolation } from '@/domain/SubjectViolation';
 import { ValidationFailedError } from '@/persistence/ValidationFailedError';
 import { CdxMessage } from '@wikimedia/codex';
 import SubjectEditor from '@/components/SubjectEditor/SubjectEditor.vue';
@@ -267,7 +267,7 @@ const { violations: serverViolations, revalidate, flush, reset } = useSubjectVal
 				selectedSchemaName.value,
 				new StatementList( statements )
 			);
-			return withoutRequiredViolations( violations );
+			return withoutMissingValueViolations( violations );
 		} catch ( error ) {
 			// The dry-run runs alongside the live validators and must never
 			// break editing or saving; the authoritative result is the save's

--- a/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
@@ -169,7 +169,7 @@ import { useSubjectStore } from '@/stores/SubjectStore.ts';
 import { useSchemaStore } from '@/stores/SchemaStore.ts';
 import { Schema } from '@/domain/Schema.ts';
 import { StatementList } from '@/domain/StatementList.ts';
-import type { SubjectViolation } from '@/domain/SubjectViolation';
+import { withoutRequiredViolations, type SubjectViolation } from '@/domain/SubjectViolation';
 import { ValidationFailedError } from '@/persistence/ValidationFailedError';
 import { CdxMessage } from '@wikimedia/codex';
 import SubjectEditor from '@/components/SubjectEditor/SubjectEditor.vue';
@@ -260,11 +260,12 @@ const { violations: serverViolations, revalidate, flush, reset } = useSubjectVal
 		}
 		const statements = [ ...subjectEditorRef.value.getSubjectData() ].filter( ( s ) => s.hasValue() );
 		try {
-			return await subjectStore.validateSubject(
+			const violations = await subjectStore.validateSubject(
 				subjectLabel.value.trim(),
 				selectedSchemaName.value,
 				new StatementList( statements )
 			);
+			return withoutRequiredViolations( violations );
 		} catch ( error ) {
 			// The dry-run runs alongside the live validators and must never
 			// break editing or saving; the authoritative result is the save's

--- a/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditorDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditorDialog.vue
@@ -124,7 +124,7 @@ import { useCloseConfirmation } from '@/composables/useCloseConfirmation.ts';
 import { useSubjectValidation } from '@/composables/useSubjectValidation.ts';
 import { NeoWikiExtension } from '@/NeoWikiExtension.ts';
 import { ValidationFailedError } from '@/persistence/ValidationFailedError';
-import { withoutRequiredViolations, type SubjectViolation } from '@/domain/SubjectViolation';
+import type { SubjectViolation } from '@/domain/SubjectViolation';
 
 type SubjectSaveHandler = ( subject: Subject, comment: string ) => Promise<void>;
 
@@ -157,12 +157,14 @@ const { violations: serverViolations, revalidate, flush, reset } = useSubjectVal
 		}
 		const statements = [ ...subjectEditorRef.value.getSubjectData() ].filter( ( s ) => s.hasValue() );
 		try {
-			const violations = await subjectStore.validateSubjectUpdate(
+			// Unlike subject creation, editing an existing subject surfaces
+			// 'required' live: an empty required field here is a real gap, not a
+			// field the user is still on their way to filling in.
+			return await subjectStore.validateSubjectUpdate(
 				props.subject.getId(),
 				props.subject.getLabel(),
 				new StatementList( statements )
 			);
-			return withoutRequiredViolations( violations );
 		} catch ( error ) {
 			// The dry-run runs alongside the live validators and must never
 			// break editing or saving; the authoritative result is the save's

--- a/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditorDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditorDialog.vue
@@ -124,7 +124,7 @@ import { useCloseConfirmation } from '@/composables/useCloseConfirmation.ts';
 import { useSubjectValidation } from '@/composables/useSubjectValidation.ts';
 import { NeoWikiExtension } from '@/NeoWikiExtension.ts';
 import { ValidationFailedError } from '@/persistence/ValidationFailedError';
-import type { SubjectViolation } from '@/domain/SubjectViolation';
+import { withoutRequiredViolations, type SubjectViolation } from '@/domain/SubjectViolation';
 
 type SubjectSaveHandler = ( subject: Subject, comment: string ) => Promise<void>;
 
@@ -157,11 +157,12 @@ const { violations: serverViolations, revalidate, flush, reset } = useSubjectVal
 		}
 		const statements = [ ...subjectEditorRef.value.getSubjectData() ].filter( ( s ) => s.hasValue() );
 		try {
-			return await subjectStore.validateSubjectUpdate(
+			const violations = await subjectStore.validateSubjectUpdate(
 				props.subject.getId(),
 				props.subject.getLabel(),
 				new StatementList( statements )
 			);
+			return withoutRequiredViolations( violations );
 		} catch ( error ) {
 			// The dry-run runs alongside the live validators and must never
 			// break editing or saving; the authoritative result is the save's

--- a/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditorDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditorDialog.vue
@@ -67,7 +67,8 @@
 				:statements="statements"
 				:schema="loadedSchema as Schema"
 				:server-violations="serverViolations"
-				@change="markChanged"
+				@change="handleEditorChange"
+				@focusout="handleEditorBlur"
 				@clear-server-violation="handleClearViolation"
 			/>
 			<div v-else>
@@ -112,6 +113,7 @@ import { cdxIconClose } from '@wikimedia/codex-icons';
 import { StatementList } from '@/domain/StatementList.ts';
 import { Subject } from '@/domain/Subject.ts';
 import { useSchemaStore } from '@/stores/SchemaStore.ts';
+import { useSubjectStore } from '@/stores/SubjectStore.ts';
 import { Schema } from '@/domain/Schema.ts';
 import SchemaEditorDialog from '@/components/SchemaEditor/SchemaEditorDialog.vue';
 import type { SchemaSaveHandler } from '@/components/SchemaEditor/SchemaEditorDialog.vue';
@@ -119,6 +121,8 @@ import CloseConfirmationDialog from '@/components/common/CloseConfirmationDialog
 import { useSchemaPermissions } from '@/composables/useSchemaPermissions.ts';
 import { useChangeDetection } from '@/composables/useChangeDetection.ts';
 import { useCloseConfirmation } from '@/composables/useCloseConfirmation.ts';
+import { useSubjectValidation } from '@/composables/useSubjectValidation.ts';
+import { NeoWikiExtension } from '@/NeoWikiExtension.ts';
 import { ValidationFailedError } from '@/persistence/ValidationFailedError';
 import type { SubjectViolation } from '@/domain/SubjectViolation';
 
@@ -134,6 +138,7 @@ const props = defineProps<{
 const emit = defineEmits( [ 'update:open' ] );
 
 const schemaStore = useSchemaStore();
+const subjectStore = useSubjectStore();
 
 interface SubjectEditorInstance {
 	getSubjectData: () => StatementList;
@@ -145,7 +150,45 @@ const loadedSchema = ref<Schema | null>( null );
 const { canEditSchema, checkEditPermission } = useSchemaPermissions();
 const { hasChanged, markChanged, resetChanged } = useChangeDetection();
 
-const serverViolations = ref<SubjectViolation[]>( [] );
+const { violations: serverViolations, revalidate, flush, reset } = useSubjectValidation(
+	async () => {
+		if ( !subjectEditorRef.value ) {
+			return [];
+		}
+		const statements = [ ...subjectEditorRef.value.getSubjectData() ].filter( ( s ) => s.hasValue() );
+		try {
+			return await subjectStore.validateSubjectUpdate(
+				props.subject.getId(),
+				props.subject.getLabel(),
+				new StatementList( statements )
+			);
+		} catch ( error ) {
+			// The dry-run runs alongside the live validators and must never
+			// break editing or saving; the authoritative result is the save's
+			// own 422 response.
+			console.error( 'Subject validation dry-run failed:', error );
+			return [];
+		}
+	},
+	{ debounceMs: NeoWikiExtension.getInstance().getValidationDebounceMs() }
+);
+
+let dirtySinceValidation = false;
+
+function handleEditorChange(): void {
+	markChanged();
+	dirtySinceValidation = true;
+	revalidate();
+}
+
+function handleEditorBlur(): void {
+	// focusout bubbles on every field-to-field move; only flush when something
+	// actually changed since the last validation, to avoid redundant requests.
+	if ( dirtySinceValidation ) {
+		dirtySinceValidation = false;
+		flush();
+	}
+}
 
 const anchorlessViolations = computed<SubjectViolation[]>( () => {
 	// SubjectEditor renders one field per entry in `statements`, which the
@@ -189,7 +232,7 @@ function onDialogUpdateOpen( value: boolean ): void {
 watch( () => props.open, ( isOpen ) => {
 	if ( isOpen ) {
 		resetChanged();
-		serverViolations.value = [];
+		reset();
 	}
 } );
 
@@ -223,7 +266,7 @@ const handleSave = async ( summary: string ): Promise<void> => {
 		return;
 	}
 
-	serverViolations.value = [];
+	await flush();
 
 	const updatedStatements = subjectEditorRef.value.getSubjectData();
 	// Filter out statements that don't have a value set.

--- a/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditorDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditorDialog.vue
@@ -239,6 +239,16 @@ watch( () => props.open, ( isOpen ) => {
 	}
 } );
 
+// Existing subjects are expected to be complete, so validate as soon as the
+// editor mounts for an open dialog: pre-existing violations (e.g. a now-empty
+// required field) surface immediately, without the user having to touch a field
+// first. (Subject creation deliberately does not do this — see the creator.)
+watch( subjectEditorRef, ( editor ) => {
+	if ( editor && props.open ) {
+		flush();
+	}
+} );
+
 watch( () => props.subject, async ( newSubject ) => {
 	if ( newSubject ) {
 		await checkEditPermission( newSubject.getSchemaName() );

--- a/resources/ext.neowiki/src/components/Value/SelectInput.vue
+++ b/resources/ext.neowiki/src/components/Value/SelectInput.vue
@@ -131,7 +131,10 @@ function validate(): void {
 	const value = selection.value.length > 0 ?
 		newStringValue( selection.value ) :
 		undefined;
-	const errors = propertyType.validate( value, props.property );
+	// 'required' is deferred to the server (surfaced at save) like every other
+	// input; we do not flag an empty select before the user has chosen a value.
+	const errors = propertyType.validate( value, props.property )
+		.filter( ( e ) => e.code !== 'required' );
 	liveValidationError.value = errors.length === 0 ? null :
 		mw.message( `neowiki-field-${ errors[ 0 ].code }`, ...( errors[ 0 ].args ?? [] ) ).text();
 }

--- a/resources/ext.neowiki/src/composables/useSubjectValidation.ts
+++ b/resources/ext.neowiki/src/composables/useSubjectValidation.ts
@@ -1,0 +1,69 @@
+import { ref, onScopeDispose, type Ref } from 'vue';
+import { SubjectViolation } from '@/domain/SubjectViolation.ts';
+
+export type SubjectValidator = () => Promise<SubjectViolation[]>;
+
+export interface UseSubjectValidationOptions {
+	debounceMs: number;
+}
+
+export interface UseSubjectValidation {
+	violations: Ref<SubjectViolation[]>;
+	revalidate: () => void;
+	flush: () => Promise<void>;
+	reset: () => void;
+}
+
+export function useSubjectValidation(
+	validate: SubjectValidator,
+	options: UseSubjectValidationOptions,
+): UseSubjectValidation {
+	const violations = ref<SubjectViolation[]>( [] );
+	let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+	let requestSequence = 0;
+
+	function clearTimer(): void {
+		if ( debounceTimer !== null ) {
+			clearTimeout( debounceTimer );
+			debounceTimer = null;
+		}
+	}
+
+	async function run( expectedSequence: number ): Promise<void> {
+		const result = await validate();
+		if ( expectedSequence !== requestSequence ) {
+			return;
+		}
+		violations.value = result;
+	}
+
+	function revalidate(): void {
+		clearTimer();
+		requestSequence++;
+		const expectedSequence = requestSequence;
+
+		if ( options.debounceMs <= 0 ) {
+			run( expectedSequence );
+			return;
+		}
+		debounceTimer = setTimeout( () => run( expectedSequence ), options.debounceMs );
+	}
+
+	async function flush(): Promise<void> {
+		clearTimer();
+		requestSequence++;
+		await run( requestSequence );
+	}
+
+	function reset(): void {
+		clearTimer();
+		requestSequence++;
+		violations.value = [];
+	}
+
+	// Discard any pending debounce when the owning component/scope is torn down,
+	// so a closed dialog never fires a stray validation request.
+	onScopeDispose( clearTimer );
+
+	return { violations, revalidate, flush, reset };
+}

--- a/resources/ext.neowiki/src/composables/useSubjectValidation.ts
+++ b/resources/ext.neowiki/src/composables/useSubjectValidation.ts
@@ -30,7 +30,14 @@ export function useSubjectValidation(
 	}
 
 	async function run( expectedSequence: number ): Promise<void> {
-		const result = await validate();
+		let result: SubjectViolation[];
+		try {
+			result = await validate();
+		} catch {
+			// A failing validator must never break editing/saving or surface as an
+			// unhandled rejection; keep the last-known violations in place.
+			return;
+		}
 		if ( expectedSequence !== requestSequence ) {
 			return;
 		}

--- a/resources/ext.neowiki/src/composables/useSubjectValidation.ts
+++ b/resources/ext.neowiki/src/composables/useSubjectValidation.ts
@@ -45,14 +45,16 @@ export function useSubjectValidation(
 	}
 
 	function revalidate(): void {
+		if ( options.debounceMs <= 0 ) {
+			// Blur-only mode: validation runs only on flush() (blur / pre-save),
+			// never on input — so a zero debounce cuts traffic instead of firing
+			// a dry-run on every keystroke.
+			return;
+		}
+
 		clearTimer();
 		requestSequence++;
 		const expectedSequence = requestSequence;
-
-		if ( options.debounceMs <= 0 ) {
-			run( expectedSequence );
-			return;
-		}
 		debounceTimer = setTimeout( () => run( expectedSequence ), options.debounceMs );
 	}
 

--- a/resources/ext.neowiki/src/domain/SubjectRepository.ts
+++ b/resources/ext.neowiki/src/domain/SubjectRepository.ts
@@ -5,6 +5,7 @@ import type { StatementList } from '@/domain/StatementList';
 import type { SchemaName } from '@/domain/Schema';
 import { PageSubjects } from '@/domain/PageSubjects';
 import type { DeserializedPageSubjects } from '@/persistence/PageSubjectsDeserializer';
+import type { SubjectViolation } from '@/domain/SubjectViolation';
 
 export interface SubjectRepository extends SubjectLookup {
 
@@ -39,6 +40,10 @@ export interface SubjectRepository extends SubjectLookup {
 	updateSubject( id: SubjectId, label: string, statements: StatementList, comment?: string ): Promise<object>;
 
 	deleteSubject( id: SubjectId, comment?: string ): Promise<boolean>;
+
+	validateSubject( label: string, schemaName: SchemaName, statements: StatementList ): Promise<SubjectViolation[]>;
+
+	validateSubjectUpdate( id: SubjectId, label: string, statements: StatementList ): Promise<SubjectViolation[]>;
 
 }
 
@@ -79,6 +84,14 @@ export class StubSubjectRepository extends InMemorySubjectLookup implements Subj
 
 	public deleteSubject( id: SubjectId, _comment?: string ): Promise<boolean> {
 		return Promise.resolve( this.subjects.delete( id.text ) );
+	}
+
+	public validateSubject( _label: string, _schemaName: SchemaName, _statements: StatementList ): Promise<SubjectViolation[]> {
+		return Promise.resolve( [] );
+	}
+
+	public validateSubjectUpdate( _id: SubjectId, _label: string, _statements: StatementList ): Promise<SubjectViolation[]> {
+		return Promise.resolve( [] );
 	}
 
 }

--- a/resources/ext.neowiki/src/domain/SubjectViolation.ts
+++ b/resources/ext.neowiki/src/domain/SubjectViolation.ts
@@ -19,3 +19,19 @@ export interface SubjectViolation {
 	readonly args: readonly unknown[];
 	readonly valuePartIndex: number | null;
 }
+
+/**
+ * 'required' violations flag fields the user has not filled in yet. Surfacing
+ * them while the user is still editing nags about a mistake not yet made, so
+ * they are withheld from the live dry-run. An empty required field is still
+ * caught at save when backend enforcement is on (the 422 response); with
+ * enforcement off (the current default) required is not yet surfaced in the
+ * editor — a non-enforcing "warning" surface is future work. Every other
+ * violation needs a value to occur, so the field was necessarily touched —
+ * those stay visible live.
+ */
+export function withoutRequiredViolations(
+	violations: readonly SubjectViolation[],
+): SubjectViolation[] {
+	return violations.filter( ( v ) => v.code !== 'required' );
+}

--- a/resources/ext.neowiki/src/domain/SubjectViolation.ts
+++ b/resources/ext.neowiki/src/domain/SubjectViolation.ts
@@ -21,14 +21,13 @@ export interface SubjectViolation {
 }
 
 /**
- * 'required' violations flag fields the user has not filled in yet. Surfacing
- * them while the user is still editing nags about a mistake not yet made, so
- * they are withheld from the live dry-run. An empty required field is still
- * caught at save when backend enforcement is on (the 422 response); with
- * enforcement off (the current default) required is not yet surfaced in the
- * editor — a non-enforcing "warning" surface is future work. Every other
- * violation needs a value to occur, so the field was necessarily touched —
- * those stay visible live.
+ * Withholds 'required' violations from the live dry-run while *creating* a
+ * subject: every required field starts empty and the user is on their way to
+ * filling them in, so flagging them mid-creation nags about a mistake not yet
+ * made. Editing an existing subject surfaces 'required' normally — there an
+ * empty required field is a real gap, not a field still being filled in. Every
+ * other violation needs a value to occur, so the field was necessarily touched;
+ * those always show live.
  */
 export function withoutRequiredViolations(
 	violations: readonly SubjectViolation[],

--- a/resources/ext.neowiki/src/domain/SubjectViolation.ts
+++ b/resources/ext.neowiki/src/domain/SubjectViolation.ts
@@ -1,9 +1,9 @@
 /**
  * Frontend mirror of the backend's Violation wire shape (see
- * src/Domain/Validation/Violation.php). Constructed when the REST
- * persistence layer deserialises a 422 response body. Not produced by
- * frontend code — the live per-input ValueValidationError type covers
- * that path.
+ * src/Domain/Validation/Violation.php). Read from the backend by the
+ * persistence layer — either deserialising a 422 response body on save, or
+ * the dry-run validate endpoints' 200 body. The live per-input
+ * ValueValidationError type covers client-side validation.
  *
  * propertyName === null is used for subject-level violations such as
  * 'schema-not-found' that don't anchor to a specific field.

--- a/resources/ext.neowiki/src/domain/SubjectViolation.ts
+++ b/resources/ext.neowiki/src/domain/SubjectViolation.ts
@@ -21,16 +21,23 @@ export interface SubjectViolation {
 }
 
 /**
- * Withholds 'required' violations from the live dry-run while *creating* a
- * subject: every required field starts empty and the user is on their way to
- * filling them in, so flagging them mid-creation nags about a mistake not yet
- * made. Editing an existing subject surfaces 'required' normally — there an
+ * Codes for violations that fire only because a field (or the subject label)
+ * has not been filled in yet. They are the only violations that can occur on a
+ * field the user has not touched.
+ */
+const MISSING_VALUE_CODES: ReadonlySet<string> = new Set( [ 'required', 'label-required' ] );
+
+/**
+ * Withholds "you have not filled this in yet" violations from the live dry-run
+ * while *creating* a subject: every field starts empty and the user is on their
+ * way to filling them in, so flagging them mid-creation nags about a mistake
+ * not yet made. Editing an existing subject surfaces them normally — there an
  * empty required field is a real gap, not a field still being filled in. Every
  * other violation needs a value to occur, so the field was necessarily touched;
  * those always show live.
  */
-export function withoutRequiredViolations(
+export function withoutMissingValueViolations(
 	violations: readonly SubjectViolation[],
 ): SubjectViolation[] {
-	return violations.filter( ( v ) => v.code !== 'required' );
+	return violations.filter( ( v ) => !MISSING_VALUE_CODES.has( v.code ) );
 }

--- a/resources/ext.neowiki/src/persistence/RestSubjectRepository.ts
+++ b/resources/ext.neowiki/src/persistence/RestSubjectRepository.ts
@@ -12,41 +12,7 @@ import type { HttpClient } from '@/infrastructure/HttpClient/HttpClient';
 import type { Subject } from '@/domain/Subject';
 import type { SubjectViolation } from '@/domain/SubjectViolation';
 import { ValidationFailedError } from '@/persistence/ValidationFailedError';
-
-function isShapedAsViolation( raw: unknown ): raw is SubjectViolation {
-	if ( typeof raw !== 'object' || raw === null ) {
-		return false;
-	}
-	const v = raw as Record<string, unknown>;
-
-	const propertyNameOk = v.propertyName === null || typeof v.propertyName === 'string';
-	const codeOk = typeof v.code === 'string' && v.code.length > 0;
-	const argsOk = v.args === undefined || Array.isArray( v.args );
-	const indexOk = v.valuePartIndex === undefined ||
-		v.valuePartIndex === null ||
-		typeof v.valuePartIndex === 'number';
-
-	return propertyNameOk && codeOk && argsOk && indexOk;
-}
-
-function parseViolations( body: unknown ): SubjectViolation[] | null {
-	if ( typeof body !== 'object' || body === null ) {
-		return null;
-	}
-	const violations = ( body as { violations?: unknown } ).violations;
-	if ( !Array.isArray( violations ) ) {
-		return null;
-	}
-	if ( !violations.every( isShapedAsViolation ) ) {
-		return null;
-	}
-	return violations.map( ( v ) => ( {
-		propertyName: v.propertyName,
-		code: v.code,
-		args: v.args ?? [],
-		valuePartIndex: v.valuePartIndex ?? null,
-	} ) );
-}
+import { parseViolations } from '@/persistence/violationParsing';
 
 async function throwOn422IfPossible( response: Response ): Promise<void> {
 	if ( response.status !== 422 ) {
@@ -280,6 +246,45 @@ export class RestSubjectRepository implements SubjectRepository {
 		}
 
 		return true;
+	}
+
+	public async validateSubject(
+		label: string,
+		schemaName: SchemaName,
+		statements: StatementList,
+	): Promise<SubjectViolation[]> {
+		return this.runValidation(
+			`${ this.mediaWikiRestApiUrl }/neowiki/v0/subject/validate`,
+			{ schema: schemaName, label, statements: statementsToJson( statements ) },
+		);
+	}
+
+	public async validateSubjectUpdate(
+		id: SubjectId,
+		label: string,
+		statements: StatementList,
+	): Promise<SubjectViolation[]> {
+		return this.runValidation(
+			`${ this.mediaWikiRestApiUrl }/neowiki/v0/subject/${ id.text }/validate`,
+			{ label, statements: statementsToJson( statements ) },
+		);
+	}
+
+	private async runValidation( url: string, payload: Record<string, unknown> ): Promise<SubjectViolation[]> {
+		let response: Response;
+		try {
+			response = await this.httpClient.post( url, payload, { headers: { 'Content-Type': 'application/json' } } );
+		} catch {
+			// 400/404 (malformed input / missing schema) reject in ProductionHttpClient — no live feedback, fall back silently.
+			return [];
+		}
+
+		if ( !response.ok ) {
+			return [];
+		}
+
+		const violations = parseViolations( await response.json() );
+		return violations ?? [];
 	}
 
 }

--- a/resources/ext.neowiki/src/persistence/violationParsing.ts
+++ b/resources/ext.neowiki/src/persistence/violationParsing.ts
@@ -1,0 +1,36 @@
+import type { SubjectViolation } from '@/domain/SubjectViolation';
+
+export function isShapedAsViolation( raw: unknown ): raw is SubjectViolation {
+	if ( typeof raw !== 'object' || raw === null ) {
+		return false;
+	}
+	const v = raw as Record<string, unknown>;
+
+	const propertyNameOk = v.propertyName === null || typeof v.propertyName === 'string';
+	const codeOk = typeof v.code === 'string' && v.code.length > 0;
+	const argsOk = v.args === undefined || Array.isArray( v.args );
+	const indexOk = v.valuePartIndex === undefined ||
+		v.valuePartIndex === null ||
+		typeof v.valuePartIndex === 'number';
+
+	return propertyNameOk && codeOk && argsOk && indexOk;
+}
+
+export function parseViolations( body: unknown ): SubjectViolation[] | null {
+	if ( typeof body !== 'object' || body === null ) {
+		return null;
+	}
+	const violations = ( body as { violations?: unknown } ).violations;
+	if ( !Array.isArray( violations ) ) {
+		return null;
+	}
+	if ( !violations.every( isShapedAsViolation ) ) {
+		return null;
+	}
+	return violations.map( ( v ) => ( {
+		propertyName: v.propertyName,
+		code: v.code,
+		args: v.args ?? [],
+		valuePartIndex: v.valuePartIndex ?? null,
+	} ) );
+}

--- a/resources/ext.neowiki/src/stores/SchemaStore.ts
+++ b/resources/ext.neowiki/src/stores/SchemaStore.ts
@@ -36,6 +36,13 @@ export const useSchemaStore = defineStore( 'schema', {
 			await Promise.all( schemaNames.map( ( name ) => this.getOrFetchSchema( name ) ) );
 			return schemaNames;
 		},
+		// Checks existence via the schema-names search (a 200 response) rather
+		// than getOrFetchSchema, which 404s for a missing name — those 404s are
+		// avoidable console/network noise when checking a not-yet-created name.
+		async schemaNameExists( name: string ): Promise<boolean> {
+			const matches = await NeoWikiExtension.getInstance().getSchemaRepository().getSchemaNames( name );
+			return matches.includes( name );
+		},
 		async saveSchema( schema: Schema, comment?: string ): Promise<void> {
 			await NeoWikiExtension.getInstance().getSchemaRepository().saveSchema( schema, comment );
 			this.setSchema( schema.getName(), schema );

--- a/resources/ext.neowiki/src/stores/SchemaStore.ts
+++ b/resources/ext.neowiki/src/stores/SchemaStore.ts
@@ -2,6 +2,17 @@ import { defineStore } from 'pinia';
 import { Schema } from '@/domain/Schema.ts';
 import { NeoWikiExtension } from '@/NeoWikiExtension.ts';
 
+/**
+ * Approximates MediaWiki title normalisation for a Schema name (schemas are
+ * wiki pages) so a duplicate-name check resolves to the same page a save would:
+ * trims, turns underscores into spaces, collapses runs of whitespace, and
+ * upper-cases the first character. The save remains the authoritative guard.
+ */
+export function normalizeSchemaName( name: string ): string {
+	const collapsed = name.trim().replace( /[\s_]+/g, ' ' );
+	return collapsed.charAt( 0 ).toUpperCase() + collapsed.slice( 1 );
+}
+
 export const useSchemaStore = defineStore( 'schema', {
 	state: () => ( {
 		schemas: new Map<string, Schema>(),
@@ -39,9 +50,12 @@ export const useSchemaStore = defineStore( 'schema', {
 		// Checks existence via the schema-names search (a 200 response) rather
 		// than getOrFetchSchema, which 404s for a missing name — those 404s are
 		// avoidable console/network noise when checking a not-yet-created name.
+		// The name is normalised so e.g. "person" or "Foo_Bar" matches the
+		// existing "Person" / "Foo Bar" the same way a save would.
 		async schemaNameExists( name: string ): Promise<boolean> {
-			const matches = await NeoWikiExtension.getInstance().getSchemaRepository().getSchemaNames( name );
-			return matches.includes( name );
+			const normalized = normalizeSchemaName( name );
+			const matches = await NeoWikiExtension.getInstance().getSchemaRepository().getSchemaNames( normalized );
+			return matches.some( ( match ) => normalizeSchemaName( match ) === normalized );
 		},
 		async saveSchema( schema: Schema, comment?: string ): Promise<void> {
 			await NeoWikiExtension.getInstance().getSchemaRepository().saveSchema( schema, comment );

--- a/resources/ext.neowiki/src/stores/SubjectStore.ts
+++ b/resources/ext.neowiki/src/stores/SubjectStore.ts
@@ -7,6 +7,7 @@ import { StatementList } from '@/domain/StatementList.ts';
 import { PageIdentifiers } from '@/domain/PageIdentifiers.ts';
 import { SubjectWithContext } from '@/domain/SubjectWithContext.ts';
 import { PageSubjects } from '@/domain/PageSubjects.ts';
+import { SubjectViolation } from '@/domain/SubjectViolation.ts';
 import { useSchemaStore } from '@/stores/SchemaStore.ts';
 export const useSubjectStore = defineStore( 'subject', {
 	state: () => ( {
@@ -46,6 +47,12 @@ export const useSubjectStore = defineStore( 'subject', {
 		async deleteSubject( subjectId: SubjectId, comment?: string ): Promise<void> {
 			await NeoWikiExtension.getInstance().getSubjectRepository().deleteSubject( subjectId, comment );
 			this.subjects.delete( subjectId.text );
+		},
+		async validateSubject( label: string, schemaName: SchemaName, statements: StatementList ): Promise<SubjectViolation[]> {
+			return NeoWikiExtension.getInstance().getSubjectRepository().validateSubject( label, schemaName, statements );
+		},
+		async validateSubjectUpdate( id: SubjectId, label: string, statements: StatementList ): Promise<SubjectViolation[]> {
+			return NeoWikiExtension.getInstance().getSubjectRepository().validateSubjectUpdate( id, label, statements );
 		},
 		async createMainSubject( pageId: number, label: string, schemaName: SchemaName, statements: StatementList, comment?: string ): Promise<SubjectId> {
 			const subjectId = await NeoWikiExtension.getInstance().getSubjectRepository().createMainSubject(

--- a/resources/ext.neowiki/tests/components/SchemaCreator/SchemaCreator.spec.ts
+++ b/resources/ext.neowiki/tests/components/SchemaCreator/SchemaCreator.spec.ts
@@ -4,7 +4,6 @@ import { createPinia, setActivePinia } from 'pinia';
 import SchemaCreator from '@/components/SchemaCreator/SchemaCreator.vue';
 import { useSchemaStore } from '@/stores/SchemaStore.ts';
 import { createI18nMock, setupMwMock } from '../../VueTestHelpers.ts';
-import { newSchema } from '@/TestHelpers.ts';
 import { NeoWikiExtension } from '@/NeoWikiExtension.ts';
 import { Service } from '@/NeoWikiServices.ts';
 import { Schema } from '@/domain/Schema.ts';
@@ -75,7 +74,7 @@ describe( 'SchemaCreator', () => {
 		setActivePinia( pinia );
 
 		schemaStore = useSchemaStore();
-		schemaStore.getOrFetchSchema = vi.fn().mockRejectedValue( new Error( 'Not found' ) );
+		schemaStore.schemaNameExists = vi.fn().mockResolvedValue( false );
 	} );
 
 	afterEach( () => {
@@ -118,7 +117,7 @@ describe( 'SchemaCreator', () => {
 	} );
 
 	it( 'shows name-taken error after debounce', async () => {
-		schemaStore.getOrFetchSchema = vi.fn().mockResolvedValue( newSchema( { title: EXISTING_SCHEMA_NAME } ) );
+		schemaStore.schemaNameExists = vi.fn().mockResolvedValue( true );
 
 		const wrapper = mountComponent();
 
@@ -143,16 +142,13 @@ describe( 'SchemaCreator', () => {
 		vi.advanceTimersByTime( DEBOUNCE_DELAY - 1 );
 		await flushPromises();
 
-		expect( schemaStore.getOrFetchSchema ).not.toHaveBeenCalled();
+		expect( schemaStore.schemaNameExists ).not.toHaveBeenCalled();
 	} );
 
 	it( 'cancels pending duplicate check when user types again', async () => {
-		schemaStore.getOrFetchSchema = vi.fn().mockImplementation( ( name: string ) => {
-			if ( name === EXISTING_SCHEMA_NAME ) {
-				return Promise.resolve( newSchema( { title: EXISTING_SCHEMA_NAME } ) );
-			}
-			return Promise.reject( new Error( 'Not found' ) );
-		} );
+		schemaStore.schemaNameExists = vi.fn().mockImplementation(
+			( name: string ) => Promise.resolve( name === EXISTING_SCHEMA_NAME ),
+		);
 
 		const wrapper = mountComponent();
 
@@ -167,15 +163,15 @@ describe( 'SchemaCreator', () => {
 
 		const field = wrapper.findComponent( { name: 'CdxField' } );
 		expect( field.props( 'status' ) ).toBe( 'default' );
-		expect( schemaStore.getOrFetchSchema ).toHaveBeenCalledWith( NEW_SCHEMA_NAME );
-		expect( schemaStore.getOrFetchSchema ).not.toHaveBeenCalledWith( EXISTING_SCHEMA_NAME );
+		expect( schemaStore.schemaNameExists ).toHaveBeenCalledWith( NEW_SCHEMA_NAME );
+		expect( schemaStore.schemaNameExists ).not.toHaveBeenCalledWith( EXISTING_SCHEMA_NAME );
 	} );
 
 	it( 'discards stale duplicate check result when user types during request', async () => {
-		let resolveSchemaPromise: ( value: Schema ) => void;
-		schemaStore.getOrFetchSchema = vi.fn().mockImplementation(
-			() => new Promise<Schema>( ( resolve ) => {
-				resolveSchemaPromise = resolve;
+		let resolveExists: ( value: boolean ) => void;
+		schemaStore.schemaNameExists = vi.fn().mockImplementation(
+			() => new Promise<boolean>( ( resolve ) => {
+				resolveExists = resolve;
 			} ),
 		);
 
@@ -188,7 +184,7 @@ describe( 'SchemaCreator', () => {
 
 		await nameInput.setValue( NEW_SCHEMA_NAME );
 
-		resolveSchemaPromise!( newSchema( { title: EXISTING_SCHEMA_NAME } ) );
+		resolveExists!( true );
 		await flushPromises();
 
 		const field = wrapper.findComponent( { name: 'CdxField' } );
@@ -207,7 +203,7 @@ describe( 'SchemaCreator', () => {
 		} );
 
 		it( 'returns false when name already exists', async () => {
-			schemaStore.getOrFetchSchema = vi.fn().mockResolvedValue( newSchema( { title: EXISTING_SCHEMA_NAME } ) );
+			schemaStore.schemaNameExists = vi.fn().mockResolvedValue( true );
 
 			const wrapper = mountComponent();
 

--- a/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
@@ -1100,5 +1100,20 @@ describe( 'SubjectCreatorDialog', () => {
 			const passed = wrapper.findComponent( SubjectEditor ).props( 'serverViolations' ) as SubjectViolation[];
 			expect( passed ).toEqual( [] );
 		} );
+
+		it( 'does not run the dry-run while the schema is an unsaved draft', async () => {
+			subjectStore.validateSubject = vi.fn().mockResolvedValue( [] );
+			const wrapper = mountComponent();
+			await switchToNewSchema( wrapper );
+			await clickContinue( wrapper );
+
+			await wrapper.findComponent( SubjectEditor ).vm.$emit( 'change' );
+			await wrapper.findComponent( SubjectEditor ).vm.$emit( 'focusout' );
+			await flushPromises();
+
+			// The draft schema does not exist server-side yet, so a dry-run would
+			// only 404; it must wait until the schema is saved.
+			expect( subjectStore.validateSubject ).not.toHaveBeenCalled();
+		} );
 	} );
 } );

--- a/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
@@ -184,7 +184,8 @@ describe( 'SubjectCreatorDialog', () => {
 			config: {
 				wgArticleId: PAGE_ID,
 				wgTitle: PAGE_TITLE,
-				// Debounce 0 makes the dry-run validation run synchronously in tests.
+				// Debounce 0 is blur-only mode: the dry-run fires on blur / pre-save
+				// (via flush()), which runs synchronously in tests.
 				wgNeoWikiValidationDebounceMs: 0,
 			},
 		} );
@@ -1053,12 +1054,13 @@ describe( 'SubjectCreatorDialog', () => {
 			await flushPromises();
 		}
 
-		it( 'surfaces dry-run violations when the editor reports a change', async () => {
+		it( 'surfaces dry-run violations on blur after an edit', async () => {
 			subjectStore.validateSubject = vi.fn().mockResolvedValue( [ dryRunViolation ] );
 			const wrapper = mountComponent();
 			await selectSchema( wrapper );
 
 			await wrapper.findComponent( SubjectEditor ).vm.$emit( 'change' );
+			await wrapper.findComponent( SubjectEditor ).vm.$emit( 'focusout' );
 			await flushPromises();
 
 			expect( subjectStore.validateSubject ).toHaveBeenCalledWith(
@@ -1077,6 +1079,7 @@ describe( 'SubjectCreatorDialog', () => {
 			await selectSchema( wrapper );
 
 			await wrapper.findComponent( SubjectEditor ).vm.$emit( 'change' );
+			await wrapper.findComponent( SubjectEditor ).vm.$emit( 'focusout' );
 			await flushPromises();
 
 			const passed = wrapper.findComponent( SubjectEditor ).props( 'serverViolations' ) as SubjectViolation[];

--- a/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
@@ -1044,8 +1044,8 @@ describe( 'SubjectCreatorDialog', () => {
 	describe( 'Server-driven dry-run validation', () => {
 		const dryRunViolation: SubjectViolation = {
 			propertyName: 'Color',
-			code: 'required',
-			args: [],
+			code: 'max-length',
+			args: [ 5 ],
 			valuePartIndex: null,
 		};
 
@@ -1084,6 +1084,21 @@ describe( 'SubjectCreatorDialog', () => {
 
 			const passed = wrapper.findComponent( SubjectEditor ).props( 'serverViolations' ) as SubjectViolation[];
 			expect( passed ).toHaveLength( 0 );
+		} );
+
+		it( 'does not surface required violations from the dry-run; they wait for save', async () => {
+			subjectStore.validateSubject = vi.fn().mockResolvedValue( [
+				{ propertyName: 'Color', code: 'required', args: [], valuePartIndex: null },
+			] );
+			const wrapper = mountComponent();
+			await selectSchema( wrapper );
+
+			await wrapper.findComponent( SubjectEditor ).vm.$emit( 'change' );
+			await wrapper.findComponent( SubjectEditor ).vm.$emit( 'focusout' );
+			await flushPromises();
+
+			const passed = wrapper.findComponent( SubjectEditor ).props( 'serverViolations' ) as SubjectViolation[];
+			expect( passed ).toEqual( [] );
 		} );
 	} );
 } );

--- a/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
@@ -1086,9 +1086,10 @@ describe( 'SubjectCreatorDialog', () => {
 			expect( passed ).toHaveLength( 0 );
 		} );
 
-		it( 'does not surface required violations from the dry-run; they wait for save', async () => {
+		it( 'does not surface missing-value violations (required, label-required) from the dry-run; they wait for save', async () => {
 			subjectStore.validateSubject = vi.fn().mockResolvedValue( [
 				{ propertyName: 'Color', code: 'required', args: [], valuePartIndex: null },
+				{ propertyName: null, code: 'label-required', args: [], valuePartIndex: null },
 			] );
 			const wrapper = mountComponent();
 			await selectSchema( wrapper );

--- a/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
@@ -184,6 +184,8 @@ describe( 'SubjectCreatorDialog', () => {
 			config: {
 				wgArticleId: PAGE_ID,
 				wgTitle: PAGE_TITLE,
+				// Debounce 0 makes the dry-run validation run synchronously in tests.
+				wgNeoWikiValidationDebounceMs: 0,
 			},
 		} );
 
@@ -193,6 +195,9 @@ describe( 'SubjectCreatorDialog', () => {
 		subjectStore = useSubjectStore();
 		subjectStore.createMainSubject = vi.fn().mockResolvedValue( new SubjectId( 's11111111111111' ) );
 		subjectStore.createChildSubject = vi.fn().mockResolvedValue( new SubjectId( 's11111111111112' ) );
+		// The dry-run validation runs alongside the live validators; stub it so
+		// it does not reach the network and stays out of the way of these tests.
+		subjectStore.validateSubject = vi.fn().mockResolvedValue( [] );
 
 		schemaStore = useSchemaStore();
 		schemaStore.getOrFetchSchema = vi.fn().mockResolvedValue( newSchema( { title: SCHEMA_NAME } ) );
@@ -1032,6 +1037,50 @@ describe( 'SubjectCreatorDialog', () => {
 
 			const after = wrapper.findComponent( SubjectEditor ).props( 'serverViolations' ) as SubjectViolation[];
 			expect( after ).toHaveLength( 0 );
+		} );
+	} );
+
+	describe( 'Server-driven dry-run validation', () => {
+		const dryRunViolation: SubjectViolation = {
+			propertyName: 'Color',
+			code: 'required',
+			args: [],
+			valuePartIndex: null,
+		};
+
+		async function selectSchema( wrapper: VueWrapper ): Promise<void> {
+			await wrapper.findComponent( SchemaLookup ).vm.$emit( 'select', SCHEMA_NAME );
+			await flushPromises();
+		}
+
+		it( 'surfaces dry-run violations when the editor reports a change', async () => {
+			subjectStore.validateSubject = vi.fn().mockResolvedValue( [ dryRunViolation ] );
+			const wrapper = mountComponent();
+			await selectSchema( wrapper );
+
+			await wrapper.findComponent( SubjectEditor ).vm.$emit( 'change' );
+			await flushPromises();
+
+			expect( subjectStore.validateSubject ).toHaveBeenCalledWith(
+				PAGE_TITLE,
+				SCHEMA_NAME,
+				expect.any( StatementList ),
+			);
+			const passed = wrapper.findComponent( SubjectEditor ).props( 'serverViolations' ) as SubjectViolation[];
+			expect( passed ).toHaveLength( 1 );
+			expect( passed[ 0 ].propertyName ).toBe( 'Color' );
+		} );
+
+		it( 'keeps editing working when the dry-run validation fails', async () => {
+			subjectStore.validateSubject = vi.fn().mockRejectedValue( new Error( 'network down' ) );
+			const wrapper = mountComponent();
+			await selectSchema( wrapper );
+
+			await wrapper.findComponent( SubjectEditor ).vm.$emit( 'change' );
+			await flushPromises();
+
+			const passed = wrapper.findComponent( SubjectEditor ).props( 'serverViolations' ) as SubjectViolation[];
+			expect( passed ).toHaveLength( 0 );
 		} );
 	} );
 } );

--- a/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditorDialog.spec.ts
@@ -9,6 +9,7 @@ import { Schema } from '@/domain/Schema.ts';
 import { PropertyDefinitionList } from '@/domain/PropertyDefinitionList.ts';
 import { createPinia, setActivePinia } from 'pinia';
 import { useSchemaStore } from '@/stores/SchemaStore.ts';
+import { useSubjectStore } from '@/stores/SubjectStore.ts';
 import { Service } from '@/NeoWikiServices.ts';
 import SchemaEditorDialog from '@/components/SchemaEditor/SchemaEditorDialog.vue';
 import SubjectEditor from '@/components/SubjectEditor/SubjectEditor.vue';
@@ -45,7 +46,11 @@ const CloseConfirmationDialogStub = {
 
 describe( 'SubjectEditorDialog', () => {
 	beforeEach( () => {
-		setupMwMock( { functions: [ 'message', 'msg', 'notify' ] } );
+		setupMwMock( {
+			functions: [ 'message', 'msg', 'notify', 'config' ],
+			// Debounce 0 makes the dry-run validation run synchronously in tests.
+			config: { wgNeoWikiValidationDebounceMs: 0 },
+		} );
 	} );
 
 	let pinia: ReturnType<typeof createPinia>;
@@ -105,6 +110,10 @@ describe( 'SubjectEditorDialog', () => {
 
 		schemaStore = useSchemaStore();
 		schemaStore.setSchema( 'TestSchema', mockSchema );
+
+		// The dry-run validation runs alongside the live validators; stub it so
+		// it does not reach the network and stays out of the way of these tests.
+		useSubjectStore().validateSubjectUpdate = vi.fn().mockResolvedValue( [] );
 	} );
 
 	it( 'renders schema as a link when user has edit permissions', async () => {
@@ -391,6 +400,64 @@ describe( 'SubjectEditorDialog', () => {
 					type: 'error',
 				} ),
 			] );
+		} );
+	} );
+
+	describe( 'Server-driven dry-run validation', () => {
+		const dryRunViolation: SubjectViolation = {
+			propertyName: 'name',
+			code: 'required',
+			args: [],
+			valuePartIndex: null,
+		};
+
+		it( 'surfaces dry-run violations when the editor reports a change', async () => {
+			const validate = vi.fn().mockResolvedValue( [ dryRunViolation ] );
+			useSubjectStore().validateSubjectUpdate = validate;
+			const wrapper = mountComponent( true, validationTestStubs );
+			await flushPromises();
+
+			await wrapper.findComponent( SubjectEditor ).vm.$emit( 'change' );
+			await flushPromises();
+
+			expect( validate ).toHaveBeenCalledWith(
+				mockSubject.getId(),
+				mockSubject.getLabel(),
+				expect.any( StatementList ),
+			);
+			const passed = wrapper.findComponent( SubjectEditor ).props( 'serverViolations' ) as SubjectViolation[];
+			expect( passed ).toHaveLength( 1 );
+			expect( passed[ 0 ].propertyName ).toBe( 'name' );
+		} );
+
+		it( 'runs the dry-run before saving so its violations surface inline', async () => {
+			useSubjectStore().validateSubjectUpdate = vi.fn().mockResolvedValue( [ dryRunViolation ] );
+			// onSave never resolves, so the dialog stays open and we can inspect
+			// the violations produced by the pre-save flush.
+			const onSave = vi.fn().mockReturnValue( new Promise<void>( () => {
+				// Intentionally never settles.
+			} ) );
+			const wrapper = mountComponent( true, validationTestStubs, onSave );
+			await flushPromises();
+
+			await wrapper.findComponent( EditSummary ).vm.$emit( 'save', '' );
+			await flushPromises();
+
+			const passed = wrapper.findComponent( SubjectEditor ).props( 'serverViolations' ) as SubjectViolation[];
+			expect( passed ).toHaveLength( 1 );
+			expect( passed[ 0 ].propertyName ).toBe( 'name' );
+		} );
+
+		it( 'keeps editing working when the dry-run validation fails', async () => {
+			useSubjectStore().validateSubjectUpdate = vi.fn().mockRejectedValue( new Error( 'network down' ) );
+			const wrapper = mountComponent( true, validationTestStubs );
+			await flushPromises();
+
+			await wrapper.findComponent( SubjectEditor ).vm.$emit( 'change' );
+			await flushPromises();
+
+			const passed = wrapper.findComponent( SubjectEditor ).props( 'serverViolations' ) as SubjectViolation[];
+			expect( passed ).toHaveLength( 0 );
 		} );
 	} );
 } );

--- a/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditorDialog.spec.ts
@@ -463,10 +463,11 @@ describe( 'SubjectEditorDialog', () => {
 			expect( passed ).toHaveLength( 0 );
 		} );
 
-		it( 'does not surface required violations from the dry-run; they wait for save', async () => {
-			useSubjectStore().validateSubjectUpdate = vi.fn().mockResolvedValue( [
-				{ propertyName: 'name', code: 'required', args: [], valuePartIndex: null },
-			] );
+		it( 'surfaces required violations from the dry-run; an existing subject flags missing required', async () => {
+			const requiredViolation: SubjectViolation = {
+				propertyName: 'name', code: 'required', args: [], valuePartIndex: null,
+			};
+			useSubjectStore().validateSubjectUpdate = vi.fn().mockResolvedValue( [ requiredViolation ] );
 			const wrapper = mountComponent( true, validationTestStubs );
 			await flushPromises();
 
@@ -475,7 +476,7 @@ describe( 'SubjectEditorDialog', () => {
 			await flushPromises();
 
 			const passed = wrapper.findComponent( SubjectEditor ).props( 'serverViolations' ) as SubjectViolation[];
-			expect( passed ).toEqual( [] );
+			expect( passed ).toEqual( [ requiredViolation ] );
 		} );
 	} );
 } );

--- a/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditorDialog.spec.ts
@@ -407,8 +407,8 @@ describe( 'SubjectEditorDialog', () => {
 	describe( 'Server-driven dry-run validation', () => {
 		const dryRunViolation: SubjectViolation = {
 			propertyName: 'name',
-			code: 'required',
-			args: [],
+			code: 'max-length',
+			args: [ 5 ],
 			valuePartIndex: null,
 		};
 
@@ -461,6 +461,21 @@ describe( 'SubjectEditorDialog', () => {
 
 			const passed = wrapper.findComponent( SubjectEditor ).props( 'serverViolations' ) as SubjectViolation[];
 			expect( passed ).toHaveLength( 0 );
+		} );
+
+		it( 'does not surface required violations from the dry-run; they wait for save', async () => {
+			useSubjectStore().validateSubjectUpdate = vi.fn().mockResolvedValue( [
+				{ propertyName: 'name', code: 'required', args: [], valuePartIndex: null },
+			] );
+			const wrapper = mountComponent( true, validationTestStubs );
+			await flushPromises();
+
+			await wrapper.findComponent( SubjectEditor ).vm.$emit( 'change' );
+			await wrapper.findComponent( SubjectEditor ).vm.$emit( 'focusout' );
+			await flushPromises();
+
+			const passed = wrapper.findComponent( SubjectEditor ).props( 'serverViolations' ) as SubjectViolation[];
+			expect( passed ).toEqual( [] );
 		} );
 	} );
 } );

--- a/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditorDialog.spec.ts
@@ -478,5 +478,21 @@ describe( 'SubjectEditorDialog', () => {
 			const passed = wrapper.findComponent( SubjectEditor ).props( 'serverViolations' ) as SubjectViolation[];
 			expect( passed ).toEqual( [ requiredViolation ] );
 		} );
+
+		it( 'validates on open so an existing subject\'s violations surface without an edit', async () => {
+			const existingViolation: SubjectViolation = {
+				propertyName: 'name', code: 'required', args: [], valuePartIndex: null,
+			};
+			const validate = vi.fn().mockResolvedValue( [ existingViolation ] );
+			useSubjectStore().validateSubjectUpdate = validate;
+
+			const wrapper = mountComponent( true, validationTestStubs );
+			await flushPromises();
+
+			// No @change / @focusout: the dialog validated the existing subject on open.
+			expect( validate ).toHaveBeenCalled();
+			const passed = wrapper.findComponent( SubjectEditor ).props( 'serverViolations' ) as SubjectViolation[];
+			expect( passed ).toEqual( [ existingViolation ] );
+		} );
 	} );
 } );

--- a/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditorDialog.spec.ts
@@ -48,7 +48,8 @@ describe( 'SubjectEditorDialog', () => {
 	beforeEach( () => {
 		setupMwMock( {
 			functions: [ 'message', 'msg', 'notify', 'config' ],
-			// Debounce 0 makes the dry-run validation run synchronously in tests.
+			// Debounce 0 is blur-only mode: the dry-run fires on blur / pre-save
+			// (via flush()), which runs synchronously in tests.
 			config: { wgNeoWikiValidationDebounceMs: 0 },
 		} );
 	} );
@@ -411,13 +412,14 @@ describe( 'SubjectEditorDialog', () => {
 			valuePartIndex: null,
 		};
 
-		it( 'surfaces dry-run violations when the editor reports a change', async () => {
+		it( 'surfaces dry-run violations on blur after an edit', async () => {
 			const validate = vi.fn().mockResolvedValue( [ dryRunViolation ] );
 			useSubjectStore().validateSubjectUpdate = validate;
 			const wrapper = mountComponent( true, validationTestStubs );
 			await flushPromises();
 
 			await wrapper.findComponent( SubjectEditor ).vm.$emit( 'change' );
+			await wrapper.findComponent( SubjectEditor ).vm.$emit( 'focusout' );
 			await flushPromises();
 
 			expect( validate ).toHaveBeenCalledWith(
@@ -454,6 +456,7 @@ describe( 'SubjectEditorDialog', () => {
 			await flushPromises();
 
 			await wrapper.findComponent( SubjectEditor ).vm.$emit( 'change' );
+			await wrapper.findComponent( SubjectEditor ).vm.$emit( 'focusout' );
 			await flushPromises();
 
 			const passed = wrapper.findComponent( SubjectEditor ).props( 'serverViolations' ) as SubjectViolation[];

--- a/resources/ext.neowiki/tests/components/Value/SelectInput.spec.ts
+++ b/resources/ext.neowiki/tests/components/Value/SelectInput.spec.ts
@@ -1,0 +1,49 @@
+import { VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CdxField } from '@wikimedia/codex';
+import SelectInput from '@/components/Value/SelectInput.vue';
+import { newSelectProperty, SelectProperty } from '@/domain/propertyTypes/Select';
+import { ValueInputProps } from '@/components/Value/ValueInputContract.ts';
+import { createTestWrapper } from '../../VueTestHelpers.ts';
+
+describe( 'SelectInput', () => {
+	beforeEach( () => {
+		vi.stubGlobal( 'mw', {
+			message: vi.fn( ( str: string ) => ( {
+				text: () => str,
+				parse: () => str,
+			} ) ),
+		} );
+	} );
+
+	function newWrapper( props: Partial<ValueInputProps<SelectProperty>> = {} ): VueWrapper {
+		return createTestWrapper( SelectInput, {
+			modelValue: undefined,
+			label: 'Status',
+			property: newSelectProperty( {
+				name: 'Status',
+				required: true,
+				options: [ { id: 'open', label: 'Open' }, { id: 'closed', label: 'Closed' } ],
+			} ),
+			...props,
+		} );
+	}
+
+	it( 'does not flag an empty required select before the user has chosen', () => {
+		const wrapper = newWrapper();
+
+		expect( wrapper.findComponent( CdxField ).props( 'status' ) ).toBe( 'default' );
+		expect( wrapper.findComponent( CdxField ).props( 'messages' ) ).toEqual( {} );
+	} );
+
+	it( 'still surfaces a server-sourced violation on the select', () => {
+		const wrapper = newWrapper( {
+			serverViolations: [
+				{ propertyName: 'Status', code: 'required', args: [], valuePartIndex: null },
+			],
+		} );
+
+		expect( wrapper.findComponent( CdxField ).props( 'status' ) ).toBe( 'error' );
+		expect( wrapper.findComponent( CdxField ).props( 'messages' ) ).toHaveProperty( 'error', 'neowiki-field-required' );
+	} );
+} );

--- a/resources/ext.neowiki/tests/components/Views/Infobox.spec.ts
+++ b/resources/ext.neowiki/tests/components/Views/Infobox.spec.ts
@@ -25,7 +25,7 @@ const $i18n = createI18nMock();
 
 describe( 'Infobox', () => {
 	beforeEach( () => {
-		setupMwMock( { functions: [ 'message', 'msg' ] } );
+		setupMwMock( { functions: [ 'message', 'msg', 'config' ] } );
 		( globalThis as any ).mw.util = {
 			getUrl: vi.fn( ( title: string ) => `/wiki/${ title }` ),
 		};
@@ -92,6 +92,7 @@ describe( 'Infobox', () => {
 
 		subjectStore = useSubjectStore();
 		subjectStore.setSubject( mockSubject );
+		subjectStore.validateSubjectUpdate = vi.fn().mockResolvedValue( [] );
 	} );
 
 	it( 'renders the title correctly', () => {

--- a/resources/ext.neowiki/tests/composables/useSubjectValidation.spec.ts
+++ b/resources/ext.neowiki/tests/composables/useSubjectValidation.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useSubjectValidation } from '@/composables/useSubjectValidation.ts';
+import { SubjectViolation } from '@/domain/SubjectViolation.ts';
+
+function violation( code: string ): SubjectViolation {
+	return { propertyName: 'Title', code, args: [], valuePartIndex: null };
+}
+
+describe( 'useSubjectValidation', () => {
+	beforeEach( () => vi.useFakeTimers() );
+	afterEach( () => vi.useRealTimers() );
+
+	it( 'coalesces rapid revalidate calls into one validation run after the debounce', async () => {
+		const validate = vi.fn().mockResolvedValue( [ violation( 'required' ) ] );
+		const { violations, revalidate } = useSubjectValidation( validate, { debounceMs: 300 } );
+
+		revalidate();
+		revalidate();
+		revalidate();
+		await vi.advanceTimersByTimeAsync( 300 );
+
+		expect( validate ).toHaveBeenCalledTimes( 1 );
+		expect( violations.value ).toEqual( [ violation( 'required' ) ] );
+	} );
+
+	it( 'discards a stale in-flight response when a newer run resolves first', async () => {
+		const validate = vi.fn()
+			.mockResolvedValueOnce( [ violation( 'stale' ) ] )
+			.mockResolvedValueOnce( [ violation( 'fresh' ) ] );
+		const { violations, flush } = useSubjectValidation( validate, { debounceMs: 0 } );
+
+		const first = flush();
+		const second = flush();
+		await Promise.all( [ first, second ] );
+
+		expect( violations.value ).toEqual( [ violation( 'fresh' ) ] );
+	} );
+
+	it( 'flush runs validation immediately regardless of debounce', async () => {
+		const validate = vi.fn().mockResolvedValue( [] );
+		const { flush } = useSubjectValidation( validate, { debounceMs: 5000 } );
+
+		await flush();
+
+		expect( validate ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/resources/ext.neowiki/tests/composables/useSubjectValidation.spec.ts
+++ b/resources/ext.neowiki/tests/composables/useSubjectValidation.spec.ts
@@ -57,4 +57,20 @@ describe( 'useSubjectValidation', () => {
 
 		expect( validate ).toHaveBeenCalledTimes( 1 );
 	} );
+
+	it( 'does not validate on input in blur-only mode (debounceMs 0); only flush validates', async () => {
+		const validate = vi.fn().mockResolvedValue( [] );
+		const { revalidate, flush } = useSubjectValidation( validate, { debounceMs: 0 } );
+
+		revalidate();
+		revalidate();
+		revalidate();
+
+		// Blur-only mode: on-input revalidation must NOT fire a dry-run; only
+		// flush() (blur / pre-save) should.
+		expect( validate ).not.toHaveBeenCalled();
+
+		await flush();
+		expect( validate ).toHaveBeenCalledTimes( 1 );
+	} );
 } );

--- a/resources/ext.neowiki/tests/composables/useSubjectValidation.spec.ts
+++ b/resources/ext.neowiki/tests/composables/useSubjectValidation.spec.ts
@@ -23,16 +23,29 @@ describe( 'useSubjectValidation', () => {
 		expect( violations.value ).toEqual( [ violation( 'required' ) ] );
 	} );
 
-	it( 'discards a stale in-flight response when a newer run resolves first', async () => {
+	it( 'discards a stale response that resolves after a newer one', async () => {
+		let resolveStale!: ( value: SubjectViolation[] ) => void;
+		let resolveFresh!: ( value: SubjectViolation[] ) => void;
 		const validate = vi.fn()
-			.mockResolvedValueOnce( [ violation( 'stale' ) ] )
-			.mockResolvedValueOnce( [ violation( 'fresh' ) ] );
+			.mockImplementationOnce( () => new Promise<SubjectViolation[]>( ( resolve ) => {
+				resolveStale = resolve;
+			} ) )
+			.mockImplementationOnce( () => new Promise<SubjectViolation[]>( ( resolve ) => {
+				resolveFresh = resolve;
+			} ) );
 		const { violations, flush } = useSubjectValidation( validate, { debounceMs: 0 } );
 
-		const first = flush();
-		const second = flush();
-		await Promise.all( [ first, second ] );
+		flush();
+		flush();
 
+		// The newer (second) request resolves first.
+		resolveFresh( [ violation( 'fresh' ) ] );
+		await Promise.resolve();
+		expect( violations.value ).toEqual( [ violation( 'fresh' ) ] );
+
+		// The stale (first) request resolves afterwards and must be discarded by the guard.
+		resolveStale( [ violation( 'stale' ) ] );
+		await Promise.resolve();
 		expect( violations.value ).toEqual( [ violation( 'fresh' ) ] );
 	} );
 

--- a/resources/ext.neowiki/tests/domain/SubjectViolation.spec.ts
+++ b/resources/ext.neowiki/tests/domain/SubjectViolation.spec.ts
@@ -1,20 +1,29 @@
 import { describe, it, expect } from 'vitest';
-import { withoutRequiredViolations, SubjectViolation } from '@/domain/SubjectViolation.ts';
+import { withoutMissingValueViolations, SubjectViolation } from '@/domain/SubjectViolation.ts';
 
 function violation( code: string, propertyName: string | null = 'Homepage' ): SubjectViolation {
 	return { propertyName, code, args: [], valuePartIndex: null };
 }
 
-describe( 'withoutRequiredViolations', () => {
+describe( 'withoutMissingValueViolations', () => {
 	it( 'removes required violations', () => {
-		expect( withoutRequiredViolations( [ violation( 'required' ) ] ) ).toEqual( [] );
+		expect( withoutMissingValueViolations( [ violation( 'required' ) ] ) ).toEqual( [] );
 	} );
 
-	it( 'keeps non-required violations and drops required ones in between', () => {
+	it( 'removes the subject-level label-required violation', () => {
+		expect( withoutMissingValueViolations( [ violation( 'label-required', null ) ] ) ).toEqual( [] );
+	} );
+
+	it( 'keeps violations that need a value, dropping missing-value ones in between', () => {
 		const invalidUrl = violation( 'invalid-url' );
 		const maxLength = violation( 'max-length', 'Title' );
 
-		const result = withoutRequiredViolations( [ invalidUrl, violation( 'required' ), maxLength ] );
+		const result = withoutMissingValueViolations( [
+			invalidUrl,
+			violation( 'required' ),
+			violation( 'label-required', null ),
+			maxLength,
+		] );
 
 		expect( result ).toEqual( [ invalidUrl, maxLength ] );
 	} );

--- a/resources/ext.neowiki/tests/domain/SubjectViolation.spec.ts
+++ b/resources/ext.neowiki/tests/domain/SubjectViolation.spec.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { withoutRequiredViolations, SubjectViolation } from '@/domain/SubjectViolation.ts';
+
+function violation( code: string, propertyName: string | null = 'Homepage' ): SubjectViolation {
+	return { propertyName, code, args: [], valuePartIndex: null };
+}
+
+describe( 'withoutRequiredViolations', () => {
+	it( 'removes required violations', () => {
+		expect( withoutRequiredViolations( [ violation( 'required' ) ] ) ).toEqual( [] );
+	} );
+
+	it( 'keeps non-required violations and drops required ones in between', () => {
+		const invalidUrl = violation( 'invalid-url' );
+		const maxLength = violation( 'max-length', 'Title' );
+
+		const result = withoutRequiredViolations( [ invalidUrl, violation( 'required' ), maxLength ] );
+
+		expect( result ).toEqual( [ invalidUrl, maxLength ] );
+	} );
+} );

--- a/resources/ext.neowiki/tests/persistence/violationParsing.spec.ts
+++ b/resources/ext.neowiki/tests/persistence/violationParsing.spec.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { parseViolations } from '@/persistence/violationParsing.ts';
+
+describe( 'parseViolations', () => {
+	it( 'parses a well-shaped violations body and defaults a missing valuePartIndex to null', () => {
+		const result = parseViolations( {
+			violations: [ { propertyName: 'Homepage', code: 'invalid-url', args: [] } ],
+		} );
+		expect( result ).toEqual( [
+			{ propertyName: 'Homepage', code: 'invalid-url', args: [], valuePartIndex: null },
+		] );
+	} );
+
+	it( 'returns null for a malformed body', () => {
+		expect( parseViolations( { violations: [ { code: 123 } ] } ) ).toBeNull();
+	} );
+
+	it( 'returns null when violations is absent', () => {
+		expect( parseViolations( {} ) ).toBeNull();
+	} );
+} );

--- a/resources/ext.neowiki/tests/stores/SchemaStore.spec.ts
+++ b/resources/ext.neowiki/tests/stores/SchemaStore.spec.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeSchemaName } from '@/stores/SchemaStore.ts';
+
+describe( 'normalizeSchemaName', () => {
+	it( 'upper-cases the first character', () => {
+		expect( normalizeSchemaName( 'person' ) ).toBe( 'Person' );
+	} );
+
+	it( 'only capitalises the first character, not later words', () => {
+		expect( normalizeSchemaName( 'person of interest' ) ).toBe( 'Person of interest' );
+	} );
+
+	it( 'turns underscores into spaces and collapses runs of whitespace', () => {
+		expect( normalizeSchemaName( 'Foo_Bar' ) ).toBe( 'Foo Bar' );
+		expect( normalizeSchemaName( 'Foo   Bar' ) ).toBe( 'Foo Bar' );
+	} );
+
+	it( 'trims surrounding whitespace', () => {
+		expect( normalizeSchemaName( '  Person  ' ) ).toBe( 'Person' );
+	} );
+
+	it( 'leaves an already-canonical name unchanged', () => {
+		expect( normalizeSchemaName( 'Validation Demo' ) ).toBe( 'Validation Demo' );
+	} );
+} );

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -320,7 +320,10 @@ class NeoWikiExtension {
 	}
 
 	public function newFrontendModuleLoader(): FrontendModuleLoader {
-		return new FrontendModuleLoader( MediaWikiServices::getInstance()->getHookContainer() );
+		return new FrontendModuleLoader(
+			MediaWikiServices::getInstance()->getHookContainer(),
+			(int)MediaWikiServices::getInstance()->getMainConfig()->get( 'NeoWikiValidationDebounceMs' ),
+		);
 	}
 
 	public function newSubjectContentRepository(): SubjectContentRepository {

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -320,9 +320,11 @@ class NeoWikiExtension {
 	}
 
 	public function newFrontendModuleLoader(): FrontendModuleLoader {
+		$debounceMs = MediaWikiServices::getInstance()->getMainConfig()->get( 'NeoWikiValidationDebounceMs' );
+
 		return new FrontendModuleLoader(
 			MediaWikiServices::getInstance()->getHookContainer(),
-			(int)MediaWikiServices::getInstance()->getMainConfig()->get( 'NeoWikiValidationDebounceMs' ),
+			is_int( $debounceMs ) ? $debounceMs : 300,
 		);
 	}
 

--- a/src/Presentation/FrontendModuleLoader.php
+++ b/src/Presentation/FrontendModuleLoader.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Presentation;
 
 use MediaWiki\HookContainer\HookContainer;
+use MediaWiki\MediaWikiServices;
 use MediaWiki\Output\OutputPage;
 use Skin;
 
@@ -18,6 +19,11 @@ class FrontendModuleLoader {
 	public function load( OutputPage $out, Skin $skin ): void {
 		$out->addModules( 'ext.neowiki' );
 		$out->addModuleStyles( 'ext.neowiki.styles' );
+
+		$out->addJsConfigVars( [
+			'wgNeoWikiValidationDebounceMs' =>
+				MediaWikiServices::getInstance()->getMainConfig()->get( 'NeoWikiValidationDebounceMs' ),
+		] );
 
 		/** @var list<string> $modules populated by hook handlers */
 		$modules = [];

--- a/src/Presentation/FrontendModuleLoader.php
+++ b/src/Presentation/FrontendModuleLoader.php
@@ -5,7 +5,6 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Presentation;
 
 use MediaWiki\HookContainer\HookContainer;
-use MediaWiki\MediaWikiServices;
 use MediaWiki\Output\OutputPage;
 use Skin;
 
@@ -13,6 +12,7 @@ class FrontendModuleLoader {
 
 	public function __construct(
 		private readonly HookContainer $hookContainer,
+		private readonly int $validationDebounceMs,
 	) {
 	}
 
@@ -21,8 +21,7 @@ class FrontendModuleLoader {
 		$out->addModuleStyles( 'ext.neowiki.styles' );
 
 		$out->addJsConfigVars( [
-			'wgNeoWikiValidationDebounceMs' =>
-				MediaWikiServices::getInstance()->getMainConfig()->get( 'NeoWikiValidationDebounceMs' ),
+			'wgNeoWikiValidationDebounceMs' => $this->validationDebounceMs,
 		] );
 
 		/** @var list<string> $modules populated by hook handlers */

--- a/tests/phpunit/Presentation/FrontendModuleLoaderTest.php
+++ b/tests/phpunit/Presentation/FrontendModuleLoaderTest.php
@@ -20,6 +20,9 @@ class FrontendModuleLoaderTest extends MediaWikiIntegrationTestCase {
 	/** @var array<int, string> */
 	private array $addedModuleStyles = [];
 
+	/** @var array<string, mixed> */
+	private array $addedJsConfigVars = [];
+
 	public function testAddsCoreModuleWhenNoExtensionsHandleHook(): void {
 		$this->clearHook( 'NeoWikiGetFrontendModules' );
 
@@ -70,8 +73,16 @@ class FrontendModuleLoaderTest extends MediaWikiIntegrationTestCase {
 		$this->assertSame( $skin, $receivedSkin );
 	}
 
-	private function newLoader(): FrontendModuleLoader {
-		return new FrontendModuleLoader( $this->getServiceContainer()->getHookContainer() );
+	public function testEmitsConfiguredValidationDebounceJsConfigVar(): void {
+		$this->clearHook( 'NeoWikiGetFrontendModules' );
+
+		$this->newLoader( 450 )->load( $this->newCapturingOutputPage(), $this->createMock( Skin::class ) );
+
+		$this->assertSame( 450, $this->addedJsConfigVars['wgNeoWikiValidationDebounceMs'] ?? null );
+	}
+
+	private function newLoader( int $validationDebounceMs = 300 ): FrontendModuleLoader {
+		return new FrontendModuleLoader( $this->getServiceContainer()->getHookContainer(), $validationDebounceMs );
 	}
 
 	private function newCapturingOutputPage(): OutputPage {
@@ -84,6 +95,15 @@ class FrontendModuleLoaderTest extends MediaWikiIntegrationTestCase {
 		$out->method( 'addModuleStyles' )->willReturnCallback(
 			function ( string|array $modules ): void {
 				$this->addedModuleStyles = array_merge( $this->addedModuleStyles, (array)$modules );
+			}
+		);
+		$out->method( 'addJsConfigVars' )->willReturnCallback(
+			function ( $keys, $value = null ): void {
+				if ( is_array( $keys ) ) {
+					$this->addedJsConfigVars = array_merge( $this->addedJsConfigVars, $keys );
+				} else {
+					$this->addedJsConfigVars[ $keys ] = $value;
+				}
 			}
 		);
 		return $out;


### PR DESCRIPTION
> Result of a design collaboration with @alistair3149; an increment of a staged validation-sync effort (plus its create/edit display-model refinement and a drive-by 404 fix), and the prototype for the demo-first ADR gate.
> Context: the NeoWiki codebase, the validation-sync design doc, and web research on client/server validation UX.
> <sub>Written by Claude Code, `Fable 5`</sub>

Introduce a debounced, sequence-guarded **dry-run validation path** that runs **alongside** the existing live validators in the Subject editor and creator. This is the *alongside-mode prototype*: server-driven validation runs and surfaces inline, but nothing is removed — so the team can evaluate it live before deciding on any larger change (deleting the duplicated TS validators is a separate, gated step, not in this PR).

### Core

- `RestSubjectRepository` gains `validateSubject` / `validateSubjectUpdate`, calling the existing read-only dry-run REST endpoints and reading violations from the 200 body (shared parser extracted to `violationParsing.ts`). A failed dry-run degrades to no violations and never blocks editing or saving.
- A `useSubjectValidation` composable owns the violations ref: `revalidate()` debounced (configurable via `$wgNeoWikiValidationDebounceMs`, default 300, `0` = blur-only), `flush()` on blur and before save, a request-sequence guard so stale responses never overwrite newer ones, and timer cleanup on scope dispose.
- Both subject dialogs feed the composable's violations into the **same ref** the inline renderer and the existing 422-on-save handling already use; the live per-field validators are unchanged.

### Display model: eager for existing subjects, lazy for new ones

Validation visibility differs by context so we never flag a field the user has not reached yet:

- **Editor (existing subject):** validates **on open** and on every edit; surfaces everything, including `required` — an empty required field on an existing subject is a real gap.
- **Creator (new subject):** validates on edit but **withholds "not filled in yet" violations** (`required`, `label-required`) until save — every field starts empty and the user is on their way to filling them in (`withoutMissingValueViolations`). `SelectInput` likewise no longer flags `required` client-side, deferring to the server like every other input.
- The dry-run is **skipped while a new schema is still an unsaved draft** (it does not exist server-side yet).

Open follow-up: under the default `$wgNeoWikiEnforceValidation = false`, the creator surfaces `required` nowhere (withheld mid-edit, and no 422 at save). Giving non-blocking save-time feedback there is the "warning vs error" model, tracked separately.

### Drive-by (pre-existing on master, unrelated to subject validation)

The schema creator's name-availability check fetched `/v1/page/Schema:{name}`, which **404s** for a not-yet-created name on every debounced keystroke. Switched to the existing `schema-names` search (a 200 response), with MediaWiki-style name normalization so the duplicate check still catches `person` / `Foo_Bar` collisions the way the page-fetch did.

Independent of #884 and #885 (the dry-run endpoints it consumes already exist on master).

## Manual Browser Check

> The point of this PR is to *watch server-driven validation work live*. Automated coverage is complete (1019 frontend tests, lint, build, PHPStan green; the dry-run endpoints have their own backend tests), but the live behavior should be observed before merging.

After `make load-test-data` and `make ts-build`:

**Editing an existing subject** (e.g. **Validation Clean** → its **Validation Demo** subject):

1. **On open**, a pre-existing violation (e.g. an empty required field) surfaces immediately — no edit needed.
2. Server violations appear inline ~300ms after you stop typing an invalid value, *in addition to* the instant client-side validation; **DevTools → Network** shows `POST .../neowiki/v0/subject/.../validate` after the pause and on blur, but **not** when merely tabbing between fields without editing.
3. Editing a flagged field clears its error immediately; the next dry-run re-asserts it if still invalid.
4. Saving still works; an enforced 422 (`$wgNeoWikiEnforceValidation = true`) surfaces inline as before.
5. With `$wgNeoWikiValidationDebounceMs = 0`, validation fires only on blur / pre-save.

**Creating a subject** (Add subject):

6. Required fields and the label stay **clean** while you fill them in — no premature "please provide a value".
7. Creating a **new schema**: typing the name produces **no `Schema:` 404s** (only `schema-names` 200s in the console / Network).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
