### PR TITLE
Link the live OpenAPI spec (neowiki.dev) from the REST API reference

### DIFF
--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -87,8 +87,8 @@ A Layout defines how a Subject is displayed.
 
 ## Full specification
 
-Every endpoint also publishes a complete OpenAPI 3.0 description — parameters, request bodies, and
-responses — generated from the live handlers.
+Every endpoint also publishes a complete OpenAPI 3.0 description: parameters, request bodies, and
+responses.
 
 Browse it live on the demo wiki:
 [neowiki.dev/w/rest.php/specs/v0/module/-](https://neowiki.dev/w/rest.php/specs/v0/module/-).

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -88,11 +88,16 @@ A Layout defines how a Subject is displayed.
 ## Full specification
 
 Every endpoint also publishes a complete OpenAPI 3.0 description — parameters, request bodies, and
-responses — generated from the live handlers. Enable it in `LocalSettings.php`:
+responses — generated from the live handlers.
+
+Browse it live on the demo wiki:
+[neowiki.dev/w/rest.php/specs/v0/module/-](https://neowiki.dev/w/rest.php/specs/v0/module/-).
+Paste that JSON into [editor.swagger.io](https://editor.swagger.io) or any OpenAPI viewer.
+
+To expose it on your own wiki, register the spec routes in `LocalSettings.php`:
 
 ```php
 $wgRestAPIAdditionalRouteFiles[] = 'includes/Rest/specs.v0.json';
 ```
 
-Then fetch `/rest.php/specs/v0/module/-` and open it in [editor.swagger.io](https://editor.swagger.io)
-or any OpenAPI viewer.
+Then fetch `/rest.php/specs/v0/module/-` on your wiki.


### PR DESCRIPTION
Follow-up to #958.

The **Full specification** section of the REST API reference now leads with a live, no-install link to the demo wiki's generated OpenAPI document:

`https://neowiki.dev/w/rest.php/specs/v0/module/-`

This lets someone evaluating NeoWiki browse the complete contract (every parameter, body field, and response) without installing anything — the remaining gap from ProfessionalWiki/NeoWiki-Website#80. The self-host instructions follow it.

Note: the pretty `/rest.php/...` path on neowiki.dev 301-redirects to the Main Page; only the `/w/rest.php/...` script path serves the spec, so that's what is linked. Verified HTTP 200 with all 14 `/neowiki/v0/*` paths present.

Caveat: this adds a live external dependency (neowiki.dev staying up with the spec route enabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
