### PR TITLE
Add ontology mapping planning doc

### DIFF
--- a/docs/adr/023-subject-sources.md
+++ b/docs/adr/023-subject-sources.md
@@ -85,7 +85,8 @@ offline, or removed schema — rendering degrades gracefully rather than breakin
 Deferred and/or still being designed; consortium feedback is expected here.
 
 - **Federation resolution** — fetch-at-read vs cache/materialise; for triple-store backends, federated queries.
-- **RDF / IRI export and ontology mapping** — see [planning/RdfMapping.md](../planning/RdfMapping.md).
+- **RDF / IRI export and ontology mapping** — see [planning/NativeRdfProjection.md](../planning/NativeRdfProjection.md)
+  and [planning/OntologyMapping.md](../planning/OntologyMapping.md).
 - **Editing sourced Subjects (write-back)** — end-of-roadmap. How useful? Things like editing Wikibase Items
   via NeoWiki UI, or editing data from a remote NeoWiki
 - **The Source interface contract** for by-id and query resolution.
@@ -109,4 +110,6 @@ Deferred and/or still being designed; consortium feedback is expected here.
   [ADR 19: Graph Database Architecture](019-graph-database-architecture.md),
   [ADR 14: Improved Id Format](014-improved-id-format.md),
   [ADR 8: One Schema per Subject](008-one-schema-per-subject.md), [ADR 18: Views](018-views.md).
-- [planning/RdfMapping.md](../planning/RdfMapping.md), [planning/GlobalProperties.md](../planning/GlobalProperties.md).
+- [planning/NativeRdfProjection.md](../planning/NativeRdfProjection.md),
+  [planning/OntologyMapping.md](../planning/OntologyMapping.md),
+  [planning/GlobalProperties.md](../planning/GlobalProperties.md).

--- a/docs/planning/ECHOLOT.md
+++ b/docs/planning/ECHOLOT.md
@@ -20,8 +20,9 @@ If you are not familiar with the NeoWiki terminology yet, see [the glossary](../
   provenance/rights *model* (T2.4) and a dedicated provenance/rights plug-in (T3.4) provide the fine-grained
   capture on top, rather than it being built into the core data model. Open: verify the data model and named-graph
   design can carry what the plug-in needs, as distinct from operational per-page named graphs (see
-  [RdfMapping.md](RdfMapping.md) Q5).
-* Does the [RDF mapping stwaman proposal](RdfMapping.md) go in the right direction? What needs to be adjusted?
+  [NativeRdfProjection.md](NativeRdfProjection.md) Q5).
+* Does the [native RDF projection strawman proposal](NativeRdfProjection.md) go in the right direction? What needs to
+  be adjusted? Same question for the [ontology mapping strawman](OntologyMapping.md).
 * Is our [Graph Model](../reference/graph-model.md) OK? In particular, is it OK to have non-Subject data in there, like the connected
   MediaWiki pages? (80% likely, briefly covered in Vienna: can filter out these values when querying)
 * How important is multilinguality for ECHOLOT? Do we need to provide anything beyond our current data model to support that?

--- a/docs/planning/NativeRdfProjection.md
+++ b/docs/planning/NativeRdfProjection.md
@@ -1,4 +1,4 @@
-# RDF Mapping Design
+# Native RDF Projection
 
 Written 2026-02-23 by Jeroen De Dauw with help from Claude Opus 4.6
 
@@ -6,17 +6,22 @@ Status: Draft, incorporating feedback from ECHOLOT partners (Bilbao meeting Marc
 
 ## Purpose
 
-This document proposes how NeoWiki's data model maps to RDF triples for the SPARQL plugin described in
-[ADR 19](../adr/019-graph-database-architecture.md). The mapping determines what RDF a triple store contains
+This document specifies how NeoWiki's data model projects to RDF triples for the SPARQL plugin described in
+[ADR 19](../adr/019-graph-database-architecture.md). The projection determines what RDF a triple store contains
 and therefore what SPARQL queries users can write. It also defines the shape of RDF exports.
 
-Specifically, this is the **native projection**: NeoWiki's own vocabulary, lossless, and the default when no ontology
-mapping is configured. It is one of several sibling projections a wiki can run — a store can instead hold a
-standard-ontology projection (CIDOC-CRM, EDM, …) defined via an [Ontology Mapping](OntologyMapping.md). Each
-configured store holds exactly one projection and is queried in that projection's vocabulary. The per-store machinery
-specified here — IRI minting, named graphs, the sync mechanism — is shared by all projections, so the SPARQL plugin is
-parameterized by projection rather than hardwired to this one. Read this document before
-[OntologyMapping.md](OntologyMapping.md), which builds on it.
+It has two jobs:
+
+1. **Specify the native projection** — RDF in NeoWiki's own vocabulary: lossless, self-sufficient, and the default
+   when no ontology mapping is configured.
+2. **Specify the projection infrastructure shared by all projections** — the IRI and namespace regime, per-page
+   named graphs, and the sync mechanism. An ontology store reuses all of this; only the triples inside each page's
+   graph differ.
+
+Everything specific to non-native targets — projecting into CIDOC-CRM, EDM, and other standard ontologies — lives in
+[OntologyMapping.md](OntologyMapping.md), which builds on this document. Native and ontology projections are
+siblings: a configured store holds exactly one projection and is queried in that projection's vocabulary, so the
+SPARQL plugin is parameterized by projection rather than hardwired to the native one. Read this document first.
 
 This is a strawman proposal. Many decisions here need input from partners with RDF and Linked Open Data expertise,
 particularly regarding ontology alignment and cultural heritage conventions. [Open questions](#open-questions) are
@@ -58,7 +63,7 @@ Standard prefixes used alongside:
 | `xsd:` | `http://www.w3.org/2001/XMLSchema#` |
 | `dcterms:` | `http://purl.org/dc/terms/` |
 
-## Mapping
+## Projection
 
 ### Subjects
 
@@ -92,10 +97,10 @@ neo-subj:s0gje3k4m8n2p1q  neo-prop:Website  "https://example.com"^^xsd:anyURI ;
 
 ### Relations
 
-Relations are the most complex part of the mapping because they carry their own ID and optional properties,
+Relations are the most complex part of the projection because they carry their own ID and optional properties,
 similar to Wikibase qualifiers.
 
-The mapping uses a **two-layer approach** inspired by [Wikibase's RDF model](https://www.mediawiki.org/wiki/Wikibase/Indexing/RDF_Dump_Format):
+The projection uses a **two-layer approach** inspired by [Wikibase's RDF model](https://www.mediawiki.org/wiki/Wikibase/Indexing/RDF_Dump_Format):
 
 **Layer 1 — Direct triples** for simple queries:
 
@@ -191,7 +196,7 @@ GRAPH neo-page:42 {
 
 On each page save, the SPARQL plugin:
 
-1. Maps the `Page` domain object to RDF triples (using the mapping above).
+1. Maps the `Page` domain object to RDF triples (using the projection above).
 2. Issues a SPARQL Update to the configured endpoint:
    ```sparql
    DROP SILENT GRAPH <neo-page:42> ;
@@ -211,27 +216,27 @@ DROP SILENT GRAPH <neo-page:42>
 
 ## What This Does Not Cover
 
-- **Ontology mapping layer.** The [Global Properties](GlobalProperties.md) document concluded that ontology
-  alignment (e.g., "Person.Name maps to `foaf:name`") should happen via a separate mapping layer, not by changing
-  the data model. That layer is designed in [Ontology Mapping](OntologyMapping.md). The RDF mapping described here emits NeoWiki-native
-  predicates; the ontology mapping layer instead projects the data into standard-ontology terms. Note that
-  this layer might need to be quite expressive: CIDOC-CRM alignment isn't just predicate renaming — it requires
+- **Ontology mapping.** The [Global Properties](GlobalProperties.md) document concluded that ontology alignment
+  (e.g., "Person.Name maps to `foaf:name`") should happen via a separate ontology mapping, not by changing the data
+  model. That mapping is designed in [Ontology Mapping](OntologyMapping.md). The projection described here emits
+  NeoWiki-native predicates; an ontology mapping instead projects the data into standard-ontology terms. Note that
+  ontology mappings need to be quite expressive: CIDOC-CRM alignment isn't just predicate renaming — it requires
   generating intermediate nodes that don't exist in NeoWiki's data. For example, a simple NeoWiki "Creator" relation
   from an Object to a Person would need to expand to `E22_Human-Made_Object → P108i_was_produced_by →
   E12_Production → P14_carried_out_by → E39_Actor` in CIDOC-CRM, creating the Production event node in RDF.
   At the ECHOLOT meeting in Bilbao (March 2026), the consortium agreed that wiki admins should be able to define
-  mappings between ontologies they care about and the NeoWiki Schemas of their wiki. This confirms the mapping
-  layer approach and means several open questions below (Q1, Q2, Q4) are less critical for the base mapping,
-  since ontology alignment is handled separately. The plan is that NeoWiki provides the mapping mechanism, data
-  modellers in the project create standard mapping + Schema bundles (e.g., for CIDOC-CRM), and users can
-  optionally install those bundles where relevant.
+  mappings between ontologies they care about and the NeoWiki Schemas of their wiki. This confirms the
+  separate-mapping approach and means several open questions below (Q1, Q2, Q4) are less critical for the native
+  projection, since ontology alignment is handled separately. The plan is that NeoWiki provides the mapping
+  mechanism, data modellers in the project create standard mapping + Schema bundles (e.g., for CIDOC-CRM), and users
+  can optionally install those bundles where relevant.
 - **Schema definitions as RDF.** Schemas could be expressed as RDFS/OWL classes with property constraints (similar
   to SHACL shapes). This is potentially valuable for validation and documentation, but is a separate concern.
 - **RDF import.** This document covers the outbound direction (NeoWiki data to RDF). Importing RDF data into
   NeoWiki Subjects is a T3.2/T4.1 concern and has its own challenges (mapping external ontologies to NeoWiki
   Schemas).
 - **RDF-star / RDF 1.2.** The grant (T3.2) and the D2.1 system spec refer to "native RDF/RDF*" import/export. The
-  base mapping deliberately targets standard RDF 1.1 (Relation reification, see Design Principle 3), and common
+  native projection deliberately targets standard RDF 1.1 (Relation reification, see Design Principle 3), and common
   target stores such as QLever do not support RDF-star. RDF-star is out of scope for now; it would only be
   revisited given a concrete need, and then at the import/export serialization layer rather than the triple store.
 
@@ -249,19 +254,19 @@ predicate? The flat approach is more natural for RDF and enables cross-schema qu
 equivalence that NeoWiki does not enforce. The scoped approach is faithful to the data model but unusual in RDF.
 
 *Feedback: The scoped approach would not be objectionable but makes ontology mapping harder — it duplicates
-properties and requires inference for mappings to function at a more general level. With the ontology mapping
-layer confirmed (see above), this question is less critical for the base mapping: NeoWiki-native predicates are
-emitted regardless, and the mapping layer translates to standard ontology terms. Tentative resolution: flat
-namespace (`$base/prop/Name`), since it is more natural for RDF and the mapping layer handles ontology
+properties and requires inference for mappings to function at a more general level. With the separate ontology
+mapping confirmed (see above), this question is less critical for the native projection: NeoWiki-native predicates
+are emitted regardless, and the ontology mapping translates to standard ontology terms. Tentative resolution: flat
+namespace (`$base/prop/Name`), since it is more natural for RDF and the ontology mapping handles ontology
 alignment.*
 
-**Q2: Standard vocabulary in the base mapping.** The strawman uses `rdf:type`, `rdfs:label`, and `dcterms:created`
-/ `dcterms:modified`. Should more standard predicates be used in the base mapping (e.g., `foaf:name` for labels,
-`dcterms:title` for page names)? Or should all standard vocabulary alignment happen in the ontology mapping layer?
+**Q2: Standard vocabulary in the native projection.** The strawman uses `rdf:type`, `rdfs:label`, and `dcterms:created`
+/ `dcterms:modified`. Should more standard predicates be used in the native projection (e.g., `foaf:name` for labels,
+`dcterms:title` for page names)? Or should all standard vocabulary alignment happen in the ontology mapping?
 
-*Less critical given the confirmed ontology mapping layer. Tentative resolution: keep the base mapping minimal
+*Less critical given the confirmed ontology mapping. Tentative resolution: keep the native projection minimal
 with the current standard predicates (`rdf:type`, `rdfs:label`, `dcterms:created/modified`). Further standard
-vocabulary alignment happens in the mapping layer.*
+vocabulary alignment happens in the ontology mapping.*
 
 **Q3: Relation representation.** The strawman uses Wikibase-style reification (a dedicated Relation node with
 `source`, `target`, `relationType`, and properties). Is this the right approach for the CH/LOD community? Are
@@ -271,16 +276,16 @@ there conventions we should follow? Should we plan the data model with future RD
 model (relationships mediated through events) which is quite different from NeoWiki's entity-property model. For
 example, a simple "Creator" relation in NeoWiki would correspond to the CIDOC-CRM path
 `E22_Human-Made_Object → P108i_was_produced_by → E12_Production → P14_carried_out_by → E39_Actor`, where the
-Production event is an intermediate entity that doesn't exist in NeoWiki's data. Does this affect the base RDF
-mapping, or is it purely an ontology mapping layer concern?
+Production event is an intermediate entity that doesn't exist in NeoWiki's data. Does this affect the native
+projection, or is it purely an ontology-mapping concern?
 
 *Feedback (TIB, Kolja, from Wikibase experience): Three approaches exist: (1) basic entity-property — simplest,
 (2) event-centric — more performant for queries but data not visible on the subject's page, (3) qualifier-based
 — familiar from Wikidata, all data on one page. The event-centric UX downside could be mitigated by displaying
 related pages on a subject's page (like transclusion of the named graph up to a defined depth). For SPARQL, the
-query limitations that SMW had with qualifiers do not occur. Tentative resolution: confirmed as an ontology
-mapping layer concern, not a base mapping concern. The base mapping represents NeoWiki's native data model;
-CIDOC-CRM event expansion happens in the mapping layer.*
+query limitations that SMW had with qualifiers do not occur. Tentative resolution: confirmed as an ontology-mapping
+concern, not a native-projection concern. The native projection represents NeoWiki's native data model; CIDOC-CRM
+event expansion happens in the ontology mapping.*
 
 **Q5: Named graph conventions.** Per-page named graphs are proposed for operational reasons (efficient sync). Are
 there CH/LOD conventions for named graph usage (e.g., per-source, per-dataset) that we should align with? Does
@@ -289,7 +294,7 @@ ECHOLOT's provenance model (T2.4) have implications for named graph design?
 *Resolved: No CH conventions exist for named graph usage. Per-page named graphs are fine for operational
 purposes. Note: per-page named graphs record only data origin (which page), not chain-of-production provenance;
 the latter is handled by the provenance model (T2.4) and a dedicated provenance plug-in (T3.4) on top of NeoWiki's
-extension points and MediaWiki versioning, not by the base mapping. See [ECHOLOT.md](ECHOLOT.md).*
+extension points and MediaWiki versioning, not by the native projection. See [ECHOLOT.md](ECHOLOT.md).*
 
 **Q6: Base URI conventions.** Should the base URI be the wiki's URL (e.g., `https://mywiki.example.org/`)? Is
 there a convention in the ECHOLOT/ECCCH context for how services should mint URIs?
@@ -310,17 +315,17 @@ choice, not an architectural one.*
 
 **Q8: Property type in RDF.** NeoWiki Statements include the "writer's schema" (the property type at write time).
 Should this be emitted as a triple on the Subject or Relation node? It's metadata about the statement, not about
-the entity. Probably only useful for debugging / round-tripping. Tentative answer: omit from base mapping, include
+the entity. Probably only useful for debugging / round-tripping. Tentative answer: omit from native projection, include
 in a "full export" mode.
 
 **Q9: Ordering of multi-valued properties.** NeoWiki stores multi-valued properties as ordered arrays. RDF triple
-sets are unordered. Accept the ordering loss for the base mapping? Or emit ordering information (adds complexity)?
+sets are unordered. Accept the ordering loss for the native projection? Or emit ordering information (adds complexity)?
 Tentative answer: accept the loss; ordering is a display concern handled by Views.
 
 *Feedback: Question raised whether ordering truly matters for some use cases (e.g., pages in a book). Tentative
-answer unchanged: accept ordering loss in the base mapping. If specific use cases require ordering, it can be
+answer unchanged: accept ordering loss in the native projection. If specific use cases require ordering, it can be
 added later (e.g., via `rdf:List` or index properties).*
 
 **Q10: Schema namespace page.** Should NeoWiki emit an RDFS/OWL definition for each Schema (as a class) and each
 Property Definition (as a property with domain/range)? This would make the RDF self-describing. Tentative answer:
-yes, but as a separate enhancement, not blocking the initial mapping.
+yes, but as a separate enhancement, not blocking the initial projection.

--- a/docs/planning/OntologyMapping.md
+++ b/docs/planning/OntologyMapping.md
@@ -28,7 +28,8 @@ intended to drive both export (native → ontology) and, later, import (ontology
 The central difficulty is that good ontology mapping is **not predicate renaming**: CIDOC-CRM and similar ontologies
 are event-centric and require *synthesizing intermediate nodes that do not exist in NeoWiki's data*. The mapping is a
 graph-to-graph transformation governed by reusable patterns. Most of this document is about expressing those patterns,
-where they come from, the import direction, and validating what the projections produce.
+where they come from, how the open flat-vs-nested modelling fork affects them, the import direction, and validating
+what the projections produce.
 
 > Terminology note: ECHOLOT partners often say "RDF mapping" for *this* — ontology alignment. In our docs,
 > [RdfMapping.md](RdfMapping.md) is the **native projection** (the default target vocabulary); this document is about
@@ -88,6 +89,28 @@ E22_Human-Made_Object  →  P108i_was_produced_by  →  E12_Production  →  P14
 The `E12_Production` node has **no counterpart in NeoWiki's data**. The mapping must mint it. This is the crux: any
 mapping formalism we adopt has to express **path expansion and node synthesis**, not just renaming. A formalism that
 only substitutes terms covers EDM but fails CIDOC-CRM — and CIDOC-CRM is the one that matters most for the case studies.
+
+### Flat vs nested native modelling (open fork)
+
+Where the structure comes from is itself undecided (2026-06-24 data-modelling call with takin and OEAW). NeoWiki can
+already express intermediate nodes as child Subjects linked by Relations; the fork is about what the modelling norm
+should be and where the burden sits:
+
+- **(a) Flat native Schemas** (e.g. birthplace directly on Person), with intermediate nodes synthesized at projection
+  time by the mapping. The cost lands in this document: the mapping must coordinate several flat fields into shared
+  nodes (birthplace and birth date must land on the *same* `E67_Birth` node).
+- **(b) Nested structure inside Schemas** (nested arrays / sub-subjects), so the native data already carries the
+  intermediate nodes and their mapping collapses toward term substitution. The cost shifts to the schema model and the
+  editing UI, which must project the nesting down into an accessible form — what Arches and ResearchSpace do. George
+  Bruseker leans (b) if the UI can project down.
+
+The fork is settled outside this document — it is a schema-model and editing-UX decision, exercised through the shared
+toy model ([Neutral Person to Many Standards](https://docs.google.com/spreadsheets/d/1j2_7j8RCUJrrMsfZaXtqHQOwp9cN9F8HIBtd3pfsToU/edit))
+that expresses one person model across several ontologies. What matters here is that the formalism needs synthesis
+capability under **either** route: not every wiki will model maximally nested (a mapping must handle whatever the
+native model is), and sibling targets decompose differently — EDM stays flat where CIDOC-CRM wants events — so no
+single nesting depth spares all projections. Route (b) reduces how often synthesis fires; it does not remove the
+requirement (Q2, Q10).
 
 ### Identity for synthesized nodes
 
@@ -292,6 +315,11 @@ the native projection vs Views?
 native + one or more ontologies), and is a native projection always available as a baseline? This makes "which
 vocabulary is in the store" a per-store configuration rather than a single global choice.
 
+**Q10: Flat vs nested native modelling.** The [fork above](#flat-vs-nested-native-modelling-open-fork): should
+case-study data live in flat Schemas with the mapping synthesizing intermediate nodes, or in nested Schemas with the
+editing UI projecting the nesting down? Settled through the toy model, outside this document. If (b) wins: what does
+nesting look like in the schema format, and how much of the synthesis machinery here stops being exercised in practice?
+
 ## Related
 
 - Planning: [RdfMapping](RdfMapping.md) (the native projection / default target),
@@ -305,4 +333,7 @@ vocabulary is in the store" a per-store configuration rather than a single globa
 - ECHOLOT tasks: T3.1 (standard schemas / ontology reuse), T3.2 (RDF export and import), T2.3 (semantic
   interoperability / ontology patterns), T4.1 (import/transformation pipelines), T4.2 (reconciliation), T4.5
   (quality checks).
+- Toy model: [Neutral Person to Many Standards](https://docs.google.com/spreadsheets/d/1j2_7j8RCUJrrMsfZaXtqHQOwp9cN9F8HIBtd3pfsToU/edit)
+  — one person model expressed across several ontologies (takin); shared evaluation vehicle for the modelling fork and
+  the first mappings.
 - Issue: [#723](https://github.com/ProfessionalWiki/NeoWiki/issues/723) (RDF mapping discussion).

--- a/docs/planning/OntologyMapping.md
+++ b/docs/planning/OntologyMapping.md
@@ -28,7 +28,7 @@ intended to drive both export (native → ontology) and, later, import (ontology
 The central difficulty is that good ontology mapping is **not predicate renaming**: CIDOC-CRM and similar ontologies
 are event-centric and require *synthesizing intermediate nodes that do not exist in NeoWiki's data*. The mapping is a
 graph-to-graph transformation governed by reusable patterns. Most of this document is about expressing those patterns,
-where they come from, and the import direction.
+where they come from, the import direction, and validating what the projections produce.
 
 > Terminology note: ECHOLOT partners often say "RDF mapping" for *this* — ontology alignment. In our docs,
 > [RdfMapping.md](RdfMapping.md) is the **native projection** (the default target vocabulary); this document is about
@@ -99,7 +99,8 @@ NeoWiki gives a natural anchor: **Relations carry a persistent ID** ([ADR 10](..
 The mediating CIDOC-CRM event node can derive its IRI from that Relation ID, so the `E12_Production` for a given Creator
 relation is the same node on every projection. Where no native ID exists (e.g. a literal-valued statement that expands
 structurally), the IRI is derived deterministically from the source Subject IRI plus the rule and a stable position key.
-Stable synthesized-node identity is also what makes the import direction tractable (below).
+Stable synthesized-node identity is also what makes the import direction tractable and validation reports traceable
+back to the wiki (both below).
 
 ## Design principles
 
@@ -198,6 +199,33 @@ So a Mapping should aim to be a bidirectional *definition*, while import and exp
 import pipeline mechanics live with T4.1. How far to shape the export formalism now for later invertibility is an open
 question.
 
+## Validating projections
+
+Ontology projections raise a validation question that native Subject validation
+([ADR 21](../adr/021-add-backend-validation.md)) cannot answer: does the projected RDF conform to the target
+ontology's expectations? Shapes for the target ontology — e.g. SHACL emitted by the T2.3 library (Q3) — can answer it,
+and two distinct failure sources make that worthwhile:
+
+- **Mapping bugs.** A rule produces structurally wrong output for every Subject it matches. Validating the projection
+  of a few sample Subjects at mapping-authoring time is effectively unit-testing the mapping.
+- **Data gaps.** The mapping is correct, but the data does not meet the target's requirements (e.g. a rights statement
+  the target ontology mandates is missing). These are per-Subject curation findings.
+
+Proposed division of labour: shape engines run in external quality tooling (T4.5), not in the wiki's editing path.
+NeoWiki's job is to keep projections checkable and findings traceable:
+
+- Export of projected RDF for a given mapping (per page and in bulk), so external validators have input.
+- Per-page named graphs ([RdfMapping.md](RdfMapping.md#named-graphs)) make re-validation incremental: only pages whose
+  graphs changed since the last run need re-checking.
+- **Traceability requirement.** A validation report references ontology-projection nodes, but the people acting on it
+  work in the wiki. Reports must be translatable back to the originating page, Subject, and property. The anchors
+  exist by construction — focus node → named graph → page; synthesized-node IRI → Relation ID → Statement; violated
+  path → the rule that emits it → the native construct the rule matches — so rules must retain that provenance.
+
+Conformance to a target ontology is a publication and import concern, not an editing concern: findings surface as
+reports and worklists (and can feed back into tightening native Schemas or mapping defaults), not as inline errors in
+the Subject editor, which stays native-validation-only.
+
 ## Scope
 
 **In scope:** defining Mappings (Schema-, Statement-, and Relation-level rules; node synthesis / path expansion;
@@ -243,9 +271,10 @@ What exactly does NeoWiki consume from the library, in what format, over what in
 the boundary between the Mapping (correspondence), the import executor (pattern recognition), and T4.1/T4.2 (pipeline,
 reconciliation)?
 
-**Q5: Validation via SHACL.** If the T2.3 library emits SHACL shapes, should NeoWiki consume them for validation
-(T3.1 constraints, T4.5 quality checks), and is mapping-time validation in scope here or in the validation workstream
-([ADR 12](../adr/012-backend-validation.md) / [ADR 21](../adr/021-add-backend-validation.md))?
+**Q5: Validation via SHACL.** [Validating projections](#validating-projections) proposes consuming shapes emitted by
+the T2.3 library to check ontology projections, with the engines in the T4.5 tooling rather than in NeoWiki. Open:
+which shapes the library actually emits and their coverage per ontology; and where findings surface for curators
+(report pages, a dashboard, an API the quality component writes back to) — in NeoWiki core or a plug-in.
 
 **Q6: One mapping per target vs combined.** A separate Mapping per (Schema, target ontology), or a single multi-target
 mapping per Schema? Per-target is more modular and independently installable; combined may reduce duplication for shared
@@ -274,5 +303,6 @@ vocabulary is in the store" a per-store configuration rather than a single globa
   [017 names as identifiers](../adr/017-names-as-identifiers.md),
   [019 graph database architecture](../adr/019-graph-database-architecture.md).
 - ECHOLOT tasks: T3.1 (standard schemas / ontology reuse), T3.2 (RDF export and import), T2.3 (semantic
-  interoperability / ontology patterns), T4.1 (import/transformation pipelines), T4.2 (reconciliation).
+  interoperability / ontology patterns), T4.1 (import/transformation pipelines), T4.2 (reconciliation), T4.5
+  (quality checks).
 - Issue: [#723](https://github.com/ProfessionalWiki/NeoWiki/issues/723) (RDF mapping discussion).

--- a/docs/planning/OntologyMapping.md
+++ b/docs/planning/OntologyMapping.md
@@ -9,54 +9,77 @@ Status: Draft strawman, for discussion with ECHOLOT partners (T2.3 and T3.x).
 
 ## Summary
 
-NeoWiki defines its own native Schemas ([ADR 6](../adr/006-schemas.md)) and projects them to NeoWiki-native RDF
-predicates ([RdfMapping.md](RdfMapping.md)). For interoperability — the core of ECHOLOT (SO2, T3.1, T3.2) — that
-native data must also be expressible in established cultural-heritage ontologies such as CIDOC-CRM, EDM, HDTO, and
-BIBFRAME.
+NeoWiki defines its own native Schemas ([ADR 6](../adr/006-schemas.md)). For RDF and SPARQL it projects that data into
+RDF; the base projection uses NeoWiki-native predicates ([RdfMapping.md](RdfMapping.md)). For interoperability — the
+core of ECHOLOT (SO2, T3.1, T3.2) — the data must instead be available in established cultural-heritage ontologies such
+as CIDOC-CRM, EDM, HDTO, and BIBFRAME.
 
-This document proposes an **ontology mapping layer**: a separate, additive layer that translates a wiki's native
-Schemas and data into standard-vocabulary RDF, without deforming the native data model. The native model stays
-canonical; mappings are first-class, authorable, optional, installable objects.
+An **ontology mapping** projects native NeoWiki data **directly into a target ontology**. That ontology RDF is what a
+configured triple store holds and what SPARQL queries run against. The NeoWiki-native projection
+([RdfMapping.md](RdfMapping.md)) and each target ontology are **sibling projections** of the same source data, selected
+per store rather than stacked: a store is configured with one projection, and different stores can hold different
+projections of the same wiki. The native projection is the default (used when no ontology mapping is configured) and
+the lossless-export target; ontology mappings define the other targets.
 
-The central design problem is that good ontology mapping is **not predicate renaming**. CIDOC-CRM and similar
-ontologies are event-centric: aligning to them requires *synthesizing intermediate nodes that do not exist in
-NeoWiki's data*. The mapping mechanism is therefore a graph-to-graph transformation governed by reusable patterns,
-not a lookup table. Most of this document is about how to express and execute those patterns, and where the patterns
-should come from.
+Mappings are first-class, authorable, installable objects, kept separate from Schemas so the native data model is not
+deformed to fit an ontology. A mapping defines the **correspondence** between NeoWiki's model and an ontology, and is
+intended to drive both export (native → ontology) and, later, import (ontology → native).
 
-> Terminology note: ECHOLOT partners often say "RDF mapping" to mean *this* — ontology alignment. In our docs,
-> [RdfMapping.md](RdfMapping.md) is the **native RDF projection** (the base serialization), and this document is the
-> **ontology mapping layer** on top of it. The two interlock but are designed and matured separately.
+The central difficulty is that good ontology mapping is **not predicate renaming**: CIDOC-CRM and similar ontologies
+are event-centric and require *synthesizing intermediate nodes that do not exist in NeoWiki's data*. The mapping is a
+graph-to-graph transformation governed by reusable patterns. Most of this document is about expressing those patterns,
+where they come from, and the import direction.
 
-## Why a separate, additive layer
+> Terminology note: ECHOLOT partners often say "RDF mapping" for *this* — ontology alignment. In our docs,
+> [RdfMapping.md](RdfMapping.md) is the **native projection** (the default target vocabulary); this document is about
+> projecting into **standard ontologies**.
 
-This direction is already settled across our planning:
+## Projections, not layers
+
+A triple store holds **one projection** of the wiki's data, in one target vocabulary, and SPARQL queries against it are
+written in that vocabulary.
+
+- The **native projection** ([RdfMapping.md](RdfMapping.md)) is the default target. A wiki with no ontology mapping
+  configured still gets RDF and SPARQL, in NeoWiki-native terms.
+- An **ontology mapping** defines an alternative target (CIDOC-CRM, EDM, …). Configure a store with that mapping and it
+  holds ontology RDF; SPARQL against it is written in that ontology.
+- Projections are **pluggable per store**, consistent with [ADR 19](../adr/019-graph-database-architecture.md) (each
+  backend owns its mapping). A wiki may run several stores with different projections — e.g. a CIDOC-CRM store for CH
+  interoperability alongside a native store for completeness.
+
+This has a deliberate consequence: **a store's query vocabulary is its projection.** Querying CIDOC-CRM means writing
+CIDOC-CRM SPARQL. Wanting the same data in two vocabularies means configuring two stores.
+
+Why the native projection stays a first-class target rather than always mapping to an ontology: standard ontologies are
+lossy and opinionated, so mapping into one can drop detail that has no place in that ontology. The triple store is a
+rebuildable projection, not the source of truth (which stays in MediaWiki revision slots,
+[ADR 4](../adr/004-use-dedicated-slot.md)), so lossy ontology projections are fine for querying; the native projection
+covers the case where nothing may be lost (e.g. a complete RDF export).
+
+## Why mapping is separate from Schemas
+
+Settled across our planning:
 
 - **Local Schemas stay canonical.** [GlobalProperties.md](GlobalProperties.md) rejected global, ontology-shaped
-  properties: the same interoperability is achievable with a mapping layer, without the UX and architectural cost of
-  forcing the data model to mirror external ontologies.
-- **Map at export time, not at modelling time.** Native schemas are defined for the wiki's own needs and mapped to
-  ontologies when RDF is produced. This keeps editing, validation, and querying working against a model users
-  understand, while still emitting standard LOD.
+  properties: the same interoperability is achievable with a mapping, without forcing the data model to mirror external
+  ontologies.
+- **Map at projection time, not at modelling time.** Schemas are defined for the wiki's own needs; the mapping to an
+  ontology is applied when RDF is produced. Editing, validation, and View-based display keep working against a model
+  users understand.
 - **Model diversity (ECHOLOT architecture principle).** No single data model is assumed; the system offers
-  transformation paths between models. One wiki may map to several target ontologies at once (KPI 2.1 targets >6
-  mapped models), and a mapping is independent, optional, and installable.
-
-The native projection ([RdfMapping.md](RdfMapping.md)) deliberately emits only NeoWiki-native predicates. The ontology
-mapping layer consumes that native data (or the Subject domain objects directly) and emits *additional* triples using
-standard vocabulary. The two are composed, not merged.
+  transformation paths between models. One wiki can target several ontologies (KPI 2.1 targets >6 mapped models), each
+  an independent, optional, installable mapping.
 
 ## What makes this hard: structural transformation
 
 Target ontologies sit on a spectrum of difficulty.
 
 **The easy tier — near 1:1 alignment.** Flat, property-centric targets (Dublin Core, much of EDM) mostly need term
-substitution: `Person.Name` → `foaf:name`, `Artwork.Creator` → `dc:creator`. A lookup table from (Schema, property)
-to a target term handles this.
+substitution: `Person.Name` → `foaf:name`, `Artwork.Creator` → `dc:creator`.
 
-**The hard tier — structural / event-centric alignment.** CIDOC-CRM, the dominant CH ontology, mediates
-relationships through events. A single native `Creator` relation from an object to a person does not map to one
-predicate; it expands to a path with an intermediate event node:
+**The hard tier — structural / event-centric alignment.** CIDOC-CRM, the dominant CH ontology, mediates relationships
+through events. A single native `Creator` relation from an object to a person does not map to one predicate; it expands
+to a path with an intermediate event node:
 
 ```
 E22_Human-Made_Object  →  P108i_was_produced_by  →  E12_Production  →  P14_carried_out_by  →  E39_Actor
@@ -64,25 +87,24 @@ E22_Human-Made_Object  →  P108i_was_produced_by  →  E12_Production  →  P14
 
 The `E12_Production` node has **no counterpart in NeoWiki's data**. The mapping must mint it. This is the crux: any
 mapping formalism we adopt has to express **path expansion and node synthesis**, not just renaming. A formalism that
-only does term substitution covers EDM but fails CIDOC-CRM — and CIDOC-CRM is the one that matters most for the case
-studies.
+only substitutes terms covers EDM but fails CIDOC-CRM — and CIDOC-CRM is the one that matters most for the case studies.
 
 ### Identity for synthesized nodes
 
-Synthesized nodes need stable, deterministic IRIs so that re-export is idempotent and the per-page named-graph sync in
-[RdfMapping.md](RdfMapping.md#named-graphs) (`DROP GRAPH` + `INSERT DATA`) stays correct.
+Synthesized nodes need stable, deterministic IRIs so that re-projecting a page is idempotent and the per-page
+named-graph sync in [RdfMapping.md](RdfMapping.md#named-graphs) (`DROP GRAPH` + `INSERT DATA`) stays correct for an
+ontology store too.
 
-NeoWiki gives us a natural anchor: **Relations carry a persistent ID** ([ADR 10](../adr/010-add-guids-to-relations.md),
-reified as a `neo:Relation` node in the native mapping). The mediating CIDOC-CRM event node can derive its IRI from
-that Relation IRI, so the `E12_Production` for a given Creator relation is the same node on every export. Where no
-native ID exists (e.g. a literal-valued statement that expands structurally), the IRI must be derived deterministically
-from the source Subject IRI plus the rule and a stable position key. This is one reason the [Layer 2 reified
-relations](RdfMapping.md#relations) earn their keep: they are the identity hook for structural mapping.
+NeoWiki gives a natural anchor: **Relations carry a persistent ID** ([ADR 10](../adr/010-add-guids-to-relations.md)).
+The mediating CIDOC-CRM event node can derive its IRI from that Relation ID, so the `E12_Production` for a given Creator
+relation is the same node on every projection. Where no native ID exists (e.g. a literal-valued statement that expands
+structurally), the IRI is derived deterministically from the source Subject IRI plus the rule and a stable position key.
+Stable synthesized-node identity is also what makes the import direction tractable (below).
 
 ## Design principles
 
-1. **Additive and non-destructive.** Mapping never changes native Schemas or stored data. It only produces RDF. A wiki
-   with no mappings still exports valid native RDF.
+1. **Non-destructive.** A mapping never changes native Schemas or stored data; it only defines a projection. A wiki with
+   no mapping still has the native projection.
 2. **Patterns are reusable and externally curated where possible.** Encoding CIDOC-CRM correctly is specialist work.
    NeoWiki should *bind* local constructs to curated ontology patterns, not re-encode ontology knowledge in its own
    codebase.
@@ -91,20 +113,19 @@ relations](RdfMapping.md#relations) earn their keep: they are the identity hook 
    "don't reinvent the query layer" stance.
 4. **Mappings are first-class wiki objects.** Authorable and versioned like other content (a wiki page and/or an
    API-writable object), not buried in server configuration. Distributable as bundles.
-5. **Bidirectional in intent, export-first in delivery.** Export (native → ontology) ships first; import
-   (ontology → native, T3.2/T4.1) reuses the same pattern vocabulary where feasible but is a separate, harder effort.
+5. **Bidirectional correspondence.** A mapping describes how NeoWiki's model and an ontology correspond, for both export
+   and import. Export ships first; import (below) reuses the correspondence but needs additional machinery.
 
 ## Strawman model
 
-A concrete proposal to react to. Details are deliberately tentative; the open questions below are where partner input
-is needed.
+A concrete proposal to react to. Details are deliberately tentative; the open questions below are where partner input is
+needed.
 
 ### The Mapping object
 
 A **Mapping** binds one source Schema to one target ontology and is a set of **rules**. It is a first-class object,
-separate from the Schema it references ([ADR 17](../adr/017-names-as-identifiers.md): Schemas are referenced by name).
-Separating it from the Schema keeps the Schema clean and lets the same Schema carry several mappings (one per target
-ontology), installed independently.
+separate from the Schema it references ([ADR 17](../adr/017-names-as-identifiers.md): Schemas are referenced by name),
+so the Schema stays clean and can carry several mappings (one per target ontology), installed independently.
 
 ```
 Mapping {
@@ -116,11 +137,12 @@ Mapping {
 
 ### Rules and the transformation
 
-Each **rule** matches a native construct — a Subject of the Schema, a Statement on a given property, or a Relation of
-a given type — and emits a **pattern**: a template of target triples that may mint intermediate nodes.
+Each **rule** matches a native construct — a Subject of the Schema, a Statement on a given property, or a Relation of a
+given type — and emits a **pattern**: target triples that may mint intermediate nodes.
 
-The most natural executable form for such a pattern is a **`CONSTRUCT`-style template** over the native triples. It is
-standard, store-agnostic, and mints nodes via deterministic IRI templates. A rule for the Creator example:
+A natural way to express a rule is a **`CONSTRUCT`-style template**: standard, store-agnostic, minting nodes via
+deterministic IRI templates. The native projection serves as the transformation's input representation, and the
+target-ontology triples it produces are what the store holds. A rule for the Creator example:
 
 ```sparql
 # rule: Artwork.Creator → CIDOC-CRM production event
@@ -137,63 +159,57 @@ WHERE {
         neo:source ?object ;
         neo:target ?actor .
   # deterministic IRI for the synthesized event, anchored on the Relation ID
-  BIND( IRI(CONCAT(STR(neo-prod:), STRAFTER(STR(?rel), STR(neo-rel:)))) AS ?production )
+  BIND( IRI(CONCAT(STR(crm-prod:), STRAFTER(STR(?rel), STR(neo-rel:)))) AS ?production )
 }
 ```
 
-Here `crm:` is CIDOC-CRM and `neo-prod:` is an illustrative namespace for synthesized event nodes; the `BIND` anchors
-that node's IRI on the Relation ID so it is stable across re-exports.
+Here `crm:` is CIDOC-CRM and `crm-prod:` is an illustrative namespace for synthesized event nodes; the `BIND` anchors
+that node's IRI on the Relation ID so it is stable across re-projections. The same Artwork Schema mapped to EDM would be
+mostly flat rules (`?object a edm:ProvidedCHO`, `?object dc:creator ?actor`) with no synthesized nodes — illustrating
+that one formalism must span both ends of the spectrum.
 
-The same Artwork Schema mapped to EDM would be mostly flat rules (`?object a edm:ProvidedCHO`,
-`?object dc:creator ?actor`) with no synthesized nodes — the easy tier — illustrating that one formalism must span
-both ends of the spectrum.
-
-`CONSTRUCT` templates are one candidate *execution* form. Whether authors write them directly, or write something
-higher-level (LinkML, SHACL rules, or Platka-sourced patterns) that compiles to them, is the central open question
-below.
+`CONSTRUCT` is one candidate form. Whether authors write templates directly, or write something higher-level (LinkML,
+SHACL rules, or patterns sourced from the T2.3 library) that compiles to them, is the central open question below.
 
 ### Where patterns come from
 
 We should not hand-encode CIDOC-CRM paths from scratch if a curated source exists. T2.3 (takin) is building a pattern
-library (Platka) that stores ontology patterns as machine-readable paths. The ideal division of labour: the pattern
-library owns the *recipe* (the exact RDF a given alignment must produce); NeoWiki owns the *binding* of local Schemas
-and data onto those recipes and the *execution* against actual Subjects. The exact interface and format are open (see
-below).
+library (Platka) that stores ontology patterns as machine-readable paths. The ideal division of labour: the library
+owns the *recipe* (the exact RDF a given alignment must produce); NeoWiki owns the *binding* of local Schemas and data
+onto those recipes and the *execution* against actual Subjects. The exact interface and format are open (below).
 
-### Execution and storage
+## Import
 
-The layer runs after the native projection. Two placements are possible and not yet decided:
+The mapping is the **correspondence** between NeoWiki's model and an ontology, so it is also the basis for importing
+ontology RDF into NeoWiki Subjects (T3.2 calls for native RDF/RDF\* import; T2.3 frames interoperability as
+bidirectional model-model mappings). Export ships first, but the formalism should be chosen with import in mind.
 
-- **Materialized:** mapped triples are written to the triple store alongside native triples (queryable in standard
-  vocabulary via SPARQL, larger store, must be kept in sync per page like the native graph).
-- **Export-only:** mapped triples are produced only for bulk RDF export / on-the-fly, leaving the live store native.
+Import is not export run backwards. A structural mapping is generally **not trivially invertible**: importing CIDOC-CRM
+means **recognising** the `E12_Production` pattern in the incoming graph and **collapsing** it back to a `Creator`
+relation — graph pattern-matching on input, not template expansion of output. Import also pulls in adjacent concerns the
+export projection does not have:
 
-## Relationship to the native RDF mapping
+- **Reconciliation / entity linking** of incoming IRIs to existing Subjects — a WP4 concern (T4.2), not the mapping
+  itself.
+- **Batch ID-minting** for many interlinked incoming Subjects (the current API mints one Subject at a time).
+- **Target-Schema selection** for incoming data.
 
-- **Composition order.** Native projection first (defines `neo-prop:*`, `neo:Relation`, IRIs, named graphs); ontology
-  layer second (reads those, emits standard-vocabulary triples).
-- **Interaction with predicate scope ([RdfMapping.md Q1](RdfMapping.md#open-questions)).** Rule left-hand sides are
-  simplest and least ambiguous when the native predicate already identifies its Schema. A flat `neo-prop:Name` forces
-  every rule to additionally constrain on `rdf:type`; scoped predicates (`neo-prop:Person/Name`) make the rule LHS
-  self-identifying. This is a point in favour of revisiting Q1's tentative "flat" resolution, and is called out here so
-  the two docs are decided together.
-- **Reified relations as identity anchors.** Covered above — the native Layer 2 `neo:Relation` node is what gives
-  synthesized event nodes stable IRIs.
+So a Mapping should aim to be a bidirectional *definition*, while import and export are separate *executors* and the
+import pipeline mechanics live with T4.1. How far to shape the export formalism now for later invertibility is an open
+question.
 
 ## Scope
 
-**In scope:** Schema-, Statement-, and Relation-level mapping rules; node synthesis / path expansion; deterministic
-IRIs for synthesized nodes; producing standard-vocabulary RDF for export (and optionally the live store); mapping
-objects as authorable, installable bundles.
+**In scope:** defining Mappings (Schema-, Statement-, and Relation-level rules; node synthesis / path expansion;
+deterministic IRIs for synthesized nodes); producing an ontology projection for a configured store and for export; the
+native projection as the default target; the Mapping as a bidirectional definition.
 
 **Out of scope (separate concerns, cross-referenced):**
 
-- The native RDF projection itself — [RdfMapping.md](RdfMapping.md).
-- Reconciliation / entity linking / `owl:sameAs` minting — WP4 (T4.2), not a mapping-layer responsibility, though
-  mapped IRIs are its input.
-- Rich chain-of-production provenance and rights — T2.4 model and a T3.4 plug-in, not the mapping layer (see
-  [ECHOLOT.md](ECHOLOT.md)).
-- The mechanics of an RDF *import* pipeline — T3.2/T4.1. Direction noted under principles, not designed here.
+- The native projection itself — [RdfMapping.md](RdfMapping.md).
+- The import *pipeline* mechanics and orchestration — T4.1.
+- Reconciliation / entity linking / `owl:sameAs` minting — WP4 (T4.2); mapped IRIs are its input.
+- Rich chain-of-production provenance and rights — T2.4 model and a T3.4 plug-in (see [ECHOLOT.md](ECHOLOT.md)).
 - Global, ontology-shaped properties — rejected in [GlobalProperties.md](GlobalProperties.md).
 
 ## Open questions
@@ -204,15 +220,14 @@ with deep CIDOC-CRM / EDM / RDF experience.
 **Q1: Mapping formalism.** The central fork. Candidates:
   1. **A NeoWiki-native mapping object** (rules compiling to `CONSTRUCT`-style templates as sketched above). Full
      control, fitted to our model; but a formalism we own and maintain.
-  2. **LinkML.** An established, tooling-rich modelling language with class/slot mappings to external vocabularies.
-     Open whether its mapping facilities are expressive enough for CIDOC-CRM-style structural expansion, or only the
-     near-1:1 tier.
+  2. **LinkML.** An established, tooling-rich modelling language with class/slot mappings to external vocabularies. Open
+     whether its mapping facilities are expressive enough for CIDOC-CRM-style structural expansion, or only the near-1:1
+     tier.
   3. **Patterns sourced from the T2.3 library (Platka).** Bind local constructs to externally-curated patterns,
-     minimizing ontology knowledge in NeoWiki. Depends on what the library can emit and how stable/queryable that
-     interface is.
+     minimizing ontology knowledge in NeoWiki. Depends on what the library can emit and how stable that interface is.
 
-  These are not mutually exclusive: e.g. consume patterns from (3), expressed in a formalism like (2), executed via
-  (1). What combination do partners recommend?
+  These are not mutually exclusive: e.g. consume patterns from (3), expressed in a formalism like (2), executed via (1).
+  What combination do partners recommend?
 
 **Q2: Expressiveness for node synthesis.** Whatever formalism is chosen, can it express path expansion and
 intermediate-node minting (the `E12_Production` case) — not just term substitution? Are SHACL Advanced Features
@@ -221,40 +236,43 @@ patterns in an executable form we can target?
 
 **Q3: Platka boundary.** Our understanding (to confirm): the T2.3 pattern library *creates* ontologies and derivatives
 (e.g. SHACL for validation) but does **not** perform ontology-to-ontology mapping. If so, NeoWiki owns Schema→ontology
-mappings, and the library supplies (a) the target patterns we emit and possibly (b) SHACL we validate against. What
-exactly does NeoWiki consume from the library, in what format, over what interface?
+mappings, and the library supplies (a) the target patterns we project to and possibly (b) SHACL we validate against.
+What exactly does NeoWiki consume from the library, in what format, over what interface?
 
-**Q4: Direction — import.** Is export-first acceptable, with import (ontology/MARC21 → native Schemas) designed later
-under T3.2/T4.1? Import is harder (target-Schema inference, reconciliation) and several case studies (ELB LODification,
-media art) lean on it. How much should the export formalism be shaped now to be invertible later?
+**Q4: Import.** How far should the export formalism be shaped now so the same Mapping can drive import later? Where is
+the boundary between the Mapping (correspondence), the import executor (pattern recognition), and T4.1/T4.2 (pipeline,
+reconciliation)?
 
 **Q5: Validation via SHACL.** If the T2.3 library emits SHACL shapes, should NeoWiki consume them for validation
 (T3.1 constraints, T4.5 quality checks), and is mapping-time validation in scope here or in the validation workstream
 ([ADR 12](../adr/012-backend-validation.md) / [ADR 21](../adr/021-add-backend-validation.md))?
 
-**Q6: One mapping per target vs combined.** A separate Mapping object per (Schema, target ontology), or a single
-multi-target mapping per Schema? Per-target is more modular and independently installable; combined may reduce
-duplication for shared sub-patterns.
+**Q6: One mapping per target vs combined.** A separate Mapping per (Schema, target ontology), or a single multi-target
+mapping per Schema? Per-target is more modular and independently installable; combined may reduce duplication for shared
+sub-patterns.
 
-**Q7: Authoring and distribution.** Where do Mapping objects live (a dedicated namespace? API-only?), who authors them
-(data modellers) vs installs them (wiki admins), and how are bundles (e.g. "CIDOC-CRM for Person / Place / Object")
-packaged and shared across wikis and across a farm?
+**Q7: Authoring and distribution.** Where do Mappings live (a dedicated namespace? API-only?), who authors them (data
+modellers) vs installs them (wiki admins), and how are bundles (e.g. "CIDOC-CRM for Person / Place / Object") packaged
+and shared across wikis and a farm?
 
 **Q8: Multilinguality.** Mapped labels should carry language tags (`@lang`); canonical values used in queries stay
-language-neutral. CH data is heavily multilingual (Basque, the ELB languages, etc.). How much of this belongs in the
-mapping layer vs the base projection vs Views?
+language-neutral. CH data is heavily multilingual (Basque, the ELB languages, etc.). How much belongs in the mapping vs
+the native projection vs Views?
 
-**Q9: Store placement.** Materialize mapped triples in the live store (standard-vocabulary SPARQL queries work
-directly, at the cost of store size and sync) or produce them export-only? Affects the SPARQL plugin's sync design.
+**Q9: Multiple projections per wiki.** Should a wiki be able to serve several projections at once (several stores:
+native + one or more ontologies), and is a native projection always available as a baseline? This makes "which
+vocabulary is in the store" a per-store configuration rather than a single global choice.
 
 ## Related
 
-- Planning: [RdfMapping](RdfMapping.md) (the native projection this builds on), [GlobalProperties](GlobalProperties.md)
-  (why mapping is a layer, not a data-model change), [SubjectSources](SubjectSources.md) (the `source → base-URI`
-  registry that is also the RDF prefix/URI map), [ECHOLOT](ECHOLOT.md).
-- ADRs: [006 schemas](../adr/006-schemas.md), [010 relation IDs](../adr/010-add-guids-to-relations.md),
+- Planning: [RdfMapping](RdfMapping.md) (the native projection / default target),
+  [GlobalProperties](GlobalProperties.md) (why mapping is separate from the data model),
+  [SubjectSources](SubjectSources.md) (the `source → base-URI` registry that is also the RDF prefix/URI map),
+  [ECHOLOT](ECHOLOT.md).
+- ADRs: [004 dedicated slot](../adr/004-use-dedicated-slot.md) (source of truth),
+  [006 schemas](../adr/006-schemas.md), [010 relation IDs](../adr/010-add-guids-to-relations.md),
   [017 names as identifiers](../adr/017-names-as-identifiers.md),
   [019 graph database architecture](../adr/019-graph-database-architecture.md).
-- ECHOLOT tasks: T3.1 (standard schemas / ontology reuse), T3.2 (RDF export), T2.3 (semantic interoperability /
-  ontology patterns), T4.1 (import/transformation pipelines).
+- ECHOLOT tasks: T3.1 (standard schemas / ontology reuse), T3.2 (RDF export and import), T2.3 (semantic
+  interoperability / ontology patterns), T4.1 (import/transformation pipelines), T4.2 (reconciliation).
 - Issue: [#723](https://github.com/ProfessionalWiki/NeoWiki/issues/723) (RDF mapping discussion).

--- a/docs/planning/OntologyMapping.md
+++ b/docs/planning/OntologyMapping.md
@@ -10,16 +10,16 @@ Status: Draft strawman, for discussion with ECHOLOT partners (T2.3 and T3.x).
 ## Summary
 
 NeoWiki defines its own native Schemas ([ADR 6](../adr/006-schemas.md)). For RDF and SPARQL it projects that data into
-RDF; the base projection uses NeoWiki-native predicates ([RdfMapping.md](RdfMapping.md)). For interoperability — the
-core of ECHOLOT (SO2, T3.1, T3.2) — the data must instead be available in established cultural-heritage ontologies such
-as CIDOC-CRM, EDM, HDTO, and BIBFRAME.
+RDF; the native projection uses NeoWiki-native predicates ([NativeRdfProjection.md](NativeRdfProjection.md)). For
+interoperability — the core of ECHOLOT (SO2, T3.1, T3.2) — the data must instead be available in established
+cultural-heritage ontologies such as CIDOC-CRM, EDM, HDTO, and BIBFRAME.
 
 An **ontology mapping** projects native NeoWiki data **directly into a target ontology**. That ontology RDF is what a
 configured triple store holds and what SPARQL queries run against. The NeoWiki-native projection
-([RdfMapping.md](RdfMapping.md)) and each target ontology are **sibling projections** of the same source data, selected
-per store rather than stacked: a store is configured with one projection, and different stores can hold different
-projections of the same wiki. The native projection is the default (used when no ontology mapping is configured) and
-the lossless-export target; ontology mappings define the other targets.
+([NativeRdfProjection.md](NativeRdfProjection.md)) and each target ontology are **sibling projections** of the same
+source data, selected per store rather than stacked: a store is configured with one projection, and different stores
+can hold different projections of the same wiki. The native projection is the default (used when no ontology mapping
+is configured) and the lossless-export target; ontology mappings define the other targets.
 
 Mappings are first-class, authorable, installable objects, kept separate from Schemas so the native data model is not
 deformed to fit an ontology. A mapping defines the **correspondence** between NeoWiki's model and an ontology, and is
@@ -31,17 +31,17 @@ graph-to-graph transformation governed by reusable patterns. Most of this docume
 where they come from, how the open flat-vs-nested modelling fork affects them, the import direction, and validating
 what the projections produce.
 
-> Terminology note: ECHOLOT partners often say "RDF mapping" for *this* — ontology alignment. In our docs,
-> [RdfMapping.md](RdfMapping.md) is the **native projection** (the default target vocabulary); this document is about
-> projecting into **standard ontologies**.
+> Terminology note: ECHOLOT partners often say "RDF mapping" for ontology alignment — that is *this* document. The
+> native vocabulary and the projection infrastructure shared by all projections (IRIs, named graphs, sync) live in
+> [NativeRdfProjection.md](NativeRdfProjection.md).
 
 ## Projections, not layers
 
 A triple store holds **one projection** of the wiki's data, in one target vocabulary, and SPARQL queries against it are
 written in that vocabulary.
 
-- The **native projection** ([RdfMapping.md](RdfMapping.md)) is the default target. A wiki with no ontology mapping
-  configured still gets RDF and SPARQL, in NeoWiki-native terms.
+- The **native projection** ([NativeRdfProjection.md](NativeRdfProjection.md)) is the default target. A wiki with no
+  ontology mapping configured still gets RDF and SPARQL, in NeoWiki-native terms.
 - An **ontology mapping** defines an alternative target (CIDOC-CRM, EDM, …). Configure a store with that mapping and it
   holds ontology RDF; SPARQL against it is written in that ontology.
 - Projections are **pluggable per store**, consistent with [ADR 19](../adr/019-graph-database-architecture.md) (each
@@ -115,8 +115,8 @@ requirement (Q2, Q10).
 ### Identity for synthesized nodes
 
 Synthesized nodes need stable, deterministic IRIs so that re-projecting a page is idempotent and the per-page
-named-graph sync in [RdfMapping.md](RdfMapping.md#named-graphs) (`DROP GRAPH` + `INSERT DATA`) stays correct for an
-ontology store too.
+named-graph sync in [NativeRdfProjection.md](NativeRdfProjection.md#named-graphs) (`DROP GRAPH` + `INSERT DATA`)
+stays correct for an ontology store too.
 
 NeoWiki gives a natural anchor: **Relations carry a persistent ID** ([ADR 10](../adr/010-add-guids-to-relations.md)).
 The mediating CIDOC-CRM event node can derive its IRI from that Relation ID, so the `E12_Production` for a given Creator
@@ -238,8 +238,8 @@ Proposed division of labour: shape engines run in external quality tooling (T4.5
 NeoWiki's job is to keep projections checkable and findings traceable:
 
 - Export of projected RDF for a given mapping (per page and in bulk), so external validators have input.
-- Per-page named graphs ([RdfMapping.md](RdfMapping.md#named-graphs)) make re-validation incremental: only pages whose
-  graphs changed since the last run need re-checking.
+- Per-page named graphs ([NativeRdfProjection.md](NativeRdfProjection.md#named-graphs)) make re-validation
+  incremental: only pages whose graphs changed since the last run need re-checking.
 - **Traceability requirement.** A validation report references ontology-projection nodes, but the people acting on it
   work in the wiki. Reports must be translatable back to the originating page, Subject, and property. The anchors
   exist by construction — focus node → named graph → page; synthesized-node IRI → Relation ID → Statement; violated
@@ -257,7 +257,8 @@ native projection as the default target; the Mapping as a bidirectional definiti
 
 **Out of scope (separate concerns, cross-referenced):**
 
-- The native projection itself — [RdfMapping.md](RdfMapping.md).
+- The native projection and the shared projection infrastructure (IRIs, named graphs, sync) —
+  [NativeRdfProjection.md](NativeRdfProjection.md).
 - The import *pipeline* mechanics and orchestration — T4.1.
 - Reconciliation / entity linking / `owl:sameAs` minting — WP4 (T4.2); mapped IRIs are its input.
 - Rich chain-of-production provenance and rights — T2.4 model and a T3.4 plug-in (see [ECHOLOT.md](ECHOLOT.md)).
@@ -322,7 +323,7 @@ nesting look like in the schema format, and how much of the synthesis machinery 
 
 ## Related
 
-- Planning: [RdfMapping](RdfMapping.md) (the native projection / default target),
+- Planning: [NativeRdfProjection](NativeRdfProjection.md) (the native projection and shared per-store infrastructure),
   [GlobalProperties](GlobalProperties.md) (why mapping is separate from the data model),
   [SubjectSources](SubjectSources.md) (the `source → base-URI` registry that is also the RDF prefix/URI map),
   [ECHOLOT](ECHOLOT.md).

--- a/docs/planning/OntologyMapping.md
+++ b/docs/planning/OntologyMapping.md
@@ -1,0 +1,260 @@
+# Ontology Mapping
+
+This is an early design document for stakeholder feedback before we start implementation and record decisions via a
+new ADR.
+
+Started 2026-06-24 by Jeroen De Dauw with help from Claude Opus 4.8.
+
+Status: Draft strawman, for discussion with ECHOLOT partners (T2.3 and T3.x).
+
+## Summary
+
+NeoWiki defines its own native Schemas ([ADR 6](../adr/006-schemas.md)) and projects them to NeoWiki-native RDF
+predicates ([RdfMapping.md](RdfMapping.md)). For interoperability — the core of ECHOLOT (SO2, T3.1, T3.2) — that
+native data must also be expressible in established cultural-heritage ontologies such as CIDOC-CRM, EDM, HDTO, and
+BIBFRAME.
+
+This document proposes an **ontology mapping layer**: a separate, additive layer that translates a wiki's native
+Schemas and data into standard-vocabulary RDF, without deforming the native data model. The native model stays
+canonical; mappings are first-class, authorable, optional, installable objects.
+
+The central design problem is that good ontology mapping is **not predicate renaming**. CIDOC-CRM and similar
+ontologies are event-centric: aligning to them requires *synthesizing intermediate nodes that do not exist in
+NeoWiki's data*. The mapping mechanism is therefore a graph-to-graph transformation governed by reusable patterns,
+not a lookup table. Most of this document is about how to express and execute those patterns, and where the patterns
+should come from.
+
+> Terminology note: ECHOLOT partners often say "RDF mapping" to mean *this* — ontology alignment. In our docs,
+> [RdfMapping.md](RdfMapping.md) is the **native RDF projection** (the base serialization), and this document is the
+> **ontology mapping layer** on top of it. The two interlock but are designed and matured separately.
+
+## Why a separate, additive layer
+
+This direction is already settled across our planning:
+
+- **Local Schemas stay canonical.** [GlobalProperties.md](GlobalProperties.md) rejected global, ontology-shaped
+  properties: the same interoperability is achievable with a mapping layer, without the UX and architectural cost of
+  forcing the data model to mirror external ontologies.
+- **Map at export time, not at modelling time.** Native schemas are defined for the wiki's own needs and mapped to
+  ontologies when RDF is produced. This keeps editing, validation, and querying working against a model users
+  understand, while still emitting standard LOD.
+- **Model diversity (ECHOLOT architecture principle).** No single data model is assumed; the system offers
+  transformation paths between models. One wiki may map to several target ontologies at once (KPI 2.1 targets >6
+  mapped models), and a mapping is independent, optional, and installable.
+
+The native projection ([RdfMapping.md](RdfMapping.md)) deliberately emits only NeoWiki-native predicates. The ontology
+mapping layer consumes that native data (or the Subject domain objects directly) and emits *additional* triples using
+standard vocabulary. The two are composed, not merged.
+
+## What makes this hard: structural transformation
+
+Target ontologies sit on a spectrum of difficulty.
+
+**The easy tier — near 1:1 alignment.** Flat, property-centric targets (Dublin Core, much of EDM) mostly need term
+substitution: `Person.Name` → `foaf:name`, `Artwork.Creator` → `dc:creator`. A lookup table from (Schema, property)
+to a target term handles this.
+
+**The hard tier — structural / event-centric alignment.** CIDOC-CRM, the dominant CH ontology, mediates
+relationships through events. A single native `Creator` relation from an object to a person does not map to one
+predicate; it expands to a path with an intermediate event node:
+
+```
+E22_Human-Made_Object  →  P108i_was_produced_by  →  E12_Production  →  P14_carried_out_by  →  E39_Actor
+```
+
+The `E12_Production` node has **no counterpart in NeoWiki's data**. The mapping must mint it. This is the crux: any
+mapping formalism we adopt has to express **path expansion and node synthesis**, not just renaming. A formalism that
+only does term substitution covers EDM but fails CIDOC-CRM — and CIDOC-CRM is the one that matters most for the case
+studies.
+
+### Identity for synthesized nodes
+
+Synthesized nodes need stable, deterministic IRIs so that re-export is idempotent and the per-page named-graph sync in
+[RdfMapping.md](RdfMapping.md#named-graphs) (`DROP GRAPH` + `INSERT DATA`) stays correct.
+
+NeoWiki gives us a natural anchor: **Relations carry a persistent ID** ([ADR 10](../adr/010-add-guids-to-relations.md),
+reified as a `neo:Relation` node in the native mapping). The mediating CIDOC-CRM event node can derive its IRI from
+that Relation IRI, so the `E12_Production` for a given Creator relation is the same node on every export. Where no
+native ID exists (e.g. a literal-valued statement that expands structurally), the IRI must be derived deterministically
+from the source Subject IRI plus the rule and a stable position key. This is one reason the [Layer 2 reified
+relations](RdfMapping.md#relations) earn their keep: they are the identity hook for structural mapping.
+
+## Design principles
+
+1. **Additive and non-destructive.** Mapping never changes native Schemas or stored data. It only produces RDF. A wiki
+   with no mappings still exports valid native RDF.
+2. **Patterns are reusable and externally curated where possible.** Encoding CIDOC-CRM correctly is specialist work.
+   NeoWiki should *bind* local constructs to curated ontology patterns, not re-encode ontology knowledge in its own
+   codebase.
+3. **Reuse a formalism; do not invent one casually.** Prefer an established mapping/transformation formalism (see open
+   questions) over a bespoke NeoWiki DSL, consistent with [ADR 19](../adr/019-graph-database-architecture.md)'s
+   "don't reinvent the query layer" stance.
+4. **Mappings are first-class wiki objects.** Authorable and versioned like other content (a wiki page and/or an
+   API-writable object), not buried in server configuration. Distributable as bundles.
+5. **Bidirectional in intent, export-first in delivery.** Export (native → ontology) ships first; import
+   (ontology → native, T3.2/T4.1) reuses the same pattern vocabulary where feasible but is a separate, harder effort.
+
+## Strawman model
+
+A concrete proposal to react to. Details are deliberately tentative; the open questions below are where partner input
+is needed.
+
+### The Mapping object
+
+A **Mapping** binds one source Schema to one target ontology and is a set of **rules**. It is a first-class object,
+separate from the Schema it references ([ADR 17](../adr/017-names-as-identifiers.md): Schemas are referenced by name).
+Separating it from the Schema keeps the Schema clean and lets the same Schema carry several mappings (one per target
+ontology), installed independently.
+
+```
+Mapping {
+  schema:  "Artwork"            # source Schema (by name)
+  target:  "cidoc-crm"          # target ontology / profile
+  rules:   [ Rule, Rule, ... ]
+}
+```
+
+### Rules and the transformation
+
+Each **rule** matches a native construct — a Subject of the Schema, a Statement on a given property, or a Relation of
+a given type — and emits a **pattern**: a template of target triples that may mint intermediate nodes.
+
+The most natural executable form for such a pattern is a **`CONSTRUCT`-style template** over the native triples. It is
+standard, store-agnostic, and mints nodes via deterministic IRI templates. A rule for the Creator example:
+
+```sparql
+# rule: Artwork.Creator → CIDOC-CRM production event
+CONSTRUCT {
+  ?object      a crm:E22_Human-Made_Object ;
+               crm:P108i_was_produced_by ?production .
+  ?production  a crm:E12_Production ;
+               crm:P14_carried_out_by ?actor .
+  ?actor       a crm:E39_Actor .
+}
+WHERE {
+  ?rel  a neo:Relation ;
+        neo:relationType neo-prop:Creator ;
+        neo:source ?object ;
+        neo:target ?actor .
+  # deterministic IRI for the synthesized event, anchored on the Relation ID
+  BIND( IRI(CONCAT(STR(neo-prod:), STRAFTER(STR(?rel), STR(neo-rel:)))) AS ?production )
+}
+```
+
+Here `crm:` is CIDOC-CRM and `neo-prod:` is an illustrative namespace for synthesized event nodes; the `BIND` anchors
+that node's IRI on the Relation ID so it is stable across re-exports.
+
+The same Artwork Schema mapped to EDM would be mostly flat rules (`?object a edm:ProvidedCHO`,
+`?object dc:creator ?actor`) with no synthesized nodes — the easy tier — illustrating that one formalism must span
+both ends of the spectrum.
+
+`CONSTRUCT` templates are one candidate *execution* form. Whether authors write them directly, or write something
+higher-level (LinkML, SHACL rules, or Platka-sourced patterns) that compiles to them, is the central open question
+below.
+
+### Where patterns come from
+
+We should not hand-encode CIDOC-CRM paths from scratch if a curated source exists. T2.3 (takin) is building a pattern
+library (Platka) that stores ontology patterns as machine-readable paths. The ideal division of labour: the pattern
+library owns the *recipe* (the exact RDF a given alignment must produce); NeoWiki owns the *binding* of local Schemas
+and data onto those recipes and the *execution* against actual Subjects. The exact interface and format are open (see
+below).
+
+### Execution and storage
+
+The layer runs after the native projection. Two placements are possible and not yet decided:
+
+- **Materialized:** mapped triples are written to the triple store alongside native triples (queryable in standard
+  vocabulary via SPARQL, larger store, must be kept in sync per page like the native graph).
+- **Export-only:** mapped triples are produced only for bulk RDF export / on-the-fly, leaving the live store native.
+
+## Relationship to the native RDF mapping
+
+- **Composition order.** Native projection first (defines `neo-prop:*`, `neo:Relation`, IRIs, named graphs); ontology
+  layer second (reads those, emits standard-vocabulary triples).
+- **Interaction with predicate scope ([RdfMapping.md Q1](RdfMapping.md#open-questions)).** Rule left-hand sides are
+  simplest and least ambiguous when the native predicate already identifies its Schema. A flat `neo-prop:Name` forces
+  every rule to additionally constrain on `rdf:type`; scoped predicates (`neo-prop:Person/Name`) make the rule LHS
+  self-identifying. This is a point in favour of revisiting Q1's tentative "flat" resolution, and is called out here so
+  the two docs are decided together.
+- **Reified relations as identity anchors.** Covered above — the native Layer 2 `neo:Relation` node is what gives
+  synthesized event nodes stable IRIs.
+
+## Scope
+
+**In scope:** Schema-, Statement-, and Relation-level mapping rules; node synthesis / path expansion; deterministic
+IRIs for synthesized nodes; producing standard-vocabulary RDF for export (and optionally the live store); mapping
+objects as authorable, installable bundles.
+
+**Out of scope (separate concerns, cross-referenced):**
+
+- The native RDF projection itself — [RdfMapping.md](RdfMapping.md).
+- Reconciliation / entity linking / `owl:sameAs` minting — WP4 (T4.2), not a mapping-layer responsibility, though
+  mapped IRIs are its input.
+- Rich chain-of-production provenance and rights — T2.4 model and a T3.4 plug-in, not the mapping layer (see
+  [ECHOLOT.md](ECHOLOT.md)).
+- The mechanics of an RDF *import* pipeline — T3.2/T4.1. Direction noted under principles, not designed here.
+- Global, ontology-shaped properties — rejected in [GlobalProperties.md](GlobalProperties.md).
+
+## Open questions
+
+These need ECHOLOT partner input, especially from T2.3 (semantic interoperability / ontology patterns) and partners
+with deep CIDOC-CRM / EDM / RDF experience.
+
+**Q1: Mapping formalism.** The central fork. Candidates:
+  1. **A NeoWiki-native mapping object** (rules compiling to `CONSTRUCT`-style templates as sketched above). Full
+     control, fitted to our model; but a formalism we own and maintain.
+  2. **LinkML.** An established, tooling-rich modelling language with class/slot mappings to external vocabularies.
+     Open whether its mapping facilities are expressive enough for CIDOC-CRM-style structural expansion, or only the
+     near-1:1 tier.
+  3. **Patterns sourced from the T2.3 library (Platka).** Bind local constructs to externally-curated patterns,
+     minimizing ontology knowledge in NeoWiki. Depends on what the library can emit and how stable/queryable that
+     interface is.
+
+  These are not mutually exclusive: e.g. consume patterns from (3), expressed in a formalism like (2), executed via
+  (1). What combination do partners recommend?
+
+**Q2: Expressiveness for node synthesis.** Whatever formalism is chosen, can it express path expansion and
+intermediate-node minting (the `E12_Production` case) — not just term substitution? Are SHACL Advanced Features
+(SPARQL-based `sh:rule`) or `CONSTRUCT` the right executable substrate? Do partners already have CIDOC-CRM expansion
+patterns in an executable form we can target?
+
+**Q3: Platka boundary.** Our understanding (to confirm): the T2.3 pattern library *creates* ontologies and derivatives
+(e.g. SHACL for validation) but does **not** perform ontology-to-ontology mapping. If so, NeoWiki owns Schema→ontology
+mappings, and the library supplies (a) the target patterns we emit and possibly (b) SHACL we validate against. What
+exactly does NeoWiki consume from the library, in what format, over what interface?
+
+**Q4: Direction — import.** Is export-first acceptable, with import (ontology/MARC21 → native Schemas) designed later
+under T3.2/T4.1? Import is harder (target-Schema inference, reconciliation) and several case studies (ELB LODification,
+media art) lean on it. How much should the export formalism be shaped now to be invertible later?
+
+**Q5: Validation via SHACL.** If the T2.3 library emits SHACL shapes, should NeoWiki consume them for validation
+(T3.1 constraints, T4.5 quality checks), and is mapping-time validation in scope here or in the validation workstream
+([ADR 12](../adr/012-backend-validation.md) / [ADR 21](../adr/021-add-backend-validation.md))?
+
+**Q6: One mapping per target vs combined.** A separate Mapping object per (Schema, target ontology), or a single
+multi-target mapping per Schema? Per-target is more modular and independently installable; combined may reduce
+duplication for shared sub-patterns.
+
+**Q7: Authoring and distribution.** Where do Mapping objects live (a dedicated namespace? API-only?), who authors them
+(data modellers) vs installs them (wiki admins), and how are bundles (e.g. "CIDOC-CRM for Person / Place / Object")
+packaged and shared across wikis and across a farm?
+
+**Q8: Multilinguality.** Mapped labels should carry language tags (`@lang`); canonical values used in queries stay
+language-neutral. CH data is heavily multilingual (Basque, the ELB languages, etc.). How much of this belongs in the
+mapping layer vs the base projection vs Views?
+
+**Q9: Store placement.** Materialize mapped triples in the live store (standard-vocabulary SPARQL queries work
+directly, at the cost of store size and sync) or produce them export-only? Affects the SPARQL plugin's sync design.
+
+## Related
+
+- Planning: [RdfMapping](RdfMapping.md) (the native projection this builds on), [GlobalProperties](GlobalProperties.md)
+  (why mapping is a layer, not a data-model change), [SubjectSources](SubjectSources.md) (the `source → base-URI`
+  registry that is also the RDF prefix/URI map), [ECHOLOT](ECHOLOT.md).
+- ADRs: [006 schemas](../adr/006-schemas.md), [010 relation IDs](../adr/010-add-guids-to-relations.md),
+  [017 names as identifiers](../adr/017-names-as-identifiers.md),
+  [019 graph database architecture](../adr/019-graph-database-architecture.md).
+- ECHOLOT tasks: T3.1 (standard schemas / ontology reuse), T3.2 (RDF export), T2.3 (semantic interoperability /
+  ontology patterns), T4.1 (import/transformation pipelines).
+- Issue: [#723](https://github.com/ProfessionalWiki/NeoWiki/issues/723) (RDF mapping discussion).

--- a/docs/planning/RdfMapping.md
+++ b/docs/planning/RdfMapping.md
@@ -10,6 +10,14 @@ This document proposes how NeoWiki's data model maps to RDF triples for the SPAR
 [ADR 19](../adr/019-graph-database-architecture.md). The mapping determines what RDF a triple store contains
 and therefore what SPARQL queries users can write. It also defines the shape of RDF exports.
 
+Specifically, this is the **native projection**: NeoWiki's own vocabulary, lossless, and the default when no ontology
+mapping is configured. It is one of several sibling projections a wiki can run — a store can instead hold a
+standard-ontology projection (CIDOC-CRM, EDM, …) defined via an [Ontology Mapping](OntologyMapping.md). Each
+configured store holds exactly one projection and is queried in that projection's vocabulary. The per-store machinery
+specified here — IRI minting, named graphs, the sync mechanism — is shared by all projections, so the SPARQL plugin is
+parameterized by projection rather than hardwired to this one. Read this document before
+[OntologyMapping.md](OntologyMapping.md), which builds on it.
+
 This is a strawman proposal. Many decisions here need input from partners with RDF and Linked Open Data expertise,
 particularly regarding ontology alignment and cultural heritage conventions. [Open questions](#open-questions) are
 collected at the end. Discussion is tracked in [#723](https://github.com/ProfessionalWiki/NeoWiki/issues/723).

--- a/docs/planning/RdfMapping.md
+++ b/docs/planning/RdfMapping.md
@@ -205,7 +205,7 @@ DROP SILENT GRAPH <neo-page:42>
 
 - **Ontology mapping layer.** The [Global Properties](GlobalProperties.md) document concluded that ontology
   alignment (e.g., "Person.Name maps to `foaf:name`") should happen via a separate mapping layer, not by changing
-  the data model. That layer is a separate design effort. The RDF mapping described here emits NeoWiki-native
+  the data model. That layer is designed in [Ontology Mapping](OntologyMapping.md). The RDF mapping described here emits NeoWiki-native
   predicates; the ontology mapping layer would emit additional triples using standard vocabulary terms. Note that
   this layer might need to be quite expressive: CIDOC-CRM alignment isn't just predicate renaming — it requires
   generating intermediate nodes that don't exist in NeoWiki's data. For example, a simple NeoWiki "Creator" relation

--- a/docs/planning/RdfMapping.md
+++ b/docs/planning/RdfMapping.md
@@ -206,7 +206,7 @@ DROP SILENT GRAPH <neo-page:42>
 - **Ontology mapping layer.** The [Global Properties](GlobalProperties.md) document concluded that ontology
   alignment (e.g., "Person.Name maps to `foaf:name`") should happen via a separate mapping layer, not by changing
   the data model. That layer is designed in [Ontology Mapping](OntologyMapping.md). The RDF mapping described here emits NeoWiki-native
-  predicates; the ontology mapping layer would emit additional triples using standard vocabulary terms. Note that
+  predicates; the ontology mapping layer instead projects the data into standard-ontology terms. Note that
   this layer might need to be quite expressive: CIDOC-CRM alignment isn't just predicate renaming — it requires
   generating intermediate nodes that don't exist in NeoWiki's data. For example, a simple NeoWiki "Creator" relation
   from an Object to a Person would need to expand to `E22_Human-Made_Object → P108i_was_produced_by →

--- a/docs/planning/SubjectSources.md
+++ b/docs/planning/SubjectSources.md
@@ -251,7 +251,7 @@ id; rich chain-of-production provenance is a separate model.
   [008 one-schema-per-subject](../adr/008-one-schema-per-subject.md),
   [014 improved-id-format](../adr/014-improved-id-format.md), [015 dedicated editors](../adr/015-dedicated-editors.md),
   [018 views](../adr/018-views.md), [019 graph database architecture](../adr/019-graph-database-architecture.md).
-- Planning: [GlobalProperties](GlobalProperties.md), [RdfMapping](RdfMapping.md).
+- Planning: [GlobalProperties](GlobalProperties.md), [RdfMapping](RdfMapping.md), [OntologyMapping](OntologyMapping.md).
 - Issues: [#889](https://github.com/ProfessionalWiki/NeoWiki/issues/889) (refresh-without-edit; replaces the closed
   #782), [#905](https://github.com/ProfessionalWiki/NeoWiki/issues/905) (multi-wiki node identity),
   [#789](https://github.com/ProfessionalWiki/NeoWiki/issues/789) (public PHP API),

--- a/docs/planning/SubjectSources.md
+++ b/docs/planning/SubjectSources.md
@@ -119,7 +119,8 @@ product-line schema the others lack). The shared graph still allows **cross-wiki
 schema is local to another wiki **cannot be rendered or edited cross-wiki via the View system or the normal editing
 UIs** — HW accepted this limitation for the MVP. Such cross-wiki access must **degrade gracefully** (an informative
 error or an import option), not break the page. Across *independent* instances no shared registry can be assumed, so
-references stay `(source, name)` with the mapping layer ([RdfMapping.md](RdfMapping.md)) aligning vocabularies.
+references stay `(source, name)` with the ontology mapping ([OntologyMapping.md](OntologyMapping.md)) aligning
+vocabularies.
 
 ## Storage and query (Neo4j)
 
@@ -251,7 +252,8 @@ id; rich chain-of-production provenance is a separate model.
   [008 one-schema-per-subject](../adr/008-one-schema-per-subject.md),
   [014 improved-id-format](../adr/014-improved-id-format.md), [015 dedicated editors](../adr/015-dedicated-editors.md),
   [018 views](../adr/018-views.md), [019 graph database architecture](../adr/019-graph-database-architecture.md).
-- Planning: [GlobalProperties](GlobalProperties.md), [RdfMapping](RdfMapping.md), [OntologyMapping](OntologyMapping.md).
+- Planning: [GlobalProperties](GlobalProperties.md), [NativeRdfProjection](NativeRdfProjection.md),
+  [OntologyMapping](OntologyMapping.md).
 - Issues: [#889](https://github.com/ProfessionalWiki/NeoWiki/issues/889) (refresh-without-edit; replaces the closed
   #782), [#905](https://github.com/ProfessionalWiki/NeoWiki/issues/905) (multi-wiki node identity),
   [#789](https://github.com/ProfessionalWiki/NeoWiki/issues/789) (public PHP API),


### PR DESCRIPTION
Strawman planning doc for **ontology mapping** — projecting native NeoWiki data into standard cultural-heritage ontologies (CIDOC-CRM, EDM, HDTO, BIBFRAME) for ECHOLOT interoperability (T3.1/T3.2).

An ontology mapping projects native data **directly into a target ontology**; that RDF is what a configured triple store holds and what SPARQL queries run against. The native projection and each target ontology are **sibling projections** selected per store — native is the default and the lossless-export target. Mappings are first-class, installable objects kept separate from Schemas, defining a **bidirectional** correspondence (export ships first; import needs its own machinery).

Covers: a CONSTRUCT-based strawman with deterministic IRIs for synthesized nodes (the CIDOC-CRM production-event case), the open flat-vs-nested modelling fork from the 2026-06-24 data-modelling call (toy-model spreadsheet linked as its evaluation vehicle), projection validation via target-ontology shapes (engines in T4.5 tooling, findings traceable back to page/Subject/property), the import direction, and the formalism fork (native rules vs LinkML vs T2.3/Platka patterns) for partner feedback.

Also **renames `RdfMapping.md` → `NativeRdfProjection.md`**: "RDF mapping" is the term partners use for ontology alignment — the one thing that doc is *not* about — so the old name misdirected. Its Purpose now states the doc's two jobs explicitly: (1) specify the native projection (default vocabulary, lossless), and (2) specify the projection infrastructure shared by all projections (IRI regime, per-page named graphs, sync) — an ontology store reuses all of that; only the triples inside each page's graph differ. The SPARQL plugin is parameterized by projection. Cross-references updated in SubjectSources, the ECHOLOT planning doc, and ADR 23.

Relates to https://github.com/ProfessionalWiki/NeoWiki/issues/723. Companion: shape-languages position doc in https://github.com/ProfessionalWiki/NeoWiki/pull/983.

> Result of design sessions with @JeroenDeDauw, incorporating the 2026-06-24 ECHOLOT data-modelling call with George Bruseker and Denitsa Nenova (takin) and Matej Ďurčo (OEAW).
> Context: the NeoWiki codebase and docs (RdfMapping/NativeRdfProjection, GlobalProperties, SubjectSources, ADRs, glossary), the ECHOLOT grant and project-context material, and the call transcript.
> <sub>Written by Claude Code — `Opus 4.8` (1M context) and `Fable 5`, effort max</sub>
