### PR TITLE
Add five city subjects to the demo data

### DIFF
--- a/DemoData/Subject/Aix-en-Provence.json
+++ b/DemoData/Subject/Aix-en-Provence.json
@@ -1,0 +1,23 @@
+{
+	"mainSubject": "sEpfwJLnQ2vK7mR",
+	"subjects": {
+		"sEpfwJLnQ2vK7mR": {
+			"label": "Aix-en-Provence",
+			"schema": "City",
+			"statements": {
+				"Country": {
+					"type": "text",
+					"value": [ "France" ]
+				},
+				"Population": {
+					"type": "number",
+					"value": 149695
+				},
+				"Website": {
+					"type": "url",
+					"value": [ "https://www.aixenprovence.fr" ]
+				}
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Aix-en-Provence.wikitext
+++ b/DemoData/Subject/Aix-en-Provence.wikitext
@@ -1,0 +1,3 @@
+'''Aix-en-Provence''' is a city in the Provence region of southern France, founded by the Romans as Aquae Sextiae. Its old town, thermal springs, and the tree-lined Cours Mirabeau make it one of the country's best-preserved historic centres.
+
+The city is closely associated with the painter Paul Cézanne, who was born and worked there, and maintains a long university tradition alongside the art collections of the Musée Granet.

--- a/DemoData/Subject/Alcalá_de_Henares.json
+++ b/DemoData/Subject/Alcalá_de_Henares.json
@@ -1,0 +1,23 @@
+{
+	"mainSubject": "sEpfwJLnT4bH9xC",
+	"subjects": {
+		"sEpfwJLnT4bH9xC": {
+			"label": "Alcalá de Henares",
+			"schema": "City",
+			"statements": {
+				"Country": {
+					"type": "text",
+					"value": [ "Spain" ]
+				},
+				"Population": {
+					"type": "number",
+					"value": 200702
+				},
+				"Website": {
+					"type": "url",
+					"value": [ "https://www.ayto-alcaladehenares.es" ]
+				}
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Alcalá_de_Henares.wikitext
+++ b/DemoData/Subject/Alcalá_de_Henares.wikitext
@@ -1,0 +1,3 @@
+'''Alcalá de Henares''' is a historic city in the Community of Madrid, Spain, on the river Henares. Its university and historic precinct were inscribed as a UNESCO World Heritage Site in 1998, recognised as one of the world's first planned university cities.
+
+The city is the birthplace of Miguel de Cervantes, author of Don Quixote, and preserves a strong literary and academic heritage centred on the historic University of Alcalá.

--- a/DemoData/Subject/Antwerp.json
+++ b/DemoData/Subject/Antwerp.json
@@ -1,0 +1,23 @@
+{
+	"mainSubject": "sEpfwJLnW5dG3kP",
+	"subjects": {
+		"sEpfwJLnW5dG3kP": {
+			"label": "Antwerp",
+			"schema": "City",
+			"statements": {
+				"Country": {
+					"type": "text",
+					"value": [ "Belgium" ]
+				},
+				"Population": {
+					"type": "number",
+					"value": 565039
+				},
+				"Website": {
+					"type": "url",
+					"value": [ "https://www.antwerpen.be" ]
+				}
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Antwerp.wikitext
+++ b/DemoData/Subject/Antwerp.wikitext
@@ -1,0 +1,3 @@
+'''Antwerp''' is the largest city in the Flemish Region of Belgium and a major port on the river Scheldt. A leading centre of trade and the arts since the 16th century, its historic centre and harbour have long shaped the city's wealth and culture.
+
+Antwerp is strongly associated with the painter Peter Paul Rubens, whose house and studio survive as a museum, and holds major collections at the Royal Museum of Fine Arts and the Museum aan de Stroom.

--- a/DemoData/Subject/Bilbao.json
+++ b/DemoData/Subject/Bilbao.json
@@ -1,0 +1,23 @@
+{
+	"mainSubject": "sEpfwJLnY6fM8nU",
+	"subjects": {
+		"sEpfwJLnY6fM8nU": {
+			"label": "Bilbao",
+			"schema": "City",
+			"statements": {
+				"Country": {
+					"type": "text",
+					"value": [ "Spain" ]
+				},
+				"Population": {
+					"type": "number",
+					"value": 347342
+				},
+				"Website": {
+					"type": "url",
+					"value": [ "https://www.bilbao.eus" ]
+				}
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Bilbao.wikitext
+++ b/DemoData/Subject/Bilbao.wikitext
@@ -1,0 +1,3 @@
+'''Bilbao''' is the largest city of the Basque Country in northern Spain, set on the estuary of the river Nervión. Once an industrial and shipbuilding hub, it has reinvented itself as a centre for culture, services, and tourism.
+
+The city is best known for the Guggenheim Museum Bilbao, whose 1997 opening sparked the urban renewal often called the "Bilbao effect", alongside the long-established Bilbao Fine Arts Museum.

--- a/DemoData/Subject/Stockholm.json
+++ b/DemoData/Subject/Stockholm.json
@@ -1,0 +1,23 @@
+{
+	"mainSubject": "sEpfwJLnZ7hN4qT",
+	"subjects": {
+		"sEpfwJLnZ7hN4qT": {
+			"label": "Stockholm",
+			"schema": "City",
+			"statements": {
+				"Country": {
+					"type": "text",
+					"value": [ "Sweden" ]
+				},
+				"Population": {
+					"type": "number",
+					"value": 996264
+				},
+				"Website": {
+					"type": "url",
+					"value": [ "https://www.stockholm.se" ]
+				}
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Stockholm.wikitext
+++ b/DemoData/Subject/Stockholm.wikitext
@@ -1,0 +1,3 @@
+'''Stockholm''' is the capital and largest city of Sweden, built across fourteen islands where Lake Mälaren meets the Baltic Sea. Its well-preserved medieval old town, Gamla Stan, lies at the heart of the modern city.
+
+Stockholm is a leading Nordic centre for culture and research, home to institutions such as the Vasa Museum and the Nationalmuseum, and the city where the Nobel Prize ceremony is held each year.


### PR DESCRIPTION
> Result of back-and-forth with @JeroenDeDauw, who set the selection criteria: two cities sorting alphabetically before Amsterdam, three after, fitting the existing dataset or cultural-heritage themes.
> Context: the NeoWiki DemoData and its authoring conventions, plus web research to verify each city's population and official website.
> <sub>Written by Claude Code, `Opus 4.8`</sub>

Broaden the demo wiki's geographic and cultural-heritage coverage with five additional City subjects:

- Aix-en-Provence (France)
- Alcalá de Henares (Spain)
- Antwerp (Belgium)
- Bilbao (Spain)
- Stockholm (Sweden)

Two sort alphabetically before the existing Amsterdam and three after, giving a better spread for demonstrating sorting and queries. Each city extends a country already in the dataset and/or fits a cultural-heritage use case. Each Subject carries Country, Population, and Website, with a paired Wikipedia-style prose page, following the DemoData conventions.

Populations are official municipality figures (INSEE, INE, Statbel, SCB); websites are the official municipal domains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
