### PR TITLE
Reuse bundled referenced subjects when loading a Subject

### DIFF
--- a/resources/ext.neowiki/src/domain/SubjectRepository.ts
+++ b/resources/ext.neowiki/src/domain/SubjectRepository.ts
@@ -4,10 +4,13 @@ import { InMemorySubjectLookup } from '@/domain/SubjectLookup';
 import type { StatementList } from '@/domain/StatementList';
 import type { SchemaName } from '@/domain/Schema';
 import { PageSubjects } from '@/domain/PageSubjects';
+import { SubjectMap } from '@/domain/SubjectMap';
 import type { DeserializedPageSubjects } from '@/persistence/PageSubjectsDeserializer';
 import type { SubjectViolation } from '@/domain/SubjectViolation';
 
 export interface SubjectRepository extends SubjectLookup {
+
+	getSubjectWithReferencedSubjects( id: SubjectId ): Promise<SubjectMap>;
 
 	getPageSubjects( pageId: number ): Promise<DeserializedPageSubjects>;
 
@@ -48,6 +51,13 @@ export interface SubjectRepository extends SubjectLookup {
 }
 
 export class StubSubjectRepository extends InMemorySubjectLookup implements SubjectRepository {
+
+	public async getSubjectWithReferencedSubjects( id: SubjectId ): Promise<SubjectMap> {
+		const subject = await this.getSubject( id );
+		const referencedSubjects = await subject.getReferencedSubjects( this );
+
+		return new SubjectMap( subject, ...referencedSubjects );
+	}
 
 	public getPageSubjects( pageId: number ): Promise<DeserializedPageSubjects> {
 		return Promise.resolve( {

--- a/resources/ext.neowiki/src/persistence/RestSubjectRepository.ts
+++ b/resources/ext.neowiki/src/persistence/RestSubjectRepository.ts
@@ -10,6 +10,7 @@ import { StatementList, statementsToJson } from '@/domain/StatementList';
 import { type SchemaName } from '@/domain/Schema';
 import type { HttpClient } from '@/infrastructure/HttpClient/HttpClient';
 import type { Subject } from '@/domain/Subject';
+import { SubjectMap } from '@/domain/SubjectMap';
 import type { SubjectViolation } from '@/domain/SubjectViolation';
 import { ValidationFailedError } from '@/persistence/ValidationFailedError';
 import { parseViolations } from '@/persistence/violationParsing';
@@ -115,6 +116,29 @@ export class RestSubjectRepository implements SubjectRepository {
 	}
 
 	public async getSubject( id: SubjectId ): Promise<Subject> {
+		const bundle = await this.fetchSubjectBundle( id );
+
+		return this.subjectDeserializer.deserialize( bundle.subjects[ bundle.requestedId ] );
+	}
+
+	/**
+	 * The `expand=relations` response bundles the requested Subject together with
+	 * every Subject its relations target, so a View can resolve relation labels
+	 * without re-fetching each target individually.
+	 */
+	public async getSubjectWithReferencedSubjects( id: SubjectId ): Promise<SubjectMap> {
+		const bundle = await this.fetchSubjectBundle( id );
+
+		return new SubjectMap(
+			...Object.values( bundle.subjects ).map(
+				( subjectData ) => this.subjectDeserializer.deserialize( subjectData ),
+			),
+		);
+	}
+
+	private async fetchSubjectBundle(
+		id: SubjectId,
+	): Promise<{ requestedId: string; subjects: Record<string, SubjectJson> }> {
 		let url = `${ this.mediaWikiRestApiUrl }/neowiki/v0/subject/${ id.text }?expand=page|relations`;
 
 		if ( this.revisionId !== undefined ) {
@@ -133,9 +157,7 @@ export class RestSubjectRepository implements SubjectRepository {
 			throw new Error( 'Subject not found' );
 		}
 
-		const subjectData = data.subjects[ data.requestedId ];
-
-		return this.subjectDeserializer.deserialize( subjectData );
+		return { requestedId: data.requestedId, subjects: data.subjects };
 	}
 
 	public async createMainSubject(

--- a/resources/ext.neowiki/src/persistence/StoreStateLoader.ts
+++ b/resources/ext.neowiki/src/persistence/StoreStateLoader.ts
@@ -44,27 +44,23 @@ export class StoreStateLoader {
 	}
 
 	private async loadForSubject( subjectId: SubjectId ): Promise<void> {
-		const subjectStore = useSubjectStore(); // TODO: inject
-		const schemaStore = useSchemaStore(); // TODO: inject
+		// The repository bundles the requested Subject with the Subjects its
+		// relations target, so storing them all avoids a re-fetch per relation.
+		const subjects = await this.subjectRepo.getSubjectWithReferencedSubjects( subjectId );
+		const requestedSubject = subjects.get( subjectId );
 
-		const subject = await this.subjectRepo.getSubject( subjectId );
-
-		if ( subject !== undefined ) {
-			subjectStore.setSubject( subject );
-
-			const schema = await this.schemaRepo.getSchema( subject.getSchemaName() ); // TODO: handle not found
-			schemaStore.setSchema( subject.getSchemaName(), schema );
-
-			const referencedSubjects = await subject.getReferencedSubjects( this.subjectRepo );
-			for ( const referencedSubject of referencedSubjects ) {
-				subjectStore.setSubject( referencedSubject );
-			}
-
-			// TODO: we can just call await schemaStore.getOrFetchSchema().
-			// Shall we remove the getOrFetch methods from the Stores?
-			// If we keep them, we can just as well use them here.
-			// Argument for removal: keep the Stores simple.
+		if ( requestedSubject === undefined ) {
+			return;
 		}
+
+		const subjectStore = useSubjectStore(); // TODO: inject
+		for ( const subject of subjects ) {
+			subjectStore.setSubject( subject );
+		}
+
+		const schemaStore = useSchemaStore(); // TODO: inject
+		const schema = await this.schemaRepo.getSchema( requestedSubject.getSchemaName() ); // TODO: handle not found
+		schemaStore.setSchema( requestedSubject.getSchemaName(), schema );
 	}
 
 }

--- a/resources/ext.neowiki/tests/persistence/RestSubjectRepository.neo4j.spec.ts
+++ b/resources/ext.neowiki/tests/persistence/RestSubjectRepository.neo4j.spec.ts
@@ -7,6 +7,7 @@ import { Statement } from '@/domain/Statement';
 import { PropertyName } from '@/domain/PropertyDefinition';
 import { newStringValue } from '@/domain/Value';
 import { TextType } from '@/domain/propertyTypes/Text';
+import { RelationType } from '@/domain/propertyTypes/Relation';
 import { InMemoryHttpClient } from '@/infrastructure/HttpClient/InMemoryHttpClient';
 import { UrlType } from '@/domain/propertyTypes/Url';
 import { NeoWikiExtension } from '@/NeoWikiExtension';
@@ -99,6 +100,99 @@ describe( 'RestSubjectRepository', () => {
 
 			await expect( repository.getSubject( new SubjectId( ID ) ) )
 				.rejects.toThrow( 'No response found for URL: ' + url );
+		} );
+
+	} );
+
+	describe( 'getSubjectWithReferencedSubjects', () => {
+
+		const requestedId = 's11111111111111';
+		const referencedId1 = 's22222222222222';
+		const referencedId2 = 's33333333333333';
+
+		const bundleResponse = {
+			requestedId: requestedId,
+			subjects: {
+				[ requestedId ]: {
+					id: requestedId,
+					label: 'Main',
+					schema: 'Company',
+					pageId: 1,
+					pageTitle: 'Main',
+					statements: {
+						Products: {
+							value: [ { target: referencedId1 }, { target: referencedId2 } ],
+							type: RelationType.typeName,
+						},
+					},
+				},
+				[ referencedId1 ]: {
+					id: referencedId1,
+					label: 'Product One',
+					schema: 'Product',
+					pageId: 2,
+					pageTitle: 'Product One',
+					statements: {},
+				},
+				[ referencedId2 ]: {
+					id: referencedId2,
+					label: 'Product Two',
+					schema: 'Product',
+					pageId: 3,
+					pageTitle: 'Product Two',
+					statements: {},
+				},
+			},
+		};
+
+		function repositoryReturning( response: object ): RestSubjectRepository {
+			return newRepository( 'https://example.com/rest.php', new InMemoryHttpClient( {
+				[ `https://example.com/rest.php/neowiki/v0/subject/${ requestedId }?expand=page|relations` ]:
+					new Response( JSON.stringify( response ), { status: 200 } ),
+			} ) );
+		}
+
+		it( 'returns the requested Subject together with every bundled referenced Subject', async () => {
+			const repository = repositoryReturning( bundleResponse );
+
+			const subjects = await repository.getSubjectWithReferencedSubjects( new SubjectId( requestedId ) );
+
+			expect( subjects.keys().sort() ).toEqual(
+				[ requestedId, referencedId1, referencedId2 ].sort(),
+			);
+			expect( subjects.get( new SubjectId( requestedId ) )?.getLabel() ).toBe( 'Main' );
+			expect( subjects.get( new SubjectId( referencedId1 ) )?.getLabel() ).toBe( 'Product One' );
+			expect( subjects.get( new SubjectId( referencedId2 ) )?.getLabel() ).toBe( 'Product Two' );
+		} );
+
+		it( 'deserializes referenced Subjects with their page context', async () => {
+			const repository = repositoryReturning( bundleResponse );
+
+			const subjects = await repository.getSubjectWithReferencedSubjects( new SubjectId( requestedId ) );
+
+			const referenced = subjects.get( new SubjectId( referencedId1 ) ) as SubjectWithContext;
+			expect( referenced.getPageIdentifiers().getPageName() ).toBe( 'Product One' );
+		} );
+
+		it( 'issues a single request for the whole bundle', async () => {
+			const inMemoryHttpClient = new InMemoryHttpClient( {
+				[ `https://example.com/rest.php/neowiki/v0/subject/${ requestedId }?expand=page|relations` ]:
+					new Response( JSON.stringify( bundleResponse ), { status: 200 } ),
+			} );
+			const getSpy = vi.spyOn( inMemoryHttpClient, 'get' );
+
+			const repository = newRepository( 'https://example.com/rest.php', inMemoryHttpClient );
+
+			await repository.getSubjectWithReferencedSubjects( new SubjectId( requestedId ) );
+
+			expect( getSpy ).toHaveBeenCalledOnce();
+		} );
+
+		it( 'throws when the requested Subject is missing from the response', async () => {
+			const repository = repositoryReturning( {} );
+
+			await expect( repository.getSubjectWithReferencedSubjects( new SubjectId( requestedId ) ) )
+				.rejects.toThrow( 'Subject not found' );
 		} );
 
 	} );

--- a/resources/ext.neowiki/tests/persistence/StoreStateLoader.spec.ts
+++ b/resources/ext.neowiki/tests/persistence/StoreStateLoader.spec.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { StoreStateLoader } from '@/persistence/StoreStateLoader';
+import { StubSubjectRepository } from '@/domain/SubjectRepository';
+import { InMemorySchemaRepository } from '@/application/SchemaRepository';
+import { InMemoryLayoutLookup } from '@/application/LayoutLookup';
+import { SubjectMap } from '@/domain/SubjectMap';
+import { SubjectId } from '@/domain/SubjectId';
+import { Subject } from '@/domain/Subject';
+import { newSchema, newSubject } from '@/TestHelpers';
+import { useSubjectStore } from '@/stores/SubjectStore';
+import { useSchemaStore } from '@/stores/SchemaStore';
+import { RelationType } from '@/domain/propertyTypes/Relation';
+import { Neo } from '@/Neo';
+
+const mainId = new SubjectId( 's11111111111111' );
+const referencedId1 = new SubjectId( 's22222222222222' );
+const referencedId2 = new SubjectId( 's33333333333333' );
+
+/**
+ * Records how the loader reaches the repository so tests can assert that
+ * referenced Subjects come from the single bundle rather than per-target fetches.
+ */
+class RecordingSubjectRepository extends StubSubjectRepository {
+
+	public getSubjectCallCount = 0;
+
+	public getSubjectWithReferencedSubjectsCallCount = 0;
+
+	public constructor( private readonly bundle: SubjectMap ) {
+		super( [] );
+	}
+
+	public override async getSubject( id: SubjectId ): Promise<Subject> {
+		this.getSubjectCallCount++;
+		const subject = this.bundle.get( id );
+		if ( subject === undefined ) {
+			throw new Error( `Subject ${ id.text } not found` );
+		}
+		return subject;
+	}
+
+	public override async getSubjectWithReferencedSubjects( _id: SubjectId ): Promise<SubjectMap> {
+		this.getSubjectWithReferencedSubjectsCallCount++;
+		return this.bundle;
+	}
+
+}
+
+function newMainSubjectWithRelationsTo( ...targets: SubjectId[] ): Subject {
+	return newSubject( {
+		id: mainId,
+		schemaName: 'Company',
+		statements: Neo.getInstance().getSubjectDeserializer().deserializeStatements( {
+			Products: {
+				value: targets.map( ( target ) => ( { target: target.text } ) ),
+				type: RelationType.typeName,
+			},
+		} ),
+	} );
+}
+
+function newLoader( repository: RecordingSubjectRepository ): StoreStateLoader {
+	return new StoreStateLoader(
+		repository,
+		new InMemorySchemaRepository( [ newSchema( { title: 'Company' } ) ] ),
+		new InMemoryLayoutLookup( [] ),
+	);
+}
+
+describe( 'StoreStateLoader', () => {
+
+	beforeEach( () => {
+		setActivePinia( createPinia() );
+	} );
+
+	it( 'stores the requested Subject and its referenced Subjects', async () => {
+		const main = newMainSubjectWithRelationsTo( referencedId1, referencedId2 );
+		const referenced1 = newSubject( { id: referencedId1, label: 'Product One', schemaName: 'Product' } );
+		const referenced2 = newSubject( { id: referencedId2, label: 'Product Two', schemaName: 'Product' } );
+		const repository = new RecordingSubjectRepository( new SubjectMap( main, referenced1, referenced2 ) );
+
+		await newLoader( repository ).loadSubjectsAndSchemas( new Set( [ mainId.text ] ) );
+
+		const subjectStore = useSubjectStore();
+		expect( subjectStore.getSubject( mainId ) ).toEqual( main );
+		expect( subjectStore.getSubject( referencedId1 ) ).toEqual( referenced1 );
+		expect( subjectStore.getSubject( referencedId2 ) ).toEqual( referenced2 );
+	} );
+
+	it( 'loads referenced Subjects from the bundle without re-fetching them individually', async () => {
+		const main = newMainSubjectWithRelationsTo( referencedId1, referencedId2 );
+		const referenced1 = newSubject( { id: referencedId1, label: 'Product One', schemaName: 'Product' } );
+		const referenced2 = newSubject( { id: referencedId2, label: 'Product Two', schemaName: 'Product' } );
+		const repository = new RecordingSubjectRepository( new SubjectMap( main, referenced1, referenced2 ) );
+
+		await newLoader( repository ).loadSubjectsAndSchemas( new Set( [ mainId.text ] ) );
+
+		expect( repository.getSubjectWithReferencedSubjectsCallCount ).toBe( 1 );
+		expect( repository.getSubjectCallCount ).toBe( 0 );
+	} );
+
+	it( 'stores the schema of the requested Subject', async () => {
+		const main = newMainSubjectWithRelationsTo( referencedId1 );
+		const referenced1 = newSubject( { id: referencedId1, label: 'Product One', schemaName: 'Product' } );
+		const repository = new RecordingSubjectRepository( new SubjectMap( main, referenced1 ) );
+
+		await newLoader( repository ).loadSubjectsAndSchemas( new Set( [ mainId.text ] ) );
+
+		expect( useSchemaStore().getSchema( 'Company' ) ).toEqual( newSchema( { title: 'Company' } ) );
+	} );
+
+} );


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/784

When a View renders a Subject with relations, the
`subject/{id}?expand=relations` response already bundles every related Subject.
`RestSubjectRepository.getSubject` discarded all but the requested one, and
`StoreStateLoader` then re-fetched each relation target via
`getReferencedSubjects` — one redundant HTTP request (and graph-backed read) per
relation.

Add `RestSubjectRepository.getSubjectWithReferencedSubjects`, which deserializes
the whole bundle into a SubjectMap (sharing the fetch with `getSubject` via a
private helper). `StoreStateLoader.loadForSubject` now stores the requested
Subject and its referenced Subjects from that single response, dropping the
per-target fetches. This mirrors the existing page-subjects path
(`getPageSubjects` -> `loadPageSubjects`).

A Subject with N relations now costs 1 request instead of N+1. Verified against
the demo `ACME Inc` Subject: the endpoint returns the main Subject plus its 8
distinct referenced Subjects in one response, and StoreStateLoader issues a
single repository call with zero per-target re-fetches.

> Worked from the @alistair3149-directed task to confirm #784 was still live and
> fix it; the approach (surface the bundle, mirror the page-subjects path) was
> confirmed against the codebase.
> Context: the NeoWiki frontend (RestSubjectRepository, StoreStateLoader,
> StatementList) and the live demo REST response.
> <sub>Written by Claude Code, `Opus 4.8 (1M context)`</sub>

