### PR TITLE
Add missing neowiki-field-label-required message

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -345,6 +345,7 @@
 				"neowiki-field-single-value-only",
 				"neowiki-field-type-mismatch",
 				"neowiki-field-schema-not-found",
+				"neowiki-field-label-required",
 				"neowiki-select-placeholder",
 				"neowiki-select-no-results",
 				"neowiki-select-unknown-option",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -68,6 +68,7 @@
 	"neowiki-field-single-value-only": "Only one value can be selected.",
 	"neowiki-field-type-mismatch": "This value was saved as type \"$1\" but the property now expects \"$2\".",
 	"neowiki-field-schema-not-found": "The schema \"$1\" is missing. Restore it before saving.",
+	"neowiki-field-label-required": "Please provide a label for the subject.",
 	"neowiki-select-placeholder": "Select an option",
 	"neowiki-select-no-results": "No matching options.",
 	"neowiki-select-unknown-option": "(unknown option)",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -145,6 +145,7 @@
 	"neowiki-field-single-value-only": "Validation error shown when multiple values are selected for a single-select property.",
 	"neowiki-field-type-mismatch": "Validation error shown when a Statement's stored type no longer matches the property's current type (e.g. the Schema changed after the value was saved). $1 is the type the value was written as; $2 is the type the property now expects.",
 	"neowiki-field-schema-not-found": "Form-level error shown when the backend reports the Subject's Schema page is missing. $1 is the schema name.",
+	"neowiki-field-label-required": "Form-level error shown when the backend reports the Subject is missing its required display label.",
 	"neowiki-select-placeholder": "Placeholder text shown in the select dropdown before any option is chosen.",
 	"neowiki-select-no-results": "Message shown in the multi-select dropdown when the typed text does not match any available option.",
 	"neowiki-field-invalid-datetime": "Validation error shown when the entered date and time value cannot be parsed. DateTime values must be strict ISO 8601 / xsd:dateTime strings with an explicit timezone offset or 'Z' (for example, '2025-06-15T12:00:00Z' or '2025-06-15T12:00:00+02:00'). Partial values such as year-only or date-only are rejected, and min/max bounds are inclusive.",


### PR DESCRIPTION
Found while reviewing #886. This change sits on top of that PR's branch.

The backend `SubjectValidator` emits a `label-required` violation (anchorless, `propertyName` null) for an empty subject label, and the dialogs render anchorless violations by building the message key `neowiki-field-<code>`. The key was absent from `i18n/en.json`, `i18n/qqq.json`, and the `ext.neowiki` ResourceLoader `messages` array, so the editor rendered the raw `⧼neowiki-field-label-required⧽` placeholder. The server-driven dry-run is the first path that lets this code reach the renderer. Registered in all three places.

Reproduce on the pre-fix code:
1. Open a page's Subjects manager at `<wiki>/wiki/<Page>?action=subjects` (with the demo data, `Validation Clean` works well).
2. Click **Add subject**, then choose the **Validation Demo** schema.
3. Clear the **Label** field and wait for the dry-run to run (the debounce, 300 ms by default).

The form-level error then shows the raw `⧼neowiki-field-label-required⧽` key instead of a localized message such as "Please provide a label for the subject."

| | |
|---|---|
| **Empty label, pre-fix.** The subject creator surfaces the raw `⧼neowiki-field-label-required⧽` key in the form-level error banner. | <img width="512" height="718" alt="label-required-raw-key" src="https://github.com/user-attachments/assets/090b3c92-ec10-45c3-b58b-4589f2a1778e" /> |
