### PR TITLE
Isolate graph projection failures so they never hard-fail edits

### DIFF
--- a/src/Domain/GraphDatabase/CompositeGraphDatabasePlugin.php
+++ b/src/Domain/GraphDatabase/CompositeGraphDatabasePlugin.php
@@ -4,18 +4,17 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Domain\GraphDatabase;
 
-use Exception;
 use ProfessionalWiki\NeoWiki\Domain\Page\Page;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
-use Psr\Log\LoggerInterface;
 
 /**
- * Fans a page event out to every registered graph database plugin, isolating failures per plugin.
+ * Fans a page event out to every registered graph database plugin.
  *
- * The graph projection is derived, rebuildable state (see the RebuildGraphDatabases maintenance
- * script), so a projection write must never abort the wiki edit/delete that triggered it, and one
- * failing backend must not stop the others from being written. Each plugin call is therefore
- * isolated: a throwing plugin is logged as an error and skipped, and the remaining plugins still run.
+ * This composite propagates failures: if a plugin throws, the throw escapes and later plugins do
+ * not run. That is what the RebuildGraphDatabases maintenance script needs, so it can report which
+ * pages failed to reconcile. The hook-facing production wiring wraps each plugin in a
+ * FailureIsolatingGraphDatabasePlugin so a projection failure never aborts the triggering user
+ * operation; see NeoWikiExtension.
  */
 class CompositeGraphDatabasePlugin implements GraphDatabasePlugin {
 
@@ -24,43 +23,20 @@ class CompositeGraphDatabasePlugin implements GraphDatabasePlugin {
 	 */
 	private array $plugins;
 
-	public function __construct(
-		private readonly LoggerInterface $logger,
-		GraphDatabasePlugin ...$plugins
-	) {
+	public function __construct( GraphDatabasePlugin ...$plugins ) {
 		$this->plugins = $plugins;
 	}
 
 	public function savePage( Page $page ): void {
 		foreach ( $this->plugins as $plugin ) {
-			try {
-				$plugin->savePage( $page );
-			} catch ( Exception $e ) {
-				$this->logProjectionFailure( $plugin, 'save', $page->getId(), $e );
-			}
+			$plugin->savePage( $page );
 		}
 	}
 
 	public function deletePage( PageId $pageId ): void {
 		foreach ( $this->plugins as $plugin ) {
-			try {
-				$plugin->deletePage( $pageId );
-			} catch ( Exception $e ) {
-				$this->logProjectionFailure( $plugin, 'delete', $pageId, $e );
-			}
+			$plugin->deletePage( $pageId );
 		}
-	}
-
-	private function logProjectionFailure( GraphDatabasePlugin $plugin, string $operation, PageId $pageId, Exception $e ): void {
-		$backend = $plugin::class;
-
-		$this->logger->error(
-			"NeoWiki failed to {$operation} page {$pageId->id} in graph backend {$backend}. "
-			. 'The wiki edit was not blocked, but this backend is now out of sync for that page. '
-			. 'Run the RebuildGraphDatabases maintenance script to reconcile it. '
-			. 'Underlying error: ' . $e->getMessage(),
-			[ 'exception' => $e ]
-		);
 	}
 
 }

--- a/src/Domain/GraphDatabase/CompositeGraphDatabasePlugin.php
+++ b/src/Domain/GraphDatabase/CompositeGraphDatabasePlugin.php
@@ -4,9 +4,19 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Domain\GraphDatabase;
 
+use Exception;
 use ProfessionalWiki\NeoWiki\Domain\Page\Page;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+use Psr\Log\LoggerInterface;
 
+/**
+ * Fans a page event out to every registered graph database plugin, isolating failures per plugin.
+ *
+ * The graph projection is derived, rebuildable state (see the RebuildGraphDatabases maintenance
+ * script), so a projection write must never abort the wiki edit/delete that triggered it, and one
+ * failing backend must not stop the others from being written. Each plugin call is therefore
+ * isolated: a throwing plugin is logged as an error and skipped, and the remaining plugins still run.
+ */
 class CompositeGraphDatabasePlugin implements GraphDatabasePlugin {
 
 	/**
@@ -14,20 +24,43 @@ class CompositeGraphDatabasePlugin implements GraphDatabasePlugin {
 	 */
 	private array $plugins;
 
-	public function __construct( GraphDatabasePlugin ...$plugins ) {
+	public function __construct(
+		private readonly LoggerInterface $logger,
+		GraphDatabasePlugin ...$plugins
+	) {
 		$this->plugins = $plugins;
 	}
 
 	public function savePage( Page $page ): void {
 		foreach ( $this->plugins as $plugin ) {
-			$plugin->savePage( $page );
+			try {
+				$plugin->savePage( $page );
+			} catch ( Exception $e ) {
+				$this->logProjectionFailure( $plugin, 'save', $page->getId(), $e );
+			}
 		}
 	}
 
 	public function deletePage( PageId $pageId ): void {
 		foreach ( $this->plugins as $plugin ) {
-			$plugin->deletePage( $pageId );
+			try {
+				$plugin->deletePage( $pageId );
+			} catch ( Exception $e ) {
+				$this->logProjectionFailure( $plugin, 'delete', $pageId, $e );
+			}
 		}
+	}
+
+	private function logProjectionFailure( GraphDatabasePlugin $plugin, string $operation, PageId $pageId, Exception $e ): void {
+		$backend = $plugin::class;
+
+		$this->logger->error(
+			"NeoWiki failed to {$operation} page {$pageId->id} in graph backend {$backend}. "
+			. 'The wiki edit was not blocked, but this backend is now out of sync for that page. '
+			. 'Run the RebuildGraphDatabases maintenance script to reconcile it. '
+			. 'Underlying error: ' . $e->getMessage(),
+			[ 'exception' => $e ]
+		);
 	}
 
 }

--- a/src/Domain/GraphDatabase/FailureIsolatingGraphDatabasePlugin.php
+++ b/src/Domain/GraphDatabase/FailureIsolatingGraphDatabasePlugin.php
@@ -1,0 +1,75 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\GraphDatabase;
+
+use Exception;
+use ProfessionalWiki\NeoWiki\Domain\Page\Page;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+use Psr\Log\LoggerInterface;
+use Wikimedia\Rdbms\DBError;
+use Wikimedia\RequestTimeout\TimeoutException;
+
+/**
+ * Wraps a single graph database plugin so a projection failure never aborts the wiki
+ * edit/delete/undelete that triggered it.
+ *
+ * The graph projection is derived, rebuildable state (see the RebuildGraphDatabases maintenance
+ * script), so a failing backend must not fail the triggering user operation. A throwing plugin is
+ * caught at the \Exception boundary — which covers the connection and transaction failures a down
+ * Neo4j (or SPARQL endpoint) raises — logged as an error on the NeoWiki channel, and swallowed, so
+ * the triggering operation still commits.
+ *
+ * Two kinds of throwable are deliberately let through instead of swallowed:
+ *
+ * - \Error is not caught at all. A programming bug (type error, bad method call) must surface as a
+ *   bug, not masquerade as a backend outage.
+ * - TimeoutException and DBError are re-thrown. A request timeout must keep aborting the request
+ *   rather than being defeated here, and a wiki-database error belongs to the triggering operation:
+ *   swallowing it would only mask the root cause of the commit failure that is coming anyway.
+ *
+ * Isolation is per plugin, so composing several of these (one per backend) lets one backend fail
+ * without starving the others. This decorator is used only on the hook-facing write path; the
+ * RebuildGraphDatabases maintenance path deliberately runs the propagating
+ * CompositeGraphDatabasePlugin so it can report which pages failed to reconcile. See NeoWikiExtension.
+ */
+class FailureIsolatingGraphDatabasePlugin implements GraphDatabasePlugin {
+
+	public function __construct(
+		private readonly GraphDatabasePlugin $plugin,
+		private readonly LoggerInterface $logger,
+	) {
+	}
+
+	public function savePage( Page $page ): void {
+		try {
+			$this->plugin->savePage( $page );
+		} catch ( TimeoutException | DBError $e ) {
+			throw $e;
+		} catch ( Exception $e ) {
+			$this->logProjectionFailure( 'save', $page->getId(), $e );
+		}
+	}
+
+	public function deletePage( PageId $pageId ): void {
+		try {
+			$this->plugin->deletePage( $pageId );
+		} catch ( TimeoutException | DBError $e ) {
+			throw $e;
+		} catch ( Exception $e ) {
+			$this->logProjectionFailure( 'delete', $pageId, $e );
+		}
+	}
+
+	private function logProjectionFailure( string $operation, PageId $pageId, Exception $e ): void {
+		$this->logger->error(
+			'NeoWiki failed to ' . $operation . ' page ' . $pageId->id . ' in graph backend '
+			. $this->plugin::class . '. The triggering operation was not aborted, but this backend is '
+			. 'now out of sync for that page. Run the RebuildGraphDatabases maintenance script to '
+			. 'reconcile it. Underlying error: ' . $e->getMessage(),
+			[ 'exception' => $e ]
+		);
+	}
+
+}

--- a/src/Domain/GraphDatabase/GraphDatabasePlugin.php
+++ b/src/Domain/GraphDatabase/GraphDatabasePlugin.php
@@ -7,6 +7,18 @@ namespace ProfessionalWiki\NeoWiki\Domain\GraphDatabase;
 use ProfessionalWiki\NeoWiki\Domain\Page\Page;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 
+/**
+ * Projects wiki page changes into a graph database backend.
+ *
+ * Implementations signal a projection failure by throwing. How that throw is handled depends on the
+ * call path, not on the implementation:
+ *
+ * - On the hook-facing write path (edit/delete/undelete), the production wiring isolates and logs
+ *   each plugin (via FailureIsolatingGraphDatabasePlugin), so a throw does not abort the triggering
+ *   user operation and one failing backend does not starve the others.
+ * - On maintenance rebuilds (RebuildGraphDatabases), the wiring propagates failures so they are
+ *   reported truthfully per page instead of being silently swallowed.
+ */
 interface GraphDatabasePlugin {
 
 	public function savePage( Page $page ): void;

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -45,6 +45,7 @@ use ProfessionalWiki\NeoWiki\Infrastructure\ProductionIdGenerator;
 use ProfessionalWiki\NeoWiki\Persistence\CorePagePropertyProvider;
 use ProfessionalWiki\NeoWiki\Domain\Page\PagePropertyProviderRegistry;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\CompositeGraphDatabasePlugin;
+use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\FailureIsolatingGraphDatabasePlugin;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphBackendNotConfiguredException;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphDatabasePlugin;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphDatabasePluginRegistry;
@@ -120,6 +121,7 @@ class NeoWikiExtension {
 	private bool $extensionsRegistered = false;
 	private SubjectRepository $subjectRepository;
 	private CompositeGraphDatabasePlugin $graphDatabasePlugin;
+	private CompositeGraphDatabasePlugin $isolatingGraphDatabasePlugin;
 	private GraphDatabasePluginRegistry $graphDatabasePluginRegistry;
 	private ?Neo4jPlugin $neo4jPlugin = null;
 	private ClientInterface $neo4jClient;
@@ -216,9 +218,26 @@ class NeoWikiExtension {
 		return $this->pagePropertyProviderRegistry;
 	}
 
+	/**
+	 * Hook-facing write path (edit/delete/undelete). Each backend is isolated and logged, so a
+	 * projection failure never aborts the triggering user operation and one failing backend does not
+	 * starve the others. See FailureIsolatingGraphDatabasePlugin.
+	 */
 	public function getStoreContentUC(): OnRevisionCreatedHandler {
+		return $this->newStoreContentHandler( $this->getIsolatingGraphDatabasePlugin() );
+	}
+
+	/**
+	 * Maintenance rebuild path (RebuildGraphDatabases). Failures propagate so the script reports which
+	 * pages failed to reconcile, rather than the hook path's per-plugin isolation swallowing them.
+	 */
+	private function newRebuildStoreContentHandler(): OnRevisionCreatedHandler {
+		return $this->newStoreContentHandler( $this->getGraphDatabasePlugin() );
+	}
+
+	private function newStoreContentHandler( GraphDatabasePlugin $graphDatabasePlugin ): OnRevisionCreatedHandler {
 		return new OnRevisionCreatedHandler(
-			$this->getGraphDatabasePlugin(),
+			$graphDatabasePlugin,
 			new PagePropertiesBuilder(
 				revisionStore: MediaWikiServices::getInstance()->getRevisionStore(),
 				contentHandlerFactory: MediaWikiServices::getInstance()->getContentHandlerFactory(),
@@ -228,26 +247,55 @@ class NeoWikiExtension {
 		);
 	}
 
+	/**
+	 * Propagating fan-out over every backend, used by the maintenance rebuild path so failures surface.
+	 */
 	public function getGraphDatabasePlugin(): GraphDatabasePlugin {
 		if ( !isset( $this->graphDatabasePlugin ) ) {
-			// Seed core's Neo4j plugin directly into the composite, not the registry. Registering it via
-			// the registry would make getGraphDatabasePluginRegistry() build the Neo4j plugin, whose
-			// construction transitively fires the NeoWikiRegistration hook and re-enters that accessor.
-			// Composing core here keeps the registry extension-only and the plugin order deterministic.
-			$plugins = $this->getGraphDatabasePluginRegistry()->getPlugins();
-
-			$neo4jPlugin = $this->getNeo4jPlugin();
-			if ( $neo4jPlugin !== null ) {
-				array_unshift( $plugins, $neo4jPlugin->getGraphDatabasePlugin() );
-			}
-
-			$this->graphDatabasePlugin = new CompositeGraphDatabasePlugin(
-				LoggerFactory::getInstance( 'NeoWiki' ),
-				...$plugins
-			);
+			$this->graphDatabasePlugin = new CompositeGraphDatabasePlugin( ...$this->getGraphDatabasePlugins() );
 		}
 
 		return $this->graphDatabasePlugin;
+	}
+
+	/**
+	 * Hook-path fan-out: each backend individually wrapped so a projection failure is isolated and
+	 * logged rather than aborting the triggering user operation.
+	 */
+	private function getIsolatingGraphDatabasePlugin(): GraphDatabasePlugin {
+		if ( !isset( $this->isolatingGraphDatabasePlugin ) ) {
+			$logger = LoggerFactory::getInstance( 'NeoWiki' );
+
+			$this->isolatingGraphDatabasePlugin = new CompositeGraphDatabasePlugin(
+				...array_map(
+					static fn ( GraphDatabasePlugin $plugin ) => new FailureIsolatingGraphDatabasePlugin( $plugin, $logger ),
+					$this->getGraphDatabasePlugins()
+				)
+			);
+		}
+
+		return $this->isolatingGraphDatabasePlugin;
+	}
+
+	/**
+	 * The graph database plugins to fan out to, Neo4j first when a backend is configured.
+	 *
+	 * Core's Neo4j plugin is seeded directly here, not via the registry. Registering it via the
+	 * registry would make getGraphDatabasePluginRegistry() build the Neo4j plugin, whose construction
+	 * transitively fires the NeoWikiRegistration hook and re-enters that accessor. Composing core here
+	 * keeps the registry extension-only and the plugin order deterministic.
+	 *
+	 * @return GraphDatabasePlugin[]
+	 */
+	private function getGraphDatabasePlugins(): array {
+		$plugins = $this->getGraphDatabasePluginRegistry()->getPlugins();
+
+		$neo4jPlugin = $this->getNeo4jPlugin();
+		if ( $neo4jPlugin !== null ) {
+			array_unshift( $plugins, $neo4jPlugin->getGraphDatabasePlugin() );
+		}
+
+		return $plugins;
 	}
 
 	public function getGraphDatabasePluginRegistry(): GraphDatabasePluginRegistry {
@@ -403,7 +451,7 @@ class NeoWikiExtension {
 
 	public function newSubjectPageRebuilder(): SubjectPageRebuilder {
 		return new SubjectPageRebuilder(
-			$this->getStoreContentUC(),
+			$this->newRebuildStoreContentHandler(),
 			MediaWikiServices::getInstance()->getWikiPageFactory()
 		);
 	}

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -216,6 +216,7 @@ class NeoWikiExtension {
 			// construction transitively fires the NeoWikiRegistration hook and re-enters that accessor.
 			// Composing core here keeps the registry extension-only and the plugin order deterministic.
 			$this->graphDatabasePlugin = new CompositeGraphDatabasePlugin(
+				LoggerFactory::getInstance( 'NeoWiki' ),
 				$this->getNeo4jPlugin()->getGraphDatabasePlugin(),
 				...$this->getGraphDatabasePluginRegistry()->getPlugins()
 			);

--- a/tests/phpunit/Application/RebuildPathPropagatesProjectionFailureTest.php
+++ b/tests/phpunit/Application/RebuildPathPropagatesProjectionFailureTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Application;
+
+use MediaWiki\Title\Title;
+use ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiRegistrar;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\ThrowingGraphDatabasePlugin;
+use RuntimeException;
+
+/**
+ * Guards the split between the two write paths at the wiring level: the maintenance rebuild path
+ * must run the propagating composite, so a backend failure escapes the rebuilder to where the
+ * RebuildGraphDatabases per-page catch reports it. If the rebuild path were wired with the hook
+ * path's failure-isolating composite instead, the throw would be swallowed and the script would
+ * falsely report every page as rebuilt.
+ *
+ * @covers \ProfessionalWiki\NeoWiki\NeoWikiExtension
+ * @covers \ProfessionalWiki\NeoWiki\Application\SubjectPageRebuilder
+ * @group Database
+ */
+class RebuildPathPropagatesProjectionFailureTest extends NeoWikiIntegrationTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->setUpNeo4j();
+		$this->createSchema( TestSubject::DEFAULT_SCHEMA_ID );
+		$this->markPageTableAsUsed();
+	}
+
+	protected function tearDown(): void {
+		parent::tearDown();
+		// The test rebuilds the singleton with a throwing plugin registered; reset it so later tests
+		// get a clean instance rebuilt without the temporary hook.
+		NeoWikiExtension::resetInstance();
+	}
+
+	public function testRebuildPropagatesBackendFailureSoTheScriptCanReportIt(): void {
+		$this->createPageWithSubjects( 'Rebuild failure page', TestSubject::build() );
+
+		$this->registerThrowingGraphDatabasePlugin();
+		$rebuilder = NeoWikiExtension::getInstance()->newSubjectPageRebuilder();
+
+		$this->expectException( RuntimeException::class );
+		$this->expectExceptionMessage( ThrowingGraphDatabasePlugin::FAILURE_MESSAGE );
+
+		$rebuilder->rebuild( Title::newFromText( 'Rebuild failure page' ) );
+	}
+
+	private function registerThrowingGraphDatabasePlugin(): void {
+		$this->setTemporaryHook(
+			'NeoWikiRegistration',
+			static function ( NeoWikiRegistrar $registrar ): void {
+				$registrar->addGraphDatabasePlugin( new ThrowingGraphDatabasePlugin() );
+			}
+		);
+		NeoWikiExtension::resetInstance();
+	}
+
+}

--- a/tests/phpunit/Domain/GraphDatabase/CompositeGraphDatabasePluginTest.php
+++ b/tests/phpunit/Domain/GraphDatabase/CompositeGraphDatabasePluginTest.php
@@ -6,31 +6,21 @@ namespace ProfessionalWiki\NeoWiki\Tests\Domain\GraphDatabase;
 
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\CompositeGraphDatabasePlugin;
+use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\FailureIsolatingGraphDatabasePlugin;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphDatabasePlugin;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestPage;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpyGraphDatabasePlugin;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\ThrowingGraphDatabasePlugin;
-use Psr\Log\Test\TestLogger;
+use Psr\Log\NullLogger;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\Domain\GraphDatabase\CompositeGraphDatabasePlugin
  */
 class CompositeGraphDatabasePluginTest extends TestCase {
 
-	private TestLogger $logger;
-
-	protected function setUp(): void {
-		parent::setUp();
-		$this->logger = new TestLogger();
-	}
-
-	private function newComposite( GraphDatabasePlugin ...$plugins ): CompositeGraphDatabasePlugin {
-		return new CompositeGraphDatabasePlugin( $this->logger, ...$plugins );
-	}
-
 	public function testEmptyCompositeDoesNotThrow(): void {
-		$composite = $this->newComposite();
+		$composite = new CompositeGraphDatabasePlugin();
 
 		$composite->savePage( TestPage::build() );
 		$composite->deletePage( new PageId( 1 ) );
@@ -41,7 +31,7 @@ class CompositeGraphDatabasePluginTest extends TestCase {
 	public function testSavePageDispatchesToAllPlugins(): void {
 		$spy1 = new SpyGraphDatabasePlugin();
 		$spy2 = new SpyGraphDatabasePlugin();
-		$composite = $this->newComposite( $spy1, $spy2 );
+		$composite = new CompositeGraphDatabasePlugin( $spy1, $spy2 );
 
 		$page = TestPage::build( id: 42 );
 		$composite->savePage( $page );
@@ -53,7 +43,7 @@ class CompositeGraphDatabasePluginTest extends TestCase {
 	public function testDeletePageDispatchesToAllPlugins(): void {
 		$spy1 = new SpyGraphDatabasePlugin();
 		$spy2 = new SpyGraphDatabasePlugin();
-		$composite = $this->newComposite( $spy1, $spy2 );
+		$composite = new CompositeGraphDatabasePlugin( $spy1, $spy2 );
 
 		$pageId = new PageId( 42 );
 		$composite->deletePage( $pageId );
@@ -64,7 +54,7 @@ class CompositeGraphDatabasePluginTest extends TestCase {
 
 	public function testSinglePluginReceivesAllCalls(): void {
 		$spy = new SpyGraphDatabasePlugin();
-		$composite = $this->newComposite( $spy );
+		$composite = new CompositeGraphDatabasePlugin( $spy );
 
 		$page1 = TestPage::build( id: 1 );
 		$page2 = TestPage::build( id: 2 );
@@ -76,62 +66,51 @@ class CompositeGraphDatabasePluginTest extends TestCase {
 		$this->assertCount( 1, $spy->deletedPageIds );
 	}
 
-	public function testSavePageReachesPluginsAfterAThrowingOne(): void {
+	public function testSavePagePropagatesAPluginFailure(): void {
+		$composite = new CompositeGraphDatabasePlugin( new ThrowingGraphDatabasePlugin() );
+
+		$this->expectExceptionMessage( ThrowingGraphDatabasePlugin::FAILURE_MESSAGE );
+
+		$composite->savePage( TestPage::build() );
+	}
+
+	public function testDeletePagePropagatesAPluginFailure(): void {
+		$composite = new CompositeGraphDatabasePlugin( new ThrowingGraphDatabasePlugin() );
+
+		$this->expectExceptionMessage( ThrowingGraphDatabasePlugin::FAILURE_MESSAGE );
+
+		$composite->deletePage( new PageId( 1 ) );
+	}
+
+	/**
+	 * The production hook-path wiring wraps each plugin in a FailureIsolatingGraphDatabasePlugin. This
+	 * proves that arrangement isolates per plugin: a failing backend in the middle neither aborts the
+	 * fan-out nor starves the plugins before or after it.
+	 *
+	 * @covers \ProfessionalWiki\NeoWiki\Domain\GraphDatabase\FailureIsolatingGraphDatabasePlugin
+	 */
+	public function testComposingIsolatedPluginsLetsOneFailWithoutStarvingTheOthers(): void {
 		$spyBefore = new SpyGraphDatabasePlugin();
 		$spyAfter = new SpyGraphDatabasePlugin();
-		$composite = $this->newComposite(
-			$spyBefore,
-			new ThrowingGraphDatabasePlugin(),
-			$spyAfter
+		$composite = new CompositeGraphDatabasePlugin(
+			$this->isolated( $spyBefore ),
+			$this->isolated( new ThrowingGraphDatabasePlugin() ),
+			$this->isolated( $spyAfter )
 		);
 
 		$page = TestPage::build( id: 42 );
-		$composite->savePage( $page );
-
-		$this->assertSame( [ $page ], $spyBefore->savedPages );
-		$this->assertSame( [ $page ], $spyAfter->savedPages, 'a plugin failure must not starve later plugins' );
-	}
-
-	public function testDeletePageReachesPluginsAfterAThrowingOne(): void {
-		$spyBefore = new SpyGraphDatabasePlugin();
-		$spyAfter = new SpyGraphDatabasePlugin();
-		$composite = $this->newComposite(
-			$spyBefore,
-			new ThrowingGraphDatabasePlugin(),
-			$spyAfter
-		);
-
 		$pageId = new PageId( 42 );
+		$composite->savePage( $page );
 		$composite->deletePage( $pageId );
 
+		$this->assertSame( [ $page ], $spyBefore->savedPages, 'a plugin before the failing one still runs' );
+		$this->assertSame( [ $page ], $spyAfter->savedPages, 'a plugin after the failing one is not starved' );
 		$this->assertSame( [ $pageId ], $spyBefore->deletedPageIds );
-		$this->assertSame( [ $pageId ], $spyAfter->deletedPageIds, 'a plugin failure must not starve later plugins' );
+		$this->assertSame( [ $pageId ], $spyAfter->deletedPageIds );
 	}
 
-	public function testFailingSavePageIsLoggedAsErrorWithReconciliationHint(): void {
-		$composite = $this->newComposite( new ThrowingGraphDatabasePlugin() );
-
-		$composite->savePage( TestPage::build( id: 42 ) );
-
-		$this->assertTrue( $this->logger->hasErrorThatContains( 'RebuildGraphDatabases' ) );
-		$this->assertTrue( $this->logger->hasErrorThatContains( '42' ) );
-	}
-
-	public function testFailingDeletePageIsLoggedAsErrorWithReconciliationHint(): void {
-		$composite = $this->newComposite( new ThrowingGraphDatabasePlugin() );
-
-		$composite->deletePage( new PageId( 42 ) );
-
-		$this->assertTrue( $this->logger->hasErrorThatContains( 'RebuildGraphDatabases' ) );
-		$this->assertTrue( $this->logger->hasErrorThatContains( '42' ) );
-	}
-
-	public function testSucceedingProjectionIsNotLogged(): void {
-		$composite = $this->newComposite( new SpyGraphDatabasePlugin() );
-
-		$composite->savePage( TestPage::build( id: 42 ) );
-
-		$this->assertFalse( $this->logger->hasErrorRecords() );
+	private function isolated( GraphDatabasePlugin $plugin ): FailureIsolatingGraphDatabasePlugin {
+		return new FailureIsolatingGraphDatabasePlugin( $plugin, new NullLogger() );
 	}
 
 }

--- a/tests/phpunit/Domain/GraphDatabase/CompositeGraphDatabasePluginTest.php
+++ b/tests/phpunit/Domain/GraphDatabase/CompositeGraphDatabasePluginTest.php
@@ -6,17 +6,31 @@ namespace ProfessionalWiki\NeoWiki\Tests\Domain\GraphDatabase;
 
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\CompositeGraphDatabasePlugin;
+use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphDatabasePlugin;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestPage;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpyGraphDatabasePlugin;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\ThrowingGraphDatabasePlugin;
+use Psr\Log\Test\TestLogger;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\Domain\GraphDatabase\CompositeGraphDatabasePlugin
  */
 class CompositeGraphDatabasePluginTest extends TestCase {
 
+	private TestLogger $logger;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->logger = new TestLogger();
+	}
+
+	private function newComposite( GraphDatabasePlugin ...$plugins ): CompositeGraphDatabasePlugin {
+		return new CompositeGraphDatabasePlugin( $this->logger, ...$plugins );
+	}
+
 	public function testEmptyCompositeDoesNotThrow(): void {
-		$composite = new CompositeGraphDatabasePlugin();
+		$composite = $this->newComposite();
 
 		$composite->savePage( TestPage::build() );
 		$composite->deletePage( new PageId( 1 ) );
@@ -27,7 +41,7 @@ class CompositeGraphDatabasePluginTest extends TestCase {
 	public function testSavePageDispatchesToAllPlugins(): void {
 		$spy1 = new SpyGraphDatabasePlugin();
 		$spy2 = new SpyGraphDatabasePlugin();
-		$composite = new CompositeGraphDatabasePlugin( $spy1, $spy2 );
+		$composite = $this->newComposite( $spy1, $spy2 );
 
 		$page = TestPage::build( id: 42 );
 		$composite->savePage( $page );
@@ -39,7 +53,7 @@ class CompositeGraphDatabasePluginTest extends TestCase {
 	public function testDeletePageDispatchesToAllPlugins(): void {
 		$spy1 = new SpyGraphDatabasePlugin();
 		$spy2 = new SpyGraphDatabasePlugin();
-		$composite = new CompositeGraphDatabasePlugin( $spy1, $spy2 );
+		$composite = $this->newComposite( $spy1, $spy2 );
 
 		$pageId = new PageId( 42 );
 		$composite->deletePage( $pageId );
@@ -50,7 +64,7 @@ class CompositeGraphDatabasePluginTest extends TestCase {
 
 	public function testSinglePluginReceivesAllCalls(): void {
 		$spy = new SpyGraphDatabasePlugin();
-		$composite = new CompositeGraphDatabasePlugin( $spy );
+		$composite = $this->newComposite( $spy );
 
 		$page1 = TestPage::build( id: 1 );
 		$page2 = TestPage::build( id: 2 );
@@ -60,6 +74,64 @@ class CompositeGraphDatabasePluginTest extends TestCase {
 
 		$this->assertSame( [ $page1, $page2 ], $spy->savedPages );
 		$this->assertCount( 1, $spy->deletedPageIds );
+	}
+
+	public function testSavePageReachesPluginsAfterAThrowingOne(): void {
+		$spyBefore = new SpyGraphDatabasePlugin();
+		$spyAfter = new SpyGraphDatabasePlugin();
+		$composite = $this->newComposite(
+			$spyBefore,
+			new ThrowingGraphDatabasePlugin(),
+			$spyAfter
+		);
+
+		$page = TestPage::build( id: 42 );
+		$composite->savePage( $page );
+
+		$this->assertSame( [ $page ], $spyBefore->savedPages );
+		$this->assertSame( [ $page ], $spyAfter->savedPages, 'a plugin failure must not starve later plugins' );
+	}
+
+	public function testDeletePageReachesPluginsAfterAThrowingOne(): void {
+		$spyBefore = new SpyGraphDatabasePlugin();
+		$spyAfter = new SpyGraphDatabasePlugin();
+		$composite = $this->newComposite(
+			$spyBefore,
+			new ThrowingGraphDatabasePlugin(),
+			$spyAfter
+		);
+
+		$pageId = new PageId( 42 );
+		$composite->deletePage( $pageId );
+
+		$this->assertSame( [ $pageId ], $spyBefore->deletedPageIds );
+		$this->assertSame( [ $pageId ], $spyAfter->deletedPageIds, 'a plugin failure must not starve later plugins' );
+	}
+
+	public function testFailingSavePageIsLoggedAsErrorWithReconciliationHint(): void {
+		$composite = $this->newComposite( new ThrowingGraphDatabasePlugin() );
+
+		$composite->savePage( TestPage::build( id: 42 ) );
+
+		$this->assertTrue( $this->logger->hasErrorThatContains( 'RebuildGraphDatabases' ) );
+		$this->assertTrue( $this->logger->hasErrorThatContains( '42' ) );
+	}
+
+	public function testFailingDeletePageIsLoggedAsErrorWithReconciliationHint(): void {
+		$composite = $this->newComposite( new ThrowingGraphDatabasePlugin() );
+
+		$composite->deletePage( new PageId( 42 ) );
+
+		$this->assertTrue( $this->logger->hasErrorThatContains( 'RebuildGraphDatabases' ) );
+		$this->assertTrue( $this->logger->hasErrorThatContains( '42' ) );
+	}
+
+	public function testSucceedingProjectionIsNotLogged(): void {
+		$composite = $this->newComposite( new SpyGraphDatabasePlugin() );
+
+		$composite->savePage( TestPage::build( id: 42 ) );
+
+		$this->assertFalse( $this->logger->hasErrorRecords() );
 	}
 
 }

--- a/tests/phpunit/Domain/GraphDatabase/FailureIsolatingGraphDatabasePluginTest.php
+++ b/tests/phpunit/Domain/GraphDatabase/FailureIsolatingGraphDatabasePluginTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Domain\GraphDatabase;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\FailureIsolatingGraphDatabasePlugin;
+use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphDatabasePlugin;
+use ProfessionalWiki\NeoWiki\Domain\Page\Page;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestPage;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpyGraphDatabasePlugin;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\ThrowingGraphDatabasePlugin;
+use Psr\Log\Test\TestLogger;
+use Throwable;
+use Wikimedia\Rdbms\DBError;
+use Wikimedia\RequestTimeout\TimeoutException;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Domain\GraphDatabase\FailureIsolatingGraphDatabasePlugin
+ */
+class FailureIsolatingGraphDatabasePluginTest extends TestCase {
+
+	private TestLogger $logger;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->logger = new TestLogger();
+	}
+
+	private function newDecorator( GraphDatabasePlugin $plugin ): FailureIsolatingGraphDatabasePlugin {
+		return new FailureIsolatingGraphDatabasePlugin( $plugin, $this->logger );
+	}
+
+	public function testSavePageIsDelegatedToTheWrappedPlugin(): void {
+		$spy = new SpyGraphDatabasePlugin();
+		$page = TestPage::build( id: 42 );
+
+		$this->newDecorator( $spy )->savePage( $page );
+
+		$this->assertSame( [ $page ], $spy->savedPages );
+	}
+
+	public function testDeletePageIsDelegatedToTheWrappedPlugin(): void {
+		$spy = new SpyGraphDatabasePlugin();
+		$pageId = new PageId( 42 );
+
+		$this->newDecorator( $spy )->deletePage( $pageId );
+
+		$this->assertSame( [ $pageId ], $spy->deletedPageIds );
+	}
+
+	public function testSucceedingProjectionLogsNothing(): void {
+		$this->newDecorator( new SpyGraphDatabasePlugin() )->savePage( TestPage::build( id: 42 ) );
+
+		$this->assertSame( [], $this->logger->records );
+	}
+
+	public function testFailingSaveIsSwallowedAndLoggedWithAnActionableMessage(): void {
+		$this->newDecorator( new ThrowingGraphDatabasePlugin() )->savePage( TestPage::build( id: 42 ) );
+
+		$this->assertTrue( $this->logger->hasErrorRecords(), 'the failure is logged at error level' );
+
+		$message = $this->logger->records[0]['message'];
+		$this->assertStringContainsString( 'save', $message );
+		$this->assertStringContainsString( '42', $message );
+		$this->assertStringContainsString( ThrowingGraphDatabasePlugin::class, $message, 'names the failing backend' );
+		$this->assertStringContainsString( ThrowingGraphDatabasePlugin::FAILURE_MESSAGE, $message, 'carries the underlying error' );
+		$this->assertStringContainsString( 'RebuildGraphDatabases', $message, 'points at the reconciliation script' );
+		$this->assertStringContainsString( 'triggering operation', $message, 'stays operation-neutral' );
+	}
+
+	public function testFailingDeleteIsSwallowedAndLoggedForTheDeleteOperation(): void {
+		$this->newDecorator( new ThrowingGraphDatabasePlugin() )->deletePage( new PageId( 42 ) );
+
+		$this->assertTrue( $this->logger->hasErrorRecords() );
+
+		$message = $this->logger->records[0]['message'];
+		$this->assertStringContainsString( 'delete', $message, 'reflects the actual operation, not a hardcoded edit/save' );
+		$this->assertStringContainsString( '42', $message );
+		$this->assertStringContainsString( 'RebuildGraphDatabases', $message );
+	}
+
+	public function testRequestTimeoutIsReThrownRatherThanSwallowed(): void {
+		$decorator = $this->newDecorator( $this->pluginThrowing( new TimeoutException( 'request exceeded the limit', 30.0 ) ) );
+
+		$this->expectException( TimeoutException::class );
+
+		$decorator->savePage( TestPage::build() );
+	}
+
+	public function testDatabaseErrorIsReThrownRatherThanSwallowed(): void {
+		$decorator = $this->newDecorator( $this->pluginThrowing( new DBError( null, 'the wiki database is down' ) ) );
+
+		$this->expectException( DBError::class );
+
+		$decorator->deletePage( new PageId( 1 ) );
+	}
+
+	private function pluginThrowing( Throwable $error ): GraphDatabasePlugin {
+		return new class( $error ) implements GraphDatabasePlugin {
+
+			public function __construct(
+				private readonly Throwable $error
+			) {
+			}
+
+			public function savePage( Page $page ): void {
+				throw $this->error;
+			}
+
+			public function deletePage( PageId $pageId ): void {
+				throw $this->error;
+			}
+
+		};
+	}
+
+}

--- a/tests/phpunit/EntryPoints/ExtensionGraphDatabasePluginDispatchTest.php
+++ b/tests/phpunit/EntryPoints/ExtensionGraphDatabasePluginDispatchTest.php
@@ -20,9 +20,11 @@ use ProfessionalWiki\RedHerb\RedHerbGraphDatabasePlugin;
  * extension-registered plugins, not just that they get added to the registry. RedHerb
  * registers a real GraphDatabasePlugin via the NeoWikiRegistration hook; this test reads
  * the live registered instance back out of the registry and confirms it recorded the
- * save/delete events that NeoWikiExtension::getGraphDatabasePlugin() fanned out to it.
+ * save/delete events that the hook-facing wiring fanned out to it, passing cleanly through
+ * the per-plugin failure isolation.
  *
  * @covers \ProfessionalWiki\NeoWiki\Domain\GraphDatabase\CompositeGraphDatabasePlugin
+ * @covers \ProfessionalWiki\NeoWiki\Domain\GraphDatabase\FailureIsolatingGraphDatabasePlugin
  * @covers \ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphDatabasePluginRegistry
  * @group Database
  */

--- a/tests/phpunit/EntryPoints/OnRevisionCreatedHandlerTest.php
+++ b/tests/phpunit/EntryPoints/OnRevisionCreatedHandlerTest.php
@@ -8,7 +8,7 @@ use MediaWiki\Revision\RevisionAccessException;
 use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Revision\RevisionSlots;
 use MediaWiki\User\UserIdentityValue;
-use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\CompositeGraphDatabasePlugin;
+use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\FailureIsolatingGraphDatabasePlugin;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphDatabasePlugin;
 use ProfessionalWiki\NeoWiki\Domain\Page\PagePropertyProviderRegistry;
 use ProfessionalWiki\NeoWiki\EntryPoints\OnRevisionCreatedHandler;
@@ -80,9 +80,10 @@ class OnRevisionCreatedHandlerTest extends NeoWikiIntegrationTestCase {
 	public function testUnreachableBackendDoesNotHardFailRevisionHandling(): void {
 		$revision = $this->createPageWithSubjects( 'Page with a failing backend', TestSubject::build() );
 
-		// The isolating composite is what production wires into the handler, wrapping a backend that is down.
+		// The isolating decorator is what production wires around each backend on the hook path; here it
+		// wraps a backend that is down.
 		$handler = $this->newHandlerWith(
-			new CompositeGraphDatabasePlugin( new NullLogger(), new ThrowingGraphDatabasePlugin() )
+			new FailureIsolatingGraphDatabasePlugin( new ThrowingGraphDatabasePlugin(), new NullLogger() )
 		);
 
 		$wrote = $handler->onRevisionCreated( $revision, new UserIdentityValue( 1, 'Tester' ) );

--- a/tests/phpunit/EntryPoints/OnRevisionCreatedHandlerTest.php
+++ b/tests/phpunit/EntryPoints/OnRevisionCreatedHandlerTest.php
@@ -8,12 +8,16 @@ use MediaWiki\Revision\RevisionAccessException;
 use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Revision\RevisionSlots;
 use MediaWiki\User\UserIdentityValue;
+use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\CompositeGraphDatabasePlugin;
+use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphDatabasePlugin;
 use ProfessionalWiki\NeoWiki\Domain\Page\PagePropertyProviderRegistry;
 use ProfessionalWiki\NeoWiki\EntryPoints\OnRevisionCreatedHandler;
 use ProfessionalWiki\NeoWiki\PagePropertiesBuilder;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpyGraphDatabasePlugin;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\ThrowingGraphDatabasePlugin;
+use Psr\Log\NullLogger;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\EntryPoints\OnRevisionCreatedHandler
@@ -73,11 +77,28 @@ class OnRevisionCreatedHandlerTest extends NeoWikiIntegrationTestCase {
 		$this->assertCount( 1, $this->graphStore->savedPages );
 	}
 
+	public function testUnreachableBackendDoesNotHardFailRevisionHandling(): void {
+		$revision = $this->createPageWithSubjects( 'Page with a failing backend', TestSubject::build() );
+
+		// The isolating composite is what production wires into the handler, wrapping a backend that is down.
+		$handler = $this->newHandlerWith(
+			new CompositeGraphDatabasePlugin( new NullLogger(), new ThrowingGraphDatabasePlugin() )
+		);
+
+		$wrote = $handler->onRevisionCreated( $revision, new UserIdentityValue( 1, 'Tester' ) );
+
+		$this->assertTrue( $wrote, 'a projection write to an unreachable backend must not propagate out of the handler' );
+	}
+
 	private function newHandler(): OnRevisionCreatedHandler {
+		return $this->newHandlerWith( $this->graphStore );
+	}
+
+	private function newHandlerWith( GraphDatabasePlugin $graphStore ): OnRevisionCreatedHandler {
 		$services = $this->getServiceContainer();
 
 		return new OnRevisionCreatedHandler(
-			$this->graphStore,
+			$graphStore,
 			new PagePropertiesBuilder(
 				revisionStore: $services->getRevisionStore(),
 				contentHandlerFactory: $services->getContentHandlerFactory(),

--- a/tests/phpunit/TestDoubles/ThrowingGraphDatabasePlugin.php
+++ b/tests/phpunit/TestDoubles/ThrowingGraphDatabasePlugin.php
@@ -15,7 +15,7 @@ use RuntimeException;
  */
 class ThrowingGraphDatabasePlugin implements GraphDatabasePlugin {
 
-	public const FAILURE_MESSAGE = 'projection backend unreachable';
+	public const string FAILURE_MESSAGE = 'projection backend unreachable';
 
 	public function savePage( Page $page ): void {
 		throw new RuntimeException( self::FAILURE_MESSAGE );

--- a/tests/phpunit/TestDoubles/ThrowingGraphDatabasePlugin.php
+++ b/tests/phpunit/TestDoubles/ThrowingGraphDatabasePlugin.php
@@ -1,0 +1,28 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\TestDoubles;
+
+use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphDatabasePlugin;
+use ProfessionalWiki\NeoWiki\Domain\Page\Page;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+use RuntimeException;
+
+/**
+ * Stands in for a graph backend that is down: every projection write throws,
+ * the way an unreachable Neo4j or SPARQL endpoint does.
+ */
+class ThrowingGraphDatabasePlugin implements GraphDatabasePlugin {
+
+	public const FAILURE_MESSAGE = 'projection backend unreachable';
+
+	public function savePage( Page $page ): void {
+		throw new RuntimeException( self::FAILURE_MESSAGE );
+	}
+
+	public function deletePage( PageId $pageId ): void {
+		throw new RuntimeException( self::FAILURE_MESSAGE );
+	}
+
+}


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/1024

The graph projection is derived, rebuildable state, so a projection write must never abort the wiki edit/delete/undelete that triggered it, and one failing backend must not block writes to the others. The *maintenance rebuild* has the opposite need: it must surface failures so an admin knows the graph is still out of sync.

## Two write paths, two failure policies

Failure handling now depends on the call path, not on the plugin:

- **Hook path (edit / delete / undelete).** `getStoreContentUC()` composes each backend wrapped in a new `FailureIsolatingGraphDatabasePlugin`. A throwing backend is caught, logged as an error on the `NeoWiki` channel, and skipped, so the triggering operation still commits and the other backends still run.
- **Rebuild path (`RebuildGraphDatabases`).** `newSubjectPageRebuilder()` uses the plain, propagating `CompositeGraphDatabasePlugin`. Failures escape to the script's per-page `catch`, which reports `Failed <page>: …` and a truthful `Rebuilt X of N` count.

`NeoWikiExtension` splits the two via one private handler builder plus two named accessors, so the composition is not duplicated. The `GraphDatabasePlugin` interface documents the contract: implementations signal failure by throwing; the wiring decides whether that throw is isolated or propagated.

This replaces the first cut, where the isolation lived *inside* `CompositeGraphDatabasePlugin` and was therefore shared by the rebuild path too — so `RebuildGraphDatabases` silently swallowed backend failures and falsely printed `Rebuilt N of N`, gutting the remediation story. The composite is now a plain, propagating fan-out again.

## The decorator

`FailureIsolatingGraphDatabasePlugin` wraps one backend. On `savePage` / `deletePage` it delegates inside a `try`/`catch` and, on failure, logs an operation-neutral error naming the backend, the operation, the page id, the underlying error, and the `RebuildGraphDatabases` reconciliation hint (with `[ 'exception' => $e ]` context). Deliberately:

- **`\Error` is not caught** — a programming bug must surface, not masquerade as a backend outage.
- **`TimeoutException` and `DBError` are re-thrown** — a request timeout must keep aborting the request, and a wiki-database error belongs to the triggering operation (swallowing it would only mask the root cause of the commit failure that is coming anyway).

Placement: next to `CompositeGraphDatabasePlugin` in `src/Domain/GraphDatabase/`. Its non-domain dependencies are the PSR-3 `LoggerInterface` and the `Wikimedia\Rdbms\DBError` / `Wikimedia\RequestTimeout\TimeoutException` classes named in the re-throw clause — the coupling the re-throw semantics buy — and it is a structural sibling of the composite. The existing decorator precedent (`CachingSchemaLookup`) lives in Persistence only because it is coupled to concrete caching infrastructure, which does not apply here.

## Deliberately out of scope

- **No-backend-configured degradation** landed via #1016 (conditional surface registration + the `GraphBackendNotConfigured` seam), now merged into this branch. This change is the configured-but-unreachable (outage) follow-up that #1016 deferred.
- **No job-queue / DeferredUpdate retry** of failed projections. `RebuildGraphDatabases` is the reconciliation path.

## Open questions

- The issue asked for "a log channel plus a signal admins can act on". The error log is that signal, but on a default install the `NeoWiki` log channel is often unrouted — verified here, the error reached no log file or container stderr. In practice the **truthful `RebuildGraphDatabases` output is the reliable signal**. A stronger persistent signal (a tracked "graph out of sync" flag, a dashboard, or an alert) remains a deliberate follow-up, not built here.

## Testing

- **Decorator unit tests:** delegation on success; swallow-and-log on failure (asserting the message names the backend, carries the underlying error, points at `RebuildGraphDatabases`, and stays operation-neutral); no log on success; and the two re-throws (`TimeoutException`, `DBError`) each in its own test.
- **Composite tests:** now assert propagation, plus a composite-of-decorated case proving per-plugin isolation with spies *before and after* the throwing plugin.
- **New wiring-level test:** drives `newSubjectPageRebuilder()` with a registered throwing plugin and asserts the failure escapes the rebuilder — exactly where the maintenance script's per-page `catch` sees it. This guards the regression that this revision fixes.
- Full suite green (1490 tests), `make cs` (phpcs + phpstan level 9) clean.
- **Live end-to-end on the dev stack:** with Neo4j stopped, `RebuildGraphDatabases` printed `Failed …` for every page and `Rebuilt 0 of 75 pages`, while a subject-page edit still committed (new revision); restarting Neo4j and rerunning reconciled `75 of 75`.

> Scope for #1024 was drafted in an orchestrating Claude session and approved by @JeroenDeDauw; this revision was produced autonomously by a background agent, with no human review of the diff yet. An adversarial AI review round in the same session flagged two blocking issues in the first cut — the maintenance rebuild path falsely reporting success, and a post-#1016 merge conflict on `NeoWikiExtension.php` — which this revision fixes. Test-driven (decorator, wiring-split, and rebuild-path tests), then verified with the full PHPUnit suite, phpcs and phpstan, and a live end-to-end check that stopped this stack's Neo4j, confirmed the rebuild script now reports failures truthfully and that a subject edit still commits, then reconciled via `RebuildGraphDatabases`.
> Context: the NeoWiki graph-plugin composite and edit/rebuild wiring, issues #1024 / #895 / #877, the merged #1016 (no-backend degradation), and ADR 019.
> <sub>Written by Claude Code, `Opus 4.8 (max)`</sub>

