### PR TITLE
Skip undeserializable referenced Subjects instead of failing the load

### DIFF
--- a/resources/ext.neowiki/src/domain/SubjectRepository.ts
+++ b/resources/ext.neowiki/src/domain/SubjectRepository.ts
@@ -4,13 +4,23 @@ import { InMemorySubjectLookup } from '@/domain/SubjectLookup';
 import type { StatementList } from '@/domain/StatementList';
 import type { SchemaName } from '@/domain/Schema';
 import { PageSubjects } from '@/domain/PageSubjects';
-import { SubjectMap } from '@/domain/SubjectMap';
+import type { Subject } from '@/domain/Subject';
 import type { DeserializedPageSubjects } from '@/persistence/PageSubjectsDeserializer';
 import type { SubjectViolation } from '@/domain/SubjectViolation';
 
+export interface SubjectWithReferencedSubjects {
+	requestedSubject: Subject;
+	referencedSubjects: Subject[];
+}
+
 export interface SubjectRepository extends SubjectLookup {
 
-	getSubjectWithReferencedSubjects( id: SubjectId ): Promise<SubjectMap>;
+	/**
+	 * Returns the Subject together with the Subjects its relations target,
+	 * so relation labels can be shown without fetching each target individually.
+	 * Referenced Subjects that cannot be loaded are omitted rather than failing the whole call.
+	 */
+	getSubjectWithReferencedSubjects( id: SubjectId ): Promise<SubjectWithReferencedSubjects>;
 
 	getPageSubjects( pageId: number ): Promise<DeserializedPageSubjects>;
 
@@ -52,11 +62,13 @@ export interface SubjectRepository extends SubjectLookup {
 
 export class StubSubjectRepository extends InMemorySubjectLookup implements SubjectRepository {
 
-	public async getSubjectWithReferencedSubjects( id: SubjectId ): Promise<SubjectMap> {
+	public async getSubjectWithReferencedSubjects( id: SubjectId ): Promise<SubjectWithReferencedSubjects> {
 		const subject = await this.getSubject( id );
-		const referencedSubjects = await subject.getReferencedSubjects( this );
 
-		return new SubjectMap( subject, ...referencedSubjects );
+		return {
+			requestedSubject: subject,
+			referencedSubjects: [ ...await subject.getReferencedSubjects( this ) ],
+		};
 	}
 
 	public getPageSubjects( pageId: number ): Promise<DeserializedPageSubjects> {

--- a/resources/ext.neowiki/src/persistence/RestSubjectRepository.ts
+++ b/resources/ext.neowiki/src/persistence/RestSubjectRepository.ts
@@ -1,4 +1,4 @@
-import type { SubjectRepository } from '@/domain/SubjectRepository';
+import type { SubjectRepository, SubjectWithReferencedSubjects } from '@/domain/SubjectRepository';
 import { SubjectId } from '@/domain/SubjectId';
 import type { SubjectDeserializer } from '@/persistence/SubjectDeserializer';
 import {
@@ -10,7 +10,6 @@ import { StatementList, statementsToJson } from '@/domain/StatementList';
 import { type SchemaName } from '@/domain/Schema';
 import type { HttpClient } from '@/infrastructure/HttpClient/HttpClient';
 import type { Subject } from '@/domain/Subject';
-import { SubjectMap } from '@/domain/SubjectMap';
 import type { SubjectViolation } from '@/domain/SubjectViolation';
 import { ValidationFailedError } from '@/persistence/ValidationFailedError';
 import { parseViolations } from '@/persistence/violationParsing';
@@ -46,6 +45,11 @@ export type SubjectJson = {
 	pageTitle: string;
 	requestedId: string;
 	value?: unknown;
+};
+
+type SubjectBundleJson = {
+	requestedId: string;
+	subjects: Record<string, SubjectJson>;
 };
 
 export class RestSubjectRepository implements SubjectRepository {
@@ -125,20 +129,35 @@ export class RestSubjectRepository implements SubjectRepository {
 	 * The `expand=relations` response bundles the requested Subject together with
 	 * every Subject its relations target, so a View can resolve relation labels
 	 * without re-fetching each target individually.
+	 *
+	 * Referenced Subjects that fail to deserialize are skipped: a broken relation
+	 * target should not prevent the requested Subject from loading.
 	 */
-	public async getSubjectWithReferencedSubjects( id: SubjectId ): Promise<SubjectMap> {
+	public async getSubjectWithReferencedSubjects( id: SubjectId ): Promise<SubjectWithReferencedSubjects> {
 		const bundle = await this.fetchSubjectBundle( id );
 
-		return new SubjectMap(
-			...Object.values( bundle.subjects ).map(
-				( subjectData ) => this.subjectDeserializer.deserialize( subjectData ),
-			),
-		);
+		return {
+			requestedSubject: this.subjectDeserializer.deserialize( bundle.subjects[ bundle.requestedId ] ),
+			referencedSubjects: this.deserializeReferencedSubjects( bundle ),
+		};
 	}
 
-	private async fetchSubjectBundle(
-		id: SubjectId,
-	): Promise<{ requestedId: string; subjects: Record<string, SubjectJson> }> {
+	private deserializeReferencedSubjects( bundle: SubjectBundleJson ): Subject[] {
+		return Object.entries( bundle.subjects )
+			.filter( ( [ id ] ) => id !== bundle.requestedId )
+			.map( ( [ , subjectData ] ) => this.deserializeOrNull( subjectData ) )
+			.filter( ( subject ): subject is Subject => subject !== null );
+	}
+
+	private deserializeOrNull( subjectData: SubjectJson ): Subject|null {
+		try {
+			return this.subjectDeserializer.deserialize( subjectData );
+		} catch ( _error ) {
+			return null;
+		}
+	}
+
+	private async fetchSubjectBundle( id: SubjectId ): Promise<SubjectBundleJson> {
 		let url = `${ this.mediaWikiRestApiUrl }/neowiki/v0/subject/${ id.text }?expand=page|relations`;
 
 		if ( this.revisionId !== undefined ) {

--- a/resources/ext.neowiki/src/persistence/StoreStateLoader.ts
+++ b/resources/ext.neowiki/src/persistence/StoreStateLoader.ts
@@ -46,15 +46,12 @@ export class StoreStateLoader {
 	private async loadForSubject( subjectId: SubjectId ): Promise<void> {
 		// The repository bundles the requested Subject with the Subjects its
 		// relations target, so storing them all avoids a re-fetch per relation.
-		const subjects = await this.subjectRepo.getSubjectWithReferencedSubjects( subjectId );
-		const requestedSubject = subjects.get( subjectId );
-
-		if ( requestedSubject === undefined ) {
-			return;
-		}
+		const { requestedSubject, referencedSubjects } =
+			await this.subjectRepo.getSubjectWithReferencedSubjects( subjectId );
 
 		const subjectStore = useSubjectStore(); // TODO: inject
-		for ( const subject of subjects ) {
+		subjectStore.setSubject( requestedSubject );
+		for ( const subject of referencedSubjects ) {
 			subjectStore.setSubject( subject );
 		}
 

--- a/resources/ext.neowiki/tests/persistence/RestSubjectRepository.neo4j.spec.ts
+++ b/resources/ext.neowiki/tests/persistence/RestSubjectRepository.neo4j.spec.ts
@@ -113,6 +113,14 @@ describe( 'RestSubjectRepository', () => {
 		const bundleResponse = {
 			requestedId: requestedId,
 			subjects: {
+				[ referencedId1 ]: {
+					id: referencedId1,
+					label: 'Product One',
+					schema: 'Product',
+					pageId: 2,
+					pageTitle: 'Product One',
+					statements: {},
+				},
 				[ requestedId ]: {
 					id: requestedId,
 					label: 'Main',
@@ -125,14 +133,6 @@ describe( 'RestSubjectRepository', () => {
 							type: RelationType.typeName,
 						},
 					},
-				},
-				[ referencedId1 ]: {
-					id: referencedId1,
-					label: 'Product One',
-					schema: 'Product',
-					pageId: 2,
-					pageTitle: 'Product One',
-					statements: {},
 				},
 				[ referencedId2 ]: {
 					id: referencedId2,
@@ -155,22 +155,22 @@ describe( 'RestSubjectRepository', () => {
 		it( 'returns the requested Subject together with every bundled referenced Subject', async () => {
 			const repository = repositoryReturning( bundleResponse );
 
-			const subjects = await repository.getSubjectWithReferencedSubjects( new SubjectId( requestedId ) );
+			const { requestedSubject, referencedSubjects } =
+				await repository.getSubjectWithReferencedSubjects( new SubjectId( requestedId ) );
 
-			expect( subjects.keys().sort() ).toEqual(
-				[ requestedId, referencedId1, referencedId2 ].sort(),
+			expect( requestedSubject.getLabel() ).toBe( 'Main' );
+			expect( referencedSubjects.map( ( subject ) => subject.getLabel() ) ).toEqual(
+				[ 'Product One', 'Product Two' ],
 			);
-			expect( subjects.get( new SubjectId( requestedId ) )?.getLabel() ).toBe( 'Main' );
-			expect( subjects.get( new SubjectId( referencedId1 ) )?.getLabel() ).toBe( 'Product One' );
-			expect( subjects.get( new SubjectId( referencedId2 ) )?.getLabel() ).toBe( 'Product Two' );
 		} );
 
 		it( 'deserializes referenced Subjects with their page context', async () => {
 			const repository = repositoryReturning( bundleResponse );
 
-			const subjects = await repository.getSubjectWithReferencedSubjects( new SubjectId( requestedId ) );
+			const { referencedSubjects } =
+				await repository.getSubjectWithReferencedSubjects( new SubjectId( requestedId ) );
 
-			const referenced = subjects.get( new SubjectId( referencedId1 ) ) as SubjectWithContext;
+			const referenced = referencedSubjects[ 0 ] as SubjectWithContext;
 			expect( referenced.getPageIdentifiers().getPageName() ).toBe( 'Product One' );
 		} );
 
@@ -193,6 +193,51 @@ describe( 'RestSubjectRepository', () => {
 
 			await expect( repository.getSubjectWithReferencedSubjects( new SubjectId( requestedId ) ) )
 				.rejects.toThrow( 'Subject not found' );
+		} );
+
+		function subjectWithUnknownPropertyType( id: string ): object {
+			return {
+				id: id,
+				label: 'Broken',
+				schema: 'Product',
+				pageId: 4,
+				pageTitle: 'Broken',
+				statements: {
+					Mystery: {
+						value: 'x',
+						type: 'unregistered-property-type',
+					},
+				},
+			};
+		}
+
+		it( 'skips referenced Subjects that fail to deserialize', async () => {
+			const repository = repositoryReturning( {
+				requestedId: requestedId,
+				subjects: {
+					[ referencedId1 ]: subjectWithUnknownPropertyType( referencedId1 ),
+					[ requestedId ]: bundleResponse.subjects[ requestedId ],
+					[ referencedId2 ]: bundleResponse.subjects[ referencedId2 ],
+				},
+			} );
+
+			const { requestedSubject, referencedSubjects } =
+				await repository.getSubjectWithReferencedSubjects( new SubjectId( requestedId ) );
+
+			expect( requestedSubject.getLabel() ).toBe( 'Main' );
+			expect( referencedSubjects.map( ( subject ) => subject.getId().text ) ).toEqual( [ referencedId2 ] );
+		} );
+
+		it( 'throws when the requested Subject fails to deserialize', async () => {
+			const repository = repositoryReturning( {
+				requestedId: requestedId,
+				subjects: {
+					[ requestedId ]: subjectWithUnknownPropertyType( requestedId ),
+				},
+			} );
+
+			await expect( repository.getSubjectWithReferencedSubjects( new SubjectId( requestedId ) ) )
+				.rejects.toThrow( 'Unknown property type' );
 		} );
 
 	} );

--- a/resources/ext.neowiki/tests/persistence/StoreStateLoader.spec.ts
+++ b/resources/ext.neowiki/tests/persistence/StoreStateLoader.spec.ts
@@ -2,9 +2,9 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { createPinia, setActivePinia } from 'pinia';
 import { StoreStateLoader } from '@/persistence/StoreStateLoader';
 import { StubSubjectRepository } from '@/domain/SubjectRepository';
+import type { SubjectWithReferencedSubjects } from '@/domain/SubjectRepository';
 import { InMemorySchemaRepository } from '@/application/SchemaRepository';
 import { InMemoryLayoutLookup } from '@/application/LayoutLookup';
-import { SubjectMap } from '@/domain/SubjectMap';
 import { SubjectId } from '@/domain/SubjectId';
 import { Subject } from '@/domain/Subject';
 import { newSchema, newSubject } from '@/TestHelpers';
@@ -27,20 +27,16 @@ class RecordingSubjectRepository extends StubSubjectRepository {
 
 	public getSubjectWithReferencedSubjectsCallCount = 0;
 
-	public constructor( private readonly bundle: SubjectMap ) {
-		super( [] );
+	public constructor( private readonly bundle: SubjectWithReferencedSubjects ) {
+		super( [ bundle.requestedSubject, ...bundle.referencedSubjects ] );
 	}
 
 	public override async getSubject( id: SubjectId ): Promise<Subject> {
 		this.getSubjectCallCount++;
-		const subject = this.bundle.get( id );
-		if ( subject === undefined ) {
-			throw new Error( `Subject ${ id.text } not found` );
-		}
-		return subject;
+		return super.getSubject( id );
 	}
 
-	public override async getSubjectWithReferencedSubjects( _id: SubjectId ): Promise<SubjectMap> {
+	public override async getSubjectWithReferencedSubjects( _id: SubjectId ): Promise<SubjectWithReferencedSubjects> {
 		this.getSubjectWithReferencedSubjectsCallCount++;
 		return this.bundle;
 	}
@@ -78,7 +74,9 @@ describe( 'StoreStateLoader', () => {
 		const main = newMainSubjectWithRelationsTo( referencedId1, referencedId2 );
 		const referenced1 = newSubject( { id: referencedId1, label: 'Product One', schemaName: 'Product' } );
 		const referenced2 = newSubject( { id: referencedId2, label: 'Product Two', schemaName: 'Product' } );
-		const repository = new RecordingSubjectRepository( new SubjectMap( main, referenced1, referenced2 ) );
+		const repository = new RecordingSubjectRepository(
+			{ requestedSubject: main, referencedSubjects: [ referenced1, referenced2 ] },
+		);
 
 		await newLoader( repository ).loadSubjectsAndSchemas( new Set( [ mainId.text ] ) );
 
@@ -92,7 +90,9 @@ describe( 'StoreStateLoader', () => {
 		const main = newMainSubjectWithRelationsTo( referencedId1, referencedId2 );
 		const referenced1 = newSubject( { id: referencedId1, label: 'Product One', schemaName: 'Product' } );
 		const referenced2 = newSubject( { id: referencedId2, label: 'Product Two', schemaName: 'Product' } );
-		const repository = new RecordingSubjectRepository( new SubjectMap( main, referenced1, referenced2 ) );
+		const repository = new RecordingSubjectRepository(
+			{ requestedSubject: main, referencedSubjects: [ referenced1, referenced2 ] },
+		);
 
 		await newLoader( repository ).loadSubjectsAndSchemas( new Set( [ mainId.text ] ) );
 
@@ -103,7 +103,9 @@ describe( 'StoreStateLoader', () => {
 	it( 'stores the schema of the requested Subject', async () => {
 		const main = newMainSubjectWithRelationsTo( referencedId1 );
 		const referenced1 = newSubject( { id: referencedId1, label: 'Product One', schemaName: 'Product' } );
-		const repository = new RecordingSubjectRepository( new SubjectMap( main, referenced1 ) );
+		const repository = new RecordingSubjectRepository(
+			{ requestedSubject: main, referencedSubjects: [ referenced1 ] },
+		);
 
 		await newLoader( repository ).loadSubjectsAndSchemas( new Set( [ mainId.text ] ) );
 


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/975

That PR made `getSubjectWithReferencedSubjects` deserialize every bundled Subject with no per-entry
fault tolerance. Before it, referenced Subjects were fetched per target through
`StatementList.getReferencedSubjects`, which caught failures and skipped the broken target. Since
the PR, one referenced Subject that fails to deserialize (e.g. a Property Type known to PHP but not
registered in the frontend, such as when an extension's frontend module fails to load) rejects the
whole load, and `NeoWikiApp`'s unguarded `onMounted` then renders every View on the page blank.

Restore the old tolerance at the single-request path: deserialize the requested Subject strictly
and skip referenced Subjects that fail to deserialize.

Also make the repository return `{ requestedSubject, referencedSubjects }` instead of a flat
`SubjectMap`, mirroring `DeserializedPageSubjects`. Carrying "which Subject was requested" in the
type removes the unreachable silent early-return in `StoreStateLoader.loadForSubject` and the need
to re-derive the requested Subject by id.

> Follow-up scoped by @JeroenDeDauw to the high-confidence findings of a review of PR 975.
> Context: the NeoWiki frontend codebase, the PR 975 diff, and verification against a local dev
> wiki (unit tests seen failing before the fix; ACME Inc demo page checked in the browser after).
> <sub>Written by Claude Code, `Fable 5`</sub>