### PR TITLE
Demo & dev environment: fix `make down`, add `make demo`/`make pull`, tidy install docs

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -72,10 +72,11 @@ inside the stack via `make bash` or `docker compose exec`.
 
 - `Dockerfile` — multi-stage build with `production-mw` (prebuilt demo), `final-mw`
   (release tag), and `dev-mw` (the dev image with mounted NeoWiki source).
-- `docker-compose.yml` — base services (`mediawiki`, `db`, `neo`, plus profile-gated
-  `test_neo`, `node`, `mailcatcher`, `caddy`).
+- `docker-compose.yml` — base "try-it-out" services (`mediawiki`, `db`, `neo`) plus
+  the profile-gated `caddy` (the `server` profile, for HTTPS hosting).
 - `docker-compose.dev.yml` — dev overlay; switches `mediawiki` to the dev image,
-  bind-mounts the NeoWiki source, and sets `MW_MODE=dev`.
+  bind-mounts the NeoWiki source, sets `MW_MODE=dev`, and adds the dev-only sidecars
+  `test_neo`, `node`, and `mailcatcher`.
 - `docker-compose.tools.yml` — opt-in overlay that exposes Neo4j to the host.
 - `SettingsTemplate.php` — `LocalSettings.php` that branches on `MW_MODE`.
 - `.env.dist` — tracked defaults; auto-copied to `.env` on first `make dev`.

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -5,47 +5,14 @@ big structural changes will happen, and key functionality is still missing.
 
 This directory contains files for the Dockerized development environment and for the pre-built demo Docker image.
 
-## Prerequisites
+## Installing and running
 
-- Docker and Docker Compose
+This file is a reference for the `Docker/` directory itself. For instructions:
 
-## Develop NeoWiki
-
-For the developer workflow (`make dev`, `make phpunit`, etc.), see
-[`../README.md`](../README.md). All commands run from the extension root, not from
-`Docker/`.
-
-## Try it out (prebuilt image)
-
-Run NeoWiki against the published demo image without building locally. From the
-extension root:
-
-```bash
-cd ..              # extension root
-make up            # docker compose up -d, prebuilt ghcr image
-make install-db
-make load-neo4j-users
-make import-demo-data
-```
-
-Then open http://localhost:8484 and log in as `AdminName` (default password
-`AdminPassword`, configurable in `Docker/.env`).
-
-## Server deployment
-
-To deploy on a server with automatic HTTPS via Caddy:
-
-1. Copy `Docker/.env.dist` to `Docker/.env` and change all values marked with
-   `# Change for production`, including `MW_SERVER` (e.g. `https://wiki.example.com`).
-
-2. Start all services including Caddy:
-   ```bash
-   docker compose --profile server up -d
-   ```
-
-3. Run the install/load steps from the try-it-out section above.
-
-4. Access your wiki at the configured `MW_SERVER` URL.
+- Demo / try-it-out stack and server (Caddy) deployment: see
+  [Installation](../docs/operations/installation.md).
+- Developer workflow (`make dev`, `make phpunit`, etc.): see [`../README.md`](../README.md).
+  All commands run from the extension root, not from `Docker/`.
 
 ## Reserved host ports
 
@@ -70,8 +37,10 @@ inside the stack via `make bash` or `docker compose exec`.
 
 ## Files
 
-- `Dockerfile` — multi-stage build with `production-mw` (prebuilt demo), `final-mw`
-  (release tag), and `dev-mw` (the dev image with mounted NeoWiki source).
+- `Dockerfile` — multi-stage build: `production-mw` (MediaWiki + NeoWiki on the
+  production `php.ini`; intermediate, no `LocalSettings.php`), `final-mw` (the prebuilt
+  demo image published as `ghcr.io/professionalwiki/neowiki:latest`, which bakes in
+  `LocalSettings.php`), and `dev-mw` (the dev image with mounted NeoWiki source).
 - `docker-compose.yml` — base "try-it-out" services (`mediawiki`, `db`, `neo`) plus
   the profile-gated `caddy` (the `server` profile, for HTTPS hosting).
 - `docker-compose.dev.yml` — dev overlay; switches `mediawiki` to the dev image,

--- a/Docker/docker-compose.dev.yml
+++ b/Docker/docker-compose.dev.yml
@@ -28,3 +28,44 @@ services:
       # inconsistency, but it stops a non-existent file from being bind-mounted as
       # an empty directory.
       - ./mediawiki/vendor:/var/www/html/w/vendor:z
+
+  # Dev-only sidecars. They live in this overlay (not the base file) so the base
+  # "try-it-out" stack stays minimal and so `make down` removes them as orphans
+  # regardless of the compose backend. See the Makefile `down` target.
+  test_neo:
+    image: neo4j:enterprise
+    restart: unless-stopped
+    volumes:
+      - test-neo4j-data:/data
+    environment:
+      - NEO4J_ACCEPT_LICENSE_AGREEMENT=eval
+      # Hardcoded password (intentional): NeoWiki's test suite uses this
+      # fixed credential to connect to the test Neo4j instance. Do not
+      # parameterize without also updating the test configuration.
+      - NEO4J_AUTH=neo4j/password
+      - NEO4J_server_bolt_listen__address=:7689
+      - NEO4J_server_http_listen__address=:7475
+    healthcheck:
+      test: "wget http://localhost:7475/browser -O - | grep 'Neo4j Browser'"
+      interval: 5s
+      timeout: 1s
+      retries: 10
+
+  node:
+    image: node:24
+    restart: on-failure:3
+    working_dir: /workspace/resources/ext.neowiki
+    volumes:
+      - ../:/workspace:z
+    command: sh -c "npm install && npm run build:watch"
+    environment:
+      - npm_config_cache=/tmp/.npm
+
+  mailcatcher:
+    image: sj26/mailcatcher
+    restart: unless-stopped
+    ports:
+      - "${MAILCATCHER_PORT:-1080}:1080"
+
+volumes:
+  test-neo4j-data:

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       timeout: 5s
       retries: 1
 
-  # NOTE (v2 shared-backend mode): in a future iteration, db/neo/test_neo will
+  # NOTE (v2 shared-backend mode): in a future iteration, db and neo will
   # be tagged with a `local-backend` profile so they can be opted out of when
   # SHARED_BACKEND=1 is set, allowing multiple worktrees to share an external
   # MariaDB and Neo4j instance. In v1 they stay on by default (no profile).
@@ -61,43 +61,9 @@ services:
       timeout: 1s
       retries: 10
 
-  test_neo:
-    image: neo4j:enterprise
-    profiles: [dev]
-    restart: unless-stopped
-    volumes:
-      - test-neo4j-data:/data
-    environment:
-      - NEO4J_ACCEPT_LICENSE_AGREEMENT=eval
-      # Hardcoded password (intentional): NeoWiki's test suite uses this
-      # fixed credential to connect to the test Neo4j instance. Do not
-      # parameterize without also updating the test configuration.
-      - NEO4J_AUTH=neo4j/password
-      - NEO4J_server_bolt_listen__address=:7689
-      - NEO4J_server_http_listen__address=:7475
-    healthcheck:
-      test: "wget http://localhost:7475/browser -O - | grep 'Neo4j Browser'"
-      interval: 5s
-      timeout: 1s
-      retries: 10
-
-  node:
-    image: node:24
-    profiles: [dev]
-    restart: on-failure:3
-    working_dir: /workspace/resources/ext.neowiki
-    volumes:
-      - ../:/workspace:z
-    command: sh -c "npm install && npm run build:watch"
-    environment:
-      - npm_config_cache=/tmp/.npm
-
-  mailcatcher:
-    image: sj26/mailcatcher
-    profiles: [dev]
-    restart: unless-stopped
-    ports:
-      - "${MAILCATCHER_PORT:-1080}:1080"
+  # The dev-only sidecars (test_neo, node, mailcatcher) live in
+  # docker-compose.dev.yml, not here, so `make up` stays minimal and `make down`
+  # can clean them up as orphans on every compose backend (see that file).
 
   caddy:
     image: caddy:2.10-alpine
@@ -121,6 +87,5 @@ volumes:
   mediawiki-db-data:
   mediawiki-images-data:
   neo4j-data:
-  test-neo4j-data:
   caddy-data:
   caddy-config:

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ PORT_RANGE_END := 8499
 # ---- Compose invocations -----------------------------------------------------
 
 DC := docker compose -p $(PROJECT_NAME) -f Docker/docker-compose.yml
-DC_DEV := $(DC) -f Docker/docker-compose.dev.yml --profile dev
+DC_DEV := $(DC) -f Docker/docker-compose.dev.yml
 DC_TOOLS := $(DC_DEV) -f Docker/docker-compose.tools.yml
 
 IS_PODMAN := $(shell (docker --version 2>/dev/null | grep -qi podman || command -v podman >/dev/null 2>&1) && echo 1 || echo 0)
@@ -98,7 +98,7 @@ stop: ## Stop containers (preserves volumes)
 	$(DC_DEV) stop
 
 down: ## Stop and remove containers (preserves volumes)
-	$(DC_DEV) down
+	$(DC) down --remove-orphans
 
 logs: ## Tail logs from all services
 	$(DC_DEV) logs -f
@@ -339,7 +339,7 @@ ts-lint: _wait-node ## Run TS linter
 .PHONY: reset import-demo-data rebuild-graph-databases update-dot-php smoke-test
 
 reset: ## Wipe DB + Neo4j volumes and reseed demo data (containers stay)
-	$(DC_DEV) down --volumes
+	$(DC) down --volumes --remove-orphans
 	$(DC_DEV) up -d
 	@$(MAKE) --no-print-directory _wait-mw
 	$(MAKE) --no-print-directory install-db

--- a/Makefile
+++ b/Makefile
@@ -49,10 +49,22 @@ help:
 
 # ---- Lifecycle (host only) ---------------------------------------------------
 
-.PHONY: up dev dev-tools _dev-tools-impl stop down logs ps bash
+.PHONY: up pull demo dev dev-tools _dev-tools-impl stop down logs ps bash
 
 up: ## Bring up try-it-out stack (no profile, prebuilt image)
 	$(DC) up -d
+
+pull: ## Pull the latest prebuilt demo image
+	$(DC) pull
+
+demo: ## One-command demo: pull image, start stack, install + seed (idempotent)
+	$(DC) pull
+	$(DC) up -d
+	@$(MAKE) --no-print-directory _wait-mw
+	@$(MAKE) --no-print-directory _first-run-seed-demo
+	@echo ""
+	@echo "Demo wiki ready at: http://localhost:$$MW_SERVER_PORT"
+	@echo "Log in as AdminName (password: $$MW_ADMIN_PASSWORD)."
 
 dev: bootstrap ensure-port ## Bring up dev stack (build image, install, seed, wait for health)
 	@$(MAKE) --no-print-directory _dev-impl
@@ -164,6 +176,18 @@ _first-run-seed:
 		$(MAKE) --no-print-directory import-demo-data; \
 	fi
 	@# TS install/build are handled by the node sidecar on startup (npm install && npm run build:watch).
+
+# Demo variant of the seed: no dev-only steps (test_neo, composer install). Uses
+# $(DC) since the demo stack has no dev overlay. Idempotent like _first-run-seed.
+.PHONY: _first-run-seed-demo
+_first-run-seed-demo:
+	@if $(DC) exec -T db sh -c "mariadb -u $$MARIADB_USER -p$$MARIADB_PASSWORD $$MARIADB_DATABASE -e 'SELECT 1 FROM page LIMIT 1' 2>/dev/null" >/dev/null 2>&1; then \
+		echo "Wiki already initialized; skipping install."; \
+	else \
+		$(MAKE) --no-print-directory install-db; \
+		$(MAKE) --no-print-directory load-neo4j-users; \
+		$(MAKE) --no-print-directory import-demo-data; \
+	fi
 
 # ---- DB and Neo4j init -------------------------------------------------------
 
@@ -338,7 +362,10 @@ ts-lint: _wait-node ## Run TS linter
 
 .PHONY: reset import-demo-data rebuild-graph-databases update-dot-php smoke-test
 
-reset: ## Wipe DB + Neo4j volumes and reseed demo data (containers stay)
+# Wipe and reseed the dev stack. The down is stack-agnostic — --remove-orphans
+# reaps the dev sidecars too — so it uses $(DC); the up must be the dev variant,
+# since reset rebuilds the dev stack (note setup-test-neo below).
+reset: ## Wipe DB + Neo4j volumes and reseed demo data (recreates the dev stack)
 	$(DC) down --volumes --remove-orphans
 	$(DC_DEV) up -d
 	@$(MAKE) --no-print-directory _wait-mw

--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
 # NeoWiki
 
-[NeoWiki](https://professional.wiki/en/neowiki) is a collaborative knowledge management system on top of MediaWiki and graph databases.
+[NeoWiki](https://neowiki.ai) is a collaborative knowledge management system on top of MediaWiki and graph databases.
 
 [![Mastodon](https://img.shields.io/mastodon/follow/116122313808578574)](https://mastodon.social/@NeoWiki)
 [![Bluesky](https://img.shields.io/bluesky/followers/NeoWiki.bsky.social)](https://bsky.app/profile/neowiki.bsky.social)
 [![X](https://img.shields.io/twitter/follow/NeoWikiAI)](https://x.com/NeoWikiAI)
+
+## Installation
+
+NeoWiki is not production ready yet. We support two installation use cases:
+
+* A **demo environment** for evaluation and experimentation. See [installation.md](docs/operations/installation.md).
+* A **development environment** with configuration and tools for enhancing NeoWiki. See the "Development" section below.
 
 ## Technical Documentation
 

--- a/README.md
+++ b/README.md
@@ -81,5 +81,5 @@ $wgDebugLogGroups['neowiki'] = '/tmp/neowiki-debug.log';
 
 ### Try-it-out and server deployment
 
-For a prebuilt try-it-out stack or server deployment with Caddy, see
-[`Docker/README.md`](./Docker/README.md).
+For the prebuilt try-it-out stack or server deployment with Caddy, see
+[Installation](docs/operations/installation.md).

--- a/docs/operations/installation.md
+++ b/docs/operations/installation.md
@@ -22,19 +22,14 @@ You need:
 
 The commands assume a Unix-like shell, so on Windows run them under WSL.
 
-Download the `ProfessionalWiki/NeoWiki` repository and run these commands from its root:
+Download the `ProfessionalWiki/NeoWiki` repository and run this from its root:
 
 ```sh
-make up
-make install-db
-make load-neo4j-users
+make demo
 ```
 
-Optionally run the below to populate your wiki with demo data:
-
-```sh
-make import-demo-data
-```
+This pulls the latest demo image, starts the stack, installs the wiki, and loads the demo
+data. Later, `make pull` refreshes the image and `make down` stops and removes the containers.
 
 Open `http://localhost:8484` and log in as `AdminName` with the password `AdminPassword`.
 
@@ -50,7 +45,8 @@ every value marked `# Change for production`, which covers the passwords and `MW
 docker compose --profile server up -d
 ```
 
-Then run the make commands listed above against it. This is still an evaluation setup, not a production deployment.
+Then run `make install-db`, `make load-neo4j-users` and `make import-demo-data` against it. This is still an
+evaluation setup, not a production deployment.
 
 ## Method B: Add to an existing MediaWiki
 

--- a/docs/operations/installation.md
+++ b/docs/operations/installation.md
@@ -3,13 +3,15 @@ title: Installation
 order: 1
 ---
 
-# Installing NeoWiki
+# Installing the NeoWiki Demo
 
 NeoWiki is pre-release software. It is not production ready, and breaking changes can land at any time without a
 migration path. Treat any install as an evaluation or pilot and run it on disposable data.
 
 There are two ways to install NeoWiki, both covered below. The Docker stack is self-contained and the fastest way to a
 working wiki, so use it for evaluation. The manual install adds NeoWiki to a MediaWiki you already run.
+
+To install the development environment, see the [README](../../README.md) instead.
 
 ## Method A: Docker
 
@@ -26,6 +28,11 @@ Download the `ProfessionalWiki/NeoWiki` repository and run these commands from i
 make up
 make install-db
 make load-neo4j-users
+```
+
+Optionally run the below to populate your wiki with demo data:
+
+```sh
 make import-demo-data
 ```
 

--- a/docs/operations/installation.md
+++ b/docs/operations/installation.md
@@ -31,6 +31,8 @@ make demo
 This pulls the latest demo image, starts the stack, installs the wiki, and loads the demo
 data. Later, `make pull` refreshes the image and `make down` stops and removes the containers.
 
+For an empty wiki without the sample data, run `make up && make install-db && make load-neo4j-users` instead.
+
 Open `http://localhost:8484` and log in as `AdminName` with the password `AdminPassword`.
 
 You now have a complete evaluation instance with the development UI enabled and demo data loaded.


### PR DESCRIPTION
> Result of iterative work with @JeroenDeDauw: he hit the `make up` / `make down` inconsistency, then drove the broader demo/dev-environment cleanup.
> Context: the NeoWiki dev-environment `Makefile`, `Docker/docker-compose*.yml`, and the install docs. Tested on both `podman-compose` and the docker compose plugin, plus a real isolated `make demo` run.
> <sub>Written by Claude Code, `Opus 4.8 (1M context)`</sub>

Tidies the demo and developer environments, which had drifted apart.

**`make down` fix (the original bug).** `make up` brings up the profile-less try-it-out stack, but `make down` used `--profile dev` + the dev overlay, so after the documented `make up` flow it tried to remove the `mailcatcher`/`node`/`test_neo` containers it never created — noisy "no such container" errors (loud on podman-compose, which the install docs target). The two compose backends have opposite requirements (podman-compose errors when `--profile dev` is set but the containers are absent; the docker compose plugin needs the profile to remove containers gated in a loaded file), so the fix moves the dev-only sidecars from the base file into `docker-compose.dev.yml` and lets a base-file `down --remove-orphans` reap them as orphans. Clean on both backends for the `make up` and `make dev` teardown paths.

**Install docs.** README routes to the demo (`installation.md`) vs dev (Development section). `Docker/README.md` drops the try-it-out/server instructions it duplicated from `installation.md` (links to them instead) and keeps only its unique reference content — reserved host ports (an anchor target of inbound links) and the file layout — with the Dockerfile target labels corrected (`final-mw`, not `production-mw`, is the published `:latest` demo).

**`make demo` / `make pull`.** `make demo` is a one-command evaluator setup (pull, start, install, seed) mirroring `make dev`, idempotent on re-run. `make pull` refreshes the published image, which `make up` alone never does once it's cached. `reset` gains a comment explaining its intentional `$(DC)`-down / `$(DC_DEV)`-up asymmetry and a corrected help string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)