### PR TITLE
Surface server violations on untouched single relations

### DIFF
--- a/resources/ext.neowiki/src/components/Value/RelationInput.vue
+++ b/resources/ext.neowiki/src/components/Value/RelationInput.vue
@@ -80,11 +80,8 @@ function relevantServerViolations(): readonly SubjectViolation[] {
 	return ( props.serverViolations ?? [] ).filter( ( v ) => v.propertyName === name );
 }
 
-const fieldMessages = computed<ValidationMessages>( () => {
-	if ( Object.keys( liveFieldMessages.value ).length > 0 ) {
-		return liveFieldMessages.value;
-	}
-	// Fall back to server violations (field-level, since NeoMultiLookupInput has no per-index slot).
+// Field-level server violation (NeoMultiLookupInput has no per-index slot).
+function serverFieldMessages(): ValidationMessages {
 	const hit = relevantServerViolations()[ 0 ];
 	if ( hit ) {
 		return {
@@ -92,6 +89,13 @@ const fieldMessages = computed<ValidationMessages>( () => {
 		};
 	}
 	return {};
+}
+
+const fieldMessages = computed<ValidationMessages>( () => {
+	if ( Object.keys( liveFieldMessages.value ).length > 0 ) {
+		return liveFieldMessages.value;
+	}
+	return serverFieldMessages();
 } );
 
 const displayedFieldMessages = computed( (): ValidationMessages => {
@@ -101,17 +105,16 @@ const displayedFieldMessages = computed( (): ValidationMessages => {
 	if ( props.property.multiple || touched.value ) {
 		return fieldMessages.value;
 	}
-	return {};
+	// Server-sourced violations (dry-run / save-time 422) surface before the field
+	// is touched; only the live client check waits for blur.
+	return serverFieldMessages();
 } );
 
 const fieldStatus = computed( (): 'error' | 'default' => {
 	if ( props.property.multiple || singleHasUnmatchedText.value ) {
 		return 'default';
 	}
-	if ( touched.value && fieldMessages.value.error ) {
-		return 'error';
-	}
-	return 'default';
+	return displayedFieldMessages.value.error !== undefined ? 'error' : 'default';
 } );
 
 function emitClearIfServerViolationPresent(): void {

--- a/resources/ext.neowiki/tests/components/Value/RelationInput.spec.ts
+++ b/resources/ext.neowiki/tests/components/Value/RelationInput.spec.ts
@@ -166,6 +166,37 @@ describe( 'RelationInput', () => {
 			expect( field.props( 'messages' ) ).toEqual( {} );
 			expect( field.props( 'status' ) ).toBe( 'default' );
 		} );
+
+		it( 'surfaces a server violation on an untouched single relation', () => {
+			const wrapper = newWrapper( {
+				// Optional field so the live client check produces nothing; the message
+				// can only originate from the server-sourced violation.
+				property: newRelationProperty( { name: 'Owner', targetSchema: 'Company' } ),
+				serverViolations: [
+					{ propertyName: 'Owner', code: 'type-mismatch', args: [], valuePartIndex: null },
+				],
+			} );
+
+			const field = wrapper.findComponent( CdxField );
+			expect( field.props( 'messages' ) ).toEqual( { error: 'neowiki-field-type-mismatch' } );
+			expect( field.props( 'status' ) ).toBe( 'error' );
+		} );
+
+		it( 'keeps a server violation suppressed while the lookup reports unmatched text', async () => {
+			const wrapper = newWrapper( {
+				property: newRelationProperty( { name: 'Owner', targetSchema: 'Company' } ),
+				serverViolations: [
+					{ propertyName: 'Owner', code: 'type-mismatch', args: [], valuePartIndex: null },
+				],
+			} );
+
+			wrapper.findComponent( SubjectLookup ).vm.$emit( 'blur', true );
+			await wrapper.vm.$nextTick();
+
+			const field = wrapper.findComponent( CdxField );
+			expect( field.props( 'messages' ) ).toEqual( {} );
+			expect( field.props( 'status' ) ).toBe( 'default' );
+		} );
 	} );
 
 	describe( 'multiple mode', () => {


### PR DESCRIPTION
> Result of working through a validation parity audit with @alistair3149 — a precursor to removing NeoWiki's duplicated client-side validators in favour of server-driven validation. Context: the NeoWiki frontend validation flow and the create/edit dry-run model.
> <sub>Written by Claude Code, `Opus 4.8`</sub>

RelationInput gated its field message and status on the field being touched (focused then blurred). For a single (non-multiple) relation, a server-sourced violation — such as a `required` error from the save-time 422 — stayed hidden until the user focused the field, and was also excluded from the dialog's anchorless banner because its property name matches a rendered field. An empty required relation could pass review invisibly.

Server-sourced violations now surface regardless of touch; only the live client check still waits for blur. The creator is unaffected: its dry-run already strips `required`/`label-required`, so an untouched required relation produces no server violation to show.

## Manual Browser Check

Use a schema with a **required, single-value relation** property (e.g. a "Company" relation).

1. **Editor surfaces it:** open the Subject editor for an existing subject whose required relation is empty, without touching the relation field. Expect a red `required` error on the field immediately (previously silent).
2. **Save path:** attempt to save with the required relation still empty. Expect the inline error on the relation field, not only a generic toast.
3. **Creator stays quiet (regression guard):** create a new subject with that schema and do not touch the relation field. Expect no premature `required` error until you interact and blur, or attempt to save.
4. **Multiple mode unchanged:** a required multi-value relation still shows its message immediately, as before.
