### PR TITLE
Add an event-centric Person/Birth demo corpus

### DIFF
--- a/DemoData/Module/NeoWikiDemo.lua
+++ b/DemoData/Module/NeoWikiDemo.lua
@@ -278,4 +278,82 @@ function p.schema( frame )
 	return renderRowsAsTable( rows, { 'Name', 'Type', 'Required', 'Details' } )
 end
 
+local PERSON_EVENTS_MONTHS = {
+	'January', 'February', 'March', 'April', 'May', 'June',
+	'July', 'August', 'September', 'October', 'November', 'December'
+}
+
+-- Formats an ISO yyyy-mm-dd string as "21 March 1685" without relying on
+-- MediaWiki's date parsing, which is unreliable for pre-modern years.
+local function personEventsFormatDate( iso )
+	local y, m, d = string.match( iso or '', '^(%d+)-(%d+)-(%d+)$' )
+	if not y then
+		return iso or ''
+	end
+	return tonumber( d ) .. ' ' .. ( PERSON_EVENTS_MONTHS[tonumber( m )] or m ) .. ' ' .. y
+end
+
+local function personEventsBirthLinks( rows )
+	local links = {}
+	for _, row in ipairs( rows or {} ) do
+		links[#links + 1] = '[[' .. row.birth .. ']]'
+	end
+	return links
+end
+
+-- Renders the current Person page's life events by reverse-querying the graph:
+-- the canonical edges run Birth -> Person, so "was born" (CIDOC P98i) is derived
+-- here rather than stored as an inverse edge. Date is read as b.Date[0] because
+-- the `date` property is stored as a string list; switch to toString(b.Date[0])
+-- if/when date is stored as a native Neo4j date.
+function p.personEvents( frame )
+	local name = mw.title.getCurrentTitle().text
+
+	local born = nw.query(
+		'MATCH (b:Birth)-[:`Brought into life`]->(p:Person {name: $name}) ' ..
+		'OPTIONAL MATCH (b)-[:`Took place at`]->(pl:Place) ' ..
+		'RETURN b.name AS birth, pl.name AS place, b.Date[0] AS date',
+		{ name = name }
+	)
+	local asFather = nw.query(
+		'MATCH (b:Birth)-[:`From father`]->(p:Person {name: $name}) RETURN b.name AS birth ORDER BY birth',
+		{ name = name }
+	)
+	local asMother = nw.query(
+		'MATCH (b:Birth)-[:`By mother`]->(p:Person {name: $name}) RETURN b.name AS birth ORDER BY birth',
+		{ name = name }
+	)
+
+	local parts = {}
+
+	if born and born[1] then
+		local row = born[1]
+		local sentence = 'Born'
+		if row.date and row.date ~= '' then
+			sentence = sentence .. ' ' .. personEventsFormatDate( row.date )
+		end
+		if row.place and row.place ~= '' then
+			sentence = sentence .. ' in [[' .. row.place .. ']]'
+		end
+		sentence = sentence .. ' (see [[' .. row.birth .. ']]).'
+		parts[#parts + 1] = sentence
+	end
+
+	local fatherLinks = personEventsBirthLinks( asFather )
+	if #fatherLinks > 0 then
+		parts[#parts + 1] = 'Father in ' .. table.concat( fatherLinks, ', ' ) .. '.'
+	end
+
+	local motherLinks = personEventsBirthLinks( asMother )
+	if #motherLinks > 0 then
+		parts[#parts + 1] = 'Mother in ' .. table.concat( motherLinks, ', ' ) .. '.'
+	end
+
+	if #parts == 0 then
+		return ''
+	end
+
+	return "'''Life events:''' " .. table.concat( parts, ' ' )
+end
+
 return p

--- a/DemoData/Module/NeoWikiDemo.lua
+++ b/DemoData/Module/NeoWikiDemo.lua
@@ -316,11 +316,11 @@ function p.personEvents( frame )
 		{ name = name }
 	)
 	local asFather = nw.query(
-		'MATCH (b:Birth)-[:`From father`]->(p:Person {name: $name}) RETURN b.name AS birth ORDER BY birth',
+		'MATCH (b:Birth)-[:`From father`]->(p:Person {name: $name}) RETURN b.name AS birth, b.Date[0] AS date ORDER BY date',
 		{ name = name }
 	)
 	local asMother = nw.query(
-		'MATCH (b:Birth)-[:`By mother`]->(p:Person {name: $name}) RETURN b.name AS birth ORDER BY birth',
+		'MATCH (b:Birth)-[:`By mother`]->(p:Person {name: $name}) RETURN b.name AS birth, b.Date[0] AS date ORDER BY date',
 		{ name = name }
 	)
 

--- a/DemoData/Module/NeoWikiDemo.lua
+++ b/DemoData/Module/NeoWikiDemo.lua
@@ -293,67 +293,43 @@ local function personEventsFormatDate( iso )
 	return tonumber( d ) .. ' ' .. ( PERSON_EVENTS_MONTHS[tonumber( m )] or m ) .. ' ' .. y
 end
 
-local function personEventsBirthLinks( rows )
-	local links = {}
-	for _, row in ipairs( rows or {} ) do
-		links[#links + 1] = '[[' .. row.birth .. ']]'
-	end
-	return links
-end
+local PERSON_EVENTS_ROLES = {
+	['Brought into life'] = 'Born',
+	['By mother'] = 'Mother',
+	['From father'] = 'Father',
+}
 
--- Renders the current Person page's life events by reverse-querying the graph:
--- the canonical edges run Birth -> Person, so "was born" (CIDOC P98i) is derived
--- here rather than stored as an inverse edge. Date is read as b.Date[0] because
--- the `date` property is stored as a string list; switch to toString(b.Date[0])
--- if/when date is stored as a native Neo4j date.
+-- Renders the current Person page's life events as a table by reverse-querying
+-- the graph: the canonical edges run Birth -> Person, so a person's role in each
+-- event ("was born" / CIDOC P98i, mother, father) is derived here rather than
+-- stored as an inverse edge. Date is read as b.Date[0] because the `date` property
+-- is stored as a string list; switch to toString(b.Date[0]) if/when date is stored
+-- as a native Neo4j date.
 function p.personEvents( frame )
 	local name = mw.title.getCurrentTitle().text
 
-	local born = nw.query(
-		'MATCH (b:Birth)-[:`Brought into life`]->(p:Person {name: $name}) ' ..
+	local events = nw.query(
+		'MATCH (b:Birth)-[r]->(p:Person {name: $name}) ' ..
 		'OPTIONAL MATCH (b)-[:`Took place at`]->(pl:Place) ' ..
-		'RETURN b.name AS birth, pl.name AS place, b.Date[0] AS date',
-		{ name = name }
-	)
-	local asFather = nw.query(
-		'MATCH (b:Birth)-[:`From father`]->(p:Person {name: $name}) RETURN b.name AS birth, b.Date[0] AS date ORDER BY date',
-		{ name = name }
-	)
-	local asMother = nw.query(
-		'MATCH (b:Birth)-[:`By mother`]->(p:Person {name: $name}) RETURN b.name AS birth, b.Date[0] AS date ORDER BY date',
+		'RETURN type(r) AS role, b.name AS event, b.Date[0] AS date, pl.name AS place ORDER BY date',
 		{ name = name }
 	)
 
-	local parts = {}
-
-	if born and born[1] then
-		local row = born[1]
-		local sentence = 'Born'
-		if row.date and row.date ~= '' then
-			sentence = sentence .. ' ' .. personEventsFormatDate( row.date )
-		end
-		if row.place and row.place ~= '' then
-			sentence = sentence .. ' in [[' .. row.place .. ']]'
-		end
-		sentence = sentence .. ' (see [[' .. row.birth .. ']]).'
-		parts[#parts + 1] = sentence
-	end
-
-	local fatherLinks = personEventsBirthLinks( asFather )
-	if #fatherLinks > 0 then
-		parts[#parts + 1] = 'Father in ' .. table.concat( fatherLinks, ', ' ) .. '.'
-	end
-
-	local motherLinks = personEventsBirthLinks( asMother )
-	if #motherLinks > 0 then
-		parts[#parts + 1] = 'Mother in ' .. table.concat( motherLinks, ', ' ) .. '.'
-	end
-
-	if #parts == 0 then
+	if not events or #events == 0 then
 		return ''
 	end
 
-	return "'''Life events:''' " .. table.concat( parts, ' ' )
+	local rows = {}
+	for _, e in ipairs( events ) do
+		rows[#rows + 1] = {
+			Role = PERSON_EVENTS_ROLES[e.role] or e.role,
+			Event = e.event,
+			Date = e.date and personEventsFormatDate( e.date ) or '',
+			Place = e.place or '',
+		}
+	end
+
+	return "'''Life events'''\n" .. renderRowsAsTable( rows, { 'Role', 'Event', 'Date', 'Place' }, { 'Event', 'Place' } )
 end
 
 return p

--- a/DemoData/Page/Main_Page.wikitext
+++ b/DemoData/Page/Main_Page.wikitext
@@ -33,6 +33,10 @@ card1_title=Museum collection
 |card3_title=Research catalog
 |card3_description=Track publications, authors, institutions, and projects.
 |card3_link=Research catalog
+
+|card4_title=People and life events
+|card4_description=Model births as their own Subjects, in CIDOC CRM style.
+|card4_link=People and life events
 }}
 
 == Build on it ==

--- a/DemoData/Page/People_and_life_events.wikitext
+++ b/DemoData/Page/People_and_life_events.wikitext
@@ -1,0 +1,55 @@
+A demo dataset that models people and their births as separate Subjects, in the event-centric style of CIDOC CRM (the cultural-heritage reference model that Arches is built on). It uses three generations of the Bach family, scoped deliberately rather than exhaustively. The data is curated for demonstration and is not authoritative.
+
+== Featured ==
+
+{{#invoke:SubjectRow|render|s1bachaaaaaaab2|s1bachaaaaaaaa3}}
+
+== Who was born where, and when? ==
+
+{{#invoke:NeoWikiDemo|query|MATCH (b:Birth)-[:`Brought into life`]->(p:Person) OPTIONAL MATCH (b)-[:`Took place at`]->(pl:Place) RETURN p.name AS Person, pl.name AS Place, b.Date[0] AS Date ORDER BY Date|columns=Person, Place, Date|linkColumns=Person, Place}}
+
+== Browse ==
+
+Each birth is its own Subject linking a child, mother, father, place, and date. Johann Sebastian Bach appears in four births, once as a child and three times as a father, which a person-centric model could not express cleanly.
+
+{{#invoke:NeoWikiDemo|query|MATCH (b:Birth)-[:`Brought into life`]->(c:Person) OPTIONAL MATCH (b)-[:`By mother`]->(m:Person) OPTIONAL MATCH (b)-[:`From father`]->(f:Person) OPTIONAL MATCH (b)-[:`Took place at`]->(pl:Place) RETURN c.name AS Child, m.name AS Mother, f.name AS Father, pl.name AS Place, b.Date[0] AS Date ORDER BY Date|columns=Child, Mother, Father, Place, Date|linkColumns=Child, Mother, Father, Place}}
+
+== Mapping to CIDOC CRM ==
+
+This dataset partially maps to [http://www.cidoc-crm.org/ CIDOC CRM]. The canonical statements run from the event to the person (E67 Birth, P98 brought into life, E21 Person); the reverse "was born" (P98i) is not stored as a separate edge but derived by [[Module:NeoWikiDemo]] reverse-querying the graph, which is how CIDOC inverse properties work.
+
+{| class="wikitable"
+! NeoWiki !! CIDOC CRM !! URI
+|-
+| Schema Person || E21 Person || http://www.cidoc-crm.org/cidoc-crm/E21_Person
+|-
+| Schema Birth || E67 Birth || http://www.cidoc-crm.org/cidoc-crm/E67_Birth
+|-
+| Schema Place || E53 Place || http://www.cidoc-crm.org/cidoc-crm/E53_Place
+|-
+| Birth: Brought into life || P98 brought into life (inverse P98i was born) || http://www.cidoc-crm.org/cidoc-crm/P98_brought_into_life
+|-
+| Birth: By mother || P96 by mother || http://www.cidoc-crm.org/cidoc-crm/P96_by_mother
+|-
+| Birth: From father || P97 from father || http://www.cidoc-crm.org/cidoc-crm/P97_from_father
+|-
+| Birth: Took place at || P7 took place at || http://www.cidoc-crm.org/cidoc-crm/P7_took_place_at
+|-
+| Birth: Date || P4 has time-span (E52 Time-Span; the date is the time-span's P82 value, collapsed to one date) || http://www.cidoc-crm.org/cidoc-crm/P4_has_time-span
+|-
+| Person: Also known as || P1 is identified by (E41 Appellation) || http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by
+|-
+| Person / Place: Description || P3 has note (E62 String) || http://www.cidoc-crm.org/cidoc-crm/P3_has_note
+|-
+| Place: Coordinates || P168 place is defined by (E94 Space Primitive) || http://www.cidoc-crm.org/cidoc-crm/P168_place_is_defined_by
+|-
+| Place: Country || No direct CIDOC property: denormalised country-name label (a faithful model would use P89 falls within a containing E53 Place) || http://www.cidoc-crm.org/cidoc-crm/P89_falls_within
+|}
+
+== How this is built ==
+
+* Schemas: [[Schema:Person]], [[Schema:Birth]], [[Schema:Place]]
+* The "was born" line on each person page is computed by [[Module:NeoWikiDemo]] (the <code>personEvents</code> function), which reverse-queries the graph rather than storing an inverse edge.
+* The tables above come from Cypher queries via [[Module:NeoWikiDemo]].
+* See the source of one subject: [{{fullurl:Birth of Johann Sebastian Bach|action=edit}} Edit Birth of Johann Sebastian Bach]
+* [{{fullurl:{{FULLPAGENAME}}|action=edit}} Edit this page]

--- a/DemoData/Page/People_and_life_events.wikitext
+++ b/DemoData/Page/People_and_life_events.wikitext
@@ -41,7 +41,7 @@ This dataset partially maps to [http://www.cidoc-crm.org/ CIDOC CRM]. The canoni
 |-
 | Person / Place: Description || P3 has note (E62 String) || http://www.cidoc-crm.org/cidoc-crm/P3_has_note
 |-
-| Place: Coordinates || P168 place is defined by (E94 Space Primitive) || http://www.cidoc-crm.org/cidoc-crm/P168_place_is_defined_by
+| Place: Coordinates || P168 place is defined by (E94 Space Primitive); stored as a lat/long display label, not a WKT/GML geometry literal || http://www.cidoc-crm.org/cidoc-crm/P168_place_is_defined_by
 |-
 | Place: Country || No direct CIDOC property: denormalised country-name label (a faithful model would use P89 falls within a containing E53 Place) || http://www.cidoc-crm.org/cidoc-crm/P89_falls_within
 |}

--- a/DemoData/Schema/Birth.json
+++ b/DemoData/Schema/Birth.json
@@ -1,0 +1,34 @@
+{
+	"description": "The birth of a person, modelled as its own event Subject. Maps to CIDOC CRM E67 Birth (http://www.cidoc-crm.org/cidoc-crm/E67_Birth).",
+	"propertyDefinitions": {
+		"Brought into life": {
+			"type": "relation",
+			"relation": "Brought into life",
+			"targetSchema": "Person",
+			"required": true,
+			"description": "The person born. CIDOC P98 brought into life (inverse P98i was born)."
+		},
+		"By mother": {
+			"type": "relation",
+			"relation": "By mother",
+			"targetSchema": "Person",
+			"description": "The mother. CIDOC P96 by mother."
+		},
+		"From father": {
+			"type": "relation",
+			"relation": "From father",
+			"targetSchema": "Person",
+			"description": "The father. CIDOC P97 from father."
+		},
+		"Took place at": {
+			"type": "relation",
+			"relation": "Took place at",
+			"targetSchema": "Place",
+			"description": "Where the birth happened. CIDOC P7 took place at."
+		},
+		"Date": {
+			"type": "date",
+			"description": "When the birth happened. CIDOC P4 has time-span (E52 Time-Span); the date is the time-span's value, collapsed here to a single date."
+		}
+	}
+}

--- a/DemoData/Schema/Person.json
+++ b/DemoData/Schema/Person.json
@@ -1,0 +1,14 @@
+{
+	"description": "A human being. Maps to CIDOC CRM E21 Person (http://www.cidoc-crm.org/cidoc-crm/E21_Person). Deliberately lean: life events such as birth live on their own Subjects, not as fields here.",
+	"propertyDefinitions": {
+		"Description": {
+			"type": "text",
+			"description": "Short biography. CIDOC P3 has note."
+		},
+		"Also known as": {
+			"type": "text",
+			"multiple": true,
+			"description": "Alternative names and appellations. CIDOC P1 is identified by (E41 Appellation)."
+		}
+	}
+}

--- a/DemoData/Schema/Place.json
+++ b/DemoData/Schema/Place.json
@@ -1,0 +1,17 @@
+{
+	"description": "A geographic place. Maps to CIDOC CRM E53 Place (http://www.cidoc-crm.org/cidoc-crm/E53_Place).",
+	"propertyDefinitions": {
+		"Country": {
+			"type": "text",
+			"description": "Country name. Denormalised label; no direct CIDOC property (a faithful model would use P89 falls within a containing E53 Place)."
+		},
+		"Coordinates": {
+			"type": "text",
+			"description": "Latitude and longitude. CIDOC P168 place is defined by (E94 Space Primitive)."
+		},
+		"Description": {
+			"type": "text",
+			"description": "Short description. CIDOC P3 has note."
+		}
+	}
+}

--- a/DemoData/Schema/Place.json
+++ b/DemoData/Schema/Place.json
@@ -7,7 +7,7 @@
 		},
 		"Coordinates": {
 			"type": "text",
-			"description": "Latitude and longitude. CIDOC P168 place is defined by (E94 Space Primitive)."
+			"description": "Latitude and longitude display label. CIDOC P168 place is defined by (E94 Space Primitive); a faithful model would store a WKT/GML geometry literal (e.g. POINT(longitude latitude)), not this human-readable string."
 		},
 		"Description": {
 			"type": "text",

--- a/DemoData/Subject/Anna_Magdalena_Bach.json
+++ b/DemoData/Subject/Anna_Magdalena_Bach.json
@@ -1,0 +1,13 @@
+{
+	"mainSubject": "s1bachaaaaaaaa5",
+	"subjects": {
+		"s1bachaaaaaaaa5": {
+			"label": "Anna Magdalena Bach",
+			"schema": "Person",
+			"statements": {
+				"Description": { "type": "text", "value": [ "Second wife of Johann Sebastian Bach; mother of Johann Christian Bach." ] },
+				"Also known as": { "type": "text", "value": [ "Anna Magdalena Wilcke" ] }
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Anna_Magdalena_Bach.wikitext
+++ b/DemoData/Subject/Anna_Magdalena_Bach.wikitext
@@ -1,0 +1,1 @@
+{{#invoke:NeoWikiDemo|personEvents}}

--- a/DemoData/Subject/Birth_of_Carl_Philipp_Emanuel_Bach.json
+++ b/DemoData/Subject/Birth_of_Carl_Philipp_Emanuel_Bach.json
@@ -1,0 +1,16 @@
+{
+	"mainSubject": "s1bachaaaaaaab4",
+	"subjects": {
+		"s1bachaaaaaaab4": {
+			"label": "Birth of Carl Philipp Emanuel Bach",
+			"schema": "Birth",
+			"statements": {
+				"Brought into life": { "type": "relation", "value": [ { "id": "r1bachaaaaaaab2", "target": "s1bachaaaaaaaa7" } ] },
+				"By mother": { "type": "relation", "value": [ { "id": "r1bachaaaaaaab3", "target": "s1bachaaaaaaaa4" } ] },
+				"From father": { "type": "relation", "value": [ { "id": "r1bachaaaaaaab4", "target": "s1bachaaaaaaaa3" } ] },
+				"Took place at": { "type": "relation", "value": [ { "id": "r1bachaaaaaaab5", "target": "s1bachaaaaaaac3" } ] },
+				"Date": { "type": "date", "value": [ "1714-03-08" ] }
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Birth_of_Johann_Ambrosius_Bach.json
+++ b/DemoData/Subject/Birth_of_Johann_Ambrosius_Bach.json
@@ -1,0 +1,14 @@
+{
+	"mainSubject": "s1bachaaaaaaab1",
+	"subjects": {
+		"s1bachaaaaaaab1": {
+			"label": "Birth of Johann Ambrosius Bach",
+			"schema": "Birth",
+			"statements": {
+				"Brought into life": { "type": "relation", "value": [ { "id": "r1bachaaaaaaaa1", "target": "s1bachaaaaaaaa1" } ] },
+				"Took place at": { "type": "relation", "value": [ { "id": "r1bachaaaaaaaa2", "target": "s1bachaaaaaaac1" } ] },
+				"Date": { "type": "date", "value": [ "1645-02-22" ] }
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Birth_of_Johann_Christian_Bach.json
+++ b/DemoData/Subject/Birth_of_Johann_Christian_Bach.json
@@ -1,0 +1,16 @@
+{
+	"mainSubject": "s1bachaaaaaaab5",
+	"subjects": {
+		"s1bachaaaaaaab5": {
+			"label": "Birth of Johann Christian Bach",
+			"schema": "Birth",
+			"statements": {
+				"Brought into life": { "type": "relation", "value": [ { "id": "r1bachaaaaaaab6", "target": "s1bachaaaaaaaa8" } ] },
+				"By mother": { "type": "relation", "value": [ { "id": "r1bachaaaaaaab7", "target": "s1bachaaaaaaaa5" } ] },
+				"From father": { "type": "relation", "value": [ { "id": "r1bachaaaaaaab8", "target": "s1bachaaaaaaaa3" } ] },
+				"Took place at": { "type": "relation", "value": [ { "id": "r1bachaaaaaaab9", "target": "s1bachaaaaaaac4" } ] },
+				"Date": { "type": "date", "value": [ "1735-09-05" ] }
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Birth_of_Johann_Sebastian_Bach.json
+++ b/DemoData/Subject/Birth_of_Johann_Sebastian_Bach.json
@@ -1,0 +1,16 @@
+{
+	"mainSubject": "s1bachaaaaaaab2",
+	"subjects": {
+		"s1bachaaaaaaab2": {
+			"label": "Birth of Johann Sebastian Bach",
+			"schema": "Birth",
+			"statements": {
+				"Brought into life": { "type": "relation", "value": [ { "id": "r1bachaaaaaaaa3", "target": "s1bachaaaaaaaa3" } ] },
+				"By mother": { "type": "relation", "value": [ { "id": "r1bachaaaaaaaa4", "target": "s1bachaaaaaaaa2" } ] },
+				"From father": { "type": "relation", "value": [ { "id": "r1bachaaaaaaaa5", "target": "s1bachaaaaaaaa1" } ] },
+				"Took place at": { "type": "relation", "value": [ { "id": "r1bachaaaaaaaa6", "target": "s1bachaaaaaaac2" } ] },
+				"Date": { "type": "date", "value": [ "1685-03-21" ] }
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Birth_of_Johann_Sebastian_Bach.wikitext
+++ b/DemoData/Subject/Birth_of_Johann_Sebastian_Bach.wikitext
@@ -1,0 +1,1 @@
+The '''birth of Johann Sebastian Bach''' took place in [[Eisenach]] on 21 March 1685 (Old Style; 31 March 1685 in the Gregorian calendar). He was baptised two days later, on 23 March, at St George's Church in Eisenach.

--- a/DemoData/Subject/Birth_of_Wilhelm_Friedemann_Bach.json
+++ b/DemoData/Subject/Birth_of_Wilhelm_Friedemann_Bach.json
@@ -1,0 +1,16 @@
+{
+	"mainSubject": "s1bachaaaaaaab3",
+	"subjects": {
+		"s1bachaaaaaaab3": {
+			"label": "Birth of Wilhelm Friedemann Bach",
+			"schema": "Birth",
+			"statements": {
+				"Brought into life": { "type": "relation", "value": [ { "id": "r1bachaaaaaaaa7", "target": "s1bachaaaaaaaa6" } ] },
+				"By mother": { "type": "relation", "value": [ { "id": "r1bachaaaaaaaa8", "target": "s1bachaaaaaaaa4" } ] },
+				"From father": { "type": "relation", "value": [ { "id": "r1bachaaaaaaaa9", "target": "s1bachaaaaaaaa3" } ] },
+				"Took place at": { "type": "relation", "value": [ { "id": "r1bachaaaaaaab1", "target": "s1bachaaaaaaac3" } ] },
+				"Date": { "type": "date", "value": [ "1710-11-22" ] }
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Carl_Philipp_Emanuel_Bach.json
+++ b/DemoData/Subject/Carl_Philipp_Emanuel_Bach.json
@@ -1,0 +1,13 @@
+{
+	"mainSubject": "s1bachaaaaaaaa7",
+	"subjects": {
+		"s1bachaaaaaaaa7": {
+			"label": "Carl Philipp Emanuel Bach",
+			"schema": "Person",
+			"statements": {
+				"Description": { "type": "text", "value": [ "Composer; second surviving son of Johann Sebastian Bach." ] },
+				"Also known as": { "type": "text", "value": [ "C. P. E. Bach", "the Berlin Bach", "the Hamburg Bach" ] }
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Carl_Philipp_Emanuel_Bach.wikitext
+++ b/DemoData/Subject/Carl_Philipp_Emanuel_Bach.wikitext
@@ -1,0 +1,3 @@
+'''Carl Philipp Emanuel Bach''' was a German composer of the transition from the Baroque to the Classical era, the second surviving son of [[Johann Sebastian Bach]] and [[Maria Barbara Bach]]. He was born in [[Weimar]] in 1714.
+
+{{#invoke:NeoWikiDemo|personEvents}}

--- a/DemoData/Subject/Eisenach.json
+++ b/DemoData/Subject/Eisenach.json
@@ -1,0 +1,14 @@
+{
+	"mainSubject": "s1bachaaaaaaac2",
+	"subjects": {
+		"s1bachaaaaaaac2": {
+			"label": "Eisenach",
+			"schema": "Place",
+			"statements": {
+				"Country": { "type": "text", "value": [ "Germany" ] },
+				"Coordinates": { "type": "text", "value": [ "50.9747, 10.3247" ] },
+				"Description": { "type": "text", "value": [ "Town in Thuringia, Germany; birthplace of Johann Sebastian Bach." ] }
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Erfurt.json
+++ b/DemoData/Subject/Erfurt.json
@@ -1,0 +1,14 @@
+{
+	"mainSubject": "s1bachaaaaaaac1",
+	"subjects": {
+		"s1bachaaaaaaac1": {
+			"label": "Erfurt",
+			"schema": "Place",
+			"statements": {
+				"Country": { "type": "text", "value": [ "Germany" ] },
+				"Coordinates": { "type": "text", "value": [ "50.9787, 11.0328" ] },
+				"Description": { "type": "text", "value": [ "City in Thuringia, Germany; birthplace of Johann Ambrosius Bach." ] }
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Johann_Ambrosius_Bach.json
+++ b/DemoData/Subject/Johann_Ambrosius_Bach.json
@@ -1,0 +1,12 @@
+{
+	"mainSubject": "s1bachaaaaaaaa1",
+	"subjects": {
+		"s1bachaaaaaaaa1": {
+			"label": "Johann Ambrosius Bach",
+			"schema": "Person",
+			"statements": {
+				"Description": { "type": "text", "value": [ "German musician; director of the town musicians in Eisenach and father of Johann Sebastian Bach." ] }
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Johann_Ambrosius_Bach.wikitext
+++ b/DemoData/Subject/Johann_Ambrosius_Bach.wikitext
@@ -1,0 +1,1 @@
+{{#invoke:NeoWikiDemo|personEvents}}

--- a/DemoData/Subject/Johann_Christian_Bach.json
+++ b/DemoData/Subject/Johann_Christian_Bach.json
@@ -1,0 +1,13 @@
+{
+	"mainSubject": "s1bachaaaaaaaa8",
+	"subjects": {
+		"s1bachaaaaaaaa8": {
+			"label": "Johann Christian Bach",
+			"schema": "Person",
+			"statements": {
+				"Description": { "type": "text", "value": [ "Composer; youngest son of Johann Sebastian Bach, active in London." ] },
+				"Also known as": { "type": "text", "value": [ "J. C. Bach", "the London Bach" ] }
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Johann_Christian_Bach.wikitext
+++ b/DemoData/Subject/Johann_Christian_Bach.wikitext
@@ -1,0 +1,3 @@
+'''Johann Christian Bach''' was a German composer who settled in London, the youngest son of [[Johann Sebastian Bach]] and [[Anna Magdalena Bach]]. He was born in [[Leipzig]] in 1735 and became known as the London Bach.
+
+{{#invoke:NeoWikiDemo|personEvents}}

--- a/DemoData/Subject/Johann_Sebastian_Bach.json
+++ b/DemoData/Subject/Johann_Sebastian_Bach.json
@@ -1,0 +1,13 @@
+{
+	"mainSubject": "s1bachaaaaaaaa3",
+	"subjects": {
+		"s1bachaaaaaaaa3": {
+			"label": "Johann Sebastian Bach",
+			"schema": "Person",
+			"statements": {
+				"Description": { "type": "text", "value": [ "German composer and organist of the Baroque period." ] },
+				"Also known as": { "type": "text", "value": [ "J. S. Bach" ] }
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Johann_Sebastian_Bach.wikitext
+++ b/DemoData/Subject/Johann_Sebastian_Bach.wikitext
@@ -1,0 +1,3 @@
+'''Johann Sebastian Bach''' was a German composer and organist of the Baroque period, born in [[Eisenach]] in 1685. He was the son of [[Johann Ambrosius Bach]] and the father of [[Wilhelm Friedemann Bach]], [[Carl Philipp Emanuel Bach]], and [[Johann Christian Bach]].
+
+{{#invoke:NeoWikiDemo|personEvents}}

--- a/DemoData/Subject/Leipzig.json
+++ b/DemoData/Subject/Leipzig.json
@@ -1,0 +1,14 @@
+{
+	"mainSubject": "s1bachaaaaaaac4",
+	"subjects": {
+		"s1bachaaaaaaac4": {
+			"label": "Leipzig",
+			"schema": "Place",
+			"statements": {
+				"Country": { "type": "text", "value": [ "Germany" ] },
+				"Coordinates": { "type": "text", "value": [ "51.3397, 12.3731" ] },
+				"Description": { "type": "text", "value": [ "City in Saxony, Germany, where Johann Sebastian Bach was Thomaskantor." ] }
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Maria_Barbara_Bach.json
+++ b/DemoData/Subject/Maria_Barbara_Bach.json
@@ -1,0 +1,12 @@
+{
+	"mainSubject": "s1bachaaaaaaaa4",
+	"subjects": {
+		"s1bachaaaaaaaa4": {
+			"label": "Maria Barbara Bach",
+			"schema": "Person",
+			"statements": {
+				"Description": { "type": "text", "value": [ "First wife of Johann Sebastian Bach; mother of Wilhelm Friedemann and Carl Philipp Emanuel Bach." ] }
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Maria_Barbara_Bach.wikitext
+++ b/DemoData/Subject/Maria_Barbara_Bach.wikitext
@@ -1,0 +1,1 @@
+{{#invoke:NeoWikiDemo|personEvents}}

--- a/DemoData/Subject/Maria_Elisabeth_Lämmerhirt.json
+++ b/DemoData/Subject/Maria_Elisabeth_Lämmerhirt.json
@@ -1,0 +1,12 @@
+{
+	"mainSubject": "s1bachaaaaaaaa2",
+	"subjects": {
+		"s1bachaaaaaaaa2": {
+			"label": "Maria Elisabeth Lämmerhirt",
+			"schema": "Person",
+			"statements": {
+				"Description": { "type": "text", "value": [ "Mother of Johann Sebastian Bach and wife of Johann Ambrosius Bach." ] }
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Maria_Elisabeth_Lämmerhirt.wikitext
+++ b/DemoData/Subject/Maria_Elisabeth_Lämmerhirt.wikitext
@@ -1,0 +1,1 @@
+{{#invoke:NeoWikiDemo|personEvents}}

--- a/DemoData/Subject/Weimar.json
+++ b/DemoData/Subject/Weimar.json
@@ -1,0 +1,14 @@
+{
+	"mainSubject": "s1bachaaaaaaac3",
+	"subjects": {
+		"s1bachaaaaaaac3": {
+			"label": "Weimar",
+			"schema": "Place",
+			"statements": {
+				"Country": { "type": "text", "value": [ "Germany" ] },
+				"Coordinates": { "type": "text", "value": [ "50.9795, 11.3235" ] },
+				"Description": { "type": "text", "value": [ "City in Thuringia, Germany, where Johann Sebastian Bach served as court organist." ] }
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Wilhelm_Friedemann_Bach.json
+++ b/DemoData/Subject/Wilhelm_Friedemann_Bach.json
@@ -1,0 +1,13 @@
+{
+	"mainSubject": "s1bachaaaaaaaa6",
+	"subjects": {
+		"s1bachaaaaaaaa6": {
+			"label": "Wilhelm Friedemann Bach",
+			"schema": "Person",
+			"statements": {
+				"Description": { "type": "text", "value": [ "Composer and organist; eldest surviving son of Johann Sebastian Bach." ] },
+				"Also known as": { "type": "text", "value": [ "the Halle Bach" ] }
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Wilhelm_Friedemann_Bach.wikitext
+++ b/DemoData/Subject/Wilhelm_Friedemann_Bach.wikitext
@@ -1,0 +1,3 @@
+'''Wilhelm Friedemann Bach''' was a German composer and organist, the eldest surviving son of [[Johann Sebastian Bach]] and [[Maria Barbara Bach]]. He was born in [[Weimar]] in 1710.
+
+{{#invoke:NeoWikiDemo|personEvents}}


### PR DESCRIPTION
## What this adds

A new `DemoData/` corpus modelling people and their births in the event-centric style of CIDOC CRM (the cultural-heritage reference model Arches is built on), where a Birth is its own Subject rather than flat fields on a Person. It covers three generations of the Bach family (8 persons, 5 births, 4 places).

New schemas: `Person` (CIDOC E21), `Birth` (E67), `Place` (E53). A hub page, `People and life events`, presents the data with two Cypher tables and a NeoWiki-to-CIDOC mapping table (with cidoc-crm.org links), plus a card on the Main Page.

## Why these choices

- **An event, not fields.** Modelling Birth as its own Subject lets one event tie together a child, mother, father, place, and date, and lets a person appear in many events in different roles. J. S. Bach is the child in his own Birth and the father in three of his sons' Births; Johann Ambrosius is the child in his and the father in J. S. Bach's. Flat `Born`-style fields cannot express that.
- **Its own page, not a child Subject.** Each Birth is a standalone Subject on its own page, not a child Subject nested under a person's page. A child Subject has to live on a single participant's page, which would imply that participant has primacy (the person born over their parents, say); an event with several participants shouldn't have to nominate a primary owner. Keeping the Birth separate sidesteps that. (It could technically be a child Subject; this is a deliberate modelling choice.)
- **A musician, not a painter.** The demo already models painters under the `Artist` schema. A musician overlaps no existing schema, so this corpus does not create two competing representations of the same kind of entity.
- **CIDOC directionality preserved.** The only stored edges run Event to Person (`P98 brought into life`, `P96 by mother`, `P97 from father`, `P7 took place at`). The Person-side "was born" (inverse `P98i`) is not stored as a second edge; it is derived by a new `personEvents` function in `Module:NeoWikiDemo` that reverse-queries the graph. This mirrors how a triplestore (and Arches) asserts a CIDOC property once and reads its inverse off the same edge, and it keeps `Person` deliberately lean.
- **Honest, partial mapping.** Where the demo simplifies, the mapping table says so. `Place.Country` is labelled a denormalised country-name label with no direct CIDOC property (a faithful model would use `P89 falls within` to a containing `E53 Place`); the `Date` row notes the value sits inside the `E52 Time-Span` (via `P82`), collapsed here to one date.
- **Open-world scope, not a data gap.** The root Birth (Johann Ambrosius) records a child, place, and date but no parents. That is a deliberate three-generation scope boundary, not a claim that his parents are unknown (they are documented), framed so it does not misrepresent the record.

## Date storage

NeoWiki currently stores `date` values as a string list, so the Cypher reads `b.Date[0]`. When typed `date` storage lands (the mechanism from #812, which currently covers only `dateTime`), this becomes a one-token change to `toString(b.Date[0])` in the `personEvents` function and the two hub queries; nothing else changes.

## Verification

Imported via `make dev` into a local stack and checked in the browser:
- Import completes with no failures.
- `Schema:Person` / `Birth` / `Place` exist; Birth subjects show participants, place, and date.
- Person pages render the derived life-events table (J. S. Bach born in Eisenach, father in three births; Maria Barbara mother in two; Anna Magdalena mother in one), confirming the reverse-query and the multi-role / two-mothers behaviour.
- The hub's two Cypher tables and the CIDOC mapping table populate; the Main Page shows the new card.

## Screenshots

|  |  |
|---|---|
| **An event as its own Subject:** the Birth links child, mother, father, place, and date. | <img width="1440" height="960" alt="birth-of-johann-sebastian-bach" src="https://github.com/user-attachments/assets/e5bb4e0c-2471-445f-b466-f283cdac28c5" /> |
| **A lean Person beside derived life events:** the Person infobox carries no birth fields; "was born" and "father in" are computed by reverse-querying the events. | <img width="1440" height="960" alt="person-johann-sebastian-bach" src="https://github.com/user-attachments/assets/4eb74ba0-d8f3-4f7f-89a6-cb7f4f4bebe6" /> |
| **The hub:** Cypher tables over the Bach family plus the NeoWiki-to-CIDOC mapping table. | <img width="1440" height="2479" alt="hub-people-and-life-events" src="https://github.com/user-attachments/assets/d54b8345-97a5-4c9a-9344-8cd905c39bcd" /> |
| **A Place subject:** Country and Coordinates. | <img width="1440" height="960" alt="place-eisenach" src="https://github.com/user-attachments/assets/273b12ac-de83-473a-8323-e6dc3188f18d" /> |
| **The Birth schema** (CIDOC E67) and its properties. | <img width="1440" height="960" alt="schema-birth" src="https://github.com/user-attachments/assets/090c6070-1de5-4580-a248-a3b086ebe911" /> |
| **The hub linked from the demo Main Page.** | <img width="1440" height="1441" alt="main-page-card" src="https://github.com/user-attachments/assets/5dab919e-82ec-4729-810a-43f691ad64f4" /> |


🤖 Generated with [Claude Code](https://claude.com/claude-code)


