### PR TITLE
Retarget the operations maintenance guide at evaluation

### DIFF
--- a/docs/operations/maintenance.md
+++ b/docs/operations/maintenance.md
@@ -5,87 +5,36 @@ order: 2
 
 # Maintaining NeoWiki
 
-This guide covers keeping an evaluation or pilot NeoWiki instance running: rebuilding the graph, backups, upgrades,
-operational caveats, and light hardening notes. For first-time setup, see [installation](installation.md).
+This covers the upkeep an evaluation NeoWiki instance needs: rebuilding the graph and the current limitations to be
+aware of. For first-time setup, see [installation](installation.md).
 
 ## Rebuilding the graph
 
-NeoWiki has two stores: the **canonical data** in MediaWiki revision slots (the source of truth) and a **regenerable
-secondary projection** in Neo4j. The graph can be wiped and rebuilt at any time from the canonical slots. From the
-MediaWiki root:
+NeoWiki stores its canonical data in MediaWiki revision slots and keeps a regenerable copy in Neo4j for querying. You
+can wipe and rebuild the Neo4j copy from the canonical slots at any time. From the MediaWiki root:
 
 ```sh
 php maintenance/run.php NeoWiki:RebuildGraphDatabases
 ```
 
-It re-saves every Subject from each page's latest revision.
+It re-saves every Subject from each page's latest revision. Run it to:
 
-Run it when you need to:
+- Recover after a Neo4j wipe or restore.
+- Refresh the projection after an upgrade that changes how data is stored.
+- Fix drift, such as the stale `Page.name` values left by page moves.
 
-- **Recover after a Neo4j wipe or restore** — rebuild the projection from the canonical store.
-- **Apply a projection-changing upgrade** — see [Upgrades](#upgrades) below.
-- **Fix projection drift** — for example, stale `Page.name` values after page moves (see
-  [Operational caveats](#operational-caveats)).
+Two things to plan around:
 
-Two caveats to plan around:
+- It does not clear the graph first, so orphan nodes from a drifted projection can survive a rebuild. For a
+  guaranteed-clean result, wipe the Neo4j data volume before rebuilding.
+- It runs as a single sequential process with no batching or resume, so the time scales with the number of pages. Plan
+  downtime on large wikis.
 
-- **It does not truncate the graph first.** Orphan nodes from a drifted projection can persist after a rebuild. If you
-  need a guaranteed-clean result, wipe the Neo4j data directory or volume before rebuilding.
-- **It is single-process and sequential.** There is no batching, resume, or throttling, so a rebuild scales linearly
-  with the number of pages. Plan downtime on large wikis.
+## Current limitations
 
-## Backups
+Two known limitations while NeoWiki is pre-release:
 
-Back up the **canonical store and standard MediaWiki state**:
-
-- The **MediaWiki database** — this holds the canonical revision slots, which are the source of truth for all Schemas,
-  Subjects, and Layouts.
-- **Uploaded files and images**, and **`LocalSettings.php`** — the same MediaWiki state you would back up for any wiki.
-
-**Neo4j does not need to be backed up.** The graph is a regenerable projection that you can always recreate from the
-canonical store with the rebuild script above. Backing it up is optional and only a recovery-time optimization — it
-saves a rebuild, nothing more.
-
-## Upgrades
-
-NeoWiki adds no SQL tables, so an upgrade is a **code swap** plus MediaWiki's standard updater. From the MediaWiki
-root:
-
-```sh
-php maintenance/run.php update --quick
-```
-
-After upgrades that **change the projection encoding**, also rebuild the graph so the projection matches the new
-format:
-
-```sh
-php maintenance/run.php NeoWiki:RebuildGraphDatabases
-```
-
-Because NeoWiki is **pre-release software**, breaking schema and data-format changes can land between versions without
-a migration path. Read the release notes before upgrading, and keep a backup of the MediaWiki database first.
-
-## Operational caveats
-
-Current limitations to be aware of when operating an instance:
-
-- **Page moves leave `Page.name` stale.** Moving or renaming a page does not update the projection, so the `Page.name`
-  value in Neo4j drifts until you run a rebuild. Tracked in
-  [#875](https://github.com/ProfessionalWiki/NeoWiki/issues/875).
-- **A Neo4j outage hard-fails writes.** Graph writes are synchronous with no retry or queue, so edits, deletes, and
-  undeletes fail while Neo4j is unreachable; only the read/query path degrades gracefully. Treat Neo4j availability as
-  required for write availability. Tracked in [#877](https://github.com/ProfessionalWiki/NeoWiki/issues/877).
-- **Keep the development UI off.** Set `$wgNeoWikiEnableDevelopmentUI = false` on any instance others can reach.
-
-## Hardening notes
-
-NeoWiki restricts all graph access to the backend ([ADR 013](../adr/013-restrict-neo4j-access.md)); the wiki is the
-only client that talks to Neo4j. To keep an evaluation or pilot instance safe:
-
-- **Use encrypted Bolt.** Prefer the `neo4j+s://` scheme so the connection between the wiki and Neo4j is encrypted.
-- **Use strong credentials.** Replace any default passwords, and use a least-privilege user for the read URL.
-- **Do not expose graph endpoints publicly.** The Neo4j Bolt endpoint — and any SPARQL endpoint — must not be
-  reachable from the public internet.
-- **Keep the dev UI off.** As above, `$wgNeoWikiEnableDevelopmentUI = false`.
-
-Before exposing an instance to others, read the [security policy](../../SECURITY.md).
+- **Page moves do not update the graph.** Moving or renaming a page leaves its `Page.name` in Neo4j stale until you
+  rebuild. Tracked in #875.
+- **A Neo4j outage blocks writes.** Edits, deletes, and undeletes fail while Neo4j is unreachable; only reads and
+  queries keep working. Tracked in #877.

--- a/docs/operations/maintenance.md
+++ b/docs/operations/maintenance.md
@@ -20,7 +20,6 @@ php maintenance/run.php NeoWiki:RebuildGraphDatabases
 It re-saves every Subject from each page's latest revision. Run it to:
 
 - Recover after a Neo4j wipe or restore.
-- Refresh the projection after an upgrade that changes how data is stored.
 - Fix drift, such as the stale `Page.name` values left by page moves.
 
 Two things to plan around:
@@ -29,6 +28,21 @@ Two things to plan around:
   guaranteed-clean result, wipe the Neo4j data volume before rebuilding.
 - It runs as a single sequential process with no batching or resume, so the time scales with the number of pages. Plan
   downtime on large wikis.
+
+## Upgrades
+
+NeoWiki adds no database tables of its own, so an upgrade is a code swap plus MediaWiki's standard updater. Update the
+NeoWiki code, then run the updater from the MediaWiki root:
+
+```sh
+php maintenance/run.php update --quick
+```
+
+If the new version changes how data is stored in the graph, [rebuild the projection](#rebuilding-the-graph) afterwards
+so it matches.
+
+NeoWiki is pre-release, so a new version can change the schema or data format with no migration path. Your evaluation
+data may not survive an upgrade, so be ready to rebuild it from scratch.
 
 ## Current limitations
 


### PR DESCRIPTION
> Result of a back-and-forth with @JeroenDeDauw, who chose to cut the production-only sections and preserve them in #892, and to keep an evaluation-framed Upgrades section.
> Context: the `docs/operations/maintenance.md` page, the NeoWiki codebase (verified the page-move hook stub and issue states), and the NeoWiki-Website docs-sync setup.
> <sub>Written by Claude Code, `Opus 4.8`</sub>

Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/893

Applies the same evaluation-focused treatment to `maintenance.md` that #893 did for `installation.md`. The technical claims were accurate, so this is mostly trimming and re-framing.

- Keeps what an evaluator does: **rebuilding the graph** (no-truncate and sequential caveats), **upgrading** (code swap + updater, rebuild if the data format changed), and the **current limitations** (page moves leave `Page.name` stale; a Neo4j outage blocks writes).
- Re-frames Upgrades for evaluation: be ready to rebuild your eval data rather than "back up the database first."
- Cuts the production-only sections (Backups, Hardening notes) as premature for eval-only software. Their prose is preserved on https://github.com/ProfessionalWiki/NeoWiki/issues/892 to fold into the production guide later.
- Plain language, no em-dashes; removed the `SECURITY.md` link (not published on the docs site); issue references (`#875`, `#877`) are plain text rather than GitHub links.

Verified while reviewing: `onPageMoveComplete` is an empty stub (#875 open), the write path hard-fails on a Neo4j outage (#877 open), and the rebuild does not truncate.

## Manual review

Renders on neowiki.ai (the `docs/` tree auto-syncs). Worth a glance at the rendered Markdown and that the `installation.md` link resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)