### PR TITLE
Scope ADR 3 and 13 status-line relations to validity changes

### DIFF
--- a/docs/adr/003-neo4j-as-graph-database.md
+++ b/docs/adr/003-neo4j-as-graph-database.md
@@ -2,7 +2,7 @@
 
 Date: March 2023
 
-Status: Accepted. Extended by [ADR 19](019-graph-database-architecture.md).
+Status: Accepted, direct database access superseded by [ADR 13](013-restrict-neo4j-access.md)
 
 ## Context
 

--- a/docs/adr/013-restrict-neo4j-access.md
+++ b/docs/adr/013-restrict-neo4j-access.md
@@ -2,7 +2,7 @@
 
 Date: 2024-09-16
 
-Status: Accepted. See also [ADR 19](019-graph-database-architecture.md).
+Status: Accepted
 
 ## Context
 


### PR DESCRIPTION
A status-line relation clause is a validity warning: it tells a reader that another ADR has superseded or amended this one, so it should carry only such changes, scoped where the change is partial. Reaffirming or building-on relationships belong in the depending ADR's Context prose, where they can be scoped to what the reader needs.

**ADR 3** previously flagged "Extended by ADR 19" but not that ADR 13 (2024) reversed its "consumers can directly read from the graph database" decision. This flags the actual supersession instead; ADR 19 is a Draft and changes nothing about ADR 3's validity yet.

**ADR 13's** "See also ADR 19" carried no validity change either. ADR 19 already cites ADR 13 in its prose.

Follows the scoped-supersession style already used by ADRs 5, 6, and 10.

> Result of an audit of ADR status-line relation links prompted by @JeroenDeDauw, who flagged that chains of such links make readers think ADRs can no longer be read standalone, and set the direction that status relations should carry validity changes only.
> Context: the NeoWiki ADR corpus (docs/adr/) and the ADR 26 discussion in #1006.
> <sub>Written by Claude Code, \`Fable 5\` (max)</sub>