### PR TITLE
Verify page-node name uses the content-language namespace prefix

### DIFF
--- a/tests/phpunit/EntryPoints/NamespacedPageGraphProjectionTest.php
+++ b/tests/phpunit/EntryPoints/NamespacedPageGraphProjectionTest.php
@@ -36,6 +36,19 @@ class NamespacedPageGraphProjectionTest extends NeoWikiIntegrationTestCase {
 		);
 	}
 
+	public function testPageNodeNameUsesContentLanguageNamespacePrefix(): void {
+		$this->setContentLang( 'de' );
+
+		$revision = $this->createPageWithSubjects( self::PAGE_NAME, TestSubject::build() );
+
+		// The German content language localizes the "Help" namespace to "Hilfe", proving the
+		// stored name uses the content-language prefix, not a canonical or interface-language one.
+		$this->assertSame(
+			'Hilfe:Namespaced subject page',
+			$this->readPageNodeName( $revision->getPageId() )
+		);
+	}
+
 	public function testPageNodeStoresNamespaceId(): void {
 		$revision = $this->createPageWithSubjects( self::PAGE_NAME, TestSubject::build() );
 


### PR DESCRIPTION
> Implements a test-coverage suggestion I raised while reviewing #946, at @JeroenDeDauw's request.
> Context: the NeoWiki codebase, PR #946, and MediaWiki's content-language namespace handling.
> <sub>Written by Claude Code, `Opus 4.8 (1M context)`</sub>

Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/946

Adds an integration test asserting the page node's `name` carries the content-language namespace prefix, not a canonical English or interface-language one.

The existing `testPageNodeNameIncludesNamespacePrefix` runs on the default English test wiki, where the content-language prefix (`Help:`) and the canonical English name coincide, so it cannot detect a regression to canonical or hardcoded namespace names. This test sets the content language to German and asserts the stored name is `Hilfe:...`, locking in the content-language behaviour the relation link URL relies on for wikis whose content language is not English.

Verified by mutation: with the namespace stripped (`getText()`) the test fails with `Namespaced subject page`; with a canonical English prefix it fails with `Help:...`; it passes only with the content-language `getPrefixedText()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)