### PR TITLE
Record SHACL and ShEx as considered alternatives in ADR 009

### DIFF
--- a/docs/adr/009-move-away-from-json-schema.md
+++ b/docs/adr/009-move-away-from-json-schema.md
@@ -27,3 +27,33 @@ Including:
   would not have sufficed anyway.
 * We no longer expose schemas in a standard format. If such a requirement arises we can still implement it via a
   web API that converts our custom schema format to JSON schema.
+
+## Alternatives Considered
+
+*Added 2026-06-28. NeoWiki's move toward RDF and Linked Open Data (see
+[ADR 19](019-graph-database-architecture.md)) makes RDF-native shape languages an obvious question. This section
+records why they are not used as our internal schema format. The decision against JSON Schema itself is the subject
+of this ADR, above.*
+
+### RDF shape languages: SHACL and ShEx
+
+[SHACL](https://www.w3.org/TR/shacl/) (a W3C standard) and [ShEx](https://shex.io/) (a grammar-based schema language,
+used by Wikidata for its EntitySchemas) both describe and validate the shape of **RDF graphs**.
+
+Not adopted as our internal schema format, for the same reasons we moved away from JSON Schema, which apply more
+strongly here:
+
+* **They target RDF graphs, which is not our internal model.** Our data are Subjects and Statements stored as JSON
+  ([ADR 2](002-store-data-as-json.md)); RDF is one of several *projection/export* targets, each owning its own
+  mapping ([ADR 19](019-graph-database-architecture.md)). Defining schemas in an RDF-native language would couple the
+  core to RDF and undercut that backend-agnostic, map-at-export approach.
+* **They are validation languages, not editing schemas.** The driving reason in this ADR — alignment with how our UIs
+  represent and edit data — has no counterpart in SHACL or ShEx, which say nothing about form-based creation and
+  editing of data.
+* **They carry expressivity we do not need.** Open-world graph semantics, logical shape algebra, and (for SHACL)
+  SPARQL-based constraints are exactly the kind of accidental complexity this ADR moves away from.
+
+This does not rule out *emitting* SHACL or ShEx as a downstream artifact: generating shapes from our native schemas
+at RDF-export time — for RDF-side validation, documentation, or interoperability — is a separate and potentially
+valuable concern (see [planning/RdfMapping.md](../planning/RdfMapping.md)). That is a mapping output, not the schema
+format itself.

--- a/docs/adr/009-move-away-from-json-schema.md
+++ b/docs/adr/009-move-away-from-json-schema.md
@@ -6,11 +6,11 @@ Status: Accepted
 
 ## Context
 
-In ADR 006 we decided to use JSON Schema for our schemas. However, we have since found that using
+In ADR 006, we decided to use JSON Schema for our schemas. However, we have since found that using
 JSON schema internally introduces accidental complexity.
 
-The accidental complexity comes from expressivity of JSON schema that we do not need and from a mismatch between
-JSON schema and how our UIs represent and edit data.
+The accidental complexity comes from the expressivity of JSON schema that we do not need, and from a mismatch
+between JSON schema and how our UIs represent and edit data.
 
 ## Decision
 
@@ -25,35 +25,26 @@ Including:
 * We can simplify our code dealing with schemas, especially code related to handling of multiple values.
 * We can no longer use standard JSON-schema-based validators to validate Subjects. Then again, we anticipated those
   would not have sufficed anyway.
-* We no longer expose schemas in a standard format. If such a requirement arises we can still implement it via a
+* We no longer expose schemas in a standard format. If such a requirement arises, we can still implement it via a
   web API that converts our custom schema format to JSON schema.
 
 ## Alternatives Considered
 
-*Added 2026-06-28. NeoWiki's move toward RDF and Linked Open Data (see
-[ADR 19](019-graph-database-architecture.md)) makes RDF-native shape languages an obvious question. This section
-records why they are not used as our internal schema format. The decision against JSON Schema itself is the subject
-of this ADR, above.*
+### Continued usage of JSON Schema
+
+We would need to maintain a higher level of internal complexity. Users who need JSON Schema can still easily be
+accommodated via a new API endpoint that does simple translation.
 
 ### RDF shape languages: SHACL and ShEx
 
 [SHACL](https://www.w3.org/TR/shacl/) (a W3C standard) and [ShEx](https://shex.io/) (a grammar-based schema language,
 used by Wikidata for its EntitySchemas) both describe and validate the shape of **RDF graphs**.
 
-Not adopted as our internal schema format, for the same reasons we moved away from JSON Schema, which apply more
-strongly here:
+Not adopted as our internal schema format, for the same reasons we moved away from JSON Schema. Our editing UIs
+cannot handle all their expressivity. Nearly all potential users are better served with a subset of their
+expressivity, avoiding both unnecessary implementation and carry costs, and complexity in the UIs and elsewhere.
 
-* **They target RDF graphs, which is not our internal model.** Our data are Subjects and Statements stored as JSON
-  ([ADR 2](002-store-data-as-json.md)); RDF is one of several *projection/export* targets, each owning its own
-  mapping ([ADR 19](019-graph-database-architecture.md)). Defining schemas in an RDF-native language would couple the
-  core to RDF and undercut that backend-agnostic, map-at-export approach.
-* **They are validation languages, not editing schemas.** The driving reason in this ADR — alignment with how our UIs
-  represent and edit data — has no counterpart in SHACL or ShEx, which say nothing about form-based creation and
-  editing of data.
-* **They carry expressivity we do not need.** Open-world graph semantics, logical shape algebra, and (for SHACL)
-  SPARQL-based constraints are exactly the kind of accidental complexity this ADR moves away from.
+Additionally, our data model is not an RDF graph.
 
-This does not rule out *emitting* SHACL or ShEx as a downstream artifact: generating shapes from our native schemas
-at RDF-export time — for RDF-side validation, documentation, or interoperability — is a separate and potentially
-valuable concern (see [planning/RdfMapping.md](../planning/RdfMapping.md)). That is a mapping output, not the schema
-format itself.
+This does not rule out *emitting* SHACL or ShEx as a downstream artifact. We could generate shapes from our native
+schemas, for instance, at RDF-export time.


### PR DESCRIPTION
NeoWiki's RDF/Linked-Open-Data direction ([ADR 019](https://github.com/ProfessionalWiki/NeoWiki/blob/master/docs/adr/019-graph-database-architecture.md)) makes RDF-native shape languages an obvious "why not just use SHACL?" question, but the decision not to use them as our internal schema format was nowhere recorded — ADR 009 only argued against JSON Schema.

Adds an "Alternatives Considered" section explaining why SHACL and ShEx are not used as the internal schema format (RDF-graph-oriented, validation- rather than editing-focused, more expressive than needed), while noting they remain viable as downstream export artifacts generated from native schemas.

---

> Identified by @JeroenDeDauw, who asked whether the decision against SHACL/ShEx was documented and directed this amendment to ADR 009.
> Context: the NeoWiki ADRs and planning docs (ADR 019 graph-database architecture, `planning/RdfMapping.md`) and the ECHOLOT RDF/ontology context.
> <sub>Written by Claude Code, `Opus 4.8 (1M context)`</sub>
