### PR TITLE
Treat null property bounds from serialization as unset

### DIFF
--- a/resources/ext.neowiki/src/domain/propertyTypes/Date.ts
+++ b/resources/ext.neowiki/src/domain/propertyTypes/Date.ts
@@ -92,8 +92,8 @@ export class DateType extends BasePropertyType<DateProperty, StringValue> {
 	public createPropertyDefinitionFromJson( base: PropertyDefinition, json: any ): DateProperty {
 		return {
 			...base,
-			minimum: json.minimum,
-			maximum: json.maximum,
+			minimum: json.minimum ?? undefined,
+			maximum: json.maximum ?? undefined,
 		} as DateProperty;
 	}
 

--- a/resources/ext.neowiki/src/domain/propertyTypes/DateTime.ts
+++ b/resources/ext.neowiki/src/domain/propertyTypes/DateTime.ts
@@ -107,8 +107,8 @@ export class DateTimeType extends BasePropertyType<DateTimeProperty, StringValue
 	public createPropertyDefinitionFromJson( base: PropertyDefinition, json: any ): DateTimeProperty {
 		return {
 			...base,
-			minimum: json.minimum,
-			maximum: json.maximum,
+			minimum: json.minimum ?? undefined,
+			maximum: json.maximum ?? undefined,
 		} as DateTimeProperty;
 	}
 

--- a/resources/ext.neowiki/src/domain/propertyTypes/Number.ts
+++ b/resources/ext.neowiki/src/domain/propertyTypes/Number.ts
@@ -28,9 +28,9 @@ export class NumberType extends BasePropertyType<NumberProperty, NumberValue> {
 	public createPropertyDefinitionFromJson( base: PropertyDefinition, json: any ): NumberProperty {
 		return {
 			...base,
-			precision: json.precision,
-			minimum: json.minimum,
-			maximum: json.maximum,
+			precision: json.precision ?? undefined,
+			minimum: json.minimum ?? undefined,
+			maximum: json.maximum ?? undefined,
 		} as NumberProperty;
 	}
 

--- a/resources/ext.neowiki/tests/domain/propertyTypes/Date.spec.ts
+++ b/resources/ext.neowiki/tests/domain/propertyTypes/Date.spec.ts
@@ -55,6 +55,21 @@ describe( 'newDateProperty', () => {
 
 } );
 
+describe( 'createPropertyDefinitionFromJson', () => {
+	const dateType = new DateType();
+
+	it( 'normalizes null minimum and maximum to undefined', () => {
+		// The PHP serializer emits these as null when unset; null must not leak into the string|undefined fields.
+		const property = dateType.createPropertyDefinitionFromJson(
+			{ name: new PropertyName( 'Date' ), type: 'date', description: '', required: false },
+			{ type: 'date', minimum: null, maximum: null },
+		);
+
+		expect( property.minimum ).toBeUndefined();
+		expect( property.maximum ).toBeUndefined();
+	} );
+} );
+
 describe( 'validate', () => {
 	const dateType = new DateType();
 

--- a/resources/ext.neowiki/tests/domain/propertyTypes/DateTime.spec.ts
+++ b/resources/ext.neowiki/tests/domain/propertyTypes/DateTime.spec.ts
@@ -55,6 +55,21 @@ describe( 'newDateTimeProperty', () => {
 
 } );
 
+describe( 'createPropertyDefinitionFromJson', () => {
+	const dateTimeType = new DateTimeType();
+
+	it( 'normalizes null minimum and maximum to undefined', () => {
+		// The PHP serializer emits these as null when unset; null must not leak into the string|undefined fields.
+		const property = dateTimeType.createPropertyDefinitionFromJson(
+			{ name: new PropertyName( 'DateTime' ), type: 'dateTime', description: '', required: false },
+			{ type: 'dateTime', minimum: null, maximum: null },
+		);
+
+		expect( property.minimum ).toBeUndefined();
+		expect( property.maximum ).toBeUndefined();
+	} );
+} );
+
 describe( 'validate', () => {
 	const dateTimeType = new DateTimeType();
 

--- a/resources/ext.neowiki/tests/domain/propertyTypes/Number.spec.ts
+++ b/resources/ext.neowiki/tests/domain/propertyTypes/Number.spec.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { newNumberProperty, NumberType } from '@/domain/propertyTypes/Number';
+import { newNumberProperty, NumberType, type NumberProperty } from '@/domain/propertyTypes/Number';
 import { PropertyName } from '@/domain/PropertyDefinition';
 import { newNumberValue } from '@/domain/Value';
+
+function numberPropertyFromJson( json: Record<string, unknown> ): NumberProperty {
+	return new NumberType().createPropertyDefinitionFromJson(
+		{ name: new PropertyName( 'Year' ), type: 'number', description: '', required: false },
+		{ type: 'number', ...json },
+	);
+}
 
 describe( 'NumberType', () => {
 
@@ -81,6 +88,26 @@ describe( 'newNumberProperty', () => {
 	} );
 } );
 
+describe( 'createPropertyDefinitionFromJson', () => {
+
+	it( 'normalizes null precision, minimum and maximum to undefined', () => {
+		// The PHP serializer emits these as null when unset; null must not leak into the number|undefined fields.
+		const property = numberPropertyFromJson( { precision: null, minimum: null, maximum: null } );
+
+		expect( property.precision ).toBeUndefined();
+		expect( property.minimum ).toBeUndefined();
+		expect( property.maximum ).toBeUndefined();
+	} );
+
+	it( 'preserves zero precision, minimum and maximum as real values', () => {
+		const property = numberPropertyFromJson( { precision: 0, minimum: 0, maximum: 0 } );
+
+		expect( property.precision ).toBe( 0 );
+		expect( property.minimum ).toBe( 0 );
+		expect( property.maximum ).toBe( 0 );
+	} );
+} );
+
 describe( 'validate', () => {
 	const numberType = new NumberType();
 
@@ -150,5 +177,23 @@ describe( 'validate', () => {
 			code: 'max-value',
 			args: [ 100 ],
 		} ] );
+	} );
+
+	it( 'treats a null maximum from backend serialization as unset', () => {
+		// Regression: a null maximum coerced to 0, so any positive value reported "Maximum value is null".
+		const property = numberPropertyFromJson( { minimum: null, maximum: null } );
+
+		const errors = numberType.validate( newNumberValue( 2025 ), property );
+
+		expect( errors ).toEqual( [] );
+	} );
+
+	it( 'treats a null minimum from backend serialization as unset', () => {
+		// Regression: a null minimum coerced to 0, so any negative value reported "Minimum value is null".
+		const property = numberPropertyFromJson( { minimum: null, maximum: null } );
+
+		const errors = numberType.validate( newNumberValue( -5 ), property );
+
+		expect( errors ).toEqual( [] );
 	} );
 } );


### PR DESCRIPTION
> Result of @alistair3149 finding the bug and providing exact reproduction steps, then directing the review, smoke test, and PR.
> Context: the NeoWiki codebase (frontend property-type adapters and PHP `nonCoreToJson` serialization), verified against the live demo data.
> <sub>Written by Claude Code, `Opus 4.8 (1M context)`</sub>

Entering a valid number such as `2025` into a number property with unset bounds (e.g. the demo Attendance "Year" field)
showed the validation error "Maximum value is null".

## Root cause

PHP `nonCoreToJson()` always serializes unset `precision`/`minimum`/`maximum` as explicit JSON `null` (the REST schema
endpoint returns `"maximum": null`), and the frontend per-type adapters copied these raw into fields typed
`number | undefined`. `validate()` guards with `!== undefined`, which `null` passes, and JavaScript coerces `null` to `0`
in numeric comparison, so `2025 > null` becomes `2025 > 0` and produces a spurious `max-value` violation. The same leak
affects `minimum` (negative inputs) and `precision` (`NumberDisplay` rounds via `toFixed(0)`).

## Fix

Normalize `null` to `undefined` with `?? undefined` in the affected adapters, matching the pattern already used in
`Text.ts`:

- `Number.ts`: precision, minimum, maximum
- `Date.ts` / `DateTime.ts`: minimum, maximum (these fail open today; fixed for type-correctness and consistency)

`?? undefined` rather than `|| undefined` preserves legitimate zero bounds (the demo "Visitors" property uses
`minimum: 0` and `precision: 0`). Regression tests reproduce the exact failure (`{ code: 'max-value', args: [null] }`)
and the zero-preservation case.

## Manual Browser Check

1. Open `/w/index.php?title=Mus%C3%A9e_d%27Orsay&action=subjects` (hard-reload to bypass the ResourceLoader cache).
2. Click "Add subject", pick the **Attendance** schema, and type `2025` in the **Year** field.
3. Expect no "Maximum value is null" error; the value is accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
