### PR TITLE
Note the Lua inverse-display trade-offs on the life-events hub

### DIFF
--- a/DemoData/Page/People_and_life_events.wikitext
+++ b/DemoData/Page/People_and_life_events.wikitext
@@ -49,7 +49,7 @@ This dataset partially maps to [http://www.cidoc-crm.org/ CIDOC CRM]. The canoni
 == How this is built ==
 
 * Schemas: [[Schema:Person]], [[Schema:Birth]], [[Schema:Place]]
-* The "was born" line on each person page is computed by [[Module:NeoWikiDemo]] (the <code>personEvents</code> function), which reverse-queries the graph rather than storing an inverse edge. This Lua reverse-query is the display approach available today; it runs outside the view system, so schema-configured display attributes do not apply, and a first-class display path for inverse and child Subjects is an open question.
+* The "was born" line on each person page is computed by [[Module:NeoWikiDemo]] (the <code>personEvents</code> function), which reverse-queries the graph rather than storing an inverse edge. This Lua reverse-query is the display approach available today; using the view system for first-class display is an open task.
 * The tables above come from Cypher queries via [[Module:NeoWikiDemo]].
 * See the source of one subject: [{{fullurl:Birth of Johann Sebastian Bach|action=edit}} Edit Birth of Johann Sebastian Bach]
 * [{{fullurl:{{FULLPAGENAME}}|action=edit}} Edit this page]

--- a/DemoData/Page/People_and_life_events.wikitext
+++ b/DemoData/Page/People_and_life_events.wikitext
@@ -49,7 +49,7 @@ This dataset partially maps to [http://www.cidoc-crm.org/ CIDOC CRM]. The canoni
 == How this is built ==
 
 * Schemas: [[Schema:Person]], [[Schema:Birth]], [[Schema:Place]]
-* The "was born" line on each person page is computed by [[Module:NeoWikiDemo]] (the <code>personEvents</code> function), which reverse-queries the graph rather than storing an inverse edge.
+* The "was born" line on each person page is computed by [[Module:NeoWikiDemo]] (the <code>personEvents</code> function), which reverse-queries the graph rather than storing an inverse edge. This Lua reverse-query is the display approach available today; it runs outside the view system, so schema-configured display attributes do not apply, and a first-class display path for inverse and child Subjects is an open question.
 * The tables above come from Cypher queries via [[Module:NeoWikiDemo]].
 * See the source of one subject: [{{fullurl:Birth of Johann Sebastian Bach|action=edit}} Edit Birth of Johann Sebastian Bach]
 * [{{fullurl:{{FULLPAGENAME}}|action=edit}} Edit this page]


### PR DESCRIPTION
> Result of reviewing #927 with @JeroenDeDauw; this is the one editorialization item surfaced by that review.
> Context: the NeoWiki DemoData corpus and the People and life events hub.
> <sub>Written by Claude Code, `Opus 4.8`</sub>

Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/927

The hub presented the `personEvents` Lua reverse-query as the way to show a person's inverse/child Subjects without noting its trade-offs. Add one sentence flagging that it runs outside the view system (so schema-configured display attributes don't apply) and that a first-class display path for inverse and child Subjects is an open question.