### PR TITLE
Bump eslint-config-wikimedia to 0.32.4

### DIFF
--- a/resources/ext.neowiki/package-lock.json
+++ b/resources/ext.neowiki/package-lock.json
@@ -23,7 +23,7 @@
 				"@wmde/eslint-config-wikimedia-typescript": "^0.2.14",
 				"axios": "^1.15.2",
 				"eslint": "^8.57.0",
-				"eslint-config-wikimedia": "^0.32.3",
+				"eslint-config-wikimedia": "^0.32.4",
 				"eslint-plugin-n": "^17.10.2",
 				"eslint-plugin-unicorn": "^55.0.0",
 				"jsdom": "^25.0.0",
@@ -307,20 +307,20 @@
 			}
 		},
 		"node_modules/@es-joy/jsdoccomment": {
-			"version": "0.76.0",
-			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.76.0.tgz",
-			"integrity": "sha512-g+RihtzFgGTx2WYCuTHbdOXJeAlGnROws0TeALx9ow/ZmOROOZkVg5wp/B44n0WJgI4SQFP1eWM2iRPlU2Y14w==",
+			"version": "0.86.0",
+			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.86.0.tgz",
+			"integrity": "sha512-ukZmRQ81WiTpDWO6D/cTBM7XbrNtutHKvAVnZN/8pldAwLoJArGOvkNyxPTBGsPjsoaQBJxlH+tE2TNA/92Qgw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "^1.0.8",
-				"@typescript-eslint/types": "^8.46.0",
-				"comment-parser": "1.4.1",
-				"esquery": "^1.6.0",
-				"jsdoc-type-pratt-parser": "~6.10.0"
+				"@typescript-eslint/types": "^8.58.0",
+				"comment-parser": "1.4.6",
+				"esquery": "^1.7.0",
+				"jsdoc-type-pratt-parser": "~7.2.0"
 			},
 			"engines": {
-				"node": ">=20.11.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			}
 		},
 		"node_modules/@es-joy/resolve.exports": {
@@ -3526,9 +3526,9 @@
 			}
 		},
 		"node_modules/comment-parser": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
-			"integrity": "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==",
+			"version": "1.4.6",
+			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.6.tgz",
+			"integrity": "sha512-ObxuY6vnbWTN6Od72xfwN9DbzC7Y2vv8u1Soi9ahRKL37gb6y1qk6/dgjs+3JWuXJHWvsg3BXIwzd/rkmAwavg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4528,35 +4528,37 @@
 			}
 		},
 		"node_modules/eslint-config-wikimedia": {
-			"version": "0.32.3",
-			"resolved": "https://registry.npmjs.org/eslint-config-wikimedia/-/eslint-config-wikimedia-0.32.3.tgz",
-			"integrity": "sha512-Ekz2/ozpCCjQl3VbC6dW7ChqoW7FRilLDxmJ+FJOZhIxxzZSZR5QqQOAGWSZAlG1ONkZbYV/TPwGLWZcrNxyaA==",
+			"version": "0.32.4",
+			"resolved": "https://registry.npmjs.org/eslint-config-wikimedia/-/eslint-config-wikimedia-0.32.4.tgz",
+			"integrity": "sha512-zcHJYss2vo8HK5PzkFuaV9mzaSGRuhA+jFGoQ4rNIwWz0usZsuQ2LYpkKxrbCVX1CbV0PzG+jJ6p0cLI+G37JQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@stylistic/eslint-plugin": "^3.1.0",
-				"@typescript-eslint/eslint-plugin": "8.46.0",
-				"@typescript-eslint/parser": "8.46.0",
+				"@typescript-eslint/eslint-plugin": "8.54.0",
+				"@typescript-eslint/parser": "8.54.0",
 				"browserslist-config-wikimedia": "^0.7.0",
-				"eslint": "^8.57.0",
-				"eslint-plugin-compat": "^6.0.2",
+				"eslint-plugin-compat": "^6.1.0",
 				"eslint-plugin-es-x": "^8.7.0",
-				"eslint-plugin-jest": "^29.0.1",
-				"eslint-plugin-jsdoc": "61.3.0",
+				"eslint-plugin-jest": "^29.12.2",
+				"eslint-plugin-jsdoc": "^62.9.0",
 				"eslint-plugin-json-es": "^1.6.0",
-				"eslint-plugin-mediawiki": "^0.8.2",
+				"eslint-plugin-mediawiki": "^0.8.3",
 				"eslint-plugin-mocha": "^10.5.0",
-				"eslint-plugin-n": "^17.23.1",
-				"eslint-plugin-no-jquery": "^3.1.1",
-				"eslint-plugin-qunit": "^8.2.5",
-				"eslint-plugin-security": "^3.0.1",
+				"eslint-plugin-n": "^17.24.0",
+				"eslint-plugin-no-jquery": "^4.0.0",
+				"eslint-plugin-qunit": "^8.2.6",
+				"eslint-plugin-security": "^4.0.0",
 				"eslint-plugin-unicorn": "^56.0.1",
 				"eslint-plugin-vue": "^9.33.0",
-				"eslint-plugin-wdio": "^9.16.2",
+				"eslint-plugin-wdio": "9.23.0",
 				"eslint-plugin-yml": "^1.19.0"
 			},
 			"engines": {
 				"node": ">=20 <25"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0"
 			}
 		},
 		"node_modules/eslint-config-wikimedia/node_modules/@stylistic/eslint-plugin": {
@@ -4580,21 +4582,20 @@
 			}
 		},
 		"node_modules/eslint-config-wikimedia/node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.46.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.46.0.tgz",
-			"integrity": "sha512-hA8gxBq4ukonVXPy0OKhiaUh/68D0E88GSmtC1iAEnGaieuDi38LhS7jdCHRLi6ErJBNDGCzvh5EnzdPwUc0DA==",
+			"version": "8.54.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.54.0.tgz",
+			"integrity": "sha512-hAAP5io/7csFStuOmR782YmTthKBJ9ND3WVL60hcOjvtGFb+HJxH4O5huAcmcZ9v9G8P+JETiZ/G1B8MALnWZQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@eslint-community/regexpp": "^4.10.0",
-				"@typescript-eslint/scope-manager": "8.46.0",
-				"@typescript-eslint/type-utils": "8.46.0",
-				"@typescript-eslint/utils": "8.46.0",
-				"@typescript-eslint/visitor-keys": "8.46.0",
-				"graphemer": "^1.4.0",
-				"ignore": "^7.0.0",
+				"@eslint-community/regexpp": "^4.12.2",
+				"@typescript-eslint/scope-manager": "8.54.0",
+				"@typescript-eslint/type-utils": "8.54.0",
+				"@typescript-eslint/utils": "8.54.0",
+				"@typescript-eslint/visitor-keys": "8.54.0",
+				"ignore": "^7.0.5",
 				"natural-compare": "^1.4.0",
-				"ts-api-utils": "^2.1.0"
+				"ts-api-utils": "^2.4.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4604,72 +4605,23 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.46.0",
-				"eslint": "^8.57.0 || ^9.0.0",
-				"typescript": ">=4.8.4 <6.0.0"
-			}
-		},
-		"node_modules/eslint-config-wikimedia/node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/type-utils": {
-			"version": "8.46.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.46.0.tgz",
-			"integrity": "sha512-hy+lvYV1lZpVs2jRaEYvgCblZxUoJiPyCemwbQZ+NGulWkQRy0HRPYAoef/CNSzaLt+MLvMptZsHXHlkEilaeg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@typescript-eslint/types": "8.46.0",
-				"@typescript-eslint/typescript-estree": "8.46.0",
-				"@typescript-eslint/utils": "8.46.0",
-				"debug": "^4.3.4",
-				"ts-api-utils": "^2.1.0"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"eslint": "^8.57.0 || ^9.0.0",
-				"typescript": ">=4.8.4 <6.0.0"
-			}
-		},
-		"node_modules/eslint-config-wikimedia/node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
-			"version": "8.46.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.46.0.tgz",
-			"integrity": "sha512-nD6yGWPj1xiOm4Gk0k6hLSZz2XkNXhuYmyIrOWcHoPuAhjT9i5bAG+xbWPgFeNR8HPHHtpNKdYUXJl/D3x7f5g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.7.0",
-				"@typescript-eslint/scope-manager": "8.46.0",
-				"@typescript-eslint/types": "8.46.0",
-				"@typescript-eslint/typescript-estree": "8.46.0"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
+				"@typescript-eslint/parser": "^8.54.0",
 				"eslint": "^8.57.0 || ^9.0.0",
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
 		"node_modules/eslint-config-wikimedia/node_modules/@typescript-eslint/parser": {
-			"version": "8.46.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.0.tgz",
-			"integrity": "sha512-n1H6IcDhmmUEG7TNVSspGmiHHutt7iVKtZwRppD7e04wha5MrkV1h3pti9xQLcCMt6YWsncpoT0HMjkH1FNwWQ==",
+			"version": "8.54.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.54.0.tgz",
+			"integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.46.0",
-				"@typescript-eslint/types": "8.46.0",
-				"@typescript-eslint/typescript-estree": "8.46.0",
-				"@typescript-eslint/visitor-keys": "8.46.0",
-				"debug": "^4.3.4"
+				"@typescript-eslint/scope-manager": "8.54.0",
+				"@typescript-eslint/types": "8.54.0",
+				"@typescript-eslint/typescript-estree": "8.54.0",
+				"@typescript-eslint/visitor-keys": "8.54.0",
+				"debug": "^4.4.3"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4684,15 +4636,15 @@
 			}
 		},
 		"node_modules/eslint-config-wikimedia/node_modules/@typescript-eslint/project-service": {
-			"version": "8.46.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.46.0.tgz",
-			"integrity": "sha512-OEhec0mH+U5Je2NZOeK1AbVCdm0ChyapAyTeXVIYTPXDJ3F07+cu87PPXcGoYqZ7M9YJVvFnfpGg1UmCIqM+QQ==",
+			"version": "8.54.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.54.0.tgz",
+			"integrity": "sha512-YPf+rvJ1s7MyiWM4uTRhE4DvBXrEV+d8oC3P9Y2eT7S+HBS0clybdMIPnhiATi9vZOYDc7OQ1L/i6ga6NFYK/g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.46.0",
-				"@typescript-eslint/types": "^8.46.0",
-				"debug": "^4.3.4"
+				"@typescript-eslint/tsconfig-utils": "^8.54.0",
+				"@typescript-eslint/types": "^8.54.0",
+				"debug": "^4.4.3"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4706,14 +4658,14 @@
 			}
 		},
 		"node_modules/eslint-config-wikimedia/node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.46.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.46.0.tgz",
-			"integrity": "sha512-lWETPa9XGcBes4jqAMYD9fW0j4n6hrPtTJwWDmtqgFO/4HF4jmdH/Q6wggTw5qIT5TXjKzbt7GsZUBnWoO3dqw==",
+			"version": "8.54.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.54.0.tgz",
+			"integrity": "sha512-27rYVQku26j/PbHYcVfRPonmOlVI6gihHtXFbTdB5sb6qA0wdAQAbyXFVarQ5t4HRojIz64IV90YtsjQSSGlQg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.46.0",
-				"@typescript-eslint/visitor-keys": "8.46.0"
+				"@typescript-eslint/types": "8.54.0",
+				"@typescript-eslint/visitor-keys": "8.54.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4724,9 +4676,9 @@
 			}
 		},
 		"node_modules/eslint-config-wikimedia/node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.46.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.46.0.tgz",
-			"integrity": "sha512-WrYXKGAHY836/N7zoK/kzi6p8tXFhasHh8ocFL9VZSAkvH956gfeRfcnhs3xzRy8qQ/dq3q44v1jvQieMFg2cw==",
+			"version": "8.54.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.54.0.tgz",
+			"integrity": "sha512-dRgOyT2hPk/JwxNMZDsIXDgyl9axdJI3ogZ2XWhBPsnZUv+hPesa5iuhdYt2gzwA9t8RE5ytOJ6xB0moV0Ujvw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4740,10 +4692,35 @@
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
+		"node_modules/eslint-config-wikimedia/node_modules/@typescript-eslint/type-utils": {
+			"version": "8.54.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.54.0.tgz",
+			"integrity": "sha512-hiLguxJWHjjwL6xMBwD903ciAwd7DmK30Y9Axs/etOkftC3ZNN9K44IuRD/EB08amu+Zw6W37x9RecLkOo3pMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "8.54.0",
+				"@typescript-eslint/typescript-estree": "8.54.0",
+				"@typescript-eslint/utils": "8.54.0",
+				"debug": "^4.4.3",
+				"ts-api-utils": "^2.4.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0",
+				"typescript": ">=4.8.4 <6.0.0"
+			}
+		},
 		"node_modules/eslint-config-wikimedia/node_modules/@typescript-eslint/types": {
-			"version": "8.46.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.46.0.tgz",
-			"integrity": "sha512-bHGGJyVjSE4dJJIO5yyEWt/cHyNwga/zXGJbJJ8TiO01aVREK6gCTu3L+5wrkb1FbDkQ+TKjMNe9R/QQQP9+rA==",
+			"version": "8.54.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.54.0.tgz",
+			"integrity": "sha512-PDUI9R1BVjqu7AUDsRBbKMtwmjWcn4J3le+5LpcFgWULN3LvHC5rkc9gCVxbrsrGmO1jfPybN5s6h4Jy+OnkAA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4755,22 +4732,21 @@
 			}
 		},
 		"node_modules/eslint-config-wikimedia/node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.46.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.46.0.tgz",
-			"integrity": "sha512-ekDCUfVpAKWJbRfm8T1YRrCot1KFxZn21oV76v5Fj4tr7ELyk84OS+ouvYdcDAwZL89WpEkEj2DKQ+qg//+ucg==",
+			"version": "8.54.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.54.0.tgz",
+			"integrity": "sha512-BUwcskRaPvTk6fzVWgDPdUndLjB87KYDrN5EYGetnktoeAvPtO4ONHlAZDnj5VFnUANg0Sjm7j4usBlnoVMHwA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.46.0",
-				"@typescript-eslint/tsconfig-utils": "8.46.0",
-				"@typescript-eslint/types": "8.46.0",
-				"@typescript-eslint/visitor-keys": "8.46.0",
-				"debug": "^4.3.4",
-				"fast-glob": "^3.3.2",
-				"is-glob": "^4.0.3",
-				"minimatch": "^9.0.4",
-				"semver": "^7.6.0",
-				"ts-api-utils": "^2.1.0"
+				"@typescript-eslint/project-service": "8.54.0",
+				"@typescript-eslint/tsconfig-utils": "8.54.0",
+				"@typescript-eslint/types": "8.54.0",
+				"@typescript-eslint/visitor-keys": "8.54.0",
+				"debug": "^4.4.3",
+				"minimatch": "^9.0.5",
+				"semver": "^7.7.3",
+				"tinyglobby": "^0.2.15",
+				"ts-api-utils": "^2.4.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4783,14 +4759,38 @@
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
-		"node_modules/eslint-config-wikimedia/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.46.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.46.0.tgz",
-			"integrity": "sha512-FrvMpAK+hTbFy7vH5j1+tMYHMSKLE6RzluFJlkFNKD0p9YsUT75JlBSmr5so3QRzvMwU5/bIEdeNrxm8du8l3Q==",
+		"node_modules/eslint-config-wikimedia/node_modules/@typescript-eslint/utils": {
+			"version": "8.54.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.54.0.tgz",
+			"integrity": "sha512-9Cnda8GS57AQakvRyG0PTejJNlA2xhvyNtEVIMlDWOOeEyBkYWhGPnfrIAnqxLMTSTo6q8g12XVjjev5l1NvMA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.46.0",
+				"@eslint-community/eslint-utils": "^4.9.1",
+				"@typescript-eslint/scope-manager": "8.54.0",
+				"@typescript-eslint/types": "8.54.0",
+				"@typescript-eslint/typescript-estree": "8.54.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0",
+				"typescript": ">=4.8.4 <6.0.0"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "8.54.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.54.0.tgz",
+			"integrity": "sha512-VFlhGSl4opC0bprJiItPQ1RfUhGDIBokcPwaFH4yiBCaNPeld/9VeXbiPO1cLyorQi1G1vL+ecBk1x8o1axORA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "8.54.0",
 				"eslint-visitor-keys": "^4.2.1"
 			},
 			"engines": {
@@ -4809,9 +4809,9 @@
 			"license": "MIT"
 		},
 		"node_modules/eslint-config-wikimedia/node_modules/brace-expansion": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-			"integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+			"integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4858,40 +4858,6 @@
 			"integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
 			"dev": true,
 			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/eslint-config-wikimedia/node_modules/eslint-plugin-wdio": {
-			"version": "9.27.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-wdio/-/eslint-plugin-wdio-9.27.0.tgz",
-			"integrity": "sha512-3dJajV64PW1F4xANuO+7JR9DKMtkPhsFj/ZeXnbSJqroHPzsRQAqGcjt4q63KfSR85lBheOePYt61cUqfUei1w==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18.20.0"
-			},
-			"peerDependencies": {
-				"eslint": "^9.39.2",
-				"globals": "^16.5.0",
-				"typescript-eslint": "^8.54.0"
-			},
-			"peerDependenciesMeta": {
-				"typescript-eslint": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/eslint-config-wikimedia/node_modules/globals": {
-			"version": "16.5.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
-			"integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -5003,32 +4969,63 @@
 			}
 		},
 		"node_modules/eslint-plugin-jsdoc": {
-			"version": "61.3.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-61.3.0.tgz",
-			"integrity": "sha512-E4m/5J5lrasd63Z74q4CCZ4PFnywnnrcvA7zZ98802NPhrZKKTp5NH+XAT+afcjXp2ps2/OQF5gPSWCT2XFCJg==",
+			"version": "62.9.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-62.9.0.tgz",
+			"integrity": "sha512-PY7/X4jrVgoIDncUmITlUqK546Ltmx/Pd4Hdsu4CvSjryQZJI2mEV4vrdMufyTetMiZ5taNSqvK//BTgVUlNkA==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"@es-joy/jsdoccomment": "~0.76.0",
+				"@es-joy/jsdoccomment": "~0.86.0",
 				"@es-joy/resolve.exports": "1.2.0",
 				"are-docs-informative": "^0.0.2",
-				"comment-parser": "1.4.1",
+				"comment-parser": "1.4.6",
 				"debug": "^4.4.3",
 				"escape-string-regexp": "^4.0.0",
-				"espree": "^10.4.0",
-				"esquery": "^1.6.0",
+				"espree": "^11.2.0",
+				"esquery": "^1.7.0",
 				"html-entities": "^2.6.0",
 				"object-deep-merge": "^2.0.0",
 				"parse-imports-exports": "^0.2.4",
-				"semver": "^7.7.3",
+				"semver": "^7.7.4",
 				"spdx-expression-parse": "^4.0.0",
 				"to-valid-identifier": "^1.0.0"
 			},
 			"engines": {
-				"node": ">=20.11.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			},
 			"peerDependencies": {
-				"eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
+				"eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+			}
+		},
+		"node_modules/eslint-plugin-jsdoc/node_modules/eslint-visitor-keys": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint-plugin-jsdoc/node_modules/espree": {
+			"version": "11.2.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+			"integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"acorn": "^8.16.0",
+				"acorn-jsx": "^5.3.2",
+				"eslint-visitor-keys": "^5.0.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/eslint-plugin-json-es": {
@@ -5077,9 +5074,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-mediawiki": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-mediawiki/-/eslint-plugin-mediawiki-0.8.2.tgz",
-			"integrity": "sha512-ydYrpkzm8IVVDQA96QPF3HnFd2xjkIEh7gixD2gvOqUbUZF0p36LtpWXOFAlPWAvHLePWbNNTD5ovd3d4hEtog==",
+			"version": "0.8.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-mediawiki/-/eslint-plugin-mediawiki-0.8.3.tgz",
+			"integrity": "sha512-RQKZd40C1taMDk5N9+aFLEBGBB95RNG7Gc54EsJ8pHsJu8//nIdpxNFWPtQz6RNxz6pZUXBnMCxzkMOLM3Mm1w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5196,13 +5193,13 @@
 			}
 		},
 		"node_modules/eslint-plugin-no-jquery": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-no-jquery/-/eslint-plugin-no-jquery-3.1.1.tgz",
-			"integrity": "sha512-LTLO3jH/Tjr1pmxCEqtV6qmt+OChv8La4fwgG470JRpgxyFF4NOzoC9CRy92GIWD3Yjl0qLEgPmD2FLQWcNEjg==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-no-jquery/-/eslint-plugin-no-jquery-4.0.0.tgz",
+			"integrity": "sha512-ZR631D3qIQfgjKOAcgvYa5cB8xdTvFXAD5MbK5x5WltLSwFxmGnoaTXNtnptFU7py07ALrIe5dZRYncu4RD/Ug==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
-				"eslint": ">=8.0.0"
+				"eslint": ">=8.0.0 <9.0.0"
 			}
 		},
 		"node_modules/eslint-plugin-qunit": {
@@ -5223,9 +5220,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-security": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-3.0.1.tgz",
-			"integrity": "sha512-XjVGBhtDZJfyuhIxnQ/WMm385RbX3DBu7H1J7HNNhmB2tnGxMeqVSnYv79oAj992ayvIBZghsymwkYFS6cGH4Q==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-4.0.0.tgz",
+			"integrity": "sha512-tfuQT8K/Li1ZxhFzyD8wPIKtlzZxqBcPr9q0jFMQ77wWAbKBVEhaMPVQRTMTvCMUDhwBe5vPVqQPwAGk/ASfxQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -5306,6 +5303,16 @@
 			},
 			"peerDependencies": {
 				"eslint": "^6.2.0 || ^7.0.0 || ^8.0.0 || ^9.0.0"
+			}
+		},
+		"node_modules/eslint-plugin-wdio": {
+			"version": "9.23.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-wdio/-/eslint-plugin-wdio-9.23.0.tgz",
+			"integrity": "sha512-8tcpupzp2Qmv+uSfhzeHi42LVA9PyjkpMBPclSIkPxBfXpj4fMrejwAHu1PROh1OmJN1VQcGQUTWvSzyRcV2vA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.20.0"
 			}
 		},
 		"node_modules/eslint-plugin-yml": {
@@ -7102,9 +7109,9 @@
 			}
 		},
 		"node_modules/jsdoc-type-pratt-parser": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-6.10.0.tgz",
-			"integrity": "sha512-+LexoTRyYui5iOhJGn13N9ZazL23nAHGkXsa1p/C8yeq79WRfLBag6ZZ0FQG2aRoc9yfo59JT9EYCQonOkHKkQ==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.2.0.tgz",
+			"integrity": "sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -8002,9 +8009,9 @@
 			"license": "MIT"
 		},
 		"node_modules/object-deep-merge": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-2.0.0.tgz",
-			"integrity": "sha512-3DC3UMpeffLTHiuXSy/UG4NOIYTLlY9u3V82+djSCLYClWobZiS4ivYzpIUWrRY/nfsJ8cWsKyG3QfyLePmhvg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-2.0.1.tgz",
+			"integrity": "sha512-aKttDKcU3pyZqKcCkDhsMn70WmZFG2JGDQLP9EcLyTSIFQRCPWLAmBZRLJnrVUrhPG1jETEEbfdgbNtJf1LyMg==",
 			"dev": true,
 			"license": "MIT"
 		},

--- a/resources/ext.neowiki/package.json
+++ b/resources/ext.neowiki/package.json
@@ -32,7 +32,7 @@
 		"@wmde/eslint-config-wikimedia-typescript": "^0.2.14",
 		"axios": "^1.15.2",
 		"eslint": "^8.57.0",
-		"eslint-config-wikimedia": "^0.32.3",
+		"eslint-config-wikimedia": "^0.32.4",
 		"eslint-plugin-n": "^17.10.2",
 		"eslint-plugin-unicorn": "^55.0.0",
 		"jsdom": "^25.0.0",


### PR DESCRIPTION
## What

Bumps `eslint-config-wikimedia` from `^0.32.3` to `^0.32.4` in `resources/ext.neowiki` and regenerates the lockfile.

## Why

A clean `npm ci` of the frontend toolchain emitted an `ERESOLVE overriding peer dependency` warning (visible in CI logs, e.g. DockerWiki builds that compile this extension's frontend):

```
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: eslint-plugin-wdio@9.27.0
npm warn peer eslint@"^9.39.2" from eslint-plugin-wdio@9.27.0
npm warn   eslint-plugin-wdio@"^9.16.2" from eslint-config-wikimedia@0.32.3
```

`eslint-config-wikimedia@0.32.3` declares a floating `eslint-plugin-wdio: ^9.16.2`. That range resolved up to `9.27.0`, which bumped its peer requirement to `eslint@^9.39.2`, while this toolchain pins `eslint@^8.57.0`. npm overrode the peer and carried on (warning, not an error), but the install was noisy.

`0.32.4` pins `eslint-plugin-wdio` to exactly `9.23.0`, whose peer range still accepts eslint 8, so the warning disappears. eslint itself stays on 8; no flat-config migration and no lint-rule changes are involved (patch bump of the shared config).

The lockfile diff is confined to the `eslint-config-wikimedia` dev-lint subtree (the wdio swap plus its `@typescript-eslint` transitives); the production dependency tree is untouched.

## Verification

- `npm ci` before: emits the ERESOLVE peer warning above.
- `npm ci` after: no ERESOLVE output; `eslint --version` reports `v8.57.1`; `eslint --print-config` resolves the config cleanly.