### PR TITLE
Add ADR 023: Subject Sources

### DIFF
--- a/docs/adr/023-subject-sources.md
+++ b/docs/adr/023-subject-sources.md
@@ -66,10 +66,9 @@ from it rather than a re-keying of stored data.
 
 A schema is resolved through a Source and may be read-only (a code-defined built-in, or a remote-owned schema) or
 writeable (an ordinary local schema). A schema reference is `(source, name)` ([ADR 17](017-names-as-identifiers.md)),
-and a schema's source is independent of the subject's source (e.g., Subject from `WikitextSource`).
-In a farm, schemas are per-wiki with a delivered common
-baseline; a Subject whose schema is local to another wiki can be queried cross-wiki but not rendered or edited
-cross-wiki through the View system, and such cross-wiki access degrades gracefully rather than failing.
+and a schema's source is independent of the subject's source. Rendering a sourced Subject therefore resolves the
+schema through *its* Source, which may differ from the subject's. When a schema cannot be resolved — a foreign,
+offline, or removed schema — rendering degrades gracefully rather than breaking the page.
 
 ## Consequences
 
@@ -94,7 +93,7 @@ Deferred and/or still being designed; consortium feedback is expected here.
 ## Alternatives Considered
 
 - **Global properties / a single shared schema set.** Rejected ([planning/GlobalProperties.md](../planning/GlobalProperties.md));
-  name consistency is handled per-schema, and farm schemas are per-wiki with a delivered baseline.
+  name consistency is handled per-schema.
 - **Schemaless Subjects.** Disallowed ([ADR 8](008-one-schema-per-subject.md)); free-form tables use an ordinary
   schema edited through a table UI.
 - **Model Page Properties (approval, metadata) as Subjects.** Rejected for this use case: they are facts about a page,

--- a/docs/adr/023-subject-sources.md
+++ b/docs/adr/023-subject-sources.md
@@ -54,7 +54,7 @@ doubling as the RDF prefix map. The first increment — per-wiki node identity i
 
 A schema is resolved through a Source and may be read-only (a code-defined built-in, or a remote-owned schema) or
 writeable (an ordinary local schema). A schema reference is `(source, name)` ([ADR 17](017-names-as-identifiers.md)),
-and a schema's source is independent of the subject's source (i.e., Subject from `WikitextSource`).
+and a schema's source is independent of the subject's source (e.g., Subject from `WikitextSource`).
 In a farm, schemas are per-wiki with a delivered common
 baseline; a Subject whose schema is local to another wiki can be queried cross-wiki but not rendered or edited
 cross-wiki through the View system, and such cross-wiki access degrades gracefully rather than failing.

--- a/docs/adr/023-subject-sources.md
+++ b/docs/adr/023-subject-sources.md
@@ -54,7 +54,8 @@ doubling as the RDF prefix map. The first increment — per-wiki node identity i
 
 A schema is resolved through a Source and may be read-only (a code-defined built-in, or a remote-owned schema) or
 writeable (an ordinary local schema). A schema reference is `(source, name)` ([ADR 17](017-names-as-identifiers.md)),
-and a schema's source is independent of the subject's source. In a farm, schemas are per-wiki with a delivered common
+and a schema's source is independent of the subject's source (i.e., Subject from `WikitextSource`).
+In a farm, schemas are per-wiki with a delivered common
 baseline; a Subject whose schema is local to another wiki can be queried cross-wiki but not rendered or edited
 cross-wiki through the View system, and such cross-wiki access degrades gracefully rather than failing.
 
@@ -71,24 +72,23 @@ cross-wiki through the View system, and such cross-wiki access degrades graceful
 
 Deferred and/or still being designed; consortium feedback is expected here.
 
-- **Federation resolution** — fetch-at-read vs cache/materialise; for triple-store backends, federated query.
+- **Federation resolution** — fetch-at-read vs cache/materialise; for triple-store backends, federated queries.
 - **RDF / IRI export and ontology mapping** — see [planning/RdfMapping.md](../planning/RdfMapping.md).
-- **Editing sourced Subjects (write-back)** — end-of-roadmap; enables gradual migration off an on-wiki SMW/Wikibase
-  store and bidirectional flow with other systems.
-- **Rendering sourced Subjects in Views** — read-only; needs a source-aware load path. Deferred, not foreclosed.
+- **Editing sourced Subjects (write-back)** — end-of-roadmap. How useful? Things like editing Wikibase Items
+  via NeoWiki UI, or editing data from a remote NeoWiki
 - **The Source interface contract** for by-id and query resolution.
 
 ## Alternatives Considered
 
-- **Surface all sourced data as editor-Subjects with capability flags.** Rejected: it conflates a "this is sourced"
-  read-only with an access-rights read-only, adding user-facing complexity for no benefit.
-- **Model page-facts (approval, metadata) as Subjects.** Rejected for this use case: they are facts about a page,
-  simpler as page-node properties; modelling them as slot-backed Subjects would make recording them a new, unapproved
-  page revision.
 - **Global properties / a single shared schema set.** Rejected ([planning/GlobalProperties.md](../planning/GlobalProperties.md));
   name consistency is handled per-schema, and farm schemas are per-wiki with a delivered baseline.
 - **Schemaless Subjects.** Disallowed ([ADR 8](008-one-schema-per-subject.md)); free-form tables use an ordinary
   schema edited through a table UI.
+- **Model page-facts (approval, metadata) as Subjects.** Rejected for this use case: they are facts about a page,
+  simpler as page-node properties; modelling them as slot-backed Subjects would make recording them a new, unapproved
+  page revision.
+- **Materialization only.** We'd avoid adding subject sources and continue without support for displaying anything that is
+  not a "normal local Subject" via the View system. You'd only be able to display it via userland scripting on top of queries.
 
 ## Related
 

--- a/docs/adr/023-subject-sources.md
+++ b/docs/adr/023-subject-sources.md
@@ -1,0 +1,100 @@
+# Subject Sources
+
+Date: 2026-06-22
+
+Status: Draft
+
+## Context
+
+NeoWiki assumes every Subject is local, editable, and versioned — stored in a MediaWiki revision slot
+([ADR 4](004-use-dedicated-slot.md)) and projected into the graph ([ADR 19](019-graph-database-architecture.md)).
+Several needed capabilities do not fit that assumption: page and approval metadata, free-form (Confluence-style)
+tables, cross-wiki metadata in a wiki farm, and structured data drawn from other systems (another NeoWiki, an on-wiki
+SMW or Wikibase store, external services).
+
+The detailed exploration is in [planning/SubjectSources.md](../planning/SubjectSources.md). This ADR records the model.
+Sections under **Open questions** are where the design is still settling — notably federation and RDF — and where
+consortium feedback is expected.
+
+## Decision
+
+### Subjects come from pluggable Sources
+
+A Subject is produced by a **Source**. The local revision slot is the default Source; others — an on-wiki SMW/Wikibase
+store, another NeoWiki, an external system — supply Subjects too. A **Source registry** maps a source key to its
+Source, which is the authority for its Subjects' capabilities, identity, and schema resolution. A wiki farm is simply
+more registered Sources.
+
+### A source decides editability; nothing else branches
+
+There is no per-Source capability matrix. The only distinction:
+
+- **Local Subjects** are editable through the normal editor (subject to access rights) and versioned.
+- **Sourced Subjects** are read-only. Writing back to a source is deferred (see Open questions).
+
+Every Subject, whatever its source, renders through the existing Views (sourced ones read-only) and is queryable once
+materialised in the graph.
+
+### Page-facts are not Subjects
+
+Approval state and system page metadata (`name`, `creationTime`, `lastEditor`, `categories`) are **facts about a page**,
+not Subjects. They are stored as properties on the page node and surfaced via query (Cypher), not the View or editor.
+The Source model could represent them as read-only Subjects; for this use case it deliberately does not.
+
+### Identity
+
+A Subject's id is a pair `(source, localId)`. The existing `SubjectId` ([ADR 14](014-improved-id-format.md)) is widened
+to carry a source, defaulting to local — a bare nanoid still means a local Subject. `localId` is opaque outside its
+Source (a nanoid locally; a page id or a remote id / URI elsewhere); each Source owns its grammar, validation, and
+minting. The structured pair is canonical; IRI and CURIE forms are projections of it, with the source-to-base-URI map
+doubling as the RDF prefix map. The first increment — per-wiki node identity in a shared graph — is decided in
+[ADR 22](022-multi-wiki-node-identity.md).
+
+### Schemas come from Sources
+
+A schema is resolved through a Source and may be read-only (a code-defined built-in, or a remote-owned schema) or
+writeable (an ordinary local schema). A schema reference is `(source, name)` ([ADR 17](017-names-as-identifiers.md)),
+and a schema's source is independent of the subject's source. In a farm, schemas are per-wiki with a delivered common
+baseline; a Subject whose schema is local to another wiki can be queried cross-wiki but not rendered or edited
+cross-wiki through the View system, and such cross-wiki access degrades gracefully rather than failing.
+
+## Consequences
+
+- One model spans local data, on-wiki SMW/Wikibase adoption, cross-wiki farm metadata, and external/federated data,
+  rather than separate mechanisms.
+- The View, query, and editing surfaces stay Subject-shaped; they gain only a read-only state for sourced Subjects.
+- Approval and page metadata are queryable without being Subjects, so recording them does not create a page revision.
+- Materialisation is required for a Subject to be queryable; sourced data that is not materialised is fetchable by id
+  but not queryable.
+
+## Open questions
+
+Deferred and/or still being designed; consortium feedback is expected here.
+
+- **Federation resolution** — fetch-at-read vs cache/materialise; for triple-store backends, federated query.
+- **RDF / IRI export and ontology mapping** — see [planning/RdfMapping.md](../planning/RdfMapping.md).
+- **Editing sourced Subjects (write-back)** — end-of-roadmap; enables gradual migration off an on-wiki SMW/Wikibase
+  store and bidirectional flow with other systems.
+- **Rendering sourced Subjects in Views** — read-only; needs a source-aware load path. Deferred, not foreclosed.
+- **The Source interface contract** for by-id and query resolution.
+
+## Alternatives Considered
+
+- **Surface all sourced data as editor-Subjects with capability flags.** Rejected: it conflates a "this is sourced"
+  read-only with an access-rights read-only, adding user-facing complexity for no benefit.
+- **Model page-facts (approval, metadata) as Subjects.** Rejected for this use case: they are facts about a page,
+  simpler as page-node properties; modelling them as slot-backed Subjects would make recording them a new, unapproved
+  page revision.
+- **Global properties / a single shared schema set.** Rejected ([planning/GlobalProperties.md](../planning/GlobalProperties.md));
+  name consistency is handled per-schema, and farm schemas are per-wiki with a delivered baseline.
+- **Schemaless Subjects.** Disallowed ([ADR 8](008-one-schema-per-subject.md)); free-form tables use an ordinary
+  schema edited through a table UI.
+
+## Related
+
+- [planning/SubjectSources.md](../planning/SubjectSources.md) — detailed exploration behind this ADR.
+- [ADR 22: Multi-wiki Graph Node Identity](022-multi-wiki-node-identity.md),
+  [ADR 19: Graph Database Architecture](019-graph-database-architecture.md),
+  [ADR 14: Improved Id Format](014-improved-id-format.md),
+  [ADR 8: One Schema per Subject](008-one-schema-per-subject.md), [ADR 18: Views](018-views.md).
+- [planning/RdfMapping.md](../planning/RdfMapping.md), [planning/GlobalProperties.md](../planning/GlobalProperties.md).

--- a/docs/adr/023-subject-sources.md
+++ b/docs/adr/023-subject-sources.md
@@ -32,23 +32,35 @@ The distinction:
 - **Local Subjects** are editable through the normal editor (subject to access rights) and versioned.
 - **Sourced Subjects** are read-only. Writing back to a source is deferred (see Open questions).
 
-Every Subject, whatever its source, renders through the existing Views (sourced ones read-only) and is queryable in
-the graph.
+Every Subject, whatever its source, renders through the existing Views (sourced ones read-only) and is queryable once
+materialised in the graph.
 
-### Page-facts are not Subjects
+Editability is the only capability the model varies today, and it bundles *editable + versioned* (local) against
+*read-only* (sourced). This is not a permanent two-state space: the deferred write-back capability will make some
+sourced Subjects writeable, reintroducing per-source variation — so "sourced ⇒ read-only" is the current scope, not a
+closed decision.
 
-Approval state and system page metadata (`name`, `creationTime`, `lastEditor`, `categories`) are **facts about a page**,
-not Subjects. They are stored as properties on the page node and surfaced via query (Cypher), not the View or editor.
-The Source model could represent them as read-only Subjects; for this use case it deliberately does not.
+### Page Properties are not exposed via Subjects
+
+Approval state and system page metadata (`name`, `creationTime`, `lastEditor`, `categories`) are
+[Page Properties](../concepts/glossary.md#page-property) — facts stored on the page node, the built-in ones plus any an
+extension contributes through the `PagePropertyProvider` plugin. They are surfaced via query (Cypher), not through the
+View or editor. The Source model could expose them as read-only Subjects; for this use case it deliberately does not —
+they stay Page Properties.
 
 ### Identity
 
 A Subject's id is a pair `(source, localId)`. The existing `SubjectId` ([ADR 14](014-improved-id-format.md)) is widened
 to carry a source, defaulting to local — a bare nanoid still means a local Subject. `localId` is opaque outside its
 Source (a nanoid locally; a page id or a remote id / URI elsewhere); each Source owns its grammar, validation, and
-minting. The structured pair is canonical; IRI and CURIE forms are projections of it, with the source-to-base-URI map
-doubling as the RDF prefix map. The first increment — per-wiki node identity in a shared graph — is decided in
-[ADR 22](022-multi-wiki-node-identity.md).
+minting. The pair is the canonical **reference** form (relation targets, view ids, fetch); IRI and CURIE forms are
+projections of it, with the source-to-base-URI map doubling as the RDF prefix map. ADR 14's fixed-length and
+time-sortable guarantees hold only for local nanoids, not for arbitrary `localId`s.
+
+This ratifies the two forward-compatibility assumptions of [ADR 22](022-multi-wiki-node-identity.md), which decided the
+first increment (per-wiki node identity in a shared graph): the local source key is the MediaWiki Wiki ID, and a local
+Subject stays **stored** as a bare nanoid (with `wiki_id` as a property), the `(source, localId)` pair being derived
+from it rather than a re-keying of stored data.
 
 ### Schemas come from Sources
 
@@ -64,7 +76,8 @@ cross-wiki through the View system, and such cross-wiki access degrades graceful
 - One model spans local data, on-wiki SMW/Wikibase adoption, cross-wiki farm metadata, and external/federated data,
   rather than separate mechanisms.
 - The View, query, and editing surfaces stay Subject-shaped; they gain only a read-only state for sourced Subjects.
-- Approval and page metadata are queryable without being Subjects, so recording them does not create a page revision.
+- Approval and page metadata stay Page Properties, queryable without being exposed as Subjects, so recording them does
+  not create a page revision.
 - Materialisation is required for a Subject to be queryable; sourced data that is not materialised is fetchable by id
   but not queryable.
 
@@ -84,8 +97,8 @@ Deferred and/or still being designed; consortium feedback is expected here.
   name consistency is handled per-schema, and farm schemas are per-wiki with a delivered baseline.
 - **Schemaless Subjects.** Disallowed ([ADR 8](008-one-schema-per-subject.md)); free-form tables use an ordinary
   schema edited through a table UI.
-- **Model page-facts (approval, metadata) as Subjects.** Rejected for this use case: they are facts about a page,
-  simpler as page-node properties; modelling them as slot-backed Subjects would make recording them a new, unapproved
+- **Model Page Properties (approval, metadata) as Subjects.** Rejected for this use case: they are facts about a page,
+  simpler kept on the page node; modelling them as slot-backed Subjects would make recording them a new, unapproved
   page revision.
 - **Materialization only.** We'd avoid adding subject sources and continue without support for displaying anything that is
   not a "normal local Subject" via the View system. You'd only be able to display it via userland scripting on top of queries.

--- a/docs/adr/023-subject-sources.md
+++ b/docs/adr/023-subject-sources.md
@@ -4,36 +4,36 @@ Date: 2026-06-22
 
 Status: Draft
 
+Feedback desired! Also see the **Open questions** section below.
+
 ## Context
 
-NeoWiki assumes every Subject is local, editable, and versioned — stored in a MediaWiki revision slot
-([ADR 4](004-use-dedicated-slot.md)) and projected into the graph ([ADR 19](019-graph-database-architecture.md)).
-Several needed capabilities do not fit that assumption: page and approval metadata, free-form (Confluence-style)
-tables, cross-wiki metadata in a wiki farm, and structured data drawn from other systems (another NeoWiki, an on-wiki
-SMW or Wikibase store, external services).
+Prior to this ADR, NeoWiki assumed every Subject is local, editable, versioned, stored in a MediaWiki revision slot
+([ADR 4](004-use-dedicated-slot.md)), and projected into the graph ([ADR 19](019-graph-database-architecture.md)).
 
-The detailed exploration is in [planning/SubjectSources.md](../planning/SubjectSources.md). This ADR records the model.
-Sections under **Open questions** are where the design is still settling — notably federation and RDF — and where
-consortium feedback is expected.
+Several needed capabilities do not fit that assumption: cross-wiki metadata in a wiki farm, page and approval metadata, free-form (Confluence-style)
+tables, and structured data drawn from other systems (another NeoWiki, an on-wiki SMW or Wikibase store, external services).
+
+The detailed exploration is in [planning/SubjectSources.md](../planning/SubjectSources.md).
 
 ## Decision
 
 ### Subjects come from pluggable Sources
 
-A Subject is produced by a **Source**. The local revision slot is the default Source; others — an on-wiki SMW/Wikibase
-store, another NeoWiki, an external system — supply Subjects too. A **Source registry** maps a source key to its
+A Subject is produced by a **Source**. The local revision slot is the default Source; others, like an on-wiki SMW/Wikibase
+store, another NeoWiki, or an external system, can also supply Subjects. A **Source registry** maps a source key to its
 Source, which is the authority for its Subjects' capabilities, identity, and schema resolution. A wiki farm is simply
 more registered Sources.
 
-### A source decides editability; nothing else branches
+### A source decides editability
 
-There is no per-Source capability matrix. The only distinction:
+The distinction:
 
 - **Local Subjects** are editable through the normal editor (subject to access rights) and versioned.
 - **Sourced Subjects** are read-only. Writing back to a source is deferred (see Open questions).
 
-Every Subject, whatever its source, renders through the existing Views (sourced ones read-only) and is queryable once
-materialised in the graph.
+Every Subject, whatever its source, renders through the existing Views (sourced ones read-only) and is queryable in
+the graph.
 
 ### Page-facts are not Subjects
 


### PR DESCRIPTION
The broad Subject Sources ADR — **Draft**, intended as the digestible decision record and a feedback vehicle (the planning doc is too sprawling to review). It distils `planning/SubjectSources.md`; that doc stays as the deep-dive behind it.

**Decided (settled core):**
- Subjects come from pluggable **Sources** (registry; local slot is the default). A source decides only **editability** — local editable+versioned, sourced read-only; all Subjects render via Views (sourced read-only) and are queryable once materialised. No per-Source capability matrix.
- **Page-facts** (approval, system metadata) are **not** Subjects — page-node properties, query-only.
- Identity is `(source, localId)` (widening `SubjectId`, default local); schemas come from Sources and may be read-only; farm schemas are per-wiki with a delivered baseline.

**Open questions (where ECHOLOT feedback lands):** federation resolution, RDF/IRI export + ontology mapping, write-back, and in-View rendering of sourced Subjects — all deferred/still-settling.

Multi-wiki node identity is decided separately in ADR 22 (#907). Written in the durable/neutral style of the ADR-022 trim.

> Result of design work with @JeroenDeDauw, distilled from the Subject Sources planning doc and the PR #888 review.
> <sub>Written by Claude Code, \`Opus 4.8 (1M context)\`</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)