### PR TITLE
Centralize required-deferral validation across value inputs

### DIFF
--- a/resources/ext.neowiki/src/components/Value/BooleanInput.vue
+++ b/resources/ext.neowiki/src/components/Value/BooleanInput.vue
@@ -39,6 +39,7 @@ import { BooleanType, BooleanProperty } from '@/domain/propertyTypes/Boolean.ts'
 import { ValueInputEmits, ValueInputExposes, ValueInputProps } from '@/components/Value/ValueInputContract.ts';
 import { NeoWikiServices } from '@/NeoWikiServices.ts';
 import { useFieldServerViolation } from '@/composables/useFieldServerViolation.ts';
+import { liveValidationErrors } from '@/composables/useValueValidation.ts';
 
 const props = withDefaults(
 	defineProps<ValueInputProps<BooleanProperty>>(),
@@ -71,7 +72,7 @@ const internalValue = ref<boolean>( toBoolean( props.modelValue ) );
 const propertyType = NeoWikiServices.getPropertyTypeRegistry().getType( BooleanType.typeName );
 
 function validate( value: BooleanValue ): void {
-	const errors = propertyType.validate( value, props.property );
+	const errors = liveValidationErrors( value, propertyType, props.property );
 	liveValidationError.value = errors.length === 0 ? null :
 		mw.message( `neowiki-field-${ errors[ 0 ].code }`, ...( errors[ 0 ].args ?? [] ) ).text();
 }

--- a/resources/ext.neowiki/src/components/Value/DateInput.vue
+++ b/resources/ext.neowiki/src/components/Value/DateInput.vue
@@ -39,6 +39,7 @@ import { fromDateInputValue, toDateInputValue } from '@/domain/propertyTypes/dat
 import { ValueInputEmits, ValueInputExposes, ValueInputProps } from '@/components/Value/ValueInputContract.ts';
 import { NeoWikiServices } from '@/NeoWikiServices.ts';
 import { useFieldServerViolation } from '@/composables/useFieldServerViolation.ts';
+import { liveValidationErrors } from '@/composables/useValueValidation.ts';
 
 const props = withDefaults(
 	defineProps<ValueInputProps<DateProperty>>(),
@@ -90,10 +91,7 @@ function onInput( newValue: string ): void {
 }
 
 function validate( value: StringValue | undefined ): void {
-	// Suppress the live 'required' error so an untouched date field isn't
-	// flagged before the user has entered a value; the server still enforces it.
-	const errors = propertyType.validate( value, props.property )
-		.filter( ( e ) => e.code !== 'required' );
+	const errors = liveValidationErrors( value, propertyType, props.property );
 	if ( errors.length === 0 ) {
 		liveValidationError.value = null;
 		return;

--- a/resources/ext.neowiki/src/components/Value/DateTimeInput.vue
+++ b/resources/ext.neowiki/src/components/Value/DateTimeInput.vue
@@ -39,6 +39,7 @@ import { fromLocalInputValue, toLocalInputValue } from '@/domain/propertyTypes/d
 import { ValueInputEmits, ValueInputExposes, ValueInputProps } from '@/components/Value/ValueInputContract.ts';
 import { NeoWikiServices } from '@/NeoWikiServices.ts';
 import { useFieldServerViolation } from '@/composables/useFieldServerViolation.ts';
+import { liveValidationErrors } from '@/composables/useValueValidation.ts';
 
 const props = withDefaults(
 	defineProps<ValueInputProps<DateTimeProperty>>(),
@@ -90,10 +91,7 @@ function onInput( newValue: string ): void {
 }
 
 function validate( value: StringValue | undefined ): void {
-	// Suppress the live 'required' error so an untouched datetime field isn't
-	// flagged before the user has entered a value; the server still enforces it.
-	const errors = propertyType.validate( value, props.property )
-		.filter( ( e ) => e.code !== 'required' );
+	const errors = liveValidationErrors( value, propertyType, props.property );
 	if ( errors.length === 0 ) {
 		liveValidationError.value = null;
 		return;

--- a/resources/ext.neowiki/src/components/Value/NumberInput.vue
+++ b/resources/ext.neowiki/src/components/Value/NumberInput.vue
@@ -36,6 +36,7 @@ import { NumberType, NumberProperty } from '@/domain/propertyTypes/Number.ts';
 import { ValueInputEmits, ValueInputExposes, ValueInputProps } from '@/components/Value/ValueInputContract.ts';
 import { NeoWikiServices } from '@/NeoWikiServices.ts';
 import { useFieldServerViolation } from '@/composables/useFieldServerViolation.ts';
+import { liveValidationErrors } from '@/composables/useValueValidation.ts';
 
 const props = withDefaults(
 	defineProps<ValueInputProps<NumberProperty>>(),
@@ -87,7 +88,7 @@ function onInput( newValue: string ): void {
 }
 
 function validate( value: NumberValue | undefined ): void {
-	const errors = propertyType.validate( value, props.property );
+	const errors = liveValidationErrors( value, propertyType, props.property );
 	liveValidationError.value = errors.length === 0 ? null :
 		mw.message( `neowiki-field-${ errors[ 0 ].code }`, ...( errors[ 0 ].args ?? [] ) ).text();
 }

--- a/resources/ext.neowiki/src/components/Value/SelectInput.vue
+++ b/resources/ext.neowiki/src/components/Value/SelectInput.vue
@@ -51,6 +51,7 @@ import { resolveSelectLabel, SelectProperty, SelectType } from '@/domain/propert
 import { ValueInputEmits, ValueInputExposes, ValueInputProps } from '@/components/Value/ValueInputContract.ts';
 import { NeoWikiServices } from '@/NeoWikiServices.ts';
 import { SubjectViolation } from '@/domain/SubjectViolation.ts';
+import { liveValidationErrors } from '@/composables/useValueValidation.ts';
 
 const props = withDefaults(
 	defineProps<ValueInputProps<SelectProperty>>(),
@@ -131,10 +132,7 @@ function validate(): void {
 	const value = selection.value.length > 0 ?
 		newStringValue( selection.value ) :
 		undefined;
-	// 'required' is deferred to the server (surfaced at save) like every other
-	// input; we do not flag an empty select before the user has chosen a value.
-	const errors = propertyType.validate( value, props.property )
-		.filter( ( e ) => e.code !== 'required' );
+	const errors = liveValidationErrors( value, propertyType, props.property );
 	liveValidationError.value = errors.length === 0 ? null :
 		mw.message( `neowiki-field-${ errors[ 0 ].code }`, ...( errors[ 0 ].args ?? [] ) ).text();
 }

--- a/resources/ext.neowiki/src/composables/useStringValueInput.ts
+++ b/resources/ext.neowiki/src/composables/useStringValueInput.ts
@@ -6,7 +6,7 @@ import { newStringValue, ValueType } from '@/domain/Value.ts';
 import { MultiStringProperty } from '@/domain/PropertyDefinition.ts';
 import { PropertyType } from '@/domain/PropertyType.ts';
 import { NeoWikiServices } from '@/NeoWikiServices.ts';
-import { validateValue } from '@/composables/useValueValidation.ts';
+import { liveValidationMessages } from '@/composables/useValueValidation.ts';
 import { SubjectViolation } from '@/domain/SubjectViolation.ts';
 
 interface UseStringValueInputReturn {
@@ -66,7 +66,7 @@ export function useStringValueInput<P extends MultiStringProperty>(
 			if ( property.value.uniqueItems && inputValue !== '' && valuesToValidate.slice( 0, index ).includes( inputValue ) ) {
 				perInputErrors[ index ] = { error: mw.message( 'neowiki-field-unique' ).text() };
 			} else {
-				perInputErrors[ index ] = validateValue( newStringValue( inputValue ), propertyType, property.value );
+				perInputErrors[ index ] = liveValidationMessages( newStringValue( inputValue ), propertyType, property.value );
 			}
 		} );
 

--- a/resources/ext.neowiki/src/composables/useValueValidation.ts
+++ b/resources/ext.neowiki/src/composables/useValueValidation.ts
@@ -1,19 +1,58 @@
 import { Value } from '@/domain/Value';
-import { PropertyType } from '@/domain/PropertyType';
+import { PropertyType, ValueValidationError } from '@/domain/PropertyType';
 import { PropertyDefinition } from '@/domain/PropertyDefinition';
 import { ValidationMessages } from '@wikimedia/codex';
 
-export function validateValue( value: Value, propertyType: PropertyType, property: PropertyDefinition ): ValidationMessages {
-	const validationErrors = propertyType.validate( value, property );
+/**
+ * Validation codes the server is authoritative for. They are not surfaced in
+ * live client-side validation, so a value field is not flagged before the user
+ * has entered a value; the server still returns and enforces them at save time
+ * (and via its dry-run). This is the single source of truth for that policy:
+ * every value input runs its live validation through liveValidationErrors() or
+ * liveValidationMessages() rather than filtering codes itself.
+ */
+export const SERVER_ENFORCED_CODES: readonly string[] = [ 'required' ];
 
-	if ( validationErrors.length > 0 ) {
+/**
+ * The errors a value input should surface live: the full client-side
+ * validation minus the codes the server is authoritative for.
+ */
+export function liveValidationErrors(
+	value: Value | undefined,
+	propertyType: PropertyType,
+	property: PropertyDefinition,
+): ValueValidationError[] {
+	return propertyType.validate( value, property )
+		.filter( ( error ) => !SERVER_ENFORCED_CODES.includes( error.code ) );
+}
+
+function firstErrorMessage( errors: ValueValidationError[] ): ValidationMessages {
+	const error = errors[ 0 ];
+	if ( error ) {
 		return {
 			error: mw.message(
-				`neowiki-field-${ validationErrors[ 0 ].code }`,
-				...( validationErrors[ 0 ].args ?? [] ),
+				`neowiki-field-${ error.code }`,
+				...( error.args ?? [] ),
 			).text(),
 		};
 	}
 
 	return {};
+}
+
+/**
+ * Format the first validation error, including the server-enforced codes. Value
+ * inputs use {@link liveValidationMessages} instead, which omits those codes;
+ * this full-validation variant is kept as part of the public API surface.
+ */
+export function validateValue( value: Value, propertyType: PropertyType, property: PropertyDefinition ): ValidationMessages {
+	return firstErrorMessage( propertyType.validate( value, property ) );
+}
+
+/**
+ * Format the live errors for a value input: the server-enforced codes are not
+ * surfaced. See {@link liveValidationErrors}.
+ */
+export function liveValidationMessages( value: Value, propertyType: PropertyType, property: PropertyDefinition ): ValidationMessages {
+	return firstErrorMessage( liveValidationErrors( value, propertyType, property ) );
 }

--- a/resources/ext.neowiki/tests/components/Value/NumberInput.spec.ts
+++ b/resources/ext.neowiki/tests/components/Value/NumberInput.spec.ts
@@ -47,6 +47,33 @@ describe( 'NumberInput', () => {
 		expect( wrapper.findComponent( CdxField ).props( 'messages' ) ).toHaveProperty( 'error', 'neowiki-field-max-value' );
 	} );
 
+	it( 'does not flag required after the user clears the value', async () => {
+		const wrapper = newWrapper( {
+			modelValue: newNumberValue( 42 ),
+			property: newNumberProperty( { required: true } ),
+		} );
+
+		await wrapper.find( 'input' ).setValue( '' );
+
+		expect( wrapper.findComponent( CdxField ).props( 'status' ) ).toBe( 'default' );
+		expect( wrapper.findComponent( CdxField ).props( 'messages' ) ).toEqual( {} );
+	} );
+
+	it( 'still surfaces a server-sourced required violation on the number field', () => {
+		// A valid value is supplied so live validation cannot itself emit
+		// 'required'; the surfaced error therefore proves the server path.
+		const wrapper = newWrapper( {
+			modelValue: newNumberValue( 42 ),
+			property: newNumberProperty( { name: 'Foo', required: true } ),
+			serverViolations: [
+				{ propertyName: 'Foo', code: 'required', args: [], valuePartIndex: null },
+			],
+		} );
+
+		expect( wrapper.findComponent( CdxField ).props( 'status' ) ).toBe( 'error' );
+		expect( wrapper.findComponent( CdxField ).props( 'messages' ) ).toHaveProperty( 'error', 'neowiki-field-required' );
+	} );
+
 	describe( 'getCurrentValue', () => {
 		it( 'returns initial value', () => {
 			const wrapper = newWrapper( {

--- a/resources/ext.neowiki/tests/composables/useStringValueInput.spec.ts
+++ b/resources/ext.neowiki/tests/composables/useStringValueInput.spec.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach, type MockedFunction } from 'vites
 import { nextTick } from 'vue';
 
 vi.mock( '@/composables/useValueValidation.ts', () => ( {
-	validateValue: vi.fn(),
+	liveValidationMessages: vi.fn(),
 } ) );
 
 vi.mock( '@/NeoWikiServices.ts', () => ( {
@@ -14,14 +14,14 @@ vi.mock( '@/NeoWikiServices.ts', () => ( {
 	},
 } ) );
 
-import { validateValue } from '@/composables/useValueValidation.ts';
+import { liveValidationMessages } from '@/composables/useValueValidation.ts';
 import { useStringValueInput } from '@/composables/useStringValueInput.ts';
 import { Value, newStringValue, ValueType } from '@/domain/Value.ts';
 import { MultiStringProperty, PropertyName, PropertyDefinition } from '@/domain/PropertyDefinition.ts';
 import { PropertyType, ValueValidationError } from '@/domain/PropertyType.ts';
 import { NeoWikiServices } from '@/NeoWikiServices.ts';
 
-const mockedValidateValue = validateValue as MockedFunction<typeof validateValue>;
+const mockedLiveValidationMessages = liveValidationMessages as MockedFunction<typeof liveValidationMessages>;
 
 vi.stubGlobal( 'mw', {
 	message: vi.fn( ( key: string ) => ( {
@@ -68,7 +68,7 @@ describe( 'useStringValueInput', () => {
 
 	beforeEach( () => {
 		vi.clearAllMocks();
-		mockedValidateValue.mockReturnValue( {} );
+		mockedLiveValidationMessages.mockReturnValue( {} );
 
 		mockPropertyType = createMockPropertyType( mockPropertyTypeNameFromComposable );
 
@@ -97,7 +97,7 @@ describe( 'useStringValueInput', () => {
 
 			const { fieldMessages, inputMessages } = createComposable( { modelValue: undefined, property: testProperty } );
 
-			expect( mockedValidateValue ).not.toHaveBeenCalled();
+			expect( mockedLiveValidationMessages ).not.toHaveBeenCalled();
 			expect( fieldMessages.value ).toEqual( {} );
 			expect( inputMessages.value ).toEqual( [] );
 		} );
@@ -110,12 +110,12 @@ describe( 'useStringValueInput', () => {
 
 		it( 'initializes internalValue with a StringValue-like object if modelValue is a valid StringValue', () => {
 			const initialValue = newStringValue( 'hello' );
-			mockedValidateValue.mockReturnValue( {} );
+			mockedLiveValidationMessages.mockReturnValue( {} );
 			const { getCurrentValue } = createComposable( { modelValue: initialValue } );
 			const currentValue = getCurrentValue();
 
 			expect( currentValue ).toEqual( newStringValue( 'hello' ) );
-			expect( mockedValidateValue ).toHaveBeenCalledWith( initialValue, mockPropertyType, expect.any( Object ) );
+			expect( mockedLiveValidationMessages ).toHaveBeenCalledWith( initialValue, mockPropertyType, expect.any( Object ) );
 		} );
 
 		it( 'initializes internalValue to undefined if modelValue is StringValue with only empty strings', () => {
@@ -133,24 +133,24 @@ describe( 'useStringValueInput', () => {
 		} );
 
 		it( 'initializes displayValues correctly based on modelValue', () => {
-			mockedValidateValue.mockReturnValue( {} );
+			mockedLiveValidationMessages.mockReturnValue( {} );
 			const { displayValues } = createComposable( { modelValue: newStringValue( 'test1', 'test2' ) } );
 
 			expect( displayValues.value ).toEqual( [ 'test1', 'test2' ] );
-			expect( mockedValidateValue ).toHaveBeenCalledTimes( 2 );
-			expect( mockedValidateValue ).toHaveBeenCalledWith( newStringValue( 'test1' ), mockPropertyType, expect.any( Object ) );
-			expect( mockedValidateValue ).toHaveBeenCalledWith( newStringValue( 'test2' ), mockPropertyType, expect.any( Object ) );
+			expect( mockedLiveValidationMessages ).toHaveBeenCalledTimes( 2 );
+			expect( mockedLiveValidationMessages ).toHaveBeenCalledWith( newStringValue( 'test1' ), mockPropertyType, expect.any( Object ) );
+			expect( mockedLiveValidationMessages ).toHaveBeenCalledWith( newStringValue( 'test2' ), mockPropertyType, expect.any( Object ) );
 		} );
 
 		it( 'initializes displayValues to an empty array if modelValue is undefined', () => {
 			const { displayValues } = createComposable( { modelValue: undefined } );
 
 			expect( displayValues.value ).toEqual( [] );
-			expect( mockedValidateValue ).not.toHaveBeenCalled();
+			expect( mockedLiveValidationMessages ).not.toHaveBeenCalled();
 		} );
 
 		it( 'fetches startIcon using ComponentRegistry and provides it via computed ref', () => {
-			mockedValidateValue.mockReturnValue( {} );
+			mockedLiveValidationMessages.mockReturnValue( {} );
 			const { startIcon } = createComposable();
 
 			expect( startIcon ).toBe( 'testIcon' );
@@ -161,7 +161,7 @@ describe( 'useStringValueInput', () => {
 	describe( 'onInput', () => {
 		it( 'updates internalValue and emits update:modelValue for a single valid input', () => {
 			const currentProperty = createMockPropertyDefinition( { multiple: false } );
-			mockedValidateValue.mockReturnValue( {} );
+			mockedLiveValidationMessages.mockReturnValue( {} );
 			const { onInput, getCurrentValue, inputMessages, fieldMessages } = createComposable( {
 				property: currentProperty,
 			} );
@@ -171,14 +171,14 @@ describe( 'useStringValueInput', () => {
 			const currentValue = getCurrentValue();
 			expect( currentValue ).toEqual( newStringValue( 'new value' ) );
 			expect( mockEmit ).toHaveBeenCalledWith( 'update:modelValue', currentValue );
-			expect( mockedValidateValue ).toHaveBeenCalledWith( newStringValue( 'new value' ), mockPropertyType, currentProperty );
+			expect( mockedLiveValidationMessages ).toHaveBeenCalledWith( newStringValue( 'new value' ), mockPropertyType, currentProperty );
 			expect( inputMessages.value ).toEqual( [ {} ] );
 			expect( fieldMessages.value ).toEqual( {} );
 		} );
 
 		it( 'updates internalValue and emits for multiple valid inputs', () => {
 			const currentProperty = createMockPropertyDefinition( { multiple: true } );
-			mockedValidateValue.mockReturnValue( {} );
+			mockedLiveValidationMessages.mockReturnValue( {} );
 			const { onInput, getCurrentValue, inputMessages, fieldMessages } = createComposable( {
 				property: currentProperty,
 			} );
@@ -188,33 +188,33 @@ describe( 'useStringValueInput', () => {
 			const currentValue = getCurrentValue();
 			expect( currentValue ).toEqual( newStringValue( 'val1', 'val2' ) );
 			expect( mockEmit ).toHaveBeenCalledWith( 'update:modelValue', currentValue );
-			expect( mockedValidateValue ).toHaveBeenCalledWith( newStringValue( 'val1' ), mockPropertyType, currentProperty );
-			expect( mockedValidateValue ).toHaveBeenCalledWith( newStringValue( 'val2' ), mockPropertyType, currentProperty );
+			expect( mockedLiveValidationMessages ).toHaveBeenCalledWith( newStringValue( 'val1' ), mockPropertyType, currentProperty );
+			expect( mockedLiveValidationMessages ).toHaveBeenCalledWith( newStringValue( 'val2' ), mockPropertyType, currentProperty );
 			expect( inputMessages.value ).toEqual( [ {}, {} ] );
 			expect( fieldMessages.value ).toEqual( {} );
 		} );
 
 		it( 'sets internalValue to undefined if all inputs become empty', () => {
 			const currentProperty = createMockPropertyDefinition( { multiple: false } );
-			mockedValidateValue.mockReturnValue( {} );
+			mockedLiveValidationMessages.mockReturnValue( {} );
 			const { onInput, getCurrentValue, inputMessages, fieldMessages } = createComposable( {
 				modelValue: newStringValue( 'initial' ),
 				property: currentProperty,
 			} );
-			mockedValidateValue.mockClear();
+			mockedLiveValidationMessages.mockClear();
 
 			onInput( '' );
 
 			expect( getCurrentValue() ).toBeUndefined();
 			expect( mockEmit ).toHaveBeenCalledWith( 'update:modelValue', undefined );
-			expect( mockedValidateValue ).toHaveBeenCalledWith( newStringValue( '' ), mockPropertyType, currentProperty );
+			expect( mockedLiveValidationMessages ).toHaveBeenCalledWith( newStringValue( '' ), mockPropertyType, currentProperty );
 			expect( inputMessages.value ).toEqual( [ {} ] );
 			expect( fieldMessages.value ).toEqual( {} );
 		} );
 
 		it( 'filters out empty strings from multiple inputs before creating StringValue for internal state, but validates all', () => {
 			const currentProperty = createMockPropertyDefinition( { multiple: true } );
-			mockedValidateValue.mockReturnValue( {} );
+			mockedLiveValidationMessages.mockReturnValue( {} );
 			const { onInput, getCurrentValue, inputMessages, fieldMessages } = createComposable( {
 				property: currentProperty,
 			} );
@@ -225,10 +225,10 @@ describe( 'useStringValueInput', () => {
 			expect( currentValue ).toEqual( newStringValue( 'val1', 'val3' ) );
 			expect( mockEmit ).toHaveBeenCalledWith( 'update:modelValue', currentValue );
 
-			expect( mockedValidateValue ).toHaveBeenCalledWith( newStringValue( 'val1' ), mockPropertyType, currentProperty );
-			expect( mockedValidateValue ).toHaveBeenCalledWith( newStringValue( '' ), mockPropertyType, currentProperty );
-			expect( mockedValidateValue ).toHaveBeenCalledWith( newStringValue( 'val3' ), mockPropertyType, currentProperty );
-			expect( mockedValidateValue ).toHaveBeenCalledTimes( 4 );
+			expect( mockedLiveValidationMessages ).toHaveBeenCalledWith( newStringValue( 'val1' ), mockPropertyType, currentProperty );
+			expect( mockedLiveValidationMessages ).toHaveBeenCalledWith( newStringValue( '' ), mockPropertyType, currentProperty );
+			expect( mockedLiveValidationMessages ).toHaveBeenCalledWith( newStringValue( 'val3' ), mockPropertyType, currentProperty );
+			expect( mockedLiveValidationMessages ).toHaveBeenCalledTimes( 4 );
 
 			expect( inputMessages.value ).toEqual( [ {}, {}, {}, {} ] );
 			expect( fieldMessages.value ).toEqual( {} );
@@ -236,19 +236,19 @@ describe( 'useStringValueInput', () => {
 
 		it( 'sets internalValue to undefined if only empty strings are provided in multiple inputs', () => {
 			const currentProperty = createMockPropertyDefinition( { multiple: true } );
-			mockedValidateValue.mockReturnValue( {} );
+			mockedLiveValidationMessages.mockReturnValue( {} );
 			const { onInput, getCurrentValue, inputMessages, fieldMessages } = createComposable( {
 				modelValue: newStringValue( 'initial' ),
 				property: currentProperty,
 			} );
-			mockedValidateValue.mockClear();
+			mockedLiveValidationMessages.mockClear();
 
 			onInput( [ '', '' ] );
 
 			expect( getCurrentValue() ).toBeUndefined();
 			expect( mockEmit ).toHaveBeenCalledWith( 'update:modelValue', undefined );
-			expect( mockedValidateValue ).toHaveBeenCalledWith( newStringValue( '' ), mockPropertyType, currentProperty );
-			expect( mockedValidateValue ).toHaveBeenCalledTimes( 2 );
+			expect( mockedLiveValidationMessages ).toHaveBeenCalledWith( newStringValue( '' ), mockPropertyType, currentProperty );
+			expect( mockedLiveValidationMessages ).toHaveBeenCalledTimes( 2 );
 			expect( inputMessages.value ).toEqual( [ {}, {} ] );
 			expect( fieldMessages.value ).toEqual( {} );
 		} );
@@ -257,7 +257,7 @@ describe( 'useStringValueInput', () => {
 	describe( 'Validation (doValidateInputs and its effects)', () => {
 		it( 'emits invalid input through to the backend (backend is the authoritative validator)', () => {
 			const validationError = { error: 'Invalid URL' };
-			mockedValidateValue.mockReturnValue( validationError );
+			mockedLiveValidationMessages.mockReturnValue( validationError );
 			const testProperty = createMockPropertyDefinition( { multiple: false } );
 			const { onInput, displayValues, getCurrentValue, fieldMessages } = createComposable( {
 				property: testProperty,
@@ -272,7 +272,7 @@ describe( 'useStringValueInput', () => {
 		} );
 
 		it( 'emits invalid replacement input so the backend sees it (no silent drop)', () => {
-			mockedValidateValue.mockReturnValue( {} );
+			mockedLiveValidationMessages.mockReturnValue( {} );
 			const testProperty = createMockPropertyDefinition( { multiple: false } );
 			const { onInput, displayValues, getCurrentValue, fieldMessages } = createComposable( {
 				modelValue: newStringValue( 'https://example.com' ),
@@ -280,7 +280,7 @@ describe( 'useStringValueInput', () => {
 			} );
 
 			const validationError = { error: 'Invalid URL' };
-			mockedValidateValue.mockReturnValue( validationError );
+			mockedLiveValidationMessages.mockReturnValue( validationError );
 
 			onInput( 'h' );
 
@@ -290,18 +290,18 @@ describe( 'useStringValueInput', () => {
 			expect( mockEmit ).toHaveBeenCalledWith( 'update:modelValue', newStringValue( 'h' ) );
 		} );
 
-		it( 'populates inputMessages and fieldMessages with errors from validateValue', () => {
-			const validationError = { error: 'Invalid from validateValue' };
-			mockedValidateValue.mockReturnValue( validationError );
+		it( 'populates inputMessages and fieldMessages with errors from liveValidationMessages', () => {
+			const validationError = { error: 'Invalid from liveValidationMessages' };
+			mockedLiveValidationMessages.mockReturnValue( validationError );
 			const testProperty = createMockPropertyDefinition( { multiple: false } );
 			const { onInput, inputMessages, fieldMessages } = createComposable( {
 				property: testProperty,
 			} );
-			mockedValidateValue.mockClear();
+			mockedLiveValidationMessages.mockClear();
 
 			onInput( 'trigger validation' );
 
-			expect( mockedValidateValue ).toHaveBeenCalledWith( newStringValue( 'trigger validation' ), mockPropertyType, testProperty );
+			expect( mockedLiveValidationMessages ).toHaveBeenCalledWith( newStringValue( 'trigger validation' ), mockPropertyType, testProperty );
 			expect( inputMessages.value ).toEqual( [ validationError ] );
 			expect( fieldMessages.value ).toEqual( validationError );
 		} );
@@ -309,7 +309,7 @@ describe( 'useStringValueInput', () => {
 		it( 'populates inputMessages but not fieldMessages for multiple inputs with errors', () => {
 			const validationError1 = { error: 'Error 1' };
 			const validationError3 = { warning: 'Warning 3' };
-			mockedValidateValue
+			mockedLiveValidationMessages
 				.mockReturnValueOnce( validationError1 )
 				.mockReturnValueOnce( {} )
 				.mockReturnValueOnce( validationError3 );
@@ -317,30 +317,30 @@ describe( 'useStringValueInput', () => {
 			const { onInput, inputMessages, fieldMessages } = createComposable( {
 				property: testProperty,
 			} );
-			mockedValidateValue.mockClear();
+			mockedLiveValidationMessages.mockClear();
 
 			onInput( [ 'input1', 'input2', 'input3' ] );
 
-			expect( mockedValidateValue ).toHaveBeenCalledWith( newStringValue( 'input1' ), mockPropertyType, testProperty );
-			expect( mockedValidateValue ).toHaveBeenCalledWith( newStringValue( 'input2' ), mockPropertyType, testProperty );
-			expect( mockedValidateValue ).toHaveBeenCalledWith( newStringValue( 'input3' ), mockPropertyType, testProperty );
+			expect( mockedLiveValidationMessages ).toHaveBeenCalledWith( newStringValue( 'input1' ), mockPropertyType, testProperty );
+			expect( mockedLiveValidationMessages ).toHaveBeenCalledWith( newStringValue( 'input2' ), mockPropertyType, testProperty );
+			expect( mockedLiveValidationMessages ).toHaveBeenCalledWith( newStringValue( 'input3' ), mockPropertyType, testProperty );
 			expect( inputMessages.value ).toEqual( [ validationError1, {}, validationError3 ] );
 			expect( fieldMessages.value ).toEqual( {} );
 		} );
 
 		it( 'handles uniqueItems validation for multiple inputs', () => {
 			const testProperty = createMockPropertyDefinition( { multiple: true, uniqueItems: true } );
-			mockedValidateValue.mockReturnValue( {} );
+			mockedLiveValidationMessages.mockReturnValue( {} );
 			const { onInput, inputMessages, fieldMessages } = createComposable( {
 				property: testProperty,
 			} );
-			mockedValidateValue.mockClear();
+			mockedLiveValidationMessages.mockClear();
 
 			onInput( [ 'duplicate', 'unique', 'duplicate' ] );
 
-			expect( mockedValidateValue ).toHaveBeenCalledWith( newStringValue( 'duplicate' ), mockPropertyType, testProperty );
-			expect( mockedValidateValue ).toHaveBeenCalledWith( newStringValue( 'unique' ), mockPropertyType, testProperty );
-			expect( mockedValidateValue ).toHaveBeenCalledTimes( 2 );
+			expect( mockedLiveValidationMessages ).toHaveBeenCalledWith( newStringValue( 'duplicate' ), mockPropertyType, testProperty );
+			expect( mockedLiveValidationMessages ).toHaveBeenCalledWith( newStringValue( 'unique' ), mockPropertyType, testProperty );
+			expect( mockedLiveValidationMessages ).toHaveBeenCalledTimes( 2 );
 
 			expect( inputMessages.value[ 0 ] ).toEqual( {} );
 			expect( inputMessages.value[ 1 ] ).toEqual( {} );
@@ -348,15 +348,15 @@ describe( 'useStringValueInput', () => {
 			expect( fieldMessages.value ).toEqual( {} );
 		} );
 
-		it( 'initial validation is run on setup with modelValue, calling validateValue', () => {
+		it( 'initial validation is run on setup with modelValue, calling liveValidationMessages', () => {
 			const initialValue = newStringValue( 'initial value' );
 			const validationError = { error: 'Initial validation error' };
-			mockedValidateValue.mockReturnValue( validationError );
+			mockedLiveValidationMessages.mockReturnValue( validationError );
 			const currentProperty = createMockPropertyDefinition( {} );
 
 			const { inputMessages, fieldMessages } = createComposable( { modelValue: initialValue, property: currentProperty } );
 
-			expect( mockedValidateValue ).toHaveBeenCalledWith( initialValue, mockPropertyType, currentProperty );
+			expect( mockedLiveValidationMessages ).toHaveBeenCalledWith( initialValue, mockPropertyType, currentProperty );
 			expect( inputMessages.value ).toEqual( [ validationError ] );
 			expect( fieldMessages.value ).toEqual( validationError );
 		} );
@@ -368,20 +368,20 @@ describe( 'useStringValueInput', () => {
 			const modelValueRef = ref<Value | undefined>( initialModelValue );
 			const propertyRef = ref( createMockPropertyDefinition( { multiple: false } ) ) as Ref<MultiStringProperty>;
 
-			mockedValidateValue.mockReturnValueOnce( {} );
+			mockedLiveValidationMessages.mockReturnValueOnce( {} );
 			const composableInstance = useStringValueInput( modelValueRef, propertyRef, mockEmit, mockPropertyType );
-			expect( mockedValidateValue ).toHaveBeenCalledWith( initialModelValue, mockPropertyType, propertyRef.value );
+			expect( mockedLiveValidationMessages ).toHaveBeenCalledWith( initialModelValue, mockPropertyType, propertyRef.value );
 			expect( composableInstance.inputMessages.value ).toEqual( [ {} ] );
 			expect( composableInstance.fieldMessages.value ).toEqual( {} );
 
 			const newModelValue = newStringValue( 'changed' );
 			const validationError = { error: 'Error on changed' };
-			mockedValidateValue.mockReset().mockReturnValue( validationError );
+			mockedLiveValidationMessages.mockReset().mockReturnValue( validationError );
 
 			modelValueRef.value = newModelValue;
 			await nextTick();
 
-			expect( mockedValidateValue ).toHaveBeenCalledWith( newModelValue, mockPropertyType, propertyRef.value );
+			expect( mockedLiveValidationMessages ).toHaveBeenCalledWith( newModelValue, mockPropertyType, propertyRef.value );
 			expect( composableInstance.getCurrentValue() ).toEqual( newStringValue( 'changed' ) );
 			expect( composableInstance.inputMessages.value ).toEqual( [ validationError ] );
 			expect( composableInstance.fieldMessages.value ).toEqual( validationError );
@@ -392,22 +392,22 @@ describe( 'useStringValueInput', () => {
 			const modelValueRef = ref<Value | undefined>( initialModelValue );
 			const propertyRef = ref( createMockPropertyDefinition( { required: false, multiple: false } ) ) as Ref<MultiStringProperty>;
 
-			mockedValidateValue.mockReturnValueOnce( {} );
+			mockedLiveValidationMessages.mockReturnValueOnce( {} );
 			const { inputMessages, fieldMessages: composableFieldMessages, displayValues } = useStringValueInput( modelValueRef, propertyRef, mockEmit, mockPropertyType );
-			expect( mockedValidateValue ).toHaveBeenCalledWith( initialModelValue, mockPropertyType, propertyRef.value );
+			expect( mockedLiveValidationMessages ).toHaveBeenCalledWith( initialModelValue, mockPropertyType, propertyRef.value );
 			expect( inputMessages.value ).toEqual( [ {} ] );
 			expect( composableFieldMessages.value ).toEqual( {} );
 
 			let newTestProperty = createMockPropertyDefinition( { required: true, multiple: false } );
 			newTestProperty = markRaw( newTestProperty );
 			const validationErrorOnPropChange = { error: 'Error on prop change' };
-			mockedValidateValue.mockReset().mockReturnValue( validationErrorOnPropChange );
+			mockedLiveValidationMessages.mockReset().mockReturnValue( validationErrorOnPropChange );
 
 			propertyRef.value = newTestProperty;
 			await nextTick();
 
 			const currentValueForValidation = displayValues.value.length > 0 ? newStringValue( ...displayValues.value ) : newStringValue( '' );
-			expect( mockedValidateValue ).toHaveBeenCalledWith( currentValueForValidation, mockPropertyType, newTestProperty );
+			expect( mockedLiveValidationMessages ).toHaveBeenCalledWith( currentValueForValidation, mockPropertyType, newTestProperty );
 			expect( inputMessages.value ).toEqual( [ validationErrorOnPropChange ] );
 			expect( composableFieldMessages.value ).toEqual( validationErrorOnPropChange );
 		} );
@@ -415,7 +415,7 @@ describe( 'useStringValueInput', () => {
 
 	describe( 'getCurrentValue', () => {
 		it( 'returns the current internalValue', () => {
-			mockedValidateValue.mockReturnValue( {} );
+			mockedLiveValidationMessages.mockReturnValue( {} );
 			const { getCurrentValue, onInput } = createComposable();
 
 			expect( getCurrentValue() ).toBeUndefined();
@@ -443,7 +443,7 @@ describe( 'useStringValueInput', () => {
 			const modelValueRef = ref<Value | undefined>( undefined );
 			const propertyRef = ref( createMockPropertyDefinition( property ) ) as Ref<MultiStringProperty>;
 			const serverViolationsRef = ref<any[]>( violations );
-			mockedValidateValue.mockReturnValue( {} );
+			mockedLiveValidationMessages.mockReturnValue( {} );
 
 			const result = useStringValueInput(
 				modelValueRef,
@@ -480,7 +480,7 @@ describe( 'useStringValueInput', () => {
 
 		it( 'live error takes precedence over server violation for single-value property', async () => {
 			const liveError = { error: 'live-validation-error' };
-			mockedValidateValue.mockReturnValue( liveError );
+			mockedLiveValidationMessages.mockReturnValue( liveError );
 			const modelValueRef = ref<Value | undefined>( newStringValue( 'bad' ) );
 			const propertyRef = ref( createMockPropertyDefinition( {
 				name: new PropertyName( 'testProp' ),
@@ -516,7 +516,7 @@ describe( 'useStringValueInput', () => {
 		} );
 
 		it( 'emits clear-server-violation when user edits a single-value field that had a server violation', async () => {
-			mockedValidateValue.mockReturnValue( {} );
+			mockedLiveValidationMessages.mockReturnValue( {} );
 			const { onInput } = createComposableWithViolations(
 				[ { propertyName: 'testProp', code: 'required', args: [], valuePartIndex: null } ],
 				{ name: new PropertyName( 'testProp' ), multiple: false },
@@ -531,7 +531,7 @@ describe( 'useStringValueInput', () => {
 		} );
 
 		it( 'does not emit clear-server-violation when no server violation exists for this property', async () => {
-			mockedValidateValue.mockReturnValue( {} );
+			mockedLiveValidationMessages.mockReturnValue( {} );
 			const { onInput } = createComposableWithViolations(
 				[],
 				{ name: new PropertyName( 'testProp' ), multiple: false },
@@ -543,7 +543,7 @@ describe( 'useStringValueInput', () => {
 		} );
 
 		it( 'emits clear-server-violation only for the changed index in a multi-value field', async () => {
-			mockedValidateValue.mockReturnValue( {} );
+			mockedLiveValidationMessages.mockReturnValue( {} );
 			const modelValueRef = ref<Value | undefined>( newStringValue( 'https://ok.example', 'bad' ) );
 			const propertyRef = ref( createMockPropertyDefinition( {
 				name: new PropertyName( 'testProp' ),
@@ -573,7 +573,7 @@ describe( 'useStringValueInput', () => {
 		} );
 
 		it( 'does not emit clear-server-violation when editing index 0 and violation is only at index 1', async () => {
-			mockedValidateValue.mockReturnValue( {} );
+			mockedLiveValidationMessages.mockReturnValue( {} );
 			const modelValueRef = ref<Value | undefined>( newStringValue( 'first', 'bad' ) );
 			const propertyRef = ref( createMockPropertyDefinition( {
 				name: new PropertyName( 'testProp' ),
@@ -600,7 +600,7 @@ describe( 'useStringValueInput', () => {
 		} );
 
 		it( 'recomputes messages when serverViolations ref changes', async () => {
-			mockedValidateValue.mockReturnValue( {} );
+			mockedLiveValidationMessages.mockReturnValue( {} );
 			const modelValueRef = ref<Value | undefined>( undefined );
 			const propertyRef = ref( createMockPropertyDefinition( {
 				name: new PropertyName( 'testProp' ),

--- a/resources/ext.neowiki/tests/composables/useValueValidation.spec.ts
+++ b/resources/ext.neowiki/tests/composables/useValueValidation.spec.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+	SERVER_ENFORCED_CODES,
+	liveValidationErrors,
+	liveValidationMessages,
+	validateValue,
+} from '@/composables/useValueValidation.ts';
+import { PropertyType, ValueValidationError } from '@/domain/PropertyType.ts';
+import { Value, newStringValue } from '@/domain/Value.ts';
+import { PropertyDefinition } from '@/domain/PropertyDefinition.ts';
+
+vi.stubGlobal( 'mw', {
+	message: vi.fn( ( key: string ) => ( {
+		text: () => key,
+		parse: () => key,
+	} ) ),
+} );
+
+function propertyTypeReturning( errors: ValueValidationError[] ): PropertyType {
+	return { validate: () => errors } as unknown as PropertyType;
+}
+
+const anyValue: Value = newStringValue( 'x' );
+const anyProperty = {} as PropertyDefinition;
+
+describe( 'useValueValidation', () => {
+	it( 'treats required as a server-enforced code', () => {
+		expect( SERVER_ENFORCED_CODES ).toContain( 'required' );
+	} );
+
+	describe( 'liveValidationErrors', () => {
+		it( 'drops server-enforced codes while keeping the surrounding ones', () => {
+			const propertyType = propertyTypeReturning( [
+				{ code: 'min-value', args: [ 1 ] },
+				{ code: 'required' },
+				{ code: 'max-value', args: [ 9 ] },
+			] );
+
+			const errors = liveValidationErrors( anyValue, propertyType, anyProperty );
+
+			expect( errors ).toEqual( [
+				{ code: 'min-value', args: [ 1 ] },
+				{ code: 'max-value', args: [ 9 ] },
+			] );
+		} );
+
+		it( 'returns no errors when only a server-enforced code is present', () => {
+			const propertyType = propertyTypeReturning( [ { code: 'required' } ] );
+
+			expect( liveValidationErrors( anyValue, propertyType, anyProperty ) ).toEqual( [] );
+		} );
+	} );
+
+	describe( 'liveValidationMessages', () => {
+		it( 'formats the first live error and skips server-enforced codes', () => {
+			const propertyType = propertyTypeReturning( [
+				{ code: 'required' },
+				{ code: 'min-value' },
+			] );
+
+			expect( liveValidationMessages( anyValue, propertyType, anyProperty ) )
+				.toEqual( { error: 'neowiki-field-min-value' } );
+		} );
+
+		it( 'returns no message when only a server-enforced code is present', () => {
+			const propertyType = propertyTypeReturning( [ { code: 'required' } ] );
+
+			expect( liveValidationMessages( anyValue, propertyType, anyProperty ) ).toEqual( {} );
+		} );
+	} );
+
+	describe( 'validateValue', () => {
+		it( 'surfaces server-enforced codes, unlike the live helpers', () => {
+			const propertyType = propertyTypeReturning( [ { code: 'required' } ] );
+
+			expect( validateValue( anyValue, propertyType, anyProperty ) )
+				.toEqual( { error: 'neowiki-field-required' } );
+		} );
+	} );
+} );


### PR DESCRIPTION
> Surfaced while reviewing #933 / #941 with @alistair3149, who asked whether the per-input `required` filter should be replaced with a cleaner single source of truth.
> Context: the NeoWiki codebase — every value input component and the shared validation helpers.
> <sub>Written by Claude Code, `Opus 4.8`</sub>

Supersedes #941. Follows-up to #933.

## Why

#886 established that `required` is enforced by the server and is not flagged in live client-side validation before the user has entered a value. Each value input applied that policy itself: `SelectInput`, `DateInput`, and `DateTimeInput` filtered the `required` code inline (`.filter( e => e.code !== 'required' )`); `NumberInput` and the `TextInput` / `UrlInput` path did not, so they still flagged `required` live after a field was filled and then cleared; `RelationInput` uses its own `touched` gate. The rule lived in several places, which is why `DateInput` / `DateTimeInput` were missed in #933 and `NumberInput` needed the #941 follow-up.

## What

A single source of truth in `useValueValidation.ts`:

- `SERVER_ENFORCED_CODES = [ 'required' ]` — the codes the server is authoritative for.
- `liveValidationErrors()` — `propertyType.validate()` minus those codes; used by the single-value inputs.
- `liveValidationMessages()` — the formatted variant; used by `useStringValueInput` (Text / Url).
- `validateValue()` is unchanged in behavior (still surfaces every code, including `required`). It no longer has an internal caller — the string inputs moved to `liveValidationMessages` — and is kept as the full-validation variant.

Every value input now routes its live validation through the shared helper instead of filtering inline.

`useValueValidation` is re-exported by `public-api.ts` (`export *`), so the three new symbols (`SERVER_ENFORCED_CODES`, `liveValidationErrors`, `liveValidationMessages`) become part of the public API surface — intentional, since extension-authored value inputs should be able to apply the same policy. Flag if you'd rather they stay internal.

Behavior:

- `SelectInput` / `DateInput` / `DateTimeInput`: no change (same filter, now centralized).
- `NumberInput`, `TextInput`, `UrlInput`: now defer `required` to the server too — they previously flagged it live after a field was filled and then cleared. This folds in and supersedes #941.
- `BooleanInput`: no observable change (`BooleanType` never emits `required`); routed through the helper for uniformity.
- Schema editor: unchanged (`TextAttributesEditor` uses its own local validation, not these helpers).

`RelationInput` is intentionally left out: it gates error display behind a `touched` ref, and reconciling that with server-violation surfacing is a separate change being handled elsewhere.

## Tests

- New `useValueValidation.spec.ts` pins the policy at the source (the live helpers drop `required` and keep other codes; `validateValue` keeps `required`).
- `NumberInput.spec.ts` gains a regression test (a cleared required field is no longer flagged — it fails without the filter) and a server-sourced-`required` isolation test.
- `useStringValueInput.spec.ts` is updated to the renamed helper (a pure rename; assertion count unchanged).

## Manual Browser Check

1. Create or edit a Schema with a required `number` property (and a required `text` property).
2. Open the subject creation / editing form, type a value into the field, then clear it.
3. **Before:** a red "Please provide a value." appeared the moment the field was cleared. **After:** the field stays clean (`default` status); `required` is enforced by the server at save, consistent with date, datetime, and select fields.
4. Confirm `min` / `max` (number) and other live validations still appear immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
