### PR TITLE
Fall back to a portable lock when flock is unavailable

### DIFF
--- a/Docker/scripts/set-port.sh
+++ b/Docker/scripts/set-port.sh
@@ -7,7 +7,10 @@ set -e
 
 REQUESTED="${1:-}"
 ENV_FILE="${ENV_FILE:-Docker/.env}"
-LOCK_FILE="/tmp/.neowiki-port-allocation.lock"
+LOCK_FILE="${LOCK_FILE:-${TMPDIR:-/tmp}/.neowiki-port-allocation.$(id -u).lock}"
+LOCK_DIR="${LOCK_DIR:-${TMPDIR:-/tmp}/.neowiki-port-allocation.$(id -u).lock.d}"
+LOCK_TIMEOUT="${LOCK_TIMEOUT:-100}"
+FLOCK_BIN="${FLOCK_BIN:-flock}"
 
 # Reserved ranges. Document any change in Docker/README.md.
 MW_RANGE_START="${PORT_RANGE_START:-8484}"
@@ -65,10 +68,51 @@ allocate() {
     return 1
 }
 
-# Take the lock once around the whole allocation pass so concurrent worktrees
-# do not pick the same port between is_port_free and the eventual bind.
-exec 200>"$LOCK_FILE"
-flock -x 200
+# Serialize concurrent allocation passes by the same user (e.g. parallel
+# worktrees) so two runs do not both read the same port as free and claim it.
+# Prefer flock(1): a kernel-managed lock released automatically on process death,
+# even on SIGKILL. Where flock is unavailable (stock macOS does not ship it), fall
+# back to a portable directory mutex. The lock is per-user (paths carry the uid)
+# so distinct users on a shared host never contend.
+#
+# Best-effort either way: the lock is released when this pass exits, before the
+# caller binds the port, so it narrows but cannot fully eliminate a same-port
+# race between cold-start worktrees.
+acquire_lock() {
+    if command -v "$FLOCK_BIN" >/dev/null 2>&1; then
+        exec 200>"$LOCK_FILE"
+        "$FLOCK_BIN" -x 200
+        return
+    fi
+    acquire_dir_lock
+}
+
+# Directory-mutex fallback for hosts without flock(1). A directory has no kernel
+# auto-release, so a lock orphaned by a crashed run is reclaimed by checking the
+# recorded holder PID's liveness. The steal renames first so only one racer can
+# reclaim a given stale lock (an unconditional rm could delete a fresh lock that
+# another run just took). A reused holder PID reads as alive, so recovery waits
+# out LOCK_TIMEOUT instead — a bounded delay, never a deadlock.
+acquire_dir_lock() {
+    local waited=0 holder
+    until mkdir "$LOCK_DIR" 2>/dev/null; do
+        holder=$( cat "$LOCK_DIR/pid" 2>/dev/null || true )
+        if [ -n "$holder" ] && ! kill -0 "$holder" 2>/dev/null; then
+            mv "$LOCK_DIR" "$LOCK_DIR.stale.$$" 2>/dev/null && rm -rf "$LOCK_DIR.stale.$$"
+            continue
+        fi
+        waited=$(( waited + 1 ))
+        if [ "$waited" -ge "$LOCK_TIMEOUT" ]; then
+            echo "Timed out waiting for the port-allocation lock ($LOCK_DIR)." >&2
+            return 1
+        fi
+        sleep 0.1
+    done
+    echo $$ > "$LOCK_DIR/pid"
+    trap 'rm -rf "$LOCK_DIR"' EXIT
+}
+
+acquire_lock
 
 if [ -n "$REQUESTED" ]; then
     if ! is_port_free "$REQUESTED"; then

--- a/Docker/tests/test-set-port.sh
+++ b/Docker/tests/test-set-port.sh
@@ -88,7 +88,18 @@ run_sut() {
     ENV_FILE="$ENV_FILE" \
     PORT_RANGE_START="$TEST_RANGE_START" \
     PORT_RANGE_END="$TEST_RANGE_END" \
+    LOCK_DIR="${LOCK_DIR:-$WORK/lock.d}" \
+    LOCK_FILE="${LOCK_FILE:-$WORK/lock.file}" \
+    LOCK_TIMEOUT="${LOCK_TIMEOUT:-100}" \
+    FLOCK_BIN="${FLOCK_BIN:-flock}" \
         bash "$SUT" "$arg"
+}
+
+# Run the SUT as if flock(1) were unavailable (stock macOS), forcing the portable
+# directory-mutex fallback. Points FLOCK_BIN at a non-existent command so the
+# script's own `command -v` probe fails, exactly as on a host without flock.
+run_sut_no_flock() {
+    FLOCK_BIN="neowiki-no-such-flock" run_sut "$@"
 }
 
 reset_env() {
@@ -201,6 +212,30 @@ else
     fail "Error message should mention in-use. Got: $err_output"
 fi
 release_all
+
+echo
+color '36' "Case 8: flock unavailable (stock macOS) -> still allocates in-range"
+reset_env ""
+rc=0
+run_sut_no_flock "" >/dev/null 2>&1 || rc=$?
+assert_eq "Exits cleanly without flock" "$rc" "0"
+assert_in_range "MW port allocated without flock" "$(env_value MW_SERVER_PORT)" "$TEST_RANGE_START" "$TEST_RANGE_END"
+
+echo
+color '36' "Case 9: fallback path recovers a stale lock from a crashed run"
+reset_env ""
+stale_dir="$WORK/stale-lock.d"
+rm -rf "$stale_dir"; mkdir -p "$stale_dir"
+# A PID above pid_max can never be a live process, so the recorded holder reads
+# as dead deterministically (no spawn/kill/PID-reuse timing to flake on).
+echo 2147483647 > "$stale_dir/pid"
+rc=0
+LOCK_DIR="$stale_dir" LOCK_TIMEOUT=5 run_sut_no_flock "" >/dev/null 2>&1 || rc=$?
+assert_eq "Recovers from stale lock and exits cleanly" "$rc" "0"
+assert_in_range "MW port allocated despite stale lock" "$(env_value MW_SERVER_PORT)" "$TEST_RANGE_START" "$TEST_RANGE_END"
+# The stale dir is reclaimed and cleaned up only on the fallback path; if the
+# flock branch had run instead it would sit untouched. This pins the path.
+assert_eq "Stale lock reclaimed (fallback path exercised)" "$([ -e "$stale_dir" ] && echo present || echo gone)" "gone"
 
 # ---- Summary -----------------------------------------------------------------
 


### PR DESCRIPTION
> Driven by @alistair3149: flagged macOS as a supported platform, chose flock-with-fallback over a pure rewrite or requiring flock as a prerequisite, and directed the code review.
> Context: the NeoWiki dev-env Makefile and `Docker/scripts` port-allocation tooling, plus a code review of the change.
> <sub>Written by Claude Code, `Opus 4.8`</sub>

`set-port.sh` serialized concurrent port allocation with `flock(1)` (util-linux), which stock macOS does not ship, so `make dev` aborted on first run with `flock: command not found` on a supported platform.

Keep flock where present — its kernel-managed lock auto-releases on process death, even on SIGKILL — and fall back to an atomic, per-user directory mutex where it is absent (e.g. macOS). The fallback recovers a lock orphaned by a crashed run via the holder PID's liveness, stealing through an atomic rename so a concurrent run cannot delete a freshly taken lock.

`test-set-port.sh` exercises both paths: the existing cases run under real flock, while two new cases force the fallback (allocation works without flock; a stale lock from a dead holder is recovered).
