### PR TITLE
Clone only the bundled MediaWiki submodules NeoWiki loads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ bootstrap: ## Clone MW core into Docker/mediawiki/ and prep gitignored files (id
 			"$${MW_GIT_URL:-https://github.com/wikimedia/mediawiki}" \
 			Docker/mediawiki; \
 		echo "Fetching the bundled extensions/skins NeoWiki loads..."; \
-		git -C Docker/mediawiki submodule update --init --recursive \
+		git -C Docker/mediawiki submodule update --init --recursive --depth 1 \
 			extensions/CodeEditor \
 			extensions/ParserFunctions \
 			extensions/Scribunto \

--- a/Makefile
+++ b/Makefile
@@ -87,14 +87,30 @@ _dev-tools-impl:
 # Populates the gitignored prerequisites that the build context needs:
 # Docker/mediawiki/ (a vendored MediaWiki core checkout) and an empty
 # Docker/LocalSettings.local.php for the per-worktree override bind-mount.
+#
+# Only the bundled extensions/skins that Docker/SettingsTemplate.php loads are
+# fetched as submodules, not MediaWiki's full bundle, to keep the clone fast and
+# small. When you wfLoadExtension/wfLoadSkin something new there, add its
+# submodule to the list below.
 .PHONY: bootstrap
 bootstrap: ## Clone MW core into Docker/mediawiki/ and prep gitignored files (idempotent)
 	@if [ ! -d Docker/mediawiki/.git ]; then \
 		echo "Cloning MediaWiki $${MW_BRANCH:-REL1_43} into Docker/mediawiki/..."; \
-		git clone --depth 1 --recurse-submodules \
+		git clone --depth 1 \
 			--branch "$${MW_BRANCH:-REL1_43}" \
 			"$${MW_GIT_URL:-https://github.com/wikimedia/mediawiki}" \
 			Docker/mediawiki; \
+		echo "Fetching the bundled extensions/skins NeoWiki loads..."; \
+		git -C Docker/mediawiki submodule update --init --recursive \
+			extensions/CodeEditor \
+			extensions/ParserFunctions \
+			extensions/Scribunto \
+			extensions/SyntaxHighlight_GeSHi \
+			extensions/VisualEditor \
+			extensions/WikiEditor \
+			skins/MonoBook \
+			skins/Timeless \
+			skins/Vector; \
 	fi
 	@touch Docker/LocalSettings.local.php
 


### PR DESCRIPTION
> Result of back-and-forth with @JeroenDeDauw, who set the direction and the keep-set.
> Context: the NeoWiki dev env — the `bootstrap` Makefile target, `Docker/SettingsTemplate.php` (what actually loads), the cloned MW core's `.gitmodules`, and a footprint measurement of the existing clone.
> <sub>Written by Claude Code, `Opus 4.8 (1M context)`</sub>

`make dev`'s `bootstrap` cloned MediaWiki core with `--recurse-submodules`, pulling all 37 bundled extension/skin submodules. NeoWiki's `Docker/SettingsTemplate.php` only loads 9 of them (6 extensions + 3 skins); the other 28 were fetched and never enabled.

This clones core without `--recurse-submodules` and inits only the loaded set, cutting the bundled-submodule fetch from 37 to 9 repositories (~520 MB less to download and check out on a fresh bootstrap).

Safe because those 9 are exactly what `SettingsTemplate.php` loads: CodeEditor's only dependency (WikiEditor) is included, `--recursive` pulls VisualEditor's `lib/ve`, and the dropped submodules are never referenced. The list must stay in sync with `SettingsTemplate.php`; an added comment notes this.

Forward-only: existing checkouts keep their full bundle until re-bootstrapped from scratch.
