### PR TITLE
Fetch the bundled MediaWiki submodules shallow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ bootstrap: ## Clone MW core into Docker/mediawiki/ and prep gitignored files (id
 			"$${MW_GIT_URL:-https://github.com/wikimedia/mediawiki}" \
 			Docker/mediawiki; \
 		echo "Fetching the bundled extensions/skins NeoWiki loads..."; \
-		git -C Docker/mediawiki submodule update --init --recursive \
+		git -C Docker/mediawiki submodule update --init --recursive --depth 1 \
 			extensions/CodeEditor \
 			extensions/ParserFunctions \
 			extensions/Scribunto \


### PR DESCRIPTION
Builds on #914, which restricts the bootstrap clone to the bundled extensions/skins NeoWiki actually loads.

This makes that submodule fetch shallow by passing `--depth 1` to `git submodule update`, so each kept submodule is checked out at its pinned commit without its full history.

It relies on the submodule remote serving fetch-by-SHA: with `--depth 1`, `git submodule update` fetches the superproject-pinned commit directly rather than a branch tip, so the checkout lands on the exact pinned revision instead of failing with `reference is not a tree`. gerrit (the bundled submodules' origin) serves these by-SHA fetches, confirmed for all nine submodules plus VisualEditor's nested `lib/ve`.

Forward-only, same as the parent PR: existing checkouts are untouched until re-bootstrapped from scratch.