### PR TITLE
Link the OpenAPI description from the REST API intro

### DIFF
--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -13,11 +13,13 @@ Voice: terse — every sentence earns its place; link to the format docs instead
 
 # REST API
 
-NeoWiki's REST API lives under `/rest.php/neowiki/v0/*` and uses JSON. It covers Subjects (structured
-entities) with their Schemas and Layouts, plus a read-only Cypher endpoint for querying the graph.
+NeoWiki's REST API lives under `/rest.php/neowiki/v0/*` and uses JSON.
 
-Reads are public unless the wiki restricts them. Writes require a logged-in user with edit rights and a
-CSRF token.
+By default, reads are public and writes require a logged-in user with edit rights and a CSRF token. Additional
+permissions might be required depending on the wiki configuration.
+
+You can find all endpoints in [the OpenAPI 3.0 description](#full-specification) exposed via the REST API itself.
+Demo wiki example: [neowiki.dev/w/rest.php/specs/v0/module/-](https://neowiki.dev/w/rest.php/specs/v0/module/-)
 
 ## Endpoints
 


### PR DESCRIPTION
The intro now points to the full OpenAPI 3.0 description up front instead of listing what the API covers, and notes that a wiki's configuration may require permissions beyond the default public reads and authenticated writes.