### PR TITLE
Provide revision content to PagePropertyProviderContext

### DIFF
--- a/docs/extending/extending.md
+++ b/docs/extending/extending.md
@@ -104,7 +104,15 @@ class StaticPagePropertyProvider implements PagePropertyProvider {
 Register with `NeoWikiRegistrar::addPagePropertyProvider()`. Keys are merged across all providers into one
 key/value map, with the last-registered provider winning on a key collision, so namespace your keys (e.g. with an
 extension prefix). The context exposes the page id, title and namespace, creation and modification times,
-categories, and last editor. Example:
+categories, and last editor, plus the revision's main slot content, so providers can derive Page Properties from
+the content without re-fetching or re-parsing it.
+
+To derive Page Properties from the content, prefer the parse products: `categories`, and `parserProperties` — the
+MediaWiki page properties recorded during parsing (e.g. those a parser hook sets via
+`ParserOutput::setPageProperty`). These are template-expansion-safe and robust. (Note that `parserProperties` are
+an input from MediaWiki's parse; they are not the NeoWiki Page Properties this provider returns.) The raw main
+slot `content` and its `contentModel` are also exposed, but scraping raw wikitext is fragile — reach for them
+mainly when handling a custom, non-wikitext content model that the parse products do not cover. Example:
 [`src/StaticPagePropertyProvider.php`](https://github.com/ProfessionalWiki/NeoWiki/blob/master/tests/RedHerb/src/StaticPagePropertyProvider.php).
 
 ### Edit notices

--- a/docs/reference/extending.md
+++ b/docs/reference/extending.md
@@ -87,7 +87,10 @@ class StaticPagePropertyProvider implements PagePropertyProvider {
 ```
 
 Register with `NeoWikiRegistrar::addPagePropertyProvider()`. The context exposes the page id, title,
-creation and modification times, categories, and last editor. Example:
+creation and modification times, categories, and last editor. It also exposes the revision's main slot
+content (plus its content model) and the properties recorded during parsing of that content (MediaWiki
+page properties, e.g. those set by parser hooks via `ParserOutput::setPageProperty`), so providers can
+derive Page Properties from the page content without re-fetching or re-parsing it. Example:
 [`src/StaticPagePropertyProvider.php`](https://github.com/ProfessionalWiki/NeoWiki/blob/master/tests/RedHerb/src/StaticPagePropertyProvider.php).
 
 ### Reading NeoWiki data and authorization

--- a/docs/reference/extending.md
+++ b/docs/reference/extending.md
@@ -87,10 +87,16 @@ class StaticPagePropertyProvider implements PagePropertyProvider {
 ```
 
 Register with `NeoWikiRegistrar::addPagePropertyProvider()`. The context exposes the page id, title,
-creation and modification times, categories, and last editor. It also exposes the revision's main slot
-content (plus its content model) and the properties recorded during parsing of that content (MediaWiki
-page properties, e.g. those set by parser hooks via `ParserOutput::setPageProperty`), so providers can
-derive Page Properties from the page content without re-fetching or re-parsing it. Example:
+creation and modification times, categories, and last editor, so providers can derive Page Properties
+from the page content without re-fetching or re-parsing it.
+
+To derive Page Properties from the content, prefer the parse products: `categories`, and
+`parserProperties` — the MediaWiki page properties recorded during parsing (e.g. those a parser hook
+sets via `ParserOutput::setPageProperty`). These are template-expansion-safe and robust. (Note that
+`parserProperties` are an input from MediaWiki's parse; they are not the NeoWiki Page Properties this
+provider returns.) The raw main slot `content` and its `contentModel` are also exposed, but scraping
+raw wikitext is fragile — reach for them mainly when handling a custom, non-wikitext content model that
+the parse products do not cover. Example:
 [`src/StaticPagePropertyProvider.php`](https://github.com/ProfessionalWiki/NeoWiki/blob/master/tests/RedHerb/src/StaticPagePropertyProvider.php).
 
 ### Reading NeoWiki data and authorization

--- a/src/Domain/Page/PagePropertyProviderContext.php
+++ b/src/Domain/Page/PagePropertyProviderContext.php
@@ -13,6 +13,14 @@ readonly class PagePropertyProviderContext {
 	 * @param string $modificationTime In the standard MediaWiki format, ie 20230726163439
 	 * @param string[] $categories
 	 * @param string $lastEditor Plain username of the last editor, e.g. "JohnDoe". Empty string if unknown.
+	 * @param string $content Serialized main slot content of the revision, e.g. the wikitext.
+	 *   Empty string if the content is unavailable.
+	 * @param string $contentModel Content model of the main slot, e.g. "wikitext".
+	 *   Empty string if the content is unavailable.
+	 * @param array<string, int|float|string|bool|null> $parserProperties Properties recorded during parsing of the
+	 *   content (MediaWiki page properties, e.g. "defaultsort" or values set by parser hooks via
+	 *   ParserOutput::setPageProperty). These are inputs from the parse, not to be confused with the NeoWiki
+	 *   Page Properties that providers return.
 	 */
 	public function __construct(
 		public PageId $pageId,
@@ -22,6 +30,9 @@ readonly class PagePropertyProviderContext {
 		public string $modificationTime,
 		public array $categories,
 		public string $lastEditor,
+		public string $content,
+		public string $contentModel,
+		public array $parserProperties,
 	) {
 	}
 

--- a/src/PagePropertiesBuilder.php
+++ b/src/PagePropertiesBuilder.php
@@ -4,8 +4,10 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki;
 
+use MediaWiki\Content\Content;
 use MediaWiki\Content\IContentHandlerFactory;
 use MediaWiki\Content\Renderer\ContentParseParams;
+use MediaWiki\Parser\ParserOutput;
 use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Revision\RevisionStore;
 use MediaWiki\Revision\SlotRecord;
@@ -40,6 +42,8 @@ readonly class PagePropertiesBuilder {
 
 	private function buildContext( RevisionRecord $revision, ?UserIdentity $user ): PagePropertyProviderContext {
 		$linkTarget = $revision->getPageAsLinkTarget();
+		$content = $revision->getContent( SlotRecord::MAIN );
+		$parserOutput = $content === null ? null : $this->parse( $content, $revision );
 
 		return new PagePropertyProviderContext(
 			pageId: new PageId( $revision->getPageId() ),
@@ -47,9 +51,17 @@ readonly class PagePropertiesBuilder {
 			namespaceId: $linkTarget->getNamespace(),
 			creationTime: $this->getCreationTime( $revision ),
 			modificationTime: $this->getModificationTime( $revision ),
-			categories: $this->getCategories( $revision ),
+			categories: $parserOutput === null ? [] : $parserOutput->getCategoryNames(),
 			lastEditor: $user?->getName() ?? '',
+			content: $content === null ? '' : $content->serialize(),
+			contentModel: $content === null ? '' : $content->getModel(),
+			parserProperties: $parserOutput === null ? [] : $parserOutput->getPageProperties(),
 		);
+	}
+
+	private function parse( Content $content, RevisionRecord $revision ): ParserOutput {
+		return $this->contentHandlerFactory->getContentHandler( $content->getModel() )
+			->getParserOutput( $content, new ContentParseParams( $revision->getPage() ) );
 	}
 
 	private function getCreationTime( RevisionRecord $revision ): string {
@@ -70,21 +82,6 @@ readonly class PagePropertiesBuilder {
 		}
 
 		return $time;
-	}
-
-	/**
-	 * @return string[]
-	 */
-	private function getCategories( RevisionRecord $revision ): array {
-		$content = $revision->getContent( SlotRecord::MAIN );
-
-		if ( $content === null ) {
-			return [];
-		}
-
-		return $this->contentHandlerFactory->getContentHandler( $content->getModel() )
-			->getParserOutput( $content, new ContentParseParams( $revision->getPage() ) )
-			->getCategoryNames();
 	}
 
 }

--- a/src/PagePropertiesBuilder.php
+++ b/src/PagePropertiesBuilder.php
@@ -4,8 +4,10 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki;
 
+use MediaWiki\Content\Content;
 use MediaWiki\Content\IContentHandlerFactory;
 use MediaWiki\Content\Renderer\ContentParseParams;
+use MediaWiki\Parser\ParserOutput;
 use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Revision\RevisionStore;
 use MediaWiki\Revision\SlotRecord;
@@ -40,6 +42,8 @@ readonly class PagePropertiesBuilder implements PagePropertiesSource {
 
 	private function buildContext( RevisionRecord $revision, ?UserIdentity $user ): PagePropertyProviderContext {
 		$linkTarget = $revision->getPageAsLinkTarget();
+		$content = $revision->getContent( SlotRecord::MAIN );
+		$parserOutput = $content === null ? null : $this->parse( $content, $revision );
 
 		return new PagePropertyProviderContext(
 			pageId: new PageId( $revision->getPageId() ),
@@ -47,9 +51,17 @@ readonly class PagePropertiesBuilder implements PagePropertiesSource {
 			namespaceId: $linkTarget->getNamespace(),
 			creationTime: $this->getCreationTime( $revision ),
 			modificationTime: $this->getModificationTime( $revision ),
-			categories: $this->getCategories( $revision ),
+			categories: $parserOutput === null ? [] : $parserOutput->getCategoryNames(),
 			lastEditor: $user?->getName() ?? '',
+			content: $content === null ? '' : $content->serialize(),
+			contentModel: $content === null ? '' : $content->getModel(),
+			parserProperties: $parserOutput === null ? [] : $parserOutput->getPageProperties(),
 		);
+	}
+
+	private function parse( Content $content, RevisionRecord $revision ): ParserOutput {
+		return $this->contentHandlerFactory->getContentHandler( $content->getModel() )
+			->getParserOutput( $content, new ContentParseParams( $revision->getPage() ) );
 	}
 
 	private function getCreationTime( RevisionRecord $revision ): string {
@@ -70,21 +82,6 @@ readonly class PagePropertiesBuilder implements PagePropertiesSource {
 		}
 
 		return $time;
-	}
-
-	/**
-	 * @return string[]
-	 */
-	private function getCategories( RevisionRecord $revision ): array {
-		$content = $revision->getContent( SlotRecord::MAIN );
-
-		if ( $content === null ) {
-			return [];
-		}
-
-		return $this->contentHandlerFactory->getContentHandler( $content->getModel() )
-			->getParserOutput( $content, new ContentParseParams( $revision->getPage() ) )
-			->getCategoryNames();
 	}
 
 }

--- a/tests/phpunit/PagePropertiesBuilderTest.php
+++ b/tests/phpunit/PagePropertiesBuilderTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests;
+
+use ProfessionalWiki\NeoWiki\Domain\Page\PagePropertyProviderContext;
+use ProfessionalWiki\NeoWiki\Domain\Page\PagePropertyProviderRegistry;
+use ProfessionalWiki\NeoWiki\PagePropertiesBuilder;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpyPagePropertyProvider;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\PagePropertiesBuilder
+ * @group Database
+ */
+class PagePropertiesBuilderTest extends NeoWikiIntegrationTestCase {
+
+	public function testProviderReceivesContent(): void {
+		$context = $this->getContextForNewPageWithContent( 'Some text [[Category:Cats]]' );
+
+		$this->assertSame( 'Some text [[Category:Cats]]', $context->content );
+	}
+
+	public function testProviderReceivesContentModel(): void {
+		$context = $this->getContextForNewPageWithContent( 'Whatever wikitext' );
+
+		$this->assertSame( CONTENT_MODEL_WIKITEXT, $context->contentModel );
+	}
+
+	public function testProviderReceivesParserRecordedProperties(): void {
+		$context = $this->getContextForNewPageWithContent( 'Sorted {{DEFAULTSORT:Zebra}}' );
+
+		$this->assertSame( 'Zebra', $context->parserProperties['defaultsort'] );
+	}
+
+	public function testProviderReceivesCategoriesFromParsedContent(): void {
+		$context = $this->getContextForNewPageWithContent( 'Some text [[Category:Cats]]' );
+
+		$this->assertSame( [ 'Cats' ], $context->categories );
+	}
+
+	private function getContextForNewPageWithContent( string $wikitext ): PagePropertyProviderContext {
+		$revision = $this->editPage( 'PagePropertiesBuilderTestPage', $wikitext )->getNewRevision();
+
+		$spy = new SpyPagePropertyProvider();
+
+		$this->newPagePropertiesBuilder( $spy )->getPagePropertiesFor( $revision, null );
+
+		return $spy->getReceivedContext();
+	}
+
+	private function newPagePropertiesBuilder( SpyPagePropertyProvider $provider ): PagePropertiesBuilder {
+		$registry = new PagePropertyProviderRegistry();
+		$registry->addProvider( $provider );
+
+		$services = $this->getServiceContainer();
+
+		return new PagePropertiesBuilder(
+			revisionStore: $services->getRevisionStore(),
+			contentHandlerFactory: $services->getContentHandlerFactory(),
+			titleFormatter: $services->getTitleFormatter(),
+			providerRegistry: $registry,
+		);
+	}
+
+}

--- a/tests/phpunit/Persistence/CorePagePropertyProviderTest.php
+++ b/tests/phpunit/Persistence/CorePagePropertyProviderTest.php
@@ -82,6 +82,9 @@ class CorePagePropertyProviderTest extends TestCase {
 				modificationTime: $modificationTime,
 				categories: $categories,
 				lastEditor: $lastEditor,
+				content: 'Whatever content',
+				contentModel: 'wikitext',
+				parserProperties: [],
 			)
 		);
 	}

--- a/tests/phpunit/TestDoubles/SpyPagePropertyProvider.php
+++ b/tests/phpunit/TestDoubles/SpyPagePropertyProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\TestDoubles;
+
+use ProfessionalWiki\NeoWiki\Domain\Page\PagePropertyProvider;
+use ProfessionalWiki\NeoWiki\Domain\Page\PagePropertyProviderContext;
+
+class SpyPagePropertyProvider implements PagePropertyProvider {
+
+	private ?PagePropertyProviderContext $receivedContext = null;
+
+	public function getProperties( PagePropertyProviderContext $context ): array {
+		$this->receivedContext = $context;
+		return [];
+	}
+
+	public function getReceivedContext(): PagePropertyProviderContext {
+		if ( $this->receivedContext === null ) {
+			throw new \LogicException( 'getProperties was not called' );
+		}
+
+		return $this->receivedContext;
+	}
+
+}


### PR DESCRIPTION
> Result of back and forth with @JeroenDeDauw on the design direction.
> Context: the NeoWiki codebase and the discussion on the issue.
> <sub>Written by Claude Code, `Fable 5`</sub>

Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/979

`PagePropertiesBuilder` already loaded the revision's main slot content and parsed it to extract categories, but threw everything else away. Providers wanting to derive Page Properties from the content had to re-fetch and re-parse it themselves - and since the context carries no revision ID, they could only look up the latest revision of the page, which is redundant work and subtly racy.

The context now additionally exposes:

* `content` - the serialized main slot content, e.g. the wikitext
* `contentModel` - e.g. "wikitext"
* `parserProperties` - the MediaWiki page properties recorded while parsing the content (e.g. "defaultsort", or values set by parser hooks via `ParserOutput::setPageProperty`)

Design notes:

* The context is a Domain value object holding only scalars and arrays. Exposing `RevisionRecord`, `Content`, or `ParserOutput` directly would put MediaWiki core classes into the Domain layer and make provider tests heavyweight. The relevant data is flattened instead, following the approach already used for `categories`.
* `parserProperties` covers the template-expansion-safe path: extensions whose parser hooks already record values during the parse can read them back in their provider instead of re-analyzing raw markup. The parse NeoWiki already performs for categories is reused, so no additional parse happens.
* When the content is unavailable (e.g. suppressed), `content` and `contentModel` are empty strings and `parserProperties` is empty, matching the existing behavior of `categories`.
* `contentModel` became load-bearing while this PR was open: since https://github.com/ProfessionalWiki/NeoWiki/pull/1226 every page is projected, so main slots that are not wikitext (JSON, Lua, CSS, …) now reach providers too, and the raw `content` string is only interpretable together with its model.

Note: content-derived properties refresh only when a new revision is stored, so values coming from transcluded templates can go stale - the same existing limitation as categories.
