### PR TITLE
Fix relation-type and target-schema editing in the schema editor

### DIFF
--- a/resources/ext.neowiki/src/components/SchemaEditor/Property/RelationAttributesEditor.vue
+++ b/resources/ext.neowiki/src/components/SchemaEditor/Property/RelationAttributesEditor.vue
@@ -25,7 +25,7 @@
 				{{ $i18n( 'neowiki-property-editor-target-schema' ).text() }}
 			</template>
 			<SchemaLookup
-				:selected="property.targetSchema ?? null"
+				:selected="property.targetSchema || null"
 				@select="updateTargetSchema"
 			/>
 		</CdxField>
@@ -54,7 +54,7 @@ const emit = defineEmits<AttributesEditorEmits<RelationProperty>>();
 const relationInput = ref( props.property.relation || props.property.name.toString() );
 
 watch( () => props.property.relation, ( newValue ) => {
-	relationInput.value = newValue || props.property.name.toString();
+	relationInput.value = newValue;
 } );
 
 onMounted( () => {
@@ -77,10 +77,7 @@ const targetSchemaError = computed<string | null>( () =>
 
 const updateRelation = ( value: string ): void => {
 	relationInput.value = value;
-	const trimmed = value.trim();
-	if ( trimmed !== '' ) {
-		emit( 'update:property', { relation: trimmed } );
-	}
+	emit( 'update:property', { relation: value.trim() } );
 };
 
 const updateTargetSchema = ( schemaName: string ): void => {

--- a/resources/ext.neowiki/src/components/common/SchemaLookup.vue
+++ b/resources/ext.neowiki/src/components/common/SchemaLookup.vue
@@ -77,10 +77,8 @@ async function onLookupInput( value: string ): Promise<void> {
 	}
 }
 
-function onSchemaSelected( schemaName: string ): void {
-	if ( schemaName ) {
-		emit( 'select', schemaName );
-	}
+function onSchemaSelected( schemaName: string | null ): void {
+	emit( 'select', schemaName ?? '' );
 }
 
 function focus(): void {

--- a/resources/ext.neowiki/src/components/common/SchemaLookup.vue
+++ b/resources/ext.neowiki/src/components/common/SchemaLookup.vue
@@ -9,6 +9,7 @@
 			:placeholder="$i18n( 'neowiki-subject-creator-schema-search-placeholder' ).text()"
 			@input="onLookupInput"
 			@update:selected="onSchemaSelected"
+			@blur="reconcileOnBlur"
 		/>
 	</div>
 </template>
@@ -31,21 +32,16 @@ const emit = defineEmits<{
 const schemaStore = useSchemaStore();
 const selectedSchema = ref<string | null>( props.selected ?? null );
 const inputText = ref<string>( props.selected ?? '' );
-const menuItems = ref<MenuItemData[]>(
-	props.selected ? [ { label: props.selected, value: props.selected } ] : []
-);
+const menuItems = ref<MenuItemData[]>( [] );
 const lookupRef = ref<InstanceType<typeof CdxLookup> | null>( null );
 let requestSequence = 0;
 
-watch( () => props.selected, ( value ) => {
-	selectedSchema.value = value ?? null;
-	inputText.value = value ?? '';
-	if ( value && !menuItems.value.some( ( item ) => item.value === value ) ) {
-		menuItems.value = [ { label: value, value: value } ];
-	} else if ( !value ) {
-		menuItems.value = [];
-	}
-} );
+function syncFromSelected(): void {
+	selectedSchema.value = props.selected ?? null;
+	inputText.value = props.selected ?? '';
+}
+
+watch( () => props.selected, syncFromSelected );
 
 async function onLookupInput( value: string ): Promise<void> {
 	if ( !value ) {
@@ -80,9 +76,25 @@ async function onLookupInput( value: string ): Promise<void> {
 function onSchemaSelected( schemaName: string | null ): void {
 	if ( schemaName ) {
 		emit( 'select', schemaName );
-	} else if ( !inputText.value ) {
-		emit( 'select', '' );
 	}
+}
+
+// The field may only hold a schema that was picked from the menu. CdxLookup nulls
+// its selection while the user types, so on blur reconcile the unconfirmed text:
+// clear when emptied, otherwise revert to the last committed value.
+function reconcileOnBlur(): void {
+	if ( selectedSchema.value !== null ) {
+		return;
+	}
+
+	if ( inputText.value === '' ) {
+		if ( props.selected ) {
+			emit( 'select', '' );
+		}
+		return;
+	}
+
+	syncFromSelected();
 }
 
 function focus(): void {

--- a/resources/ext.neowiki/src/components/common/SchemaLookup.vue
+++ b/resources/ext.neowiki/src/components/common/SchemaLookup.vue
@@ -78,7 +78,11 @@ async function onLookupInput( value: string ): Promise<void> {
 }
 
 function onSchemaSelected( schemaName: string | null ): void {
-	emit( 'select', schemaName ?? '' );
+	if ( schemaName ) {
+		emit( 'select', schemaName );
+	} else if ( !inputText.value ) {
+		emit( 'select', '' );
+	}
 }
 
 function focus(): void {

--- a/resources/ext.neowiki/tests/components/SchemaEditor/Property/RelationAttributesEditor.spec.ts
+++ b/resources/ext.neowiki/tests/components/SchemaEditor/Property/RelationAttributesEditor.spec.ts
@@ -63,6 +63,14 @@ describe( 'RelationAttributesEditor', () => {
 			expect( wrapper.findComponent( SchemaLookupStub ).props( 'selected' ) ).toBe( 'Office' );
 		} );
 
+		it( 'passes null to SchemaLookup when no target schema is set', () => {
+			const wrapper = newWrapper( {
+				property: relationProperty( { targetSchema: '' } ),
+			} );
+
+			expect( wrapper.findComponent( SchemaLookupStub ).props( 'selected' ) ).toBe( null );
+		} );
+
 		it( 'displays the stored relation in the input', () => {
 			const wrapper = newWrapper( {
 				property: relationProperty( { relation: 'Has gadget' } ),
@@ -77,6 +85,18 @@ describe( 'RelationAttributesEditor', () => {
 			} );
 
 			expect( wrapper.findComponent( CdxTextInput ).props( 'modelValue' ) ).toBe( 'Main product' );
+		} );
+
+		it( 'clears the displayed relation when the stored relation is emptied', async () => {
+			const wrapper = newWrapper( {
+				property: relationProperty( { relation: 'Has product', name: new PropertyName( 'Main product' ) } ),
+			} );
+
+			await wrapper.setProps( {
+				property: relationProperty( { relation: '', name: new PropertyName( 'Main product' ) } ),
+			} );
+
+			expect( wrapper.findComponent( CdxTextInput ).props( 'modelValue' ) ).toBe( '' );
 		} );
 	} );
 
@@ -115,12 +135,28 @@ describe( 'RelationAttributesEditor', () => {
 			expect( wrapper.emitted( 'update:property' )?.[ 0 ] ).toEqual( [ { relation: 'Owns' } ] );
 		} );
 
+		it( 'emits an empty relation when the field is cleared', async () => {
+			const wrapper = newWrapper();
+
+			await wrapper.findComponent( CdxTextInput ).vm.$emit( 'update:modelValue', '' );
+
+			expect( wrapper.emitted( 'update:property' )?.[ 0 ] ).toEqual( [ { relation: '' } ] );
+		} );
+
 		it( 'emits targetSchema when the picker selects a schema', async () => {
 			const wrapper = newWrapper();
 
 			await wrapper.findComponent( SchemaLookupStub ).vm.$emit( 'select', 'Office' );
 
 			expect( wrapper.emitted( 'update:property' )?.[ 0 ] ).toEqual( [ { targetSchema: 'Office' } ] );
+		} );
+
+		it( 'emits an empty target schema when the picker is cleared', async () => {
+			const wrapper = newWrapper();
+
+			await wrapper.findComponent( SchemaLookupStub ).vm.$emit( 'select', '' );
+
+			expect( wrapper.emitted( 'update:property' )?.[ 0 ] ).toEqual( [ { targetSchema: '' } ] );
 		} );
 
 		it( 'emits multiple when the checkbox is toggled', async () => {
@@ -148,10 +184,9 @@ describe( 'RelationAttributesEditor', () => {
 			const props = fieldProps( wrapper, '.relation-attributes__relation' );
 			expect( props.status ).toBe( 'error' );
 			expect( props.messages ).toEqual( { error: 'Relation type is required.' } );
-			expect( wrapper.emitted( 'update:property' ) ).toBeFalsy();
 		} );
 
-		it( 'treats a whitespace-only relation as required and does not emit it', async () => {
+		it( 'treats a whitespace-only relation as required', async () => {
 			const wrapper = newWrapper();
 
 			await wrapper.findComponent( CdxTextInput ).vm.$emit( 'update:modelValue', '   ' );
@@ -159,7 +194,6 @@ describe( 'RelationAttributesEditor', () => {
 			const props = fieldProps( wrapper, '.relation-attributes__relation' );
 			expect( props.status ).toBe( 'error' );
 			expect( props.messages ).toEqual( { error: 'Relation type is required.' } );
-			expect( wrapper.emitted( 'update:property' ) ).toBeFalsy();
 		} );
 
 		it( 'shows a required error when the target schema is empty', () => {

--- a/resources/ext.neowiki/tests/components/SchemaEditor/Property/RelationAttributesEditor.spec.ts
+++ b/resources/ext.neowiki/tests/components/SchemaEditor/Property/RelationAttributesEditor.spec.ts
@@ -89,11 +89,11 @@ describe( 'RelationAttributesEditor', () => {
 
 		it( 'clears the displayed relation when the stored relation is emptied', async () => {
 			const wrapper = newWrapper( {
-				property: relationProperty( { relation: 'Has product', name: new PropertyName( 'Main product' ) } ),
+				property: relationProperty( { relation: 'Has product' } ),
 			} );
 
 			await wrapper.setProps( {
-				property: relationProperty( { relation: '', name: new PropertyName( 'Main product' ) } ),
+				property: relationProperty( { relation: '' } ),
 			} );
 
 			expect( wrapper.findComponent( CdxTextInput ).props( 'modelValue' ) ).toBe( '' );

--- a/resources/ext.neowiki/tests/components/common/SchemaLookup.spec.ts
+++ b/resources/ext.neowiki/tests/components/common/SchemaLookup.spec.ts
@@ -138,6 +138,24 @@ describe( 'SchemaLookup', () => {
 		expect( lookup.props( 'menuItems' ) ).toEqual( [] );
 	} );
 
+	it( 'emits the selected schema when one is chosen', () => {
+		const wrapper = mountComponent();
+		const lookup = wrapper.findComponent( CdxLookup );
+
+		lookup.vm.$emit( 'update:selected', 'Product' );
+
+		expect( wrapper.emitted( 'select' )?.[ 0 ] ).toEqual( [ 'Product' ] );
+	} );
+
+	it( 'emits an empty selection when the lookup is cleared', () => {
+		const wrapper = mountComponent();
+		const lookup = wrapper.findComponent( CdxLookup );
+
+		lookup.vm.$emit( 'update:selected', null );
+
+		expect( wrapper.emitted( 'select' )?.[ 0 ] ).toEqual( [ '' ] );
+	} );
+
 	it( 'exposes focus method', () => {
 		const CdxLookupStub = {
 			template: '<div><input /></div>',

--- a/resources/ext.neowiki/tests/components/common/SchemaLookup.spec.ts
+++ b/resources/ext.neowiki/tests/components/common/SchemaLookup.spec.ts
@@ -1,5 +1,6 @@
 import { mount, VueWrapper, flushPromises } from '@vue/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { nextTick } from 'vue';
 import SchemaLookup from '@/components/common/SchemaLookup.vue';
 import { createPinia, setActivePinia } from 'pinia';
 import { useSchemaStore } from '@/stores/SchemaStore.ts';
@@ -37,133 +38,177 @@ describe( 'SchemaLookup', () => {
 		schemaStore.searchAndFetchMissingSchemas = vi.fn().mockResolvedValue( [] );
 	} );
 
-	it( 'searches for schemas when input changes', () => {
-		const wrapper = mountComponent();
-		const lookup = wrapper.findComponent( CdxLookup );
+	describe( 'searching', () => {
+		it( 'searches for schemas when input changes', () => {
+			const wrapper = mountComponent();
+			const lookup = wrapper.findComponent( CdxLookup );
 
-		lookup.vm.$emit( 'input', 'test query' );
+			lookup.vm.$emit( 'input', 'test query' );
 
-		expect( schemaStore.searchAndFetchMissingSchemas ).toHaveBeenCalledWith( 'test query' );
-	} );
-
-	it( 'updates menu items with search results', async () => {
-		const mockResults = [ 'Schema1', 'Schema2' ];
-		schemaStore.searchAndFetchMissingSchemas.mockResolvedValue( mockResults );
-		schemaStore.schemas.set( 'Schema1', new Schema( 'Schema1', 'First description', new PropertyDefinitionList( [] ) ) );
-		schemaStore.schemas.set( 'Schema2', new Schema( 'Schema2', 'Second description', new PropertyDefinitionList( [] ) ) );
-
-		const wrapper = mountComponent();
-		const lookup = wrapper.findComponent( CdxLookup );
-
-		lookup.vm.$emit( 'input', 'test' );
-		await flushPromises();
-
-		expect( lookup.props( 'menuItems' ) ).toEqual( [
-			{ label: 'Schema1', value: 'Schema1', description: 'First description' },
-			{ label: 'Schema2', value: 'Schema2', description: 'Second description' },
-		] );
-	} );
-
-	it( 'omits description from menu items when schema has empty description', async () => {
-		schemaStore.searchAndFetchMissingSchemas.mockResolvedValue( [ 'WithDesc', 'NoDesc' ] );
-		schemaStore.schemas.set( 'WithDesc', new Schema( 'WithDesc', 'Has a description', new PropertyDefinitionList( [] ) ) );
-		schemaStore.schemas.set( 'NoDesc', new Schema( 'NoDesc', '', new PropertyDefinitionList( [] ) ) );
-
-		const wrapper = mountComponent();
-		const lookup = wrapper.findComponent( CdxLookup );
-
-		lookup.vm.$emit( 'input', 'test' );
-		await flushPromises();
-
-		expect( lookup.props( 'menuItems' ) ).toEqual( [
-			{ label: 'WithDesc', value: 'WithDesc', description: 'Has a description' },
-			{ label: 'NoDesc', value: 'NoDesc', description: undefined },
-		] );
-	} );
-
-	it( 'discards stale search results when a newer request completes first', async () => {
-		let resolveFirst: ( value: string[] ) => void;
-		const firstCallPromise = new Promise<string[]>( ( resolve ) => {
-			resolveFirst = resolve;
+			expect( schemaStore.searchAndFetchMissingSchemas ).toHaveBeenCalledWith( 'test query' );
 		} );
 
-		schemaStore.searchAndFetchMissingSchemas = vi.fn()
-			.mockReturnValueOnce( firstCallPromise )
-			.mockResolvedValueOnce( [ 'SecondSchema' ] );
+		it( 'updates menu items with search results', async () => {
+			schemaStore.searchAndFetchMissingSchemas.mockResolvedValue( [ 'Schema1', 'Schema2' ] );
+			schemaStore.schemas.set( 'Schema1', new Schema( 'Schema1', 'First description', new PropertyDefinitionList( [] ) ) );
+			schemaStore.schemas.set( 'Schema2', new Schema( 'Schema2', 'Second description', new PropertyDefinitionList( [] ) ) );
 
-		schemaStore.schemas.set( 'FirstSchema', new Schema( 'FirstSchema', 'Stale', new PropertyDefinitionList( [] ) ) );
-		schemaStore.schemas.set( 'SecondSchema', new Schema( 'SecondSchema', 'Fresh', new PropertyDefinitionList( [] ) ) );
+			const wrapper = mountComponent();
+			const lookup = wrapper.findComponent( CdxLookup );
 
-		const wrapper = mountComponent();
-		const lookup = wrapper.findComponent( CdxLookup );
+			lookup.vm.$emit( 'input', 'test' );
+			await flushPromises();
 
-		lookup.vm.$emit( 'input', 'first' );
-		lookup.vm.$emit( 'input', 'second' );
-		await flushPromises();
+			expect( lookup.props( 'menuItems' ) ).toEqual( [
+				{ label: 'Schema1', value: 'Schema1', description: 'First description' },
+				{ label: 'Schema2', value: 'Schema2', description: 'Second description' },
+			] );
+		} );
 
-		expect( lookup.props( 'menuItems' ) ).toEqual( [
-			{ label: 'SecondSchema', value: 'SecondSchema', description: 'Fresh' },
-		] );
+		it( 'omits description from menu items when schema has empty description', async () => {
+			schemaStore.searchAndFetchMissingSchemas.mockResolvedValue( [ 'WithDesc', 'NoDesc' ] );
+			schemaStore.schemas.set( 'WithDesc', new Schema( 'WithDesc', 'Has a description', new PropertyDefinitionList( [] ) ) );
+			schemaStore.schemas.set( 'NoDesc', new Schema( 'NoDesc', '', new PropertyDefinitionList( [] ) ) );
 
-		resolveFirst!( [ 'FirstSchema' ] );
-		await flushPromises();
+			const wrapper = mountComponent();
+			const lookup = wrapper.findComponent( CdxLookup );
 
-		expect( lookup.props( 'menuItems' ) ).toEqual( [
-			{ label: 'SecondSchema', value: 'SecondSchema', description: 'Fresh' },
-		] );
+			lookup.vm.$emit( 'input', 'test' );
+			await flushPromises();
+
+			expect( lookup.props( 'menuItems' ) ).toEqual( [
+				{ label: 'WithDesc', value: 'WithDesc', description: 'Has a description' },
+				{ label: 'NoDesc', value: 'NoDesc', description: undefined },
+			] );
+		} );
+
+		it( 'discards stale search results when a newer request completes first', async () => {
+			let resolveFirst: ( value: string[] ) => void;
+			const firstCallPromise = new Promise<string[]>( ( resolve ) => {
+				resolveFirst = resolve;
+			} );
+
+			schemaStore.searchAndFetchMissingSchemas = vi.fn()
+				.mockReturnValueOnce( firstCallPromise )
+				.mockResolvedValueOnce( [ 'SecondSchema' ] );
+
+			schemaStore.schemas.set( 'FirstSchema', new Schema( 'FirstSchema', 'Stale', new PropertyDefinitionList( [] ) ) );
+			schemaStore.schemas.set( 'SecondSchema', new Schema( 'SecondSchema', 'Fresh', new PropertyDefinitionList( [] ) ) );
+
+			const wrapper = mountComponent();
+			const lookup = wrapper.findComponent( CdxLookup );
+
+			lookup.vm.$emit( 'input', 'first' );
+			lookup.vm.$emit( 'input', 'second' );
+			await flushPromises();
+
+			expect( lookup.props( 'menuItems' ) ).toEqual( [
+				{ label: 'SecondSchema', value: 'SecondSchema', description: 'Fresh' },
+			] );
+
+			resolveFirst!( [ 'FirstSchema' ] );
+			await flushPromises();
+
+			expect( lookup.props( 'menuItems' ) ).toEqual( [
+				{ label: 'SecondSchema', value: 'SecondSchema', description: 'Fresh' },
+			] );
+		} );
 	} );
 
-	it( 'reflects the selected prop on the lookup', () => {
-		const wrapper = mountComponent( { selected: 'Product' } );
-		const lookup = wrapper.findComponent( CdxLookup );
+	describe( 'committing a selection', () => {
+		it( 'emits the chosen schema when one is selected', () => {
+			const wrapper = mountComponent();
+			const lookup = wrapper.findComponent( CdxLookup );
 
-		expect( lookup.props( 'selected' ) ).toBe( 'Product' );
-		expect( lookup.props( 'inputValue' ) ).toBe( 'Product' );
-		expect( lookup.props( 'menuItems' ) ).toEqual( [ { label: 'Product', value: 'Product' } ] );
+			lookup.vm.$emit( 'update:selected', 'Product' );
+
+			expect( wrapper.emitted( 'select' )?.[ 0 ] ).toEqual( [ 'Product' ] );
+		} );
+
+		it( 'does not emit while the selection is being changed by typing', () => {
+			const wrapper = mountComponent( { selected: 'Product' } );
+			const lookup = wrapper.findComponent( CdxLookup );
+
+			lookup.vm.$emit( 'update:input-value', 'Off' );
+			lookup.vm.$emit( 'update:selected', null );
+
+			expect( wrapper.emitted( 'select' ) ).toBeFalsy();
+		} );
+
+		it( 'keeps a chosen schema untouched on blur', () => {
+			const wrapper = mountComponent( { selected: 'Product' } );
+			const lookup = wrapper.findComponent( CdxLookup );
+
+			lookup.vm.$emit( 'update:selected', 'Office' );
+			lookup.vm.$emit( 'update:input-value', 'Office' );
+			lookup.vm.$emit( 'blur' );
+
+			expect( wrapper.emitted( 'select' ) ).toEqual( [ [ 'Office' ] ] );
+		} );
 	} );
 
-	it( 'updates the lookup when the selected prop changes after mount', async () => {
-		const wrapper = mountComponent();
-		const lookup = wrapper.findComponent( CdxLookup );
+	describe( 'rejecting invalid input', () => {
+		it( 'reverts unmatched typed text to the committed schema on blur', async () => {
+			const wrapper = mountComponent( { selected: 'Product' } );
+			const lookup = wrapper.findComponent( CdxLookup );
 
-		await wrapper.setProps( { selected: 'NewSchema' } );
+			lookup.vm.$emit( 'update:selected', null );
+			lookup.vm.$emit( 'update:input-value', 'Produc' );
+			lookup.vm.$emit( 'blur' );
+			await nextTick();
 
-		expect( lookup.props( 'selected' ) ).toBe( 'NewSchema' );
-		expect( lookup.props( 'inputValue' ) ).toBe( 'NewSchema' );
-		expect( lookup.props( 'menuItems' ) ).toEqual( [ { label: 'NewSchema', value: 'NewSchema' } ] );
-
-		await wrapper.setProps( { selected: null } );
-
-		expect( lookup.props( 'inputValue' ) ).toBe( '' );
-		expect( lookup.props( 'menuItems' ) ).toEqual( [] );
+			expect( lookup.props( 'inputValue' ) ).toBe( 'Product' );
+			expect( wrapper.emitted( 'select' ) ).toBeFalsy();
+		} );
 	} );
 
-	it( 'emits the selected schema when one is chosen', () => {
-		const wrapper = mountComponent();
-		const lookup = wrapper.findComponent( CdxLookup );
+	describe( 'clearing', () => {
+		it( 'clears the selection when the field is emptied and blurred', () => {
+			const wrapper = mountComponent( { selected: 'Product' } );
+			const lookup = wrapper.findComponent( CdxLookup );
 
-		lookup.vm.$emit( 'update:selected', 'Product' );
+			lookup.vm.$emit( 'update:selected', null );
+			lookup.vm.$emit( 'update:input-value', '' );
+			lookup.vm.$emit( 'blur' );
 
-		expect( wrapper.emitted( 'select' )?.[ 0 ] ).toEqual( [ 'Product' ] );
+			expect( wrapper.emitted( 'select' )?.[ 0 ] ).toEqual( [ '' ] );
+		} );
+
+		it( 'does not emit a clear when an unset field is blurred', () => {
+			const wrapper = mountComponent();
+			const lookup = wrapper.findComponent( CdxLookup );
+
+			lookup.vm.$emit( 'update:selected', null );
+			lookup.vm.$emit( 'update:input-value', '' );
+			lookup.vm.$emit( 'blur' );
+
+			expect( wrapper.emitted( 'select' ) ).toBeFalsy();
+		} );
 	} );
 
-	it( 'emits an empty selection when the lookup is cleared', () => {
-		const wrapper = mountComponent();
-		const lookup = wrapper.findComponent( CdxLookup );
+	describe( 'reflecting the selected prop', () => {
+		it( 'shows the selected schema in the field', () => {
+			const wrapper = mountComponent( { selected: 'Product' } );
+			const lookup = wrapper.findComponent( CdxLookup );
 
-		lookup.vm.$emit( 'update:selected', null );
+			expect( lookup.props( 'selected' ) ).toBe( 'Product' );
+			expect( lookup.props( 'inputValue' ) ).toBe( 'Product' );
+		} );
 
-		expect( wrapper.emitted( 'select' )?.[ 0 ] ).toEqual( [ '' ] );
-	} );
+		it( 'updates the field when the selected prop changes', async () => {
+			const wrapper = mountComponent();
+			const lookup = wrapper.findComponent( CdxLookup );
 
-	it( 'does not emit a clear while the user is typing a replacement', () => {
-		const wrapper = mountComponent( { selected: 'Product' } );
-		const lookup = wrapper.findComponent( CdxLookup );
+			await wrapper.setProps( { selected: 'NewSchema' } );
 
-		lookup.vm.$emit( 'update:input-value', 'Off' );
-		lookup.vm.$emit( 'update:selected', null );
+			expect( lookup.props( 'selected' ) ).toBe( 'NewSchema' );
+			expect( lookup.props( 'inputValue' ) ).toBe( 'NewSchema' );
 
-		expect( wrapper.emitted( 'select' ) ).toBeFalsy();
+			await wrapper.setProps( { selected: null } );
+
+			expect( lookup.props( 'selected' ) ).toBe( null );
+			expect( lookup.props( 'inputValue' ) ).toBe( '' );
+		} );
 	} );
 
 	it( 'exposes focus method', () => {

--- a/resources/ext.neowiki/tests/components/common/SchemaLookup.spec.ts
+++ b/resources/ext.neowiki/tests/components/common/SchemaLookup.spec.ts
@@ -156,6 +156,16 @@ describe( 'SchemaLookup', () => {
 		expect( wrapper.emitted( 'select' )?.[ 0 ] ).toEqual( [ '' ] );
 	} );
 
+	it( 'does not emit a clear while the user is typing a replacement', () => {
+		const wrapper = mountComponent( { selected: 'Product' } );
+		const lookup = wrapper.findComponent( CdxLookup );
+
+		lookup.vm.$emit( 'update:input-value', 'Off' );
+		lookup.vm.$emit( 'update:selected', null );
+
+		expect( wrapper.emitted( 'select' ) ).toBeFalsy();
+	} );
+
 	it( 'exposes focus method', () => {
 		const CdxLookupStub = {
 			template: '<div><input /></div>',


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/950

> Result of @JeroenDeDauw's review of #950 and a follow-on design discussion: he requested the review, diagnosed the target-schema field as a free-text input that should be a constrained picker, and chose the searchable-dropdown direction.
> Context: the NeoWiki codebase, PR #950, the sibling lookups, and a live browser check on Schema:Company.
> <sub>Written by Claude Code, `Opus 4.8`</sub>

Two editing fixes in the Schema editor's relation property, both stemming from fields that let the displayed value drift away from what gets stored.

## Relation type (free-text edge label)

`updateRelation` now emits the trimmed value even when empty, and the `relation` watcher no longer falls back to the property name. Clearing the field shows the required error and updates the model instead of silently keeping the previous value. The name fallback remains the on-create default (initial value + `onMounted`), preserving the "derive-on-create only" behaviour from #950.

## Target schema (reference to an existing schema)

The field is a `CdxLookup`, so typed text could drift from the actual selection (e.g. `Produc` while `Product` stayed selected) with no feedback — and that stale value could be saved by changing another field. It is now a **constrained picker**: it only ever holds an existing schema or nothing.

- **Pick** from the menu commits the schema.
- **Empty + blur** clears it (and the relation editor shows "Target schema is required.").
- **Unmatched text + blur** reverts to the last committed value.

Filtering still uses the existing server-side prefix search (`schema-names` API). `SubjectCreatorDialog`, which shares `SchemaLookup`, already ignores empty selections, so its behaviour is unchanged.

Required-field errors remain inline-only and still do not block Save — that schema-editor-wide gating was deferred in #950 and is unchanged here.

## Known follow-up (not in this PR)

"Browse the full schema list before typing" is not included: the `schema-names` API is a prefix search capped at 10 results that rejects an empty query, so there is no cheap way to preload all names. Enabling browse needs a small new list-all-schema-names endpoint.

## Tests

- `RelationAttributesEditor`: clearing emits an empty relation; a cleared field stays empty (no name snap-back); whitespace-only is trimmed/required; `null` is passed to the lookup when no target schema is set.
- `SchemaLookup`: server search + result rendering; pick commits; unmatched text reverts on blur; empty + blur clears; an unset field is not cleared.
- Full vitest suite green (1055 tests); build + lint clean.

## Manual browser check (done; recorded here for re-verification)

On `Schema:Company` → **Edit schema** → select **Main product**:

1. **Relation type:** clear it → stays empty, shows "Relation type is required."; type `  Owns  ` → stored trimmed.
2. **Target schema:** backspace `Product` → `Produc`, click away → reverts to `Product`.
3. **Target schema:** type `Off`, pick **Office** from the dropdown → commits, no mid-type blanking.
4. **Target schema:** clear it, click away → empty + "Target schema is required."

🤖 Generated with [Claude Code](https://claude.com/claude-code)