### PR TITLE
Register Neo4j connection settings in extension.json config

### DIFF
--- a/docs/operations/installation.md
+++ b/docs/operations/installation.md
@@ -121,11 +121,9 @@ wfLoadExtension( 'ParserFunctions' );
 $wgNeoWikiEnableDevelopmentUI = false; // keep dev UI off
 ```
 
-The two Neo4j URL settings have **no default**. Until both are set, the wiki throws a `RuntimeException` on every
-request. The URL format is `bolt://user:password@host:7687`; the `neo4j://` scheme and the other connection schemes
-supported by the laudis client also work. Note that these two settings are **not yet registered in
-`extension.json`**, so they do **not** appear on `Special:Version`. This is tracked in
-[issue #876](https://github.com/ProfessionalWiki/NeoWiki/issues/876).
+Both Neo4j URL settings are **required**: until both are set, the wiki throws a `RuntimeException` on every request.
+The URL format is `bolt://user:password@host:7687`; the `neo4j://` scheme and the other connection schemes supported
+by the laudis client also work.
 
 ### 4. Create the read-only Neo4j user
 

--- a/extension.json
+++ b/extension.json
@@ -150,6 +150,14 @@
 				"default": { "timeoutSeconds": 30, "maxRows": 5000 },
 				"expensive": { "timeoutSeconds": 300, "maxRows": 50000 }
 			}
+		},
+		"NeoWikiNeo4jInternalWriteUrl": {
+			"description": "Bolt URL NeoWiki uses to write the graph projection to Neo4j.",
+			"value": null
+		},
+		"NeoWikiNeo4jInternalReadUrl": {
+			"description": "Bolt URL NeoWiki uses for read and query traffic against Neo4j; should use a least-privilege Neo4j user.",
+			"value": null
 		}
 	},
 


### PR DESCRIPTION
Closes #876.

`$wgNeoWikiNeo4jInternalWriteUrl` and `$wgNeoWikiNeo4jInternalReadUrl` are required by `NeoWikiConfigFactory` but were never declared in `extension.json`'s `config` block. With no registered default, `GlobalVarConfig::get()` on an unset value throws a low-level `ConfigException` ("undefined option: 'NeoWikiNeo4jInternalWriteUrl'") inside the `is_string( $config->get( ... ) )` check, so the factory's own `RuntimeException( 'Missing required config: ...' )` fallback is never reached on a fresh, unconfigured install.

This registers both keys with a `null` default. With the global now defined, `get()` returns `null`, `is_string()` is false, and the factory throws the intended `RuntimeException` that names the missing setting. The settings are also declared in one canonical place.

One correction to the issue's premise: registering the keys does **not** make them appear on `Special:Version` (MediaWiki does not surface config values there). The benefit is the clearer configuration error and idiomatic declaration, not `Special:Version` visibility.

`docs/operations/installation.md` (added in the recently merged #878) carried a `#876` reference noting these settings were unregistered and so absent from `Special:Version`. Since this PR resolves #876, that paragraph is updated and the now-stale caveat and reference removed.