### PR TITLE
Link the feedback discussions from the planning docs

### DIFF
--- a/docs/planning/NativeRdfProjection.md
+++ b/docs/planning/NativeRdfProjection.md
@@ -4,7 +4,7 @@ Written 2026-02-23 by Jeroen De Dauw with help from Claude Opus 4.6
 
 Status: Draft, incorporating feedback from ECHOLOT partners (Bilbao meeting March 2026 and async discussion)
 
-Feedback: [discussion #999](https://github.com/ProfessionalWiki/NeoWiki/discussions/999).
+Discussion: [#999](https://github.com/ProfessionalWiki/NeoWiki/discussions/999).
 
 ## Purpose
 

--- a/docs/planning/NativeRdfProjection.md
+++ b/docs/planning/NativeRdfProjection.md
@@ -4,6 +4,8 @@ Written 2026-02-23 by Jeroen De Dauw with help from Claude Opus 4.6
 
 Status: Draft, incorporating feedback from ECHOLOT partners (Bilbao meeting March 2026 and async discussion)
 
+Feedback: [discussion #999](https://github.com/ProfessionalWiki/NeoWiki/discussions/999).
+
 ## Purpose
 
 This document specifies how NeoWiki's data model projects to RDF triples for the SPARQL plugin described in
@@ -25,7 +27,7 @@ SPARQL plugin is parameterized by projection rather than hardwired to the native
 
 This is a strawman proposal. Many decisions here need input from partners with RDF and Linked Open Data expertise,
 particularly regarding ontology alignment and cultural heritage conventions. [Open questions](#open-questions) are
-collected at the end. Discussion is tracked in [#723](https://github.com/ProfessionalWiki/NeoWiki/issues/723).
+collected at the end.
 
 ## Design Principles
 

--- a/docs/planning/OntologyMapping.md
+++ b/docs/planning/OntologyMapping.md
@@ -7,7 +7,7 @@ Started 2026-06-24 by Jeroen De Dauw with help from Claude Opus 4.8.
 
 Status: Draft strawman, for discussion with ECHOLOT partners (T2.3 and T3.x).
 
-Feedback: [discussion #996](https://github.com/ProfessionalWiki/NeoWiki/discussions/996).
+Discussion: [#996](https://github.com/ProfessionalWiki/NeoWiki/discussions/996).
 
 ## Summary
 
@@ -347,5 +347,5 @@ nesting look like in the schema format, and how much of the synthesis machinery 
 - Toy model: [Neutral Person to Many Standards](https://docs.google.com/spreadsheets/d/1j2_7j8RCUJrrMsfZaXtqHQOwp9cN9F8HIBtd3pfsToU/edit)
   — one person model expressed across several ontologies (takin); shared evaluation vehicle for the modelling fork and
   the first mappings.
-- Discussions: [#996](https://github.com/ProfessionalWiki/NeoWiki/discussions/996) (feedback on this doc),
-  [#999](https://github.com/ProfessionalWiki/NeoWiki/discussions/999) (native projection feedback).
+- Discussions: [#996](https://github.com/ProfessionalWiki/NeoWiki/discussions/996) (this doc),
+  [#999](https://github.com/ProfessionalWiki/NeoWiki/discussions/999) (native projection).

--- a/docs/planning/OntologyMapping.md
+++ b/docs/planning/OntologyMapping.md
@@ -7,6 +7,8 @@ Started 2026-06-24 by Jeroen De Dauw with help from Claude Opus 4.8.
 
 Status: Draft strawman, for discussion with ECHOLOT partners (T2.3 and T3.x).
 
+Feedback: [discussion #996](https://github.com/ProfessionalWiki/NeoWiki/discussions/996).
+
 ## Summary
 
 NeoWiki defines its own native Schemas ([ADR 6](../adr/006-schemas.md)). For RDF and SPARQL it projects that data into

--- a/docs/planning/OntologyMapping.md
+++ b/docs/planning/OntologyMapping.md
@@ -347,4 +347,5 @@ nesting look like in the schema format, and how much of the synthesis machinery 
 - Toy model: [Neutral Person to Many Standards](https://docs.google.com/spreadsheets/d/1j2_7j8RCUJrrMsfZaXtqHQOwp9cN9F8HIBtd3pfsToU/edit)
   — one person model expressed across several ontologies (takin); shared evaluation vehicle for the modelling fork and
   the first mappings.
-- Issue: [#723](https://github.com/ProfessionalWiki/NeoWiki/issues/723) (RDF mapping discussion).
+- Discussions: [#996](https://github.com/ProfessionalWiki/NeoWiki/discussions/996) (feedback on this doc),
+  [#999](https://github.com/ProfessionalWiki/NeoWiki/discussions/999) (native projection feedback).

--- a/docs/planning/ShapeLanguages.md
+++ b/docs/planning/ShapeLanguages.md
@@ -5,6 +5,8 @@ Written 2026-07-03 by Jeroen De Dauw with help from Claude Fable 5.
 Status: Position for discussion with ECHOLOT partners (T2.3, T3.x, T4.5). We are explicitly after disagreement and
 additions: if an argument below is wrong, or a use case is missing, please say so.
 
+Feedback: [discussion #997](https://github.com/ProfessionalWiki/NeoWiki/discussions/997).
+
 ## Position
 
 [SHACL](https://www.w3.org/TR/shacl/) (a W3C Recommendation) and [ShEx](https://shex.io/) (used by Wikidata for its

--- a/docs/planning/ShapeLanguages.md
+++ b/docs/planning/ShapeLanguages.md
@@ -5,7 +5,7 @@ Written 2026-07-03 by Jeroen De Dauw with help from Claude Fable 5.
 Status: Position for discussion with ECHOLOT partners (T2.3, T3.x, T4.5). We are explicitly after disagreement and
 additions: if an argument below is wrong, or a use case is missing, please say so.
 
-Feedback: [discussion #997](https://github.com/ProfessionalWiki/NeoWiki/discussions/997).
+Discussion: [#997](https://github.com/ProfessionalWiki/NeoWiki/discussions/997).
 
 ## Position
 


### PR DESCRIPTION
Adds a one-line discussion link to each of the three RDF planning docs, and retargets the old issue reference:

- OntologyMapping.md → [discussion #996](https://github.com/ProfessionalWiki/NeoWiki/discussions/996)
- ShapeLanguages.md → [discussion #997](https://github.com/ProfessionalWiki/NeoWiki/discussions/997)
- NativeRdfProjection.md → [discussion #999](https://github.com/ProfessionalWiki/NeoWiki/discussions/999) (converted from issue #723; the in-paragraph #723 reference is replaced by the standard header line, and OntologyMapping's Related now points at the discussions)

The links are labelled "Discussion:" (not "Feedback:"): partners are participants shaping the direction, not reviewers of finished work.

> <sub>Set up by Claude Code, `Fable 5 (max)`, with @JeroenDeDauw</sub>
