### PR TITLE
Stop showing required errors on untouched date and datetime fields

### DIFF
--- a/resources/ext.neowiki/src/components/Value/DateInput.vue
+++ b/resources/ext.neowiki/src/components/Value/DateInput.vue
@@ -90,7 +90,10 @@ function onInput( newValue: string ): void {
 }
 
 function validate( value: StringValue | undefined ): void {
-	const errors = propertyType.validate( value, props.property );
+	// Suppress the live 'required' error so an untouched date field isn't
+	// flagged before the user has entered a value; the server still enforces it.
+	const errors = propertyType.validate( value, props.property )
+		.filter( ( e ) => e.code !== 'required' );
 	if ( errors.length === 0 ) {
 		liveValidationError.value = null;
 		return;

--- a/resources/ext.neowiki/src/components/Value/DateTimeInput.vue
+++ b/resources/ext.neowiki/src/components/Value/DateTimeInput.vue
@@ -90,7 +90,10 @@ function onInput( newValue: string ): void {
 }
 
 function validate( value: StringValue | undefined ): void {
-	const errors = propertyType.validate( value, props.property );
+	// Suppress the live 'required' error so an untouched datetime field isn't
+	// flagged before the user has entered a value; the server still enforces it.
+	const errors = propertyType.validate( value, props.property )
+		.filter( ( e ) => e.code !== 'required' );
 	if ( errors.length === 0 ) {
 		liveValidationError.value = null;
 		return;

--- a/resources/ext.neowiki/tests/components/Value/DateInput.spec.ts
+++ b/resources/ext.neowiki/tests/components/Value/DateInput.spec.ts
@@ -66,10 +66,22 @@ describe( 'DateInput', () => {
 		expect( wrapper.find( 'input' ).attributes( 'max' ) ).toBe( '2030-12-31' );
 	} );
 
-	it( 'shows required error when required property has empty value', () => {
+	it( 'does not flag an empty required date before the user has picked a value', () => {
 		const wrapper = newWrapper( {
 			modelValue: undefined,
 			property: newDateProperty( { required: true } ),
+		} );
+
+		expect( wrapper.findComponent( CdxField ).props( 'status' ) ).toBe( 'default' );
+		expect( wrapper.findComponent( CdxField ).props( 'messages' ) ).toEqual( {} );
+	} );
+
+	it( 'still surfaces a server-sourced required violation on the date field', () => {
+		const wrapper = newWrapper( {
+			property: newDateProperty( { name: 'Foo', required: true } ),
+			serverViolations: [
+				{ propertyName: 'Foo', code: 'required', args: [], valuePartIndex: null },
+			],
 		} );
 
 		expect( wrapper.findComponent( CdxField ).props( 'status' ) ).toBe( 'error' );

--- a/resources/ext.neowiki/tests/components/Value/DateInput.spec.ts
+++ b/resources/ext.neowiki/tests/components/Value/DateInput.spec.ts
@@ -77,7 +77,10 @@ describe( 'DateInput', () => {
 	} );
 
 	it( 'still surfaces a server-sourced required violation on the date field', () => {
+		// A valid value is supplied so live validation cannot itself emit
+		// 'required'; the surfaced error therefore proves the server path.
 		const wrapper = newWrapper( {
+			modelValue: newStringValue( '2025-06-15' ),
 			property: newDateProperty( { name: 'Foo', required: true } ),
 			serverViolations: [
 				{ propertyName: 'Foo', code: 'required', args: [], valuePartIndex: null },

--- a/resources/ext.neowiki/tests/components/Value/DateTimeInput.spec.ts
+++ b/resources/ext.neowiki/tests/components/Value/DateTimeInput.spec.ts
@@ -70,10 +70,22 @@ describe( 'DateTimeInput', () => {
 		expect( wrapper.find( 'input' ).attributes( 'max' ) ).toBe( toLocalInputValue( maximum ) );
 	} );
 
-	it( 'shows required error when required property has empty value', () => {
+	it( 'does not flag an empty required datetime before the user has picked a value', () => {
 		const wrapper = newWrapper( {
 			modelValue: undefined,
 			property: newDateTimeProperty( { required: true } ),
+		} );
+
+		expect( wrapper.findComponent( CdxField ).props( 'status' ) ).toBe( 'default' );
+		expect( wrapper.findComponent( CdxField ).props( 'messages' ) ).toEqual( {} );
+	} );
+
+	it( 'still surfaces a server-sourced required violation on the datetime field', () => {
+		const wrapper = newWrapper( {
+			property: newDateTimeProperty( { name: 'Foo', required: true } ),
+			serverViolations: [
+				{ propertyName: 'Foo', code: 'required', args: [], valuePartIndex: null },
+			],
 		} );
 
 		expect( wrapper.findComponent( CdxField ).props( 'status' ) ).toBe( 'error' );

--- a/resources/ext.neowiki/tests/components/Value/DateTimeInput.spec.ts
+++ b/resources/ext.neowiki/tests/components/Value/DateTimeInput.spec.ts
@@ -81,7 +81,10 @@ describe( 'DateTimeInput', () => {
 	} );
 
 	it( 'still surfaces a server-sourced required violation on the datetime field', () => {
+		// A valid value is supplied so live validation cannot itself emit
+		// 'required'; the surfaced error therefore proves the server path.
 		const wrapper = newWrapper( {
+			modelValue: newStringValue( '2025-06-15T14:00:00Z' ),
 			property: newDateTimeProperty( { name: 'Foo', required: true } ),
 			serverViolations: [
 				{ propertyName: 'Foo', code: 'required', args: [], valuePartIndex: null },


### PR DESCRIPTION
Follows up #886, which introduced server-driven validation and the rule that an empty required field is not flagged client-side until the user interacts with it (the server surfaces `required` at save and via its dry-run). `SelectInput` got that treatment, but `DateInput` and `DateTimeInput` were missed: they run their field validator on mount with an empty value, so a required Date or DateTime field showed a red "Please provide a value." the moment a creation form opened, inconsistent with every other field type.

This filters the client-side `required` code out of the live validation in both date inputs, mirroring `SelectInput`. The change is display-only: the server still returns the `required` violation, so save-time enforcement and the editor's surfacing of pre-existing violations on existing subjects are unchanged. Only `required` is filtered; `min-value`, `max-value`, and `invalid-date` / `invalid-datetime` still surface live.

The two date specs previously pinned the old behavior ("shows required error when required property has empty value"); those are flipped to assert the field is not flagged on an untouched required value, and each gains a test that a server-sourced `required` violation still surfaces on the field.

### Screenshots

| | |
|---|---|
| **Before.** A required Date field is flagged on an untouched creation form. | <img width="1920" height="1080" alt="finding-a-required-date-premature-error" src="https://github.com/user-attachments/assets/d3baaee4-3dbd-4477-bbcf-19cf5a606ab8" /> |
| **After.** The same field stays clean until a value is entered. | <img width="1920" height="1080" alt="finding-a-FIXED-required-date-clean" src="https://github.com/user-attachments/assets/3d18e89c-062b-46c8-a66e-3c1bbf04d409" />|

🤖 Generated with [Claude Code](https://claude.com/claude-code)
