### PR TITLE
Point cypher result-format docs at the open tracker, not shipped nw.query

### DIFF
--- a/docs/reference/parser-functions.md
+++ b/docs/reference/parser-functions.md
@@ -130,8 +130,10 @@ Passing a value to another extension's parser function:
 Executes a read-only Cypher query and returns the raw results as JSON in a code block. Mainly
 useful for development and debugging.
 
-For end-user dashboards, formatted query result rendering and a Lua `nw.query()` function are
-planned (see [#736](https://github.com/ProfessionalWiki/NeoWiki/issues/736)).
+For end-user dashboards, formatted query result rendering is planned (see
+[#809](https://github.com/ProfessionalWiki/NeoWiki/issues/809)). A Lua
+[`nw.query()`](lua-api.md#nwquerycypher-params) function is already available for building
+custom result formatting in templates.
 
 ### Syntax
 


### PR DESCRIPTION
The `{{#cypher_raw}}` reference bundled formatted query result rendering and `nw.query()`
together as "planned (see #736)". #736 (nw.query) has since shipped, and the still-open work — a
formatted query result rendering mechanism — is tracked by #809. Point the formatted-rendering
note at #809 and link the now-available nw.query to the Lua API reference.

> Spotted by @JeroenDeDauw while auditing the docs for links broken by the LegacyNeoWiki→NeoWiki repo renumbering; this reference was stale rather than renumbered.
> Context: the NeoWiki reference docs and GitHub issue history (#736, #809).
> <sub>Written by Claude Code, `Opus 4.8`</sub>
