### PR TITLE
Test that a rejected NeoJson POST writes nothing

### DIFF
--- a/tests/phpunit/EntryPoints/SpecialPages/SpecialNeoJsonTest.php
+++ b/tests/phpunit/EntryPoints/SpecialPages/SpecialNeoJsonTest.php
@@ -4,10 +4,13 @@ namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\SpecialPages;
 
 use MediaWiki\Page\PageIdentity;
 use MediaWiki\Permissions\Authority;
+use MediaWiki\Request\FauxRequest;
 use MediaWiki\Tests\Unit\Permissions\MockAuthorityTrait;
 use PermissionsError;
 use ProfessionalWiki\NeoWiki\EntryPoints\SpecialPages\SpecialNeoJson;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use SpecialPageTestBase;
+use WikiPage;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\EntryPoints\SpecialPages\SpecialNeoJson
@@ -56,6 +59,44 @@ class SpecialNeoJsonTest extends SpecialPageTestBase {
 		);
 
 		$this->assertStringContainsString( 'wpjson', $output );
+	}
+
+	public function testPostByUserWhoCannotEditTargetPageWritesNothing(): void {
+		$page = $this->getExistingTestPage( 'NeoJsonProtectedTarget' );
+		$title = $page->getTitle();
+		$this->protectAgainstNonSysopEdits( $page );
+
+		$user = $this->getTestUser()->getUser();
+
+		$request = new FauxRequest(
+			[
+				'wpjson' => '[]',
+				'wpEditToken' => $user->getEditToken(),
+			],
+			wasPosted: true
+		);
+
+		try {
+			$this->executeSpecialPage( $title->getPrefixedText(), $request, null, $user );
+			$this->fail( 'Expected a PermissionsError for a user who cannot edit the protected page' );
+		} catch ( PermissionsError ) {
+		}
+
+		$this->assertNull(
+			NeoWikiExtension::getInstance()->newSubjectContentRepository()->getSubjectContentByPageTitle( $title ),
+			'The rejected POST must not have written any Subject content'
+		);
+	}
+
+	private function protectAgainstNonSysopEdits( WikiPage $page ): void {
+		$cascade = false;
+		$page->doUpdateRestrictions(
+			[ 'edit' => 'sysop' ],
+			[],
+			$cascade,
+			'Protect for permission test',
+			$this->getTestSysop()->getUser()
+		);
 	}
 
 	private function authorityWithGlobalEditButNoPageEdit(): Authority {


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1002

The permission fix added to `Special:NeoJson` gates the write, but the two new tests only exercise the GET render (both pass a null request). The actual vulnerability is a POST that overwrites a page's Subject content; that path had no test. A refactor that moved the check after `addHtmlForm()` (or gated it on a GET request) would leave both existing tests green while reopening the write bypass.

Add an integration test that POSTs valid Subject JSON with a real edit token as a user who holds the wiki-global `edit` right but cannot edit the sysop-protected target page, and asserts both that a `PermissionsError` is thrown and that no Subject content was written. Asserting no-write (not just the exception) is what catches the check-after-form regression: verified by temporarily moving the check after `addHtmlForm()`, which lets the write land and fails only this assertion.

> @malberts asked me to review #1002, reproduce its manual check, and probe the UI; this test and the decision to add it are mine, produced autonomously. He then reviewed it, pressing on the assertion-message convention and try/catch vs `expectException`, and confirmed the current form unchanged.
> Context: the NeoWiki codebase, PR #1002, and MediaWiki permission internals; reviewed with parallel subagents and reproduced the POST write-bypass end-to-end before adding the test.
> <sub>Written by Claude Code, `Opus 4.8 (1M context)`</sub>
