### PR TITLE
Label subject page-tools as view-only for users who cannot edit

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -33,7 +33,9 @@
 	"neowiki-page-tools-label": "NeoWiki",
 	"neowiki-page-tools-create-subject": "Create subject",
 	"neowiki-page-tools-manage-subjects": "Manage subjects",
+	"neowiki-page-tools-view-subjects": "View subjects",
 	"neowiki-page-tools-edit-json": "View or edit JSON",
+	"neowiki-page-tools-view-json": "View JSON",
 
 	"neowiki-property-editor-name": "Name",
 	"neowiki-property-editor-type": "Type",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -31,7 +31,10 @@
 
 	"neowiki-page-tools-label": "Heading for the NeoWiki section in the MediaWiki sidebar (shown as a group label in legacy skins and inside the page tools menu in modern Vector).",
 	"neowiki-page-tools-create-subject": "Label for the sidebar link that opens the 'create subject' dialog. The dialog creates a main subject if the page has none, or a child subject otherwise.",
+	"neowiki-page-tools-manage-subjects": "Label for the sidebar link to the Subject management page, shown to users who may edit. See neowiki-page-tools-view-subjects for the read-only variant.",
+	"neowiki-page-tools-view-subjects": "Read-only counterpart of neowiki-page-tools-manage-subjects: label for the sidebar link to the Subject management page, shown to users who lack edit permission.",
 	"neowiki-page-tools-edit-json": "Label for the sidebar link that navigates to Special:NeoJson for the current page. Only visible when development UIs are enabled.",
+	"neowiki-page-tools-view-json": "Read-only counterpart of neowiki-page-tools-edit-json: label for the sidebar link to Special:NeoJson, shown to users who lack edit permission. Only visible when development UIs are enabled.",
 
 	"neowiki-subject-creator-creating-schema": "Subtitle shown in the subject creator dialog header when the user is creating a new schema.",
 	"neowiki-subject-creator-create-schema": "Label for the button that creates a new schema in the subject creator dialog.",

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -236,13 +236,15 @@ class NeoWikiHooks {
 		}
 
 		$extension = NeoWikiExtension::getInstance();
+		$authorizer = $extension->newSubjectAuthorizer( $skin->getAuthority() );
 
 		$pageToolsItems = ( new PageToolsBuilder() )->build(
 			title: $title,
 			isContentNamespace: MediaWikiServices::getInstance()
 				->getNamespaceInfo()
 				->isContent( $title->getNamespace() ),
-			canCreateMainSubject: $extension->newSubjectAuthorizer( $skin->getAuthority() )->canCreateMainSubject(),
+			canCreateMainSubject: $authorizer->canCreateMainSubject(),
+			canEditSubject: $authorizer->canEditSubject(),
 			isLatestRevision: self::pageIsLatestRevision( $skin->getOutput() ),
 			devUiEnabled: $extension->isDevelopmentUIEnabled(),
 			currentAction: MediaWikiServices::getInstance()

--- a/src/Presentation/PageToolsBuilder.php
+++ b/src/Presentation/PageToolsBuilder.php
@@ -17,6 +17,7 @@ class PageToolsBuilder {
 		Title $title,
 		bool $isContentNamespace,
 		bool $canCreateMainSubject,
+		bool $canEditSubject,
 		bool $isLatestRevision,
 		bool $devUiEnabled,
 		string $currentAction
@@ -40,7 +41,9 @@ class PageToolsBuilder {
 
 		if ( $title->canExist() && $currentAction !== SubjectsAction::ACTION_NAME ) {
 			$items[] = [
-				'text' => wfMessage( 'neowiki-page-tools-manage-subjects' )->text(),
+				'text' => wfMessage(
+					$canEditSubject ? 'neowiki-page-tools-manage-subjects' : 'neowiki-page-tools-view-subjects'
+				)->text(),
 				'href' => $title->getLocalURL( [ 'action' => SubjectsAction::ACTION_NAME ] ),
 				'id' => 't-neowiki-manage-subjects',
 			];
@@ -48,7 +51,9 @@ class PageToolsBuilder {
 
 		if ( $devUiEnabled ) {
 			$items[] = [
-				'text' => wfMessage( 'neowiki-page-tools-edit-json' )->text(),
+				'text' => wfMessage(
+					$canEditSubject ? 'neowiki-page-tools-edit-json' : 'neowiki-page-tools-view-json'
+				)->text(),
 				'href' => SkinComponentUtils::makeSpecialUrlSubpage( 'NeoJson', $title->getFullText() ),
 				'id' => 't-neowiki-edit-json',
 			];

--- a/tests/phpunit/Presentation/PageToolsBuilderTest.php
+++ b/tests/phpunit/Presentation/PageToolsBuilderTest.php
@@ -83,12 +83,26 @@ class PageToolsBuilderTest extends MediaWikiIntegrationTestCase {
 		);
 	}
 
+	public function testUsesViewLabelsWhenUserCannotEditSubjects(): void {
+		$this->assertSame(
+			[
+				$this->manageSubjectsItem( 'neowiki-page-tools-view-subjects' ),
+				$this->editJsonItem( 'neowiki-page-tools-view-json' ),
+			],
+			$this->build(
+				canCreateMainSubject: false,
+				canEditSubject: false
+			)
+		);
+	}
+
 	/**
 	 * @return list<array<string, mixed>>
 	 */
 	private function build(
 		bool $isContentNamespace = true,
 		bool $canCreateMainSubject = true,
+		bool $canEditSubject = true,
 		bool $isLatestRevision = true,
 		bool $devUiEnabled = true,
 		string $currentAction = 'view'
@@ -97,6 +111,7 @@ class PageToolsBuilderTest extends MediaWikiIntegrationTestCase {
 			title: Title::newFromText( self::PAGE_NAME ),
 			isContentNamespace: $isContentNamespace,
 			canCreateMainSubject: $canCreateMainSubject,
+			canEditSubject: $canEditSubject,
 			isLatestRevision: $isLatestRevision,
 			devUiEnabled: $devUiEnabled,
 			currentAction: $currentAction
@@ -120,9 +135,9 @@ class PageToolsBuilderTest extends MediaWikiIntegrationTestCase {
 	/**
 	 * @return array<string, mixed>
 	 */
-	private function manageSubjectsItem(): array {
+	private function manageSubjectsItem( string $messageKey = 'neowiki-page-tools-manage-subjects' ): array {
 		return [
-			'text' => wfMessage( 'neowiki-page-tools-manage-subjects' )->text(),
+			'text' => wfMessage( $messageKey )->text(),
 			'href' => Title::newFromText( self::PAGE_NAME )->getLocalURL( [ 'action' => 'subjects' ] ),
 			'id' => 't-neowiki-manage-subjects',
 		];
@@ -131,9 +146,9 @@ class PageToolsBuilderTest extends MediaWikiIntegrationTestCase {
 	/**
 	 * @return array<string, mixed>
 	 */
-	private function editJsonItem(): array {
+	private function editJsonItem( string $messageKey = 'neowiki-page-tools-edit-json' ): array {
 		return [
-			'text' => wfMessage( 'neowiki-page-tools-edit-json' )->text(),
+			'text' => wfMessage( $messageKey )->text(),
 			'href' => SkinComponentUtils::makeSpecialUrlSubpage( 'NeoJson', self::PAGE_NAME ),
 			'id' => 't-neowiki-edit-json',
 		];


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/962

Users without the edit right can still open the Subject management page (it requires only read) and `Special:NeoJson` when development UIs are enabled, but both links were always labelled for editing ("Manage subjects", "View or edit JSON"). Show "View subjects" and "View JSON" for these users instead. The "Create subject" link stays gated on edit, and link IDs are unchanged.

> Result of back and forth with @JeroenDeDauw refining the read-only UX.
> Context: the NeoWiki codebase.
> <sub>Written by Claude Code, `Opus 4.8`</sub>