### PR TITLE
Enforce per-page edit permission on Subject write endpoints

### DIFF
--- a/src/Application/Actions/CreateSubject/CreateSubjectAction.php
+++ b/src/Application/Actions/CreateSubject/CreateSubjectAction.php
@@ -39,14 +39,19 @@ readonly class CreateSubjectAction {
 			throw new InvalidArgumentException( 'SubjectLabel cannot be empty' );
 		}
 
-		if ( ( $request->isMainSubject && !$this->subjectAuthorizer->canCreateMainSubject(
-				) ) || !$this->subjectAuthorizer->canCreateChildSubject() ) {
+		$pageId = new PageId( $request->pageId );
+
+		$authorized = $request->isMainSubject
+			? $this->subjectAuthorizer->canCreateMainSubject( $pageId )
+			: $this->subjectAuthorizer->canCreateChildSubject( $pageId );
+
+		if ( !$authorized ) {
 			throw new RuntimeException( 'You do not have the necessary permissions to create this subject' );
 		}
 
 		$subject = $this->buildSubject( $request );
 
-		$pageSubjects = $this->subjectRepository->getSubjectsByPageId( new PageId( $request->pageId ) );
+		$pageSubjects = $this->subjectRepository->getSubjectsByPageId( $pageId );
 
 		try {
 			if ( $request->isMainSubject ) {
@@ -66,7 +71,7 @@ readonly class CreateSubjectAction {
 			return;
 		}
 
-		$this->subjectRepository->savePageSubjects( $pageSubjects, new PageId( $request->pageId ), $request->comment );
+		$this->subjectRepository->savePageSubjects( $pageSubjects, $pageId, $request->comment );
 		$this->presenter->presentCreated( $subject->id->text, $violations );
 	}
 

--- a/src/Application/Actions/DeleteSubject/DeleteSubjectAction.php
+++ b/src/Application/Actions/DeleteSubject/DeleteSubjectAction.php
@@ -4,21 +4,29 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Application\Actions\DeleteSubject;
 
+use ProfessionalWiki\NeoWiki\Application\PageIdentifiersLookup;
+use ProfessionalWiki\NeoWiki\Application\SubjectAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\SubjectRepository;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
-use ProfessionalWiki\NeoWiki\Application\SubjectAuthorizer;
+use RuntimeException;
 
 readonly class DeleteSubjectAction {
 
 	public function __construct(
 		private SubjectRepository $subjectRepository,
-		private SubjectAuthorizer $subjectAuthorizer
+		private SubjectAuthorizer $subjectAuthorizer,
+		private PageIdentifiersLookup $pageIdentifiersLookup
 	) {
 	}
 
 	public function deleteSubject( SubjectId $subjectId, ?string $comment ): void {
-		if ( !$this->subjectAuthorizer->canDeleteSubject() ) {
-			throw new \RuntimeException( 'You do not have the necessary permissions to delete this subject' );
+		// A null pageId (unresolvable Subject) makes the authorizer fall back to the global 'edit' right.
+		// This cannot bypass page protection: the repository resolves the page via the same lookup, so an
+		// unresolvable Subject results in a no-op delete rather than a write to a protected page.
+		$pageId = $this->pageIdentifiersLookup->getPageIdOfSubject( $subjectId )?->getId();
+
+		if ( !$this->subjectAuthorizer->canDeleteSubject( $pageId ) ) {
+			throw new RuntimeException( 'You do not have the necessary permissions to delete this subject' );
 		}
 
 		$this->subjectRepository->deleteSubject( $subjectId, $comment );

--- a/src/Application/Actions/ReplaceSubject/ReplaceSubjectAction.php
+++ b/src/Application/Actions/ReplaceSubject/ReplaceSubjectAction.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Application\Actions\ReplaceSubject;
 
 use InvalidArgumentException;
+use ProfessionalWiki\NeoWiki\Application\PageIdentifiersLookup;
 use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
 use ProfessionalWiki\NeoWiki\Application\SelectStatementResolver;
 use ProfessionalWiki\NeoWiki\Application\StatementListBuilder;
@@ -30,6 +31,7 @@ readonly class ReplaceSubjectAction {
 		private ProposedSubjectValidator $proposedSubjectValidator,
 		private ReplaceSubjectPresenter $presenter,
 		private bool $validationEnforced,
+		private PageIdentifiersLookup $pageIdentifiersLookup,
 	) {
 	}
 
@@ -41,7 +43,12 @@ readonly class ReplaceSubjectAction {
 			throw new InvalidArgumentException( 'SubjectLabel cannot be empty' );
 		}
 
-		if ( !$this->subjectAuthorizer->canEditSubject() ) {
+		// A null pageId (unresolvable Subject) makes the authorizer fall back to the global 'edit' right.
+		// This cannot bypass page protection: an unresolvable Subject has no content to replace, so the
+		// update below is a no-op rather than a write to a protected page.
+		$pageId = $this->pageIdentifiersLookup->getPageIdOfSubject( $subjectId )?->getId();
+
+		if ( !$this->subjectAuthorizer->canEditSubject( $pageId ) ) {
 			throw new SubjectEditNotAuthorizedException();
 		}
 

--- a/src/Application/Actions/SetMainSubject/SetMainSubjectAction.php
+++ b/src/Application/Actions/SetMainSubject/SetMainSubjectAction.php
@@ -21,11 +21,12 @@ readonly class SetMainSubjectAction {
 	}
 
 	public function setMainSubject( SetMainSubjectRequest $request ): void {
-		if ( !$this->subjectAuthorizer->canEditSubject() ) {
+		$pageId = new PageId( $request->pageId );
+
+		if ( !$this->subjectAuthorizer->canEditSubject( $pageId ) ) {
 			throw new \RuntimeException( 'You do not have the necessary permissions to change the main subject' );
 		}
 
-		$pageId = new PageId( $request->pageId );
 		$pageSubjects = $this->subjectRepository->getSubjectsByPageId( $pageId );
 		$previousMain = $pageSubjects->getMainSubject();
 

--- a/src/Application/Actions/SetSubjectsOrdering/SetSubjectsOrderingAction.php
+++ b/src/Application/Actions/SetSubjectsOrdering/SetSubjectsOrderingAction.php
@@ -22,11 +22,12 @@ readonly class SetSubjectsOrderingAction {
 	}
 
 	public function setOrdering( SetSubjectsOrderingRequest $request ): void {
-		if ( !$this->subjectAuthorizer->canEditSubject() ) {
+		$pageId = new PageId( $request->pageId );
+
+		if ( !$this->subjectAuthorizer->canEditSubject( $pageId ) ) {
 			throw new RuntimeException( 'You do not have the necessary permissions to change the subject ordering' );
 		}
 
-		$pageId = new PageId( $request->pageId );
 		$pageSubjects = $this->subjectRepository->getSubjectsByPageId( $pageId );
 
 		if ( $this->matchesCurrent( $pageSubjects, $request ) ) {

--- a/src/Application/SubjectAuthorizer.php
+++ b/src/Application/SubjectAuthorizer.php
@@ -4,14 +4,16 @@ declare( strict_types=1 );
 
 namespace ProfessionalWiki\NeoWiki\Application;
 
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+
 interface SubjectAuthorizer {
 
-	public function canCreateMainSubject(): bool;
+	public function canCreateMainSubject( ?PageId $pageId ): bool;
 
-	public function canCreateChildSubject(): bool;
+	public function canCreateChildSubject( ?PageId $pageId ): bool;
 
-	public function canEditSubject(): bool;
+	public function canEditSubject( ?PageId $pageId ): bool;
 
-	public function canDeleteSubject(): bool;
+	public function canDeleteSubject( ?PageId $pageId ): bool;
 
 }

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -82,7 +82,8 @@ class NeoWikiHooks {
 	}
 
 	private static function shouldShowSubjectCreator( OutputPage $out ): bool {
-		return NeoWikiExtension::getInstance()->newSubjectAuthorizer( $out->getAuthority() )->canCreateMainSubject()
+		return NeoWikiExtension::getInstance()->newSubjectAuthorizer( $out->getAuthority() )
+				->canCreateMainSubject( new PageId( $out->getTitle()->getArticleID() ) )
 			&& self::pageIsLatestRevision( $out );
 	}
 
@@ -237,14 +238,15 @@ class NeoWikiHooks {
 
 		$extension = NeoWikiExtension::getInstance();
 		$authorizer = $extension->newSubjectAuthorizer( $skin->getAuthority() );
+		$pageId = new PageId( $title->getArticleID() );
 
 		$pageToolsItems = ( new PageToolsBuilder() )->build(
 			title: $title,
 			isContentNamespace: MediaWikiServices::getInstance()
 				->getNamespaceInfo()
 				->isContent( $title->getNamespace() ),
-			canCreateMainSubject: $authorizer->canCreateMainSubject(),
-			canEditSubject: $authorizer->canEditSubject(),
+			canCreateMainSubject: $authorizer->canCreateMainSubject( $pageId ),
+			canEditSubject: $authorizer->canEditSubject( $pageId ),
 			isLatestRevision: self::pageIsLatestRevision( $skin->getOutput() ),
 			devUiEnabled: $extension->isDevelopmentUIEnabled(),
 			currentAction: MediaWikiServices::getInstance()

--- a/src/Infrastructure/AuthorityBasedSubjectAuthorizer.php
+++ b/src/Infrastructure/AuthorityBasedSubjectAuthorizer.php
@@ -5,29 +5,45 @@ declare( strict_types=1 );
 namespace ProfessionalWiki\NeoWiki\Infrastructure;
 
 use MediaWiki\Permissions\Authority;
+use MediaWiki\Title\TitleFactory;
 use ProfessionalWiki\NeoWiki\Application\SubjectAuthorizer;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 
 class AuthorityBasedSubjectAuthorizer implements SubjectAuthorizer {
 
 	public function __construct(
-		private Authority $authority
+		private Authority $authority,
+		private TitleFactory $titleFactory
 	) {
 	}
 
-	public function canCreateMainSubject(): bool {
-		return $this->authority->isAllowed( 'edit' );
+	public function canCreateMainSubject( ?PageId $pageId ): bool {
+		return $this->canEditPage( $pageId );
 	}
 
-	public function canCreateChildSubject(): bool {
-		return $this->authority->isAllowed( 'edit' );
+	public function canCreateChildSubject( ?PageId $pageId ): bool {
+		return $this->canEditPage( $pageId );
 	}
 
-	public function canEditSubject(): bool {
-		return $this->authority->isAllowed( 'edit' );
+	public function canEditSubject( ?PageId $pageId ): bool {
+		return $this->canEditPage( $pageId );
 	}
 
-	public function canDeleteSubject(): bool {
-		return $this->authority->isAllowed( 'edit' );
+	public function canDeleteSubject( ?PageId $pageId ): bool {
+		return $this->canEditPage( $pageId );
+	}
+
+	private function canEditPage( ?PageId $pageId ): bool {
+		$title = $pageId === null ? null : $this->titleFactory->newFromID( $pageId->id );
+
+		if ( $title === null ) {
+			// The page could not be resolved (e.g. the Subject is not indexed). Fall back to the
+			// wiki-global edit right so authorization never fails open, while page-level protection
+			// is still enforced for every Subject whose page can be resolved.
+			return $this->authority->isAllowed( 'edit' );
+		}
+
+		return $this->authority->definitelyCan( 'edit', $title );
 	}
 
 }

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -399,7 +399,8 @@ class NeoWikiExtension {
 	public function newDeleteSubjectAction( Authority $authority ): DeleteSubjectAction {
 		return new DeleteSubjectAction(
 			subjectRepository: $this->getSubjectRepository(),
-			subjectAuthorizer: $this->newSubjectAuthorizer( $authority )
+			subjectAuthorizer: $this->newSubjectAuthorizer( $authority ),
+			pageIdentifiersLookup: $this->getPageIdentifiersLookup()
 		);
 	}
 
@@ -421,7 +422,8 @@ class NeoWikiExtension {
 
 	public function newSubjectAuthorizer( Authority $authority ): SubjectAuthorizer {
 		return new AuthorityBasedSubjectAuthorizer(
-			authority: $authority
+			authority: $authority,
+			titleFactory: MediaWikiServices::getInstance()->getTitleFactory()
 		);
 	}
 
@@ -545,6 +547,7 @@ class NeoWikiExtension {
 			proposedSubjectValidator: $this->getProposedSubjectValidator(),
 			presenter: $presenter,
 			validationEnforced: $this->isValidationEnforced(),
+			pageIdentifiersLookup: $this->getPageIdentifiersLookup(),
 		);
 	}
 

--- a/tests/RedHerb/src/RedHerbSidebarHook.php
+++ b/tests/RedHerb/src/RedHerbSidebarHook.php
@@ -25,8 +25,9 @@ class RedHerbSidebarHook implements SidebarBeforeOutputHook {
 		if ( $title !== null && $title->exists() ) {
 			$extension = NeoWikiExtension::getInstance();
 			$authorizer = $extension->newSubjectAuthorizer( $skin->getAuthority() );
+			$pageId = new PageId( $title->getArticleID() );
 
-			if ( $authorizer->canCreateChildSubject() ) {
+			if ( $authorizer->canCreateChildSubject( $pageId ) ) {
 				$links[] = [
 					'id' => 'redherb-sidebar-create-child-company',
 					'text' => $skin->msg( 'redherb-sidebar-create-child-company' )->text(),
@@ -36,9 +37,9 @@ class RedHerbSidebarHook implements SidebarBeforeOutputHook {
 			}
 
 			if (
-				$authorizer->canEditSubject()
+				$authorizer->canEditSubject( $pageId )
 				&& $extension->newPageSubjectsLookup()
-					->pageHasMainSubject( new PageId( $title->getArticleID() ) )
+					->pageHasMainSubject( $pageId )
 			) {
 				$links[] = [
 					'id' => 'redherb-sidebar-edit-main-subject',

--- a/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
@@ -32,6 +32,7 @@ use ProfessionalWiki\NeoWiki\Application\SubjectAuthorizer;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestRelation;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestStatement;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\FailingSubjectAuthorizer;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpySubjectAuthorizer;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySchemaLookup;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectRepository;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SucceedingSubjectAuthorizer;
@@ -168,6 +169,23 @@ class CreateSubjectActionTest extends TestCase {
 				statements: []
 			)
 		);
+	}
+
+	public function testMainSubjectCreationDoesNotRequireChildPermission(): void {
+		$this->authorizer = new SpySubjectAuthorizer( mainAllowed: true, childAllowed: false );
+		$this->subjectRepository->savePageSubjects( PageSubjects::newEmpty(), new PageId( 1 ) );
+
+		$this->newCreateSubjectAction()->createSubject(
+			new CreateSubjectRequest(
+				pageId: 1,
+				isMainSubject: true,
+				label: 'Some Label',
+				schemaName: 'some-schema-id',
+				statements: []
+			)
+		);
+
+		$this->assertSame( 's' . self::STUB_ID, $this->presenterSpy->result );
 	}
 
 	public function testCommentIsPassedToRepository(): void {

--- a/tests/phpunit/Application/Actions/DeleteSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/DeleteSubjectActionTest.php
@@ -7,10 +7,14 @@ namespace ProfessionalWiki\NeoWiki\Tests\Application\Actions;
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Application\Actions\DeleteSubject\DeleteSubjectAction;
 use ProfessionalWiki\NeoWiki\Application\SubjectRepository;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageIdentifiers;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\FailingSubjectAuthorizer;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemoryPageIdentifiersLookup;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectRepository;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpySubjectAuthorizer;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SucceedingSubjectAuthorizer;
 
 /**
@@ -36,10 +40,26 @@ class DeleteSubjectActionTest extends TestCase {
 		$this->assertSame( 'Removed by curator', $repository->comments[self::SUBJECT_ID] );
 	}
 
+	public function testAuthorizesAgainstTheSubjectsResolvedPage(): void {
+		$authorizer = new SpySubjectAuthorizer();
+		$action = new DeleteSubjectAction(
+			$this->newRepositoryWithSubject(),
+			$authorizer,
+			new InMemoryPageIdentifiersLookup( [
+				[ new SubjectId( self::SUBJECT_ID ), new PageIdentifiers( new PageId( 7 ), 'Owning page', 0 ) ]
+			] )
+		);
+
+		$action->deleteSubject( new SubjectId( self::SUBJECT_ID ), null );
+
+		$this->assertEquals( new PageId( 7 ), $authorizer->authorizedPageId );
+	}
+
 	public function testThrowsWhenUserMayNotDeleteSubject(): void {
 		$action = new DeleteSubjectAction(
 			new InMemorySubjectRepository(),
-			new FailingSubjectAuthorizer()
+			new FailingSubjectAuthorizer(),
+			$this->pageIdentifiersLookupWithSubject()
 		);
 
 		$this->expectException( \RuntimeException::class );
@@ -55,7 +75,17 @@ class DeleteSubjectActionTest extends TestCase {
 	}
 
 	private function newAction( SubjectRepository $repository ): DeleteSubjectAction {
-		return new DeleteSubjectAction( $repository, new SucceedingSubjectAuthorizer() );
+		return new DeleteSubjectAction(
+			$repository,
+			new SucceedingSubjectAuthorizer(),
+			$this->pageIdentifiersLookupWithSubject()
+		);
+	}
+
+	private function pageIdentifiersLookupWithSubject(): InMemoryPageIdentifiersLookup {
+		return new InMemoryPageIdentifiersLookup( [
+			[ new SubjectId( self::SUBJECT_ID ), new PageIdentifiers( new PageId( 1 ), 'Test page', 0 ) ]
+		] );
 	}
 
 }

--- a/tests/phpunit/Application/Actions/ReplaceSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/ReplaceSubjectActionTest.php
@@ -13,6 +13,8 @@ use ProfessionalWiki\NeoWiki\Application\Subject\Exception\SubjectEditNotAuthori
 use ProfessionalWiki\NeoWiki\Application\Subject\Exception\SubjectNotFoundException;
 use ProfessionalWiki\NeoWiki\Application\Validation\ProposedSubjectValidator;
 use ProfessionalWiki\NeoWiki\Application\Validation\SubjectValidator;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageIdentifiers;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeRegistry;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeToValueType;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\SelectOption;
@@ -31,8 +33,10 @@ use ProfessionalWiki\NeoWiki\Application\SubjectAuthorizer;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestStatement;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\FailingSubjectAuthorizer;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemoryPageIdentifiersLookup;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySchemaLookup;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectRepository;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpySubjectAuthorizer;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubIdGenerator;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SucceedingSubjectAuthorizer;
 
@@ -75,6 +79,9 @@ class ReplaceSubjectActionTest extends TestCase {
 			),
 			presenter: $this->presenterSpy,
 			validationEnforced: $validationEnforced,
+			pageIdentifiersLookup: new InMemoryPageIdentifiersLookup( [
+				[ new SubjectId( self::SUBJECT_ID ), new PageIdentifiers( new PageId( 1 ), 'Test page', 0 ) ]
+			] ),
 		);
 	}
 
@@ -165,6 +172,15 @@ class ReplaceSubjectActionTest extends TestCase {
 		$this->newAction()->replace( new SubjectId( self::SUBJECT_ID ), 'Label', [], 'Edit summary' );
 
 		$this->assertSame( 'Edit summary', $this->subjectRepository->comments[self::SUBJECT_ID] );
+	}
+
+	public function testAuthorizesAgainstTheSubjectsResolvedPage(): void {
+		$spy = new SpySubjectAuthorizer();
+		$this->subjectRepository->updateSubject( TestSubject::build( id: new SubjectId( self::SUBJECT_ID ) ) );
+
+		$this->newAction( $spy )->replace( new SubjectId( self::SUBJECT_ID ), 'Label', [], null );
+
+		$this->assertEquals( new PageId( 1 ), $spy->authorizedPageId );
 	}
 
 	public function testUnauthorizedThrows(): void {

--- a/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\REST;
 
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Page\PageIdentity;
 use MediaWiki\Rest\HttpException;
 use MediaWiki\Rest\RequestData;
 use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
@@ -124,6 +125,25 @@ class CreateSubjectApiTest extends NeoWikiIntegrationTestCase {
 		$this->assertSame( 'error', $responseData['status'] );
 		$this->assertSame( 'You do not have the necessary permissions to create this subject', $responseData['message'] );
 		$this->assertArrayNotHasKey( 'violations', $responseData );
+	}
+
+	public function testDeniedOnProtectedPageDespiteGlobalEditRight(): void {
+		$this->createSchema( 'Employee' );
+
+		$response = $this->executeHandler(
+			$this->newCreateSubjectApi(),
+			$this->createValidRequestData(),
+			authority: $this->mockRegisteredAuthority(
+				// Holds the wiki-global 'edit' right, but cannot edit this specific (e.g. protected) page.
+				static fn ( string $permission, ?PageIdentity $page = null ): bool =>
+					$permission === 'edit' && $page === null
+			)
+		);
+
+		$responseData = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertSame( 403, $response->getStatusCode() );
+		$this->assertSame( 'You do not have the necessary permissions to create this subject', $responseData['message'] );
 	}
 
 	public function testResponseIncludesViolationsWhenRequiredPropertyMissing(): void {

--- a/tests/phpunit/Infrastructure/AuthorityBasedSubjectAuthorizerTest.php
+++ b/tests/phpunit/Infrastructure/AuthorityBasedSubjectAuthorizerTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Infrastructure;
+
+use MediaWiki\Page\PageIdentity;
+use MediaWiki\Permissions\Authority;
+use MediaWiki\Tests\Unit\Permissions\MockAuthorityTrait;
+use MediaWiki\Title\Title;
+use MediaWiki\Title\TitleFactory;
+use MediaWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+use ProfessionalWiki\NeoWiki\Infrastructure\AuthorityBasedSubjectAuthorizer;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Infrastructure\AuthorityBasedSubjectAuthorizer
+ */
+class AuthorityBasedSubjectAuthorizerTest extends MediaWikiIntegrationTestCase {
+
+	use MockAuthorityTrait;
+
+	private const int PAGE_ID = 42;
+
+	public function testCanCreateMainSubjectIsDeniedWhenThePageCannotBeEdited(): void {
+		$authorizer = $this->newAuthorizer( $this->authorityWithGlobalEditButNoPageEdit() );
+
+		$this->assertFalse( $authorizer->canCreateMainSubject( new PageId( self::PAGE_ID ) ) );
+	}
+
+	public function testCanCreateChildSubjectIsDeniedWhenThePageCannotBeEdited(): void {
+		$authorizer = $this->newAuthorizer( $this->authorityWithGlobalEditButNoPageEdit() );
+
+		$this->assertFalse( $authorizer->canCreateChildSubject( new PageId( self::PAGE_ID ) ) );
+	}
+
+	public function testCanEditSubjectIsDeniedWhenThePageCannotBeEdited(): void {
+		$authorizer = $this->newAuthorizer( $this->authorityWithGlobalEditButNoPageEdit() );
+
+		$this->assertFalse( $authorizer->canEditSubject( new PageId( self::PAGE_ID ) ) );
+	}
+
+	public function testCanDeleteSubjectIsDeniedWhenThePageCannotBeEdited(): void {
+		$authorizer = $this->newAuthorizer( $this->authorityWithGlobalEditButNoPageEdit() );
+
+		$this->assertFalse( $authorizer->canDeleteSubject( new PageId( self::PAGE_ID ) ) );
+	}
+
+	public function testEditIsAllowedWhenThePageCanBeEdited(): void {
+		$authorizer = $this->newAuthorizer( $this->authorityThatCanEditEveryPage() );
+
+		$this->assertTrue( $authorizer->canEditSubject( new PageId( self::PAGE_ID ) ) );
+	}
+
+	public function testFallsBackToGlobalEditRightWhenThePageCannotBeResolved(): void {
+		$authorizer = new AuthorityBasedSubjectAuthorizer(
+			$this->authorityThatCanEditEveryPage(),
+			$this->titleFactoryReturningNull()
+		);
+
+		$this->assertTrue( $authorizer->canEditSubject( new PageId( self::PAGE_ID ) ) );
+	}
+
+	public function testDeniesUnresolvablePageWhenUserLacksGlobalEditRight(): void {
+		$authorizer = new AuthorityBasedSubjectAuthorizer(
+			$this->authorityWithoutAnyPermissions(),
+			$this->titleFactoryReturningNull()
+		);
+
+		$this->assertFalse( $authorizer->canEditSubject( new PageId( self::PAGE_ID ) ) );
+	}
+
+	public function testFallsBackToGlobalEditRightWhenNoPageIsGiven(): void {
+		$authorizer = $this->newAuthorizer( $this->authorityThatCanEditEveryPage() );
+
+		$this->assertTrue( $authorizer->canDeleteSubject( null ) );
+	}
+
+	public function testDeniesWhenNoPageIsGivenAndUserLacksGlobalEditRight(): void {
+		$authorizer = $this->newAuthorizer( $this->authorityWithoutAnyPermissions() );
+
+		$this->assertFalse( $authorizer->canDeleteSubject( null ) );
+	}
+
+	private function newAuthorizer( Authority $authority ): AuthorityBasedSubjectAuthorizer {
+		return new AuthorityBasedSubjectAuthorizer( $authority, $this->titleFactoryReturningPage() );
+	}
+
+	/**
+	 * Holds the wiki-global 'edit' right, but cannot edit any specific page
+	 * (as when the page is protected or in a restricted namespace).
+	 */
+	private function authorityWithGlobalEditButNoPageEdit(): Authority {
+		$canEditGloballyButNotPerPage = static fn ( string $permission, ?PageIdentity $page = null ): bool =>
+			$permission === 'edit' && $page === null;
+
+		return $this->mockRegisteredAuthority( $canEditGloballyButNotPerPage );
+	}
+
+	private function authorityThatCanEditEveryPage(): Authority {
+		$allowEverything = static fn ( string $permission, ?PageIdentity $page = null ): bool => true;
+
+		return $this->mockRegisteredAuthority( $allowEverything );
+	}
+
+	private function authorityWithoutAnyPermissions(): Authority {
+		$denyEverything = static fn ( string $permission, ?PageIdentity $page = null ): bool => false;
+
+		return $this->mockRegisteredAuthority( $denyEverything );
+	}
+
+	private function titleFactoryReturningPage(): TitleFactory {
+		$factory = $this->createStub( TitleFactory::class );
+		$factory->method( 'newFromID' )->willReturn( Title::makeTitle( NS_MAIN, 'Protected page' ) );
+		return $factory;
+	}
+
+	private function titleFactoryReturningNull(): TitleFactory {
+		$factory = $this->createStub( TitleFactory::class );
+		$factory->method( 'newFromID' )->willReturn( null );
+		return $factory;
+	}
+
+}

--- a/tests/phpunit/TestDoubles/FailingSubjectActionAuthorizer.php
+++ b/tests/phpunit/TestDoubles/FailingSubjectActionAuthorizer.php
@@ -5,22 +5,23 @@ declare( strict_types=1 );
 namespace ProfessionalWiki\NeoWiki\Tests\TestDoubles;
 
 use ProfessionalWiki\NeoWiki\Application\SubjectAuthorizer;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 
 class FailingSubjectActionAuthorizer implements SubjectAuthorizer {
 
-	public function canCreateMainSubject(): bool {
+	public function canCreateMainSubject( ?PageId $pageId ): bool {
 		return false;
 	}
 
-	public function canCreateChildSubject(): bool {
+	public function canCreateChildSubject( ?PageId $pageId ): bool {
 		return false;
 	}
 
-	public function canEditSubject(): bool {
+	public function canEditSubject( ?PageId $pageId ): bool {
 		return false;
 	}
 
-	public function canDeleteSubject(): bool {
+	public function canDeleteSubject( ?PageId $pageId ): bool {
 		return false;
 	}
 

--- a/tests/phpunit/TestDoubles/FailingSubjectAuthorizer.php
+++ b/tests/phpunit/TestDoubles/FailingSubjectAuthorizer.php
@@ -5,21 +5,22 @@ declare( strict_types=1 );
 namespace ProfessionalWiki\NeoWiki\Tests\TestDoubles;
 
 use ProfessionalWiki\NeoWiki\Application\SubjectAuthorizer;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 
 class FailingSubjectAuthorizer implements SubjectAuthorizer {
-	public function canCreateMainSubject(): bool {
+	public function canCreateMainSubject( ?PageId $pageId ): bool {
 		return false;
 	}
 
-	public function canCreateChildSubject(): bool {
+	public function canCreateChildSubject( ?PageId $pageId ): bool {
 		return false;
 	}
 
-	public function canEditSubject(): bool {
+	public function canEditSubject( ?PageId $pageId ): bool {
 		return false;
 	}
 
-	public function canDeleteSubject(): bool {
+	public function canDeleteSubject( ?PageId $pageId ): bool {
 		return false;
 	}
 }

--- a/tests/phpunit/TestDoubles/SpySubjectAuthorizer.php
+++ b/tests/phpunit/TestDoubles/SpySubjectAuthorizer.php
@@ -1,0 +1,45 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\TestDoubles;
+
+use ProfessionalWiki\NeoWiki\Application\SubjectAuthorizer;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+
+/**
+ * Configurable per-method authorizer that records the last PageId it was asked about.
+ */
+class SpySubjectAuthorizer implements SubjectAuthorizer {
+
+	public ?PageId $authorizedPageId = null;
+
+	public function __construct(
+		private bool $mainAllowed = true,
+		private bool $childAllowed = true,
+		private bool $editAllowed = true,
+		private bool $deleteAllowed = true,
+	) {
+	}
+
+	public function canCreateMainSubject( ?PageId $pageId ): bool {
+		$this->authorizedPageId = $pageId;
+		return $this->mainAllowed;
+	}
+
+	public function canCreateChildSubject( ?PageId $pageId ): bool {
+		$this->authorizedPageId = $pageId;
+		return $this->childAllowed;
+	}
+
+	public function canEditSubject( ?PageId $pageId ): bool {
+		$this->authorizedPageId = $pageId;
+		return $this->editAllowed;
+	}
+
+	public function canDeleteSubject( ?PageId $pageId ): bool {
+		$this->authorizedPageId = $pageId;
+		return $this->deleteAllowed;
+	}
+
+}

--- a/tests/phpunit/TestDoubles/SucceedingSubjectAuthorizer.php
+++ b/tests/phpunit/TestDoubles/SucceedingSubjectAuthorizer.php
@@ -5,21 +5,22 @@ declare( strict_types=1 );
 namespace ProfessionalWiki\NeoWiki\Tests\TestDoubles;
 
 use ProfessionalWiki\NeoWiki\Application\SubjectAuthorizer;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 
 class SucceedingSubjectAuthorizer implements SubjectAuthorizer {
-	public function canCreateMainSubject(): bool {
+	public function canCreateMainSubject( ?PageId $pageId ): bool {
 		return true;
 	}
 
-	public function canCreateChildSubject(): bool {
+	public function canCreateChildSubject( ?PageId $pageId ): bool {
 		return true;
 	}
 
-	public function canEditSubject(): bool {
+	public function canEditSubject( ?PageId $pageId ): bool {
 		return true;
 	}
 
-	public function canDeleteSubject(): bool {
+	public function canDeleteSubject( ?PageId $pageId ): bool {
 		return true;
 	}
 }


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/NeoWiki/issues/101

The six Subject write REST endpoints (create main/child Subject, replace Subject, delete Subject, set main Subject, set Subject ordering) authorized writes with the wiki-global `edit` right (`Authority::isAllowed('edit')`) only. Subjects live in a page's revision slot, so any user holding the global edit right could create, replace, delete, or reorder Subjects on an edit-protected page or in a restricted namespace via the REST API, bypassing page protection. Blocked users were unaffected by the check too, since neither the REST framework's write gate nor `isAllowed('edit')` consults blocks.

`SubjectAuthorizer` now takes the target page and `AuthorityBasedSubjectAuthorizer` checks `Authority::definitelyCan('edit', $title)`, which enforces page protection, restricted namespaces, and user blocks. Create / set-main / set-ordering pass the request's page id; delete / replace resolve the Subject's owning page via the existing `PageIdentifiersLookup`. When the page cannot be resolved, authorization falls back to the global `edit` right instead of skipping the check, a fail-closed floor that cannot bypass protection because an unresolvable Subject is a no-op write.

The page-tools and RedHerb sidebar "create/edit subject" hints now reflect per-page edit rights.

Per-title read gaps and cross-page enumeration leaks surfaced by the same audit are out of scope for this change.

## Manual Browser Check

1. Create a page and protect it for editing (edit = sysop).
2. Log in as a non-sysop user that holds the `edit` right, and open one of that wiki's pages so `mw` is loaded.
3. From the browser console, POST to `<wgScriptPath>/rest.php/neowiki/v0/page/<protectedPageId>/mainSubject` with an `X-CSRF-TOKEN` header (`await new mw.Api().getToken('csrf')`) and body `{"label":"x","schema":"Employee","statements":{}}`.
   → **403** "You do not have the necessary permissions to create this subject".
4. Repeat against an unprotected page → **201**.

> Directed by @alistair3149; the fix approach and scope were decided in review with them.
> Context: the NeoWiki codebase, MediaWiki REST/permissions internals, and an adversarial multi-agent audit of all 17 Subject/Schema/Layout/query REST endpoints.
> <sub>Written by Claude Code, `Opus 4.8 (1M context)`</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
