### PR TITLE
Record 2026-07-03 WP2/3/4 call input in the RDF planning docs

### DIFF
--- a/docs/planning/GlobalProperties.md
+++ b/docs/planning/GlobalProperties.md
@@ -87,3 +87,20 @@ With global properties:
 - UX suffers notably
 - The boundary between what lives on the property, the Schema, and the View needs to be resolved
 - Additional refactoring work
+
+## Addendum: use cases from the 2026-07-03 WP2/3/4 discussion
+
+Two use cases sharpen both columns above:
+
+- **For global-style use: load a standard ontology and go (takin).** Institutions that already live in a standard
+  (EDM, CIDOC-CRM, Wikidata's model) want to install NeoWiki, load that vocabulary, and produce conformant data
+  natively — the way Omeka or Arches users work — without first inventing local names. Under local properties this is
+  served by preloaded schema + ontology-mapping bundles ([OntologyMapping.md](OntologyMapping.md)): installing a
+  bundle yields working Schemas plus projections in the target vocabulary out of the box.
+- **For local properties: serving many masters (takin).** ECHOLOT targets several ontologies at once (CIDOC-CRM, EDM,
+  Wikidata's model). Committing the data model to any one of them forces awkward translations to all the others, or
+  "Frankenstein models" mixing several; neutral local Schemas mapped outward keep every target first-class.
+
+Whether local-plus-mappings delivers the load-and-go experience is to be tested empirically (proposed 2026-07-03):
+implement the shared person toy model as a native Schema, define an ontology mapping for it, and project to EDM end
+to end (see [OntologyMapping.md](OntologyMapping.md)).

--- a/docs/planning/NativeRdfProjection.md
+++ b/docs/planning/NativeRdfProjection.md
@@ -260,6 +260,11 @@ are emitted regardless, and the ontology mapping translates to standard ontology
 namespace (`$base/prop/Name`), since it is more natural for RDF and the ontology mapping handles ontology
 alignment.*
 
+*Additional input (2026-07-03): when authoring ontology mappings, same-named properties across Schemas must be
+disambiguated as (Schema, property) pairs regardless of predicate scope, and with a flat namespace any mapping rule
+that reads the native projection needs an `rdf:type` constraint to select the right Schema's property. Recorded as a
+cost of the flat resolution, not a reversal.*
+
 **Q2: Standard vocabulary in the native projection.** The strawman uses `rdf:type`, `rdfs:label`, and `dcterms:created`
 / `dcterms:modified`. Should more standard predicates be used in the native projection (e.g., `foaf:name` for labels,
 `dcterms:title` for page names)? Or should all standard vocabulary alignment happen in the ontology mapping?
@@ -328,4 +333,7 @@ added later (e.g., via `rdf:List` or index properties).*
 
 **Q10: Schema namespace page.** Should NeoWiki emit an RDFS/OWL definition for each Schema (as a class) and each
 Property Definition (as a property with domain/range)? This would make the RDF self-describing. Tentative answer:
-yes, but as a separate enhancement, not blocking the initial projection.
+yes, but as a separate enhancement, not blocking the initial projection. Partner demand recorded (takin, 2026-07-03):
+an RDFS export of local Schemas is wanted as an input for authoring ontology mappings — a wiki's Schemas are
+effectively its own ontology, and the native projection should be able to say so in RDF. See also the generated shape
+exports in [ShapeLanguages.md](ShapeLanguages.md).

--- a/docs/planning/OntologyMapping.md
+++ b/docs/planning/OntologyMapping.md
@@ -106,7 +106,10 @@ should be and where the burden sits:
 
 The fork is settled outside this document — it is a schema-model and editing-UX decision, exercised through the shared
 toy model ([Neutral Person to Many Standards](https://docs.google.com/spreadsheets/d/1j2_7j8RCUJrrMsfZaXtqHQOwp9cN9F8HIBtd3pfsToU/edit))
-that expresses one person model across several ontologies. What matters here is that the formalism needs synthesis
+that expresses one person model across several ontologies. The same toy model doubles as the first end-to-end
+exercise of this document's approach: implement its neutral person schema in NeoWiki, define a Mapping for it, and
+project to EDM first — the near-1:1 tier — proving or disproving the mechanism by doing (proposed at the 2026-07-03
+WP2/3/4 call). What matters here is that the formalism needs synthesis
 capability under **either** route: not every wiki will model maximally nested (a mapping must handle whatever the
 native model is), and sibling targets decompose differently — EDM stays flat where CIDOC-CRM wants events — so no
 single nesting depth spares all projections. Route (b) reduces how often synthesis fires; it does not remove the
@@ -279,7 +282,9 @@ with deep CIDOC-CRM / EDM / RDF experience.
      minimizing ontology knowledge in NeoWiki. Depends on what the library can emit and how stable that interface is.
 
   These are not mutually exclusive: e.g. consume patterns from (3), expressed in a formalism like (2), executed via (1).
-  What combination do partners recommend?
+  What combination do partners recommend? Independent of the combination: survey existing CH mapping tooling before
+  building — mature ontology-mapping frameworks exist in this space, and reusing or aligning with one may beat
+  rebuilding (George, 2026-07-03).
 
 **Q2: Expressiveness for node synthesis.** Whatever formalism is chosen, can it express path expansion and
 intermediate-node minting (the `E12_Production` case) — not just term substitution? Are SHACL Advanced Features
@@ -298,7 +303,10 @@ reconciliation)?
 **Q5: Validation via SHACL.** [Validating projections](#validating-projections) proposes consuming shapes emitted by
 the T2.3 library to check ontology projections, with the engines in the T4.5 tooling rather than in NeoWiki. Open:
 which shapes the library actually emits and their coverage per ontology; and where findings surface for curators
-(report pages, a dashboard, an API the quality component writes back to) — in NeoWiki core or a plug-in.
+(report pages, a dashboard, an API the quality component writes back to) — in NeoWiki core or a plug-in. Candidate
+engine (suggested 2026-07-03): [rudof](https://github.com/rudof-project/rudof) — Rust, SHACL + ShEx, has an MCP
+interface, and can validate a QLever endpoint directly; endpoint-side validation still needs the traceability path
+above, since the store has no sync-back to the wiki.
 
 **Q6: One mapping per target vs combined.** A separate Mapping per (Schema, target ontology), or a single multi-target
 mapping per Schema? Per-target is more modular and independently installable; combined may reduce duplication for shared

--- a/docs/planning/ShapeLanguages.md
+++ b/docs/planning/ShapeLanguages.md
@@ -89,7 +89,10 @@ that ontology's expectations — both that the mapping produces correct structur
 mapping-authoring time) and that the data meets the target's requirements (e.g. a mandatory rights statement is
 missing). Engines run in external quality tooling (T4.5), not in the wiki's editing path; NeoWiki provides projected
 RDF, incremental re-validation via per-page named graphs, and traceability of findings back to page, Subject, and
-property. Detailed in [OntologyMapping](OntologyMapping.md) ("Validating projections").
+property. Detailed in [OntologyMapping](OntologyMapping.md) ("Validating projections"). A candidate engine
+(suggested 2026-07-03): [rudof](https://github.com/rudof-project/rudof) — Rust, SHACL + ShEx, MCP interface, can
+validate a QLever endpoint directly; endpoint-side validation still needs the traceability path here, since the
+store has no sync-back to the wiki.
 
 Workflow-wise, conformance is a publication and import concern, surfaced as reports and worklists — the pattern
 Wikidata uses for property-constraint reports — and as pre-publication gates where output must pass a target's


### PR DESCRIPTION
Folds the 2026-07-03 WP2+WP3+WP4 call input into the RDF planning docs:

- **OntologyMapping**: the shared person toy model doubles as the proposed first end-to-end exercise of the approach (native schema → Mapping → EDM projection, the near-1:1 tier — prove by doing); Q1 adds "survey existing CH mapping tooling before building"; Q5 records rudof as a candidate conformance engine.
- **NativeRdfProjection**: Q1 records the mapping-authoring disambiguation cost of the flat predicate namespace; Q10 (RDFS self-description of Schemas) now carries recorded partner demand as an input for authoring ontology mappings.
- **GlobalProperties**: dated addendum with two use cases sharpening both columns — load-a-standard-ontology-and-go (served under local properties by preloaded schema + mapping bundles) and serving-many-masters (for local) — plus the proposed empirical person→EDM test.
- **ShapeLanguages**: rudof noted as a candidate engine for projection conformance, with the no-sync-back caveat for validating a QLever endpoint directly.

> Distilled from the 2026-07-03 WP2/3/4 call (TIB, OEAW, JSI, takin, PW) with @JeroenDeDauw, who calibrated what was proposal vs decision.
> Context: the call transcript, the NeoWiki planning docs and ADRs, and the ECHOLOT project-context material.
> <sub>Written by Claude Code, `Fable 5 (max)`</sub>
