### PR TITLE
Fix special-values link in ADR 011

### DIFF
--- a/docs/adr/011-include-writers-schema.md
+++ b/docs/adr/011-include-writers-schema.md
@@ -94,7 +94,7 @@ Option B: include info on the statement (property) level
 }
 ```
 
-Option B2: option B with possible approach for [special values](https://github.com/ProfessionalWiki/NeoWiki/issues/356)
+Option B2: option B with possible approach for [special values](https://github.com/ProfessionalWiki/NeoWiki/issues/937)
 
 ```json
 {


### PR DESCRIPTION
The "special values" link in ADR 011 pointed to NeoWiki#356, an unrelated PR. Point it to NeoWiki#937, which tracks the no-value / some-value / complex-value question the ADR refers to.

<sub>Written by Claude Code, `Opus 4.8`. Jeroen (@JeroenDeDauw) spotted the dead link while checking whether we track the no-value/some-value concept, and recreated the issue as #937.</sub>