### PR TITLE
Invoke maintenance scripts via run.php

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -348,10 +348,10 @@ reset: ## Wipe DB + Neo4j volumes and reseed demo data (containers stay)
 	$(MAKE) --no-print-directory import-demo-data
 
 import-demo-data: ## Import the NeoWiki demo subjects
-	$(EXEC_MW_ROOT) php extensions/NeoWiki/maintenance/ImportDemoData.php
+	$(EXEC_MW_ROOT) php maintenance/run.php NeoWiki:ImportDemoData
 
 rebuild-graph-databases: ## Rebuild Neo4j projection from MariaDB
-	$(EXEC_MW_ROOT) php extensions/NeoWiki/maintenance/RebuildGraphDatabases.php
+	$(EXEC_MW_ROOT) php maintenance/run.php NeoWiki:RebuildGraphDatabases
 
 update-dot-php: ## Run MW maintenance/update.php
 	$(EXEC_MW_ROOT) php maintenance/run.php update --quick

--- a/docs/operations/installation.md
+++ b/docs/operations/installation.md
@@ -21,7 +21,7 @@ NeoWiki has two stores, and understanding the split explains the rest of this gu
   in a dedicated `neo` revision slot. This is the source of truth, versioned like any other wiki content.
 - **Neo4j holds a regenerable secondary projection.** The graph database is a query-optimized copy of the canonical
   data. It can be wiped and rebuilt at any time from the revision slots via
-  `maintenance/RebuildGraphDatabases.php`, so it never holds data you cannot recover.
+  `maintenance/run.php NeoWiki:RebuildGraphDatabases`, so it never holds data you cannot recover.
 
 Although the projection is regenerable, **Neo4j is effectively required today**. The wiki throws a `RuntimeException`
 on *every* request until both Neo4j connection URLs are configured, and page edits that touch structured data fail if
@@ -165,7 +165,7 @@ If subject pages already exist in the wiki (for example after an import), build 
 canonical revision-slot data:
 
 ```sh
-php extensions/NeoWiki/maintenance/RebuildGraphDatabases.php
+php maintenance/run.php NeoWiki:RebuildGraphDatabases
 ```
 
 ## Configuration reference

--- a/docs/operations/maintenance.md
+++ b/docs/operations/maintenance.md
@@ -15,11 +15,10 @@ secondary projection** in Neo4j. The graph can be wiped and rebuilt at any time 
 MediaWiki root:
 
 ```sh
-php extensions/NeoWiki/maintenance/RebuildGraphDatabases.php
+php maintenance/run.php NeoWiki:RebuildGraphDatabases
 ```
 
-This is run by **full path**, not as a registered MediaWiki maintenance-script name (it is not registered with
-`maintenance/run.php`). It re-saves every Subject from each page's latest revision.
+It re-saves every Subject from each page's latest revision.
 
 Run it when you need to:
 
@@ -60,7 +59,7 @@ After upgrades that **change the projection encoding**, also rebuild the graph s
 format:
 
 ```sh
-php extensions/NeoWiki/maintenance/RebuildGraphDatabases.php
+php maintenance/run.php NeoWiki:RebuildGraphDatabases
 ```
 
 Because NeoWiki is **pre-release software**, breaking schema and data-format changes can land between versions without


### PR DESCRIPTION
Companion to ProfessionalWiki/NeoWiki-Docker#131 (same change in the dev/Docker repo).

Running extension maintenance scripts by file path is deprecated since MediaWiki 1.40 (`maintenance/doMaintenance.php` prints a deprecation notice). The supported entry point is `maintenance/run.php <Extension>:<Script>`.

`RebuildGraphDatabases` and `ImportDemoData` both already resolve via that convention (verified locally: `php maintenance/run.php NeoWiki:RebuildGraphDatabases --help` runs the script). This switches the invocations to the modern form:

- **`Makefile`**: the `import-demo-data` and `rebuild-graph-databases` targets.
- **`docs/operations/installation.md`** and **`docs/operations/maintenance.md`**: the rebuild commands.

It also removes a stale claim in `maintenance.md` that the rebuild script "is not registered with `maintenance/run.php`"; it is reachable via the `Extension:Script` convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
