### PR TITLE
Fix incorrect datetime values in query results

### DIFF
--- a/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jResultNormalizer.php
+++ b/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jResultNormalizer.php
@@ -4,6 +4,8 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence;
 
+use DateTimeImmutable;
+use DateTimeZone;
 use Laudis\Neo4j\Types\AbstractCypherObject;
 use Laudis\Neo4j\Types\CypherList;
 use Laudis\Neo4j\Types\CypherMap;
@@ -90,7 +92,7 @@ class Neo4jResultNormalizer {
 		}
 
 		if ( $value instanceof LocalDateTime ) {
-			return $value->toDateTime()->format( 'Y-m-d\TH:i:s' )
+			return gmdate( 'Y-m-d\TH:i:s', $value->getSeconds() )
 				. $this->fractionalSeconds( $value->getNanoseconds() );
 		}
 
@@ -113,9 +115,9 @@ class Neo4jResultNormalizer {
 	private function offsetDateTimeToIso( DateTime $value ): string {
 		$offsetSeconds = $value->getTimeZoneOffsetSeconds();
 
-		// toDateTime() yields the correct UTC instant for both legacy and non-legacy
-		// wire encodings; adding the offset gives the wall-clock time to render.
-		$wallClockTimestamp = $value->toDateTime()->getTimestamp() + $offsetSeconds;
+		// getSeconds() is the UTC epoch; add the offset to get the wall-clock time
+		// that the offset suffix labels.
+		$wallClockTimestamp = $value->getSeconds() + $offsetSeconds;
 
 		return gmdate( 'Y-m-d\TH:i:s', $wallClockTimestamp )
 			. $this->fractionalSeconds( $value->getNanoseconds() )
@@ -123,7 +125,8 @@ class Neo4jResultNormalizer {
 	}
 
 	private function zoneIdDateTimeToIso( DateTimeZoneId $value ): string {
-		$dateTime = $value->toDateTime();
+		$dateTime = ( new DateTimeImmutable( '@' . $value->getSeconds() ) )
+			->setTimezone( new DateTimeZone( $value->getTimezoneIdentifier() ) );
 
 		return $dateTime->format( 'Y-m-d\TH:i:s' )
 			. $this->fractionalSeconds( $value->getNanoseconds() )

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jResultNormalizerTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jResultNormalizerTest.php
@@ -199,14 +199,13 @@ class Neo4jResultNormalizerTest extends TestCase {
 		);
 	}
 
-	public function testLegacyBoltDatetimeIsNotDoubleOffset(): void {
-		// On a legacy (pre-Bolt-v5) connection getSeconds() is the local epoch, not UTC.
+	public function testZonedDatetimeWithNanosecondPrecisionKeepsInstant(): void {
 		$result = new CypherList( [ new CypherMap( [
-			'at' => new DateTime( 1623759572, 0, 1172, true ),
+			'at' => new DateTime( 1704067200, 999999999, 0, false ),
 		] ) ] );
 
 		$this->assertSame(
-			[ 1 => [ 'at' => '2021-06-15T12:19:32+00:19' ] ],
+			[ 1 => [ 'at' => '2024-01-01T00:00:00.999999999+00:00' ] ],
 			$this->newNormalizer()->convertRows( $result )
 		);
 	}
@@ -218,6 +217,28 @@ class Neo4jResultNormalizerTest extends TestCase {
 
 		$this->assertSame(
 			[ 1 => [ 'at' => '2023-09-13T14:22:23+00:00' ] ],
+			$this->newNormalizer()->convertRows( $result )
+		);
+	}
+
+	public function testZoneIdDatetimeWithNanosecondPrecisionKeepsInstant(): void {
+		$result = new CypherList( [ new CypherMap( [
+			'at' => new DateTimeZoneId( 1704067200, 999999, 'UTC' ),
+		] ) ] );
+
+		$this->assertSame(
+			[ 1 => [ 'at' => '2024-01-01T00:00:00.000999999+00:00' ] ],
+			$this->newNormalizer()->convertRows( $result )
+		);
+	}
+
+	public function testLocalDatetimeWithNanosecondPrecisionKeepsWallClock(): void {
+		$result = new CypherList( [ new CypherMap( [
+			'at' => new LocalDateTime( 1704067200, 555555555 ),
+		] ) ] );
+
+		$this->assertSame(
+			[ 1 => [ 'at' => '2024-01-01T00:00:00.555555555' ] ],
 			$this->newNormalizer()->convertRows( $result )
 		);
 	}

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jResultNormalizerTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jResultNormalizerTest.php
@@ -199,6 +199,17 @@ class Neo4jResultNormalizerTest extends TestCase {
 		);
 	}
 
+	public function testNegativeOffsetDatetimeRendersMinusSign(): void {
+		$result = new CypherList( [ new CypherMap( [
+			'at' => new DateTime( 1694614943, 0, -18000, false ),
+		] ) ] );
+
+		$this->assertSame(
+			[ 1 => [ 'at' => '2023-09-13T09:22:23-05:00' ] ],
+			$this->newNormalizer()->convertRows( $result )
+		);
+	}
+
 	public function testZonedDatetimeWithNanosecondPrecisionKeepsInstant(): void {
 		$result = new CypherList( [ new CypherMap( [
 			'at' => new DateTime( 1704067200, 999999999, 0, false ),
@@ -217,6 +228,17 @@ class Neo4jResultNormalizerTest extends TestCase {
 
 		$this->assertSame(
 			[ 1 => [ 'at' => '2023-09-13T14:22:23+00:00' ] ],
+			$this->newNormalizer()->convertRows( $result )
+		);
+	}
+
+	public function testZoneIdDatetimeResolvesNonUtcZoneToOffset(): void {
+		$result = new CypherList( [ new CypherMap( [
+			'at' => new DateTimeZoneId( 1694614943, 0, 'Europe/Berlin' ),
+		] ) ] );
+
+		$this->assertSame(
+			[ 1 => [ 'at' => '2023-09-13T16:22:23+02:00' ] ],
 			$this->newNormalizer()->convertRows( $result )
 		);
 	}


### PR DESCRIPTION
Follow-up from an AI review of #812, fixing a result-rendering bug found there.

The Laudis client's `toDateTime()` applies sub-second precision via `DateTimeImmutable::modify()` with a fractional-microsecond string, which PHP's relative-date parser mis-handles for certain sub-microsecond nanosecond values. It is erratic rather than uniform: `999999999` ns corrupts the year (`RETURN datetime('2024-01-01T00:00:00.999999999Z')` came back as year 9999) and `555555555` ns throws an uncaught `DateMalformedStringException`, while other sub-microsecond values such as `1` ns and `123456789` ns render fine. NeoWiki's own statement writes are whole-microsecond (nanoseconds a multiple of 1000), so stored subject values were never affected; the bug hit arbitrary query results (`datetime()` literals with sub-microsecond precision, or nanosecond-precision data written by other Bolt clients).

The normalizer now computes the wall clock from the raw `seconds` and offset, so the `nanoseconds` field only ever feeds the fractional-seconds renderer and every value is handled.

## Two commits: the fix, and separate coverage

The change is split into two commits with different intent:

- **The fix** — the normalizer change plus regression tests that **fail against the pre-fix code** (the year-9999, `+9h9m`, and thrown-exception cases). These prove the fix.
- **Coverage only** — two tests for rendering paths the suite did not exercise (negative UTC offsets, and non-UTC `DateTimeZoneId` zones). Both paths already behaved correctly, so these tests **pass on the pre-fix code too**; they pin existing behaviour against future regressions and are deliberately kept out of the fix commit so the fix's proof stays unambiguous.

## Dropping the legacy (pre-Bolt-v5) datetime branch

Zoned datetimes have two Bolt wire encodings: the modern one (Bolt v5, where the `seconds` field is the UTC epoch) and a legacy one (Bolt ≤ 4.x, where `seconds` is the offset-shifted local epoch). The Laudis driver distinguishes them purely by protocol structure (`legacy = !($struct instanceof \Bolt\protocol\v5\structures\DateTime)`), so the flag is only ever set for a pre-v5 connection.

NeoWiki requires Neo4j 5.x over Bolt (`docs/operations/installation.md`), and Neo4j 5.x always negotiates Bolt 5, so a legacy-encoded datetime cannot occur in a supported deployment. Rather than carry a branch that can only execute against an unsupported (and separately broken on the write side) Neo4j 4.x, this renders only the UTC-epoch encoding and drops the legacy handling. Behaviour on any supported stack is unchanged; the only path that changes is one that can never be reached there.

> Review fix written by Claude Code, `Fable 5 (max)`, from an adversarial multi-agent review of #812 with @malberts; corruption reproduced and the fix verified against a live dev stack. The legacy-drop rationale was confirmed against the vendored Laudis 3.6.0 driver source and the Neo4j version requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
