### PR TITLE
Defer the required check to the server in NumberInput

### DIFF
--- a/resources/ext.neowiki/src/components/Value/NumberInput.vue
+++ b/resources/ext.neowiki/src/components/Value/NumberInput.vue
@@ -87,7 +87,10 @@ function onInput( newValue: string ): void {
 }
 
 function validate( value: NumberValue | undefined ): void {
-	const errors = propertyType.validate( value, props.property );
+	// Suppress the live 'required' error so an empty number field isn't
+	// flagged before the user has entered a value; the server still enforces it.
+	const errors = propertyType.validate( value, props.property )
+		.filter( ( e ) => e.code !== 'required' );
 	liveValidationError.value = errors.length === 0 ? null :
 		mw.message( `neowiki-field-${ errors[ 0 ].code }`, ...( errors[ 0 ].args ?? [] ) ).text();
 }

--- a/resources/ext.neowiki/tests/components/Value/NumberInput.spec.ts
+++ b/resources/ext.neowiki/tests/components/Value/NumberInput.spec.ts
@@ -47,6 +47,33 @@ describe( 'NumberInput', () => {
 		expect( wrapper.findComponent( CdxField ).props( 'messages' ) ).toHaveProperty( 'error', 'neowiki-field-max-value' );
 	} );
 
+	it( 'does not flag required after the user clears the value', async () => {
+		const wrapper = newWrapper( {
+			modelValue: newNumberValue( 42 ),
+			property: newNumberProperty( { required: true } ),
+		} );
+
+		await wrapper.find( 'input' ).setValue( '' );
+
+		expect( wrapper.findComponent( CdxField ).props( 'status' ) ).toBe( 'default' );
+		expect( wrapper.findComponent( CdxField ).props( 'messages' ) ).toEqual( {} );
+	} );
+
+	it( 'still surfaces a server-sourced required violation on the number field', () => {
+		// A valid value is supplied so live validation cannot itself emit
+		// 'required'; the surfaced error therefore proves the server path.
+		const wrapper = newWrapper( {
+			modelValue: newNumberValue( 42 ),
+			property: newNumberProperty( { name: 'Foo', required: true } ),
+			serverViolations: [
+				{ propertyName: 'Foo', code: 'required', args: [], valuePartIndex: null },
+			],
+		} );
+
+		expect( wrapper.findComponent( CdxField ).props( 'status' ) ).toBe( 'error' );
+		expect( wrapper.findComponent( CdxField ).props( 'messages' ) ).toHaveProperty( 'error', 'neowiki-field-required' );
+	} );
+
 	describe( 'getCurrentValue', () => {
 		it( 'returns initial value', () => {
 			const wrapper = newWrapper( {


### PR DESCRIPTION
> Surfaced as a consistency follow-up while reviewing #933 with @alistair3149, who directed it be fixed as a separate PR.
> Context: the NeoWiki codebase and the #933 review (all single-value input components and their required-handling).
> <sub>Written by Claude Code, `Opus 4.8`</sub>

Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/933.

#933 filtered the client-side `required` code out of the live validation in `DateInput` and `DateTimeInput`, matching `SelectInput`, so a required field is not flagged before the user enters a value — `required` is deferred to the server (surfaced at save and via its dry-run).

`NumberInput` was the remaining single-value input that still emitted `required` live: after the user types a value and then clears it, `onInput` emits `undefined`, so `validate` produced a live `required` error. That was inconsistent with `SelectInput` / `DateInput` / `DateTimeInput` (which filter it) and with `TextInput` / `UrlInput` (whose empty value never runs field-level live validation).

This applies the same one-line filter to `NumberInput`'s `validate`. The change is display-only: the server still returns the `required` violation, so save-time enforcement and the surfacing of pre-existing server violations are unchanged. Only `required` is filtered; `min-value` and `max-value` still surface live.

`NumberInput`'s empty state on mount is `newNumberValue( NaN )` (never `undefined`), so it never showed `required` on an untouched field — only after a clear. The new regression spec reproduces exactly that path and fails without the filter.

`RelationInput` also surfaces a live `required` after a touch-then-clear, but it uses a different `touched`-gated display strategy whose interaction with surfacing server violations is a separate question, so it is intentionally left out of this change.

## Manual Browser Check

1. Create or edit a Schema with a **required** `number` property.
2. Open the subject creation/editing form for that Schema.
3. Type a number into the field, then clear it.
4. **Before:** a red "Please provide a value." appeared the moment the field was cleared. **After:** the field stays clean (`default` status); `required` is enforced by the server at save, consistent with date, datetime, and select fields.
5. Confirm `min`/`max` errors still appear live (enter an out-of-range number on a property with a minimum or maximum).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
