### PR TITLE
Add `make remove` to wipe containers and data volumes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ help:
 
 # ---- Lifecycle (host only) ---------------------------------------------------
 
-.PHONY: up pull demo dev dev-tools _dev-tools-impl stop down logs ps bash
+.PHONY: up pull demo dev dev-tools _dev-tools-impl stop down remove logs ps bash
 
 up: ## Bring up try-it-out stack (no profile, prebuilt image)
 	$(DC) up -d
@@ -111,6 +111,9 @@ stop: ## Stop containers (preserves volumes)
 
 down: ## Stop and remove containers (preserves volumes)
 	$(DC) down --remove-orphans
+
+remove: ## Stop and remove containers AND volumes (deletes all data)
+	$(DC) down --volumes --remove-orphans
 
 logs: ## Tail logs from all services
 	$(DC_DEV) logs -f
@@ -362,11 +365,11 @@ ts-lint: _wait-node ## Run TS linter
 
 .PHONY: reset import-demo-data rebuild-graph-databases update-dot-php smoke-test
 
-# Wipe and reseed the dev stack. The down is stack-agnostic — --remove-orphans
-# reaps the dev sidecars too — so it uses $(DC); the up must be the dev variant,
-# since reset rebuilds the dev stack (note setup-test-neo below).
+# Wipe and reseed the dev stack. The teardown (make remove) is stack-agnostic —
+# --remove-orphans reaps the dev sidecars too — while the up must be the dev
+# variant, since reset rebuilds the dev stack (note setup-test-neo below).
 reset: ## Wipe DB + Neo4j volumes and reseed demo data (recreates the dev stack)
-	$(DC) down --volumes --remove-orphans
+	$(MAKE) --no-print-directory remove
 	$(DC_DEV) up -d
 	@$(MAKE) --no-print-directory _wait-mw
 	$(MAKE) --no-print-directory install-db

--- a/docs/operations/installation.md
+++ b/docs/operations/installation.md
@@ -29,7 +29,8 @@ make demo
 ```
 
 This pulls the latest demo image, starts the stack, installs the wiki, and loads the demo
-data. Later, `make pull` refreshes the image and `make down` stops and removes the containers.
+data. Later, `make pull` refreshes the image, `make down` stops and removes the containers, and
+`make remove` also deletes the data volumes.
 
 For an empty wiki without the sample data, run `make up && make install-db && make load-neo4j-users` instead.
 


### PR DESCRIPTION
> Follow-up requested by @JeroenDeDauw after #911 merged.
> Context: the NeoWiki dev-environment `Makefile` and install docs; tested with an isolated throwaway compose project.
> <sub>Written by Claude Code, `Opus 4.8 (1M context)`</sub>

Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/911

`make down` stops and removes containers but preserves volumes. `make remove` is the full-wipe counterpart — `down --volumes --remove-orphans` — for tearing a stack down completely, e.g. removing a demo and its data. `reset` now delegates its teardown step to `make remove` rather than repeating the command, and the install docs mention `make remove` alongside `make down`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)