### PR TITLE
Expose the page namespace ID through PageIdentifiers and the subject REST API

### DIFF
--- a/docs/reference/subject-format.md
+++ b/docs/reference/subject-format.md
@@ -193,8 +193,10 @@ See [ADR 014](../adr/014-improved-id-format.md) for details on the ID format.
 
 Returns the same statement format as storage, with additional fields:
 - `requestedId`: The ID that was requested
-- Each subject includes `id`, `pageId`, and `pageTitle` fields. `pageTitle` is the full page
-  title including the namespace prefix (e.g. `Help:Installation`).
+- Each subject includes an `id` field. Passing `?expand=page` adds the page fields `pageId`,
+  `pageTitle`, and `pageNamespaceId`. `pageTitle` is the full page title including the namespace prefix
+  (e.g. `Help:Installation`); `pageNamespaceId` is the page's canonical MediaWiki namespace ID (e.g. `0`
+  for the main namespace, `12` for Help), which is stable regardless of the wiki's content language.
 
 ### Writing Subjects
 
@@ -222,8 +224,8 @@ Full replace of the Subject's writable state (label and statements). The request
 | `statements` | Yes | Map of property name to Statement. Property names not in the map are deleted from the Subject. Pass `{}` to clear all statements. |
 | `comment` | No | Optional edit summary. |
 
-The Subject's `id`, `schema`, `pageId`, and `pageTitle` are immutable after creation and are
-not part of the request body. If sent, they are ignored.
+The Subject's `id`, `schema`, `pageId`, `pageTitle`, and `pageNamespaceId` are immutable after creation
+and are not part of the request body. If sent, they are ignored.
 
 Relation IDs can be omitted for new relations (a fresh ID is generated server-side).
 

--- a/src/Application/Queries/GetPageSubjects/GetPageSubjectsQuery.php
+++ b/src/Application/Queries/GetPageSubjects/GetPageSubjectsQuery.php
@@ -72,6 +72,7 @@ readonly class GetPageSubjectsQuery {
 			statements: $this->arrayifyStatements( $subject->getStatements() ),
 			pageId: $pageIdentifiers?->getId()->id,
 			pageTitle: $pageIdentifiers?->getTitle(),
+			pageNamespaceId: $pageIdentifiers?->getNamespaceId(),
 		);
 	}
 

--- a/src/Application/Queries/GetSubject/GetSubjectQuery.php
+++ b/src/Application/Queries/GetSubject/GetSubjectQuery.php
@@ -63,6 +63,7 @@ readonly class GetSubjectQuery {
 			statements: $this->arrayifyStatements( $subject->getStatements() ),
 			pageId: $pageIdentifiers?->getId()->id,
 			pageTitle: $pageIdentifiers?->getTitle(),
+			pageNamespaceId: $pageIdentifiers?->getNamespaceId(),
 		);
 	}
 

--- a/src/Application/Queries/GetSubject/GetSubjectResponseItem.php
+++ b/src/Application/Queries/GetSubject/GetSubjectResponseItem.php
@@ -16,6 +16,7 @@ readonly class GetSubjectResponseItem {
 		public array $statements,
 		public ?int $pageId,
 		public ?string $pageTitle,
+		public ?int $pageNamespaceId,
 	) {
 	}
 

--- a/src/Domain/Page/PageIdentifiers.php
+++ b/src/Domain/Page/PageIdentifiers.php
@@ -9,6 +9,7 @@ readonly class PageIdentifiers {
 	public function __construct(
 		private PageId $id,
 		private string $title,
+		private int $namespaceId,
 	) {
 	}
 
@@ -18,6 +19,10 @@ readonly class PageIdentifiers {
 
 	public function getTitle(): string {
 		return $this->title;
+	}
+
+	public function getNamespaceId(): int {
+		return $this->namespaceId;
 	}
 
 }

--- a/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jPageIdentifiersLookup.php
+++ b/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jPageIdentifiersLookup.php
@@ -31,7 +31,7 @@ class Neo4jPageIdentifiersLookup implements PageIdentifiersLookup {
 				$result = $transaction->run(
 					'
 					MATCH (page:Page)-[:HasSubject]->(subject {id: $subjectId})
-					RETURN page.id AS id, page.name as name',
+					RETURN page.id AS id, page.name AS name, page.namespaceId AS namespaceId',
 					[ 'subjectId' => $subjectId->text ]
 				);
 
@@ -40,10 +40,11 @@ class Neo4jPageIdentifiersLookup implements PageIdentifiersLookup {
 				if ( array_key_exists( 0, $arrayResult ) && is_array( $arrayResult[0] ) ) {
 					$page = $arrayResult[0];
 
-					if ( array_key_exists( 'id', $page ) && array_key_exists( 'name', $page ) ) {
+					if ( array_key_exists( 'id', $page ) && array_key_exists( 'name', $page ) && array_key_exists( 'namespaceId', $page ) ) {
 						return new PageIdentifiers(
 							id: new PageId( (int)$page['id'] ),
-							title: $page['name']
+							title: $page['name'],
+							namespaceId: (int)$page['namespaceId'],
 						);
 					}
 				}

--- a/src/Presentation/RestGetPageSubjectsPresenter.php
+++ b/src/Presentation/RestGetPageSubjectsPresenter.php
@@ -51,6 +51,7 @@ class RestGetPageSubjectsPresenter implements GetPageSubjectsPresenter {
 			if ( $subject->pageId !== null ) {
 				$entry['pageId'] = $subject->pageId;
 				$entry['pageTitle'] = $subject->pageTitle;
+				$entry['pageNamespaceId'] = $subject->pageNamespaceId;
 			}
 
 			$entry['statements'] = $subject->statements;

--- a/src/Presentation/RestGetSubjectPresenter.php
+++ b/src/Presentation/RestGetSubjectPresenter.php
@@ -39,6 +39,7 @@ class RestGetSubjectPresenter implements GetSubjectPresenter {
 			if ( $subject->pageId !== null ) {
 				$map[$subject->id]['pageId'] = $subject->pageId;
 				$map[$subject->id]['pageTitle'] = $subject->pageTitle;
+				$map[$subject->id]['pageNamespaceId'] = $subject->pageNamespaceId;
 			}
 
 			$map[$subject->id]['statements'] = $subject->statements;

--- a/tests/phpunit/Application/Queries/GetPageSubjects/GetPageSubjectsQueryTest.php
+++ b/tests/phpunit/Application/Queries/GetPageSubjects/GetPageSubjectsQueryTest.php
@@ -92,6 +92,7 @@ class GetPageSubjectsQueryTest extends TestCase {
 						],
 						pageId: null,
 						pageTitle: null,
+						pageNamespaceId: null,
 					),
 					's11111111111ca2' => new GetSubjectResponseItem(
 						id: 's11111111111ca2',
@@ -100,6 +101,7 @@ class GetPageSubjectsQueryTest extends TestCase {
 						statements: [],
 						pageId: null,
 						pageTitle: null,
+						pageNamespaceId: null,
 					),
 					's11111111111ca3' => new GetSubjectResponseItem(
 						id: 's11111111111ca3',
@@ -108,6 +110,7 @@ class GetPageSubjectsQueryTest extends TestCase {
 						statements: [],
 						pageId: null,
 						pageTitle: null,
+						pageNamespaceId: null,
 					),
 					's11111111111ca1' => new GetSubjectResponseItem(
 						id: 's11111111111ca1',
@@ -116,6 +119,7 @@ class GetPageSubjectsQueryTest extends TestCase {
 						statements: [],
 						pageId: null,
 						pageTitle: null,
+						pageNamespaceId: null,
 					),
 				]
 			),
@@ -315,7 +319,7 @@ class GetPageSubjectsQueryTest extends TestCase {
 		$referenced = TestSubject::build( id: 's11111111111tar' );
 		$subjectLookup = new InMemorySubjectLookup( $referenced );
 		$pageIdentifiersLookup = new InMemoryPageIdentifiersLookup( [
-			[ $referenced->id, new PageIdentifiers( new PageId( 137 ), 'Target Page' ) ],
+			[ $referenced->id, new PageIdentifiers( new PageId( 137 ), 'Target Page', 12 ) ],
 		] );
 
 		$presenter = $this->newSpyPresenter();
@@ -325,6 +329,7 @@ class GetPageSubjectsQueryTest extends TestCase {
 
 		$this->assertSame( 137, $presenter->response->referencedSubjects['s11111111111tar']->pageId );
 		$this->assertSame( 'Target Page', $presenter->response->referencedSubjects['s11111111111tar']->pageTitle );
+		$this->assertSame( 12, $presenter->response->referencedSubjects['s11111111111tar']->pageNamespaceId );
 	}
 
 	public function testReferencedSubjectsAndSchemasAreNullWhenNotRequested(): void {

--- a/tests/phpunit/Application/Queries/GetSubject/GetSubjectQueryTest.php
+++ b/tests/phpunit/Application/Queries/GetSubject/GetSubjectQueryTest.php
@@ -96,6 +96,7 @@ class GetSubjectQueryTest extends TestCase {
 						],
 						pageId: null,
 						pageTitle: null,
+						pageNamespaceId: null,
 					)
 				]
 			),
@@ -146,8 +147,8 @@ class GetSubjectQueryTest extends TestCase {
 			$spyPresenter,
 			new InMemorySubjectLookup( $subject ),
 			new InMemoryPageIdentifiersLookup( [
-				[ new SubjectId( TestSubject::ZERO_GUID ), new PageIdentifiers( new PageId( 1 ), 'wrong title' ) ],
-				[ $subject->id, new PageIdentifiers( new PageId( 42 ), 'right title' ) ],
+				[ new SubjectId( TestSubject::ZERO_GUID ), new PageIdentifiers( new PageId( 1 ), 'wrong title', 0 ) ],
+				[ $subject->id, new PageIdentifiers( new PageId( 42 ), 'right title', 12 ) ],
 			] ),
 		);
 
@@ -161,6 +162,7 @@ class GetSubjectQueryTest extends TestCase {
 
 		$this->assertSame( 42, $response->subjects[$response->requestedId]->pageId );
 		$this->assertSame( 'right title', $response->subjects[$response->requestedId]->pageTitle );
+		$this->assertSame( 12, $response->subjects[$response->requestedId]->pageNamespaceId );
 	}
 
 	public function testIncludeReferencedSubjects(): void {
@@ -193,8 +195,8 @@ class GetSubjectQueryTest extends TestCase {
 			$spyPresenter,
 			new InMemorySubjectLookup( $subject, $referencedSubject ),
 			new InMemoryPageIdentifiersLookup( [
-				[ $subject->id, new PageIdentifiers( new PageId( 42 ), 'subject title' ) ],
-				[ $referencedSubject->id, new PageIdentifiers( new PageId( 1337 ), 'referenced title' ) ],
+				[ $subject->id, new PageIdentifiers( new PageId( 42 ), 'subject title', 0 ) ],
+				[ $referencedSubject->id, new PageIdentifiers( new PageId( 1337 ), 'referenced title', 12 ) ],
 			] ),
 		);
 
@@ -211,6 +213,7 @@ class GetSubjectQueryTest extends TestCase {
 		$this->assertSame( 'referenced subject', $response->subjects[$referencedSubject->id->text]->label );
 		$this->assertSame( 1337, $response->subjects[$referencedSubject->id->text]->pageId );
 		$this->assertSame( 'referenced title', $response->subjects[$referencedSubject->id->text]->pageTitle );
+		$this->assertSame( 12, $response->subjects[$referencedSubject->id->text]->pageNamespaceId );
 	}
 
 }

--- a/tests/phpunit/EntryPoints/REST/GetSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/GetSubjectApiTest.php
@@ -209,6 +209,7 @@ JSON,
             "schema": "GetSubjectApiTestSchema",
             "pageId": $firstPageId,
             "pageTitle": "GetSubjectApiTest0000",
+            "pageNamespaceId": 0,
             "statements": {
                 "MyRelation": {
                 	"type": "relation",
@@ -231,6 +232,7 @@ JSON,
             "schema": "GetSubjectApiTestSchema",
             "pageId": $firstPageId,
             "pageTitle": "GetSubjectApiTest0000",
+            "pageNamespaceId": 0,
             "statements": []
         },
         "sTestGSA1111113": {
@@ -239,6 +241,7 @@ JSON,
             "schema": "GetSubjectApiTestSchema",
             "pageId": $secondPageId,
             "pageTitle": "GetSubjectApiTest0002",
+            "pageNamespaceId": 0,
             "statements": {
                 "MyRelation": {
                 "type": "relation",

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jPageIdentifiersLookupTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jPageIdentifiersLookupTest.php
@@ -65,7 +65,7 @@ class Neo4jPageIdentifiersLookupTest extends NeoWikiIntegrationTestCase {
 
 		$queryStore->savePage( TestPage::build(
 			id: 42,
-			properties: TestPageProperties::build( title: 'Bar' ),
+			properties: TestPageProperties::build( title: 'Bar', namespaceId: 12 ),
 			childSubjects: new SubjectMap(
 				TestSubject::build( id: self::GUID_1 ),
 				TestSubject::build( id: self::GUID_2 ), // Target
@@ -82,7 +82,7 @@ class Neo4jPageIdentifiersLookupTest extends NeoWikiIntegrationTestCase {
 		) );
 
 		$this->assertEquals(
-			new PageIdentifiers( new PageId( 42 ), 'Bar' ),
+			new PageIdentifiers( new PageId( 42 ), 'Bar', 12 ),
 			$this->newLookup( $this->getClient() )->getPageIdOfSubject( new SubjectId( self::GUID_2 ) )
 		);
 	}

--- a/tests/phpunit/Persistence/MediaWiki/Subject/PointInTimeSubjectLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/Subject/PointInTimeSubjectLookupTest.php
@@ -157,6 +157,7 @@ class PointInTimeSubjectLookupTest extends NeoWikiIntegrationTestCase {
 			new PageIdentifiers(
 				new PageId( $crossPageRevision->getPage()->getId() ),
 				'PitTestCrossPage',
+				0,
 			),
 		);
 
@@ -180,6 +181,7 @@ class PointInTimeSubjectLookupTest extends NeoWikiIntegrationTestCase {
 			new PageIdentifiers(
 				new PageId( 404404404 ),
 				'NonexistentPage',
+				0,
 			),
 		);
 


### PR DESCRIPTION
> Implements a read-path follow-up @JeroenDeDauw asked for after the #946 review: expose the canonical namespace ID so API/Cypher consumers don't have to parse the content-language page-title prefix.
> Context: the NeoWiki codebase, PR #946, the PageIdentifiers → GetSubject/GetPageSubjects → REST chain, and MediaWiki namespace localization.
> <sub>Written by Claude Code, `Opus 4.8 (1M context)`</sub>

Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/946

The page node carries a canonical `namespaceId` (added in #946), but it was only reachable via Cypher. Read code and the subject REST API exposed only the page title (`name`, the content-language prefixed string), so a consumer needing the namespace had to parse that locale-dependent prefix — the fragility `namespaceId` exists to avoid. Since the graph is itself a public surface (users author Cypher against the node properties), the canonical ID belongs on the read/API surface too.

This change:
- adds `namespaceId` to the `PageIdentifiers` domain object;
- reads it from the page node in `Neo4jPageIdentifiersLookup`;
- exposes it as `pageNamespaceId` in the `GetSubject` and `GetPageSubjects` REST responses, alongside `pageId` and `pageTitle`.

`pageNamespaceId` is a canonical, language-independent integer (e.g. `0` main, `12` Help), stable across wikis and content languages.

The frontend is unchanged: its only consumer builds same-wiki relation links from `pageTitle` via `mw.util.getUrl` and does not need the namespace yet.

## Verification

- Tests added/extended at each layer: `Neo4jPageIdentifiersLookupTest` (lookup reads the stored ID), `GetSubjectQueryTest` / `GetPageSubjectsQueryTest` (query threads it through), `GetSubjectApiTest` (REST JSON exposes `pageNamespaceId`). Both new behaviours were seen failing via mutation (wrong ID in the lookup; dropped field in the presenter).
- Full PHPUnit suite (1345 tests), phpcs and phpstan green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)