### PR TITLE
Declare mediawiki.storage dependency for ext.neowiki module

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -260,7 +260,8 @@
 			"dependencies": [
 				"vue",
 				"pinia",
-				"mediawiki.user"
+				"mediawiki.user",
+				"mediawiki.storage"
 			],
 			"codexComponents": [
 				"CdxAccordion",


### PR DESCRIPTION
## Problem

NeoWiki views (`.ext-neowiki-view` infoboxes) render on Vector 2022 but not on other skins such as legacy Vector and Chameleon on some installs.

## Root cause

The `ext.neowiki` frontend uses `mw.storage.session` (in `PendingNotification`, run during app initialization) but the module declared only `vue`, `pinia` and `mediawiki.user` as dependencies. `mw.storage` is provided by the `mediawiki.storage` module, so when nothing else on the page has already loaded it, `mw.storage` is `undefined` and `ext.neowiki` throws as it executes. The whole module then fails, `NeoWikiApp` never mounts, and none of the `.ext-neowiki-view` placeholders are filled.

This stayed hidden wherever another module happens to load `mediawiki.storage` first:

- **VisualEditor**'s init modules depend on it and load on every page when VE is installed (so installs with VE, including our demo, work on every skin).
- **`skins.vector.js`** depends on it, so Vector 2022 works even without VE.

That combination is exactly why the reporter saw views only on Vector 2022 (an install without VisualEditor pulling `mediawiki.storage` in): the error surfaced as `can't access property "session", mw.storage is undefined` on Chameleon and legacy Vector.

## Fix

Declare `mediawiki.storage` as a dependency of `ext.neowiki`, so ResourceLoader loads it before the module on every skin and install, independent of VisualEditor.

## Verification

Verified end-to-end with automated browser checks (Playwright) on a local stack with VisualEditor disabled (so nothing masks the missing dependency), on the **Chameleon** skin (the reported skin) and on legacy Vector:

- Without the fix: `mw.storage` is `undefined`, `mediawiki.storage` is registered but never loaded, the console shows `TypeError: Cannot read properties of undefined (reading 'session')` in `ext.neowiki`, and the view placeholder stays empty.
- With the fix: `mediawiki.storage` loads before `ext.neowiki`, `mw.storage` is defined, and the infobox renders.

Vector 2022 renders even without the fix (its `skins.vector.js` loads `mediawiki.storage`), and with VisualEditor enabled every skin renders, both matching the masking described above.

## Test coverage

No automated test is added. The only meaningful regression guard would be an end-to-end test that loads a page without VisualEditor and asserts the view renders; there is no such harness, and a unit test asserting the dependency string is present in `extension.json` would only verify ResourceLoader configuration (a framework contract), not NeoWiki behaviour, so it would not earn its keep. Flagging the end-to-end coverage gap here rather than papering over it with a config change-detector.

Closes #899