### PR TITLE
Scope Neo4j page-node identity per wiki

### DIFF
--- a/docs/reference/graph-model.md
+++ b/docs/reference/graph-model.md
@@ -28,9 +28,15 @@ via Relations.
 Every page that contains structured data has a corresponding `:Page` node. These nodes make page metadata available
 for graph queries.
 
+Page identity is scoped per wiki. A shared graph can hold pages from multiple wikis (e.g. a wiki farm), and MediaWiki
+page ids are only unique within a single wiki. Each page node therefore carries a `wiki_id` and is identified by the
+`(wiki_id, id)` pair ([ADR 22](../adr/022-multi-wiki-node-identity.md)). In a single-wiki install there is one
+`wiki_id` value and behaviour is unchanged.
+
 | Property | Neo4j Type | Description |
 |----------|------------|-------------|
-| `id` | integer | MediaWiki page ID (unique) |
+| `wiki_id` | string | [MediaWiki Wiki ID](https://www.mediawiki.org/wiki/Manual:Wiki_ID) (database name + table prefix) of the owning wiki |
+| `id` | integer | MediaWiki page ID (unique per wiki) |
 | `name` | string | Page title |
 | `creationTime` | datetime | When the page was created |
 | `lastUpdated` | datetime | When the page was last modified |
@@ -51,6 +57,11 @@ their Schema (e.g., `:Subject:Person`, `:Subject:Company`). The Schema label cha
 |----------|------------|-------------|
 | `id` | string | Subject ID, 15 characters starting with `s` (unique) |
 | `name` | string | Subject label |
+| `wiki_id` | string | [MediaWiki Wiki ID](https://www.mediawiki.org/wiki/Manual:Wiki_ID) of the wiki that owns the Subject |
+
+Unlike page ids, Subject ids are globally unique nanoids ([ADR 14](../adr/014-improved-id-format.md)), so a Subject's
+identity is its `id` alone. The `wiki_id` is carried only for per-wiki query filtering in a shared graph; Subject-id
+namespacing is deferred ([ADR 22](../adr/022-multi-wiki-node-identity.md)).
 
 ### Dynamic properties
 
@@ -90,13 +101,15 @@ When a Subject is deleted but still has incoming relations from other Subjects, 
 
 ## Constraints
 
-Two uniqueness constraints are intended for the graph — `Page.id` is unique and `Subject.id` is unique. These are
-**not** created automatically yet ([#874](https://github.com/ProfessionalWiki/NeoWiki/issues/874)).
+Two uniqueness constraints are intended for the graph — the `(wiki_id, id)` pair is unique on `:Page` nodes
+([ADR 22](../adr/022-multi-wiki-node-identity.md)), and `Subject.id` is unique. These are **not** created
+automatically yet ([#874](https://github.com/ProfessionalWiki/NeoWiki/issues/874)).
 
 ## Related Documentation
 
 - [ADR 3: Neo4j as Graph Database](../adr/003-neo4j-as-graph-database.md)
 - [ADR 4: Use Dedicated Slot](../adr/004-use-dedicated-slot.md) — primary storage in MediaWiki revision slots
 - [ADR 13: Restrict Neo4j Access](../adr/013-restrict-neo4j-access.md) — backend-only access to Neo4j
+- [ADR 22: Multi-wiki Graph Node Identity](../adr/022-multi-wiki-node-identity.md) — per-wiki page identity in a shared graph
 - [Subject Format](subject-format.md) — JSON format for Subject data in revision slots
 - [Schema Format](schema-format.md) — JSON format for Schema definitions

--- a/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jConstraintUpdater.php
+++ b/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jConstraintUpdater.php
@@ -12,16 +12,31 @@ class Neo4jConstraintUpdater {
 	}
 
 	public function createDefaultConstraints(): void {
-		$this->createNodePropertyConstraint( 'Page', 'id' );
-		$this->createNodePropertyConstraint( 'Subject', 'id' );
+		// Page identity is scoped per wiki: pages from different wikis may share an id
+		// in a shared graph, so uniqueness is on the (wiki_id, id) pair rather than id alone.
+		$this->createNodePropertyUniquenessConstraint( 'Page', [ 'wiki_id', 'id' ] );
+
+		// Subject ids are bare nanoids that are globally unique; namespacing is deferred.
+		$this->createNodePropertyUniquenessConstraint( 'Subject', [ 'id' ] );
 	}
 
-	private function createNodePropertyConstraint( string $nodeLabel, string $propertyName ): void {
+	/**
+	 * @param string[] $propertyNames
+	 */
+	private function createNodePropertyUniquenessConstraint( string $nodeLabel, array $propertyNames ): void {
+		$properties = implode(
+			', ',
+			array_map(
+				static fn ( string $propertyName ): string => 'node.' . Cypher::escape( $propertyName ),
+				$propertyNames
+			)
+		);
+
 		$this->queryEngine->runWriteQuery(
-			'CREATE CONSTRAINT ' . Cypher::escape( $nodeLabel . ' ' . $propertyName ) . '
+			'CREATE CONSTRAINT ' . Cypher::escape( $nodeLabel . ' ' . implode( ' ', $propertyNames ) ) . '
 			 IF NOT EXISTS
 			 FOR (node:' . Cypher::escape( $nodeLabel ) . ')
-			 REQUIRE node.' . Cypher::escape( $propertyName ) . ' IS UNIQUE'
+			 REQUIRE (' . $properties . ') IS UNIQUE'
 		);
 	}
 

--- a/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jPageIdentifiersLookup.php
+++ b/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jPageIdentifiersLookup.php
@@ -25,6 +25,9 @@ class Neo4jPageIdentifiersLookup implements PageIdentifiersLookup {
 				/**
 				 * @var SummarizedResult $result
 				 */
+				// The page is reached by traversing HasSubject from a globally-unique
+				// Subject id, so it is unambiguous without wiki-scoping: a Subject is only
+				// ever linked to its own wiki's page node.
 				$result = $transaction->run(
 					'
 					MATCH (page:Page)-[:HasSubject]->(subject {id: $subjectId})

--- a/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jQueryStore.php
+++ b/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jQueryStore.php
@@ -23,6 +23,7 @@ readonly class Neo4jQueryStore implements GraphDatabasePlugin, Neo4jQueryEngine,
 		private ClientInterface $client,
 		private ClientInterface $readOnlyClient,
 		private Neo4jSubjectUpdaterFactory $subjectUpdaterFactory,
+		private string $wikiId,
 	) {
 	}
 
@@ -32,8 +33,10 @@ readonly class Neo4jQueryStore implements GraphDatabasePlugin, Neo4jQueryEngine,
 			[ $typedSetClauses, $typedParams, $properties ] = $this->extractTypedValues( $properties );
 
 			$cypher = '
-				// Create or update the page
-				MERGE (page:Page {id: $pageId})
+				// Create or update the page. Page identity is scoped per wiki so that
+				// pages from different wikis sharing the same id do not collide in a shared graph.
+				// The wiki_id is persisted by the MERGE pattern itself.
+				MERGE (page:Page {id: $pageId, wiki_id: $wikiId})
 				SET page += $properties
 				SET page.id = $pageId';
 
@@ -60,6 +63,7 @@ readonly class Neo4jQueryStore implements GraphDatabasePlugin, Neo4jQueryEngine,
 				array_merge(
 					[
 						'pageId' => $page->getId()->id,
+						'wikiId' => $this->wikiId,
 						'subjectIds' => $page->getSubjects()->getAllSubjects()->getIdsAsTextArray(),
 						'properties' => new CypherMap( $properties ),
 					],
@@ -144,8 +148,8 @@ readonly class Neo4jQueryStore implements GraphDatabasePlugin, Neo4jQueryEngine,
 	private function deletePageNode( TransactionInterface $transaction, PageId $pageId ): void {
 		// TODO: Redlinks: page should not always be deleted due to incoming links? Difference between ID and title in meaning
 		$transaction->run(
-			'MATCH (page:Page {id: $pageId}) DETACH DELETE page',
-			[ 'pageId' => $pageId->id ]
+			'MATCH (page:Page {id: $pageId, wiki_id: $wikiId}) DETACH DELETE page',
+			[ 'pageId' => $pageId->id, 'wikiId' => $this->wikiId ]
 		);
 	}
 
@@ -158,9 +162,9 @@ readonly class Neo4jQueryStore implements GraphDatabasePlugin, Neo4jQueryEngine,
 		 * @var SummarizedResult $results
 		 */
 		$results = $transaction->run(
-			'MATCH (page:Page {id: $pageId})-[:HasSubject]->(subject:Subject)
+			'MATCH (page:Page {id: $pageId, wiki_id: $wikiId})-[:HasSubject]->(subject:Subject)
 				RETURN subject.id AS id, subject AS properties, labels(subject) AS labels',
-			[ 'pageId' => $pageId->id ]
+			[ 'pageId' => $pageId->id, 'wikiId' => $this->wikiId ]
 		);
 
 		return array_map(

--- a/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectUpdater.php
+++ b/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectUpdater.php
@@ -22,7 +22,8 @@ class Neo4jSubjectUpdater {
 		private readonly PageId $pageId,
 		private readonly SchemaLookup $schemaRepository,
 		private readonly Neo4jValueBuilderRegistry $valueBuilderRegistry,
-		private readonly LoggerInterface $logger
+		private readonly LoggerInterface $logger,
+		private readonly string $wikiId,
 	) {
 	}
 
@@ -52,6 +53,7 @@ class Neo4jSubjectUpdater {
 					[
 						'name' => $subject->label->text,
 						'id' => $subject->id->text,
+						'wiki_id' => $this->wikiId,
 					]
 				),
 			]
@@ -83,10 +85,11 @@ class Neo4jSubjectUpdater {
 
 	private function updateHasSubjectRelation( Subject $subject, bool $isMainSubject ): void {
 		$this->transaction->run(
-			'MATCH (page:Page {id: $pageId}), (subject {id: $subjectId})
+			'MATCH (page:Page {id: $pageId, wiki_id: $wikiId}), (subject {id: $subjectId})
 					MERGE (page)-[:HasSubject {isMain: $isMainSubject}]->(subject)',
 			[
 				'pageId' => $this->pageId->id,
+				'wikiId' => $this->wikiId,
 				'subjectId' => $subject->id->text,
 				'isMainSubject' => $isMainSubject,
 			]

--- a/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectUpdaterFactory.php
+++ b/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectUpdaterFactory.php
@@ -14,7 +14,8 @@ class Neo4jSubjectUpdaterFactory {
 	public function __construct(
 		private readonly SchemaLookup $schemaLookup,
 		private readonly Neo4jValueBuilderRegistry $valueBuilderRegistry,
-		private readonly LoggerInterface $logger
+		private readonly LoggerInterface $logger,
+		private readonly string $wikiId,
 	) {
 	}
 
@@ -24,7 +25,8 @@ class Neo4jSubjectUpdaterFactory {
 			$pageId,
 			$this->schemaLookup,
 			$this->valueBuilderRegistry,
-			$this->logger
+			$this->logger,
+			$this->wikiId,
 		);
 	}
 

--- a/src/NeoWikiConfig.php
+++ b/src/NeoWikiConfig.php
@@ -10,6 +10,7 @@ readonly class NeoWikiConfig {
 		public bool $enableDevelopmentUIs,
 		public string $neo4jInternalWriteUrl,
 		public string $neo4jInternalReadUrl,
+		public string $wikiId,
 	) {
 	}
 

--- a/src/NeoWikiConfigFactory.php
+++ b/src/NeoWikiConfigFactory.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki;
 
 use MediaWiki\Config\Config;
+use MediaWiki\WikiMap\WikiMap;
 use RuntimeException;
 
 class NeoWikiConfigFactory {
@@ -14,6 +15,7 @@ class NeoWikiConfigFactory {
 			enableDevelopmentUIs: $config->get( 'NeoWikiEnableDevelopmentUI' ) === true,
 			neo4jInternalWriteUrl: $this->buildInternalWriteUrl( $config ),
 			neo4jInternalReadUrl: $this->builtInternalReadUrl( $config ),
+			wikiId: WikiMap::getCurrentWikiId(),
 		);
 	}
 

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -233,8 +233,10 @@ class NeoWikiExtension {
 			subjectUpdaterFactory: new Neo4jSubjectUpdaterFactory(
 				schemaLookup: $schemaLookup, // Note: this is a hack, we should have a proper test environment
 				valueBuilderRegistry: $this->getValueBuilderRegistry(),
-				logger: LoggerFactory::getInstance( 'NeoWiki' )
+				logger: LoggerFactory::getInstance( 'NeoWiki' ),
+				wikiId: $this->config->wikiId,
 			),
+			wikiId: $this->config->wikiId,
 		);
 	}
 

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jConstraintUpdaterTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jConstraintUpdaterTest.php
@@ -33,16 +33,18 @@ class Neo4jConstraintUpdaterTest extends NeoWikiIntegrationTestCase {
 
 		$updater->createDefaultConstraints();
 
-		$result = $store->runReadQuery( 'SHOW CONSTRAINTS YIELD name, type, entityType, labelsOrTypes, properties' );
+		$result = $store->runReadQuery(
+			'SHOW CONSTRAINTS YIELD name, type, entityType, labelsOrTypes, properties ORDER BY name'
+		);
 
 		$this->assertSame(
 			[
 				[
-					'name' => 'Page id',
+					'name' => 'Page wiki_id id',
 					'type' => 'NODE_PROPERTY_UNIQUENESS',
 					'entityType' => 'NODE',
 					'labelsOrTypes' => [ 'Page' ],
-					'properties' => [ 'id' ],
+					'properties' => [ 'wiki_id', 'id' ],
 				],
 				[
 					'name' => 'Subject id',
@@ -70,21 +72,39 @@ class Neo4jConstraintUpdaterTest extends NeoWikiIntegrationTestCase {
 		);
 	}
 
-	public function testPageWithDuplicateIdCannotBeCreated(): void {
+	public function testPageWithDuplicateIdInSameWikiCannotBeCreated(): void {
+		$this->newConstraintUpdater()->createDefaultConstraints();
+
+		$store = $this->newQueryStore();
+		$wikiId = NeoWikiExtension::getInstance()->config->wikiId;
+
+		$store->savePage( TestPage::build( id: 42 ) );
+
+		$this->expectException( Neo4jException::class );
+		$this->expectExceptionMessageMatches(
+			'/Neo.ClientError.Schema.ConstraintValidationFailed.*already exists with label `Page`/'
+		);
+
+		$store->runWriteQuery(
+			'CREATE (:Page {name: "Test", id: 42, wiki_id: "' . $wikiId . '"} )'
+		);
+	}
+
+	public function testPagesWithSameIdInDifferentWikisCanCoexist(): void {
 		$this->newConstraintUpdater()->createDefaultConstraints();
 
 		$store = $this->newQueryStore();
 
 		$store->savePage( TestPage::build( id: 42 ) );
 
-		$this->expectException( Neo4jException::class );
-		$this->expectExceptionMessageMatches(
-			'/Neo.ClientError.Schema.ConstraintValidationFailed.*already exists with label `Page` and property `id` = 42"/'
+		// A page with the same id but a different wiki_id must not violate the composite constraint.
+		$store->runWriteQuery(
+			'CREATE (:Page {name: "Test", id: 42, wiki_id: "some_other_wiki"} )'
 		);
 
-		$store->runWriteQuery(
-			'CREATE (:Page {name: "Test", id: 42} )'
-		);
+		$result = $store->runReadQuery( 'MATCH (page:Page {id: 42}) RETURN count(page) AS count' );
+
+		$this->assertSame( 2, $result->first()->toRecursiveArray()['count'] );
 	}
 
 	public function testSubjectWithDuplicateIdCannotBeCreated(): void {

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jQueryStoreTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jQueryStoreTest.php
@@ -18,6 +18,8 @@ use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectMap;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jQueryStore;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jSubjectUpdaterFactory;
+use Psr\Log\NullLogger;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestPage;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestRelation;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestStatement;
@@ -64,6 +66,24 @@ class Neo4jQueryStoreTest extends NeoWikiIntegrationTestCase {
 		);
 	}
 
+	private function newQueryStoreForWiki( string $wikiId ): Neo4jQueryStore {
+		$extension = NeoWikiExtension::getInstance();
+
+		return new Neo4jQueryStore(
+			client: $extension->getNeo4jClient(),
+			readOnlyClient: $extension->getReadOnlyNeo4jClient(),
+			subjectUpdaterFactory: new Neo4jSubjectUpdaterFactory(
+				schemaLookup: new InMemorySchemaLookup(
+					TestSchema::build( name: TestSubject::DEFAULT_SCHEMA_ID )
+				),
+				valueBuilderRegistry: $extension->getValueBuilderRegistry(),
+				logger: new NullLogger(),
+				wikiId: $wikiId,
+			),
+			wikiId: $wikiId,
+		);
+	}
+
 	public function testSavesPageIdAndTitle(): void {
 		$store = $this->newQueryStore();
 
@@ -90,6 +110,121 @@ class Neo4jQueryStoreTest extends NeoWikiIntegrationTestCase {
 		$this->assertSame(
 			'TestPage',
 			$page['name']
+		);
+	}
+
+	public function testSavesWikiIdOnPageNode(): void {
+		$store = $this->newQueryStoreForWiki( 'my_wiki' );
+
+		$store->savePage( TestPage::build( id: 42 ) );
+
+		$result = $store->runReadQuery( 'MATCH (page:Page {id: 42}) RETURN page.wiki_id AS wikiId' );
+
+		$this->assertSame( 'my_wiki', $result->first()->toRecursiveArray()['wikiId'] );
+	}
+
+	public function testSavesWikiIdOnSubjectNodes(): void {
+		$store = $this->newQueryStoreForWiki( 'my_wiki' );
+
+		$store->savePage( TestPage::build(
+			id: 42,
+			mainSubject: TestSubject::build( id: self::GUID_1 ),
+			childSubjects: new SubjectMap(
+				TestSubject::build( id: self::GUID_2 ),
+			)
+		) );
+
+		$result = $store->runReadQuery(
+			'MATCH (subject:Subject) RETURN subject.id AS id, subject.wiki_id AS wikiId ORDER BY id'
+		)->toRecursiveArray();
+
+		$this->assertSame(
+			[
+				[ 'id' => self::GUID_1, 'wikiId' => 'my_wiki' ],
+				[ 'id' => self::GUID_2, 'wikiId' => 'my_wiki' ],
+			],
+			$result
+		);
+	}
+
+	public function testPagesWithSameIdInDifferentWikisDoNotOverwriteEachOther(): void {
+		$wikiA = $this->newQueryStoreForWiki( 'wiki_a' );
+		$wikiB = $this->newQueryStoreForWiki( 'wiki_b' );
+
+		$wikiA->savePage( TestPage::build( id: 42, properties: TestPageProperties::build( title: 'Page on wiki A' ) ) );
+		$wikiB->savePage( TestPage::build( id: 42, properties: TestPageProperties::build( title: 'Page on wiki B' ) ) );
+
+		$result = $this->newQueryStore()->runReadQuery(
+			'MATCH (page:Page {id: 42}) RETURN page.wiki_id AS wikiId, page.name AS name ORDER BY wikiId'
+		)->toRecursiveArray();
+
+		$this->assertSame(
+			[
+				[ 'wikiId' => 'wiki_a', 'name' => 'Page on wiki A' ],
+				[ 'wikiId' => 'wiki_b', 'name' => 'Page on wiki B' ],
+			],
+			$result
+		);
+	}
+
+	public function testDeletingPageOnlyDeletesItInItsOwnWiki(): void {
+		$wikiA = $this->newQueryStoreForWiki( 'wiki_a' );
+		$wikiB = $this->newQueryStoreForWiki( 'wiki_b' );
+
+		$wikiA->savePage( TestPage::build( id: 42, properties: TestPageProperties::build( title: 'Page on wiki A' ) ) );
+		$wikiB->savePage( TestPage::build( id: 42, properties: TestPageProperties::build( title: 'Page on wiki B' ) ) );
+
+		$wikiA->deletePage( new PageId( 42 ) );
+
+		$result = $this->newQueryStore()->runReadQuery(
+			'MATCH (page:Page {id: 42}) RETURN page.wiki_id AS wikiId, page.name AS name ORDER BY wikiId'
+		)->toRecursiveArray();
+
+		$this->assertSame(
+			[
+				[ 'wikiId' => 'wiki_b', 'name' => 'Page on wiki B' ],
+			],
+			$result
+		);
+	}
+
+	public function testSubjectsAreLinkedToTheirOwnWikiPageOnly(): void {
+		$wikiA = $this->newQueryStoreForWiki( 'wiki_a' );
+		$wikiB = $this->newQueryStoreForWiki( 'wiki_b' );
+
+		$wikiA->savePage( TestPage::build( id: 42, mainSubject: TestSubject::build( id: self::GUID_1 ) ) );
+		$wikiB->savePage( TestPage::build( id: 42, mainSubject: TestSubject::build( id: self::GUID_2 ) ) );
+
+		$result = $this->newQueryStore()->runReadQuery(
+			'MATCH (page:Page {id: 42})-[:HasSubject]->(subject)
+			 RETURN page.wiki_id AS wikiId, subject.id AS subjectId ORDER BY wikiId, subjectId'
+		)->toRecursiveArray();
+
+		$this->assertSame(
+			[
+				[ 'wikiId' => 'wiki_a', 'subjectId' => self::GUID_1 ],
+				[ 'wikiId' => 'wiki_b', 'subjectId' => self::GUID_2 ],
+			],
+			$result
+		);
+	}
+
+	public function testDeletingPageOnlyDeletesItsOwnWikiSubjects(): void {
+		$wikiA = $this->newQueryStoreForWiki( 'wiki_a' );
+		$wikiB = $this->newQueryStoreForWiki( 'wiki_b' );
+
+		$wikiA->savePage( TestPage::build( id: 42, mainSubject: TestSubject::build( id: self::GUID_1 ) ) );
+		$wikiB->savePage( TestPage::build( id: 42, mainSubject: TestSubject::build( id: self::GUID_2 ) ) );
+
+		$wikiA->deletePage( new PageId( 42 ) );
+
+		$result = $this->newQueryStore()->runReadQuery(
+			'MATCH (subject:Subject) RETURN subject.id AS id ORDER BY id'
+		)->toRecursiveArray();
+
+		$this->assertSame(
+			[ [ 'id' => self::GUID_2 ] ],
+			$result
 		);
 	}
 

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jQueryStoreTimeoutTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jQueryStoreTimeoutTest.php
@@ -57,6 +57,7 @@ class Neo4jQueryStoreTimeoutTest extends TestCase {
 			$this->createMock( ClientInterface::class ),
 			$readOnlyClient,
 			$this->createMock( Neo4jSubjectUpdaterFactory::class ),
+			'test_wiki',
 		);
 	}
 

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectUpdaterTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectUpdaterTest.php
@@ -57,7 +57,8 @@ class Neo4jSubjectUpdaterTest extends TestCase {
 			$this->pageId,
 			$this->schemaLookup,
 			$valueBuilderRegistry ?? Neo4jValueBuilderRegistry::withCoreBuilders(),
-			$this->logger
+			$this->logger,
+			'test_wiki',
 		);
 	}
 

--- a/tests/phpunit/NeoWikiIntegrationTestCase.php
+++ b/tests/phpunit/NeoWikiIntegrationTestCase.php
@@ -29,6 +29,7 @@ class NeoWikiIntegrationTestCase extends MediaWikiIntegrationTestCase {
 			$client = NeoWikiExtension::getInstance()->getNeo4jClient();
 			$client->run( 'MATCH (n) DETACH DELETE n' );
 			$client->run( 'DROP CONSTRAINT `Page id` IF EXISTS' );
+			$client->run( 'DROP CONSTRAINT `Page wiki_id id` IF EXISTS' );
 			$client->run( 'DROP CONSTRAINT `Subject id` IF EXISTS' );
 		}
 		catch ( \Exception ) {


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/905

In a shared-graph wiki farm, MediaWiki page ids are per-wiki sequential, so `Page` nodes from different wikis collided on `id` and overwrote each other.

Stamp a `wiki_id` property (the MediaWiki Wiki ID) on page and subject nodes, and scope page-node identity to the `(wiki_id, id)` pair: the `savePage` MERGE, the page-node lookups (delete, subjects-of-page, HasSubject linking) and the uniqueness constraint now key on both properties. Subject ids stay bare, globally unique nanoids and only gain the `wiki_id` property for filtering; per-subject-id namespacing is deferred to the Subject Sources work.

`wiki_id` is resolved once at wiring time (`WikiMap::getCurrentWikiId()`) and injected into the Neo4j layer, keeping that layer free of MediaWiki globals. The domain `Page` and `Subject` are unchanged. Single-wiki installs are unaffected: with one `wiki_id`, `(wiki_id, id)` behaves exactly like `id`.

Implements the design in ADR 22 (#907) and updates `graph-model.md` accordingly. **Depends on #907** for the ADR file (it should merge first).

> Result of implementing @JeroenDeDauw's design (issue #905 + ADR #907, from the Subject Sources work) and @malberts' cross-wiki collision finding.
> Context: the NeoWiki Neo4j persistence layer, ADRs (esp. 1, 14, 19), ADR #907, graph-model.md, and the MediaWiki Wiki ID manual.
> <sub>Written by Claude Code, `Opus 4.8 (1M context)`</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
