### PR TITLE
Compose core Neo4j outside the graph-database plugin registry

### DIFF
--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -215,7 +215,12 @@ class NeoWikiExtension {
 
 	public function getGraphDatabasePlugin(): GraphDatabasePlugin {
 		if ( !isset( $this->graphDatabasePlugin ) ) {
+			// Seed core's Neo4j plugin directly into the composite, not the registry. Registering it via
+			// the registry would make getGraphDatabasePluginRegistry() build the Neo4j plugin, whose
+			// construction transitively fires the NeoWikiRegistration hook and re-enters that accessor.
+			// Composing core here keeps the registry extension-only and the plugin order deterministic.
 			$this->graphDatabasePlugin = new CompositeGraphDatabasePlugin(
+				$this->getNeo4jPlugin()->getGraphDatabasePlugin(),
 				...$this->getGraphDatabasePluginRegistry()->getPlugins()
 			);
 		}
@@ -226,13 +231,6 @@ class NeoWikiExtension {
 	public function getGraphDatabasePluginRegistry(): GraphDatabasePluginRegistry {
 		if ( !isset( $this->graphDatabasePluginRegistry ) ) {
 			$this->graphDatabasePluginRegistry = new GraphDatabasePluginRegistry();
-			// Registry order is not guaranteed: building the Neo4j plugin can transitively fire the
-			// NeoWikiRegistration hook (getNeo4jPlugin -> getSchemaLookup -> getPropertyTypeRegistry),
-			// so extension plugins may be registered before or after this core seed depending on which
-			// accessor runs first. The composite fan-out is order-independent; do not rely on order.
-			$this->graphDatabasePluginRegistry->addPlugin(
-				$this->getNeo4jPlugin()->getGraphDatabasePlugin()
-			);
 		}
 
 		$this->ensureExtensionsRegistered();

--- a/tests/phpunit/EntryPoints/NeoWikiRegistrationHookTest.php
+++ b/tests/phpunit/EntryPoints/NeoWikiRegistrationHookTest.php
@@ -7,6 +7,7 @@ namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints;
 use MediaWiki\Registration\ExtensionRegistry;
 use MediaWikiIntegrationTestCase;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+use ProfessionalWiki\RedHerb\RedHerbGraphDatabasePlugin;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiRegistrar
@@ -44,7 +45,9 @@ class NeoWikiRegistrationHookTest extends MediaWikiIntegrationTestCase {
 	public function testRedHerbRegistersGraphDatabasePlugin(): void {
 		$plugins = NeoWikiExtension::getInstance()->getGraphDatabasePluginRegistry()->getPlugins();
 
-		$this->assertGreaterThan( 1, count( $plugins ), 'Should have more than just the core Neo4j plugin' );
+		// The registry holds extension-contributed plugins only; core Neo4j is composed separately.
+		$this->assertCount( 1, $plugins );
+		$this->assertContainsOnlyInstancesOf( RedHerbGraphDatabasePlugin::class, $plugins );
 	}
 
 }


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/978
For https://github.com/ProfessionalWiki/NeoWiki/issues/895

#978 seeds core's Neo4j plugin into the same registry extensions write to. Since building the Neo4j plugin transitively fires the `NeoWikiRegistration` hook (`getNeo4jPlugin -> getSchemaLookup -> getPropertyTypeRegistry -> ensureExtensionsRegistered`), `getGraphDatabasePluginRegistry()` re-enters itself while seeding. That reentrancy causes:

- **Double-built Neo4j plugin:** when `getNeo4jPlugin()` is the first accessor to trigger registration (Cypher REST, `{{#cypher_raw}}`, `nw.query`, page move via `getWriteQueryEngine()`), the null-check guard is defeated, so the composite dispatches to a different `Neo4jQueryStore` instance than the query/write path. Benign today (readonly/stateless store, shared clients) but a latent trap.
- **Eager Neo4j construction on the registration path:** `ensureExtensionsRegistered()` (fired on most subject/schema renders and validations) now builds both Neo4j clients where it built none before. `withDriver()` validates the URL scheme eagerly, so a malformed neo4j URL breaks ordinary renders, not just graph ops.
- **Nondeterministic plugin order,** hence the "do not rely on order" comment.

Compose core directly into the composite instead, leaving the registry extension-only. `getGraphDatabasePluginRegistry()` no longer builds Neo4j, so it no longer re-enters itself or eagerly constructs clients; Neo4j is lazy again, composite order is deterministic (core first), and composite assignment is atomic again (a throwing seed can no longer memoize a Neo4j-less registry).

`testRedHerbRegistersGraphDatabasePlugin` now asserts the registry holds exactly the extension plugin; it fails on the pre-change wiring (registry size 2).

Not included: per-plugin error isolation in the composite fan-out (a throwing extension plugin still aborts the loop and can skip core's projection) — that's an isolate-vs-fail-fast design decision better made explicitly.

## Verification

- `make cs` green; full PHPUnit suite green (1366 tests). Reverting only the production change makes `testRedHerbRegistersGraphDatabasePlugin` fail (registry size 2), confirming it guards the invariant.
- Live smoke: `POST /neowiki/v0/query/cypher` on a seeded wiki returns the expected `count(p)` — the exact `getNeo4jPlugin()`-first path — and the projection/dispatch integration tests confirm core Neo4j and extension plugins still receive save/delete.

> Follow-up to a multi-agent review of #978 that @JeroenDeDauw directed; he asked for the follow-up PR and left the scope to me. This implements that review's top recommendation.
> Context: the NeoWiki codebase, ADR 019, issue #895, and PR #978.
> <sub>Written by Claude Code, `Opus 4.8 (1M context, max)`</sub>
