### PR TITLE
Add "All schemas" link to the NeoWiki sidebar section on Schema pages

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -470,7 +470,6 @@
 				"neowiki-layout-display-schema",
 				"neowiki-layout-display-view-type",
 				"neowiki-layout-display-rules-caption",
-				"neowiki-layout-sidebar-all-layouts",
 				"neowiki-layout-display-rule-property",
 				"neowiki-layout-display-rule-attributes",
 				"neowiki-layout-display-no-rules",

--- a/i18n/_Aliases.php
+++ b/i18n/_Aliases.php
@@ -5,4 +5,5 @@ $specialPageAliases = [];
 $specialPageAliases['en'] = [
 	'NeoJson' => [ 'NeoJson' ],
 	'Schemas' => [ 'Schemas' ],
+	'Layouts' => [ 'Layouts' ],
 ];

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -168,6 +168,7 @@
 	"neowiki-schemas-column-description": "Description",
 	"neowiki-schemas-column-properties": "Properties",
 	"neowiki-schemas-empty": "No schemas have been created yet.",
+	"neowiki-schema-sidebar-all-schemas": "All schemas",
 
 	"neowiki-schema-delete": "Delete schema",
 	"neowiki-schema-delete-confirm-title": "Delete schema?",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -74,6 +74,7 @@
 	"neowiki-schemas-column-description": "Column header for schema description in the schemas list table on [[Special:Schemas]].",
 	"neowiki-schemas-column-properties": "Column header for the number of property definitions in the schemas list table on [[Special:Schemas]].",
 	"neowiki-schemas-empty": "Message shown when no schemas exist yet on [[Special:Schemas]].",
+	"neowiki-schema-sidebar-all-schemas": "Label for the link in the NeoWiki section of the sidebar on Schema pages that navigates to [[Special:Schemas]].",
 
 	"neowiki-schema-delete": "Aria label for the delete button on a Schema row in the schemas list.",
 	"neowiki-schema-delete-confirm-title": "Title of the confirmation dialog shown when deleting a schema.",
@@ -109,7 +110,7 @@
 	"neowiki-layout-display-rule-type": "Column header for the property type in the display rules table.",
 	"neowiki-layout-display-rule-attributes": "Column header for display attributes in the display rules table.",
 	"neowiki-layout-display-no-rules": "Message shown when a layout has no display rules, meaning all schema properties are shown in their default order.",
-	"neowiki-layout-sidebar-all-layouts": "Label for the link in the Tools sidebar on Layout pages that navigates to [[Special:Layouts]].",
+	"neowiki-layout-sidebar-all-layouts": "Label for the link in the NeoWiki section of the sidebar on Layout pages that navigates to [[Special:Layouts]].",
 
 	"neowiki-editing-layout": "Title of the dialog for editing a layout. $1 is the layout name.",
 	"neowiki-save-layout": "Label for the save button in the layout editor dialog.",

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -223,22 +223,10 @@ class NeoWikiHooks {
 			return;
 		}
 
-		if ( $title->getNamespace() === NeoWikiExtension::NS_LAYOUT ) {
-			$sidebar['TOOLBOX'] ??= [];
-			array_unshift(
-				$sidebar['TOOLBOX'],
-				[
-					'text' => wfMessage( 'neowiki-layout-sidebar-all-layouts' )->text(),
-					'href' => SpecialPage::getTitleFor( 'Layouts' )->getLocalURL(),
-					'id' => 't-neowiki-layouts',
-				]
-			);
-		}
-
 		$extension = NeoWikiExtension::getInstance();
 		$authorizer = $extension->newSubjectAuthorizer( $skin->getAuthority() );
 
-		$pageToolsItems = ( new PageToolsBuilder() )->build(
+		$neoWikiTools = ( new PageToolsBuilder() )->build(
 			title: $title,
 			isContentNamespace: MediaWikiServices::getInstance()
 				->getNamespaceInfo()
@@ -252,11 +240,45 @@ class NeoWikiHooks {
 				->getActionName( $skin->getContext() )
 		);
 
-		if ( $pageToolsItems !== [] ) {
+		if ( $title->getNamespace() === NeoWikiExtension::NS_SCHEMA ) {
+			$neoWikiTools[] = self::allPagesLink(
+				$skin,
+				specialPage: 'Schemas',
+				message: 'neowiki-schema-sidebar-all-schemas',
+				linkId: 't-neowiki-schemas'
+			);
+		}
+
+		if ( $title->getNamespace() === NeoWikiExtension::NS_LAYOUT ) {
+			$neoWikiTools[] = self::allPagesLink(
+				$skin,
+				specialPage: 'Layouts',
+				message: 'neowiki-layout-sidebar-all-layouts',
+				linkId: 't-neowiki-layouts'
+			);
+		}
+
+		if ( $neoWikiTools !== [] ) {
 			// The section array key is used by MediaWiki as the message key for
 			// the section heading, so it must match an existing message name.
-			$sidebar['neowiki-page-tools-label'] = $pageToolsItems;
+			$sidebar['neowiki-page-tools-label'] = $neoWikiTools;
 		}
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	private static function allPagesLink(
+		Skin $skin,
+		string $specialPage,
+		string $message,
+		string $linkId
+	): array {
+		return [
+			'text' => $skin->msg( $message )->text(),
+			'href' => SpecialPage::getTitleFor( $specialPage )->getLocalURL(),
+			'id' => $linkId,
+		];
 	}
 
 	public static function onSkinTemplateNavigationUniversal( SkinTemplate $sktemplate, array &$links ): void {

--- a/tests/phpunit/EntryPoints/NeoWikiSidebarLinkTest.php
+++ b/tests/phpunit/EntryPoints/NeoWikiSidebarLinkTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints;
+
+use MediaWiki\Context\RequestContext;
+use MediaWiki\Title\Title;
+use ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiHooks;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiHooks::onSidebarBeforeOutput
+ * @group Database
+ */
+class NeoWikiSidebarLinkTest extends NeoWikiIntegrationTestCase {
+
+	private const NEOWIKI_SECTION = 'neowiki-page-tools-label';
+
+	public function testAllSchemasLinkIsPlacedInTheNeoWikiSection(): void {
+		$this->assertAllPagesLinkInNeoWikiSection(
+			namespace: NeoWikiExtension::NS_SCHEMA,
+			linkId: 't-neowiki-schemas',
+			text: 'All schemas',
+			hrefContains: 'Schemas',
+			hrefExcludes: 'Layouts'
+		);
+	}
+
+	public function testAllLayoutsLinkIsPlacedInTheNeoWikiSection(): void {
+		$this->assertAllPagesLinkInNeoWikiSection(
+			namespace: NeoWikiExtension::NS_LAYOUT,
+			linkId: 't-neowiki-layouts',
+			text: 'All layouts',
+			hrefContains: 'Layouts',
+			hrefExcludes: 'Schemas'
+		);
+	}
+
+	public function testAddsNoAllPagesLinkOutsideSchemaAndLayoutNamespaces(): void {
+		$sidebar = $this->buildSidebar( Title::makeTitle( NS_MAIN, 'Ordinary Page' ) );
+
+		$this->assertNull( $this->findLinkById( $sidebar[self::NEOWIKI_SECTION] ?? [], 't-neowiki-schemas' ) );
+		$this->assertNull( $this->findLinkById( $sidebar[self::NEOWIKI_SECTION] ?? [], 't-neowiki-layouts' ) );
+	}
+
+	private function assertAllPagesLinkInNeoWikiSection(
+		int $namespace,
+		string $linkId,
+		string $text,
+		string $hrefContains,
+		string $hrefExcludes
+	): void {
+		$sidebar = $this->buildSidebar( Title::makeTitle( $namespace, 'Example' ) );
+
+		$link = $this->findLinkById( $sidebar[self::NEOWIKI_SECTION] ?? [], $linkId );
+
+		$this->assertNotNull( $link, "Expected the $linkId link in the NeoWiki sidebar section." );
+		$this->assertSame( $text, $link['text'] );
+		$this->assertStringContainsString( $hrefContains, $link['href'] );
+		$this->assertStringNotContainsString( $hrefExcludes, $link['href'] );
+
+		$this->assertNull(
+			$this->findLinkById( $sidebar['TOOLBOX'] ?? [], $linkId ),
+			"The $linkId link must not be in the generic Tools section."
+		);
+	}
+
+	private function buildSidebar( Title $title ): array {
+		$context = new RequestContext();
+		$context->setTitle( $title );
+
+		$sidebar = [];
+		NeoWikiHooks::onSidebarBeforeOutput( $context->getSkin(), $sidebar );
+
+		return $sidebar;
+	}
+
+	private function findLinkById( array $links, string $id ): ?array {
+		foreach ( $links as $link ) {
+			if ( ( $link['id'] ?? null ) === $id ) {
+				return $link;
+			}
+		}
+
+		return null;
+	}
+
+}


### PR DESCRIPTION
> Implemented at @alistair3149's direction (issue #696), including feedback to place the link in NeoWiki's own
> sidebar section rather than the generic Tools section.
> Context: the NeoWiki codebase and PR #692 ("All layouts" sidebar link) as the reference implementation.
> <sub>Written by Claude Code, `Opus 4.8 (1M context)`</sub>

Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/696

Add an "All schemas" link to the **NeoWiki** sidebar section (alongside the subject tools) on Schema namespace pages,
linking to Special:Schemas.

For consistency, the "All layouts" link from #692 moves out of the generic Tools section into the same NeoWiki
section. While relocating it, this also fixes two pre-existing loose ends on the Layouts special page: its missing
special-page alias (which logged a "no alias" warning on every render) and a stray, unused ResourceLoader message
registration.

## Manual Browser Check

1. Open any Schema-namespace page (e.g. `Schema:Person`; it does not need to exist).
2. In the left sidebar, find the **NeoWiki** section and confirm an **All schemas** link appears that navigates to
   `Special:Schemas`.
3. Open a Layout-namespace page (e.g. `Layout:Anything`) and confirm the **All layouts** link now appears in that same
   **NeoWiki** section (it previously sat in the generic Tools section) and points to `Special:Layouts`.
4. Open a normal content page and confirm neither link appears (the NeoWiki section still shows the usual subject tools).
