### PR TITLE
Register graph-database surfaces only when a backend is configured

### DIFF
--- a/docs/operations/installation.md
+++ b/docs/operations/installation.md
@@ -108,8 +108,8 @@ Add the following to your `LocalSettings.php`:
 ```php
 wfLoadExtension( 'NeoWiki' );
 
-// Required. NeoWiki has no working state without a Neo4j connection.
-// For a simple setup, point both URLs at the same Neo4j user.
+// Required for NeoWiki's features. Without them the wiki still loads and ordinary pages work,
+// but NeoWiki's features are disabled. For a simple setup, point both URLs at the same Neo4j user.
 $wgNeoWikiNeo4jInternalWriteUrl = 'bolt://neo4j:SECRET@neo4j-host:7687';
 $wgNeoWikiNeo4jInternalReadUrl  = 'bolt://neo4j:SECRET@neo4j-host:7687';
 
@@ -119,8 +119,9 @@ wfLoadExtension( 'CodeEditor' );
 wfLoadExtension( 'ParserFunctions' );
 ```
 
-Both URLs are required. Until both are set, the wiki throws a `RuntimeException` on every request. The format is
-`bolt://user:password@host:7687`.
+Both URLs are required for NeoWiki's structured-data features. Without them the wiki still loads and ordinary
+pages render, but NeoWiki's features are disabled and the query surfaces (`{{#cypher_raw}}`, `nw.query`,
+`POST /neowiki/v0/query/cypher`) are absent. The format is `bolt://user:password@host:7687`.
 
 ### 4. Run the updater
 
@@ -162,11 +163,14 @@ These are the settings you are most likely to change. For the full list with des
 
 | Setting | Purpose | Default | Required |
 |---|---|---|---|
-| `$wgNeoWikiNeo4jInternalWriteUrl` | Bolt URL for writing the graph projection | _none_ | Yes |
-| `$wgNeoWikiNeo4jInternalReadUrl` | Bolt URL for read and query traffic | _none_ | Yes |
+| `$wgNeoWikiNeo4jInternalWriteUrl` | Bolt URL for writing the graph projection | _none_ | For features¹ |
+| `$wgNeoWikiNeo4jInternalReadUrl` | Bolt URL for read and query traffic | _none_ | For features¹ |
 | `$wgNeoWikiEnableDevelopmentUI` | Enables development-only UIs | `false` | No |
 | `$wgNeoWikiEnforceValidation` | Rejects writes that introduce new constraint violations | `false` | No |
 | `$wgNeoWikiAutoRenderMainSubject` | Automatically renders a page's Main Subject as an infobox | `true` | No |
+
+¹ Required for NeoWiki's structured-data features. The wiki still loads without them; NeoWiki's features are
+simply disabled until both are set.
 
 ## Production hardening
 

--- a/docs/reference/lua-api.md
+++ b/docs/reference/lua-api.md
@@ -167,7 +167,8 @@ end
 
 Runs a read-only Cypher query against the graph database and returns each row as a Lua table. Use
 this when a single property lookup is not enough — for example, to join multiple Subjects, filter
-or sort in the query, or build a custom table.
+or sort in the query, or build a custom table. It is available only when a Neo4j graph backend is
+configured; on a wiki without one, `mw.neowiki.query` is nil.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|

--- a/docs/reference/parser-functions.md
+++ b/docs/reference/parser-functions.md
@@ -128,7 +128,8 @@ Passing a value to another extension's parser function:
 ## `{{#cypher_raw}}`
 
 Executes a read-only Cypher query and returns the raw results as JSON in a code block. Mainly
-useful for development and debugging.
+useful for development and debugging. It is available only when a Neo4j graph backend is configured;
+on a wiki without one, `{{#cypher_raw: …}}` is not registered and renders as ordinary wikitext.
 
 For end-user dashboards, formatted query result rendering is planned (see
 [#809](https://github.com/ProfessionalWiki/NeoWiki/issues/809)). A Lua

--- a/docs/reference/query-api.md
+++ b/docs/reference/query-api.md
@@ -1,7 +1,8 @@
 # Query API
 
 `POST /neowiki/v0/query/cypher` runs a read-only Cypher query against the configured Neo4j backend and returns
-results as a structured JSON envelope.
+results as a structured JSON envelope. The endpoint exists only when a Neo4j graph backend is configured; on a
+wiki without one the route is absent and does not appear in the OpenAPI spec.
 
 ## Stability
 

--- a/extension.json
+++ b/extension.json
@@ -18,6 +18,8 @@
 		"MediaWiki": ">= 1.43.0"
 	},
 
+	"callback": "ProfessionalWiki\\NeoWiki\\NeoWikiExtension::onExtensionRegistration",
+
 	"MessagesDirs": {
 		"NeoWiki": [
 			"i18n"
@@ -258,11 +260,6 @@
 			"path": "/neowiki/v0/subject/{subjectId}/validate",
 			"method": [ "POST" ],
 			"factory": "ProfessionalWiki\\NeoWiki\\NeoWikiExtension::newValidateSubjectUpdateApi"
-		},
-		{
-			"path": "/neowiki/v0/query/cypher",
-			"method": [ "POST" ],
-			"factory": "ProfessionalWiki\\NeoWiki\\NeoWikiExtension::newCypherQueryApi"
 		}
 	],
 

--- a/src/Application/NullSubjectLabelLookup.php
+++ b/src/Application/NullSubjectLabelLookup.php
@@ -1,0 +1,13 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application;
+
+class NullSubjectLabelLookup implements SubjectLabelLookup {
+
+	public function getSubjectLabelsMatching( string $search, int $limit, string $schemaName ): array {
+		return [];
+	}
+
+}

--- a/src/Domain/GraphDatabase/GraphBackendNotConfigured.php
+++ b/src/Domain/GraphDatabase/GraphBackendNotConfigured.php
@@ -1,0 +1,25 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\GraphDatabase;
+
+use RuntimeException;
+
+/**
+ * Thrown when code that needs a graph database backend is reached on a wiki that has none configured.
+ *
+ * NeoWiki requires a configured graph backend to provide its structured-data features; a wiki with no
+ * backend is a misconfiguration, not a supported operating mode (see ADR 019, which defers full
+ * no-backend operation). This is a catchable, expected-runtime-state signal (unlike the LogicException
+ * guards on genuinely gated surfaces), so degradation boundaries can turn it into a clear notice.
+ */
+class GraphBackendNotConfigured extends RuntimeException {
+
+	public function __construct(
+		string $message = 'NeoWiki requires a configured graph database backend. Configure the Neo4j read and write Bolt URLs.'
+	) {
+		parent::__construct( $message );
+	}
+
+}

--- a/src/Domain/GraphDatabase/GraphBackendNotConfiguredException.php
+++ b/src/Domain/GraphDatabase/GraphBackendNotConfiguredException.php
@@ -14,7 +14,7 @@ use RuntimeException;
  * no-backend operation). This is a catchable, expected-runtime-state signal (unlike the LogicException
  * guards on genuinely gated surfaces), so degradation boundaries can turn it into a clear notice.
  */
-class GraphBackendNotConfigured extends RuntimeException {
+class GraphBackendNotConfiguredException extends RuntimeException {
 
 	public function __construct(
 		string $message = 'NeoWiki requires a configured graph database backend. Configure the Neo4j read and write Bolt URLs.'

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -48,9 +48,10 @@ class NeoWikiHooks {
 	}
 
 	private static function handleContentPage( OutputPage $out, Skin $skin ): void {
-		// NeoWiki requires a graph backend. Rather than 500 on every content page of a misconfigured
-		// wiki (subject reads/rendering below reach the Neo4j-only reverse index), skip injection and
-		// warn loudly. This keeps the wiki usable so an admin can fix the config.
+		// Skip injection and warn loudly instead of 500ing every content page, so plain content pages
+		// still render on a wiki with no graph backend. Pages whose wikitext uses the graph-backed
+		// surfaces ({{#neowiki_value}}, the mw.neowiki getters) still fail their parse until the
+		// no-backend degradation work (#895); {{#view}} degrades to its client-side placeholder per component.
 		if ( NeoWikiExtension::getInstance()->getNeo4jPlugin() === null ) {
 			self::logMissingGraphBackend();
 			return;

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\EntryPoints;
 
 use MediaWiki\Html\Html;
+use MediaWiki\Logger\LoggerFactory;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Output\OutputPage;
 use MediaWiki\Page\ProperPageIdentity;
@@ -18,7 +19,6 @@ use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\EntryPoints\Content\SchemaContent;
 use ProfessionalWiki\NeoWiki\EntryPoints\Content\SubjectContent;
 use ProfessionalWiki\NeoWiki\EntryPoints\Content\LayoutContent;
-use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\ParserFunction\CypherRawParserFunction;
 use ProfessionalWiki\NeoWiki\Application\SubjectResolver;
 use ProfessionalWiki\NeoWiki\EntryPoints\Actions\SubjectsAction;
 use ProfessionalWiki\NeoWiki\EntryPoints\Scribunto\ScribuntoLuaLibrary;
@@ -48,6 +48,14 @@ class NeoWikiHooks {
 	}
 
 	private static function handleContentPage( OutputPage $out, Skin $skin ): void {
+		// NeoWiki requires a graph backend. Rather than 500 on every content page of a misconfigured
+		// wiki (subject reads/rendering below reach the Neo4j-only reverse index), skip injection and
+		// warn loudly. This keeps the wiki usable so an admin can fix the config.
+		if ( NeoWikiExtension::getInstance()->getNeo4jPlugin() === null ) {
+			self::logMissingGraphBackend();
+			return;
+		}
+
 		NeoWikiExtension::getInstance()->newFrontendModuleLoader()->load( $out, $skin );
 		$out->addHtml( self::getNeoWikiAppHtml( $out ) );
 
@@ -62,6 +70,17 @@ class NeoWikiHooks {
 		$out->clearHTML();
 		$out->addHTML( $builder->mainSubjectHtml( $out->getTitle(), $revisionId ) );
 		$out->addHTML( $html );
+	}
+
+	private static function logMissingGraphBackend(): void {
+		$config = NeoWikiExtension::getInstance()->config;
+		$onlyOneUrlSet = ( $config->neo4jInternalReadUrl !== null ) !== ( $config->neo4jInternalWriteUrl !== null );
+
+		$message = $onlyOneUrlSet
+			? 'NeoWiki: only one of the Neo4j read/write Bolt URLs is configured; both are required. NeoWiki features are disabled.'
+			: 'NeoWiki: no graph database backend configured; NeoWiki features are disabled. Configure the Neo4j read and write Bolt URLs.';
+
+		LoggerFactory::getInstance( 'NeoWiki' )->warning( $message );
 	}
 
 	private static function getNeoWikiAppHtml( OutputPage $out ): string {
@@ -122,15 +141,7 @@ class NeoWikiHooks {
 	}
 
 	public static function onParserFirstCallInit( Parser $parser ): void {
-		$parser->setFunctionHook(
-			'cypher_raw',
-			static function ( Parser $parser, string $cypherQuery ): string {
-				$parserFunction = new CypherRawParserFunction(
-					NeoWikiExtension::getInstance()->newCypherQueryService()
-				);
-				return $parserFunction->handle( $parser, $cypherQuery );
-			}
-		);
+		NeoWikiExtension::getInstance()->getNeo4jPlugin()?->registerParserFunctions( $parser );
 
 		$parser->setFunctionHook(
 			'view',

--- a/src/EntryPoints/Scribunto/ScribuntoLuaLibrary.php
+++ b/src/EntryPoints/Scribunto/ScribuntoLuaLibrary.php
@@ -60,9 +60,13 @@ class ScribuntoLuaLibrary extends LibraryBase {
 			'getMainSubject' => [ $this, 'getMainSubject' ],
 			'getSubject' => [ $this, 'getSubject' ],
 			'getChildSubjects' => [ $this, 'getChildSubjects' ],
-			'query' => [ $this, 'query' ],
 			'getSchema' => [ $this, 'getSchema' ],
 		];
+
+		$neo4jFunctions = NeoWikiExtension::getInstance()->getNeo4jPlugin()?->getLuaLibraryFunctionNames() ?? [];
+		foreach ( $neo4jFunctions as $name ) {
+			$lib[$name] = [ $this, $name ];
+		}
 
 		return $this->getEngine()->registerInterface(
 			__DIR__ . '/mw.neowiki.lua', $lib, []

--- a/src/EntryPoints/Scribunto/mw.neowiki.lua
+++ b/src/EntryPoints/Scribunto/mw.neowiki.lua
@@ -6,6 +6,13 @@ function neowiki.setupInterface()
 	php = mw_interface
 	mw_interface = nil
 
+	-- query is only registered on the PHP side when a Neo4j backend is configured.
+	-- Drop the Lua wrapper too, so mw.neowiki.query is genuinely absent otherwise
+	-- (rather than a function that fails one call deeper on a nil php.query).
+	if not php.query then
+		neowiki.query = nil
+	end
+
 	mw = mw or {}
 	mw.neowiki = neowiki
 

--- a/src/GraphDatabasePlugins/Neo4j/EntryPoints/REST/Neo4jRouteRegistration.php
+++ b/src/GraphDatabasePlugins/Neo4j/EntryPoints/REST/Neo4jRouteRegistration.php
@@ -1,0 +1,24 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\REST;
+
+use ProfessionalWiki\NeoWiki\NeoWikiConfig;
+
+class Neo4jRouteRegistration {
+
+	/**
+	 * REST route files the Neo4j plugin contributes given the resolved Bolt URLs.
+	 *
+	 * @return string[]
+	 */
+	public static function routeFiles( ?string $readUrl, ?string $writeUrl ): array {
+		if ( !NeoWikiConfig::neo4jConfigured( $readUrl, $writeUrl ) ) {
+			return [];
+		}
+
+		return [ __DIR__ . '/neo4jRoutes.json' ];
+	}
+
+}

--- a/src/GraphDatabasePlugins/Neo4j/EntryPoints/REST/neo4jRoutes.json
+++ b/src/GraphDatabasePlugins/Neo4j/EntryPoints/REST/neo4jRoutes.json
@@ -1,0 +1,9 @@
+[
+	{
+		"path": "/neowiki/v0/query/cypher",
+		"method": [
+			"POST"
+		],
+		"factory": "ProfessionalWiki\\NeoWiki\\NeoWikiExtension::newCypherQueryApi"
+	}
+]

--- a/src/GraphDatabasePlugins/Neo4j/Neo4jPlugin.php
+++ b/src/GraphDatabasePlugins/Neo4j/Neo4jPlugin.php
@@ -90,8 +90,6 @@ readonly class Neo4jPlugin {
 		);
 	}
 
-	// Public: NeoWikiExtension::newCypherQueryService() calls this cross-class. A `private` here is a
-	// fatal "Call to private method" on every configured query path (REST, Lua). Keep it public.
 	public function newQueryService(): Neo4jQueryService {
 		return new Neo4jQueryService(
 			$this->readQueryEngine,

--- a/src/GraphDatabasePlugins/Neo4j/Neo4jPlugin.php
+++ b/src/GraphDatabasePlugins/Neo4j/Neo4jPlugin.php
@@ -5,11 +5,18 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j;
 
 use Laudis\Neo4j\Contracts\ClientInterface;
+use MediaWiki\Parser\Parser;
 use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphDatabasePlugin;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\CompositeCypherQueryValidator;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\ExplainCypherQueryValidator;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\KeywordCypherQueryValidator;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jQueryService;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jReadQueryEngine;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\ParserFunction\CypherRawParserFunction;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jClientReadQueryEngine;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jProjectionStore;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jResultNormalizer;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jSubjectUpdaterFactory;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jValueBuilderRegistry;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jWriteQueryEngine;
@@ -25,6 +32,7 @@ readonly class Neo4jPlugin {
 	private GraphDatabasePlugin $projectionStore;
 	private Neo4jReadQueryEngine $readQueryEngine;
 	private Neo4jWriteQueryEngine $writeQueryEngine;
+	private ClientInterface $readOnlyClient;
 
 	public function __construct(
 		ClientInterface $client,
@@ -46,6 +54,7 @@ readonly class Neo4jPlugin {
 		);
 		$this->readQueryEngine = new Neo4jClientReadQueryEngine( $readOnlyClient );
 		$this->writeQueryEngine = new Neo4jWriteQueryEngine( $client );
+		$this->readOnlyClient = $readOnlyClient;
 	}
 
 	public function getGraphDatabasePlugin(): GraphDatabasePlugin {
@@ -58,6 +67,40 @@ readonly class Neo4jPlugin {
 
 	public function getWriteQueryEngine(): Neo4jWriteQueryEngine {
 		return $this->writeQueryEngine;
+	}
+
+	/**
+	 * The Lua library function names this plugin contributes to mw.neowiki. The handler for each
+	 * lives on ScribuntoLuaLibrary (it needs LibraryBase services); the plugin's presence is the gate.
+	 *
+	 * @return string[]
+	 */
+	public function getLuaLibraryFunctionNames(): array {
+		return [ 'query' ];
+	}
+
+	public function registerParserFunctions( Parser $parser ): void {
+		$queryService = $this->newQueryService();
+
+		$parser->setFunctionHook(
+			'cypher_raw',
+			static function ( Parser $parser, string $cypherQuery ) use ( $queryService ): string {
+				return ( new CypherRawParserFunction( $queryService ) )->handle( $parser, $cypherQuery );
+			}
+		);
+	}
+
+	// Public: NeoWikiExtension::newCypherQueryService() calls this cross-class. A `private` here is a
+	// fatal "Call to private method" on every configured query path (REST, Lua). Keep it public.
+	public function newQueryService(): Neo4jQueryService {
+		return new Neo4jQueryService(
+			$this->readQueryEngine,
+			new CompositeCypherQueryValidator( [
+				new KeywordCypherQueryValidator(),
+				new ExplainCypherQueryValidator( $this->readOnlyClient ),
+			] ),
+			new Neo4jResultNormalizer(),
+		);
 	}
 
 }

--- a/src/NeoWikiConfig.php
+++ b/src/NeoWikiConfig.php
@@ -8,10 +8,18 @@ readonly class NeoWikiConfig {
 
 	public function __construct(
 		public bool $enableDevelopmentUIs,
-		public string $neo4jInternalWriteUrl,
-		public string $neo4jInternalReadUrl,
+		public ?string $neo4jInternalWriteUrl,
+		public ?string $neo4jInternalReadUrl,
 		public string $wikiId,
 	) {
+	}
+
+	public function hasNeo4jBackend(): bool {
+		return self::neo4jConfigured( $this->neo4jInternalReadUrl, $this->neo4jInternalWriteUrl );
+	}
+
+	public static function neo4jConfigured( ?string $readUrl, ?string $writeUrl ): bool {
+		return $readUrl !== null && $writeUrl !== null;
 	}
 
 }

--- a/src/NeoWikiConfigFactory.php
+++ b/src/NeoWikiConfigFactory.php
@@ -6,41 +6,31 @@ namespace ProfessionalWiki\NeoWiki;
 
 use MediaWiki\Config\Config;
 use MediaWiki\WikiMap\WikiMap;
-use RuntimeException;
 
 class NeoWikiConfigFactory {
 
 	public function buildFromMediaWikiConfig( Config $config ): NeoWikiConfig {
 		return new NeoWikiConfig(
 			enableDevelopmentUIs: $config->get( 'NeoWikiEnableDevelopmentUI' ) === true,
-			neo4jInternalWriteUrl: $this->buildInternalWriteUrl( $config ),
-			neo4jInternalReadUrl: $this->builtInternalReadUrl( $config ),
+			neo4jInternalWriteUrl: self::resolveWriteUrl( $this->configString( $config, 'NeoWikiNeo4jInternalWriteUrl' ) ),
+			neo4jInternalReadUrl: self::resolveReadUrl( $this->configString( $config, 'NeoWikiNeo4jInternalReadUrl' ) ),
 			wikiId: WikiMap::getCurrentWikiId(),
 		);
 	}
 
-	private function buildInternalWriteUrl( Config $config ): string {
-		if ( is_string( getenv( 'NEO4J_URL_OVERRIDE' ) ) ) { // Used by the CI to change its test config
-			return getenv( 'NEO4J_URL_OVERRIDE' );
-		}
-
-		if ( is_string( $config->get( 'NeoWikiNeo4jInternalWriteUrl' ) ) ) {
-			return $config->get( 'NeoWikiNeo4jInternalWriteUrl' );
-		}
-
-		throw new RuntimeException( 'Missing required config: NeoWikiNeo4jInternalWriteUrl' );
+	private function configString( Config $config, string $key ): ?string {
+		$value = $config->get( $key );
+		return is_string( $value ) ? $value : null;
 	}
 
-	private function builtInternalReadUrl( Config $config ): string {
-		if ( is_string( getenv( 'NEO4J_URL_READ_OVERRIDE' ) ) ) { // Used by the CI to change its test config
-			return getenv( 'NEO4J_URL_READ_OVERRIDE' );
-		}
+	public static function resolveWriteUrl( ?string $configValue ): ?string {
+		$override = getenv( 'NEO4J_URL_OVERRIDE' ); // Used by the CI to change its test config
+		return is_string( $override ) ? $override : $configValue;
+	}
 
-		if ( is_string( $config->get( 'NeoWikiNeo4jInternalReadUrl' ) ) ) {
-			return $config->get( 'NeoWikiNeo4jInternalReadUrl' );
-		}
-
-		throw new RuntimeException( 'Missing required config: NeoWikiNeo4jInternalReadUrl' );
+	public static function resolveReadUrl( ?string $configValue ): ?string {
+		$override = getenv( 'NEO4J_URL_READ_OVERRIDE' ); // Used by the CI to change its test config
+		return is_string( $override ) ? $override : $configValue;
 	}
 
 }

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki;
 
 use Exception;
+use LogicException;
 use Laudis\Neo4j\ClientBuilder;
 use Laudis\Neo4j\Contracts\ClientInterface;
 use MediaWiki\Context\RequestContext;
@@ -16,9 +17,6 @@ use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Session\CsrfTokenSet;
 use ProfessionalWiki\NeoWiki\Application\Actions\CreateSubject\CreateSubjectAction;
 use ProfessionalWiki\NeoWiki\Application\Actions\CreateSubject\CreateSubjectPresenter;
-use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\CompositeCypherQueryValidator;
-use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\CypherQueryValidator;
-use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jResultNormalizer;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jQueryService;
 use ProfessionalWiki\NeoWiki\Application\Actions\DeleteSubject\DeleteSubjectAction;
 use ProfessionalWiki\NeoWiki\Application\Actions\SetMainSubject\SetMainSubjectAction;
@@ -47,12 +45,14 @@ use ProfessionalWiki\NeoWiki\Infrastructure\ProductionIdGenerator;
 use ProfessionalWiki\NeoWiki\Persistence\CorePagePropertyProvider;
 use ProfessionalWiki\NeoWiki\Domain\Page\PagePropertyProviderRegistry;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\CompositeGraphDatabasePlugin;
+use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphBackendNotConfigured;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphDatabasePlugin;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphDatabasePluginRegistry;
 use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
 use ProfessionalWiki\NeoWiki\Application\SelectStatementResolver;
 use ProfessionalWiki\NeoWiki\Application\SelectValueResolver;
 use ProfessionalWiki\NeoWiki\Application\SubjectLabelLookup;
+use ProfessionalWiki\NeoWiki\Application\NullSubjectLabelLookup;
 use ProfessionalWiki\NeoWiki\Application\LayoutLookup;
 use ProfessionalWiki\NeoWiki\Application\SubjectAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\SubjectPageRebuilder;
@@ -74,6 +74,7 @@ use ProfessionalWiki\NeoWiki\EntryPoints\REST\GetSchemaSummariesApi;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\GetSubjectApi;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\GetSubjectLabelsApi;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\REST\CypherQueryApi;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\REST\Neo4jRouteRegistration;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\ReplaceSubjectApi;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\SetMainSubjectApi;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\SetSubjectsOrderingApi;
@@ -94,8 +95,6 @@ use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\LayoutPersistenceDeserializer
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\WikiPageSchemaLookup;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\WikiPageLayoutLookup;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jPageIdentifiersLookup;
-use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\ExplainCypherQueryValidator;
-use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\KeywordCypherQueryValidator;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Neo4jPlugin;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jSubjectLabelLookup;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jValueBuilderRegistry;
@@ -125,16 +124,34 @@ class NeoWikiExtension {
 	private ?Neo4jPlugin $neo4jPlugin = null;
 	private ClientInterface $neo4jClient;
 	private ClientInterface $readOnlyNeo4jClient;
+	private static ?self $instance = null;
 
 	public static function getInstance(): self {
-		/** @var ?self $instance */
-		static $instance = null;
-
-		$instance ??= new self(
+		self::$instance ??= new self(
 			( new NeoWikiConfigFactory() )->buildFromMediaWikiConfig( MediaWikiServices::getInstance()->getMainConfig() )
 		);
 
-		return $instance;
+		return self::$instance;
+	}
+
+	// Test seam: NeoWikiExtension caches config-derived state in a singleton with no other reset.
+	// Tests that vary graph-backend config must rebuild it. See NeoWikiIntegrationTestCase::runWithoutGraphBackend().
+	public static function resetInstance(): void {
+		self::$instance = null;
+	}
+
+	public static function onExtensionRegistration(): void {
+		$readUrl = NeoWikiConfigFactory::resolveReadUrl(
+			is_string( $GLOBALS['wgNeoWikiNeo4jInternalReadUrl'] ?? null ) ? $GLOBALS['wgNeoWikiNeo4jInternalReadUrl'] : null
+		);
+		$writeUrl = NeoWikiConfigFactory::resolveWriteUrl(
+			is_string( $GLOBALS['wgNeoWikiNeo4jInternalWriteUrl'] ?? null ) ? $GLOBALS['wgNeoWikiNeo4jInternalWriteUrl'] : null
+		);
+
+		$GLOBALS['wgRestAPIAdditionalRouteFiles'] = array_merge(
+			$GLOBALS['wgRestAPIAdditionalRouteFiles'] ?? [],
+			Neo4jRouteRegistration::routeFiles( $readUrl, $writeUrl )
+		);
 	}
 
 	private function __construct(
@@ -219,10 +236,14 @@ class NeoWikiExtension {
 			// the registry would make getGraphDatabasePluginRegistry() build the Neo4j plugin, whose
 			// construction transitively fires the NeoWikiRegistration hook and re-enters that accessor.
 			// Composing core here keeps the registry extension-only and the plugin order deterministic.
-			$this->graphDatabasePlugin = new CompositeGraphDatabasePlugin(
-				$this->getNeo4jPlugin()->getGraphDatabasePlugin(),
-				...$this->getGraphDatabasePluginRegistry()->getPlugins()
-			);
+			$plugins = $this->getGraphDatabasePluginRegistry()->getPlugins();
+
+			$neo4jPlugin = $this->getNeo4jPlugin();
+			if ( $neo4jPlugin !== null ) {
+				array_unshift( $plugins, $neo4jPlugin->getGraphDatabasePlugin() );
+			}
+
+			$this->graphDatabasePlugin = new CompositeGraphDatabasePlugin( ...$plugins );
 		}
 
 		return $this->graphDatabasePlugin;
@@ -238,12 +259,27 @@ class NeoWikiExtension {
 		return $this->graphDatabasePluginRegistry;
 	}
 
-	public function getNeo4jPlugin(): Neo4jPlugin {
+	public function getNeo4jPlugin(): ?Neo4jPlugin {
+		if ( !$this->config->hasNeo4jBackend() ) {
+			return null;
+		}
+
 		if ( $this->neo4jPlugin === null ) {
 			$this->neo4jPlugin = $this->buildNeo4jPlugin( $this->getSchemaLookup() );
 		}
 
 		return $this->neo4jPlugin;
+	}
+
+	// Shared guard for the surfaces that only run when a backend is configured (they are reached only
+	// through registration paths that this plan gates), so callers stay non-null for the type checker.
+	public function requireNeo4jPlugin(): Neo4jPlugin {
+		$plugin = $this->getNeo4jPlugin();
+		if ( $plugin === null ) {
+			throw new LogicException( 'A configured Neo4j backend is required here.' );
+		}
+
+		return $plugin;
 	}
 
 	// Test seam: lets tests build a projection store with a custom SchemaLookup.
@@ -265,8 +301,12 @@ class NeoWikiExtension {
 
 	public function getNeo4jClient(): ClientInterface {
 		if ( !isset( $this->neo4jClient ) ) {
+			$writeUrl = $this->config->neo4jInternalWriteUrl;
+			if ( $writeUrl === null ) {
+				throw new GraphBackendNotConfigured();
+			}
 			$this->neo4jClient = ClientBuilder::create()
-				->withDriver( 'default', $this->config->neo4jInternalWriteUrl )
+				->withDriver( 'default', $writeUrl )
 				->withDefaultDriver( 'default' )
 				->build();
 		}
@@ -276,8 +316,12 @@ class NeoWikiExtension {
 
 	public function getReadOnlyNeo4jClient(): ClientInterface {
 		if ( !isset( $this->readOnlyNeo4jClient ) ) {
+			$readUrl = $this->config->neo4jInternalReadUrl;
+			if ( $readUrl === null ) {
+				throw new GraphBackendNotConfigured();
+			}
 			$this->readOnlyNeo4jClient = ClientBuilder::create()
-				->withDriver( 'default', $this->config->neo4jInternalReadUrl )
+				->withDriver( 'default', $readUrl )
 				->withDefaultDriver( 'default' )
 				->build();
 		}
@@ -285,19 +329,8 @@ class NeoWikiExtension {
 		return $this->readOnlyNeo4jClient;
 	}
 
-	public function getCypherQueryValidator(): CypherQueryValidator {
-		return new CompositeCypherQueryValidator( [
-			new KeywordCypherQueryValidator(),
-			new ExplainCypherQueryValidator( $this->getReadOnlyNeo4jClient() ),
-		] );
-	}
-
 	public function newCypherQueryService(): Neo4jQueryService {
-		return new Neo4jQueryService(
-			$this->getNeo4jPlugin()->getReadQueryEngine(),
-			$this->getCypherQueryValidator(),
-			new Neo4jResultNormalizer(),
-		);
+		return $this->requireNeo4jPlugin()->newQueryService();
 	}
 
 	public static function newCypherQueryApi(): CypherQueryApi {
@@ -307,7 +340,7 @@ class NeoWikiExtension {
 	}
 
 	public function getWriteQueryEngine(): Neo4jWriteQueryEngine {
-		return $this->getNeo4jPlugin()->getWriteQueryEngine();
+		return $this->requireNeo4jPlugin()->getWriteQueryEngine();
 	}
 
 	public function isDevelopmentUIEnabled(): bool {
@@ -420,6 +453,13 @@ class NeoWikiExtension {
 		);
 	}
 
+	// NeoWiki requires a configured graph backend: the subject -> page reverse index lives only in Neo4j,
+	// so this lookup (and Subject CRUD, {{#view}}, {{#neowiki_value}}, the mw.neowiki.* getters) needs one.
+	// A no-backend wiki is a misconfiguration, surfaced loudly rather than silently degraded:
+	// getReadOnlyNeo4jClient() throws GraphBackendNotConfigured, and the content-page render path
+	// (NeoWikiHooks::handleContentPage) short-circuits with a warning instead of failing the page. Making
+	// these work without a graph backend needs a MediaWiki-native reverse index; that is future work
+	// (#586 / #877), only worthwhile if a deliberate storage-only product is chosen (ADR 019 defers it).
 	private function getPageIdentifiersLookup(): PageIdentifiersLookup {
 		return new Neo4jPageIdentifiersLookup( $this->getReadOnlyNeo4jClient() );
 	}
@@ -515,6 +555,11 @@ class NeoWikiExtension {
 	}
 
 	public function getSubjectLabelLookup(): SubjectLabelLookup {
+		$neo4jPlugin = $this->getNeo4jPlugin();
+		if ( $neo4jPlugin === null ) {
+			return new NullSubjectLabelLookup();
+		}
+
 		return new Neo4jSubjectLabelLookup(
 			client: $this->getReadOnlyNeo4jClient()
 		);

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -141,6 +141,8 @@ class NeoWikiExtension {
 	}
 
 	public static function onExtensionRegistration(): void {
+		// This registration-time gate must agree with NeoWikiConfig::hasNeo4jBackend() at request time,
+		// so both resolve the URLs through the shared NeoWikiConfigFactory::resolveReadUrl/resolveWriteUrl helpers.
 		$readUrl = NeoWikiConfigFactory::resolveReadUrl(
 			is_string( $GLOBALS['wgNeoWikiNeo4jInternalReadUrl'] ?? null ) ? $GLOBALS['wgNeoWikiNeo4jInternalReadUrl'] : null
 		);
@@ -271,8 +273,8 @@ class NeoWikiExtension {
 		return $this->neo4jPlugin;
 	}
 
-	// Shared guard for the surfaces that only run when a backend is configured (they are reached only
-	// through registration paths that this plan gates), so callers stay non-null for the type checker.
+	// Guard for surfaces whose registration is already gated on a configured backend, so callers get a
+	// non-null plugin without repeating the null handling.
 	public function requireNeo4jPlugin(): Neo4jPlugin {
 		$plugin = $this->getNeo4jPlugin();
 		if ( $plugin === null ) {
@@ -459,7 +461,7 @@ class NeoWikiExtension {
 	// getReadOnlyNeo4jClient() throws GraphBackendNotConfiguredException, and the content-page render path
 	// (NeoWikiHooks::handleContentPage) short-circuits with a warning instead of failing the page. Making
 	// these work without a graph backend needs a MediaWiki-native reverse index; that is future work
-	// (#586 / #877), only worthwhile if a deliberate storage-only product is chosen (ADR 019 defers it).
+	// (#586 / #895), only worthwhile if a deliberate storage-only product is chosen (ADR 019 defers it).
 	private function getPageIdentifiersLookup(): PageIdentifiersLookup {
 		return new Neo4jPageIdentifiersLookup( $this->getReadOnlyNeo4jClient() );
 	}
@@ -555,8 +557,7 @@ class NeoWikiExtension {
 	}
 
 	public function getSubjectLabelLookup(): SubjectLabelLookup {
-		$neo4jPlugin = $this->getNeo4jPlugin();
-		if ( $neo4jPlugin === null ) {
+		if ( $this->getNeo4jPlugin() === null ) {
 			return new NullSubjectLabelLookup();
 		}
 

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -45,7 +45,7 @@ use ProfessionalWiki\NeoWiki\Infrastructure\ProductionIdGenerator;
 use ProfessionalWiki\NeoWiki\Persistence\CorePagePropertyProvider;
 use ProfessionalWiki\NeoWiki\Domain\Page\PagePropertyProviderRegistry;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\CompositeGraphDatabasePlugin;
-use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphBackendNotConfigured;
+use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphBackendNotConfiguredException;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphDatabasePlugin;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphDatabasePluginRegistry;
 use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
@@ -303,7 +303,7 @@ class NeoWikiExtension {
 		if ( !isset( $this->neo4jClient ) ) {
 			$writeUrl = $this->config->neo4jInternalWriteUrl;
 			if ( $writeUrl === null ) {
-				throw new GraphBackendNotConfigured();
+				throw new GraphBackendNotConfiguredException();
 			}
 			$this->neo4jClient = ClientBuilder::create()
 				->withDriver( 'default', $writeUrl )
@@ -318,7 +318,7 @@ class NeoWikiExtension {
 		if ( !isset( $this->readOnlyNeo4jClient ) ) {
 			$readUrl = $this->config->neo4jInternalReadUrl;
 			if ( $readUrl === null ) {
-				throw new GraphBackendNotConfigured();
+				throw new GraphBackendNotConfiguredException();
 			}
 			$this->readOnlyNeo4jClient = ClientBuilder::create()
 				->withDriver( 'default', $readUrl )
@@ -456,7 +456,7 @@ class NeoWikiExtension {
 	// NeoWiki requires a configured graph backend: the subject -> page reverse index lives only in Neo4j,
 	// so this lookup (and Subject CRUD, {{#view}}, {{#neowiki_value}}, the mw.neowiki.* getters) needs one.
 	// A no-backend wiki is a misconfiguration, surfaced loudly rather than silently degraded:
-	// getReadOnlyNeo4jClient() throws GraphBackendNotConfigured, and the content-page render path
+	// getReadOnlyNeo4jClient() throws GraphBackendNotConfiguredException, and the content-page render path
 	// (NeoWikiHooks::handleContentPage) short-circuits with a warning instead of failing the page. Making
 	// these work without a graph backend needs a MediaWiki-native reverse index; that is future work
 	// (#586 / #877), only worthwhile if a deliberate storage-only product is chosen (ADR 019 defers it).

--- a/tests/phpunit/Application/NullSubjectLabelLookupTest.php
+++ b/tests/phpunit/Application/NullSubjectLabelLookupTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Application;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\NullSubjectLabelLookup;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Application\NullSubjectLabelLookup
+ */
+class NullSubjectLabelLookupTest extends TestCase {
+
+	public function testReturnsNoMatches(): void {
+		$lookup = new NullSubjectLabelLookup();
+
+		$this->assertSame( [], $lookup->getSubjectLabelsMatching( 'Al', 10, 'Person' ) );
+	}
+
+}

--- a/tests/phpunit/EntryPoints/ParserFunctionRegistrationTest.php
+++ b/tests/phpunit/EntryPoints/ParserFunctionRegistrationTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints;
+
+use MediaWiki\Parser\Parser;
+use ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiHooks;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiHooks::onParserFirstCallInit
+ * @group Database
+ */
+class ParserFunctionRegistrationTest extends NeoWikiIntegrationTestCase {
+
+	public function testCypherRawRegisteredWhenConfigured(): void {
+		$parser = $this->recordingParser( $names );
+
+		NeoWikiHooks::onParserFirstCallInit( $parser );
+
+		$this->assertContains( 'cypher_raw', $names );
+		$this->assertContains( 'view', $names );
+		$this->assertContains( 'neowiki_value', $names );
+	}
+
+	public function testCypherRawNotRegisteredWithoutBackend(): void {
+		$this->runWithoutGraphBackend( function (): void {
+			$parser = $this->recordingParser( $names );
+
+			NeoWikiHooks::onParserFirstCallInit( $parser );
+
+			$this->assertNotContains( 'cypher_raw', $names );
+			$this->assertContains( 'view', $names );
+			$this->assertContains( 'neowiki_value', $names );
+		} );
+	}
+
+	private function recordingParser( ?array &$names ): Parser {
+		$names = [];
+		$parser = $this->createMock( Parser::class );
+		$parser->method( 'setFunctionHook' )->willReturnCallback(
+			static function ( string $name ) use ( &$names ): void {
+				$names[] = $name;
+			}
+		);
+		return $parser;
+	}
+
+}

--- a/tests/phpunit/EntryPoints/REST/RestApiDocsCoverageTest.php
+++ b/tests/phpunit/EntryPoints/REST/RestApiDocsCoverageTest.php
@@ -63,15 +63,18 @@ class RestApiDocsCoverageTest extends TestCase {
 	 * @return list<string> e.g. "GET /neowiki/v0/subject/{subjectId}", sorted and unique.
 	 */
 	private function registeredEndpoints(): array {
-		$contents = file_get_contents( __DIR__ . '/../../../../extension.json' );
-		$this->assertNotFalse( $contents, 'Could not read extension.json' );
-
-		$extensionJson = json_decode( $contents, true );
-		$this->assertIsArray( $extensionJson );
+		$extensionJson = $this->readJsonArray( __DIR__ . '/../../../../extension.json' );
 		$this->assertArrayHasKey( 'RestRoutes', $extensionJson );
 
+		// The Cypher route is registered per-plugin via a route file added to
+		// $wgRestAPIAdditionalRouteFiles only when Neo4j is configured, not via extension.json.
+		// It is still a real, documented endpoint, so count it as registered here too.
+		$pluginRouteFile = __DIR__
+			. '/../../../../src/GraphDatabasePlugins/Neo4j/EntryPoints/REST/neo4jRoutes.json';
+		$routes = array_merge( $extensionJson['RestRoutes'], $this->readJsonArray( $pluginRouteFile ) );
+
 		$endpoints = [];
-		foreach ( $extensionJson['RestRoutes'] as $route ) {
+		foreach ( $routes as $route ) {
 			$methods = is_array( $route['method'] ) ? $route['method'] : [ $route['method'] ];
 			foreach ( $methods as $method ) {
 				$endpoints[] = strtoupper( $method ) . ' ' . $route['path'];
@@ -79,6 +82,19 @@ class RestApiDocsCoverageTest extends TestCase {
 		}
 
 		return $this->normalise( $endpoints );
+	}
+
+	/**
+	 * @return array<mixed>
+	 */
+	private function readJsonArray( string $path ): array {
+		$contents = file_get_contents( $path );
+		$this->assertNotFalse( $contents, "Could not read $path" );
+
+		$decoded = json_decode( $contents, true );
+		$this->assertIsArray( $decoded );
+
+		return $decoded;
 	}
 
 	/**

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Application/CompositeCypherQueryValidatorIntegrationTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Application/CompositeCypherQueryValidatorIntegrationTest.php
@@ -11,7 +11,6 @@ use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\KeywordCyphe
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
 
 /**
- * @covers \ProfessionalWiki\NeoWiki\NeoWikiExtension::getCypherQueryValidator
  * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\CompositeCypherQueryValidator
  * @group Database
  */
@@ -22,19 +21,19 @@ class CompositeCypherQueryValidatorIntegrationTest extends NeoWikiIntegrationTes
 	}
 
 	public function testReadOnlyQueryIsAllowed(): void {
-		$validator = NeoWikiExtension::getInstance()->getCypherQueryValidator();
+		$validator = $this->newValidator();
 
 		$this->assertTrue( $validator->queryIsAllowed( 'MATCH (n) RETURN n LIMIT 5' ) );
 	}
 
 	public function testWriteQueryIsRejected(): void {
-		$validator = NeoWikiExtension::getInstance()->getCypherQueryValidator();
+		$validator = $this->newValidator();
 
 		$this->assertFalse( $validator->queryIsAllowed( 'CREATE (n:Test {name: "test"}) RETURN n' ) );
 	}
 
 	public function testAdminQueryIsRejected(): void {
-		$validator = NeoWikiExtension::getInstance()->getCypherQueryValidator();
+		$validator = $this->newValidator();
 
 		$this->assertFalse( $validator->queryIsAllowed( 'STOP DATABASE neo4j' ) );
 	}
@@ -52,6 +51,15 @@ class CompositeCypherQueryValidatorIntegrationTest extends NeoWikiIntegrationTes
 
 		$compositeValidator = new CompositeCypherQueryValidator( [ $keywordValidator, $explainValidator ] );
 		$this->assertFalse( $compositeValidator->queryIsAllowed( $query ) );
+	}
+
+	private function newValidator(): CompositeCypherQueryValidator {
+		return new CompositeCypherQueryValidator( [
+			new KeywordCypherQueryValidator(),
+			new ExplainCypherQueryValidator(
+				NeoWikiExtension::getInstance()->getReadOnlyNeo4jClient()
+			),
+		] );
 	}
 
 }

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/EntryPoints/REST/Neo4jRouteRegistrationTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/EntryPoints/REST/Neo4jRouteRegistrationTest.php
@@ -26,6 +26,7 @@ class Neo4jRouteRegistrationTest extends TestCase {
 
 	public function testReturnsNothingWhenOnlyOneUrlSet(): void {
 		$this->assertSame( [], Neo4jRouteRegistration::routeFiles( 'bolt://read', null ) );
+		$this->assertSame( [], Neo4jRouteRegistration::routeFiles( null, 'bolt://write' ) );
 	}
 
 	public function testRouteFileDeclaresCypherRoute(): void {

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/EntryPoints/REST/Neo4jRouteRegistrationTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/EntryPoints/REST/Neo4jRouteRegistrationTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\GraphDatabasePlugins\Neo4j\EntryPoints\REST;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\REST\Neo4jRouteRegistration;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\REST\Neo4jRouteRegistration
+ */
+class Neo4jRouteRegistrationTest extends TestCase {
+
+	public function testReturnsRouteFileWhenConfigured(): void {
+		$files = Neo4jRouteRegistration::routeFiles( 'bolt://read', 'bolt://write' );
+
+		$this->assertCount( 1, $files );
+		$this->assertStringEndsWith( 'neo4jRoutes.json', $files[0] );
+		$this->assertFileExists( $files[0] );
+	}
+
+	public function testReturnsNothingWhenUnconfigured(): void {
+		$this->assertSame( [], Neo4jRouteRegistration::routeFiles( null, null ) );
+	}
+
+	public function testReturnsNothingWhenOnlyOneUrlSet(): void {
+		$this->assertSame( [], Neo4jRouteRegistration::routeFiles( 'bolt://read', null ) );
+	}
+
+	public function testRouteFileDeclaresCypherRoute(): void {
+		$routes = json_decode( file_get_contents( Neo4jRouteRegistration::routeFiles( 'r', 'w' )[0] ), true );
+
+		$this->assertSame( '/neowiki/v0/query/cypher', $routes[0]['path'] );
+		$this->assertSame( [ 'POST' ], $routes[0]['method'] );
+		$this->assertSame(
+			'ProfessionalWiki\\NeoWiki\\NeoWikiExtension::newCypherQueryApi',
+			$routes[0]['factory']
+		);
+	}
+
+}

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Integration/QueryCypherEndToEndTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Integration/QueryCypherEndToEndTest.php
@@ -6,12 +6,16 @@ namespace ProfessionalWiki\NeoWiki\Tests\GraphDatabasePlugins\Neo4j\Integration;
 
 use MediaWiki\Rest\RequestData;
 use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\WriteQueryRejectedException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jQueryLimits;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jQueryRequest;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\REST\CypherQueryApi
  * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jQueryService
+ * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Neo4jPlugin
  * @group Database
  */
 class QueryCypherEndToEndTest extends NeoWikiIntegrationTestCase {
@@ -57,6 +61,17 @@ class QueryCypherEndToEndTest extends NeoWikiIntegrationTestCase {
 
 		$this->assertSame( 422, $response->getStatusCode() );
 		$this->assertSame( 'writeQueryRejected', $body['errorType'] );
+	}
+
+	public function testAdminQueryRejectedByProductionQueryService(): void {
+		// STOP DATABASE passes the keyword validator but the Explain layer rejects it, so this fails
+		// unless the production service composes the Explain validator, not just the keyword one.
+		$service = NeoWikiExtension::getInstance()->newCypherQueryService();
+		$request = new Neo4jQueryRequest( 'STOP DATABASE neo4j', [], new Neo4jQueryLimits( 30, 5000 ) );
+
+		$this->expectException( WriteQueryRejectedException::class );
+
+		$service->execute( $request );
 	}
 
 }

--- a/tests/phpunit/HandlesNeo4jEnvOverrides.php
+++ b/tests/phpunit/HandlesNeo4jEnvOverrides.php
@@ -1,0 +1,29 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests;
+
+/**
+ * Saves, clears, and restores the NEO4J_URL_OVERRIDE / NEO4J_URL_READ_OVERRIDE environment variables.
+ * These CI-only overrides win over config, so clearing them lets a test exercise the config-value path
+ * deterministically. Restore what was snapshotted afterwards.
+ */
+trait HandlesNeo4jEnvOverrides {
+
+	private string|false $neo4jWriteEnvOverride;
+	private string|false $neo4jReadEnvOverride;
+
+	private function snapshotAndClearNeo4jEnvOverrides(): void {
+		$this->neo4jWriteEnvOverride = getenv( 'NEO4J_URL_OVERRIDE' );
+		$this->neo4jReadEnvOverride = getenv( 'NEO4J_URL_READ_OVERRIDE' );
+		putenv( 'NEO4J_URL_OVERRIDE' );
+		putenv( 'NEO4J_URL_READ_OVERRIDE' );
+	}
+
+	private function restoreNeo4jEnvOverrides(): void {
+		putenv( $this->neo4jWriteEnvOverride === false ? 'NEO4J_URL_OVERRIDE' : "NEO4J_URL_OVERRIDE=$this->neo4jWriteEnvOverride" );
+		putenv( $this->neo4jReadEnvOverride === false ? 'NEO4J_URL_READ_OVERRIDE' : "NEO4J_URL_READ_OVERRIDE=$this->neo4jReadEnvOverride" );
+	}
+
+}

--- a/tests/phpunit/NeoWikiConfigFactoryTest.php
+++ b/tests/phpunit/NeoWikiConfigFactoryTest.php
@@ -13,25 +13,16 @@ use ProfessionalWiki\NeoWiki\NeoWikiConfigFactory;
  */
 class NeoWikiConfigFactoryTest extends TestCase {
 
-	private string|false $originalWriteOverride;
-	private string|false $originalReadOverride;
+	use HandlesNeo4jEnvOverrides;
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->originalWriteOverride = getenv( 'NEO4J_URL_OVERRIDE' );
-		$this->originalReadOverride = getenv( 'NEO4J_URL_READ_OVERRIDE' );
-		putenv( 'NEO4J_URL_OVERRIDE' );
-		putenv( 'NEO4J_URL_READ_OVERRIDE' );
+		$this->snapshotAndClearNeo4jEnvOverrides();
 	}
 
 	protected function tearDown(): void {
-		$this->restoreEnv( 'NEO4J_URL_OVERRIDE', $this->originalWriteOverride );
-		$this->restoreEnv( 'NEO4J_URL_READ_OVERRIDE', $this->originalReadOverride );
+		$this->restoreNeo4jEnvOverrides();
 		parent::tearDown();
-	}
-
-	private function restoreEnv( string $name, string|false $value ): void {
-		putenv( $value === false ? $name : "$name=$value" );
 	}
 
 	public function testUnsetUrlsProduceNullInsteadOfThrowing(): void {

--- a/tests/phpunit/NeoWikiConfigFactoryTest.php
+++ b/tests/phpunit/NeoWikiConfigFactoryTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests;
+
+use MediaWiki\Config\HashConfig;
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\NeoWikiConfigFactory;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\NeoWikiConfigFactory
+ */
+class NeoWikiConfigFactoryTest extends TestCase {
+
+	private string|false $originalWriteOverride;
+	private string|false $originalReadOverride;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->originalWriteOverride = getenv( 'NEO4J_URL_OVERRIDE' );
+		$this->originalReadOverride = getenv( 'NEO4J_URL_READ_OVERRIDE' );
+		putenv( 'NEO4J_URL_OVERRIDE' );
+		putenv( 'NEO4J_URL_READ_OVERRIDE' );
+	}
+
+	protected function tearDown(): void {
+		$this->restoreEnv( 'NEO4J_URL_OVERRIDE', $this->originalWriteOverride );
+		$this->restoreEnv( 'NEO4J_URL_READ_OVERRIDE', $this->originalReadOverride );
+		parent::tearDown();
+	}
+
+	private function restoreEnv( string $name, string|false $value ): void {
+		putenv( $value === false ? $name : "$name=$value" );
+	}
+
+	public function testUnsetUrlsProduceNullInsteadOfThrowing(): void {
+		$config = ( new NeoWikiConfigFactory() )->buildFromMediaWikiConfig( new HashConfig( [
+			'NeoWikiEnableDevelopmentUI' => false,
+			'NeoWikiNeo4jInternalWriteUrl' => null,
+			'NeoWikiNeo4jInternalReadUrl' => null,
+		] ) );
+
+		$this->assertNull( $config->neo4jInternalWriteUrl );
+		$this->assertNull( $config->neo4jInternalReadUrl );
+		$this->assertFalse( $config->hasNeo4jBackend() );
+	}
+
+	public function testConfiguredUrlsArePassedThrough(): void {
+		$config = ( new NeoWikiConfigFactory() )->buildFromMediaWikiConfig( new HashConfig( [
+			'NeoWikiEnableDevelopmentUI' => false,
+			'NeoWikiNeo4jInternalWriteUrl' => 'bolt://write:7687',
+			'NeoWikiNeo4jInternalReadUrl' => 'bolt://read:7687',
+		] ) );
+
+		$this->assertSame( 'bolt://write:7687', $config->neo4jInternalWriteUrl );
+		$this->assertSame( 'bolt://read:7687', $config->neo4jInternalReadUrl );
+		$this->assertTrue( $config->hasNeo4jBackend() );
+	}
+
+	public function testEnvOverrideWinsOverConfigValue(): void {
+		putenv( 'NEO4J_URL_OVERRIDE=bolt://env-write' );
+		putenv( 'NEO4J_URL_READ_OVERRIDE=bolt://env-read' );
+
+		$config = ( new NeoWikiConfigFactory() )->buildFromMediaWikiConfig( new HashConfig( [
+			'NeoWikiEnableDevelopmentUI' => false,
+			'NeoWikiNeo4jInternalWriteUrl' => 'bolt://config-write',
+			'NeoWikiNeo4jInternalReadUrl' => 'bolt://config-read',
+		] ) );
+
+		$this->assertSame( 'bolt://env-write', $config->neo4jInternalWriteUrl );
+		$this->assertSame( 'bolt://env-read', $config->neo4jInternalReadUrl );
+	}
+
+}

--- a/tests/phpunit/NeoWikiConfigTest.php
+++ b/tests/phpunit/NeoWikiConfigTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\NeoWikiConfig;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\NeoWikiConfig
+ */
+class NeoWikiConfigTest extends TestCase {
+
+	public function testHasNeo4jBackendWhenBothUrlsSet(): void {
+		$config = $this->newConfig( readUrl: 'bolt://read', writeUrl: 'bolt://write' );
+
+		$this->assertTrue( $config->hasNeo4jBackend() );
+	}
+
+	public function testNoNeo4jBackendWhenBothUrlsNull(): void {
+		$config = $this->newConfig( readUrl: null, writeUrl: null );
+
+		$this->assertFalse( $config->hasNeo4jBackend() );
+	}
+
+	public function testNoNeo4jBackendWhenOnlyReadUrlSet(): void {
+		$config = $this->newConfig( readUrl: 'bolt://read', writeUrl: null );
+
+		$this->assertFalse( $config->hasNeo4jBackend() );
+	}
+
+	public function testNoNeo4jBackendWhenOnlyWriteUrlSet(): void {
+		$config = $this->newConfig( readUrl: null, writeUrl: 'bolt://write' );
+
+		$this->assertFalse( $config->hasNeo4jBackend() );
+	}
+
+	private function newConfig( ?string $readUrl, ?string $writeUrl ): NeoWikiConfig {
+		return new NeoWikiConfig(
+			enableDevelopmentUIs: false,
+			neo4jInternalWriteUrl: $writeUrl,
+			neo4jInternalReadUrl: $readUrl,
+			wikiId: 'testwiki',
+		);
+	}
+
+}

--- a/tests/phpunit/NeoWikiIntegrationTestCase.php
+++ b/tests/phpunit/NeoWikiIntegrationTestCase.php
@@ -25,6 +25,8 @@ use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySchemaLookup;
 
 class NeoWikiIntegrationTestCase extends MediaWikiIntegrationTestCase {
 
+	use HandlesNeo4jEnvOverrides;
+
 	protected function setUpNeo4j(): void {
 		try {
 			$client = NeoWikiExtension::getInstance()->getNeo4jClient();
@@ -103,13 +105,10 @@ class NeoWikiIntegrationTestCase extends MediaWikiIntegrationTestCase {
 	 * @param callable(): mixed $fn
 	 */
 	protected function runWithoutGraphBackend( callable $fn ): mixed {
-		$writeOverride = getenv( 'NEO4J_URL_OVERRIDE' );
-		$readOverride = getenv( 'NEO4J_URL_READ_OVERRIDE' );
 		$config = $this->getServiceContainer()->getMainConfig();
 		$priorWriteUrl = $config->get( 'NeoWikiNeo4jInternalWriteUrl' );
 		$priorReadUrl = $config->get( 'NeoWikiNeo4jInternalReadUrl' );
-		putenv( 'NEO4J_URL_OVERRIDE' );
-		putenv( 'NEO4J_URL_READ_OVERRIDE' );
+		$this->snapshotAndClearNeo4jEnvOverrides();
 		$this->overrideConfigValue( 'NeoWikiNeo4jInternalWriteUrl', null );
 		$this->overrideConfigValue( 'NeoWikiNeo4jInternalReadUrl', null );
 		NeoWikiExtension::resetInstance();
@@ -117,8 +116,7 @@ class NeoWikiIntegrationTestCase extends MediaWikiIntegrationTestCase {
 		try {
 			return $fn();
 		} finally {
-			putenv( $writeOverride === false ? 'NEO4J_URL_OVERRIDE' : "NEO4J_URL_OVERRIDE=$writeOverride" );
-			putenv( $readOverride === false ? 'NEO4J_URL_READ_OVERRIDE' : "NEO4J_URL_READ_OVERRIDE=$readOverride" );
+			$this->restoreNeo4jEnvOverrides();
 			$this->overrideConfigValue( 'NeoWikiNeo4jInternalWriteUrl', $priorWriteUrl );
 			$this->overrideConfigValue( 'NeoWikiNeo4jInternalReadUrl', $priorReadUrl );
 			NeoWikiExtension::resetInstance();

--- a/tests/phpunit/NeoWikiIntegrationTestCase.php
+++ b/tests/phpunit/NeoWikiIntegrationTestCase.php
@@ -88,11 +88,41 @@ class NeoWikiIntegrationTestCase extends MediaWikiIntegrationTestCase {
 	}
 
 	protected function readGraph( string $cypher, array $parameters = [] ): SummarizedResult {
-		return NeoWikiExtension::getInstance()->getNeo4jPlugin()->getReadQueryEngine()->runReadQuery( $cypher, $parameters );
+		return NeoWikiExtension::getInstance()->requireNeo4jPlugin()->getReadQueryEngine()->runReadQuery( $cypher, $parameters );
 	}
 
 	protected function writeGraph( string $cypher ): SummarizedResult {
-		return NeoWikiExtension::getInstance()->getNeo4jPlugin()->getWriteQueryEngine()->runWriteQuery( $cypher );
+		return NeoWikiExtension::getInstance()->requireNeo4jPlugin()->getWriteQueryEngine()->runWriteQuery( $cypher );
+	}
+
+	/**
+	 * Runs $fn with the Neo4j backend config unset, simulating a wiki with no graph backend.
+	 * Clears the CI env overrides (which otherwise win over config), nulls both URLs, and resets the
+	 * NeoWikiExtension singleton so it rebuilds from the unconfigured config. Restores everything after.
+	 *
+	 * @param callable(): mixed $fn
+	 */
+	protected function runWithoutGraphBackend( callable $fn ): mixed {
+		$writeOverride = getenv( 'NEO4J_URL_OVERRIDE' );
+		$readOverride = getenv( 'NEO4J_URL_READ_OVERRIDE' );
+		$config = $this->getServiceContainer()->getMainConfig();
+		$priorWriteUrl = $config->get( 'NeoWikiNeo4jInternalWriteUrl' );
+		$priorReadUrl = $config->get( 'NeoWikiNeo4jInternalReadUrl' );
+		putenv( 'NEO4J_URL_OVERRIDE' );
+		putenv( 'NEO4J_URL_READ_OVERRIDE' );
+		$this->overrideConfigValue( 'NeoWikiNeo4jInternalWriteUrl', null );
+		$this->overrideConfigValue( 'NeoWikiNeo4jInternalReadUrl', null );
+		NeoWikiExtension::resetInstance();
+
+		try {
+			return $fn();
+		} finally {
+			putenv( $writeOverride === false ? 'NEO4J_URL_OVERRIDE' : "NEO4J_URL_OVERRIDE=$writeOverride" );
+			putenv( $readOverride === false ? 'NEO4J_URL_READ_OVERRIDE' : "NEO4J_URL_READ_OVERRIDE=$readOverride" );
+			$this->overrideConfigValue( 'NeoWikiNeo4jInternalWriteUrl', $priorWriteUrl );
+			$this->overrideConfigValue( 'NeoWikiNeo4jInternalReadUrl', $priorReadUrl );
+			NeoWikiExtension::resetInstance();
+		}
 	}
 
 	protected function readPageNodeName( int $pageId ): ?string {

--- a/tests/phpunit/NoGraphBackendTest.php
+++ b/tests/phpunit/NoGraphBackendTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests;
+
+use MediaWiki\CommentStore\CommentStoreComment;
+use MediaWiki\Content\WikitextContent;
+use MediaWiki\Context\RequestContext;
+use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
+use ProfessionalWiki\NeoWiki\Application\NullSubjectLabelLookup;
+use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphBackendNotConfigured;
+use ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiHooks;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jSubjectLabelLookup;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\NeoWikiExtension
+ * @group Database
+ */
+class NoGraphBackendTest extends NeoWikiIntegrationTestCase {
+
+	public function testGetNeo4jPluginIsNullWithoutBackend(): void {
+		$plugin = $this->runWithoutGraphBackend(
+			static fn() => NeoWikiExtension::getInstance()->getNeo4jPlugin()
+		);
+
+		$this->assertNull( $plugin );
+	}
+
+	public function testGetNeo4jPluginIsPresentWhenConfigured(): void {
+		$this->assertNotNull( NeoWikiExtension::getInstance()->getNeo4jPlugin() );
+	}
+
+	public function testEditSucceedsWithoutBackend(): void {
+		$this->runWithoutGraphBackend( function (): void {
+			$wikiPage = MediaWikiServices::getInstance()->getWikiPageFactory()
+				->newFromTitle( Title::newFromText( 'NoBackendEditPage' ) );
+
+			$updater = $wikiPage->newPageUpdater( $this->getTestSysop()->getUser() );
+			$updater->setContent( 'main', new WikitextContent( 'hello' ) );
+			$updater->saveRevision( CommentStoreComment::newUnsavedComment( 'no-backend edit' ) );
+
+			$this->assertTrue( $updater->wasRevisionCreated() );
+		} );
+	}
+
+	public function testSubjectLabelLookupIsNullObjectWithoutBackend(): void {
+		$lookup = $this->runWithoutGraphBackend(
+			static fn() => NeoWikiExtension::getInstance()->getSubjectLabelLookup()
+		);
+
+		$this->assertInstanceOf( NullSubjectLabelLookup::class, $lookup );
+	}
+
+	public function testSubjectLabelLookupIsNeo4jWhenConfigured(): void {
+		$this->assertInstanceOf(
+			Neo4jSubjectLabelLookup::class,
+			NeoWikiExtension::getInstance()->getSubjectLabelLookup()
+		);
+	}
+
+	public function testLuaQueryOfferedWhenConfigured(): void {
+		$names = NeoWikiExtension::getInstance()->getNeo4jPlugin()?->getLuaLibraryFunctionNames() ?? [];
+
+		$this->assertContains( 'query', $names );
+	}
+
+	public function testLuaQueryNotOfferedWithoutBackend(): void {
+		$names = $this->runWithoutGraphBackend(
+			static fn() => NeoWikiExtension::getInstance()->getNeo4jPlugin()?->getLuaLibraryFunctionNames() ?? []
+		);
+
+		$this->assertSame( [], $names );
+	}
+
+	public function testReadOnlyClientThrowsGraphBackendNotConfiguredWithoutBackend(): void {
+		$this->expectException( GraphBackendNotConfigured::class );
+
+		$this->runWithoutGraphBackend(
+			static fn() => NeoWikiExtension::getInstance()->getReadOnlyNeo4jClient()
+		);
+	}
+
+	public function testContentPageRenderDoesNotFailWithoutBackend(): void {
+		$page = $this->getExistingTestPage( 'NoBackendViewPage' );
+
+		// An edit-capable user on the latest revision triggers the subject-creator path, which builds
+		// the SubjectRepository (the Neo4j-backed reverse index) — the exact path that 500s without the guard.
+		$context = new RequestContext();
+		$context->setTitle( $page->getTitle() );
+		$context->setUser( $this->getTestSysop()->getUser() );
+		$out = $context->getOutput();
+		$out->setArticleFlag( true );
+		$out->setRevisionId( $page->getLatest() );
+
+		$this->runWithoutGraphBackend( static function () use ( $out, $context ): void {
+			NeoWikiHooks::onBeforePageDisplay( $out, $context->getSkin() );
+		} );
+
+		// The render path short-circuits on a missing backend instead of throwing.
+		$this->addToAssertionCount( 1 );
+	}
+
+}

--- a/tests/phpunit/NoGraphBackendTest.php
+++ b/tests/phpunit/NoGraphBackendTest.php
@@ -10,7 +10,7 @@ use MediaWiki\Context\RequestContext;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
 use ProfessionalWiki\NeoWiki\Application\NullSubjectLabelLookup;
-use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphBackendNotConfigured;
+use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphBackendNotConfiguredException;
 use ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiHooks;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jSubjectLabelLookup;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
@@ -75,8 +75,8 @@ class NoGraphBackendTest extends NeoWikiIntegrationTestCase {
 		$this->assertSame( [], $names );
 	}
 
-	public function testReadOnlyClientThrowsGraphBackendNotConfiguredWithoutBackend(): void {
-		$this->expectException( GraphBackendNotConfigured::class );
+	public function testReadOnlyClientThrowsGraphBackendNotConfiguredExceptionWithoutBackend(): void {
+		$this->expectException( GraphBackendNotConfiguredException::class );
 
 		$this->runWithoutGraphBackend(
 			static fn() => NeoWikiExtension::getInstance()->getReadOnlyNeo4jClient()

--- a/tests/phpunit/NoGraphBackendTest.php
+++ b/tests/phpunit/NoGraphBackendTest.php
@@ -8,12 +8,14 @@ use MediaWiki\CommentStore\CommentStoreComment;
 use MediaWiki\Content\WikitextContent;
 use MediaWiki\Context\RequestContext;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Output\OutputPage;
 use MediaWiki\Title\Title;
 use ProfessionalWiki\NeoWiki\Application\NullSubjectLabelLookup;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphBackendNotConfiguredException;
 use ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiHooks;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jSubjectLabelLookup;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+use TestLogger;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\NeoWikiExtension
@@ -84,23 +86,56 @@ class NoGraphBackendTest extends NeoWikiIntegrationTestCase {
 	}
 
 	public function testContentPageRenderDoesNotFailWithoutBackend(): void {
-		$page = $this->getExistingTestPage( 'NoBackendViewPage' );
+		$out = $this->newContentPageOutput( 'NoBackendViewPage' );
 
-		// An edit-capable user on the latest revision triggers the subject-creator path, which builds
-		// the SubjectRepository (the Neo4j-backed reverse index) — the exact path that 500s without the guard.
+		$this->runWithoutGraphBackend( static function () use ( $out ): void {
+			NeoWikiHooks::onBeforePageDisplay( $out, $out->getSkin() );
+		} );
+
+		// The guard short-circuits before getNeoWikiAppHtml() injects the app div.
+		$this->assertStringNotContainsString( 'ext-neowiki-app', $out->getHTML() );
+	}
+
+	public function testContentPageRenderInjectsAppDivWhenConfigured(): void {
+		$out = $this->newContentPageOutput( 'ConfiguredBackendViewPage' );
+
+		NeoWikiHooks::onBeforePageDisplay( $out, $out->getSkin() );
+
+		$this->assertStringContainsString( 'ext-neowiki-app', $out->getHTML() );
+	}
+
+	public function testContentPageRenderLogsWarningWithoutBackend(): void {
+		$out = $this->newContentPageOutput( 'NoBackendWarningPage' );
+
+		$logger = new TestLogger( true );
+		$this->setLogger( 'NeoWiki', $logger );
+
+		$this->runWithoutGraphBackend( static function () use ( $out ): void {
+			NeoWikiHooks::onBeforePageDisplay( $out, $out->getSkin() );
+		} );
+
+		$buffer = $logger->getBuffer();
+		$this->assertCount( 1, $buffer );
+		$this->assertSame( 'warning', $buffer[0][0] );
+		$this->assertStringContainsString( 'no graph database backend configured', $buffer[0][1] );
+	}
+
+	/**
+	 * An edit-capable user on the latest revision triggers the subject-creator path, which builds the
+	 * SubjectRepository (the Neo4j-backed reverse index) — the exact path that 500s without the guard.
+	 */
+	private function newContentPageOutput( string $pageName ): OutputPage {
+		$page = $this->getExistingTestPage( $pageName );
+
 		$context = new RequestContext();
 		$context->setTitle( $page->getTitle() );
 		$context->setUser( $this->getTestSysop()->getUser() );
+
 		$out = $context->getOutput();
 		$out->setArticleFlag( true );
 		$out->setRevisionId( $page->getLatest() );
 
-		$this->runWithoutGraphBackend( static function () use ( $out, $context ): void {
-			NeoWikiHooks::onBeforePageDisplay( $out, $context->getSkin() );
-		} );
-
-		// The render path short-circuits on a missing backend instead of throwing.
-		$this->addToAssertionCount( 1 );
+		return $out;
 	}
 
 }

--- a/tests/phpunit/OnExtensionRegistrationTest.php
+++ b/tests/phpunit/OnExtensionRegistrationTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\NeoWikiExtension::onExtensionRegistration
+ */
+class OnExtensionRegistrationTest extends TestCase {
+
+	private string|false $writeOverride;
+	private string|false $readOverride;
+	private mixed $routeFiles;
+	private mixed $writeUrl;
+	private mixed $readUrl;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->writeOverride = getenv( 'NEO4J_URL_OVERRIDE' );
+		$this->readOverride = getenv( 'NEO4J_URL_READ_OVERRIDE' );
+		$this->routeFiles = $GLOBALS['wgRestAPIAdditionalRouteFiles'] ?? null;
+		$this->writeUrl = $GLOBALS['wgNeoWikiNeo4jInternalWriteUrl'] ?? null;
+		$this->readUrl = $GLOBALS['wgNeoWikiNeo4jInternalReadUrl'] ?? null;
+
+		// Clear the CI env overrides so the config-value path is exercised deterministically.
+		putenv( 'NEO4J_URL_OVERRIDE' );
+		putenv( 'NEO4J_URL_READ_OVERRIDE' );
+		$GLOBALS['wgRestAPIAdditionalRouteFiles'] = [];
+	}
+
+	protected function tearDown(): void {
+		putenv( $this->writeOverride === false ? 'NEO4J_URL_OVERRIDE' : "NEO4J_URL_OVERRIDE=$this->writeOverride" );
+		putenv( $this->readOverride === false ? 'NEO4J_URL_READ_OVERRIDE' : "NEO4J_URL_READ_OVERRIDE=$this->readOverride" );
+		$GLOBALS['wgRestAPIAdditionalRouteFiles'] = $this->routeFiles;
+		$GLOBALS['wgNeoWikiNeo4jInternalWriteUrl'] = $this->writeUrl;
+		$GLOBALS['wgNeoWikiNeo4jInternalReadUrl'] = $this->readUrl;
+		parent::tearDown();
+	}
+
+	public function testAddsCypherRouteFileWhenConfigured(): void {
+		$GLOBALS['wgNeoWikiNeo4jInternalWriteUrl'] = 'bolt://write:7687';
+		$GLOBALS['wgNeoWikiNeo4jInternalReadUrl'] = 'bolt://read:7687';
+
+		NeoWikiExtension::onExtensionRegistration();
+
+		$this->assertCount( 1, $GLOBALS['wgRestAPIAdditionalRouteFiles'] );
+		$this->assertStringEndsWith( 'neo4jRoutes.json', $GLOBALS['wgRestAPIAdditionalRouteFiles'][0] );
+	}
+
+	public function testAddsNoRouteFileWhenUnconfigured(): void {
+		$GLOBALS['wgNeoWikiNeo4jInternalWriteUrl'] = null;
+		$GLOBALS['wgNeoWikiNeo4jInternalReadUrl'] = null;
+
+		NeoWikiExtension::onExtensionRegistration();
+
+		$this->assertSame( [], $GLOBALS['wgRestAPIAdditionalRouteFiles'] );
+	}
+
+	public function testPreservesExistingRouteFiles(): void {
+		$GLOBALS['wgRestAPIAdditionalRouteFiles'] = [ '/existing/routes.json' ];
+		$GLOBALS['wgNeoWikiNeo4jInternalWriteUrl'] = 'bolt://write:7687';
+		$GLOBALS['wgNeoWikiNeo4jInternalReadUrl'] = 'bolt://read:7687';
+
+		NeoWikiExtension::onExtensionRegistration();
+
+		$this->assertContains( '/existing/routes.json', $GLOBALS['wgRestAPIAdditionalRouteFiles'] );
+		$this->assertCount( 2, $GLOBALS['wgRestAPIAdditionalRouteFiles'] );
+	}
+
+}

--- a/tests/phpunit/OnExtensionRegistrationTest.php
+++ b/tests/phpunit/OnExtensionRegistrationTest.php
@@ -12,29 +12,25 @@ use ProfessionalWiki\NeoWiki\NeoWikiExtension;
  */
 class OnExtensionRegistrationTest extends TestCase {
 
-	private string|false $writeOverride;
-	private string|false $readOverride;
+	use HandlesNeo4jEnvOverrides;
+
 	private mixed $routeFiles;
 	private mixed $writeUrl;
 	private mixed $readUrl;
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->writeOverride = getenv( 'NEO4J_URL_OVERRIDE' );
-		$this->readOverride = getenv( 'NEO4J_URL_READ_OVERRIDE' );
 		$this->routeFiles = $GLOBALS['wgRestAPIAdditionalRouteFiles'] ?? null;
 		$this->writeUrl = $GLOBALS['wgNeoWikiNeo4jInternalWriteUrl'] ?? null;
 		$this->readUrl = $GLOBALS['wgNeoWikiNeo4jInternalReadUrl'] ?? null;
 
 		// Clear the CI env overrides so the config-value path is exercised deterministically.
-		putenv( 'NEO4J_URL_OVERRIDE' );
-		putenv( 'NEO4J_URL_READ_OVERRIDE' );
+		$this->snapshotAndClearNeo4jEnvOverrides();
 		$GLOBALS['wgRestAPIAdditionalRouteFiles'] = [];
 	}
 
 	protected function tearDown(): void {
-		putenv( $this->writeOverride === false ? 'NEO4J_URL_OVERRIDE' : "NEO4J_URL_OVERRIDE=$this->writeOverride" );
-		putenv( $this->readOverride === false ? 'NEO4J_URL_READ_OVERRIDE' : "NEO4J_URL_READ_OVERRIDE=$this->readOverride" );
+		$this->restoreNeo4jEnvOverrides();
 		$GLOBALS['wgRestAPIAdditionalRouteFiles'] = $this->routeFiles;
 		$GLOBALS['wgNeoWikiNeo4jInternalWriteUrl'] = $this->writeUrl;
 		$GLOBALS['wgNeoWikiNeo4jInternalReadUrl'] = $this->readUrl;


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/NeoWiki/issues/895

The Neo4j composition root (`Neo4jPlugin`) now owns and conditionally registers its user-facing surfaces, making the graph backend a required but pluggable dependency.

The three query surfaces gate on Neo4j being configured:

- `{{#cypher_raw}}` and `nw.query` register only when Neo4j is configured. The Lua wrapper drops `mw.neowiki.query` too, so it is genuinely absent rather than a function that fails one call deeper on a nil handler.
- `POST /neowiki/v0/query/cypher` is absent from the route table and the OpenAPI spec when unconfigured: a plugin-local route file is added to `$wgRestAPIAdditionalRouteFiles` only when configured. MediaWiki cannot filter a declared route out of the spec, so genuine absence means not declaring the route, rather than declaring one that returns `404`.
- `Neo4jPlugin` is the single builder of the Cypher query service; the REST handler and Lua runner delegate to it, which removes the duplicated validator wiring.

The Neo4j config becomes optional (nullable URLs behind a shared predicate) so the surfaces can register conditionally. That seam is what a future SPARQL/QLever backend needs, and a wiki without Neo4j no longer throws at load.

NeoWiki still needs a graph backend to deliver value, so a wiki with none configured fails loud but scoped rather than degrading silently. The content-page render path logs a clear warning and skips NeoWiki injection instead of failing the page, so plain content pages keep rendering while an admin fixes the config; pages whose wikitext uses the graph-backed surfaces (`{{#neowiki_value}}`, the `mw.neowiki` getters) still fail their parse until the no-backend degradation work in #895, while `{{#view}}` degrades to its client-side placeholder. A named `GraphBackendNotConfiguredException` marks this expected misconfiguration and gives the follow-up degradation work a catchable seam. Relation-target subject-label autocomplete degrades to an empty result, a legitimate cross-backend fallback.

Left as follow-ups: a MediaWiki-native subject→page reverse index so Subject operations work without a graph backend, and configured-but-unreachable (outage) degradation (#895, which subsumed #877).

## Review follow-ups (2026-07-11)

Four post-review commits are stacked on the original:

- 34fcd36 renames `GraphBackendNotConfigured` to `GraphBackendNotConfiguredException`, matching the codebase-wide exception naming.
- 8c08f12 tightens the new comments: drops leftover planning language, scopes the usability claim in `handleContentPage` to the boundary described above, corrects the subsumed issue reference (#877 → #895), and notes the invariant that the registration-time route gate must agree with `NeoWikiConfig::hasNeo4jBackend()`.
- 2e89398 hardens tests: the no-backend render test now asserts injection is skipped (no `ext-neowiki-app` div) and that the warning is logged; a new `QueryCypherEndToEndTest` case pins `ExplainCypherQueryValidator` in the production-wired query service (an admin query the keyword validator alone cannot catch); the env-override save/restore idiom moves into a shared `HandlesNeo4jEnvOverrides` trait; the missing write-set/read-null route-registration case is added.
- d4bbb0d updates the docs: `installation.md` no longer claims unset Bolt URLs throw at load, and `parser-functions.md` / `lua-api.md` / `query-api.md` note that the query surfaces only exist when a graph backend is configured.

## Testing

- Added or updated PHPUnit coverage: `NeoWikiConfigTest`, `NeoWikiConfigFactoryTest`, `NoGraphBackendTest`, `NullSubjectLabelLookupTest`, `ParserFunctionRegistrationTest`, `Neo4jRouteRegistrationTest`, `OnExtensionRegistrationTest`, the rewritten `CompositeCypherQueryValidatorIntegrationTest`, `QueryCypherEndToEndTest` (production validator wiring), and `RestApiDocsCoverageTest` (now also counts the plugin route file, since the Cypher route moved out of `extension.json`).
- The new tests were confirmed meaningful by seeing them fail: with the render guard removed, both the injection-skipped and warning-logged tests error on the exact `500` path; with `ExplainCypherQueryValidator` dropped from `Neo4jPlugin::newQueryService()`, the production-wiring test fails.
- Full suite green (1425 tests) including `NeoWikiLibrary`, `CypherQueryApi`, `CypherRawParserFunction`, `CompositeGraphDatabasePlugin`, and `AutoRenderMainSubject`. `make cs` and `make stan` are both clean, and CI passes on the follow-up head.
- Live smoke on a configured wiki: `POST /w/rest.php/neowiki/v0/query/cypher` returns `200 application/json`; a content page renders the main-subject infobox and the `nw.query` life-events table, with no NeoWiki console errors.

> Result of extensive design collaboration with @alistair3149, whose questions drove the key decisions: URL-presence gating, genuine REST-route absence over an in-handler `404`, and the "require a backend, fail loud but scoped" boundary that reshaped the original plan.
> Context: the NeoWiki codebase, ADR 019, issues #895, #877, and #860, and multi-agent design and review workflows over the branch.
> <sub>Written by Claude Code, `Opus 4.8` (1M context)</sub>

> **2026-07-11:** @JeroenDeDauw asked for a review with fixes pushed on top, then for this description to be brought current — two one-line directives, no correction rounds, result not yet human-reviewed. Findings came from one high-level pass plus two independent review subagents; the follow-up commits were implemented in an isolated worktree, each new test seen failing before the fix, verified with the full suite and CI.
> Context: the PR branch, the NeoWiki codebase and docs, and issues #895, #877, and #860.
> <sub>Follow-up commits written by Claude Code, `Opus 4.8 (max)` subagents; review and this update by `Fable 5 (max)`</sub>
