### PR TITLE
Use the browsable schema picker in the layout creator

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -413,7 +413,7 @@
 				"neowiki-subject-creator-schema-title",
 				"neowiki-subject-creator-existing-schema",
 				"neowiki-subject-creator-new-schema",
-				"neowiki-schema-lookup-placeholder",
+				"neowiki-schema-picker-placeholder",
 				"neowiki-schema-display-property-name",
 				"neowiki-schema-display-property-type",
 				"neowiki-schema-display-property-required",

--- a/extension.json
+++ b/extension.json
@@ -302,6 +302,7 @@
 				"CdxToggleSwitch",
 				"CdxToggleButtonGroup",
 				"CdxLookup",
+				"CdxCombobox",
 				"CdxTable",
 				"CdxInfoChip"
 			],
@@ -412,7 +413,7 @@
 				"neowiki-subject-creator-schema-title",
 				"neowiki-subject-creator-existing-schema",
 				"neowiki-subject-creator-new-schema",
-				"neowiki-subject-creator-schema-search-placeholder",
+				"neowiki-schema-lookup-placeholder",
 				"neowiki-schema-display-property-name",
 				"neowiki-schema-display-property-type",
 				"neowiki-schema-display-property-required",

--- a/extension.json
+++ b/extension.json
@@ -503,7 +503,6 @@
 				"neowiki-layout-creator-name-required",
 				"neowiki-layout-creator-name-taken",
 				"neowiki-layout-creator-schema-field",
-				"neowiki-layout-creator-schema-placeholder",
 				"neowiki-layout-creator-view-type-field",
 				"neowiki-layout-creator-view-type-placeholder",
 				"neowiki-layout-creator-save",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -103,7 +103,7 @@
 	"neowiki-subject-creator-schema-title": "Have an existing schema?",
 	"neowiki-subject-creator-existing-schema": "Use existing",
 	"neowiki-subject-creator-new-schema": "Create new",
-	"neowiki-schema-lookup-placeholder": "Select a schema",
+	"neowiki-schema-picker-placeholder": "Select a schema",
 	"neowiki-subject-creator-label-field": "Subject label",
 	"neowiki-subject-creator-label-placeholder": "Enter a label for the subject",
 	"neowiki-subject-creator-save": "Create subject",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -234,7 +234,6 @@
 	"neowiki-layout-creator-name-required": "Please enter a layout name.",
 	"neowiki-layout-creator-name-taken": "A layout with this name already exists.",
 	"neowiki-layout-creator-schema-field": "Schema",
-	"neowiki-layout-creator-schema-placeholder": "Select a schema",
 	"neowiki-layout-creator-view-type-field": "View type",
 	"neowiki-layout-creator-view-type-placeholder": "Select a view type",
 	"neowiki-layout-creator-save": "Create layout",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -103,7 +103,7 @@
 	"neowiki-subject-creator-schema-title": "Have an existing schema?",
 	"neowiki-subject-creator-existing-schema": "Use existing",
 	"neowiki-subject-creator-new-schema": "Create new",
-	"neowiki-subject-creator-schema-search-placeholder": "Search for a schema",
+	"neowiki-schema-lookup-placeholder": "Select a schema",
 	"neowiki-subject-creator-label-field": "Subject label",
 	"neowiki-subject-creator-label-placeholder": "Enter a label for the subject",
 	"neowiki-subject-creator-save": "Create subject",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -52,6 +52,7 @@
 	"neowiki-subject-editor-error": "Error notification title shown when updating a subject fails. $1 is the subject label.",
 	"neowiki-subject-editor-validation-failed": "Toast title shown when the backend rejects a Subject save under enforcement. $1 is the Subject label.",
 	"neowiki-subject-lookup-placeholder": "Placeholder text shown in the subject search input field.",
+	"neowiki-schema-lookup-placeholder": "Placeholder text shown in the schema picker input field.",
 	"neowiki-subject-lookup-no-results": "Message shown in the subject lookup dropdown when no subjects match the search query.",
 	"neowiki-subject-lookup-no-match": "Error message shown in the subject lookup when the user types text but does not select a subject from the dropdown results.",
 

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -52,7 +52,7 @@
 	"neowiki-subject-editor-error": "Error notification title shown when updating a subject fails. $1 is the subject label.",
 	"neowiki-subject-editor-validation-failed": "Toast title shown when the backend rejects a Subject save under enforcement. $1 is the Subject label.",
 	"neowiki-subject-lookup-placeholder": "Placeholder text shown in the subject search input field.",
-	"neowiki-schema-lookup-placeholder": "Placeholder text shown in the schema picker input field.",
+	"neowiki-schema-picker-placeholder": "Placeholder text shown in the schema picker input field.",
 	"neowiki-subject-lookup-no-results": "Message shown in the subject lookup dropdown when no subjects match the search query.",
 	"neowiki-subject-lookup-no-match": "Error message shown in the subject lookup when the user types text but does not select a subject from the dropdown results.",
 

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -139,7 +139,6 @@
 	"neowiki-layout-creator-name-required": "Error shown when the layout name field is empty in the layout creation dialog.",
 	"neowiki-layout-creator-name-taken": "Error shown when a layout with the entered name already exists in the layout creation dialog.",
 	"neowiki-layout-creator-schema-field": "Label for the schema selector in the layout creation dialog.",
-	"neowiki-layout-creator-schema-placeholder": "Placeholder text for the schema selector in the layout creation dialog.",
 	"neowiki-layout-creator-view-type-field": "Label for the view type selector in the layout creation dialog.",
 	"neowiki-layout-creator-view-type-placeholder": "Placeholder text for the view type selector in the layout creation dialog.",
 	"neowiki-layout-creator-save": "Label for the save button in the layout creation dialog.",

--- a/resources/ext.neowiki/src/application/SchemaLookup.ts
+++ b/resources/ext.neowiki/src/application/SchemaLookup.ts
@@ -1,9 +1,21 @@
 import type { Schema, SchemaName } from '@/domain/Schema';
 
+export interface SchemaSummary {
+	name: string;
+	description: string;
+	propertyCount: number;
+}
+
+export interface SchemaSummaryPage {
+	schemas: SchemaSummary[];
+	totalRows: number;
+}
+
 export interface SchemaLookup {
 
 	getSchema( schemaName: SchemaName ): Promise<Schema>;
 	getSchemaNames( search: string ): Promise<string[]>;
+	getSchemaSummaries( offset: number, limit: number ): Promise<SchemaSummaryPage>;
 
 }
 
@@ -29,6 +41,19 @@ export class InMemorySchemaLookup implements SchemaLookup {
 
 	public async getSchemaNames(): Promise<string[]> {
 		return [ ...this.schemaNames ];
+	}
+
+	public async getSchemaSummaries( offset: number, limit: number ): Promise<SchemaSummaryPage> {
+		const summaries = [ ...this.schemas.values() ].map( ( schema ) => ( {
+			name: schema.getName(),
+			description: schema.getDescription(),
+			propertyCount: [ ...schema.getPropertyDefinitions() ].length,
+		} ) );
+
+		return {
+			schemas: summaries.slice( offset, offset + limit ),
+			totalRows: summaries.length,
+		};
 	}
 
 	public clearSchemas(): void {

--- a/resources/ext.neowiki/src/components/LayoutsPage/LayoutCreator.vue
+++ b/resources/ext.neowiki/src/components/LayoutsPage/LayoutCreator.vue
@@ -16,7 +16,7 @@
 		</CdxField>
 
 		<CdxField>
-			<SchemaLookup
+			<SchemaPicker
 				:selected="selectedSchema"
 				@select="onSchemaSelected"
 			/>
@@ -66,7 +66,7 @@ import { NeoWikiServices } from '@/NeoWikiServices.ts';
 import { Layout, type DisplayRule } from '@/domain/Layout.ts';
 import type { PropertyDefinition } from '@/domain/PropertyDefinition.ts';
 import DisplayRuleList from '@/components/LayoutEditor/DisplayRuleList.vue';
-import SchemaLookup from '@/components/common/SchemaLookup.vue';
+import SchemaPicker from '@/components/common/SchemaPicker.vue';
 
 const emit = defineEmits<{
 	change: [];

--- a/resources/ext.neowiki/src/components/LayoutsPage/LayoutCreator.vue
+++ b/resources/ext.neowiki/src/components/LayoutsPage/LayoutCreator.vue
@@ -16,11 +16,9 @@
 		</CdxField>
 
 		<CdxField>
-			<CdxSelect
-				v-model:selected="selectedSchema"
-				:menu-items="schemaMenuItems"
-				:default-label="$i18n( 'neowiki-layout-creator-schema-placeholder' ).text()"
-				@update:selected="onSchemaSelected"
+			<SchemaLookup
+				:selected="selectedSchema"
+				@select="onSchemaSelected"
 			/>
 			<template #label>
 				{{ $i18n( 'neowiki-layout-creator-schema-field' ).text() }}
@@ -61,13 +59,14 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, shallowRef, onMounted } from 'vue';
+import { computed, ref, shallowRef } from 'vue';
 import { CdxField, CdxMessage, CdxSelect, CdxTextInput } from '@wikimedia/codex';
 import type { MenuItemData, ValidationStatusType } from '@wikimedia/codex';
 import { NeoWikiServices } from '@/NeoWikiServices.ts';
 import { Layout, type DisplayRule } from '@/domain/Layout.ts';
 import type { PropertyDefinition } from '@/domain/PropertyDefinition.ts';
 import DisplayRuleList from '@/components/LayoutEditor/DisplayRuleList.vue';
+import SchemaLookup from '@/components/common/SchemaLookup.vue';
 
 const emit = defineEmits<{
 	change: [];
@@ -84,16 +83,11 @@ const nameStatus = ref<ValidationStatusType>( 'default' );
 const nameInputRef = ref<InstanceType<typeof CdxTextInput> | null>( null );
 const selectedSchema = ref<string | null>( null );
 const selectedViewType = ref<string | null>( null );
-const schemaNames = ref<string[]>( [] );
 const schemaProperties = shallowRef<PropertyDefinition[]>( [] );
 const schemaFetchFailed = ref( false );
 const currentDisplayRules = shallowRef<DisplayRule[]>( [] );
 let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 let requestSequence = 0;
-
-const schemaMenuItems = computed<MenuItemData[]>( () =>
-	schemaNames.value.map( ( name ) => ( { label: name, value: name } ) )
-);
 
 const viewTypeMenuItems = computed<MenuItemData[]>( () =>
 	NeoWikiServices.getViewTypeRegistry().getTypeNames().map(
@@ -101,31 +95,20 @@ const viewTypeMenuItems = computed<MenuItemData[]>( () =>
 	)
 );
 
-onMounted( async () => {
-	try {
-		schemaNames.value = await schemaRepo.getSchemaNames( '' );
-	} catch ( error ) {
-		console.error( 'Failed to fetch schema names:', error );
-	}
-} );
-
 function onChange(): void {
 	emit( 'change' );
 }
 
-async function onSchemaSelected(): Promise<void> {
+async function onSchemaSelected( schemaName: string ): Promise<void> {
+	selectedSchema.value = schemaName;
 	schemaProperties.value = [];
 	schemaFetchFailed.value = false;
 
 	currentDisplayRules.value = [];
 	emit( 'change' );
 
-	if ( !selectedSchema.value ) {
-		return;
-	}
-
 	try {
-		const schema = await schemaRepo.getSchema( selectedSchema.value );
+		const schema = await schemaRepo.getSchema( schemaName );
 		schemaProperties.value = [ ...schema.getPropertyDefinitions() ];
 	} catch ( error ) {
 		console.error( 'Failed to fetch schema:', error );

--- a/resources/ext.neowiki/src/components/SchemaEditor/Property/RelationAttributesEditor.vue
+++ b/resources/ext.neowiki/src/components/SchemaEditor/Property/RelationAttributesEditor.vue
@@ -25,8 +25,9 @@
 				{{ $i18n( 'neowiki-property-editor-target-schema' ).text() }}
 			</template>
 			<SchemaLookup
-				:selected="property.targetSchema ?? null"
+				:selected="property.targetSchema || null"
 				@select="updateTargetSchema"
+				@blur="targetSchemaTouched = true"
 			/>
 		</CdxField>
 
@@ -54,7 +55,7 @@ const emit = defineEmits<AttributesEditorEmits<RelationProperty>>();
 const relationInput = ref( props.property.relation || props.property.name.toString() );
 
 watch( () => props.property.relation, ( newValue ) => {
-	relationInput.value = newValue || props.property.name.toString();
+	relationInput.value = newValue;
 } );
 
 onMounted( () => {
@@ -69,18 +70,17 @@ const relationError = computed<string | null>( () =>
 		null
 );
 
+const targetSchemaTouched = ref( false );
+
 const targetSchemaError = computed<string | null>( () =>
-	( props.property.targetSchema ?? '' ).trim() === '' ?
+	targetSchemaTouched.value && ( props.property.targetSchema ?? '' ).trim() === '' ?
 		mw.message( 'neowiki-property-editor-target-schema-required' ).text() :
 		null
 );
 
 const updateRelation = ( value: string ): void => {
 	relationInput.value = value;
-	const trimmed = value.trim();
-	if ( trimmed !== '' ) {
-		emit( 'update:property', { relation: trimmed } );
-	}
+	emit( 'update:property', { relation: value.trim() } );
 };
 
 const updateTargetSchema = ( schemaName: string ): void => {

--- a/resources/ext.neowiki/src/components/SchemaEditor/Property/RelationAttributesEditor.vue
+++ b/resources/ext.neowiki/src/components/SchemaEditor/Property/RelationAttributesEditor.vue
@@ -24,7 +24,7 @@
 			<template #label>
 				{{ $i18n( 'neowiki-property-editor-target-schema' ).text() }}
 			</template>
-			<SchemaLookup
+			<SchemaPicker
 				:selected="property.targetSchema || null"
 				@select="updateTargetSchema"
 				@blur="targetSchemaTouched = true"
@@ -47,7 +47,7 @@ import { computed, onMounted, ref, watch } from 'vue';
 import { CdxCheckbox, CdxField, CdxTextInput } from '@wikimedia/codex';
 import { RelationProperty } from '@/domain/propertyTypes/Relation.ts';
 import { AttributesEditorEmits, AttributesEditorProps } from '@/components/SchemaEditor/Property/AttributesEditorContract.ts';
-import SchemaLookup from '@/components/common/SchemaLookup.vue';
+import SchemaPicker from '@/components/common/SchemaPicker.vue';
 
 const props = defineProps<AttributesEditorProps<RelationProperty>>();
 const emit = defineEmits<AttributesEditorEmits<RelationProperty>>();

--- a/resources/ext.neowiki/src/components/SchemasPage/SchemasPage.vue
+++ b/resources/ext.neowiki/src/components/SchemasPage/SchemasPage.vue
@@ -111,6 +111,7 @@ import { NeoWikiExtension } from '@/NeoWikiExtension.ts';
 import { useSchemaPermissions } from '@/composables/useSchemaPermissions.ts';
 import { useSchemaStore } from '@/stores/SchemaStore.ts';
 import { Schema } from '@/domain/Schema.ts';
+import type { SchemaSummary } from '@/application/SchemaLookup.ts';
 import SchemaCreatorDialog from './SchemaCreatorDialog.vue';
 import SchemaEditorDialog from '@/components/SchemaEditor/SchemaEditorDialog.vue';
 import EditSummary from '@/components/common/EditSummary.vue';
@@ -165,12 +166,6 @@ const columns: TableColumn[] = [
 
 function schemaUrl( name: string ): string {
 	return mw.util.getUrl( `Schema:${ name }` );
-}
-
-interface SchemaSummary {
-	name: string;
-	description: string;
-	propertyCount: number;
 }
 
 async function fetchSchemas( offset: number, limit: number ): Promise<void> {

--- a/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
@@ -60,7 +60,7 @@
 				v-if="selectedSchemaOption === 'existing'"
 				class="ext-neowiki-subject-creator-existing"
 			>
-				<SchemaLookup
+				<SchemaPicker
 					ref="schemaLookupRef"
 					@select="onSchemaSelected"
 				/>
@@ -176,7 +176,7 @@ import SubjectEditor from '@/components/SubjectEditor/SubjectEditor.vue';
 import SchemaCreator from '@/components/SchemaCreator/SchemaCreator.vue';
 import type { SchemaCreatorExposes } from '@/components/SchemaCreator/SchemaCreator.vue';
 import EditSummary from '@/components/common/EditSummary.vue';
-import SchemaLookup from '@/components/common/SchemaLookup.vue';
+import SchemaPicker from '@/components/common/SchemaPicker.vue';
 import CloseConfirmationDialog from '@/components/common/CloseConfirmationDialog.vue';
 import SchemaAbandonmentDialog from '@/components/SubjectCreator/SchemaAbandonmentDialog.vue';
 import { useSchemaPermissions } from '@/composables/useSchemaPermissions.ts';

--- a/resources/ext.neowiki/src/components/common/SchemaLookup.vue
+++ b/resources/ext.neowiki/src/components/common/SchemaLookup.vue
@@ -1,24 +1,23 @@
 <template>
 	<div class="ext-neowiki-schema-lookup">
-		<CdxLookup
-			ref="lookupRef"
+		<CdxCombobox
+			ref="comboboxRef"
 			v-model:selected="selectedSchema"
-			v-model:input-value="inputText"
 			:menu-items="menuItems"
-			:start-icon="cdxIconSearch"
-			:placeholder="$i18n( 'neowiki-subject-creator-schema-search-placeholder' ).text()"
-			@input="onLookupInput"
-			@update:selected="onSchemaSelected"
+			:placeholder="$i18n( 'neowiki-schema-lookup-placeholder' ).text()"
+			@input="filterSchemas"
+			@update:selected="onSelect"
+			@blur="reconcileOnBlur"
 		/>
 	</div>
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue';
-import { CdxLookup } from '@wikimedia/codex';
-import { cdxIconSearch } from '@wikimedia/codex-icons';
+import { onMounted, ref, watch } from 'vue';
+import { CdxCombobox } from '@wikimedia/codex';
 import type { MenuItemData } from '@wikimedia/codex';
 import { useSchemaStore } from '@/stores/SchemaStore.ts';
+import type { SchemaSummary } from '@/application/SchemaLookup.ts';
 
 const props = defineProps<{
 	selected?: string | null;
@@ -26,69 +25,75 @@ const props = defineProps<{
 
 const emit = defineEmits<{
 	'select': [ schemaName: string ];
+	'blur': [];
 }>();
 
 const schemaStore = useSchemaStore();
-const selectedSchema = ref<string | null>( props.selected ?? null );
-const inputText = ref<string>( props.selected ?? '' );
-const menuItems = ref<MenuItemData[]>(
-	props.selected ? [ { label: props.selected, value: props.selected } ] : []
-);
-const lookupRef = ref<InstanceType<typeof CdxLookup> | null>( null );
-let requestSequence = 0;
+const selectedSchema = ref<string>( props.selected ?? '' );
+const summaries = ref<SchemaSummary[]>( [] );
+const menuItems = ref<MenuItemData[]>( [] );
+const comboboxRef = ref<InstanceType<typeof CdxCombobox> | null>( null );
 
-watch( () => props.selected, ( value ) => {
-	selectedSchema.value = value ?? null;
-	inputText.value = value ?? '';
-	if ( value && !menuItems.value.some( ( item ) => item.value === value ) ) {
-		menuItems.value = [ { label: value, value: value } ];
-	} else if ( !value ) {
-		menuItems.value = [];
-	}
+onMounted( async () => {
+	summaries.value = await schemaStore.getAllSchemaSummaries();
+	showAllSchemas();
 } );
 
-async function onLookupInput( value: string ): Promise<void> {
-	if ( !value ) {
-		menuItems.value = [];
-		return;
-	}
+watch( () => props.selected, ( value ) => {
+	selectedSchema.value = value ?? '';
+} );
 
-	const currentSequence = ++requestSequence;
+function toMenuItems( items: SchemaSummary[] ): MenuItemData[] {
+	return items.map( ( summary ) => ( {
+		label: summary.name,
+		value: summary.name,
+		description: summary.description || undefined
+	} ) );
+}
 
-	try {
-		const schemaNames = await schemaStore.searchAndFetchMissingSchemas( value );
+function showAllSchemas(): void {
+	menuItems.value = toMenuItems( summaries.value );
+}
 
-		if ( currentSequence !== requestSequence ) {
-			return;
-		}
+function findSchema( name: string ): SchemaSummary | undefined {
+	return summaries.value.find( ( summary ) => summary.name === name.trim() );
+}
 
-		menuItems.value = schemaNames.map( ( name ) => ( {
-			label: name,
-			value: name,
-			description: schemaStore.getSchema( name ).getDescription() || undefined
-		} ) );
-	} catch ( error ) {
-		if ( currentSequence !== requestSequence ) {
-			return;
-		}
+function filterSchemas( event: Event ): void {
+	const query = ( event.target as HTMLInputElement ).value.trim().toLowerCase();
+	const matches = query === '' ?
+		summaries.value :
+		summaries.value.filter( ( summary ) => summary.name.toLowerCase().includes( query ) );
+	menuItems.value = toMenuItems( matches );
+}
 
-		console.error( 'Error searching schemas:', error );
-		menuItems.value = [];
+// CdxCombobox's `selected` tracks the typed text, not only menu picks, so only
+// commit it when it is an exact existing schema name.
+function onSelect( value: string ): void {
+	if ( findSchema( value ) && value !== props.selected ) {
+		emit( 'select', value );
 	}
 }
 
-function onSchemaSelected( schemaName: string ): void {
-	if ( schemaName ) {
-		emit( 'select', schemaName );
-	}
+// On blur, snap `selected` back to the committed schema (empty for a target schema
+// that has not been set yet) so unconfirmed typing reverts and the field only ever
+// shows an existing schema. Restoring the full menu lets the committed label render.
+function reconcileOnBlur(): void {
+	selectedSchema.value = props.selected ?? '';
+	showAllSchemas();
+	emit( 'blur' );
 }
 
 function focus(): void {
-	// CdxLookup component does not expose a focus method,
-	// so we need to find the input element and focus it directly.
-	const input = ( lookupRef.value?.$el as HTMLElement )?.querySelector( 'input' );
+	const input = ( comboboxRef.value?.$el as HTMLElement )?.querySelector( 'input' );
 	input?.focus();
 }
 
 defineExpose( { focus } );
 </script>
+
+<style lang="less">
+.ext-neowiki-schema-lookup .cdx-combobox {
+	width: 100%;
+}
+</style>

--- a/resources/ext.neowiki/src/components/common/SchemaLookup.vue
+++ b/resources/ext.neowiki/src/components/common/SchemaLookup.vue
@@ -13,7 +13,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref, watch } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
 import { CdxCombobox } from '@wikimedia/codex';
 import type { MenuItemData } from '@wikimedia/codex';
 import { useSchemaStore } from '@/stores/SchemaStore.ts';
@@ -31,56 +31,57 @@ const emit = defineEmits<{
 const schemaStore = useSchemaStore();
 const selectedSchema = ref<string>( props.selected ?? '' );
 const summaries = ref<SchemaSummary[]>( [] );
-const menuItems = ref<MenuItemData[]>( [] );
+const query = ref<string>( '' );
 const comboboxRef = ref<InstanceType<typeof CdxCombobox> | null>( null );
 
+const menuItems = computed<MenuItemData[]>( () => {
+	const matches = query.value === '' ?
+		summaries.value :
+		summaries.value.filter( ( summary ) => summary.name.toLowerCase().includes( query.value ) );
+	return matches.map( ( summary ) => ( {
+		label: summary.name,
+		value: summary.name,
+		description: summary.description || undefined
+	} ) );
+} );
+
 onMounted( async () => {
-	summaries.value = await schemaStore.getAllSchemaSummaries();
-	showAllSchemas();
+	try {
+		summaries.value = await schemaStore.getAllSchemaSummaries();
+	} catch ( error ) {
+		console.error( 'Failed to load schemas for the picker:', error );
+	}
 } );
 
 watch( () => props.selected, ( value ) => {
 	selectedSchema.value = value ?? '';
 } );
 
-function toMenuItems( items: SchemaSummary[] ): MenuItemData[] {
-	return items.map( ( summary ) => ( {
-		label: summary.name,
-		value: summary.name,
-		description: summary.description || undefined
-	} ) );
-}
-
-function showAllSchemas(): void {
-	menuItems.value = toMenuItems( summaries.value );
-}
-
 function findSchema( name: string ): SchemaSummary | undefined {
 	return summaries.value.find( ( summary ) => summary.name === name.trim() );
 }
 
 function filterSchemas( event: Event ): void {
-	const query = ( event.target as HTMLInputElement ).value.trim().toLowerCase();
-	const matches = query === '' ?
-		summaries.value :
-		summaries.value.filter( ( summary ) => summary.name.toLowerCase().includes( query ) );
-	menuItems.value = toMenuItems( matches );
+	query.value = ( event.target as HTMLInputElement ).value.trim().toLowerCase();
 }
 
 // CdxCombobox's `selected` tracks the typed text, not only menu picks, so only
-// commit it when it is an exact existing schema name.
+// commit it when it resolves to an exact existing schema, and emit that schema's
+// canonical name rather than the raw input (which may carry surrounding whitespace).
 function onSelect( value: string ): void {
-	if ( findSchema( value ) && value !== props.selected ) {
-		emit( 'select', value );
+	const schema = findSchema( value );
+	if ( schema && schema.name !== props.selected ) {
+		emit( 'select', schema.name );
 	}
 }
 
 // On blur, snap `selected` back to the committed schema (empty for a target schema
 // that has not been set yet) so unconfirmed typing reverts and the field only ever
-// shows an existing schema. Restoring the full menu lets the committed label render.
+// shows an existing schema. Clearing the query restores the full menu so the
+// committed label renders.
 function reconcileOnBlur(): void {
 	selectedSchema.value = props.selected ?? '';
-	showAllSchemas();
+	query.value = '';
 	emit( 'blur' );
 }
 

--- a/resources/ext.neowiki/src/components/common/SchemaPicker.vue
+++ b/resources/ext.neowiki/src/components/common/SchemaPicker.vue
@@ -1,10 +1,10 @@
 <template>
-	<div class="ext-neowiki-schema-lookup">
+	<div class="ext-neowiki-schema-picker">
 		<CdxCombobox
 			ref="comboboxRef"
 			v-model:selected="selectedSchema"
 			:menu-items="menuItems"
-			:placeholder="$i18n( 'neowiki-schema-lookup-placeholder' ).text()"
+			:placeholder="$i18n( 'neowiki-schema-picker-placeholder' ).text()"
 			@input="filterSchemas"
 			@update:selected="onSelect"
 			@blur="reconcileOnBlur"
@@ -94,7 +94,7 @@ defineExpose( { focus } );
 </script>
 
 <style lang="less">
-.ext-neowiki-schema-lookup .cdx-combobox {
+.ext-neowiki-schema-picker .cdx-combobox {
 	width: 100%;
 }
 </style>

--- a/resources/ext.neowiki/src/persistence/RestSchemaRepository.ts
+++ b/resources/ext.neowiki/src/persistence/RestSchemaRepository.ts
@@ -1,6 +1,7 @@
 import { Schema, type SchemaName } from '@/domain/Schema';
 import type { HttpClient } from '@/infrastructure/HttpClient/HttpClient';
 import type { SchemaRepository } from '@/application/SchemaRepository';
+import type { SchemaSummaryPage } from '@/application/SchemaLookup';
 import { SchemaSerializer } from '@/persistence/SchemaSerializer.ts';
 import { SchemaDeserializer } from '@/persistence/SchemaDeserializer.ts';
 import { PageSaver } from '@/persistence/PageSaver.ts';
@@ -42,6 +43,18 @@ export class RestSchemaRepository implements SchemaRepository {
 
 		if ( !response.ok ) {
 			throw new Error( 'Error fetching schemas' );
+		}
+
+		return await response.json();
+	}
+
+	public async getSchemaSummaries( offset: number, limit: number ): Promise<SchemaSummaryPage> {
+		const response = await this.httpClient.get(
+			`${ this.mediaWikiRestApiUrl }/neowiki/v0/schemas?limit=${ limit }&offset=${ offset }`,
+		);
+
+		if ( !response.ok ) {
+			throw new Error( 'Error fetching schema summaries' );
 		}
 
 		return await response.json();

--- a/resources/ext.neowiki/src/public-api.ts
+++ b/resources/ext.neowiki/src/public-api.ts
@@ -128,7 +128,7 @@ export { default as SchemaEditorDialog } from './components/SchemaEditor/SchemaE
 export { default as SchemaCreatorDialog } from './components/SchemasPage/SchemaCreatorDialog.vue';
 export { default as SchemasPage } from './components/SchemasPage/SchemasPage.vue';
 export { default as SchemaAbandonmentDialog } from './components/SubjectCreator/SchemaAbandonmentDialog.vue';
-export { default as SchemaLookup } from './components/common/SchemaLookup.vue';
+export { default as SchemaPicker } from './components/common/SchemaPicker.vue';
 export { default as SubjectCreatorDialog } from './components/SubjectCreator/SubjectCreatorDialog.vue';
 export { default as SubjectEditor } from './components/SubjectEditor/SubjectEditor.vue';
 export { default as SubjectEditorDialog } from './components/SubjectEditor/SubjectEditorDialog.vue';

--- a/resources/ext.neowiki/src/stores/SchemaStore.ts
+++ b/resources/ext.neowiki/src/stores/SchemaStore.ts
@@ -44,11 +44,6 @@ export const useSchemaStore = defineStore( 'schema', {
 			}
 			return this.getSchema( name );
 		},
-		async searchAndFetchMissingSchemas( search: string ): Promise<string[]> {
-			const schemaNames = await NeoWikiExtension.getInstance().getSchemaRepository().getSchemaNames( search );
-			await Promise.all( schemaNames.map( ( name ) => this.getOrFetchSchema( name ) ) );
-			return schemaNames;
-		},
 		// Loads every Schema summary (name + description) once and caches it so the
 		// schema picker can show the full list and filter client-side. The cache is
 		// cleared on saveSchema. Pages through the summaries endpoint (capped at 50).
@@ -58,13 +53,18 @@ export const useSchemaStore = defineStore( 'schema', {
 			}
 
 			const repository = NeoWikiExtension.getInstance().getSchemaRepository();
+			const pageSize = 50;
 			const summaries: SchemaSummary[] = [];
 
-			let page = await repository.getSchemaSummaries( 0, 50 );
-			summaries.push( ...page.schemas );
+			const firstPage = await repository.getSchemaSummaries( 0, pageSize );
+			summaries.push( ...firstPage.schemas );
 
-			while ( summaries.length < page.totalRows && page.schemas.length > 0 ) {
-				page = await repository.getSchemaSummaries( summaries.length, 50 );
+			// Page by request offset, not by loaded count: the endpoint counts every
+			// Schema page in totalRows but omits ones it cannot load (restricted or
+			// malformed), so advancing by summaries.length would re-request earlier
+			// names and duplicate entries. Stop once the offset passes the total.
+			for ( let offset = pageSize; offset < firstPage.totalRows; offset += pageSize ) {
+				const page = await repository.getSchemaSummaries( offset, pageSize );
 				summaries.push( ...page.schemas );
 			}
 

--- a/resources/ext.neowiki/src/stores/SchemaStore.ts
+++ b/resources/ext.neowiki/src/stores/SchemaStore.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia';
 import { Schema } from '@/domain/Schema.ts';
 import { NeoWikiExtension } from '@/NeoWikiExtension.ts';
+import type { SchemaSummary } from '@/application/SchemaLookup.ts';
 
 /**
  * Approximates MediaWiki title normalisation for a Schema name (schemas are
@@ -16,6 +17,7 @@ export function normalizeSchemaName( name: string ): string {
 export const useSchemaStore = defineStore( 'schema', {
 	state: () => ( {
 		schemas: new Map<string, Schema>(),
+		allSummaries: null as SchemaSummary[] | null,
 	} ),
 	getters: {
 		getSchemas: ( state ) => state.schemas,
@@ -47,6 +49,28 @@ export const useSchemaStore = defineStore( 'schema', {
 			await Promise.all( schemaNames.map( ( name ) => this.getOrFetchSchema( name ) ) );
 			return schemaNames;
 		},
+		// Loads every Schema summary (name + description) once and caches it so the
+		// schema picker can show the full list and filter client-side. The cache is
+		// cleared on saveSchema. Pages through the summaries endpoint (capped at 50).
+		async getAllSchemaSummaries(): Promise<SchemaSummary[]> {
+			if ( this.allSummaries !== null ) {
+				return this.allSummaries;
+			}
+
+			const repository = NeoWikiExtension.getInstance().getSchemaRepository();
+			const summaries: SchemaSummary[] = [];
+
+			let page = await repository.getSchemaSummaries( 0, 50 );
+			summaries.push( ...page.schemas );
+
+			while ( summaries.length < page.totalRows && page.schemas.length > 0 ) {
+				page = await repository.getSchemaSummaries( summaries.length, 50 );
+				summaries.push( ...page.schemas );
+			}
+
+			this.allSummaries = summaries;
+			return summaries;
+		},
 		// Checks existence via the schema-names search (a 200 response) rather
 		// than getOrFetchSchema, which 404s for a missing name — those 404s are
 		// avoidable console/network noise when checking a not-yet-created name.
@@ -60,6 +84,7 @@ export const useSchemaStore = defineStore( 'schema', {
 		async saveSchema( schema: Schema, comment?: string ): Promise<void> {
 			await NeoWikiExtension.getInstance().getSchemaRepository().saveSchema( schema, comment );
 			this.setSchema( schema.getName(), schema );
+			this.allSummaries = null;
 		},
 	},
 } );

--- a/resources/ext.neowiki/tests/components/SchemaEditor/Property/RelationAttributesEditor.spec.ts
+++ b/resources/ext.neowiki/tests/components/SchemaEditor/Property/RelationAttributesEditor.spec.ts
@@ -151,14 +151,6 @@ describe( 'RelationAttributesEditor', () => {
 			expect( wrapper.emitted( 'update:property' )?.[ 0 ] ).toEqual( [ { targetSchema: 'Office' } ] );
 		} );
 
-		it( 'emits an empty target schema when the picker is cleared', async () => {
-			const wrapper = newWrapper();
-
-			await wrapper.findComponent( SchemaLookupStub ).vm.$emit( 'select', '' );
-
-			expect( wrapper.emitted( 'update:property' )?.[ 0 ] ).toEqual( [ { targetSchema: '' } ] );
-		} );
-
 		it( 'emits multiple when the checkbox is toggled', async () => {
 			const wrapper = newWrapper();
 

--- a/resources/ext.neowiki/tests/components/SchemaEditor/Property/RelationAttributesEditor.spec.ts
+++ b/resources/ext.neowiki/tests/components/SchemaEditor/Property/RelationAttributesEditor.spec.ts
@@ -9,7 +9,7 @@ import { createI18nMock, FieldProps, setupMwMock } from '../../../VueTestHelpers
 
 const SchemaLookupStub = {
 	props: [ 'selected' ],
-	emits: [ 'select' ],
+	emits: [ 'select', 'blur' ],
 	template: '<div class="schema-lookup-stub"></div>',
 };
 
@@ -63,6 +63,14 @@ describe( 'RelationAttributesEditor', () => {
 			expect( wrapper.findComponent( SchemaLookupStub ).props( 'selected' ) ).toBe( 'Office' );
 		} );
 
+		it( 'passes null to SchemaLookup when no target schema is set', () => {
+			const wrapper = newWrapper( {
+				property: relationProperty( { targetSchema: '' } ),
+			} );
+
+			expect( wrapper.findComponent( SchemaLookupStub ).props( 'selected' ) ).toBe( null );
+		} );
+
 		it( 'displays the stored relation in the input', () => {
 			const wrapper = newWrapper( {
 				property: relationProperty( { relation: 'Has gadget' } ),
@@ -77,6 +85,18 @@ describe( 'RelationAttributesEditor', () => {
 			} );
 
 			expect( wrapper.findComponent( CdxTextInput ).props( 'modelValue' ) ).toBe( 'Main product' );
+		} );
+
+		it( 'clears the displayed relation when the stored relation is emptied', async () => {
+			const wrapper = newWrapper( {
+				property: relationProperty( { relation: 'Has product' } ),
+			} );
+
+			await wrapper.setProps( {
+				property: relationProperty( { relation: '' } ),
+			} );
+
+			expect( wrapper.findComponent( CdxTextInput ).props( 'modelValue' ) ).toBe( '' );
 		} );
 	} );
 
@@ -115,12 +135,28 @@ describe( 'RelationAttributesEditor', () => {
 			expect( wrapper.emitted( 'update:property' )?.[ 0 ] ).toEqual( [ { relation: 'Owns' } ] );
 		} );
 
+		it( 'emits an empty relation when the field is cleared', async () => {
+			const wrapper = newWrapper();
+
+			await wrapper.findComponent( CdxTextInput ).vm.$emit( 'update:modelValue', '' );
+
+			expect( wrapper.emitted( 'update:property' )?.[ 0 ] ).toEqual( [ { relation: '' } ] );
+		} );
+
 		it( 'emits targetSchema when the picker selects a schema', async () => {
 			const wrapper = newWrapper();
 
 			await wrapper.findComponent( SchemaLookupStub ).vm.$emit( 'select', 'Office' );
 
 			expect( wrapper.emitted( 'update:property' )?.[ 0 ] ).toEqual( [ { targetSchema: 'Office' } ] );
+		} );
+
+		it( 'emits an empty target schema when the picker is cleared', async () => {
+			const wrapper = newWrapper();
+
+			await wrapper.findComponent( SchemaLookupStub ).vm.$emit( 'select', '' );
+
+			expect( wrapper.emitted( 'update:property' )?.[ 0 ] ).toEqual( [ { targetSchema: '' } ] );
 		} );
 
 		it( 'emits multiple when the checkbox is toggled', async () => {
@@ -148,10 +184,9 @@ describe( 'RelationAttributesEditor', () => {
 			const props = fieldProps( wrapper, '.relation-attributes__relation' );
 			expect( props.status ).toBe( 'error' );
 			expect( props.messages ).toEqual( { error: 'Relation type is required.' } );
-			expect( wrapper.emitted( 'update:property' ) ).toBeFalsy();
 		} );
 
-		it( 'treats a whitespace-only relation as required and does not emit it', async () => {
+		it( 'treats a whitespace-only relation as required', async () => {
 			const wrapper = newWrapper();
 
 			await wrapper.findComponent( CdxTextInput ).vm.$emit( 'update:modelValue', '   ' );
@@ -159,13 +194,22 @@ describe( 'RelationAttributesEditor', () => {
 			const props = fieldProps( wrapper, '.relation-attributes__relation' );
 			expect( props.status ).toBe( 'error' );
 			expect( props.messages ).toEqual( { error: 'Relation type is required.' } );
-			expect( wrapper.emitted( 'update:property' ) ).toBeFalsy();
 		} );
 
-		it( 'shows a required error when the target schema is empty', () => {
+		it( 'does not show the target schema error before the field is touched', () => {
 			const wrapper = newWrapper( {
 				property: relationProperty( { targetSchema: '' } ),
 			} );
+
+			expect( fieldProps( wrapper, '.relation-attributes__target-schema' ).status ).toBe( 'default' );
+		} );
+
+		it( 'shows a required error after the empty target schema field is blurred', async () => {
+			const wrapper = newWrapper( {
+				property: relationProperty( { targetSchema: '' } ),
+			} );
+
+			await wrapper.findComponent( SchemaLookupStub ).vm.$emit( 'blur' );
 
 			const props = fieldProps( wrapper, '.relation-attributes__target-schema' );
 			expect( props.status ).toBe( 'error' );

--- a/resources/ext.neowiki/tests/components/SchemaEditor/Property/RelationAttributesEditor.spec.ts
+++ b/resources/ext.neowiki/tests/components/SchemaEditor/Property/RelationAttributesEditor.spec.ts
@@ -7,7 +7,7 @@ import { PropertyName } from '@/domain/PropertyDefinition.ts';
 import { AttributesEditorProps } from '@/components/SchemaEditor/Property/AttributesEditorContract.ts';
 import { createI18nMock, FieldProps, setupMwMock } from '../../../VueTestHelpers.ts';
 
-const SchemaLookupStub = {
+const SchemaPickerStub = {
 	props: [ 'selected' ],
 	emits: [ 'select', 'blur' ],
 	template: '<div class="schema-lookup-stub"></div>',
@@ -37,7 +37,7 @@ describe( 'RelationAttributesEditor', () => {
 			},
 			global: {
 				mocks: { $i18n: createI18nMock() },
-				stubs: { SchemaLookup: SchemaLookupStub },
+				stubs: { SchemaPicker: SchemaPickerStub },
 			},
 		} );
 	}
@@ -51,24 +51,24 @@ describe( 'RelationAttributesEditor', () => {
 			const wrapper = newWrapper();
 
 			expect( wrapper.find( '.relation-attributes__relation' ).exists() ).toBe( true );
-			expect( wrapper.findComponent( SchemaLookupStub ).exists() ).toBe( true );
+			expect( wrapper.findComponent( SchemaPickerStub ).exists() ).toBe( true );
 			expect( wrapper.find( 'input[type="checkbox"]' ).exists() ).toBe( true );
 		} );
 
-		it( 'passes the current target schema to SchemaLookup', () => {
+		it( 'passes the current target schema to SchemaPicker', () => {
 			const wrapper = newWrapper( {
 				property: relationProperty( { targetSchema: 'Office' } ),
 			} );
 
-			expect( wrapper.findComponent( SchemaLookupStub ).props( 'selected' ) ).toBe( 'Office' );
+			expect( wrapper.findComponent( SchemaPickerStub ).props( 'selected' ) ).toBe( 'Office' );
 		} );
 
-		it( 'passes null to SchemaLookup when no target schema is set', () => {
+		it( 'passes null to SchemaPicker when no target schema is set', () => {
 			const wrapper = newWrapper( {
 				property: relationProperty( { targetSchema: '' } ),
 			} );
 
-			expect( wrapper.findComponent( SchemaLookupStub ).props( 'selected' ) ).toBe( null );
+			expect( wrapper.findComponent( SchemaPickerStub ).props( 'selected' ) ).toBe( null );
 		} );
 
 		it( 'displays the stored relation in the input', () => {
@@ -146,7 +146,7 @@ describe( 'RelationAttributesEditor', () => {
 		it( 'emits targetSchema when the picker selects a schema', async () => {
 			const wrapper = newWrapper();
 
-			await wrapper.findComponent( SchemaLookupStub ).vm.$emit( 'select', 'Office' );
+			await wrapper.findComponent( SchemaPickerStub ).vm.$emit( 'select', 'Office' );
 
 			expect( wrapper.emitted( 'update:property' )?.[ 0 ] ).toEqual( [ { targetSchema: 'Office' } ] );
 		} );
@@ -201,7 +201,7 @@ describe( 'RelationAttributesEditor', () => {
 				property: relationProperty( { targetSchema: '' } ),
 			} );
 
-			await wrapper.findComponent( SchemaLookupStub ).vm.$emit( 'blur' );
+			await wrapper.findComponent( SchemaPickerStub ).vm.$emit( 'blur' );
 
 			const props = fieldProps( wrapper, '.relation-attributes__target-schema' );
 			expect( props.status ).toBe( 'error' );

--- a/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
@@ -2,7 +2,7 @@ import { mount, VueWrapper, flushPromises } from '@vue/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ref } from 'vue';
 import SubjectCreatorDialog from '@/components/SubjectCreator/SubjectCreatorDialog.vue';
-import SchemaLookup from '@/components/common/SchemaLookup.vue';
+import SchemaPicker from '@/components/common/SchemaPicker.vue';
 import SchemaCreator from '@/components/SchemaCreator/SchemaCreator.vue';
 import EditSummary from '@/components/common/EditSummary.vue';
 import { createPinia, setActivePinia } from 'pinia';
@@ -36,7 +36,7 @@ const NEW_SCHEMA_NAME = 'NewSchema';
 
 vi.mock( '@/composables/useSchemaPermissions.ts' );
 
-const SchemaLookupStub = {
+const SchemaPickerStub = {
 	template: '<div class="schema-lookup-stub"></div>',
 	emits: [ 'select' ],
 	methods: {
@@ -129,7 +129,7 @@ describe( 'SubjectCreatorDialog', () => {
 			global: {
 				plugins: [ pinia ],
 				stubs: {
-					SchemaLookup: SchemaLookupStub,
+					SchemaPicker: SchemaPickerStub,
 					SubjectEditor: SubjectEditorStub,
 					SchemaCreator: SchemaCreatorStub,
 					EditSummary: EditSummaryStub,
@@ -246,7 +246,7 @@ describe( 'SubjectCreatorDialog', () => {
 		expect( wrapper.find( '.schema-lookup-stub' ).exists() ).toBe( true );
 		expect( wrapper.find( '.cdx-toggle-button-group-stub' ).exists() ).toBe( true );
 
-		await wrapper.findComponent( SchemaLookup ).vm.$emit( 'select', SCHEMA_NAME );
+		await wrapper.findComponent( SchemaPicker ).vm.$emit( 'select', SCHEMA_NAME );
 		await flushPromises();
 
 		expect( wrapper.find( '.schema-lookup-stub' ).exists() ).toBe( false );
@@ -273,7 +273,7 @@ describe( 'SubjectCreatorDialog', () => {
 	it( 'shows label input and SubjectEditor after schema selection', async () => {
 		const wrapper = mountComponent();
 
-		await wrapper.findComponent( SchemaLookup ).vm.$emit( 'select', SCHEMA_NAME );
+		await wrapper.findComponent( SchemaPicker ).vm.$emit( 'select', SCHEMA_NAME );
 		await flushPromises();
 
 		expect( wrapper.find( '.cdx-text-input-stub' ).exists() ).toBe( true );
@@ -284,7 +284,7 @@ describe( 'SubjectCreatorDialog', () => {
 	it( 'defaults label to page title', async () => {
 		const wrapper = mountComponent();
 
-		await wrapper.findComponent( SchemaLookup ).vm.$emit( 'select', SCHEMA_NAME );
+		await wrapper.findComponent( SchemaPicker ).vm.$emit( 'select', SCHEMA_NAME );
 		await flushPromises();
 
 		const labelInput = wrapper.find( '.cdx-text-input-stub' );
@@ -294,7 +294,7 @@ describe( 'SubjectCreatorDialog', () => {
 	it( 'calls createMainSubject on save with correct arguments', async () => {
 		const wrapper = mountComponent();
 
-		await wrapper.findComponent( SchemaLookup ).vm.$emit( 'select', SCHEMA_NAME );
+		await wrapper.findComponent( SchemaPicker ).vm.$emit( 'select', SCHEMA_NAME );
 		await flushPromises();
 
 		await wrapper.findComponent( EditSummary ).vm.$emit( 'save', 'test summary' );
@@ -312,7 +312,7 @@ describe( 'SubjectCreatorDialog', () => {
 	it( 'does not pass summary when it is empty', async () => {
 		const wrapper = mountComponent();
 
-		await wrapper.findComponent( SchemaLookup ).vm.$emit( 'select', SCHEMA_NAME );
+		await wrapper.findComponent( SchemaPicker ).vm.$emit( 'select', SCHEMA_NAME );
 		await flushPromises();
 
 		await wrapper.findComponent( EditSummary ).vm.$emit( 'save', '' );
@@ -330,7 +330,7 @@ describe( 'SubjectCreatorDialog', () => {
 	it( 'calls createChildSubject when the page already has a main subject', async () => {
 		const wrapper = mountComponent( {}, { pageHasMainSubject: true } );
 
-		await wrapper.findComponent( SchemaLookup ).vm.$emit( 'select', SCHEMA_NAME );
+		await wrapper.findComponent( SchemaPicker ).vm.$emit( 'select', SCHEMA_NAME );
 		await flushPromises();
 
 		await wrapper.findComponent( EditSummary ).vm.$emit( 'save', 'test summary' );
@@ -351,7 +351,7 @@ describe( 'SubjectCreatorDialog', () => {
 
 		subjectStore.openSubjectCreator();
 		await flushPromises();
-		await wrapper.findComponent( SchemaLookup ).vm.$emit( 'select', SCHEMA_NAME );
+		await wrapper.findComponent( SchemaPicker ).vm.$emit( 'select', SCHEMA_NAME );
 		await flushPromises();
 
 		await wrapper.findComponent( EditSummary ).vm.$emit( 'save', '' );
@@ -368,7 +368,7 @@ describe( 'SubjectCreatorDialog', () => {
 
 		subjectStore.openSubjectCreator();
 		await flushPromises();
-		await wrapper.findComponent( SchemaLookup ).vm.$emit( 'select', SCHEMA_NAME );
+		await wrapper.findComponent( SchemaPicker ).vm.$emit( 'select', SCHEMA_NAME );
 		await flushPromises();
 
 		await wrapper.findComponent( EditSummary ).vm.$emit( 'save', '' );
@@ -386,7 +386,7 @@ describe( 'SubjectCreatorDialog', () => {
 	it( 'does not save when label is empty', async () => {
 		const wrapper = mountComponent();
 
-		await wrapper.findComponent( SchemaLookup ).vm.$emit( 'select', SCHEMA_NAME );
+		await wrapper.findComponent( SchemaPicker ).vm.$emit( 'select', SCHEMA_NAME );
 		await flushPromises();
 
 		const labelInput = wrapper.find( '.cdx-text-input-stub' );
@@ -413,7 +413,7 @@ describe( 'SubjectCreatorDialog', () => {
 			expect( wrapper.find( '.ext-neowiki-subject-creator-continue' ).exists() ).toBe( true );
 		} );
 
-		it( 'does not show SchemaLookup when "Create new" is selected', async () => {
+		it( 'does not show SchemaPicker when "Create new" is selected', async () => {
 			const wrapper = mountComponent();
 
 			await switchToNewSchema( wrapper );
@@ -591,7 +591,7 @@ describe( 'SubjectCreatorDialog', () => {
 		it( 'shows back button after selecting a schema', async () => {
 			const wrapper = mountComponent();
 
-			await wrapper.findComponent( SchemaLookup ).vm.$emit( 'select', SCHEMA_NAME );
+			await wrapper.findComponent( SchemaPicker ).vm.$emit( 'select', SCHEMA_NAME );
 			await flushPromises();
 
 			expect( wrapper.find( '.ext-neowiki-subject-creator-back-button' ).exists() ).toBe( true );
@@ -600,7 +600,7 @@ describe( 'SubjectCreatorDialog', () => {
 		it( 'returns to schema selection when back button is clicked', async () => {
 			const wrapper = mountComponent();
 
-			await wrapper.findComponent( SchemaLookup ).vm.$emit( 'select', SCHEMA_NAME );
+			await wrapper.findComponent( SchemaPicker ).vm.$emit( 'select', SCHEMA_NAME );
 			await flushPromises();
 
 			expect( wrapper.find( '.subject-editor-stub' ).exists() ).toBe( true );
@@ -655,7 +655,7 @@ describe( 'SubjectCreatorDialog', () => {
 		it( 'returns to schema selector when clicking back after selecting existing schema', async () => {
 			const wrapper = mountComponent();
 
-			await wrapper.findComponent( SchemaLookup ).vm.$emit( 'select', SCHEMA_NAME );
+			await wrapper.findComponent( SchemaPicker ).vm.$emit( 'select', SCHEMA_NAME );
 			await flushPromises();
 
 			await wrapper.find( '.ext-neowiki-subject-creator-back-button' ).trigger( 'click' );
@@ -672,7 +672,7 @@ describe( 'SubjectCreatorDialog', () => {
 
 			subjectStore.openSubjectCreator();
 			await flushPromises();
-			await wrapper.findComponent( SchemaLookup ).vm.$emit( 'select', SCHEMA_NAME );
+			await wrapper.findComponent( SchemaPicker ).vm.$emit( 'select', SCHEMA_NAME );
 			await flushPromises();
 
 			const labelInput = wrapper.find( '.cdx-text-input-stub' );
@@ -706,7 +706,7 @@ describe( 'SubjectCreatorDialog', () => {
 
 			subjectStore.openSubjectCreator();
 			await flushPromises();
-			await wrapper.findComponent( SchemaLookup ).vm.$emit( 'select', SCHEMA_NAME );
+			await wrapper.findComponent( SchemaPicker ).vm.$emit( 'select', SCHEMA_NAME );
 			await flushPromises();
 
 			const labelInput = wrapper.find( '.cdx-text-input-stub' );
@@ -729,7 +729,7 @@ describe( 'SubjectCreatorDialog', () => {
 
 			subjectStore.openSubjectCreator();
 			await flushPromises();
-			await wrapper.findComponent( SchemaLookup ).vm.$emit( 'select', SCHEMA_NAME );
+			await wrapper.findComponent( SchemaPicker ).vm.$emit( 'select', SCHEMA_NAME );
 			await flushPromises();
 
 			const labelInput = wrapper.find( '.cdx-text-input-stub' );
@@ -830,7 +830,7 @@ describe( 'SubjectCreatorDialog', () => {
 
 			subjectStore.openSubjectCreator();
 			await flushPromises();
-			await wrapper.findComponent( SchemaLookup ).vm.$emit( 'select', SCHEMA_NAME );
+			await wrapper.findComponent( SchemaPicker ).vm.$emit( 'select', SCHEMA_NAME );
 			await flushPromises();
 
 			const labelInput = wrapper.find( '.cdx-text-input-stub' );
@@ -914,7 +914,7 @@ describe( 'SubjectCreatorDialog', () => {
 		async function openSelectSchemaAndSave( wrapper: VueWrapper ): Promise<void> {
 			subjectStore.openSubjectCreator();
 			await flushPromises();
-			await wrapper.findComponent( SchemaLookup ).vm.$emit( 'select', SCHEMA_NAME );
+			await wrapper.findComponent( SchemaPicker ).vm.$emit( 'select', SCHEMA_NAME );
 			await flushPromises();
 			await wrapper.findComponent( EditSummary ).vm.$emit( 'save', '' );
 			await flushPromises();
@@ -1033,7 +1033,7 @@ describe( 'SubjectCreatorDialog', () => {
 			subjectStore.openSubjectCreator();
 			await flushPromises();
 			// Re-select schema so SubjectEditor renders again
-			await wrapper.findComponent( SchemaLookup ).vm.$emit( 'select', SCHEMA_NAME );
+			await wrapper.findComponent( SchemaPicker ).vm.$emit( 'select', SCHEMA_NAME );
 			await flushPromises();
 
 			const after = wrapper.findComponent( SubjectEditor ).props( 'serverViolations' ) as SubjectViolation[];
@@ -1050,7 +1050,7 @@ describe( 'SubjectCreatorDialog', () => {
 		};
 
 		async function selectSchema( wrapper: VueWrapper ): Promise<void> {
-			await wrapper.findComponent( SchemaLookup ).vm.$emit( 'select', SCHEMA_NAME );
+			await wrapper.findComponent( SchemaPicker ).vm.$emit( 'select', SCHEMA_NAME );
 			await flushPromises();
 		}
 

--- a/resources/ext.neowiki/tests/components/common/SchemaLookup.spec.ts
+++ b/resources/ext.neowiki/tests/components/common/SchemaLookup.spec.ts
@@ -91,6 +91,18 @@ describe( 'SchemaLookup', () => {
 
 			expect( combobox.props( 'menuItems' ) ).toHaveLength( 3 );
 		} );
+
+		it( 'leaves the menu empty without throwing when loading schemas fails', async () => {
+			const consoleError = vi.spyOn( console, 'error' ).mockImplementation( () => undefined );
+			schemaStore.getAllSchemaSummaries = vi.fn().mockRejectedValue( new Error( 'load failed' ) );
+
+			const wrapper = await mountLoaded();
+			const combobox = wrapper.findComponent( CdxComboboxStub );
+
+			expect( combobox.props( 'menuItems' ) ).toEqual( [] );
+			expect( consoleError ).toHaveBeenCalled();
+			consoleError.mockRestore();
+		} );
 	} );
 
 	describe( 'committing a selection', () => {
@@ -108,6 +120,24 @@ describe( 'SchemaLookup', () => {
 			const combobox = wrapper.findComponent( CdxComboboxStub );
 
 			combobox.vm.$emit( 'update:selected', 'Off' );
+
+			expect( wrapper.emitted( 'select' ) ).toBeFalsy();
+		} );
+
+		it( 'commits the canonical schema name when the input has surrounding whitespace', async () => {
+			const wrapper = await mountLoaded();
+			const combobox = wrapper.findComponent( CdxComboboxStub );
+
+			combobox.vm.$emit( 'update:selected', 'Office ' );
+
+			expect( wrapper.emitted( 'select' )?.[ 0 ] ).toEqual( [ 'Office' ] );
+		} );
+
+		it( 'does not re-emit when the value already equals the committed schema', async () => {
+			const wrapper = await mountLoaded( { selected: 'Office' } );
+			const combobox = wrapper.findComponent( CdxComboboxStub );
+
+			combobox.vm.$emit( 'update:selected', 'Office' );
 
 			expect( wrapper.emitted( 'select' ) ).toBeFalsy();
 		} );

--- a/resources/ext.neowiki/tests/components/common/SchemaLookup.spec.ts
+++ b/resources/ext.neowiki/tests/components/common/SchemaLookup.spec.ts
@@ -1,14 +1,24 @@
 import { mount, VueWrapper, flushPromises } from '@vue/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { nextTick } from 'vue';
 import SchemaLookup from '@/components/common/SchemaLookup.vue';
 import { createPinia, setActivePinia } from 'pinia';
 import { useSchemaStore } from '@/stores/SchemaStore.ts';
-import { CdxLookup } from '@wikimedia/codex';
 import { createI18nMock } from '../../VueTestHelpers.ts';
-import { Schema } from '@/domain/Schema.ts';
-import { PropertyDefinitionList } from '@/domain/PropertyDefinitionList.ts';
 
 const $i18n = createI18nMock();
+
+const CdxComboboxStub = {
+	props: [ 'selected', 'menuItems' ],
+	emits: [ 'update:selected', 'input', 'blur' ],
+	template: '<div class="cdx-combobox-stub"></div>',
+};
+
+const SUMMARIES = [
+	{ name: 'Product', description: 'A product', propertyCount: 2 },
+	{ name: 'Office', description: 'A physical location', propertyCount: 4 },
+	{ name: 'City', description: '', propertyCount: 3 },
+];
 
 describe( 'SchemaLookup', () => {
 	let pinia: ReturnType<typeof createPinia>;
@@ -23,123 +33,144 @@ describe( 'SchemaLookup', () => {
 				},
 				plugins: [ pinia ],
 				stubs: {
-					CdxLookup: true,
+					CdxCombobox: CdxComboboxStub,
 				},
 			},
 		} )
 	);
+
+	async function mountLoaded( props: Record<string, unknown> = {} ): Promise<VueWrapper> {
+		const wrapper = mountComponent( props );
+		await flushPromises();
+		return wrapper;
+	}
+
+	function typeText( combobox: VueWrapper, value: string ): void {
+		combobox.vm.$emit( 'input', { target: { value } } );
+	}
 
 	beforeEach( () => {
 		pinia = createPinia();
 		setActivePinia( pinia );
 
 		schemaStore = useSchemaStore();
-		schemaStore.searchAndFetchMissingSchemas = vi.fn().mockResolvedValue( [] );
+		schemaStore.getAllSchemaSummaries = vi.fn().mockResolvedValue( SUMMARIES );
 	} );
 
-	it( 'searches for schemas when input changes', () => {
-		const wrapper = mountComponent();
-		const lookup = wrapper.findComponent( CdxLookup );
+	describe( 'browsing and filtering', () => {
+		it( 'populates the menu with all schemas and their descriptions on mount', async () => {
+			const wrapper = await mountLoaded();
+			const combobox = wrapper.findComponent( CdxComboboxStub );
 
-		lookup.vm.$emit( 'input', 'test query' );
-
-		expect( schemaStore.searchAndFetchMissingSchemas ).toHaveBeenCalledWith( 'test query' );
-	} );
-
-	it( 'updates menu items with search results', async () => {
-		const mockResults = [ 'Schema1', 'Schema2' ];
-		schemaStore.searchAndFetchMissingSchemas.mockResolvedValue( mockResults );
-		schemaStore.schemas.set( 'Schema1', new Schema( 'Schema1', 'First description', new PropertyDefinitionList( [] ) ) );
-		schemaStore.schemas.set( 'Schema2', new Schema( 'Schema2', 'Second description', new PropertyDefinitionList( [] ) ) );
-
-		const wrapper = mountComponent();
-		const lookup = wrapper.findComponent( CdxLookup );
-
-		lookup.vm.$emit( 'input', 'test' );
-		await flushPromises();
-
-		expect( lookup.props( 'menuItems' ) ).toEqual( [
-			{ label: 'Schema1', value: 'Schema1', description: 'First description' },
-			{ label: 'Schema2', value: 'Schema2', description: 'Second description' },
-		] );
-	} );
-
-	it( 'omits description from menu items when schema has empty description', async () => {
-		schemaStore.searchAndFetchMissingSchemas.mockResolvedValue( [ 'WithDesc', 'NoDesc' ] );
-		schemaStore.schemas.set( 'WithDesc', new Schema( 'WithDesc', 'Has a description', new PropertyDefinitionList( [] ) ) );
-		schemaStore.schemas.set( 'NoDesc', new Schema( 'NoDesc', '', new PropertyDefinitionList( [] ) ) );
-
-		const wrapper = mountComponent();
-		const lookup = wrapper.findComponent( CdxLookup );
-
-		lookup.vm.$emit( 'input', 'test' );
-		await flushPromises();
-
-		expect( lookup.props( 'menuItems' ) ).toEqual( [
-			{ label: 'WithDesc', value: 'WithDesc', description: 'Has a description' },
-			{ label: 'NoDesc', value: 'NoDesc', description: undefined },
-		] );
-	} );
-
-	it( 'discards stale search results when a newer request completes first', async () => {
-		let resolveFirst: ( value: string[] ) => void;
-		const firstCallPromise = new Promise<string[]>( ( resolve ) => {
-			resolveFirst = resolve;
+			expect( combobox.props( 'menuItems' ) ).toEqual( [
+				{ label: 'Product', value: 'Product', description: 'A product' },
+				{ label: 'Office', value: 'Office', description: 'A physical location' },
+				{ label: 'City', value: 'City', description: undefined },
+			] );
 		} );
 
-		schemaStore.searchAndFetchMissingSchemas = vi.fn()
-			.mockReturnValueOnce( firstCallPromise )
-			.mockResolvedValueOnce( [ 'SecondSchema' ] );
+		it( 'filters the menu to schemas matching the typed text', async () => {
+			const wrapper = await mountLoaded();
+			const combobox = wrapper.findComponent( CdxComboboxStub );
 
-		schemaStore.schemas.set( 'FirstSchema', new Schema( 'FirstSchema', 'Stale', new PropertyDefinitionList( [] ) ) );
-		schemaStore.schemas.set( 'SecondSchema', new Schema( 'SecondSchema', 'Fresh', new PropertyDefinitionList( [] ) ) );
+			typeText( combobox, 'off' );
+			await nextTick();
 
-		const wrapper = mountComponent();
-		const lookup = wrapper.findComponent( CdxLookup );
+			expect( combobox.props( 'menuItems' ) ).toEqual( [
+				{ label: 'Office', value: 'Office', description: 'A physical location' },
+			] );
+		} );
 
-		lookup.vm.$emit( 'input', 'first' );
-		lookup.vm.$emit( 'input', 'second' );
-		await flushPromises();
+		it( 'shows all schemas again when the input is cleared', async () => {
+			const wrapper = await mountLoaded();
+			const combobox = wrapper.findComponent( CdxComboboxStub );
 
-		expect( lookup.props( 'menuItems' ) ).toEqual( [
-			{ label: 'SecondSchema', value: 'SecondSchema', description: 'Fresh' },
-		] );
+			typeText( combobox, 'off' );
+			typeText( combobox, '' );
+			await nextTick();
 
-		resolveFirst!( [ 'FirstSchema' ] );
-		await flushPromises();
-
-		expect( lookup.props( 'menuItems' ) ).toEqual( [
-			{ label: 'SecondSchema', value: 'SecondSchema', description: 'Fresh' },
-		] );
+			expect( combobox.props( 'menuItems' ) ).toHaveLength( 3 );
+		} );
 	} );
 
-	it( 'reflects the selected prop on the lookup', () => {
-		const wrapper = mountComponent( { selected: 'Product' } );
-		const lookup = wrapper.findComponent( CdxLookup );
+	describe( 'committing a selection', () => {
+		it( 'emits the schema when an exact schema name is selected', async () => {
+			const wrapper = await mountLoaded();
+			const combobox = wrapper.findComponent( CdxComboboxStub );
 
-		expect( lookup.props( 'selected' ) ).toBe( 'Product' );
-		expect( lookup.props( 'inputValue' ) ).toBe( 'Product' );
-		expect( lookup.props( 'menuItems' ) ).toEqual( [ { label: 'Product', value: 'Product' } ] );
+			combobox.vm.$emit( 'update:selected', 'Office' );
+
+			expect( wrapper.emitted( 'select' )?.[ 0 ] ).toEqual( [ 'Office' ] );
+		} );
+
+		it( 'does not emit for a value that is not a schema name', async () => {
+			const wrapper = await mountLoaded();
+			const combobox = wrapper.findComponent( CdxComboboxStub );
+
+			combobox.vm.$emit( 'update:selected', 'Off' );
+
+			expect( wrapper.emitted( 'select' ) ).toBeFalsy();
+		} );
 	} );
 
-	it( 'updates the lookup when the selected prop changes after mount', async () => {
-		const wrapper = mountComponent();
-		const lookup = wrapper.findComponent( CdxLookup );
+	describe( 'rejecting invalid input', () => {
+		it( 'reverts to the committed schema and restores the menu on blur', async () => {
+			const wrapper = await mountLoaded( { selected: 'Product' } );
+			const combobox = wrapper.findComponent( CdxComboboxStub );
 
-		await wrapper.setProps( { selected: 'NewSchema' } );
+			combobox.vm.$emit( 'update:selected', 'xyz' );
+			combobox.vm.$emit( 'blur' );
+			await nextTick();
 
-		expect( lookup.props( 'selected' ) ).toBe( 'NewSchema' );
-		expect( lookup.props( 'inputValue' ) ).toBe( 'NewSchema' );
-		expect( lookup.props( 'menuItems' ) ).toEqual( [ { label: 'NewSchema', value: 'NewSchema' } ] );
+			expect( combobox.props( 'selected' ) ).toBe( 'Product' );
+			expect( combobox.props( 'menuItems' ) ).toHaveLength( 3 );
+			expect( wrapper.emitted( 'select' ) ).toBeFalsy();
+		} );
 
-		await wrapper.setProps( { selected: null } );
+		it( 'leaves a not-yet-set field empty on blur', async () => {
+			const wrapper = await mountLoaded();
+			const combobox = wrapper.findComponent( CdxComboboxStub );
 
-		expect( lookup.props( 'inputValue' ) ).toBe( '' );
-		expect( lookup.props( 'menuItems' ) ).toEqual( [] );
+			combobox.vm.$emit( 'update:selected', 'xyz' );
+			combobox.vm.$emit( 'blur' );
+			await nextTick();
+
+			expect( combobox.props( 'selected' ) ).toBe( '' );
+			expect( wrapper.emitted( 'select' ) ).toBeFalsy();
+		} );
+
+		it( 'emits blur so the consumer can mark the field touched', async () => {
+			const wrapper = await mountLoaded();
+			const combobox = wrapper.findComponent( CdxComboboxStub );
+
+			combobox.vm.$emit( 'blur' );
+
+			expect( wrapper.emitted( 'blur' ) ).toBeTruthy();
+		} );
+	} );
+
+	describe( 'reflecting the selected prop', () => {
+		it( 'shows the selected schema in the field', () => {
+			const wrapper = mountComponent( { selected: 'Product' } );
+			const combobox = wrapper.findComponent( CdxComboboxStub );
+
+			expect( combobox.props( 'selected' ) ).toBe( 'Product' );
+		} );
+
+		it( 'updates the field when the selected prop changes', async () => {
+			const wrapper = mountComponent();
+			const combobox = wrapper.findComponent( CdxComboboxStub );
+
+			await wrapper.setProps( { selected: 'NewSchema' } );
+			expect( combobox.props( 'selected' ) ).toBe( 'NewSchema' );
+
+			await wrapper.setProps( { selected: null } );
+			expect( combobox.props( 'selected' ) ).toBe( '' );
+		} );
 	} );
 
 	it( 'exposes focus method', () => {
-		const CdxLookupStub = {
+		const CdxComboboxInputStub = {
 			template: '<div><input /></div>',
 		};
 
@@ -150,7 +181,7 @@ describe( 'SchemaLookup', () => {
 				},
 				plugins: [ pinia ],
 				stubs: {
-					CdxLookup: CdxLookupStub,
+					CdxCombobox: CdxComboboxInputStub,
 				},
 			},
 		} );

--- a/resources/ext.neowiki/tests/components/common/SchemaPicker.spec.ts
+++ b/resources/ext.neowiki/tests/components/common/SchemaPicker.spec.ts
@@ -1,7 +1,7 @@
 import { mount, VueWrapper, flushPromises } from '@vue/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { nextTick } from 'vue';
-import SchemaLookup from '@/components/common/SchemaLookup.vue';
+import SchemaPicker from '@/components/common/SchemaPicker.vue';
 import { createPinia, setActivePinia } from 'pinia';
 import { useSchemaStore } from '@/stores/SchemaStore.ts';
 import { createI18nMock } from '../../VueTestHelpers.ts';
@@ -20,12 +20,12 @@ const SUMMARIES = [
 	{ name: 'City', description: '', propertyCount: 3 },
 ];
 
-describe( 'SchemaLookup', () => {
+describe( 'SchemaPicker', () => {
 	let pinia: ReturnType<typeof createPinia>;
 	let schemaStore: any;
 
 	const mountComponent = ( props: Record<string, unknown> = {} ): VueWrapper => (
-		mount( SchemaLookup, {
+		mount( SchemaPicker, {
 			props,
 			global: {
 				mocks: {
@@ -204,7 +204,7 @@ describe( 'SchemaLookup', () => {
 			template: '<div><input /></div>',
 		};
 
-		const wrapper = mount( SchemaLookup, {
+		const wrapper = mount( SchemaPicker, {
 			global: {
 				mocks: {
 					$i18n,

--- a/resources/ext.neowiki/tests/stores/SchemaStore.spec.ts
+++ b/resources/ext.neowiki/tests/stores/SchemaStore.spec.ts
@@ -34,6 +34,10 @@ describe( 'SchemaStore getAllSchemaSummaries', () => {
 		return { name, description: '', propertyCount: 0 };
 	}
 
+	function manySummaries( count: number, prefix: string ): ReturnType<typeof summary>[] {
+		return Array.from( { length: count }, ( _value, index ) => summary( `${ prefix }${ index }` ) );
+	}
+
 	function withRepository( repository: Record<string, unknown> ): void {
 		vi.spyOn( NeoWikiExtension, 'getInstance' ).mockReturnValue(
 			{ getSchemaRepository: () => repository } as unknown as NeoWikiExtension,
@@ -48,16 +52,32 @@ describe( 'SchemaStore getAllSchemaSummaries', () => {
 		vi.restoreAllMocks();
 	} );
 
-	it( 'pages through every schema summary', async () => {
+	it( 'pages through every schema summary across multiple pages', async () => {
 		const getSchemaSummaries = vi.fn()
-			.mockResolvedValueOnce( { schemas: [ summary( 'A' ), summary( 'B' ) ], totalRows: 3 } )
-			.mockResolvedValueOnce( { schemas: [ summary( 'C' ) ], totalRows: 3 } );
+			.mockResolvedValueOnce( { schemas: manySummaries( 50, 'A' ), totalRows: 60 } )
+			.mockResolvedValueOnce( { schemas: manySummaries( 10, 'B' ), totalRows: 60 } );
 		withRepository( { getSchemaSummaries } );
 
 		const result = await useSchemaStore().getAllSchemaSummaries();
 
-		expect( result.map( ( item ) => item.name ) ).toEqual( [ 'A', 'B', 'C' ] );
-		expect( getSchemaSummaries ).toHaveBeenNthCalledWith( 2, 2, 50 );
+		expect( result ).toHaveLength( 60 );
+		expect( getSchemaSummaries ).toHaveBeenNthCalledWith( 1, 0, 50 );
+		expect( getSchemaSummaries ).toHaveBeenNthCalledWith( 2, 50, 50 );
+	} );
+
+	it( 'advances by page size, not loaded count, when a page omits unloadable schemas', async () => {
+		// The endpoint counts 60 schema pages in totalRows but can only load 49 in the
+		// first window (one is restricted or malformed) and 10 in the second.
+		const getSchemaSummaries = vi.fn()
+			.mockResolvedValueOnce( { schemas: manySummaries( 49, 'A' ), totalRows: 60 } )
+			.mockResolvedValueOnce( { schemas: manySummaries( 10, 'B' ), totalRows: 60 } );
+		withRepository( { getSchemaSummaries } );
+
+		const result = await useSchemaStore().getAllSchemaSummaries();
+
+		expect( result ).toHaveLength( 59 );
+		expect( getSchemaSummaries ).toHaveBeenNthCalledWith( 2, 50, 50 );
+		expect( getSchemaSummaries ).toHaveBeenCalledTimes( 2 );
 	} );
 
 	it( 'caches the summaries and does not refetch on the next call', async () => {

--- a/resources/ext.neowiki/tests/stores/SchemaStore.spec.ts
+++ b/resources/ext.neowiki/tests/stores/SchemaStore.spec.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from 'vitest';
-import { normalizeSchemaName } from '@/stores/SchemaStore.ts';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { normalizeSchemaName, useSchemaStore } from '@/stores/SchemaStore.ts';
+import { NeoWikiExtension } from '@/NeoWikiExtension.ts';
+import { Schema } from '@/domain/Schema.ts';
+import { PropertyDefinitionList } from '@/domain/PropertyDefinitionList.ts';
 
 describe( 'normalizeSchemaName', () => {
 	it( 'upper-cases the first character', () => {
@@ -22,4 +26,62 @@ describe( 'normalizeSchemaName', () => {
 	it( 'leaves an already-canonical name unchanged', () => {
 		expect( normalizeSchemaName( 'Validation Demo' ) ).toBe( 'Validation Demo' );
 	} );
+} );
+
+describe( 'SchemaStore getAllSchemaSummaries', () => {
+
+	function summary( name: string ): { name: string; description: string; propertyCount: number } {
+		return { name, description: '', propertyCount: 0 };
+	}
+
+	function withRepository( repository: Record<string, unknown> ): void {
+		vi.spyOn( NeoWikiExtension, 'getInstance' ).mockReturnValue(
+			{ getSchemaRepository: () => repository } as unknown as NeoWikiExtension,
+		);
+	}
+
+	beforeEach( () => {
+		setActivePinia( createPinia() );
+	} );
+
+	afterEach( () => {
+		vi.restoreAllMocks();
+	} );
+
+	it( 'pages through every schema summary', async () => {
+		const getSchemaSummaries = vi.fn()
+			.mockResolvedValueOnce( { schemas: [ summary( 'A' ), summary( 'B' ) ], totalRows: 3 } )
+			.mockResolvedValueOnce( { schemas: [ summary( 'C' ) ], totalRows: 3 } );
+		withRepository( { getSchemaSummaries } );
+
+		const result = await useSchemaStore().getAllSchemaSummaries();
+
+		expect( result.map( ( item ) => item.name ) ).toEqual( [ 'A', 'B', 'C' ] );
+		expect( getSchemaSummaries ).toHaveBeenNthCalledWith( 2, 2, 50 );
+	} );
+
+	it( 'caches the summaries and does not refetch on the next call', async () => {
+		const getSchemaSummaries = vi.fn().mockResolvedValue( { schemas: [ summary( 'A' ) ], totalRows: 1 } );
+		withRepository( { getSchemaSummaries } );
+		const store = useSchemaStore();
+
+		await store.getAllSchemaSummaries();
+		await store.getAllSchemaSummaries();
+
+		expect( getSchemaSummaries ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'refetches summaries after a schema is saved', async () => {
+		const getSchemaSummaries = vi.fn().mockResolvedValue( { schemas: [ summary( 'A' ) ], totalRows: 1 } );
+		const saveSchema = vi.fn().mockResolvedValue( undefined );
+		withRepository( { getSchemaSummaries, saveSchema } );
+		const store = useSchemaStore();
+
+		await store.getAllSchemaSummaries();
+		await store.saveSchema( new Schema( 'B', '', new PropertyDefinitionList( [] ) ) );
+		await store.getAllSchemaSummaries();
+
+		expect( getSchemaSummaries ).toHaveBeenCalledTimes( 2 );
+	} );
+
 } );

--- a/src/Persistence/MediaWiki/schemaContentSchema.json
+++ b/src/Persistence/MediaWiki/schemaContentSchema.json
@@ -31,7 +31,39 @@
 						"uniqueItems": {
 							"type": "boolean"
 						}
-					}
+					},
+					"allOf": [
+						{
+							"if": {
+								"required": [
+									"type"
+								],
+								"properties": {
+									"type": {
+										"const": "relation"
+									}
+								}
+							},
+							"then": {
+								"required": [
+									"relation",
+									"targetSchema"
+								],
+								"properties": {
+									"relation": {
+										"type": "string",
+										"pattern": "\\S",
+										"$error": "The relation type must not be empty."
+									},
+									"targetSchema": {
+										"type": "string",
+										"pattern": "\\S",
+										"$error": "The target schema must not be empty."
+									}
+								}
+							}
+						}
+					]
 				}
 			}
 		}

--- a/tests/phpunit/Persistence/MediaWiki/SchemaContentValidatorTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/SchemaContentValidatorTest.php
@@ -120,4 +120,70 @@ JSON
 		);
 	}
 
+	public function testValidRelationPropertyPassesValidation(): void {
+		$validator = SchemaContentValidator::newInstance();
+
+		$valid = $validator->validate(
+			$this->schemaWithProperty( '{ "type": "relation", "relation": "Likes", "targetSchema": "Person" }' )
+		);
+
+		if ( !$valid ) {
+			$this->assertSame( [], $validator->getErrors() );
+		}
+
+		$this->assertTrue( $valid );
+	}
+
+	public function testEmptyRelationTypeFailsValidation(): void {
+		$validator = SchemaContentValidator::newInstance();
+
+		$this->assertFalse(
+			$validator->validate(
+				$this->schemaWithProperty( '{ "type": "relation", "relation": "", "targetSchema": "Person" }' )
+			)
+		);
+
+		$this->assertContains( 'The relation type must not be empty.', $validator->getErrors() );
+	}
+
+	public function testWhitespaceOnlyRelationTypeFailsValidation(): void {
+		$validator = SchemaContentValidator::newInstance();
+
+		$this->assertFalse(
+			$validator->validate(
+				$this->schemaWithProperty( '{ "type": "relation", "relation": "   ", "targetSchema": "Person" }' )
+			)
+		);
+
+		$this->assertContains( 'The relation type must not be empty.', $validator->getErrors() );
+	}
+
+	public function testEmptyTargetSchemaFailsValidation(): void {
+		$validator = SchemaContentValidator::newInstance();
+
+		$this->assertFalse(
+			$validator->validate(
+				$this->schemaWithProperty( '{ "type": "relation", "relation": "Likes", "targetSchema": "" }' )
+			)
+		);
+
+		$this->assertContains( 'The target schema must not be empty.', $validator->getErrors() );
+	}
+
+	/**
+	 * Wraps the property under test between two valid siblings so a regression that only
+	 * inspects the first or last property definition is caught.
+	 */
+	private function schemaWithProperty( string $propertyJson ): string {
+		return <<<JSON
+{
+	"propertyDefinitions": {
+		"before": { "type": "text" },
+		"offending": $propertyJson,
+		"after": { "type": "text" }
+	}
+}
+JSON;
+	}
+
 }


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/955

**Stacked on #953** (the `SchemaPicker` browsable picker) — this PR targets that branch, so its diff is just the layout-creator change. Merge #953 first; GitHub retargets this to `master` afterwards.

The layout creator selected the Layout's Schema with a plain `CdxSelect` fed by a separate `getSchemaNames( '' )` call (names only, no descriptions, no type-to-filter). Replace it with the shared `SchemaPicker` component, which browses the full schema list, filters as you type, shows schema descriptions, and reuses the cached all-schemas summary load — matching the subject creator and relation-property pickers.

`onSchemaSelected` now receives the picked schema name (`SchemaPicker` only commits an exact existing schema), and the dead `getSchemaNames` load and its now-orphaned placeholder message are removed.

`LayoutCreator` has no unit test to extend, so correctness here rests on `SchemaPicker`'s own coverage plus a browser check of the Layout creation dialog (open **Special:Layouts → Create Layout**). `make tsci` is green (1060 tests, build + lint).

> Directed by @JeroenDeDauw, who picked this up from the #953 review.
> Context: the NeoWiki codebase and a frontend inventory of every schema-selection site.
> <sub>Written by Claude Code, `Opus 4.8`</sub>
