### PR TITLE
Keep ADR 26 at decision altitude for a post-merge audience

### DIFF
--- a/docs/adr/026-validation-severity-levels.md
+++ b/docs/adr/026-validation-severity-levels.md
@@ -45,8 +45,8 @@ Blocking semantics:
 
 The default severity is `warning`. The architecture treats invalid Subjects as a normal state (the ADR 21 requirement
 above), so surfacing a violation without blocking is the consistent default, and blocking is the exception a schema
-author opts into deliberately. Wikidata's constraint model is precedent from the same domain: constraints are
-advisory unless individually marked as mandatory.
+author opts into. Wikidata's constraint model is precedent from the same domain: constraints are advisory unless
+individually marked as mandatory.
 
 ### Schema JSON
 
@@ -63,9 +63,9 @@ that carries the severity:
 ```
 
 For boolean Constraints (`required`, `uniqueItems`) the object form implies `true`, so it has no `value` key. For
-`options` the `value` key carries the options array. Both forms normalize to the same Constraint at the JSON boundary.
-Canonical serialization emits the shorthand when the severity is the default, so existing Schemas round-trip
-unchanged. Custom Property Types defined by extensions follow the same pattern for their own Constraint fields.
+`options` the `value` key carries the options array. Canonical serialization emits the shorthand when the severity is
+the default, so existing Schemas round-trip unchanged. Custom Property Types follow the same pattern for their own
+Constraint fields.
 
 ### Authorable and fixed severities
 
@@ -98,16 +98,15 @@ because enforcement is off by default and an admin can lift it for the duration 
 ### Wire format and domain model
 
 Every serialized violation gains an always-present `"severity": "error" | "warning"` field, in the dry-run validate
-endpoints' 200 body and in the enforcement 422 body alike. Existing consumers keep working since the field is
-additive. In the domain model, every violation carries its severity, stamped at validation time from the
-configuration of the Constraint it violates.
+endpoints' 200 body and in the enforcement 422 body alike. In the domain model, every violation carries its severity,
+stamped at validation time from the configuration of the Constraint it violates.
 
 ## Consequences
 
 Pros:
 
-* Schema authors control which constraints are strict and which are advisory, per Constraint, matching their domain
-  needs. Messy imports can be persisted with warnings while essential fields still block.
+* Schema authors control which constraints are strict and which are advisory, per Constraint. Messy imports can be
+  persisted with warnings while essential fields still block.
 * API responses distinguish warnings from errors, and the frontend can style them accordingly (Codex `warning` vs
   `error` status).
 * The wire format change is additive, and existing Schema JSON stays valid via the scalar shorthand.
@@ -129,8 +128,7 @@ Cons:
 ### Error as the default severity
 
 An `error` default would preserve the current behavior where every violation blocks under enforcement. We rejected it
-because it contradicts the invalid-Subjects requirement carried into ADR 21 from ADR 12: the system tolerates and
-surfaces invalid data, so blocking is the explicit opt-in rather than the default.
+because it contradicts the invalid-Subjects requirement carried into ADR 21 from ADR 12.
 
 ### Removing the wiki-level enforcement switch
 

--- a/docs/adr/026-validation-severity-levels.md
+++ b/docs/adr/026-validation-severity-levels.md
@@ -37,8 +37,8 @@ Blocking semantics:
 
 * `$wgNeoWikiEnforceValidation` remains the master switch. Severity never blocks a write on its own.
 * With enforcement on, a write is rejected only when it introduces new violations of severity `error`. Warnings never
-  block. The newly-introduced check from ADR 21 is unchanged, and severity is not part of violation identity in that
-  check: changing a Constraint's severity does not make an existing violation count as new.
+  block. The newly-introduced-violations check from ADR 21 is unchanged, and severity is not part of violation
+  identity in that check: changing a Constraint's severity does not make an existing violation count as new.
 * With enforcement off, no violation blocks, as today.
 * Validate and write responses always include severity, so UIs and API consumers can distinguish the tiers regardless
   of the enforcement setting.
@@ -63,10 +63,9 @@ that carries the severity:
 ```
 
 For boolean Constraints (`required`, `uniqueItems`) the object form implies `true`, so it has no `value` key. For
-`options` the `value` key carries the options array. Parsing is normalized once at each JSON boundary (the PHP
-Property Definition deserialization and its TypeScript mirror). Canonical serialization emits the shorthand when the
-severity is the default, so existing Schemas round-trip unchanged. Custom Property Types defined by extensions follow
-the same pattern for their own Constraint fields.
+`options` the `value` key carries the options array. Both forms normalize to the same Constraint at the JSON boundary.
+Canonical serialization emits the shorthand when the severity is the default, so existing Schemas round-trip
+unchanged. Custom Property Types defined by extensions follow the same pattern for their own Constraint fields.
 
 ### Authorable and fixed severities
 
@@ -92,17 +91,16 @@ carve-out:
 | `single-value-only` | multiple values on a single-value property | `error` | `multiple` declares the value's shape, like `type` itself, so it is a shape condition rather than a Constraint |
 | `schema-not-found` | the Subject's Schema page is missing | `warning` | severity configuration lives in the Schema and there is none to read from; a warning keeps the Subject editable |
 
-The malformed-value row is the main point to challenge in review: the cultural-heritage import perspective could
-argue for `warning`, since messy imports contain exactly such values. The mitigation is that enforcement is off by
-default and an admin can lift it during an import.
+The fixed `error` for uninterpretable values (`invalid-url`, `invalid-date`, `invalid-datetime`) is the most
+debatable of these classifications: messy cultural-heritage imports contain exactly such values. It stays workable
+because enforcement is off by default and an admin can lift it for the duration of an import.
 
 ### Wire format and domain model
 
 Every serialized violation gains an always-present `"severity": "error" | "warning"` field, in the dry-run validate
 endpoints' 200 body and in the enforcement 422 body alike. Existing consumers keep working since the field is
-additive. In PHP, a backed `Severity` enum is added to the validation domain model, `Violation` gains a `severity`
-property, and `Violation::isBlocking()` reduces to a severity check. Property Type validators stamp each violation
-with the severity configured on the Constraint it violates.
+additive. In the domain model, every violation carries its severity, stamped at validation time from the
+configuration of the Constraint it violates.
 
 ## Consequences
 
@@ -161,9 +159,9 @@ all co-locate severity inside the constraint's own configuration.
 ### Grouping Constraints under a `constraints` object
 
 Restructuring the property JSON to separate Constraints from Display Attributes matches the conceptual split in the
-[glossary](../concepts/glossary.md) and would be the cleanest home for severity. We rejected it for now because it restructures every serializer,
-fixture, and editor surface for the same decision, and the core `required` field has no natural place in it. The
-object form chosen here does not preclude this restructuring later.
+[glossary](../concepts/glossary.md) and would be the cleanest home for severity. We rejected it for now because it
+restructures every serializer, fixture, and editor surface for the same decision, and the core `required` field has
+no natural place in it. The object form chosen here does not preclude this restructuring later.
 
 ### Additional tiers and SHACL vocabulary
 


### PR DESCRIPTION
Tightens the draft ADR from #1006; merges into that PR's branch.

**Commit 1 — decision altitude and durable audience:**

- Recast the "main point to challenge in review" aside as a durable record of the debatable classification and its mitigation, naming the violation codes instead of "the malformed-value row", which matched no row label.
- Compress the PHP implementation detail (enum, property, `isBlocking()`) to the one durable fact: violations carry their severity, stamped at validation time from the violated Constraint's configuration.
- Drop the code-location parenthetical from the parsing note.
- Hyphenate "newly-introduced-violations check" so it reads as the check for newly introduced violations, not a check that is new.
- Reflow an overlong line.

**Commit 2 — cut restated and filler phrases:**

- The invalid-Subjects rationale appeared a third time in the error-as-default alternative; naming the requirement suffices.
- The additive-wire-format compatibility claim appeared in both the Decision and the Pros; it stays in the Pros.
- The normalize-at-the-boundary sentence restated what canonical serialization already implies.
- Filler: "matching their domain needs", "opts into deliberately", "defined by extensions" after "Custom Property Types".

The violation-code tables were verified against the source and stay: the two tables partition all 14 codes in the code today exactly.

> Fresh review of the draft ADR by Fable 5 at @JeroenDeDauw's request, cross-checking an earlier Opus 4.8 review from the same session; the ADR's factual claims (violation codes, constraint fields, config flag, `schema-not-found` carve-out, validate endpoints) were verified against the NeoWiki source.
> Context: the NeoWiki validation subsystem and Schema domain code, ADRs 12/21/25, and PR #1006.
> <sub>Written by Claude Code, `Fable 5` (max)</sub>