### PR TITLE
Run the node dev sidecar as the host user

### DIFF
--- a/Docker/docker-compose.dev.yml
+++ b/Docker/docker-compose.dev.yml
@@ -54,12 +54,23 @@ services:
   node:
     image: node:24
     restart: on-failure:3
+    # Run as the host user so node_modules/ and dist/ written into the bind mount
+    # are host-owned, matching the Makefile's EXEC_USER. The Makefile exports
+    # NODE_USER (host uid:gid under rootful Docker, 0:0 under rootless Podman, which
+    # remaps container-root to the host user). The 1000:1000 default only covers a
+    # manual `docker compose up` (outside make) on a host whose uid is 1000.
+    user: "${NODE_USER:-1000:1000}"
     working_dir: /workspace/resources/ext.neowiki
     volumes:
       - ../:/workspace:z
     command: sh -c "npm install && npm run build:watch"
     environment:
       - npm_config_cache=/tmp/.npm
+      # NODE_USER is the host's `id -u`, which on another machine may have no
+      # /etc/passwd entry in node:24 — HOME would then default to the unwritable
+      # '/'. Give npm a writable HOME for its logs/config. (On a uid-1000 host this
+      # is a no-op: uid 1000 is the image's `node` user, HOME=/home/node.)
+      - HOME=/tmp
 
   mailcatcher:
     image: sj26/mailcatcher

--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,19 @@ ifeq ($(IS_PODMAN),1)
 	# Rootless Podman maps container-root to the host user, so bind-mount writes
 	# already land with host ownership. Forcing --user would map into the subuid range.
 	EXEC_USER :=
+	# The node sidecar runs as container-root, which Podman remaps to the host user.
+	NODE_USER := 0:0
 else
 	# Rootful Docker does no UID remap: run exec as the host uid:gid so files written
 	# into bind mounts are owned by the host user, not root.
 	EXEC_USER := --user $(shell id -u):$(shell id -g)
+	# The node sidecar is a long-running service, so its user is set at compose-up
+	# time (not via exec): run it as the host uid:gid so node_modules/ and dist/ are
+	# host-owned, matching EXEC_USER. Otherwise the host-user TS targets cannot write
+	# them. Exported so `docker compose` interpolates ${NODE_USER} in the dev compose.
+	NODE_USER := $(shell id -u):$(shell id -g)
 endif
+export NODE_USER
 
 EXEC_MW := $(DC) exec -T $(EXEC_USER) mediawiki
 EXEC_MW_ROOT := $(DC) exec -T mediawiki


### PR DESCRIPTION
The `node` dev sidecar ran `npm install && npm run build:watch` as
container-root, so on a fresh stack it wrote `node_modules/`, `dist/`, and the
`*.tsbuildinfo` build-info files root-owned. The Makefile runs every other
`exec` as the host uid:gid (`EXEC_USER`) so bind-mount writes stay host-owned;
the sidecar was the one place that didn't. The host-user TS targets then failed
with EACCES writing into those root-owned trees (`make ts-test` on
`node_modules/.vite-temp`, `make ts-build` on the `*.tsbuildinfo` files).

This hits every fresh dev stack with no pre-existing `node_modules` — so
reliably in every new worktree, and on the main checkout after a clean
`make dev`. Existing stacks looked fine only because their `node_modules` had
been seeded host-owned by an earlier host-user `npm install`.

Run the sidecar as the host user, mirroring `EXEC_USER`'s engine split:

- Rootful Docker: `user: <host uid:gid>` so artifacts are host-owned.
- Rootless Podman: `0:0` (container-root), which Podman remaps to the host
  user — forcing a uid would land in the subuid range.

The Makefile computes and exports `NODE_USER`; the dev compose interpolates it
(the `1000:1000` default covers a manual `docker compose up` on a uid-1000
host). `HOME=/tmp` is added so npm has a writable HOME when the host uid has no
passwd entry in `node:24` (HOME would otherwise default to the unwritable `/`).

Verified on a fresh worktree stack: the sidecar comes up as uid 1000;
`node_modules`, `dist`, and the `*.tsbuildinfo` files land host-owned; and
`make ts-test`, `ts-build`, and `ts-lint` all pass. Before the fix,
`ts-test`/`ts-build` died with EACCES.

Upgrading an existing checkout: if `node_modules/`/`dist/` were left root-owned
by the old sidecar, the now-uid-1000 sidecar's `npm install` fails with EACCES
(it retries, then `_wait-node` times out). Clear them once with a privileged rm
— `docker run --rm -v "$PWD/resources/ext.neowiki":/w alpine sh -c 'rm -rf
/w/node_modules /w/dist /w/*.tsbuildinfo'` — then re-run `make dev`. Fresh
worktrees and checkouts are unaffected.

> Result of a diagnosis session with @alistair3149, who directed the
> investigation and the decision to fix the root cause in the dev stack rather
> than work around it in the worktree tooling.
> Context: the NeoWiki dev stack (Makefile `EXEC_USER`, the dev compose node
> sidecar) and live reproduction on a fresh worktree.
> <sub>Written by Claude Code, `Opus 4.8 (1M context)`</sub>

