### PR TITLE
Store the full prefixed page title and namespace ID on page nodes

### DIFF
--- a/docs/concepts/glossary.md
+++ b/docs/concepts/glossary.md
@@ -140,8 +140,8 @@ Display Rules have:
 A key-value pair stored on the Page node in the graph database. Page Properties are metadata about the wiki page
 itself, as opposed to Subject Statements, which are structured data about the entities described on the page.
 
-Built-in Page Properties include `name`, `creationTime`, `lastUpdated`, `categories`, and `lastEditor`. Extensions can
-contribute additional Page Properties.
+Built-in Page Properties include `name`, `namespaceId`, `creationTime`, `lastUpdated`, `categories`, and `lastEditor`.
+Extensions can contribute additional Page Properties.
 
 When using Neo4j, Page Properties are available on every Page node and are queryable via Cypher
 (e.g., `MATCH (page:Page) WHERE page.lastUpdated > datetime("2024-01-01")`).

--- a/docs/reference/graph-model.md
+++ b/docs/reference/graph-model.md
@@ -37,7 +37,8 @@ page ids are only unique within a single wiki. Each page node therefore carries 
 |----------|------------|-------------|
 | `wiki_id` | string | [MediaWiki Wiki ID](https://www.mediawiki.org/wiki/Manual:Wiki_ID) (database name + table prefix) of the owning wiki |
 | `id` | integer | MediaWiki page ID (unique per wiki) |
-| `name` | string | Page title |
+| `name` | string | Full page title, including the namespace prefix (e.g. `Help:Installation`) |
+| `namespaceId` | integer | MediaWiki namespace ID of the page (e.g. `0` for the main namespace, `12` for Help) |
 | `creationTime` | datetime | When the page was created |
 | `lastUpdated` | datetime | When the page was last modified |
 | `lastEditor` | string | Username of the last editor |

--- a/docs/reference/subject-format.md
+++ b/docs/reference/subject-format.md
@@ -193,7 +193,8 @@ See [ADR 014](../adr/014-improved-id-format.md) for details on the ID format.
 
 Returns the same statement format as storage, with additional fields:
 - `requestedId`: The ID that was requested
-- Each subject includes `id`, `pageId`, and `pageTitle` fields
+- Each subject includes `id`, `pageId`, and `pageTitle` fields. `pageTitle` is the full page
+  title including the namespace prefix (e.g. `Help:Installation`).
 
 ### Writing Subjects
 

--- a/src/Domain/Page/PagePropertyProviderContext.php
+++ b/src/Domain/Page/PagePropertyProviderContext.php
@@ -7,7 +7,8 @@ namespace ProfessionalWiki\NeoWiki\Domain\Page;
 readonly class PagePropertyProviderContext {
 
 	/**
-	 * @param string $pageTitle Page title text without namespace prefix, e.g. "My Page" not "Talk:My Page"
+	 * @param string $pageTitle Full prefixed page title, e.g. "Help:My Page" ("My Page" in the main namespace)
+	 * @param int $namespaceId MediaWiki namespace ID, e.g. 0 for the main namespace or 12 for Help
 	 * @param string $creationTime In the standard MediaWiki format, ie 20230726163439
 	 * @param string $modificationTime In the standard MediaWiki format, ie 20230726163439
 	 * @param string[] $categories
@@ -16,6 +17,7 @@ readonly class PagePropertyProviderContext {
 	public function __construct(
 		public PageId $pageId,
 		public string $pageTitle,
+		public int $namespaceId,
 		public string $creationTime,
 		public string $modificationTime,
 		public array $categories,

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -203,6 +203,7 @@ class NeoWikiExtension {
 			new PagePropertiesBuilder(
 				revisionStore: MediaWikiServices::getInstance()->getRevisionStore(),
 				contentHandlerFactory: MediaWikiServices::getInstance()->getContentHandlerFactory(),
+				titleFormatter: MediaWikiServices::getInstance()->getTitleFormatter(),
 				providerRegistry: $this->getPagePropertyProviderRegistry(),
 			)
 		);

--- a/src/PagePropertiesBuilder.php
+++ b/src/PagePropertiesBuilder.php
@@ -9,6 +9,7 @@ use MediaWiki\Content\Renderer\ContentParseParams;
 use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Revision\RevisionStore;
 use MediaWiki\Revision\SlotRecord;
+use MediaWiki\Title\TitleFormatter;
 use MediaWiki\User\UserIdentity;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageProperties;
@@ -20,6 +21,7 @@ readonly class PagePropertiesBuilder {
 	public function __construct(
 		private RevisionStore $revisionStore,
 		private IContentHandlerFactory $contentHandlerFactory,
+		private TitleFormatter $titleFormatter,
 		private PagePropertyProviderRegistry $providerRegistry,
 	) {
 	}
@@ -37,9 +39,12 @@ readonly class PagePropertiesBuilder {
 	}
 
 	private function buildContext( RevisionRecord $revision, ?UserIdentity $user ): PagePropertyProviderContext {
+		$linkTarget = $revision->getPageAsLinkTarget();
+
 		return new PagePropertyProviderContext(
 			pageId: new PageId( $revision->getPageId() ),
-			pageTitle: $revision->getPageAsLinkTarget()->getText(),
+			pageTitle: $this->titleFormatter->getPrefixedText( $linkTarget ),
+			namespaceId: $linkTarget->getNamespace(),
 			creationTime: $this->getCreationTime( $revision ),
 			modificationTime: $this->getModificationTime( $revision ),
 			categories: $this->getCategories( $revision ),

--- a/src/Persistence/CorePagePropertyProvider.php
+++ b/src/Persistence/CorePagePropertyProvider.php
@@ -13,6 +13,7 @@ class CorePagePropertyProvider implements PagePropertyProvider {
 	public function getProperties( PagePropertyProviderContext $context ): array {
 		return [
 			'name' => $context->pageTitle,
+			'namespaceId' => $context->namespaceId,
 			'creationTime' => new PageDateTime( $context->creationTime ),
 			'lastUpdated' => new PageDateTime( $context->modificationTime ),
 			'categories' => $context->categories,

--- a/tests/phpunit/Data/TestPageProperties.php
+++ b/tests/phpunit/Data/TestPageProperties.php
@@ -14,6 +14,7 @@ class TestPageProperties {
 	 */
 	public static function build(
 		string $title = 'PageTitle',
+		int $namespaceId = 0,
 		string $creationTime = '20230726163439',
 		string $modificationTime = '20230726163439',
 		array $categories = [],
@@ -23,6 +24,7 @@ class TestPageProperties {
 		return new PageProperties( array_merge(
 			[
 				'name' => $title,
+				'namespaceId' => $namespaceId,
 				'creationTime' => new PageDateTime( $creationTime ),
 				'lastUpdated' => new PageDateTime( $modificationTime ),
 				'categories' => $categories,

--- a/tests/phpunit/EntryPoints/NamespacedPageGraphProjectionTest.php
+++ b/tests/phpunit/EntryPoints/NamespacedPageGraphProjectionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints;
+
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+
+/**
+ * The page node name must carry the full title including the namespace prefix, so that
+ * consumers such as the relation value link can build a correct URL for subjects stored
+ * on pages outside the main namespace.
+ *
+ * @covers \ProfessionalWiki\NeoWiki\PagePropertiesBuilder
+ * @covers \ProfessionalWiki\NeoWiki\Persistence\CorePagePropertyProvider
+ * @group Database
+ */
+class NamespacedPageGraphProjectionTest extends NeoWikiIntegrationTestCase {
+
+	private const PAGE_NAME = 'Help:Namespaced subject page';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->setUpNeo4j();
+		$this->createSchema( TestSubject::DEFAULT_SCHEMA_ID );
+		$this->markPageTableAsUsed();
+	}
+
+	public function testPageNodeNameIncludesNamespacePrefix(): void {
+		$revision = $this->createPageWithSubjects( self::PAGE_NAME, TestSubject::build() );
+
+		$this->assertSame(
+			self::PAGE_NAME,
+			$this->readPageNodeName( $revision->getPageId() )
+		);
+	}
+
+	public function testPageNodeStoresNamespaceId(): void {
+		$revision = $this->createPageWithSubjects( self::PAGE_NAME, TestSubject::build() );
+
+		$this->assertSame(
+			NS_HELP,
+			$this->readPageNodeNamespaceId( $revision->getPageId() )
+		);
+	}
+
+}

--- a/tests/phpunit/EntryPoints/PageMoveGraphProjectionTest.php
+++ b/tests/phpunit/EntryPoints/PageMoveGraphProjectionTest.php
@@ -39,6 +39,18 @@ class PageMoveGraphProjectionTest extends NeoWikiIntegrationTestCase {
 		);
 	}
 
+	public function testMovingPageToAnotherNamespaceUpdatesNamespaceId(): void {
+		$revision = $this->createPageWithSubjects( 'Namespace move source', TestSubject::build() );
+		$pageId = $revision->getPageId();
+
+		$this->movePage( 'Namespace move source', 'Help:Namespace move target' );
+
+		$this->assertSame(
+			NS_HELP,
+			$this->readPageNodeNamespaceId( $pageId )
+		);
+	}
+
 	private function movePage( string $from, string $to ): void {
 		$movePage = MediaWikiServices::getInstance()->getMovePageFactory()->newMovePage(
 			Title::newFromText( $from ),

--- a/tests/phpunit/EntryPoints/PageMoveGraphProjectionTest.php
+++ b/tests/phpunit/EntryPoints/PageMoveGraphProjectionTest.php
@@ -51,13 +51,4 @@ class PageMoveGraphProjectionTest extends NeoWikiIntegrationTestCase {
 		DeferredUpdates::doUpdates();
 	}
 
-	private function readPageNodeName( int $pageId ): ?string {
-		$result = $this->newNeo4jQueryStore()->runReadQuery(
-			'MATCH (page:Page {id: $pageId}) RETURN page.name AS name',
-			[ 'pageId' => $pageId ]
-		);
-
-		return $result->first()->toRecursiveArray()['name'] ?? null;
-	}
-
 }

--- a/tests/phpunit/NeoWikiIntegrationTestCase.php
+++ b/tests/phpunit/NeoWikiIntegrationTestCase.php
@@ -86,4 +86,22 @@ class NeoWikiIntegrationTestCase extends MediaWikiIntegrationTestCase {
 		);
 	}
 
+	protected function readPageNodeName( int $pageId ): ?string {
+		$result = $this->newNeo4jQueryStore()->runReadQuery(
+			'MATCH (page:Page {id: $pageId}) RETURN page.name AS name',
+			[ 'pageId' => $pageId ]
+		);
+
+		return $result->first()->toRecursiveArray()['name'] ?? null;
+	}
+
+	protected function readPageNodeNamespaceId( int $pageId ): ?int {
+		$result = $this->newNeo4jQueryStore()->runReadQuery(
+			'MATCH (page:Page {id: $pageId}) RETURN page.namespaceId AS namespaceId',
+			[ 'pageId' => $pageId ]
+		);
+
+		return $result->first()->toRecursiveArray()['namespaceId'] ?? null;
+	}
+
 }

--- a/tests/phpunit/Persistence/CorePagePropertyProviderTest.php
+++ b/tests/phpunit/Persistence/CorePagePropertyProviderTest.php
@@ -19,7 +19,7 @@ class CorePagePropertyProviderTest extends TestCase {
 		$properties = $this->getPropertiesForContext();
 
 		$this->assertSame(
-			[ 'name', 'creationTime', 'lastUpdated', 'categories', 'lastEditor' ],
+			[ 'name', 'namespaceId', 'creationTime', 'lastUpdated', 'categories', 'lastEditor' ],
 			array_keys( $properties )
 		);
 	}
@@ -28,6 +28,12 @@ class CorePagePropertyProviderTest extends TestCase {
 		$properties = $this->getPropertiesForContext( pageTitle: 'Test Page' );
 
 		$this->assertSame( 'Test Page', $properties['name'] );
+	}
+
+	public function testNamespaceIdMatchesContext(): void {
+		$properties = $this->getPropertiesForContext( namespaceId: 12 );
+
+		$this->assertSame( 12, $properties['namespaceId'] );
 	}
 
 	public function testCreationTimeIsPageDateTime(): void {
@@ -61,6 +67,7 @@ class CorePagePropertyProviderTest extends TestCase {
 	 */
 	private function getPropertiesForContext(
 		string $pageTitle = 'Default Title',
+		int $namespaceId = 0,
 		string $creationTime = '20230101000000',
 		string $modificationTime = '20230101000000',
 		array $categories = [],
@@ -70,6 +77,7 @@ class CorePagePropertyProviderTest extends TestCase {
 			new PagePropertyProviderContext(
 				pageId: new PageId( 1 ),
 				pageTitle: $pageTitle,
+				namespaceId: $namespaceId,
 				creationTime: $creationTime,
 				modificationTime: $modificationTime,
 				categories: $categories,


### PR DESCRIPTION
> Result of work directed by @JeroenDeDauw, who asked to verify the bug first and then flagged the related issue #682 — expanding the scope from relation-specific to the underlying page-title representation.
> Context: the NeoWiki codebase and issues #940 and #682.
> <sub>Written by Claude Code, `Opus 4.8 (1M context)`</sub>

Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/940
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/682

Page nodes stored `name` as the namespace-stripped title (via
`LinkTarget::getText()`), so a subject on a page outside the main namespace
(e.g. `Help:Foo`) got a `name` of "Foo". The relation value renderer builds its
link from this title via `mw.util.getUrl()`, so relations to such subjects
linked to the wrong main-namespace page. The stripped name also made
`User:JohnDoe` and a mainspace `JohnDoe` indistinguishable.

`name` now holds the full prefixed title (`getPrefixedText()`), so relation
links resolve correctly and the property unambiguously identifies a page. A new
`namespaceId` page property exposes the canonical MediaWiki namespace ID for
robust namespace filtering in Cypher (`WHERE page.namespaceId = 12`), avoiding
fragile prefix-string matching on localized namespace names.

NeoWiki is not in production, so the changed `name` representation needs no data
migration.

## Verification

- New integration test creates a `Help:`-namespaced page and asserts the graph node carries the prefixed `name` and `namespaceId`; seen failing before the fix.
- Unit + integration tests for the new `namespaceId` property, verified failing without the production code.
- Full PHPUnit suite, phpcs and phpstan green.
- Confirmed on a live dev stack: the REST API returns `pageTitle: "Help:Ns Link Verify"` (the exact value the relation link is built from) and a Cypher query returns `name: "Help:Ns Link Verify"`, `namespaceId: 12`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
