### PR TITLE
Document namespaceId cross-wiki filtering caveat in the graph model

### DIFF
--- a/docs/reference/graph-model.md
+++ b/docs/reference/graph-model.md
@@ -47,6 +47,11 @@ page ids are only unique within a single wiki. Each page node therefore carries 
 `creationTime` and `lastUpdated` are stored as Neo4j datetime values (ISO 8601), converted from MediaWiki's
 `YmdHis` timestamp format.
 
+`namespaceId` holds MediaWiki's canonical namespace ID. Built-in namespaces (e.g. `0` main, `12` Help, `14`
+Category) have the same ID on every wiki, so filtering by `namespaceId` behaves consistently across a graph
+shared by multiple wikis. Custom namespaces defined via `$wgExtraNamespaces` get per-wiki IDs that may differ in
+meaning between wikis, so pair `namespaceId` with `wiki_id` to filter those unambiguously.
+
 ## Subject Nodes
 
 Each Subject stored on a page gets a `:Subject` node. Subject nodes carry two labels: `Subject` and the name of


### PR DESCRIPTION
> Implements a documentation suggestion I raised while reviewing #946, at @JeroenDeDauw's request.
> Context: the NeoWiki codebase, PR #946, and the multi-wiki graph model (ADR 22).
> <sub>Written by Claude Code, `Opus 4.8 (1M context)`</sub>

Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/946

Clarifies how the new `namespaceId` page property behaves when a graph is shared by multiple wikis. Built-in namespace IDs (e.g. `0` main, `12` Help, `14` Category) are identical on every wiki, so `namespaceId` filtering behaves consistently across wikis. Custom namespaces defined via `$wgExtraNamespaces` get per-wiki IDs that may differ in meaning between wikis, so they should be paired with `wiki_id` for unambiguous cross-wiki filtering.

This sharpens the "canonical MediaWiki namespace ID" wording from #946, which is precise for built-in namespaces but not for custom ones when the graph holds more than one wiki.

🤖 Generated with [Claude Code](https://claude.com/claude-code)