### PR TITLE
Remove no-op page-move hook; moves already update the graph

### DIFF
--- a/docs/operations/maintenance.md
+++ b/docs/operations/maintenance.md
@@ -20,7 +20,7 @@ php maintenance/run.php NeoWiki:RebuildGraphDatabases
 It re-saves every Subject from each page's latest revision. Run it to:
 
 - Recover after a Neo4j wipe or restore.
-- Fix drift, such as the stale `Page.name` values left by page moves.
+- Fix any drift between the Neo4j copy and the canonical revision slots.
 
 Two things to plan around:
 
@@ -46,9 +46,7 @@ data may not survive an upgrade, so be ready to rebuild it from scratch.
 
 ## Current limitations
 
-Two known limitations while NeoWiki is pre-release:
+One known limitation while NeoWiki is pre-release:
 
-- **Page moves do not update the graph.** Moving or renaming a page leaves its `Page.name` in Neo4j stale until you
-  rebuild. Tracked in #875.
 - **A Neo4j outage blocks writes.** Edits, deletes, and undeletes fail while Neo4j is unreachable; only reads and
   queries keep working. Tracked in #877.

--- a/extension.json
+++ b/extension.json
@@ -41,7 +41,6 @@
 		"RevisionFromEditComplete": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onRevisionFromEditComplete",
 		"PageDeleteComplete": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onPageDeleteComplete",
 		"RevisionUndeleted": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onRevisionUndeleted",
-		"PageMoveComplete": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onPageMoveComplete",
 
 		"CodeEditorGetPageLanguage": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onCodeEditorGetPageLanguage",
 

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -7,7 +7,6 @@ namespace ProfessionalWiki\NeoWiki\EntryPoints;
 use InvalidArgumentException;
 use MediaWiki\EditPage\EditPage;
 use MediaWiki\Html\Html;
-use MediaWiki\Linker\LinkTarget;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Output\OutputPage;
 use MediaWiki\Page\ProperPageIdentity;
@@ -186,17 +185,6 @@ class NeoWikiHooks {
 
 	public static function onRevisionUndeleted( RevisionRecord $restoredRevision, ?int $oldPageId ): void {
 		NeoWikiExtension::getInstance()->getStoreContentUC()->onPageUndelete( $restoredRevision );
-	}
-
-	public static function onPageMoveComplete(
-		LinkTarget $old,
-		LinkTarget $new,
-		UserIdentity $userIdentity,
-		int $pageId,
-		int $redirectId,
-		string $reason,
-		RevisionRecord $revision
-	): void {
 	}
 
 	public static function onEditFilter( EditPage $editPage, ?string $text, ?string $section, string &$error ): void {

--- a/tests/phpunit/EntryPoints/PageMoveGraphProjectionTest.php
+++ b/tests/phpunit/EntryPoints/PageMoveGraphProjectionTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints;
+
+use MediaWiki\Deferred\DeferredUpdates;
+use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+
+/**
+ * Moving a page keeps its graph node's title-derived properties in sync. This needs no
+ * dedicated move hook: core creates a null revision on the new title for every move and
+ * fires RevisionFromEditComplete for it, which rewrites the page node.
+ *
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiHooks::onRevisionFromEditComplete
+ * @group Database
+ */
+class PageMoveGraphProjectionTest extends NeoWikiIntegrationTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->setUpNeo4j();
+		$this->createSchema( TestSubject::DEFAULT_SCHEMA_ID );
+		$this->markPageTableAsUsed();
+	}
+
+	public function testMovingPageUpdatesGraphNodeName(): void {
+		$revision = $this->createPageWithSubjects( 'Original move source', TestSubject::build() );
+		$pageId = $revision->getPageId();
+
+		$this->movePage( 'Original move source', 'Renamed move target' );
+
+		$this->assertSame(
+			'Renamed move target',
+			$this->readPageNodeName( $pageId )
+		);
+	}
+
+	private function movePage( string $from, string $to ): void {
+		$movePage = MediaWikiServices::getInstance()->getMovePageFactory()->newMovePage(
+			Title::newFromText( $from ),
+			Title::newFromText( $to )
+		);
+
+		$status = $movePage->move( $this->getTestSysop()->getUser(), 'test move', false );
+		$this->assertStatusGood( $status );
+
+		DeferredUpdates::doUpdates();
+	}
+
+	private function readPageNodeName( int $pageId ): ?string {
+		$result = $this->newNeo4jQueryStore()->runReadQuery(
+			'MATCH (page:Page {id: $pageId}) RETURN page.name AS name',
+			[ 'pageId' => $pageId ]
+		);
+
+		return $result->first()->toRecursiveArray()['name'] ?? null;
+	}
+
+}


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/875

The reported staleness does not occur. Every page move creates a null
revision on the new title (inheriting all slots, including the subject
slot), and core fires RevisionFromEditComplete for it synchronously.
NeoWiki already handles that hook and rewrites the page node, keyed by
the move-stable page ID, so Page.name and the other title-derived
properties update immediately, with no rebuild needed.

The empty onPageMoveComplete handler was therefore dead code, and what
made the move path look unhandled. Remove it and its registration.
Implementing it to re-save the page would only add a redundant second
write per move.

Add a regression test that moves a page with subjects and asserts the
graph node's name follows the new title, and drop the now-incorrect
"page moves leave Page.name stale" note from the maintenance docs.

> Result of investigating #875 at @alistair3149's direction; the
> false-positive finding and the remove-dead-code resolution were his call.
> Context: the NeoWiki codebase and MediaWiki core's MovePage internals.
> <sub>Written by Claude Code, `Opus 4.8`</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
