### PR TITLE
Remove `make stop`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ help:
 
 # ---- Lifecycle (host only) ---------------------------------------------------
 
-.PHONY: up pull demo dev dev-tools _dev-tools-impl stop down remove logs ps bash
+.PHONY: up pull demo dev dev-tools _dev-tools-impl down remove logs ps bash
 
 up: ## Bring up try-it-out stack (no profile, prebuilt image)
 	$(DC) up -d
@@ -105,9 +105,6 @@ _dev-impl:
 	@echo ""
 	@echo "Dev wiki ready at: http://localhost:$$MW_SERVER_PORT"
 	@echo "Project:           $(PROJECT_NAME)"
-
-stop: ## Stop containers (preserves volumes)
-	$(DC_DEV) stop
 
 down: ## Stop and remove containers (preserves volumes)
 	$(DC) down --remove-orphans


### PR DESCRIPTION
> Follow-up from sanity-checking #911. `make stop` was the one lifecycle target
> still on the pre-#911 `$(DC_DEV)` teardown idiom, and the only one without a
> clean fix.
> <sub>Written by Claude Code, `Opus 4.8 (1M context)`. `down`/`reset` teardown verified on `podman-compose`.</sub>

Removes the `make stop` target.

The teardown family is now `down` (remove containers, keep volumes), `remove`
(remove containers and volumes, added in #913), and `reset` (wipe and reseed). All three use the
stack-agnostic `$(DC) ... --remove-orphans` invocation, which reaps the dev-only
sidecars (`test_neo`, `node`, `mailcatcher`) as orphans whether the stack was
started by `make up` or `make dev`. `stop` was the odd one out:

- **Redundant with `down`.** Its only difference is keeping the stopped containers
  instead of removing them. Here that container state is throwaway: the extension
  is bind-mounted, persistent data lives in named volumes (which `down` preserves),
  and the demo image is immutable. There is also no `start` target, so it served
  no pause/resume workflow; resuming was always `make up` / `make dev`.
- **Still on the noisy idiom.** It used `$(DC_DEV) stop`, so after the profile-less
  `make up` it referenced the dev-only sidecars that `up` never created and printed
  `no such container` errors on podman-compose, which surfaces absent containers as
  errors where the docker compose plugin stays silent. Same class of issue #911
  fixed for `down`.
- **No clean fix.** Unlike `down`/`remove`, `stop` has no `--remove-orphans`. A
  base-file `$(DC) stop` is quiet but leaves the dev sidecars (including the
  `build:watch` watcher) running; the dev-overlay form stops them but errors on the
  absent sidecars after `make up`. Dropping the target avoids the trade-off and
  keeps the teardown set consistent.

No other target, doc, or CI step referenced `stop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
