### PR TITLE
Fail fast when Docker Compose v2 is missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,15 +49,31 @@ help:
 
 # ---- Lifecycle (host only) ---------------------------------------------------
 
-.PHONY: up pull demo dev dev-tools _dev-tools-impl down remove logs ps bash
+.PHONY: up pull demo dev dev-tools _dev-tools-impl down remove logs ps bash _check-compose
 
-up: ## Bring up try-it-out stack (no profile, prebuilt image)
+# Fail fast if the `docker compose` subcommand (Compose v2+) is unavailable.
+# The dev stack is driven entirely through `docker compose`; a standalone
+# `docker-compose` binary does not satisfy this, and the compose files use
+# modern Compose Spec features (e.g. `!reset`) that the legacy V1 cannot parse.
+_check-compose:
+	@docker compose version >/dev/null 2>&1 || { \
+		echo "Error: the 'docker compose' command (Docker Compose v2+) is required but was not found." >&2; \
+		echo "" >&2; \
+		echo "NeoWiki's dev environment calls 'docker compose' (with a space). A standalone" >&2; \
+		echo "'docker-compose' binary or the legacy V1 does not satisfy this. Install the plugin:" >&2; \
+		echo "  Ubuntu/Debian:  sudo apt-get install docker-compose-v2" >&2; \
+		echo "  Other systems:  https://docs.docker.com/compose/install/" >&2; \
+		echo "Then verify with: docker compose version" >&2; \
+		exit 1; \
+	}
+
+up: _check-compose ## Bring up try-it-out stack (no profile, prebuilt image)
 	$(DC) up -d
 
 pull: ## Pull the latest prebuilt demo image
 	$(DC) pull
 
-demo: ## One-command demo: pull image, start stack, install + seed (idempotent)
+demo: _check-compose ## One-command demo: pull image, start stack, install + seed (idempotent)
 	$(DC) pull
 	$(DC) up -d
 	@$(MAKE) --no-print-directory _wait-mw
@@ -66,10 +82,10 @@ demo: ## One-command demo: pull image, start stack, install + seed (idempotent)
 	@echo "Demo wiki ready at: http://localhost:$$MW_SERVER_PORT"
 	@echo "Log in as AdminName (password: $$MW_ADMIN_PASSWORD)."
 
-dev: bootstrap ensure-port ## Bring up dev stack (build image, install, seed, wait for health)
+dev: _check-compose bootstrap ensure-port ## Bring up dev stack (build image, install, seed, wait for health)
 	@$(MAKE) --no-print-directory _dev-impl
 
-dev-tools: bootstrap ensure-port ## Like 'dev' but also exposes Neo4j Browser/Bolt to host
+dev-tools: _check-compose bootstrap ensure-port ## Like 'dev' but also exposes Neo4j Browser/Bolt to host
 	@$(MAKE) --no-print-directory _dev-tools-impl
 
 _dev-tools-impl:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ See [docs/](./docs/), especially [docs/concepts/glossary.md](./docs/concepts/glo
 
 Prerequisites:
 
-- Docker and Docker Compose
+- Docker (or a compatible runtime such as Podman)
+- Docker Compose v2+ (with the `docker compose` subcommand, not the legacy standalone `docker-compose` v1. Verify with `docker compose version`)
 - GNU Make
 
 To work on NeoWiki (edit code, run tests, see changes live), bring up the bundled dev stack:

--- a/docs/operations/installation.md
+++ b/docs/operations/installation.md
@@ -17,7 +17,8 @@ To install the development environment, see the [README on GitHub](https://githu
 
 Prerequisites:
 
-- Docker and Docker Compose
+- Docker (or a compatible runtime such as Podman)
+- Docker Compose v2+ (with the `docker compose` subcommand, not the legacy standalone `docker-compose` v1. Verify with `docker compose version`)
 - GNU Make
 
 The below commands assume a Unix-like shell, so on Windows run them under WSL.


### PR DESCRIPTION
> Diagnosed and directed by @JeroenDeDauw from a user's failed dev-env setup (the second person to hit this). The approach — a preflight check rather than supporting the EOL Compose v1 — and the prerequisite wording are his.
> Context: the NeoWiki dev-env Makefile and Docker Compose files, plus the user's error output.
> <sub>Written by Claude Code, `Opus 4.8`</sub>

The dev stack runs entirely through the `docker compose` subcommand (Compose v2+). When it is unavailable, the only signal was a cryptic "unknown docker command" deep in `make dev`, after the lengthy MediaWiki-core clone — which has tripped up several people setting up the environment.

Add a `_check-compose` preflight to the `up`, `demo`, `dev`, and `dev-tools` targets that verifies `docker compose` resolves and otherwise aborts immediately with install guidance. Clarify the prerequisite in the README and installation docs.

The legacy standalone `docker-compose` v1 is intentionally not supported: the compose files use the `!reset` Compose Spec tag that v1 cannot parse.
