### PR TITLE
Store date statements as native Neo4j dates

### DIFF
--- a/DemoData/Module/NeoWikiDemo.lua
+++ b/DemoData/Module/NeoWikiDemo.lua
@@ -302,9 +302,8 @@ local PERSON_EVENTS_ROLES = {
 -- Renders the current Person page's life events as a table by reverse-querying
 -- the graph: the canonical edges run Birth -> Person, so a person's role in each
 -- event ("was born" / CIDOC P98i, mother, father) is derived here rather than
--- stored as an inverse edge. Date is read as b.Date[0] because the `date` property
--- is stored as a string list; switch to toString(b.Date[0]) if/when date is stored
--- as a native Neo4j date.
+-- stored as an inverse edge. The `date` property is stored as a native Neo4j
+-- date list; the result normalizer renders b.Date[0] as a Y-m-d string.
 function p.personEvents( frame )
 	local name = mw.title.getCurrentTitle().text
 

--- a/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jValueBuilderRegistry.php
+++ b/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jValueBuilderRegistry.php
@@ -5,6 +5,8 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence;
 
 use DateTimeImmutable;
+use Laudis\Neo4j\Types\Date;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Property\DateProperty;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\DateTimeProperty;
 use ProfessionalWiki\NeoWiki\Domain\Value\NeoValue;
 
@@ -45,7 +47,7 @@ class Neo4jValueBuilderRegistry {
 		$registry->registerBuilder( 'select', $toScalars );
 		$registry->registerBuilder( 'boolean', $toScalars );
 		$registry->registerBuilder( 'dateTime', self::buildDateTimeNeo4jValue( ... ) );
-		$registry->registerBuilder( 'date', $toScalars );
+		$registry->registerBuilder( 'date', self::buildDateNeo4jValue( ... ) );
 
 		return $registry;
 	}
@@ -59,23 +61,55 @@ class Neo4jValueBuilderRegistry {
 	 * @return DateTimeImmutable[]
 	 */
 	private static function buildDateTimeNeo4jValue( NeoValue $value ): array {
+		return self::buildParsedValues( $value, DateTimeProperty::parseStrictDateTime( ... ) );
+	}
+
+	/**
+	 * The Laudis Date type serializes to a native Neo4j date (a DateTimeImmutable
+	 * would become a datetime), so the stored values work with Cypher temporal
+	 * operations. Strings that are not strict ISO 8601 dates are omitted from the
+	 * graph projection (the revision slot stays authoritative), which also keeps
+	 * the stored list homogeneously typed.
+	 *
+	 * @return Date[]
+	 */
+	private static function buildDateNeo4jValue( NeoValue $value ): array {
+		return self::buildParsedValues( $value, self::parseNeo4jDate( ... ) );
+	}
+
+	private static function parseNeo4jDate( string $value ): ?Date {
+		$date = DateProperty::parseStrictDate( $value );
+
+		return $date === null ? null : new Date( self::daysSinceUnixEpoch( $date ) );
+	}
+
+	private static function daysSinceUnixEpoch( DateTimeImmutable $utcMidnight ): int {
+		return intdiv( $utcMidnight->getTimestamp(), 86400 );
+	}
+
+	/**
+	 * @phan-template T of object
+	 * @param callable(string): ?T $parse
+	 * @return T[]
+	 */
+	private static function buildParsedValues( NeoValue $value, callable $parse ): array {
 		$scalars = $value->toScalars();
 
 		if ( !is_array( $scalars ) ) {
 			return [];
 		}
 
-		$dateTimes = [];
+		$values = [];
 
 		foreach ( $scalars as $string ) {
-			$dateTime = is_string( $string ) ? DateTimeProperty::parseStrictDateTime( $string ) : null;
+			$parsed = is_string( $string ) ? $parse( $string ) : null;
 
-			if ( $dateTime !== null ) {
-				$dateTimes[] = $dateTime;
+			if ( $parsed !== null ) {
+				$values[] = $parsed;
 			}
 		}
 
-		return $dateTimes;
+		return $values;
 	}
 
 }

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Formats/DateFormatNeo4jTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Formats/DateFormatNeo4jTest.php
@@ -8,8 +8,10 @@ use Laudis\Neo4j\Types\Date;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyName;
 use ProfessionalWiki\NeoWiki\Domain\Statement;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\Types\DateType;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jResultNormalizer;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestPage;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
@@ -20,15 +22,13 @@ use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
 class DateFormatNeo4jTest extends NeoWikiIntegrationTestCase {
 
 	public function setUp(): void {
-		self::markTestSkipped( 'Format not supported yet' );
-		//$this->setUpNeo4j();
+		$this->setUpNeo4j();
 	}
 
-	public function testStoresAsDates(): void {
-		$store = $this->newProjectionStore();
+	private function savePageWithDateStatement(): SubjectId {
 		$subjectId = TestSubject::uniqueId();
 
-		$store->savePage( TestPage::build(
+		$this->newProjectionStore()->savePage( TestPage::build(
 			mainSubject: TestSubject::build(
 				id: $subjectId,
 				statements: new StatementList( [
@@ -40,6 +40,12 @@ class DateFormatNeo4jTest extends NeoWikiIntegrationTestCase {
 				] )
 			),
 		) );
+
+		return $subjectId;
+	}
+
+	public function testStoresAsDates(): void {
+		$subjectId = $this->savePageWithDateStatement();
 
 		$result = $this->readGraph(
 			"MATCH (n {id: '$subjectId'}) RETURN n.MyProperty[0] + duration('P3D') AS ModifiedDate1, n.MyProperty[1] as Date2"
@@ -54,6 +60,37 @@ class DateFormatNeo4jTest extends NeoWikiIntegrationTestCase {
 			new Date( 19629 ),
 			$result['Date2']
 		);
+	}
+
+	public function testStoredDatesNormalizeToIsoStrings(): void {
+		$subjectId = $this->savePageWithDateStatement();
+
+		$rows = ( new Neo4jResultNormalizer() )->convertRows(
+			$this->readGraph(
+				"MATCH (n {id: '$subjectId'}) RETURN n.MyProperty AS dates"
+			)
+		);
+
+		$this->assertSame(
+			[ 1 => [ 'dates' => [
+				1 => '2023-09-28',
+				2 => '2023-09-29',
+			] ] ],
+			$rows
+		);
+	}
+
+	public function testDateOperationsWorkOnStoredValues(): void {
+		$subjectId = $this->savePageWithDateStatement();
+
+		$result = $this->readGraph(
+			"MATCH (n {id: '$subjectId'})
+				WHERE n.MyProperty[0] < date('2023-09-29')
+					AND n.MyProperty[1] > date('2023-09-28')
+				RETURN n.id AS id"
+		);
+
+		$this->assertSame( $subjectId->text, $result->first()->get( 'id' ) );
 	}
 
 }

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectUpdaterTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectUpdaterTest.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Tests\GraphDatabasePlugins\Neo4j\Persistence;
 
 use Laudis\Neo4j\Contracts\TransactionInterface;
+use Laudis\Neo4j\Types\Date;
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
@@ -153,6 +154,44 @@ class Neo4jSubjectUpdaterTest extends TestCase {
 		$this->newSubjectUpdater()->statementsToNodeProperties( $statements );
 
 		$this->assertSame( [], $this->logger->getLogCalls()->getMessages() );
+	}
+
+	public function testConvertsDateStatementValuesToDateObjects(): void {
+		$registry = Neo4jValueBuilderRegistry::withCoreBuilders();
+
+		$statements = new StatementList( [
+			TestStatement::build( property: 'P1', value: new StringValue( 'plain' ), propertyType: 'text' ),
+			TestStatement::build(
+				property: 'P2',
+				value: new StringValue( '2024-01-01' ),
+				propertyType: 'date'
+			),
+		] );
+
+		$this->assertEquals(
+			[
+				'P1' => [ 'plain' ],
+				'P2' => [ new Date( 19723 ) ],
+			],
+			$this->newSubjectUpdater( $registry )->statementsToNodeProperties( $statements )
+		);
+	}
+
+	public function testWarnsWhenDateValuesAreDroppedFromTheProjection(): void {
+		$statements = new StatementList( [
+			TestStatement::build(
+				property: 'P1',
+				value: new StringValue( '2024-01-01', 'not a date', '2025-06-15' ),
+				propertyType: 'date'
+			),
+		] );
+
+		$this->newSubjectUpdater()->statementsToNodeProperties( $statements );
+
+		$this->assertSame(
+			[ 'Dropped 1 unpersistable value(s) of property "P1" on page 1333333337 when projecting to the graph' ],
+			$this->logger->getLogCalls()->getMessages()
+		);
 	}
 
 	public function testSkipsStatementsWithRelationType(): void {

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jValueBuilderRegistryTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jValueBuilderRegistryTest.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Tests\GraphDatabasePlugins\Neo4j\Persistence;
 
 use DateTimeImmutable;
+use Laudis\Neo4j\Types\Date;
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Domain\Value\RelationValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
@@ -89,6 +90,43 @@ class Neo4jValueBuilderRegistryTest extends TestCase {
 			$registry->buildNeo4jValue(
 				'dateTime',
 				new StringValue( '2024-01-01T12:00:00Z', '2025-06-15T08:30:00+02:00' )
+			)
+		);
+	}
+
+	public function testDateBuilderConvertsStringsToDateObjects(): void {
+		$registry = Neo4jValueBuilderRegistry::withCoreBuilders();
+
+		$this->assertEquals(
+			[
+				new Date( 19723 ), // 2024-01-01
+				new Date( 20254 ), // 2025-06-15
+				new Date( -165 ), // 1969-07-20
+			],
+			$registry->buildNeo4jValue(
+				'date',
+				new StringValue( '2024-01-01', '2025-06-15', '1969-07-20' )
+			)
+		);
+	}
+
+	public function testDateBuilderDropsValuesThatAreNotStrictIsoDates(): void {
+		$registry = Neo4jValueBuilderRegistry::withCoreBuilders();
+
+		$this->assertEquals(
+			[
+				new Date( 19723 ), // 2024-01-01
+				new Date( 20578 ), // 2026-05-05
+			],
+			$registry->buildNeo4jValue(
+				'date',
+				new StringValue(
+					'2024-01-01',
+					'Ignored bad value',
+					'2024-01-01T12:00:00Z', // Time and timezone not allowed
+					'2024-02-30', // Calendar overflow
+					'2026-05-05',
+				)
 			)
 		);
 	}


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/989
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/812

The `date` value builder projected statement values into the graph as plain strings, so Cypher
temporal operations on them silently misbehaved: comparing a string property to a `date()` value
evaluates to `null`, which excludes the row without any error. #812 fixed this bug class for
`dateTime` but left `date` behind.

The builder now parses each value with `DateProperty::parseStrictDate()` and converts it to a
Laudis `Date` (days since the Unix epoch), which the driver serializes as a native Neo4j `DATE`.
A `DateTimeImmutable` would not do: the driver would store it as a `DATETIME`, keeping date
comparisons cross-type. Unparseable values are dropped from the projection and reported through
the existing dropped-value warning, matching the `dateTime` behavior; the shared scalar-parsing
loop is extracted into a helper used by both temporal builders. The read side already renders
native dates as `Y-m-d` strings.

Existing graph data is re-typed by the standard rebuild (`maintenance/RebuildGraphDatabases.php`);
until then, pre-existing string-stored date values silently don't match temporal comparisons.

Also unskips `DateFormatNeo4jTest`, extends it with normalization and date-comparison coverage
mirroring `DateTimeFormatNeo4jTest`, and updates the DemoData module comment that anticipated
native date storage.

> <sub>AI-authored — Claude Code, `Fable 5`; one-line fix-issue ask from @malberts on #989, no correction rounds; not human-reviewed, independently AI-reviewed in a fresh `Opus 4.8` session with no blockers; TDD (new tests seen failing on master first) on a live Neo4j dev stack, full PHPUnit + PHPCS + PHPStan green, and the demo date pages confirmed rendering (native dates, chronological ordering) via automated browser (Playwright).</sub>

