### PR TITLE
Update TypeScript to 6.0

### DIFF
--- a/resources/ext.neowiki/package-lock.json
+++ b/resources/ext.neowiki/package-lock.json
@@ -35,7 +35,7 @@
 				"sortablejs": "^1.15.0",
 				"stylelint-config-wikimedia": "^0.18.0",
 				"types-mediawiki": "^1.8.0",
-				"typescript": "^5.6.2",
+				"typescript": "^6.0.3",
 				"vite": "^5.4.1",
 				"vitest": "^2.1.1",
 				"vue": "3.4.27",
@@ -4879,6 +4879,21 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/typescript": {
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/eslint-plugin-compat": {
@@ -10964,9 +10979,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.9.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {

--- a/resources/ext.neowiki/package.json
+++ b/resources/ext.neowiki/package.json
@@ -44,7 +44,7 @@
 		"sortablejs": "^1.15.0",
 		"stylelint-config-wikimedia": "^0.18.0",
 		"types-mediawiki": "^1.8.0",
-		"typescript": "^5.6.2",
+		"typescript": "^6.0.3",
 		"vite": "^5.4.1",
 		"vitest": "^2.1.1",
 		"vue": "3.4.27",

--- a/resources/ext.neowiki/tsconfig.app.json
+++ b/resources/ext.neowiki/tsconfig.app.json
@@ -18,7 +18,6 @@
 		"strict": true,
 		"noFallthroughCasesInSwitch": true,
 
-		"baseUrl": ".",
 		"paths": {
 			"@/*": ["./src/*"]
 		}


### PR DESCRIPTION
> Investigated and verified at the direction of @alistair3149, who scoped this as the interim step after
> TypeScript 7.0 RC proved blocked (vue-tsc cannot run on the Go-native package until the TS 7.1 programmatic
> API ships). Context: the NeoWiki frontend toolchain, the TypeScript 7.0 RC release notes, and empirical
> runs of the full build/lint/test pipeline against TS 6.0.
> <sub>Written by Claude Code, `Opus 4.8`</sub>

Bump the frontend TypeScript devDependency from 5.x to 6.0, the current stable release and the last
JavaScript-based version before the Go-native 7.0 line.

TypeScript 6.0 deprecates the `baseUrl` compiler option (removed entirely in 7.0), so remove it from
`tsconfig.app.json`. The `@/*` path alias keeps working without it, since `paths` resolve relative to the
tsconfig directory.

vue-tsc, typescript-eslint, Vite and Vitest all work unchanged. This is a type-checker-only change with no
effect on the emitted bundle (Vite emits via esbuild). Verified with the full pipeline: build, lint, and 993
vitest tests pass.
