### PR TITLE
Clarify RDF-star scope and provenance ownership in planning docs

### DIFF
--- a/docs/planning/ECHOLOT.md
+++ b/docs/planning/ECHOLOT.md
@@ -14,7 +14,13 @@ If you are not familiar with the NeoWiki terminology yet, see [the glossary](../
 
 ### Medium Priority
 
-* Verify the current data model (Property-graph-like Subjects and multi-Subject support) is workable for provenance.
+* Provenance scope and ownership. The grant and the D2.1 spec call for fine-grained chain-of-production provenance
+  and rights metadata. Intended boundary: NeoWiki core provides the *foundation* — MediaWiki's per-revision
+  authorship/versioning of statements, extension points, and per-page named graphs (data origin) — while the
+  provenance/rights *model* (T2.4) and a dedicated provenance/rights plug-in (T3.4) provide the fine-grained
+  capture on top, rather than it being built into the core data model. Open: verify the data model and named-graph
+  design can carry what the plug-in needs, as distinct from operational per-page named graphs (see
+  [RdfMapping.md](RdfMapping.md) Q5).
 * Does the [RDF mapping stwaman proposal](RdfMapping.md) go in the right direction? What needs to be adjusted?
 * Is our [Graph Model](../reference/graph-model.md) OK? In particular, is it OK to have non-Subject data in there, like the connected
   MediaWiki pages? (80% likely, briefly covered in Vienna: can filter out these values when querying)

--- a/docs/planning/RdfMapping.md
+++ b/docs/planning/RdfMapping.md
@@ -281,7 +281,7 @@ ECHOLOT's provenance model (T2.4) have implications for named graph design?
 *Resolved: No CH conventions exist for named graph usage. Per-page named graphs are fine for operational
 purposes. Note: per-page named graphs record only data origin (which page), not chain-of-production provenance;
 the latter is handled by the provenance model (T2.4) and a dedicated provenance plug-in (T3.4) on top of NeoWiki's
-extension points and MediaWiki versioning, not by the base mapping. See [planning/ECHOLOT.md](ECHOLOT.md).*
+extension points and MediaWiki versioning, not by the base mapping. See [ECHOLOT.md](ECHOLOT.md).*
 
 **Q6: Base URI conventions.** Should the base URI be the wiki's URL (e.g., `https://mywiki.example.org/`)? Is
 there a convention in the ECHOLOT/ECCCH context for how services should mint URIs?

--- a/docs/planning/RdfMapping.md
+++ b/docs/planning/RdfMapping.md
@@ -222,6 +222,10 @@ DROP SILENT GRAPH <neo-page:42>
 - **RDF import.** This document covers the outbound direction (NeoWiki data to RDF). Importing RDF data into
   NeoWiki Subjects is a T3.2/T4.1 concern and has its own challenges (mapping external ontologies to NeoWiki
   Schemas).
+- **RDF-star / RDF 1.2.** The grant (T3.2) and the D2.1 system spec refer to "native RDF/RDF*" import/export. The
+  base mapping deliberately targets standard RDF 1.1 (Relation reification, see Design Principle 3), and common
+  target stores such as QLever do not support RDF-star. RDF-star is out of scope for now; it would only be
+  revisited given a concrete need, and then at the import/export serialization layer rather than the triple store.
 
 ## Open Questions
 
@@ -275,7 +279,9 @@ there CH/LOD conventions for named graph usage (e.g., per-source, per-dataset) t
 ECHOLOT's provenance model (T2.4) have implications for named graph design?
 
 *Resolved: No CH conventions exist for named graph usage. Per-page named graphs are fine for operational
-purposes.*
+purposes. Note: per-page named graphs record only data origin (which page), not chain-of-production provenance;
+the latter is handled by the provenance model (T2.4) and a dedicated provenance plug-in (T3.4) on top of NeoWiki's
+extension points and MediaWiki versioning, not by the base mapping. See [planning/ECHOLOT.md](ECHOLOT.md).*
 
 **Q6: Base URI conventions.** Should the base URI be the wiki's URL (e.g., `https://mywiki.example.org/`)? Is
 there a convention in the ECHOLOT/ECCCH context for how services should mint URIs?


### PR DESCRIPTION
> Result of a review of the ECHOLOT D2.1 system specification with @JeroenDeDauw, recording scope decisions made during it.
> Context: the NeoWiki docs/ADRs and planning notes, plus the D2.1 spec.
> <sub>Written by Claude Code, `Opus 4.8`</sub>

While reviewing the ECHOLOT D2.1 system specification, record two scope clarifications:

- RdfMapping: add an RDF-star / RDF 1.2 scope note (base mapping stays RDF 1.1 with Relation reification; QLever lacks RDF-star; revisit only on concrete need, at the interchange layer). Extend Q5 to note per-page named graphs capture data origin only, not chain-of-production provenance.
- planning/ECHOLOT: sharpen the provenance open item into an explicit scope boundary — NeoWiki core provides the foundation (versioning, extension points, named graphs); the provenance/rights model (T2.4) and plug-in (T3.4) provide fine-grained capture on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
