### PR TITLE
Implement the native RDF projection and RDF export

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
 		"composer/installers": "^2|^1.0.1",
 		"opis/json-schema": "^2.3.0",
 		"laudis/neo4j-php-client": "^3.1.2",
+		"pietercolpaert/hardf": "0.6.2",
 		"jeroen/psr-log-test-doubles": "^3.0.0",
 		"jeroen/file-fetcher": "^6.1.0",
 		"ext-json": "*",

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Key docs:
 * [Graph Model](reference/graph-model.md) - Neo4j node and relationship structure
 * [Query API](reference/query-api.md) - REST endpoint for read-only Cypher queries against the graph backend
 * [REST API](reference/rest-api.md) - The complete `/neowiki/v0/*` endpoint reference, plus the generated OpenAPI spec served at `/rest.php/specs/v0/module/-`
+* [RDF Export](reference/rdf-export.md) - Native RDF projection: config, IRI scheme, the per-page export endpoint, and the bulk dump script
 * [Extending NeoWiki](reference/extending.md) - How other extensions add property types, contribute graph data, and reuse NeoWiki's UI
 * [Installation & Maintenance](operations/installation.md) - Sysadmin guide to installing and maintaining NeoWiki
 * [Architecture Decision Records](adr/001-domain-centric-architecture.md) - Numbered, dated architectural decisions

--- a/docs/reference/extending.md
+++ b/docs/reference/extending.md
@@ -79,10 +79,24 @@ literals, keyed by the Property Type name. It returns a list of `Literal`s (one 
 ```php
 $registrar->addRdfValueMapper(
 	ColorType::NAME,
-	static fn ( $value ) => array_map(
-		static fn ( string $hex ) => RdfLiteralFactory::typed( $hex, 'string' ),
-		$value->toScalars()
-	)
+	static function ( NeoValue $value ): array {
+		// Your mapper is called for whatever a Statement holds, so guard the value shape.
+		$scalars = $value->toScalars();
+
+		if ( !is_array( $scalars ) ) {
+			return [];
+		}
+
+		$literals = [];
+
+		foreach ( $scalars as $part ) {
+			if ( is_scalar( $part ) ) {
+				$literals[] = RdfLiteralFactory::typed( (string)$part, 'string' );
+			}
+		}
+
+		return $literals;
+	}
 );
 ```
 

--- a/docs/reference/extending.md
+++ b/docs/reference/extending.md
@@ -71,6 +71,24 @@ keyed by the Property Type name:
 $registrar->addNeo4jValueBuilder( ColorType::NAME, static fn ( $value ) => $value->toScalars() );
 ```
 
+#### Contributing RDF value mappers
+
+For the [RDF export](rdf-export.md), register a mapper that turns your Property Type's value into RDF
+literals, keyed by the Property Type name. It returns a list of `Literal`s (one per value part):
+
+```php
+$registrar->addRdfValueMapper(
+	ColorType::NAME,
+	static fn ( $value ) => array_map(
+		static fn ( string $hex ) => RdfLiteralFactory::typed( $hex, 'string' ),
+		$value->toScalars()
+	)
+);
+```
+
+Without a mapper, a Property Type's Statements are omitted from the RDF export, just as they are from the
+Neo4j projection.
+
 ### Page Property Providers
 
 Page Property Providers contribute key/value metadata to the Page node in the graph (queryable via Cypher;

--- a/docs/reference/rdf-export.md
+++ b/docs/reference/rdf-export.md
@@ -70,7 +70,7 @@ curl 'https://wiki.example/rest.php/neowiki/v0/page/42/rdf?format=turtle'
 one named graph per page. Progress goes to stderr so stdout stays a clean RDF document.
 
 ```sh
-php maintenance/run.php extensions/NeoWiki/maintenance/DumpRdf.php > dump.trig
+php maintenance/run.php NeoWiki:DumpRdf > dump.trig
 ```
 
 ## Not covered here

--- a/docs/reference/rdf-export.md
+++ b/docs/reference/rdf-export.md
@@ -36,15 +36,22 @@ All NeoWiki IRIs live under `$base` (`$wgNeoWikiRdfBaseUri`). Standard vocabular
 | `neo-rel:` | `$base/relation/` | Relation node IRIs (`neo-rel:r1demo8aaaaaaD6`) |
 | `neo-page:` | `$base/page/` | Page IRIs, which are also the named-graph IRIs (`neo-page:42`) |
 
-Property and Schema names form the local part of their IRI by substituting spaces with underscores
-(e.g. `Has author` → `neo-prop:Has_author`). **Caveat:** a name that already contains an underscore
-collides with the space-substituted form of the corresponding spaced name (`Has author` and
-`Has_author` share a predicate IRI). The native projection accepts this.
+Property and Schema names form the local part of their IRI: spaces become underscores
+(e.g. `Has author` → `neo-prop:Has_author`), and any character that is illegal in an IRI (`%`, the
+specials `< > " { } | ^ \`, backtick, and control characters) is percent-encoded so an authored name
+can never break out of its IRI or forge extra triples. Non-ASCII Unicode is kept raw, so multilingual
+names stay readable. **Caveat:** the space→underscore step collides when a name already contains an
+underscore (`Has author` and `Has_author` share the `neo-prop:Has_author` predicate IRI). The native
+projection accepts this. (The base URI is trusted admin config and is not encoded.)
 
 Value types map to `xsd` datatypes: `text`/`select` → `xsd:string`, `url` → `xsd:anyURI`, `number` →
 `xsd:decimal` (or `xsd:integer` when fractionless), `boolean` → `xsd:boolean`, `date` → `xsd:date`,
 `date-time` → `xsd:dateTime`. Extensions map their own property types via
 [`addRdfValueMapper`](extending.md#contributing-rdf-value-mappers).
+
+A Subject whose Schema is unavailable (for example, its Schema page was deleted) is omitted from the
+projection entirely — the same graceful degradation as the Neo4j projection — so the two stores always
+describe the same set of entities. A warning is logged for each omitted Subject.
 
 ## Endpoint
 
@@ -55,8 +62,8 @@ back to the `Accept` header, then to TriG:
 
 | `format` | `Accept` | Content-Type | Named graph |
 |---|---|---|---|
-| `trig` (default) | `application/trig` | `application/trig` | yes |
-| `turtle` | `text/turtle` | `text/turtle` | no (same triples, no graph wrapper) |
+| `trig` (default) | `application/trig` | `application/trig; charset=utf-8` | yes |
+| `turtle` | `text/turtle` | `text/turtle; charset=utf-8` | no (same triples, no graph wrapper) |
 
 Returns `404` when the page does not exist or has no NeoWiki Subject data.
 

--- a/docs/reference/rdf-export.md
+++ b/docs/reference/rdf-export.md
@@ -1,0 +1,81 @@
+---
+title: RDF Export
+order: 8
+---
+# RDF Export
+
+NeoWiki projects its data to RDF in its own vocabulary — the **native projection**. Each wiki page
+becomes a named graph containing its page metadata, its Subjects (one RDF resource each), their
+Statements, and their Relations. The projection is lossless and self-sufficient.
+
+The model is specified in [NativeRdfProjection.md](../planning/NativeRdfProjection.md); this page is
+the as-built reference for the export surface (config, IRI scheme, endpoint, script). The SPARQL
+store and live sync, ontology mappings, and RDF import are separate, later concerns.
+
+## Configuration
+
+| Setting | Default | Purpose |
+|---|---|---|
+| `$wgNeoWikiRdfBaseUri` | the wiki's canonical URL (`$wgCanonicalServer`) | Base URI under which all NeoWiki IRIs are minted. |
+
+The base URI is wiki-level on purpose: sibling projections (native and, later, ontology-mapped)
+describe the same entities, so their Subject IRIs must be identical across stores. Set it explicitly
+to align with an institutional URI policy.
+
+## IRI scheme
+
+All NeoWiki IRIs live under `$base` (`$wgNeoWikiRdfBaseUri`). Standard vocabulary (`rdf:`, `rdfs:`,
+`xsd:`, `dcterms:`) is used for standard concepts.
+
+| Prefix | Namespace | Used for |
+|---|---|---|
+| `neo:` | `$base/ontology/` | NeoWiki vocabulary terms (`neo:Page`, `neo:Relation`, `neo:hasSubject`, `neo:source`, …) |
+| `neo-subj:` | `$base/entity/` | Subject IRIs (`neo-subj:s1demo8aaaaaab5`) |
+| `neo-prop:` | `$base/prop/` | Property and Relation-type predicates (`neo-prop:Has_author`) |
+| `neo-schema:` | `$base/schema/` | Schema classes (`neo-schema:Person`) |
+| `neo-rel:` | `$base/relation/` | Relation node IRIs (`neo-rel:r1demo8aaaaaaD6`) |
+| `neo-page:` | `$base/page/` | Page IRIs, which are also the named-graph IRIs (`neo-page:42`) |
+
+Property and Schema names form the local part of their IRI by substituting spaces with underscores
+(e.g. `Has author` → `neo-prop:Has_author`). **Caveat:** a name that already contains an underscore
+collides with the space-substituted form of the corresponding spaced name (`Has author` and
+`Has_author` share a predicate IRI). The native projection accepts this.
+
+Value types map to `xsd` datatypes: `text`/`select` → `xsd:string`, `url` → `xsd:anyURI`, `number` →
+`xsd:decimal` (or `xsd:integer` when fractionless), `boolean` → `xsd:boolean`, `date` → `xsd:date`,
+`date-time` → `xsd:dateTime`. Extensions map their own property types via
+[`addRdfValueMapper`](extending.md#contributing-rdf-value-mappers).
+
+## Endpoint
+
+`GET /rest.php/neowiki/v0/page/{pageId}/rdf`
+
+Returns the page's native projection. The format is chosen by the `format` query parameter, falling
+back to the `Accept` header, then to TriG:
+
+| `format` | `Accept` | Content-Type | Named graph |
+|---|---|---|---|
+| `trig` (default) | `application/trig` | `application/trig` | yes |
+| `turtle` | `text/turtle` | `text/turtle` | no (same triples, no graph wrapper) |
+
+Returns `404` when the page does not exist or has no NeoWiki Subject data.
+
+```sh
+curl 'https://wiki.example/rest.php/neowiki/v0/page/42/rdf?format=turtle'
+```
+
+## Bulk dump
+
+`maintenance/DumpRdf.php` streams the native projection of **every** subject page to stdout as TriG,
+one named graph per page. Progress goes to stderr so stdout stays a clean RDF document.
+
+```sh
+php maintenance/run.php extensions/NeoWiki/maintenance/DumpRdf.php > dump.trig
+```
+
+## Not covered here
+
+- SPARQL store and live sync (the projection feeds them, but they are a separate concern).
+- Ontology mappings (CIDOC-CRM, EDM, …), which project into standard-ontology terms instead.
+- RDF import.
+- RDFS/OWL self-description of Schemas.

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -49,6 +49,7 @@ Subjects and arrange them.
 | Endpoint | Description |
 |---|---|
 | `GET /neowiki/v0/page/{pageId}/subjects` | List a page's main and child Subjects. `expand` with `schemas` or `relations`. |
+| `GET /neowiki/v0/page/{pageId}/rdf` | Export the page's Subjects and metadata as RDF. `format` is `trig` (default) or `turtle`. See [RDF export](rdf-export.md). |
 | `POST /neowiki/v0/page/{pageId}/mainSubject` | Create the page's main Subject. |
 | `PUT /neowiki/v0/page/{pageId}/mainSubject` | Promote a child Subject to main, or clear it. |
 | `POST /neowiki/v0/page/{pageId}/childSubjects` | Create a child Subject on the page. |

--- a/extension.json
+++ b/extension.json
@@ -169,6 +169,10 @@
 		"NeoWikiNeo4jInternalReadUrl": {
 			"description": "Bolt URL NeoWiki uses for read and query traffic against Neo4j; should use a least-privilege Neo4j user.",
 			"value": null
+		},
+		"NeoWikiRdfBaseUri": {
+			"description": "Base URI under which the RDF export mints all NeoWiki IRIs (entity, property, schema, page, etc.). When null, defaults to the wiki's canonical URL ($wgCanonicalServer). Wiki-level on purpose, so sibling projections describe the same entities with identical IRIs.",
+			"value": null
 		}
 	},
 
@@ -193,6 +197,11 @@
 			"path": "/neowiki/v0/page/{pageId}/subjects",
 			"method": [ "GET" ],
 			"factory": "ProfessionalWiki\\NeoWiki\\NeoWikiExtension::newGetPageSubjectsApi"
+		},
+		{
+			"path": "/neowiki/v0/page/{pageId}/rdf",
+			"method": [ "GET" ],
+			"factory": "ProfessionalWiki\\NeoWiki\\NeoWikiExtension::newExportPageRdfApi"
 		},
 		{
 			"path": "/neowiki/v0/page/{pageId}/mainSubject",

--- a/maintenance/DumpRdf.php
+++ b/maintenance/DumpRdf.php
@@ -6,6 +6,7 @@ namespace ProfessionalWiki\NeoWiki\Maintenance;
 
 use Maintenance;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Storage\NameTableAccessException;
 use ProfessionalWiki\NeoWiki\Application\Rdf\RdfPageLoader;
 use ProfessionalWiki\NeoWiki\Application\Rdf\RdfPageProjector;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
@@ -73,7 +74,14 @@ class DumpRdf extends Maintenance {
 	 */
 	private function getSubjectPageIds(): array {
 		$services = MediaWikiServices::getInstance();
-		$roleId = $services->getSlotRoleStore()->getId( MediaWikiSubjectRepository::SLOT_NAME );
+
+		try {
+			$roleId = $services->getSlotRoleStore()->getId( MediaWikiSubjectRepository::SLOT_NAME );
+		} catch ( NameTableAccessException ) {
+			// No page has ever stored a Subject, so the slot role was never registered. There is
+			// nothing to dump; emit an empty document instead of crashing.
+			return [];
+		}
 
 		$rows = $this->getReplicaDB()->newSelectQueryBuilder()
 			->select( 'page_id' )

--- a/maintenance/DumpRdf.php
+++ b/maintenance/DumpRdf.php
@@ -1,0 +1,93 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Maintenance;
+
+use Maintenance;
+use MediaWiki\MediaWikiServices;
+use ProfessionalWiki\NeoWiki\Application\Rdf\RdfPageLoader;
+use ProfessionalWiki\NeoWiki\Application\Rdf\RdfPageProjector;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfFormat;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfStreamWriter;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\MediaWikiSubjectRepository;
+
+$basePath = getenv( 'MW_INSTALL_PATH' ) !== false ? getenv( 'MW_INSTALL_PATH' ) : __DIR__ . '/../../..';
+
+require_once $basePath . '/maintenance/Maintenance.php';
+
+class DumpRdf extends Maintenance {
+
+	public function __construct() {
+		parent::__construct();
+
+		$this->requireExtension( 'NeoWiki' );
+		$this->addDescription(
+			'Streams the native RDF projection of every subject page to stdout as TriG, one named '
+			. 'graph per page. Progress is written to stderr so stdout stays a clean RDF document.'
+		);
+	}
+
+	public function execute(): void {
+		$extension = NeoWikiExtension::getInstance();
+		$loader = $extension->newRdfPageLoader();
+		$projector = $extension->newRdfPageProjector();
+		$writer = $extension->getRdfSerializer()->newWriter( RdfFormat::TriG );
+
+		$pageIds = $this->getSubjectPageIds();
+		$this->error( 'Dumping RDF for ' . count( $pageIds ) . ' subject pages...' );
+
+		$dumped = 0;
+
+		foreach ( $pageIds as $pageId ) {
+			if ( $this->dumpPage( $pageId, $loader, $projector, $writer ) ) {
+				$dumped++;
+			}
+		}
+
+		$this->output( $writer->finish() );
+		$this->error( "Dumped $dumped of " . count( $pageIds ) . ' pages.' );
+	}
+
+	private function dumpPage(
+		int $pageId,
+		RdfPageLoader $loader,
+		RdfPageProjector $projector,
+		RdfStreamWriter $writer
+	): bool {
+		$page = $loader->loadByPageId( new PageId( $pageId ) );
+
+		if ( $page === null ) {
+			return false;
+		}
+
+		$this->output( $writer->write( $projector->projectPage( $page ) ) );
+
+		return true;
+	}
+
+	/**
+	 * @return int[] Page IDs of every page whose latest revision carries the NeoWiki subject slot.
+	 */
+	private function getSubjectPageIds(): array {
+		$services = MediaWikiServices::getInstance();
+		$roleId = $services->getSlotRoleStore()->getId( MediaWikiSubjectRepository::SLOT_NAME );
+
+		$rows = $this->getReplicaDB()->newSelectQueryBuilder()
+			->select( 'page_id' )
+			->from( 'page' )
+			->join( 'slots', null, 'slot_revision_id = page_latest' )
+			->where( [ 'slot_role_id' => $roleId ] )
+			->orderBy( 'page_id' )
+			->caller( __METHOD__ )
+			->fetchFieldValues();
+
+		return array_map( 'intval', $rows );
+	}
+
+}
+
+$maintClass = DumpRdf::class;
+require_once RUN_MAINTENANCE_IF_MAIN;

--- a/src/Application/Rdf/RdfPageExporter.php
+++ b/src/Application/Rdf/RdfPageExporter.php
@@ -1,0 +1,34 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application\Rdf;
+
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfFormat;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfSerializer;
+
+/**
+ * Exports a single page as a self-contained RDF document. Returns null when the page has no NeoWiki
+ * data to export (missing page or no Subject slot), so callers can map that to a 404.
+ */
+readonly class RdfPageExporter {
+
+	public function __construct(
+		private RdfPageLoader $loader,
+		private RdfPageProjector $projector,
+		private RdfSerializer $serializer,
+	) {
+	}
+
+	public function exportByPageId( PageId $pageId, RdfFormat $format ): ?string {
+		$page = $this->loader->loadByPageId( $pageId );
+
+		if ( $page === null ) {
+			return null;
+		}
+
+		return $this->serializer->serialize( $this->projector->projectPage( $page ), $format );
+	}
+
+}

--- a/src/Application/Rdf/RdfPageLoader.php
+++ b/src/Application/Rdf/RdfPageLoader.php
@@ -1,0 +1,81 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application\Rdf;
+
+use MediaWiki\Page\WikiPageFactory;
+use MediaWiki\Revision\RevisionRecord;
+use MediaWiki\Title\Title;
+use ProfessionalWiki\NeoWiki\Domain\Page\Page;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
+use ProfessionalWiki\NeoWiki\EntryPoints\Content\SubjectContent;
+use ProfessionalWiki\NeoWiki\PagePropertiesBuilder;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\MediaWikiSubjectRepository;
+
+/**
+ * Loads a {@see Page} domain object from a page's current revision so it can be projected to RDF.
+ * The revision slot is the source of truth (as in OnRevisionCreatedHandler and the graph rebuild),
+ * so the export reflects the stored data rather than the secondary graph projection.
+ *
+ * Returns null when the page does not exist or its current revision carries no Subject slot.
+ */
+class RdfPageLoader {
+
+	public function __construct(
+		private readonly WikiPageFactory $wikiPageFactory,
+		private readonly PagePropertiesBuilder $pagePropertiesBuilder,
+	) {
+	}
+
+	public function loadByPageId( PageId $pageId ): ?Page {
+		$title = Title::newFromID( $pageId->id );
+
+		if ( $title === null ) {
+			return null;
+		}
+
+		return $this->loadByTitle( $title );
+	}
+
+	public function loadByTitle( Title $title ): ?Page {
+		$revision = $this->wikiPageFactory->newFromTitle( $title )->getRevisionRecord();
+
+		if ( $revision === null ) {
+			return null;
+		}
+
+		return $this->buildPage( $revision );
+	}
+
+	private function buildPage( RevisionRecord $revision ): ?Page {
+		$content = $this->getSubjectContent( $revision );
+
+		if ( $content === null ) {
+			return null;
+		}
+
+		$subjects = $content->getPageSubjects();
+
+		return new Page(
+			id: new PageId( $revision->getPageId() ),
+			properties: $this->pagePropertiesBuilder->getPagePropertiesFor( $revision, $revision->getUser() ),
+			subjects: new PageSubjects(
+				mainSubject: $subjects->getMainSubject(),
+				childSubjects: $subjects->getChildSubjects()
+			)
+		);
+	}
+
+	private function getSubjectContent( RevisionRecord $revision ): ?SubjectContent {
+		if ( !$revision->hasSlot( MediaWikiSubjectRepository::SLOT_NAME ) ) {
+			return null;
+		}
+
+		$content = $revision->getSlots()->getContent( MediaWikiSubjectRepository::SLOT_NAME );
+
+		return $content instanceof SubjectContent ? $content : null;
+	}
+
+}

--- a/src/Application/Rdf/RdfPageProjector.php
+++ b/src/Application/Rdf/RdfPageProjector.php
@@ -18,6 +18,7 @@ use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfLiteralFactory;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfNamespaces;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfValueMapperRegistry;
 use ProfessionalWiki\NeoWiki\Domain\Relation\TypedRelation;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
 use ProfessionalWiki\NeoWiki\Domain\Statement;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use Psr\Log\LoggerInterface;
@@ -27,9 +28,9 @@ use Psr\Log\LoggerInterface;
  * one resource per Subject (rdf:type from the Schema, rdfs:label, one predicate per Statement value),
  * and the two-layer relation reification. Every quad is placed in the page's named graph.
  *
- * Schema resolution mirrors Neo4jSubjectUpdater: relations need the Subject's Schema to determine the
- * Relation Type (the predicate). When the Schema is missing, only relations are skipped; the Subject's
- * type, label and non-relation Statements still project, since those do not depend on the Schema.
+ * Schema resolution mirrors Neo4jSubjectUpdater: a Subject whose Schema is unavailable is skipped
+ * entirely (and logged), so the native projection and its sibling projections hold the same set of
+ * entities and page metadata never references a Subject that has no projected type or label.
  */
 class RdfPageProjector {
 
@@ -50,19 +51,47 @@ class RdfPageProjector {
 	public function projectPage( Page $page ): QuadList {
 		$graph = $this->namespaces->page( $page->getId() );
 
-		$quads = $this->projectPageMetadata( $page, $graph );
+		$subjects = $this->resolveSchemas( $page->getSubjects()->getAllSubjects()->asArray() );
 
-		foreach ( $page->getSubjects()->getAllSubjects()->asArray() as $subject ) {
-			$quads = array_merge( $quads, $this->projectSubject( $subject, $graph, $page->getId() ) );
+		$quads = $this->projectPageMetadata( $page, $subjects, $graph );
+
+		foreach ( $subjects as [ $subject, $schema ] ) {
+			$quads = array_merge( $quads, $this->projectSubject( $subject, $schema, $graph, $page->getId() ) );
 		}
 
 		return QuadList::fromArray( $quads );
 	}
 
 	/**
+	 * Resolves each Subject's Schema up front. A Subject whose Schema is unavailable is dropped from
+	 * the projection entirely — matching Neo4jSubjectUpdater, which skips the whole Subject — so
+	 * sibling projections hold the same entity set (the invariant the SPARQL store, #586, relies on).
+	 *
+	 * @param Subject[] $subjects
+	 * @return list<array{Subject, Schema}>
+	 */
+	private function resolveSchemas( array $subjects ): array {
+		$resolved = [];
+
+		foreach ( $subjects as $subject ) {
+			$schema = $this->schemaLookup->getSchema( $subject->getSchemaName() );
+
+			if ( $schema === null ) {
+				$this->logger->warning( 'Schema not found: ' . $subject->getSchemaName()->getText() );
+				continue;
+			}
+
+			$resolved[] = [ $subject, $schema ];
+		}
+
+		return $resolved;
+	}
+
+	/**
+	 * @param list<array{Subject, Schema}> $subjects
 	 * @return Quad[]
 	 */
-	private function projectPageMetadata( Page $page, Iri $graph ): array {
+	private function projectPageMetadata( Page $page, array $subjects, Iri $graph ): array {
 		$pageIri = $this->namespaces->page( $page->getId() );
 		$properties = $page->getProperties();
 
@@ -98,11 +127,11 @@ class RdfPageProjector {
 		}
 
 		$mainSubject = $page->getSubjects()->getMainSubject();
-		if ( $mainSubject !== null ) {
+		if ( $mainSubject !== null && $this->isProjected( $mainSubject, $subjects ) ) {
 			$quads[] = new Quad( $pageIri, $this->namespaces->term( RdfNamespaces::TERM_MAIN_SUBJECT ), $this->namespaces->subject( $mainSubject->id ), $graph );
 		}
 
-		foreach ( $page->getSubjects()->getAllSubjects()->asArray() as $subject ) {
+		foreach ( $subjects as [ $subject ] ) {
 			$quads[] = new Quad( $pageIri, $this->namespaces->term( RdfNamespaces::TERM_HAS_SUBJECT ), $this->namespaces->subject( $subject->id ), $graph );
 		}
 
@@ -110,9 +139,22 @@ class RdfPageProjector {
 	}
 
 	/**
+	 * @param list<array{Subject, Schema}> $subjects
+	 */
+	private function isProjected( Subject $mainSubject, array $subjects ): bool {
+		foreach ( $subjects as [ $subject ] ) {
+			if ( $subject->id->text === $mainSubject->id->text ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * @return Quad[]
 	 */
-	private function projectSubject( Subject $subject, Iri $graph, PageId $pageId ): array {
+	private function projectSubject( Subject $subject, Schema $schema, Iri $graph, PageId $pageId ): array {
 		$subjectIri = $this->namespaces->subject( $subject->id );
 
 		$quads = [
@@ -122,7 +164,7 @@ class RdfPageProjector {
 
 		$quads = array_merge( $quads, $this->projectStatements( $subject, $subjectIri, $graph, $pageId ) );
 
-		return array_merge( $quads, $this->projectRelations( $subject, $subjectIri, $graph ) );
+		return array_merge( $quads, $this->projectRelations( $subject, $schema, $subjectIri, $graph ) );
 	}
 
 	/**
@@ -155,16 +197,7 @@ class RdfPageProjector {
 	/**
 	 * @return Quad[]
 	 */
-	private function projectRelations( Subject $subject, Iri $subjectIri, Iri $graph ): array {
-		$schema = $this->schemaLookup->getSchema( $subject->getSchemaName() );
-
-		if ( $schema === null ) {
-			$this->logger->warning(
-				'Schema not found when projecting relations to RDF: ' . $subject->getSchemaName()->getText()
-			);
-			return [];
-		}
-
+	private function projectRelations( Subject $subject, Schema $schema, Iri $subjectIri, Iri $graph ): array {
 		$quads = [];
 
 		foreach ( $subject->getTypedRelations( $schema )->relations as $relation ) {

--- a/src/Application/Rdf/RdfPageProjector.php
+++ b/src/Application/Rdf/RdfPageProjector.php
@@ -1,0 +1,237 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application\Rdf;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
+use ProfessionalWiki\NeoWiki\Domain\Page\Page;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageValue;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\Iri;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\Literal;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\Quad;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\QuadList;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfLiteralFactory;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfNamespaces;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfValueMapperRegistry;
+use ProfessionalWiki\NeoWiki\Domain\Relation\TypedRelation;
+use ProfessionalWiki\NeoWiki\Domain\Statement;
+use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Projects a {@see Page} to the native RDF quads specified in NativeRdfProjection.md: page metadata,
+ * one resource per Subject (rdf:type from the Schema, rdfs:label, one predicate per Statement value),
+ * and the two-layer relation reification. Every quad is placed in the page's named graph.
+ *
+ * Schema resolution mirrors Neo4jSubjectUpdater: relations need the Subject's Schema to determine the
+ * Relation Type (the predicate). When the Schema is missing, only relations are skipped; the Subject's
+ * type, label and non-relation Statements still project, since those do not depend on the Schema.
+ */
+class RdfPageProjector {
+
+	private const string PROPERTY_NAME = 'name';
+	private const string PROPERTY_CREATION_TIME = 'creationTime';
+	private const string PROPERTY_LAST_UPDATED = 'lastUpdated';
+	private const string PROPERTY_LAST_EDITOR = 'lastEditor';
+	private const string PROPERTY_CATEGORIES = 'categories';
+
+	public function __construct(
+		private readonly RdfValueMapperRegistry $valueMappers,
+		private readonly RdfNamespaces $namespaces,
+		private readonly SchemaLookup $schemaLookup,
+		private readonly LoggerInterface $logger,
+	) {
+	}
+
+	public function projectPage( Page $page ): QuadList {
+		$graph = $this->namespaces->page( $page->getId() );
+
+		$quads = $this->projectPageMetadata( $page, $graph );
+
+		foreach ( $page->getSubjects()->getAllSubjects()->asArray() as $subject ) {
+			$quads = array_merge( $quads, $this->projectSubject( $subject, $graph, $page->getId() ) );
+		}
+
+		return QuadList::fromArray( $quads );
+	}
+
+	/**
+	 * @return Quad[]
+	 */
+	private function projectPageMetadata( Page $page, Iri $graph ): array {
+		$pageIri = $this->namespaces->page( $page->getId() );
+		$properties = $page->getProperties();
+
+		$quads = [ new Quad( $pageIri, $this->namespaces->rdfType(), $this->namespaces->term( RdfNamespaces::CLASS_PAGE ), $graph ) ];
+
+		$name = $properties->get( self::PROPERTY_NAME );
+		if ( is_string( $name ) && $name !== '' ) {
+			$quads[] = new Quad( $pageIri, $this->namespaces->term( RdfNamespaces::TERM_PAGE_NAME ), RdfLiteralFactory::typed( $name, 'string' ), $graph );
+		}
+
+		$created = $this->timestampLiteral( $properties->get( self::PROPERTY_CREATION_TIME ) );
+		if ( $created !== null ) {
+			$quads[] = new Quad( $pageIri, $this->namespaces->dctermsCreated(), $created, $graph );
+		}
+
+		$modified = $this->timestampLiteral( $properties->get( self::PROPERTY_LAST_UPDATED ) );
+		if ( $modified !== null ) {
+			$quads[] = new Quad( $pageIri, $this->namespaces->dctermsModified(), $modified, $graph );
+		}
+
+		$lastEditor = $properties->get( self::PROPERTY_LAST_EDITOR );
+		if ( is_string( $lastEditor ) && $lastEditor !== '' ) {
+			$quads[] = new Quad( $pageIri, $this->namespaces->term( RdfNamespaces::TERM_LAST_EDITOR ), RdfLiteralFactory::typed( $lastEditor, 'string' ), $graph );
+		}
+
+		$categories = $properties->get( self::PROPERTY_CATEGORIES );
+		if ( is_array( $categories ) ) {
+			foreach ( $categories as $category ) {
+				if ( is_string( $category ) ) {
+					$quads[] = new Quad( $pageIri, $this->namespaces->term( RdfNamespaces::TERM_CATEGORY ), RdfLiteralFactory::typed( $category, 'string' ), $graph );
+				}
+			}
+		}
+
+		$mainSubject = $page->getSubjects()->getMainSubject();
+		if ( $mainSubject !== null ) {
+			$quads[] = new Quad( $pageIri, $this->namespaces->term( RdfNamespaces::TERM_MAIN_SUBJECT ), $this->namespaces->subject( $mainSubject->id ), $graph );
+		}
+
+		foreach ( $page->getSubjects()->getAllSubjects()->asArray() as $subject ) {
+			$quads[] = new Quad( $pageIri, $this->namespaces->term( RdfNamespaces::TERM_HAS_SUBJECT ), $this->namespaces->subject( $subject->id ), $graph );
+		}
+
+		return $quads;
+	}
+
+	/**
+	 * @return Quad[]
+	 */
+	private function projectSubject( Subject $subject, Iri $graph, PageId $pageId ): array {
+		$subjectIri = $this->namespaces->subject( $subject->id );
+
+		$quads = [
+			new Quad( $subjectIri, $this->namespaces->rdfType(), $this->namespaces->schemaClass( $subject->getSchemaName() ), $graph ),
+			new Quad( $subjectIri, $this->namespaces->rdfsLabel(), RdfLiteralFactory::typed( $subject->label->text, 'string' ), $graph ),
+		];
+
+		$quads = array_merge( $quads, $this->projectStatements( $subject, $subjectIri, $graph, $pageId ) );
+
+		return array_merge( $quads, $this->projectRelations( $subject, $subjectIri, $graph ) );
+	}
+
+	/**
+	 * @return Quad[]
+	 */
+	private function projectStatements( Subject $subject, Iri $subjectIri, Iri $graph, PageId $pageId ): array {
+		$quads = [];
+
+		foreach ( $subject->getStatements()->asArray() as $statement ) {
+			$literals = $this->valueMappers->mapValue( $statement->getPropertyType(), $statement->getValue() );
+
+			// null means the Property Type has no RDF mapper (a relation, handled separately, or an
+			// unregistered type). Skip it, matching the Neo4j projection's graceful degradation.
+			if ( $literals === null ) {
+				continue;
+			}
+
+			$this->warnOnDroppedValues( $statement, count( $literals ), $pageId );
+
+			$predicate = $this->namespaces->property( $statement->getPropertyName()->text );
+
+			foreach ( $literals as $literal ) {
+				$quads[] = new Quad( $subjectIri, $predicate, $literal, $graph );
+			}
+		}
+
+		return $quads;
+	}
+
+	/**
+	 * @return Quad[]
+	 */
+	private function projectRelations( Subject $subject, Iri $subjectIri, Iri $graph ): array {
+		$schema = $this->schemaLookup->getSchema( $subject->getSchemaName() );
+
+		if ( $schema === null ) {
+			$this->logger->warning(
+				'Schema not found when projecting relations to RDF: ' . $subject->getSchemaName()->getText()
+			);
+			return [];
+		}
+
+		$quads = [];
+
+		foreach ( $subject->getTypedRelations( $schema )->relations as $relation ) {
+			$quads = array_merge( $quads, $this->projectRelation( $relation, $subjectIri, $graph ) );
+		}
+
+		return $quads;
+	}
+
+	/**
+	 * Emits the two layers for one relation: the direct triple for simple queries, and the Relation
+	 * node preserving the Relation ID, endpoints, type, and any Relation properties.
+	 *
+	 * @return Quad[]
+	 */
+	private function projectRelation( TypedRelation $relation, Iri $subjectIri, Iri $graph ): array {
+		$predicate = $this->namespaces->property( $relation->type->text );
+		$targetIri = $this->namespaces->subject( $relation->targetId );
+		$relationIri = $this->namespaces->relationNode( $relation->id );
+
+		$quads = [
+			new Quad( $subjectIri, $predicate, $targetIri, $graph ),
+			new Quad( $relationIri, $this->namespaces->rdfType(), $this->namespaces->term( RdfNamespaces::CLASS_RELATION ), $graph ),
+			new Quad( $relationIri, $this->namespaces->term( RdfNamespaces::TERM_SOURCE ), $subjectIri, $graph ),
+			new Quad( $relationIri, $this->namespaces->term( RdfNamespaces::TERM_TARGET ), $targetIri, $graph ),
+			new Quad( $relationIri, $this->namespaces->term( RdfNamespaces::TERM_RELATION_TYPE ), $predicate, $graph ),
+		];
+
+		foreach ( $relation->properties->map as $name => $value ) {
+			$literal = RdfLiteralFactory::forScalar( $value );
+
+			if ( $literal !== null ) {
+				$quads[] = new Quad( $relationIri, $this->namespaces->property( (string)$name ), $literal, $graph );
+			}
+		}
+
+		return $quads;
+	}
+
+	private function warnOnDroppedValues( Statement $statement, int $producedCount, PageId $pageId ): void {
+		$scalars = $statement->getValue()->toScalars();
+		$expectedCount = is_array( $scalars ) ? count( $scalars ) : 1;
+
+		if ( $producedCount >= $expectedCount ) {
+			return;
+		}
+
+		$this->logger->warning(
+			'Dropped ' . ( $expectedCount - $producedCount ) . ' unrepresentable value(s) of property "'
+			. $statement->getPropertyName()->text . '" on page ' . $pageId->id . ' when projecting to RDF'
+		);
+	}
+
+	private function timestampLiteral( mixed $value ): ?Literal {
+		$timestamp = $value instanceof PageValue ? $value->getValue() : $value;
+
+		if ( !is_string( $timestamp ) ) {
+			return null;
+		}
+
+		$dateTime = DateTimeImmutable::createFromFormat( 'YmdHis', $timestamp, new DateTimeZone( 'UTC' ) );
+
+		if ( $dateTime === false ) {
+			return null;
+		}
+
+		return RdfLiteralFactory::typed( $dateTime->format( 'Y-m-d\TH:i:s\Z' ), 'dateTime' );
+	}
+
+}

--- a/src/Domain/Rdf/Iri.php
+++ b/src/Domain/Rdf/Iri.php
@@ -1,0 +1,29 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\Rdf;
+
+use InvalidArgumentException;
+
+/**
+ * An absolute IRI. Stores the full IRI string; prefix abbreviation is a serialization concern
+ * handled by the {@see RdfSerializer}, so this value object never carries a prefixed name.
+ */
+readonly class Iri implements RdfTerm {
+
+	public string $value;
+
+	public function __construct( string $value ) {
+		if ( trim( $value ) === '' ) {
+			throw new InvalidArgumentException( 'IRI cannot be empty' );
+		}
+
+		$this->value = $value;
+	}
+
+	public function equals( RdfTerm $other ): bool {
+		return $other instanceof self && $this->value === $other->value;
+	}
+
+}

--- a/src/Domain/Rdf/Literal.php
+++ b/src/Domain/Rdf/Literal.php
@@ -1,0 +1,33 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\Rdf;
+
+/**
+ * An RDF literal: a lexical form plus a datatype IRI, and optionally a language tag.
+ *
+ * The native projection only mints datatyped literals (the language tag stays null), but the
+ * model carries the tag so language-tagged literals remain expressible for future projections.
+ */
+readonly class Literal implements RdfTerm {
+
+	public function __construct(
+		public string $lexicalForm,
+		public Iri $datatype,
+		public ?string $languageTag = null,
+	) {
+	}
+
+	public function isLanguageTagged(): bool {
+		return $this->languageTag !== null;
+	}
+
+	public function equals( RdfTerm $other ): bool {
+		return $other instanceof self
+			&& $this->lexicalForm === $other->lexicalForm
+			&& $this->datatype->equals( $other->datatype )
+			&& $this->languageTag === $other->languageTag;
+	}
+
+}

--- a/src/Domain/Rdf/Quad.php
+++ b/src/Domain/Rdf/Quad.php
@@ -1,0 +1,28 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\Rdf;
+
+/**
+ * A single RDF statement scoped to a named graph. Subject, predicate and graph are always IRIs;
+ * the object is an IRI or a {@see Literal}. Dropping the graph yields the triple used for Turtle.
+ */
+readonly class Quad {
+
+	public function __construct(
+		public Iri $subject,
+		public Iri $predicate,
+		public RdfTerm $object,
+		public Iri $graph,
+	) {
+	}
+
+	public function equals( self $other ): bool {
+		return $this->subject->equals( $other->subject )
+			&& $this->predicate->equals( $other->predicate )
+			&& $this->object->equals( $other->object )
+			&& $this->graph->equals( $other->graph );
+	}
+
+}

--- a/src/Domain/Rdf/QuadList.php
+++ b/src/Domain/Rdf/QuadList.php
@@ -1,0 +1,63 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\Rdf;
+
+use Countable;
+use InvalidArgumentException;
+
+readonly class QuadList implements Countable {
+
+	/**
+	 * @var Quad[]
+	 */
+	private array $quads;
+
+	public function __construct( Quad ...$quads ) {
+		$this->quads = $quads;
+	}
+
+	/**
+	 * @param Quad[] $quads
+	 */
+	public static function fromArray( array $quads ): self {
+		foreach ( $quads as $quad ) {
+			if ( !( $quad instanceof Quad ) ) {
+				throw new InvalidArgumentException( 'QuadList can only contain Quad objects' );
+			}
+		}
+
+		return new self( ...$quads );
+	}
+
+	public function merge( self $other ): self {
+		return new self( ...$this->quads, ...$other->quads );
+	}
+
+	public function contains( Quad $needle ): bool {
+		foreach ( $this->quads as $quad ) {
+			if ( $quad->equals( $needle ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * @return Quad[]
+	 */
+	public function asArray(): array {
+		return $this->quads;
+	}
+
+	public function isEmpty(): bool {
+		return $this->quads === [];
+	}
+
+	public function count(): int {
+		return count( $this->quads );
+	}
+
+}

--- a/src/Domain/Rdf/RdfFormat.php
+++ b/src/Domain/Rdf/RdfFormat.php
@@ -1,0 +1,16 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\Rdf;
+
+/**
+ * An RDF serialization format the native projection can be written as. TriG keeps the per-page
+ * named graph; Turtle emits the same triples without the graph wrapper.
+ */
+enum RdfFormat {
+
+	case Turtle;
+	case TriG;
+
+}

--- a/src/Domain/Rdf/RdfLiteralFactory.php
+++ b/src/Domain/Rdf/RdfLiteralFactory.php
@@ -1,0 +1,58 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\Rdf;
+
+/**
+ * Builds {@see Literal}s with the correct xsd datatype for the native projection. Centralizes the
+ * numeric lexical rules (fractionless floats project as xsd:integer; decimals avoid scientific
+ * notation) so the value mappers and the relation-property projection share one implementation.
+ */
+class RdfLiteralFactory {
+
+	public static function typed( string $lexicalForm, string $xsdLocalName ): Literal {
+		return new Literal( $lexicalForm, new Iri( RdfNamespaces::XSD . $xsdLocalName ) );
+	}
+
+	public static function boolean( bool $value ): Literal {
+		return self::typed( $value ? 'true' : 'false', 'boolean' );
+	}
+
+	public static function number( int|float $number ): ?Literal {
+		if ( is_int( $number ) ) {
+			return self::typed( (string)$number, 'integer' );
+		}
+
+		if ( !is_finite( $number ) ) {
+			return null;
+		}
+
+		// A fractionless float is projected as xsd:integer, matching the spec's value type mapping.
+		if ( $number === floor( $number ) && abs( $number ) < 1.0e15 ) {
+			return self::typed( (string)(int)$number, 'integer' );
+		}
+
+		return self::typed( self::decimalLexical( $number ), 'decimal' );
+	}
+
+	/**
+	 * Maps a raw scalar (as found in a Relation's property map) to a Literal, or null when it cannot
+	 * be represented (e.g. null, or a non-finite float).
+	 */
+	public static function forScalar( mixed $value ): ?Literal {
+		return match ( true ) {
+			is_string( $value ) => self::typed( $value, 'string' ),
+			is_bool( $value ) => self::boolean( $value ),
+			is_int( $value ), is_float( $value ) => self::number( $value ),
+			default => null,
+		};
+	}
+
+	private static function decimalLexical( float $number ): string {
+		$formatted = rtrim( sprintf( '%.15F', $number ), '0' );
+
+		return str_ends_with( $formatted, '.' ) ? $formatted . '0' : $formatted;
+	}
+
+}

--- a/src/Domain/Rdf/RdfNamespaces.php
+++ b/src/Domain/Rdf/RdfNamespaces.php
@@ -86,15 +86,43 @@ readonly class RdfNamespaces {
 	}
 
 	/**
-	 * Turns a Property or Schema name into the local part of its IRI by substituting spaces with
-	 * underscores (NativeRdfProjection.md Q7).
+	 * Turns a user-authored name (a Property, Schema or Relation-Type name, or a Relation-property
+	 * key) into the local part of its IRI. Every string that enters an IRI here is untrusted, so the
+	 * encoding is a security boundary, not just cosmetics: without it a name like `Rev>2020` would
+	 * close the IRIREF early and a crafted name could forge extra triples.
 	 *
-	 * CAVEAT: this collides when a name already contains an underscore. "Has author" and "Has_author"
+	 * The rule (NativeRdfProjection.md Q7):
+	 * 1. Spaces become underscores, keeping the spec's readable `neo-prop:Has_author` convention.
+	 * 2. `%` and the IRIREF-illegal ASCII characters (`< > " { } | ^ \` and backtick) plus control
+	 *    characters (0x00–0x1F, 0x7F) are percent-encoded, so a name can never break out of the IRI.
+	 * 3. Everything else, including non-ASCII Unicode, is kept raw so multilingual names stay readable.
+	 *
+	 * The base URI is trusted admin config and is not encoded here.
+	 *
+	 * CAVEAT: step 1 collides when a name already contains an underscore. "Has author" and "Has_author"
 	 * both map to the local name `Has_author` and therefore share a predicate IRI. The native
-	 * projection accepts this; disambiguation would require percent-encoding or another scheme.
+	 * projection accepts this; disambiguation would require another scheme.
 	 */
 	public static function localName( string $name ): string {
-		return str_replace( ' ', '_', $name );
+		$encoded = '';
+
+		foreach ( str_split( str_replace( ' ', '_', $name ) ) as $byte ) {
+			$encoded .= self::isIriLocalByte( $byte ) ? $byte : sprintf( '%%%02X', ord( $byte ) );
+		}
+
+		return $encoded;
+	}
+
+	private static function isIriLocalByte( string $byte ): bool {
+		$code = ord( $byte );
+
+		// Control characters (0x00–0x1F and DEL) are never allowed in an IRIREF. Bytes >= 0x80 are
+		// part of a raw UTF-8 sequence and pass through, keeping Unicode readable.
+		if ( $code <= 0x1F || $code === 0x7F ) {
+			return false;
+		}
+
+		return !in_array( $byte, [ '%', '<', '>', '"', '{', '}', '|', '^', '\\', '`' ], true );
 	}
 
 	/**

--- a/src/Domain/Rdf/RdfNamespaces.php
+++ b/src/Domain/Rdf/RdfNamespaces.php
@@ -1,0 +1,118 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\Rdf;
+
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+use ProfessionalWiki\NeoWiki\Domain\Relation\RelationId;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
+
+/**
+ * The IRI and prefix scheme for the native RDF projection (NativeRdfProjection.md § Namespaces).
+ *
+ * Every NeoWiki IRI lives under a per-wiki base URI so that sibling projections (native and
+ * ontology-mapped) mint identical entity IRIs. Standard vocabulary (rdf, rdfs, xsd, dcterms) is
+ * fixed and independent of the base.
+ */
+readonly class RdfNamespaces {
+
+	public const string RDF = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
+	public const string RDFS = 'http://www.w3.org/2000/01/rdf-schema#';
+	public const string XSD = 'http://www.w3.org/2001/XMLSchema#';
+	public const string DCTERMS = 'http://purl.org/dc/terms/';
+
+	// Local names of NeoWiki vocabulary terms under the `neo:` namespace.
+	public const string CLASS_PAGE = 'Page';
+	public const string CLASS_RELATION = 'Relation';
+	public const string TERM_PAGE_NAME = 'pageName';
+	public const string TERM_LAST_EDITOR = 'lastEditor';
+	public const string TERM_CATEGORY = 'category';
+	public const string TERM_MAIN_SUBJECT = 'mainSubject';
+	public const string TERM_HAS_SUBJECT = 'hasSubject';
+	public const string TERM_SOURCE = 'source';
+	public const string TERM_TARGET = 'target';
+	public const string TERM_RELATION_TYPE = 'relationType';
+
+	public string $baseUri;
+
+	public function __construct( string $baseUri ) {
+		$this->baseUri = rtrim( $baseUri, '/' );
+	}
+
+	public function subject( SubjectId $id ): Iri {
+		return new Iri( $this->baseUri . '/entity/' . $id->text );
+	}
+
+	public function property( string $propertyName ): Iri {
+		return new Iri( $this->baseUri . '/prop/' . self::localName( $propertyName ) );
+	}
+
+	public function schemaClass( SchemaName $schemaName ): Iri {
+		return new Iri( $this->baseUri . '/schema/' . self::localName( $schemaName->getText() ) );
+	}
+
+	public function relationNode( RelationId $id ): Iri {
+		return new Iri( $this->baseUri . '/relation/' . $id->asString() );
+	}
+
+	public function page( PageId $id ): Iri {
+		return new Iri( $this->baseUri . '/page/' . $id->id );
+	}
+
+	public function term( string $localName ): Iri {
+		return new Iri( $this->baseUri . '/ontology/' . $localName );
+	}
+
+	public function rdfType(): Iri {
+		return new Iri( self::RDF . 'type' );
+	}
+
+	public function rdfsLabel(): Iri {
+		return new Iri( self::RDFS . 'label' );
+	}
+
+	public function dctermsCreated(): Iri {
+		return new Iri( self::DCTERMS . 'created' );
+	}
+
+	public function dctermsModified(): Iri {
+		return new Iri( self::DCTERMS . 'modified' );
+	}
+
+	public function xsd( string $localName ): Iri {
+		return new Iri( self::XSD . $localName );
+	}
+
+	/**
+	 * Turns a Property or Schema name into the local part of its IRI by substituting spaces with
+	 * underscores (NativeRdfProjection.md Q7).
+	 *
+	 * CAVEAT: this collides when a name already contains an underscore. "Has author" and "Has_author"
+	 * both map to the local name `Has_author` and therefore share a predicate IRI. The native
+	 * projection accepts this; disambiguation would require percent-encoding or another scheme.
+	 */
+	public static function localName( string $name ): string {
+		return str_replace( ' ', '_', $name );
+	}
+
+	/**
+	 * @return array<string, string> Prefix label to namespace IRI, for serializer abbreviation.
+	 */
+	public function prefixMap(): array {
+		return [
+			'neo' => $this->baseUri . '/ontology/',
+			'neo-subj' => $this->baseUri . '/entity/',
+			'neo-prop' => $this->baseUri . '/prop/',
+			'neo-schema' => $this->baseUri . '/schema/',
+			'neo-rel' => $this->baseUri . '/relation/',
+			'neo-page' => $this->baseUri . '/page/',
+			'rdf' => self::RDF,
+			'rdfs' => self::RDFS,
+			'xsd' => self::XSD,
+			'dcterms' => self::DCTERMS,
+		];
+	}
+
+}

--- a/src/Domain/Rdf/RdfSerializer.php
+++ b/src/Domain/Rdf/RdfSerializer.php
@@ -1,0 +1,21 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\Rdf;
+
+/**
+ * Serializes {@see Quad}s into an RDF document. This is NeoWiki's own port; concrete implementations
+ * wrap a third-party RDF library so its term representation never leaks into the rest of the codebase.
+ */
+interface RdfSerializer {
+
+	public function serialize( QuadList $quads, RdfFormat $format ): string;
+
+	/**
+	 * Opens a streaming writer so large exports (e.g. a full dump) can be emitted incrementally
+	 * without materializing every quad at once.
+	 */
+	public function newWriter( RdfFormat $format ): RdfStreamWriter;
+
+}

--- a/src/Domain/Rdf/RdfStreamWriter.php
+++ b/src/Domain/Rdf/RdfStreamWriter.php
@@ -1,0 +1,18 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\Rdf;
+
+/**
+ * Incremental RDF writer. {@see write()} returns the serialized text produced for the given quads;
+ * {@see finish()} returns any remaining text (closing the last graph block). Callers concatenate or
+ * stream the returned chunks in order.
+ */
+interface RdfStreamWriter {
+
+	public function write( QuadList $quads ): string;
+
+	public function finish(): string;
+
+}

--- a/src/Domain/Rdf/RdfTerm.php
+++ b/src/Domain/Rdf/RdfTerm.php
@@ -1,0 +1,15 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\Rdf;
+
+/**
+ * An RDF term that can occupy the object position of a {@see Quad}: an {@see Iri} or a {@see Literal}.
+ * Blank nodes are intentionally not modelled; the native projection mints IRIs for every node.
+ */
+interface RdfTerm {
+
+	public function equals( self $other ): bool;
+
+}

--- a/src/Domain/Rdf/RdfValueMapperRegistry.php
+++ b/src/Domain/Rdf/RdfValueMapperRegistry.php
@@ -1,0 +1,168 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\Rdf;
+
+use ProfessionalWiki\NeoWiki\Domain\PropertyType\Types\BooleanType;
+use ProfessionalWiki\NeoWiki\Domain\PropertyType\Types\DateTimeType;
+use ProfessionalWiki\NeoWiki\Domain\PropertyType\Types\DateType;
+use ProfessionalWiki\NeoWiki\Domain\PropertyType\Types\NumberType;
+use ProfessionalWiki\NeoWiki\Domain\PropertyType\Types\SelectType;
+use ProfessionalWiki\NeoWiki\Domain\PropertyType\Types\TextType;
+use ProfessionalWiki\NeoWiki\Domain\PropertyType\Types\UrlType;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Property\DateProperty;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Property\DateTimeProperty;
+use ProfessionalWiki\NeoWiki\Domain\Value\NeoValue;
+
+/**
+ * Maps a Statement's {@see NeoValue} to the RDF {@see Literal}s that represent it, keyed by the
+ * Statement's Property Type. The seam mirrors Neo4jValueBuilderRegistry so extension-defined
+ * property types can contribute their RDF representation via NeoWikiRegistrar::addRdfValueMapper.
+ *
+ * Relation values are not mapped here; the projector reifies them separately (two-layer approach).
+ * A Property Type without a mapper (including an unregistered type) yields null and is skipped,
+ * matching the Neo4j projection's graceful degradation.
+ */
+class RdfValueMapperRegistry {
+
+	/**
+	 * @var array<string, callable(NeoValue): Literal[]>
+	 */
+	private array $mappers = [];
+
+	/**
+	 * @param callable(NeoValue): Literal[] $mapper
+	 */
+	public function registerMapper( string $propertyTypeName, callable $mapper ): void {
+		$this->mappers[$propertyTypeName] = $mapper;
+	}
+
+	/**
+	 * @return Literal[]|null null when no mapper is registered for the Property Type.
+	 */
+	public function mapValue( string $propertyTypeName, NeoValue $value ): ?array {
+		if ( !array_key_exists( $propertyTypeName, $this->mappers ) ) {
+			return null;
+		}
+
+		return ( $this->mappers[$propertyTypeName] )( $value );
+	}
+
+	public function hasMapper( string $propertyTypeName ): bool {
+		return array_key_exists( $propertyTypeName, $this->mappers );
+	}
+
+	public static function withCoreMappers(): self {
+		$registry = new self();
+
+		$registry->registerMapper( TextType::NAME, self::stringMapper( 'string' ) );
+		$registry->registerMapper( SelectType::NAME, self::stringMapper( 'string' ) );
+		$registry->registerMapper( UrlType::NAME, self::stringMapper( 'anyURI' ) );
+		$registry->registerMapper( NumberType::NAME, self::mapNumber( ... ) );
+		$registry->registerMapper( BooleanType::NAME, self::mapBoolean( ... ) );
+		$registry->registerMapper( DateType::NAME, self::mapDate( ... ) );
+		$registry->registerMapper( DateTimeType::NAME, self::mapDateTime( ... ) );
+
+		return $registry;
+	}
+
+	/**
+	 * @return callable(NeoValue): Literal[]
+	 */
+	private static function stringMapper( string $xsdType ): callable {
+		return static function ( NeoValue $value ) use ( $xsdType ): array {
+			$scalars = $value->toScalars();
+
+			if ( !is_array( $scalars ) ) {
+				return [];
+			}
+
+			$literals = [];
+
+			foreach ( $scalars as $part ) {
+				if ( is_scalar( $part ) ) {
+					$literals[] = RdfLiteralFactory::typed( (string)$part, $xsdType );
+				}
+			}
+
+			return $literals;
+		};
+	}
+
+	/**
+	 * @return Literal[]
+	 */
+	private static function mapNumber( NeoValue $value ): array {
+		$number = $value->toScalars();
+
+		if ( !is_int( $number ) && !is_float( $number ) ) {
+			return [];
+		}
+
+		$literal = RdfLiteralFactory::number( $number );
+
+		return $literal === null ? [] : [ $literal ];
+	}
+
+	/**
+	 * @return Literal[]
+	 */
+	private static function mapBoolean( NeoValue $value ): array {
+		$boolean = $value->toScalars();
+
+		if ( !is_bool( $boolean ) ) {
+			return [];
+		}
+
+		return [ RdfLiteralFactory::boolean( $boolean ) ];
+	}
+
+	/**
+	 * @return Literal[]
+	 */
+	private static function mapDate( NeoValue $value ): array {
+		return self::mapValidatedStrings(
+			$value,
+			'date',
+			static fn( string $string ): bool => DateProperty::parseStrictDate( $string ) !== null
+		);
+	}
+
+	/**
+	 * @return Literal[]
+	 */
+	private static function mapDateTime( NeoValue $value ): array {
+		return self::mapValidatedStrings(
+			$value,
+			'dateTime',
+			static fn( string $string ): bool => DateTimeProperty::parseStrictDateTime( $string ) !== null
+		);
+	}
+
+	/**
+	 * Keeps only the parts that are valid lexical forms for the given xsd datatype, so the projection
+	 * stays well-typed. Invalid parts are dropped, as the Neo4j projection drops unparseable dateTimes.
+	 *
+	 * @param callable(string): bool $isValid
+	 * @return Literal[]
+	 */
+	private static function mapValidatedStrings( NeoValue $value, string $xsdType, callable $isValid ): array {
+		$scalars = $value->toScalars();
+
+		if ( !is_array( $scalars ) ) {
+			return [];
+		}
+
+		$literals = [];
+
+		foreach ( $scalars as $part ) {
+			if ( is_string( $part ) && $isValid( $part ) ) {
+				$literals[] = RdfLiteralFactory::typed( $part, $xsdType );
+			}
+		}
+
+		return $literals;
+	}
+
+}

--- a/src/EntryPoints/NeoWikiRegistrar.php
+++ b/src/EntryPoints/NeoWikiRegistrar.php
@@ -10,6 +10,8 @@ use ProfessionalWiki\NeoWiki\Domain\Page\PagePropertyProvider;
 use ProfessionalWiki\NeoWiki\Domain\Page\PagePropertyProviderRegistry;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyType;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeRegistry;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\Literal;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfValueMapperRegistry;
 use ProfessionalWiki\NeoWiki\Domain\Value\NeoValue;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jValueBuilderRegistry;
 
@@ -20,6 +22,7 @@ readonly class NeoWikiRegistrar {
 		private Neo4jValueBuilderRegistry $valueBuilderRegistry,
 		private PagePropertyProviderRegistry $pagePropertyProviderRegistry,
 		private GraphDatabasePluginRegistry $graphDatabasePluginRegistry,
+		private RdfValueMapperRegistry $rdfValueMapperRegistry,
 	) {
 	}
 
@@ -32,6 +35,15 @@ readonly class NeoWikiRegistrar {
 	 */
 	public function addNeo4jValueBuilder( string $propertyTypeName, callable $builder ): void {
 		$this->valueBuilderRegistry->registerBuilder( $propertyTypeName, $builder );
+	}
+
+	/**
+	 * Registers how a Property Type's value projects to RDF literals for the native RDF export.
+	 *
+	 * @param callable(NeoValue): Literal[] $mapper
+	 */
+	public function addRdfValueMapper( string $propertyTypeName, callable $mapper ): void {
+		$this->rdfValueMapperRegistry->registerMapper( $propertyTypeName, $mapper );
 	}
 
 	public function addPagePropertyProvider( PagePropertyProvider $provider ): void {

--- a/src/EntryPoints/REST/ExportPageRdfApi.php
+++ b/src/EntryPoints/REST/ExportPageRdfApi.php
@@ -1,0 +1,100 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\EntryPoints\REST;
+
+use MediaWiki\Rest\Response;
+use MediaWiki\Rest\SimpleHandler;
+use MediaWiki\Rest\StringStream;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfFormat;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+use Wikimedia\ParamValidator\ParamValidator;
+
+/**
+ * Exports one page's Subjects and metadata as native RDF (NativeRdfProjection.md). The format is
+ * chosen by the `format` query parameter, falling back to the Accept header, then to TriG. TriG keeps
+ * the per-page named graph; Turtle emits the same triples without it.
+ */
+class ExportPageRdfApi extends SimpleHandler {
+
+	private const string FORMAT_TRIG = 'trig';
+	private const string FORMAT_TURTLE = 'turtle';
+
+	private const string CONTENT_TYPE_TRIG = 'application/trig; charset=utf-8';
+	private const string CONTENT_TYPE_TURTLE = 'text/turtle; charset=utf-8';
+
+	public function run( int $pageId ): Response {
+		$format = $this->resolveFormat();
+
+		$document = NeoWikiExtension::getInstance()
+			->newRdfPageExporter()
+			->exportByPageId( new PageId( $pageId ), $format );
+
+		if ( $document === null ) {
+			return $this->getResponseFactory()->createHttpError( 404, [
+				'message' => 'No NeoWiki data found for page: ' . $pageId,
+			] );
+		}
+
+		return $this->rdfResponse( $document, $format );
+	}
+
+	private function resolveFormat(): RdfFormat {
+		$requested = $this->getValidatedParams()['format'] ?? null;
+
+		if ( $requested === self::FORMAT_TURTLE ) {
+			return RdfFormat::Turtle;
+		}
+
+		if ( $requested === self::FORMAT_TRIG ) {
+			return RdfFormat::TriG;
+		}
+
+		return $this->formatFromAcceptHeader();
+	}
+
+	private function formatFromAcceptHeader(): RdfFormat {
+		$accept = $this->getRequest()->getHeaderLine( 'Accept' );
+
+		// TriG is a superset of Turtle, so only pick Turtle when the client asks for it specifically.
+		if ( str_contains( $accept, 'text/turtle' ) && !str_contains( $accept, 'application/trig' ) ) {
+			return RdfFormat::Turtle;
+		}
+
+		return RdfFormat::TriG;
+	}
+
+	private function rdfResponse( string $document, RdfFormat $format ): Response {
+		$response = $this->getResponseFactory()->create();
+		$response->setHeader(
+			'Content-Type',
+			$format === RdfFormat::Turtle ? self::CONTENT_TYPE_TURTLE : self::CONTENT_TYPE_TRIG
+		);
+		$response->setBody( new StringStream( $document ) );
+
+		return $response;
+	}
+
+	public function getParamSettings(): array {
+		return [
+			'pageId' => [
+				self::PARAM_SOURCE => 'path',
+				ParamValidator::PARAM_TYPE => 'integer',
+				ParamValidator::PARAM_REQUIRED => true,
+				self::PARAM_DESCRIPTION => 'MediaWiki page ID.',
+			],
+			'format' => [
+				self::PARAM_SOURCE => 'query',
+				ParamValidator::PARAM_TYPE => [
+					self::FORMAT_TRIG,
+					self::FORMAT_TURTLE,
+				],
+				ParamValidator::PARAM_REQUIRED => false,
+				self::PARAM_DESCRIPTION => 'RDF serialization to return: "trig" (default, includes the per-page named graph) or "turtle". Overrides the Accept header.',
+			],
+		];
+	}
+
+}

--- a/src/Infrastructure/Rdf/HardfRdfSerializer.php
+++ b/src/Infrastructure/Rdf/HardfRdfSerializer.php
@@ -1,0 +1,32 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Infrastructure\Rdf;
+
+use ProfessionalWiki\NeoWiki\Domain\Rdf\QuadList;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfFormat;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfSerializer;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfStreamWriter;
+
+readonly class HardfRdfSerializer implements RdfSerializer {
+
+	/**
+	 * @param array<string, string> $prefixes Prefix label to namespace IRI, used for abbreviation.
+	 */
+	public function __construct(
+		private array $prefixes,
+	) {
+	}
+
+	public function serialize( QuadList $quads, RdfFormat $format ): string {
+		$writer = $this->newWriter( $format );
+
+		return $writer->write( $quads ) . $writer->finish();
+	}
+
+	public function newWriter( RdfFormat $format ): RdfStreamWriter {
+		return new HardfRdfStreamWriter( $this->prefixes, $format );
+	}
+
+}

--- a/src/Infrastructure/Rdf/HardfRdfStreamWriter.php
+++ b/src/Infrastructure/Rdf/HardfRdfStreamWriter.php
@@ -1,0 +1,79 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Infrastructure\Rdf;
+
+use pietercolpaert\hardf\TriGWriter;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\Iri;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\Literal;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\QuadList;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfFormat;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfNamespaces;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfStreamWriter;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfTerm;
+
+/**
+ * {@see RdfStreamWriter} backed by hardf's TriGWriter. This is the only place that knows hardf's
+ * string term representation; the rest of the codebase deals in {@see \ProfessionalWiki\NeoWiki\Domain\Rdf}
+ * value objects.
+ *
+ * For Turtle the graph is dropped, so the same grouped writer emits plain triples.
+ */
+class HardfRdfStreamWriter implements RdfStreamWriter {
+
+	private TriGWriter $writer;
+	private bool $includeGraph;
+
+	/**
+	 * @param array<string, string> $prefixes Prefix label to namespace IRI.
+	 */
+	public function __construct( array $prefixes, RdfFormat $format ) {
+		$this->includeGraph = $format === RdfFormat::TriG;
+		$this->writer = new TriGWriter( [
+			'prefixes' => $prefixes,
+			'format' => $this->includeGraph ? 'trig' : 'turtle',
+		] );
+	}
+
+	public function write( QuadList $quads ): string {
+		foreach ( $quads->asArray() as $quad ) {
+			$this->writer->addTriple(
+				$quad->subject->value,
+				$quad->predicate->value,
+				$this->encodeObject( $quad->object ),
+				$this->includeGraph ? $quad->graph->value : null,
+			);
+		}
+
+		return $this->writer->read();
+	}
+
+	public function finish(): string {
+		// end() returns null only when a read callback is set, which this adapter never does.
+		return $this->writer->end() ?? '';
+	}
+
+	private function encodeObject( RdfTerm $term ): string {
+		if ( $term instanceof Iri ) {
+			return $term->value;
+		}
+
+		/** @var Literal $term */
+		return $this->encodeLiteral( $term );
+	}
+
+	private function encodeLiteral( Literal $literal ): string {
+		if ( $literal->languageTag !== null ) {
+			return '"' . $literal->lexicalForm . '"@' . $literal->languageTag;
+		}
+
+		// xsd:string is RDF's default literal type, so emit the canonical bare form.
+		if ( $literal->datatype->value === RdfNamespaces::XSD . 'string' ) {
+			return '"' . $literal->lexicalForm . '"';
+		}
+
+		return '"' . $literal->lexicalForm . '"^^' . $literal->datatype->value;
+	}
+
+}

--- a/src/NeoWikiConfig.php
+++ b/src/NeoWikiConfig.php
@@ -11,6 +11,7 @@ readonly class NeoWikiConfig {
 		public string $neo4jInternalWriteUrl,
 		public string $neo4jInternalReadUrl,
 		public string $wikiId,
+		public string $rdfBaseUri,
 	) {
 	}
 

--- a/src/NeoWikiConfigFactory.php
+++ b/src/NeoWikiConfigFactory.php
@@ -16,7 +16,24 @@ class NeoWikiConfigFactory {
 			neo4jInternalWriteUrl: $this->buildInternalWriteUrl( $config ),
 			neo4jInternalReadUrl: $this->builtInternalReadUrl( $config ),
 			wikiId: WikiMap::getCurrentWikiId(),
+			rdfBaseUri: $this->buildRdfBaseUri( $config ),
 		);
+	}
+
+	/**
+	 * The base URI for all minted RDF IRIs. Defaults to the wiki's canonical URL so IRIs are stable
+	 * and resolvable; admins can override it (e.g. to align with an institutional URI policy).
+	 */
+	private function buildRdfBaseUri( Config $config ): string {
+		$configured = $config->get( 'NeoWikiRdfBaseUri' );
+
+		if ( is_string( $configured ) && $configured !== '' ) {
+			return $configured;
+		}
+
+		$canonicalServer = $config->get( 'CanonicalServer' );
+
+		return is_string( $canonicalServer ) ? $canonicalServer : '';
 	}
 
 	private function buildInternalWriteUrl( Config $config ): string {

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -58,6 +58,14 @@ use ProfessionalWiki\NeoWiki\Application\SubjectPermissionHints;
 use ProfessionalWiki\NeoWiki\Application\SubjectWriteAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\SubjectPageRebuilder;
 use ProfessionalWiki\NeoWiki\Application\SubjectRepository;
+use ProfessionalWiki\NeoWiki\Application\Rdf\RdfPageExporter;
+use ProfessionalWiki\NeoWiki\Application\Rdf\RdfPageLoader;
+use ProfessionalWiki\NeoWiki\Application\Rdf\RdfPageProjector;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfNamespaces;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfSerializer;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfValueMapperRegistry;
+use ProfessionalWiki\NeoWiki\Infrastructure\Rdf\HardfRdfSerializer;
+use ProfessionalWiki\NeoWiki\EntryPoints\REST\ExportPageRdfApi;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jWriteQueryEngine;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeLookup;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeRegistry;
@@ -118,6 +126,7 @@ class NeoWikiExtension {
 	private PropertyTypeRegistry $propertyTypeRegistry;
 	private PagePropertyProviderRegistry $pagePropertyProviderRegistry;
 	private Neo4jValueBuilderRegistry $valueBuilderRegistry;
+	private RdfValueMapperRegistry $rdfValueMapperRegistry;
 	private bool $extensionsRegistered = false;
 	private SubjectRepository $subjectRepository;
 	private CompositeGraphDatabasePlugin $graphDatabasePlugin;
@@ -164,6 +173,16 @@ class NeoWikiExtension {
 		return $this->valueBuilderRegistry;
 	}
 
+	public function getRdfValueMapperRegistry(): RdfValueMapperRegistry {
+		if ( !isset( $this->rdfValueMapperRegistry ) ) {
+			$this->rdfValueMapperRegistry = RdfValueMapperRegistry::withCoreMappers();
+		}
+
+		$this->ensureExtensionsRegistered();
+
+		return $this->rdfValueMapperRegistry;
+	}
+
 	private function ensureExtensionsRegistered(): void {
 		if ( $this->extensionsRegistered ) {
 			return;
@@ -178,6 +197,7 @@ class NeoWikiExtension {
 				$this->getValueBuilderRegistry(),
 				$this->getPagePropertyProviderRegistry(),
 				$this->getGraphDatabasePluginRegistry(),
+				$this->getRdfValueMapperRegistry(),
 			) ]
 		);
 	}
@@ -200,13 +220,53 @@ class NeoWikiExtension {
 	public function getStoreContentUC(): OnRevisionCreatedHandler {
 		return new OnRevisionCreatedHandler(
 			$this->getGraphDatabasePlugin(),
-			new PagePropertiesBuilder(
-				revisionStore: MediaWikiServices::getInstance()->getRevisionStore(),
-				contentHandlerFactory: MediaWikiServices::getInstance()->getContentHandlerFactory(),
-				titleFormatter: MediaWikiServices::getInstance()->getTitleFormatter(),
-				providerRegistry: $this->getPagePropertyProviderRegistry(),
-			)
+			$this->getPagePropertiesBuilder(),
 		);
+	}
+
+	public function getPagePropertiesBuilder(): PagePropertiesBuilder {
+		return new PagePropertiesBuilder(
+			revisionStore: MediaWikiServices::getInstance()->getRevisionStore(),
+			contentHandlerFactory: MediaWikiServices::getInstance()->getContentHandlerFactory(),
+			titleFormatter: MediaWikiServices::getInstance()->getTitleFormatter(),
+			providerRegistry: $this->getPagePropertyProviderRegistry(),
+		);
+	}
+
+	public function getRdfNamespaces(): RdfNamespaces {
+		return new RdfNamespaces( $this->config->rdfBaseUri );
+	}
+
+	public function getRdfSerializer(): RdfSerializer {
+		return new HardfRdfSerializer( $this->getRdfNamespaces()->prefixMap() );
+	}
+
+	public function newRdfPageProjector(): RdfPageProjector {
+		return new RdfPageProjector(
+			$this->getRdfValueMapperRegistry(),
+			$this->getRdfNamespaces(),
+			$this->getSchemaLookup(),
+			LoggerFactory::getInstance( 'NeoWiki' ),
+		);
+	}
+
+	public function newRdfPageLoader(): RdfPageLoader {
+		return new RdfPageLoader(
+			MediaWikiServices::getInstance()->getWikiPageFactory(),
+			$this->getPagePropertiesBuilder(),
+		);
+	}
+
+	public function newRdfPageExporter(): RdfPageExporter {
+		return new RdfPageExporter(
+			$this->newRdfPageLoader(),
+			$this->newRdfPageProjector(),
+			$this->getRdfSerializer(),
+		);
+	}
+
+	public static function newExportPageRdfApi(): ExportPageRdfApi {
+		return new ExportPageRdfApi();
 	}
 
 	public function getGraphDatabasePlugin(): GraphDatabasePlugin {

--- a/tests/RedHerb/src/RedHerbHooks.php
+++ b/tests/RedHerb/src/RedHerbHooks.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\RedHerb;
 
 use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfLiteralFactory;
+use ProfessionalWiki\NeoWiki\Domain\Value\NeoValue;
 use ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiRegistrar;
 
 class RedHerbHooks {
@@ -14,10 +15,25 @@ class RedHerbHooks {
 		$registrar->addNeo4jValueBuilder( ColorType::NAME, static fn( $value ) => $value->toScalars() );
 		$registrar->addRdfValueMapper(
 			ColorType::NAME,
-			static fn( $value ) => array_map(
-				static fn( string $color ) => RdfLiteralFactory::typed( $color, 'string' ),
-				$value->toScalars()
-			)
+			static function ( NeoValue $value ): array {
+				// Guard the value shape like the core mappers do: an extension mapper is called for
+				// whatever a Statement holds, so tolerate a non-array or non-scalar parts.
+				$scalars = $value->toScalars();
+
+				if ( !is_array( $scalars ) ) {
+					return [];
+				}
+
+				$literals = [];
+
+				foreach ( $scalars as $part ) {
+					if ( is_scalar( $part ) ) {
+						$literals[] = RdfLiteralFactory::typed( (string)$part, 'string' );
+					}
+				}
+
+				return $literals;
+			}
 		);
 		$registrar->addPagePropertyProvider( new StaticPagePropertyProvider() );
 		$registrar->addGraphDatabasePlugin( new RedHerbGraphDatabasePlugin() );

--- a/tests/RedHerb/src/RedHerbHooks.php
+++ b/tests/RedHerb/src/RedHerbHooks.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\RedHerb;
 
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfLiteralFactory;
 use ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiRegistrar;
 
 class RedHerbHooks {
@@ -11,6 +12,13 @@ class RedHerbHooks {
 	public static function onNeoWikiRegistration( NeoWikiRegistrar $registrar ): void {
 		$registrar->addPropertyType( new ColorType() );
 		$registrar->addNeo4jValueBuilder( ColorType::NAME, static fn( $value ) => $value->toScalars() );
+		$registrar->addRdfValueMapper(
+			ColorType::NAME,
+			static fn( $value ) => array_map(
+				static fn( string $color ) => RdfLiteralFactory::typed( $color, 'string' ),
+				$value->toScalars()
+			)
+		);
 		$registrar->addPagePropertyProvider( new StaticPagePropertyProvider() );
 		$registrar->addGraphDatabasePlugin( new RedHerbGraphDatabasePlugin() );
 	}

--- a/tests/phpunit/Application/Rdf/RdfPageProjectorTest.php
+++ b/tests/phpunit/Application/Rdf/RdfPageProjectorTest.php
@@ -11,6 +11,7 @@ use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\Iri;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\Literal;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\Quad;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\QuadList;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfFormat;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfLiteralFactory;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfNamespaces;
@@ -189,8 +190,8 @@ class RdfPageProjectorTest extends TestCase {
 		) ) );
 	}
 
-	public function testMissingSchemaSkipsRelationsButKeepsTypeLabelAndStatements(): void {
-		$subject = TestSubject::build(
+	public function testSubjectWithMissingSchemaIsSkippedEntirelyWhileOtherSubjectsProject(): void {
+		$acme = TestSubject::build(
 			id: self::ACME_ID,
 			label: 'ACME Corp',
 			schemaName: new SchemaName( 'Company' ),
@@ -201,22 +202,43 @@ class RdfPageProjectorTest extends TestCase {
 				] ),
 			] )
 		);
-		$page = TestPage::build( id: 42, mainSubject: $subject );
+		$jane = TestSubject::build(
+			id: self::JANE_ID,
+			label: 'Jane Smith',
+			schemaName: new SchemaName( 'Person' ),
+		);
+		$page = TestPage::build( id: 42, mainSubject: $acme, childSubjects: new SubjectMap( $jane ) );
 
-		// No Company schema registered, so relations cannot be typed.
-		$quads = $this->newProjector( new InMemorySchemaLookup() )->projectPage( $page );
+		// Only Person is registered. The Company Schema is unavailable, so ACME is skipped entirely,
+		// mirroring Neo4jSubjectUpdater — the projection must still hold the same entity set as Neo4j.
+		$quads = $this->newProjector( new InMemorySchemaLookup(
+			TestSchema::build( name: 'Person', properties: new PropertyDefinitions( [] ) )
+		) )->projectPage( $page );
 
 		$acmeIri = $this->ns->subject( new SubjectId( self::ACME_ID ) );
-		$this->assertTrue( $quads->contains( $this->quad( $acmeIri, $this->ns->rdfType(), $this->ns->schemaClass( new SchemaName( 'Company' ) ) ) ) );
-		$this->assertTrue( $quads->contains( $this->quad( $acmeIri, $this->ns->rdfsLabel(), RdfLiteralFactory::typed( 'ACME Corp', 'string' ) ) ) );
-		$this->assertTrue( $quads->contains( $this->quad( $acmeIri, $this->ns->property( 'Founded' ), RdfLiteralFactory::typed( '2019', 'integer' ) ) ) );
+		$janeIri = $this->ns->subject( new SubjectId( self::JANE_ID ) );
+		$pageIri = $this->ns->page( new PageId( 42 ) );
 
+		// The schema-less Subject leaves no trace: no type, label, statements, or page reference.
+		$this->assertFalse( $quads->contains( $this->quad( $acmeIri, $this->ns->rdfType(), $this->ns->schemaClass( new SchemaName( 'Company' ) ) ) ) );
+		$this->assertFalse( $quads->contains( $this->quad( $acmeIri, $this->ns->rdfsLabel(), RdfLiteralFactory::typed( 'ACME Corp', 'string' ) ) ) );
+		$this->assertFalse( $quads->contains( $this->quad( $acmeIri, $this->ns->property( 'Founded' ), RdfLiteralFactory::typed( '2019', 'integer' ) ) ) );
 		$this->assertFalse(
-			$quads->contains( $this->quad( $acmeIri, $this->ns->property( 'CEO' ), $this->ns->subject( new SubjectId( self::JANE_ID ) ) ) ),
-			'The direct relation triple must be absent when the Schema is unavailable.'
+			$quads->contains( $this->quad( $pageIri, $this->ns->term( RdfNamespaces::TERM_MAIN_SUBJECT ), $acmeIri ) ),
+			'A skipped Subject must not remain the page main subject.'
 		);
+		$this->assertFalse(
+			$quads->contains( $this->quad( $pageIri, $this->ns->term( RdfNamespaces::TERM_HAS_SUBJECT ), $acmeIri ) ),
+			'A skipped Subject must not be referenced by the page.'
+		);
+
+		// The Subject whose Schema is available still projects in full.
+		$this->assertTrue( $quads->contains( $this->quad( $janeIri, $this->ns->rdfType(), $this->ns->schemaClass( new SchemaName( 'Person' ) ) ) ) );
+		$this->assertTrue( $quads->contains( $this->quad( $janeIri, $this->ns->rdfsLabel(), RdfLiteralFactory::typed( 'Jane Smith', 'string' ) ) ) );
+		$this->assertTrue( $quads->contains( $this->quad( $pageIri, $this->ns->term( RdfNamespaces::TERM_HAS_SUBJECT ), $janeIri ) ) );
+
 		$this->assertSame(
-			[ 'Schema not found when projecting relations to RDF: Company' ],
+			[ 'Schema not found: Company' ],
 			$this->logger->getLogCalls()->getMessages()
 		);
 	}
@@ -263,6 +285,97 @@ class RdfPageProjectorTest extends TestCase {
 			[ 'Dropped 1 unrepresentable value(s) of property "Established" on page 42 when projecting to RDF' ],
 			$this->logger->getLogCalls()->getMessages()
 		);
+	}
+
+	/**
+	 * A user-authored Property or Schema name must never break out of its IRI: illegal characters
+	 * are escaped so the document still parses to exactly the intended quads. The confirmed repro
+	 * strings (a name closing the IRIREF with `>`, and one forging extra `<s> <p> <o> .` triples)
+	 * must each yield a single statement quad, not injected triples.
+	 *
+	 * @dataProvider provideNamesThatMustBeEscaped
+	 */
+	public function testUserAuthoredNamesCannotBreakOutOfTheirIri( string $propertyName, string $expectedLocalName ): void {
+		$output = $this->serialize(
+			$this->newProjector( new InMemorySchemaLookup( $this->companySchema() ) )
+				->projectPage( $this->pageWithTextProperty( $propertyName ) )
+		);
+
+		$this->assertSame(
+			ParsedRdf::canonicalQuads( $this->expectedTriGForTextProperty( 'https://wiki.example/prop/' . $expectedLocalName ) ),
+			ParsedRdf::canonicalQuads( $output )
+		);
+	}
+
+	/**
+	 * @return iterable<string, array{string, string}>
+	 */
+	public static function provideNamesThatMustBeEscaped(): iterable {
+		yield 'less-than' => [ 'a<b', 'a%3Cb' ];
+		yield 'greater-than closes the IRIREF (confirmed repro)' => [ 'Rev>2020', 'Rev%3E2020' ];
+		yield 'double quote' => [ 'a"b', 'a%22b' ];
+		yield 'opening brace' => [ 'a{b', 'a%7Bb' ];
+		yield 'closing brace' => [ 'a}b', 'a%7Db' ];
+		yield 'pipe' => [ 'a|b', 'a%7Cb' ];
+		yield 'caret' => [ 'a^b', 'a%5Eb' ];
+		yield 'backslash' => [ 'a\\b', 'a%5Cb' ];
+		yield 'backtick' => [ 'a`b', 'a%60b' ];
+		yield 'percent sign' => [ 'a%b', 'a%25b' ];
+		yield 'control character' => [ "a\x01b", 'a%01b' ];
+		yield 'unicode passes through raw' => [ 'Naïve 日本語', 'Naïve_日本語' ];
+		yield 'triple injection breakout (confirmed repro)' => [
+			'p><evil-s>.<evil-s2><evil-p2><evil-o2>.<evil-s3><evil-p3',
+			'p%3E%3Cevil-s%3E.%3Cevil-s2%3E%3Cevil-p2%3E%3Cevil-o2%3E.%3Cevil-s3%3E%3Cevil-p3',
+		];
+	}
+
+	private function pageWithTextProperty( string $propertyName ): Page {
+		return TestPage::build(
+			id: 42,
+			properties: TestPageProperties::build(
+				title: 'ACME Corp',
+				creationTime: '20240301090000',
+				modificationTime: '20240301090000',
+				lastEditor: 'Admin',
+			),
+			mainSubject: TestSubject::build(
+				id: self::ACME_ID,
+				label: 'ACME Corp',
+				schemaName: new SchemaName( 'Company' ),
+				statements: new StatementList( [
+					TestStatement::build( $propertyName, new StringValue( 'v' ), 'text' ),
+				] )
+			),
+		);
+	}
+
+	private function expectedTriGForTextProperty( string $predicateIri ): string {
+		return <<<TRIG
+			@prefix neo: <https://wiki.example/ontology/> .
+			@prefix neo-subj: <https://wiki.example/entity/> .
+			@prefix neo-schema: <https://wiki.example/schema/> .
+			@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+			@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+			@prefix dcterms: <http://purl.org/dc/terms/> .
+
+			<https://wiki.example/page/42> {
+				<https://wiki.example/page/42> a neo:Page ;
+					neo:pageName "ACME Corp" ;
+					dcterms:created "2024-03-01T09:00:00Z"^^xsd:dateTime ;
+					dcterms:modified "2024-03-01T09:00:00Z"^^xsd:dateTime ;
+					neo:lastEditor "Admin" ;
+					neo:mainSubject neo-subj:s1acmeaaaaaaaa1 ;
+					neo:hasSubject neo-subj:s1acmeaaaaaaaa1 .
+
+				neo-subj:s1acmeaaaaaaaa1 a neo-schema:Company ;
+					rdfs:label "ACME Corp" ;
+					<$predicateIri> "v" .
+			}
+			TRIG;
+	}
+
+	private function serialize( QuadList $quads ): string {
+		return ( new HardfRdfSerializer( $this->ns->prefixMap() ) )->serialize( $quads, RdfFormat::TriG );
 	}
 
 	private function companySchema(): Schema {

--- a/tests/phpunit/Application/Rdf/RdfPageProjectorTest.php
+++ b/tests/phpunit/Application/Rdf/RdfPageProjectorTest.php
@@ -1,0 +1,281 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Application\Rdf;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\Rdf\RdfPageProjector;
+use ProfessionalWiki\NeoWiki\Domain\Page\Page;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\Iri;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\Literal;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\Quad;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfFormat;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfLiteralFactory;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfNamespaces;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfValueMapperRegistry;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinitions;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectMap;
+use ProfessionalWiki\NeoWiki\Domain\Value\NumberValue;
+use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
+use ProfessionalWiki\NeoWiki\Infrastructure\Rdf\HardfRdfSerializer;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestPage;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestPageProperties;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestProperty;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestRelation;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSchema;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestStatement;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
+use ProfessionalWiki\NeoWiki\Tests\Domain\Rdf\ParsedRdf;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySchemaLookup;
+use WMDE\PsrLogTestDoubles\LegacyLoggerSpy;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Application\Rdf\RdfPageProjector
+ */
+class RdfPageProjectorTest extends TestCase {
+
+	private const string ACME_ID = 's1acmeaaaaaaaa1';
+	private const string JANE_ID = 's1janeaaaaaaaa2';
+	private const string CEO_RELATION_ID = 'r1ceoaaaaaaaaa3';
+
+	private RdfNamespaces $ns;
+	private LegacyLoggerSpy $logger;
+
+	protected function setUp(): void {
+		$this->ns = new RdfNamespaces( 'https://wiki.example' );
+		$this->logger = new LegacyLoggerSpy();
+	}
+
+	private function newProjector( InMemorySchemaLookup $schemaLookup ): RdfPageProjector {
+		return new RdfPageProjector(
+			RdfValueMapperRegistry::withCoreMappers(),
+			$this->ns,
+			$schemaLookup,
+			$this->logger,
+		);
+	}
+
+	public function testProjectsTheCompleteExampleToTheSpecifiedQuadSet(): void {
+		$schemaLookup = new InMemorySchemaLookup(
+			TestSchema::build(
+				name: 'Company',
+				properties: new PropertyDefinitions( [
+					'CEO' => TestProperty::buildRelation( relationType: 'CEO', targetSchema: 'Person' ),
+				] )
+			),
+			TestSchema::build( name: 'Person', properties: new PropertyDefinitions( [] ) ),
+		);
+
+		$quads = $this->newProjector( $schemaLookup )->projectPage( $this->completeExamplePage() );
+		$output = ( new HardfRdfSerializer( $this->ns->prefixMap() ) )->serialize( $quads, RdfFormat::TriG );
+
+		$this->assertSame(
+			ParsedRdf::canonicalQuads( $this->completeExampleTriG() ),
+			ParsedRdf::canonicalQuads( $output )
+		);
+		$this->logger->assertNoLoggingCallsWhereMade();
+	}
+
+	private function completeExamplePage(): Page {
+		$acme = TestSubject::build(
+			id: self::ACME_ID,
+			label: 'ACME Corp',
+			schemaName: new SchemaName( 'Company' ),
+			statements: new StatementList( [
+				TestStatement::build( 'Website', new StringValue( 'https://acme.example' ), 'url' ),
+				TestStatement::build( 'Founded', new NumberValue( 2019 ), 'number' ),
+				TestStatement::buildRelation( 'CEO', [
+					TestRelation::build(
+						id: self::CEO_RELATION_ID,
+						targetId: self::JANE_ID,
+						properties: [ 'Since' => 2022 ],
+					),
+				] ),
+			] )
+		);
+
+		$jane = TestSubject::build(
+			id: self::JANE_ID,
+			label: 'Jane Smith',
+			schemaName: new SchemaName( 'Person' ),
+			statements: new StatementList( [
+				TestStatement::build( 'Age', new NumberValue( 45 ), 'number' ),
+			] )
+		);
+
+		return TestPage::build(
+			id: 42,
+			properties: TestPageProperties::build(
+				title: 'ACME Corp',
+				creationTime: '20240301090000',
+				modificationTime: '20251115164500',
+				lastEditor: 'Admin',
+			),
+			mainSubject: $acme,
+			childSubjects: new SubjectMap( $jane ),
+		);
+	}
+
+	private function completeExampleTriG(): string {
+		return <<<TRIG
+			@prefix neo: <https://wiki.example/ontology/> .
+			@prefix neo-subj: <https://wiki.example/entity/> .
+			@prefix neo-prop: <https://wiki.example/prop/> .
+			@prefix neo-schema: <https://wiki.example/schema/> .
+			@prefix neo-rel: <https://wiki.example/relation/> .
+			@prefix neo-page: <https://wiki.example/page/> .
+			@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+			@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+			@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+			@prefix dcterms: <http://purl.org/dc/terms/> .
+
+			neo-page:42 {
+				neo-page:42 a neo:Page ;
+					neo:pageName "ACME Corp" ;
+					dcterms:created "2024-03-01T09:00:00Z"^^xsd:dateTime ;
+					dcterms:modified "2025-11-15T16:45:00Z"^^xsd:dateTime ;
+					neo:lastEditor "Admin" ;
+					neo:mainSubject neo-subj:s1acmeaaaaaaaa1 ;
+					neo:hasSubject neo-subj:s1acmeaaaaaaaa1 ;
+					neo:hasSubject neo-subj:s1janeaaaaaaaa2 .
+
+				neo-subj:s1acmeaaaaaaaa1 a neo-schema:Company ;
+					rdfs:label "ACME Corp" ;
+					neo-prop:Website "https://acme.example"^^xsd:anyURI ;
+					neo-prop:Founded 2019 ;
+					neo-prop:CEO neo-subj:s1janeaaaaaaaa2 .
+
+				neo-rel:r1ceoaaaaaaaaa3 a neo:Relation ;
+					neo:source neo-subj:s1acmeaaaaaaaa1 ;
+					neo:target neo-subj:s1janeaaaaaaaa2 ;
+					neo:relationType neo-prop:CEO ;
+					neo-prop:Since 2022 .
+
+				neo-subj:s1janeaaaaaaaa2 a neo-schema:Person ;
+					rdfs:label "Jane Smith" ;
+					neo-prop:Age 45 .
+			}
+			TRIG;
+	}
+
+	public function testMultiValuedTextProducesRepeatedPredicates(): void {
+		$subject = TestSubject::build(
+			id: self::ACME_ID,
+			label: 'ACME Corp',
+			schemaName: new SchemaName( 'Company' ),
+			statements: new StatementList( [
+				TestStatement::build( 'Website', new StringValue( 'https://a.example', 'https://b.example' ), 'url' ),
+			] )
+		);
+		$page = TestPage::build( id: 42, mainSubject: $subject );
+
+		$quads = $this->newProjector( new InMemorySchemaLookup( $this->companySchema() ) )->projectPage( $page );
+
+		$this->assertTrue( $quads->contains( $this->quad(
+			$this->ns->subject( new SubjectId( self::ACME_ID ) ),
+			$this->ns->property( 'Website' ),
+			new Literal( 'https://a.example', $this->ns->xsd( 'anyURI' ) )
+		) ) );
+		$this->assertTrue( $quads->contains( $this->quad(
+			$this->ns->subject( new SubjectId( self::ACME_ID ) ),
+			$this->ns->property( 'Website' ),
+			new Literal( 'https://b.example', $this->ns->xsd( 'anyURI' ) )
+		) ) );
+	}
+
+	public function testMissingSchemaSkipsRelationsButKeepsTypeLabelAndStatements(): void {
+		$subject = TestSubject::build(
+			id: self::ACME_ID,
+			label: 'ACME Corp',
+			schemaName: new SchemaName( 'Company' ),
+			statements: new StatementList( [
+				TestStatement::build( 'Founded', new NumberValue( 2019 ), 'number' ),
+				TestStatement::buildRelation( 'CEO', [
+					TestRelation::build( id: self::CEO_RELATION_ID, targetId: self::JANE_ID ),
+				] ),
+			] )
+		);
+		$page = TestPage::build( id: 42, mainSubject: $subject );
+
+		// No Company schema registered, so relations cannot be typed.
+		$quads = $this->newProjector( new InMemorySchemaLookup() )->projectPage( $page );
+
+		$acmeIri = $this->ns->subject( new SubjectId( self::ACME_ID ) );
+		$this->assertTrue( $quads->contains( $this->quad( $acmeIri, $this->ns->rdfType(), $this->ns->schemaClass( new SchemaName( 'Company' ) ) ) ) );
+		$this->assertTrue( $quads->contains( $this->quad( $acmeIri, $this->ns->rdfsLabel(), RdfLiteralFactory::typed( 'ACME Corp', 'string' ) ) ) );
+		$this->assertTrue( $quads->contains( $this->quad( $acmeIri, $this->ns->property( 'Founded' ), RdfLiteralFactory::typed( '2019', 'integer' ) ) ) );
+
+		$this->assertFalse(
+			$quads->contains( $this->quad( $acmeIri, $this->ns->property( 'CEO' ), $this->ns->subject( new SubjectId( self::JANE_ID ) ) ) ),
+			'The direct relation triple must be absent when the Schema is unavailable.'
+		);
+		$this->assertSame(
+			[ 'Schema not found when projecting relations to RDF: Company' ],
+			$this->logger->getLogCalls()->getMessages()
+		);
+	}
+
+	public function testUnregisteredValueTypeStatementIsSkippedButSubjectStillProjects(): void {
+		$subject = TestSubject::build(
+			id: self::ACME_ID,
+			label: 'ACME Corp',
+			schemaName: new SchemaName( 'Company' ),
+			statements: new StatementList( [
+				TestStatement::build( 'Colour', new StringValue( 'green' ), 'colour-from-disabled-extension' ),
+			] )
+		);
+		$page = TestPage::build( id: 42, mainSubject: $subject );
+
+		$quads = $this->newProjector( new InMemorySchemaLookup( $this->companySchema() ) )->projectPage( $page );
+
+		$acmeIri = $this->ns->subject( new SubjectId( self::ACME_ID ) );
+		$this->assertTrue( $quads->contains( $this->quad( $acmeIri, $this->ns->rdfsLabel(), RdfLiteralFactory::typed( 'ACME Corp', 'string' ) ) ) );
+		$this->assertFalse(
+			$quads->contains( $this->quad( $acmeIri, $this->ns->property( 'Colour' ), RdfLiteralFactory::typed( 'green', 'string' ) ) )
+		);
+	}
+
+	public function testDroppingAnInvalidDatePartLogsAWarning(): void {
+		$subject = TestSubject::build(
+			id: self::ACME_ID,
+			label: 'ACME Corp',
+			schemaName: new SchemaName( 'Company' ),
+			statements: new StatementList( [
+				TestStatement::build( 'Established', new StringValue( '2019-01-01', 'not-a-date' ), 'date' ),
+			] )
+		);
+		$page = TestPage::build( id: 42, mainSubject: $subject );
+
+		$quads = $this->newProjector( new InMemorySchemaLookup( $this->companySchema() ) )->projectPage( $page );
+
+		$this->assertTrue( $quads->contains( $this->quad(
+			$this->ns->subject( new SubjectId( self::ACME_ID ) ),
+			$this->ns->property( 'Established' ),
+			RdfLiteralFactory::typed( '2019-01-01', 'date' )
+		) ) );
+		$this->assertSame(
+			[ 'Dropped 1 unrepresentable value(s) of property "Established" on page 42 when projecting to RDF' ],
+			$this->logger->getLogCalls()->getMessages()
+		);
+	}
+
+	private function companySchema(): Schema {
+		return TestSchema::build(
+			name: 'Company',
+			properties: new PropertyDefinitions( [
+				'CEO' => TestProperty::buildRelation( relationType: 'CEO', targetSchema: 'Person' ),
+			] )
+		);
+	}
+
+	private function quad( Iri $subject, Iri $predicate, Literal|Iri $object ): Quad {
+		return new Quad( $subject, $predicate, $object, $this->ns->page( new PageId( 42 ) ) );
+	}
+
+}

--- a/tests/phpunit/Domain/Rdf/IriTest.php
+++ b/tests/phpunit/Domain/Rdf/IriTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Domain\Rdf;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\Iri;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\Literal;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Domain\Rdf\Iri
+ */
+class IriTest extends TestCase {
+
+	public function testRejectsEmptyValue(): void {
+		$this->expectException( InvalidArgumentException::class );
+		new Iri( '   ' );
+	}
+
+	public function testEqualsMatchesSameValue(): void {
+		$this->assertTrue(
+			( new Iri( 'http://example.org/a' ) )->equals( new Iri( 'http://example.org/a' ) )
+		);
+	}
+
+	public function testEqualsRejectsDifferentValue(): void {
+		$this->assertFalse(
+			( new Iri( 'http://example.org/a' ) )->equals( new Iri( 'http://example.org/b' ) )
+		);
+	}
+
+	public function testIriDoesNotEqualLiteralWithSameString(): void {
+		$this->assertFalse(
+			( new Iri( 'http://example.org/a' ) )->equals(
+				new Literal( 'http://example.org/a', new Iri( 'http://www.w3.org/2001/XMLSchema#string' ) )
+			)
+		);
+	}
+
+}

--- a/tests/phpunit/Domain/Rdf/LiteralTest.php
+++ b/tests/phpunit/Domain/Rdf/LiteralTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Domain\Rdf;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\Iri;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\Literal;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Domain\Rdf\Literal
+ */
+class LiteralTest extends TestCase {
+
+	private function xsd( string $local ): Iri {
+		return new Iri( 'http://www.w3.org/2001/XMLSchema#' . $local );
+	}
+
+	public function testEqualsMatchesSameLexicalAndDatatype(): void {
+		$this->assertTrue(
+			( new Literal( '42', $this->xsd( 'integer' ) ) )->equals(
+				new Literal( '42', $this->xsd( 'integer' ) )
+			)
+		);
+	}
+
+	public function testEqualsRejectsDifferentDatatype(): void {
+		$this->assertFalse(
+			( new Literal( '42', $this->xsd( 'integer' ) ) )->equals(
+				new Literal( '42', $this->xsd( 'decimal' ) )
+			)
+		);
+	}
+
+	public function testEqualsRejectsDifferentLexicalForm(): void {
+		$this->assertFalse(
+			( new Literal( '42', $this->xsd( 'integer' ) ) )->equals(
+				new Literal( '43', $this->xsd( 'integer' ) )
+			)
+		);
+	}
+
+	public function testLanguageTagDistinguishesLiterals(): void {
+		$tagged = new Literal( 'Bonjour', $this->xsd( 'string' ), 'fr' );
+		$plain = new Literal( 'Bonjour', $this->xsd( 'string' ) );
+
+		$this->assertTrue( $tagged->isLanguageTagged() );
+		$this->assertFalse( $plain->isLanguageTagged() );
+		$this->assertFalse( $tagged->equals( $plain ) );
+	}
+
+}

--- a/tests/phpunit/Domain/Rdf/ParsedRdf.php
+++ b/tests/phpunit/Domain/Rdf/ParsedRdf.php
@@ -1,0 +1,43 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Domain\Rdf;
+
+use pietercolpaert\hardf\TriGParser;
+
+/**
+ * Test helper: parses an RDF document (TriG or Turtle) with hardf and returns its quads as a sorted
+ * set of canonical strings. Because both the expected document and the projector's output are run
+ * through the same parser, cosmetic differences (prefix use, the GRAPH keyword, bare vs typed numeric
+ * literals, statement order) collapse, so comparisons assert on the set of quads, not on formatting.
+ */
+final class ParsedRdf {
+
+	/**
+	 * @return list<string> Sorted "subject \t predicate \t object \t graph" lines, one per quad.
+	 */
+	public static function canonicalQuads( string $rdf ): array {
+		$triples = ( new TriGParser() )->parse( $rdf );
+
+		$lines = array_map(
+			static fn( array $triple ): string => implode( "\t", [
+				self::term( $triple['subject'] ),
+				self::term( $triple['predicate'] ),
+				self::term( $triple['object'] ),
+				self::term( $triple['graph'] ?? '' ),
+			] ),
+			$triples
+		);
+
+		sort( $lines );
+
+		return $lines;
+	}
+
+	private static function term( mixed $term ): string {
+		// The native projection never emits RDF 1.2 triple terms, so every term parses to a string.
+		return is_string( $term ) ? $term : json_encode( $term );
+	}
+
+}

--- a/tests/phpunit/Domain/Rdf/QuadListTest.php
+++ b/tests/phpunit/Domain/Rdf/QuadListTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Domain\Rdf;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\Iri;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\Literal;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\Quad;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\QuadList;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Domain\Rdf\QuadList
+ * @covers \ProfessionalWiki\NeoWiki\Domain\Rdf\Quad
+ */
+class QuadListTest extends TestCase {
+
+	private function quad( string $object ): Quad {
+		return new Quad(
+			new Iri( 'http://example.org/s' ),
+			new Iri( 'http://example.org/p' ),
+			new Iri( $object ),
+			new Iri( 'http://example.org/g' ),
+		);
+	}
+
+	public function testContainsFindsEqualQuad(): void {
+		$list = new QuadList( $this->quad( 'http://example.org/a' ), $this->quad( 'http://example.org/b' ) );
+
+		$this->assertTrue( $list->contains( $this->quad( 'http://example.org/b' ) ) );
+	}
+
+	public function testContainsRejectsAbsentQuad(): void {
+		$list = new QuadList( $this->quad( 'http://example.org/a' ) );
+
+		$this->assertFalse( $list->contains( $this->quad( 'http://example.org/z' ) ) );
+	}
+
+	public function testQuadEqualityComparesTheObjectTerm(): void {
+		$literalQuad = new Quad(
+			new Iri( 'http://example.org/s' ),
+			new Iri( 'http://example.org/p' ),
+			new Literal( 'x', new Iri( 'http://www.w3.org/2001/XMLSchema#string' ) ),
+			new Iri( 'http://example.org/g' ),
+		);
+
+		$this->assertFalse( $literalQuad->equals( $this->quad( 'x' ) ) );
+	}
+
+	public function testMergeConcatenatesBothLists(): void {
+		$merged = ( new QuadList( $this->quad( 'http://example.org/a' ) ) )
+			->merge( new QuadList( $this->quad( 'http://example.org/b' ) ) );
+
+		$this->assertCount( 2, $merged );
+		$this->assertTrue( $merged->contains( $this->quad( 'http://example.org/a' ) ) );
+		$this->assertTrue( $merged->contains( $this->quad( 'http://example.org/b' ) ) );
+	}
+
+	public function testEmptyListReportsEmpty(): void {
+		$this->assertTrue( ( new QuadList() )->isEmpty() );
+		$this->assertFalse( ( new QuadList( $this->quad( 'http://example.org/a' ) ) )->isEmpty() );
+	}
+
+}

--- a/tests/phpunit/Domain/Rdf/RdfLiteralFactoryTest.php
+++ b/tests/phpunit/Domain/Rdf/RdfLiteralFactoryTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Domain\Rdf;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\Iri;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\Literal;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfLiteralFactory;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Domain\Rdf\RdfLiteralFactory
+ */
+class RdfLiteralFactoryTest extends TestCase {
+
+	private function xsd( string $local ): Iri {
+		return new Iri( 'http://www.w3.org/2001/XMLSchema#' . $local );
+	}
+
+	public function testIntegerNumberIsXsdInteger(): void {
+		$this->assertEquals( new Literal( '2019', $this->xsd( 'integer' ) ), RdfLiteralFactory::number( 2019 ) );
+	}
+
+	public function testFractionlessFloatIsXsdInteger(): void {
+		$this->assertEquals( new Literal( '2019', $this->xsd( 'integer' ) ), RdfLiteralFactory::number( 2019.0 ) );
+	}
+
+	public function testDecimalFloatIsXsdDecimalWithoutScientificNotation(): void {
+		$this->assertEquals( new Literal( '0.0001', $this->xsd( 'decimal' ) ), RdfLiteralFactory::number( 0.0001 ) );
+	}
+
+	public function testDecimalKeepsTrailingSignificantDigits(): void {
+		$this->assertEquals( new Literal( '3.14159', $this->xsd( 'decimal' ) ), RdfLiteralFactory::number( 3.14159 ) );
+	}
+
+	public function testNonFiniteNumberYieldsNull(): void {
+		$this->assertNull( RdfLiteralFactory::number( INF ) );
+		$this->assertNull( RdfLiteralFactory::number( NAN ) );
+	}
+
+	public function testForScalarStringIsXsdString(): void {
+		$this->assertEquals( new Literal( 'Editor', $this->xsd( 'string' ) ), RdfLiteralFactory::forScalar( 'Editor' ) );
+	}
+
+	public function testForScalarBooleanIsXsdBoolean(): void {
+		$this->assertEquals( new Literal( 'false', $this->xsd( 'boolean' ) ), RdfLiteralFactory::forScalar( false ) );
+	}
+
+	public function testForScalarIntegerIsXsdInteger(): void {
+		$this->assertEquals( new Literal( '2019', $this->xsd( 'integer' ) ), RdfLiteralFactory::forScalar( 2019 ) );
+	}
+
+	public function testForScalarRejectsNullAndArrays(): void {
+		$this->assertNull( RdfLiteralFactory::forScalar( null ) );
+		$this->assertNull( RdfLiteralFactory::forScalar( [ 'x' ] ) );
+	}
+
+}

--- a/tests/phpunit/Domain/Rdf/RdfNamespacesTest.php
+++ b/tests/phpunit/Domain/Rdf/RdfNamespacesTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Domain\Rdf;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfNamespaces;
+use ProfessionalWiki\NeoWiki\Domain\Relation\RelationId;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Domain\Rdf\RdfNamespaces
+ */
+class RdfNamespacesTest extends TestCase {
+
+	private function namespaces(): RdfNamespaces {
+		return new RdfNamespaces( 'https://wiki.example' );
+	}
+
+	public function testSubjectIriUsesEntityPath(): void {
+		$this->assertSame(
+			'https://wiki.example/entity/s1demo8aaaaaab5',
+			$this->namespaces()->subject( new SubjectId( 's1demo8aaaaaab5' ) )->value
+		);
+	}
+
+	public function testPropertyIriSubstitutesSpacesWithUnderscores(): void {
+		$this->assertSame(
+			'https://wiki.example/prop/Has_author',
+			$this->namespaces()->property( 'Has author' )->value
+		);
+	}
+
+	public function testSchemaClassIriUsesSchemaPath(): void {
+		$this->assertSame(
+			'https://wiki.example/schema/Person',
+			$this->namespaces()->schemaClass( new SchemaName( 'Person' ) )->value
+		);
+	}
+
+	public function testRelationNodeIriUsesRelationPath(): void {
+		$this->assertSame(
+			'https://wiki.example/relation/r1demo8aaaaaaD6',
+			$this->namespaces()->relationNode( new RelationId( 'r1demo8aaaaaaD6' ) )->value
+		);
+	}
+
+	public function testPageIriUsesPagePath(): void {
+		$this->assertSame(
+			'https://wiki.example/page/42',
+			$this->namespaces()->page( new PageId( 42 ) )->value
+		);
+	}
+
+	public function testVocabularyTermUsesOntologyPath(): void {
+		$this->assertSame(
+			'https://wiki.example/ontology/hasSubject',
+			$this->namespaces()->term( RdfNamespaces::TERM_HAS_SUBJECT )->value
+		);
+	}
+
+	public function testTrailingSlashInBaseUriIsNormalised(): void {
+		$namespaces = new RdfNamespaces( 'https://wiki.example/' );
+
+		$this->assertSame(
+			'https://wiki.example/page/7',
+			$namespaces->page( new PageId( 7 ) )->value
+		);
+	}
+
+	public function testStandardVocabularyIsIndependentOfBase(): void {
+		$namespaces = $this->namespaces();
+
+		$this->assertSame( 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', $namespaces->rdfType()->value );
+		$this->assertSame( 'http://www.w3.org/2000/01/rdf-schema#label', $namespaces->rdfsLabel()->value );
+		$this->assertSame( 'http://purl.org/dc/terms/created', $namespaces->dctermsCreated()->value );
+		$this->assertSame( 'http://www.w3.org/2001/XMLSchema#dateTime', $namespaces->xsd( 'dateTime' )->value );
+	}
+
+	public function testPrefixMapCoversEveryNeoAndStandardNamespace(): void {
+		$this->assertSame(
+			[
+				'neo' => 'https://wiki.example/ontology/',
+				'neo-subj' => 'https://wiki.example/entity/',
+				'neo-prop' => 'https://wiki.example/prop/',
+				'neo-schema' => 'https://wiki.example/schema/',
+				'neo-rel' => 'https://wiki.example/relation/',
+				'neo-page' => 'https://wiki.example/page/',
+				'rdf' => 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+				'rdfs' => 'http://www.w3.org/2000/01/rdf-schema#',
+				'xsd' => 'http://www.w3.org/2001/XMLSchema#',
+				'dcterms' => 'http://purl.org/dc/terms/',
+			],
+			$this->namespaces()->prefixMap()
+		);
+	}
+
+}

--- a/tests/phpunit/Domain/Rdf/RdfNamespacesTest.php
+++ b/tests/phpunit/Domain/Rdf/RdfNamespacesTest.php
@@ -34,6 +34,34 @@ class RdfNamespacesTest extends TestCase {
 		);
 	}
 
+	public function testPropertyIriPercentEncodesIriIllegalCharacters(): void {
+		$this->assertSame(
+			'https://wiki.example/prop/Rev%3E2020',
+			$this->namespaces()->property( 'Rev>2020' )->value
+		);
+	}
+
+	public function testPropertyIriPercentEncodesThePercentSignItself(): void {
+		$this->assertSame(
+			'https://wiki.example/prop/100%25_growth',
+			$this->namespaces()->property( '100% growth' )->value
+		);
+	}
+
+	public function testPropertyIriKeepsUnicodeRawAndOnlySubstitutesSpaces(): void {
+		$this->assertSame(
+			'https://wiki.example/prop/Naïve_日本語',
+			$this->namespaces()->property( 'Naïve 日本語' )->value
+		);
+	}
+
+	public function testSchemaClassIriPercentEncodesIriIllegalCharacters(): void {
+		$this->assertSame(
+			'https://wiki.example/schema/Da%7Cngerous',
+			$this->namespaces()->schemaClass( new SchemaName( 'Da|ngerous' ) )->value
+		);
+	}
+
 	public function testSchemaClassIriUsesSchemaPath(): void {
 		$this->assertSame(
 			'https://wiki.example/schema/Person',

--- a/tests/phpunit/Domain/Rdf/RdfValueMapperRegistryTest.php
+++ b/tests/phpunit/Domain/Rdf/RdfValueMapperRegistryTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Domain\Rdf;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\Iri;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\Literal;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfValueMapperRegistry;
+use ProfessionalWiki\NeoWiki\Domain\Value\BooleanValue;
+use ProfessionalWiki\NeoWiki\Domain\Value\NumberValue;
+use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Domain\Rdf\RdfValueMapperRegistry
+ */
+class RdfValueMapperRegistryTest extends TestCase {
+
+	private function xsd( string $local ): Iri {
+		return new Iri( 'http://www.w3.org/2001/XMLSchema#' . $local );
+	}
+
+	public function testTextMapsEachPartToAnXsdString(): void {
+		$this->assertEquals(
+			[
+				new Literal( 'foo', $this->xsd( 'string' ) ),
+				new Literal( 'bar', $this->xsd( 'string' ) ),
+			],
+			RdfValueMapperRegistry::withCoreMappers()->mapValue( 'text', new StringValue( 'foo', 'bar' ) )
+		);
+	}
+
+	public function testUrlMapsToXsdAnyUri(): void {
+		$this->assertEquals(
+			[ new Literal( 'https://pro.wiki', $this->xsd( 'anyURI' ) ) ],
+			RdfValueMapperRegistry::withCoreMappers()->mapValue( 'url', new StringValue( 'https://pro.wiki' ) )
+		);
+	}
+
+	public function testIntegerNumberMapsToXsdInteger(): void {
+		$this->assertEquals(
+			[ new Literal( '2019', $this->xsd( 'integer' ) ) ],
+			RdfValueMapperRegistry::withCoreMappers()->mapValue( 'number', new NumberValue( 2019 ) )
+		);
+	}
+
+	public function testFractionlessFloatMapsToXsdInteger(): void {
+		$this->assertEquals(
+			[ new Literal( '2019', $this->xsd( 'integer' ) ) ],
+			RdfValueMapperRegistry::withCoreMappers()->mapValue( 'number', new NumberValue( 2019.0 ) )
+		);
+	}
+
+	public function testDecimalNumberMapsToXsdDecimalWithoutScientificNotation(): void {
+		$this->assertEquals(
+			[ new Literal( '3.14159', $this->xsd( 'decimal' ) ) ],
+			RdfValueMapperRegistry::withCoreMappers()->mapValue( 'number', new NumberValue( 3.14159 ) )
+		);
+	}
+
+	public function testBooleanMapsToXsdBoolean(): void {
+		$this->assertEquals(
+			[ new Literal( 'true', $this->xsd( 'boolean' ) ) ],
+			RdfValueMapperRegistry::withCoreMappers()->mapValue( 'boolean', new BooleanValue( true ) )
+		);
+	}
+
+	public function testDateMapsValidPartsAndDropsInvalidOnes(): void {
+		$this->assertEquals(
+			[
+				new Literal( '1685-03-21', $this->xsd( 'date' ) ),
+				new Literal( '2020-12-31', $this->xsd( 'date' ) ),
+			],
+			RdfValueMapperRegistry::withCoreMappers()->mapValue(
+				'date',
+				new StringValue( '1685-03-21', 'not a date', '2020-13-01', '2020-12-31' )
+			)
+		);
+	}
+
+	public function testDateTimeMapsValidPartsAndDropsInvalidOnes(): void {
+		$this->assertEquals(
+			[
+				new Literal( '2024-01-01T12:00:00Z', $this->xsd( 'dateTime' ) ),
+				new Literal( '2025-06-15T08:30:00+02:00', $this->xsd( 'dateTime' ) ),
+			],
+			RdfValueMapperRegistry::withCoreMappers()->mapValue(
+				'dateTime',
+				new StringValue(
+					'2024-01-01T12:00:00Z',
+					'2024-01-01T12:00:00',
+					'2025-06-15T08:30:00+02:00'
+				)
+			)
+		);
+	}
+
+	public function testUnregisteredTypeReturnsNull(): void {
+		$this->assertNull(
+			RdfValueMapperRegistry::withCoreMappers()->mapValue( 'relation', new StringValue( 'x' ) )
+		);
+		$this->assertNull(
+			RdfValueMapperRegistry::withCoreMappers()->mapValue( 'nonexistent', new StringValue( 'x' ) )
+		);
+	}
+
+	public function testHasMapperReflectsRegisteredCoreTypes(): void {
+		$registry = RdfValueMapperRegistry::withCoreMappers();
+
+		$this->assertTrue( $registry->hasMapper( 'text' ) );
+		$this->assertTrue( $registry->hasMapper( 'date' ) );
+		$this->assertFalse( $registry->hasMapper( 'relation' ) );
+	}
+
+	public function testCustomMapperCanBeRegistered(): void {
+		$registry = new RdfValueMapperRegistry();
+		$registry->registerMapper(
+			'color',
+			static fn( $value ): array => [ new Literal( '#' . $value->toScalars()[0], new Iri( 'http://example.org/hex' ) ) ]
+		);
+
+		$this->assertEquals(
+			[ new Literal( '#00ff00', new Iri( 'http://example.org/hex' ) ) ],
+			$registry->mapValue( 'color', new StringValue( '00ff00' ) )
+		);
+	}
+
+}

--- a/tests/phpunit/EntryPoints/NeoWikiRegistrarTest.php
+++ b/tests/phpunit/EntryPoints/NeoWikiRegistrarTest.php
@@ -9,6 +9,7 @@ use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphDatabasePluginRegistry;
 use ProfessionalWiki\NeoWiki\Domain\Page\PagePropertyProviderRegistry;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeRegistry;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\Types\TextType;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfValueMapperRegistry;
 use ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiRegistrar;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jValueBuilderRegistry;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpyGraphDatabasePlugin;
@@ -57,17 +58,28 @@ class NeoWikiRegistrarTest extends TestCase {
 		$this->assertSame( [ $plugin ], $pluginRegistry->getPlugins() );
 	}
 
+	public function testAddRdfValueMapperRegistersInRegistry(): void {
+		$rdfValueMapperRegistry = new RdfValueMapperRegistry();
+		$registrar = $this->newRegistrar( rdfValueMapperRegistry: $rdfValueMapperRegistry );
+
+		$registrar->addRdfValueMapper( 'custom', static fn() => [] );
+
+		$this->assertTrue( $rdfValueMapperRegistry->hasMapper( 'custom' ) );
+	}
+
 	private function newRegistrar(
 		?PropertyTypeRegistry $propertyTypeRegistry = null,
 		?Neo4jValueBuilderRegistry $valueBuilderRegistry = null,
 		?PagePropertyProviderRegistry $pagePropertyProviderRegistry = null,
 		?GraphDatabasePluginRegistry $graphDatabasePluginRegistry = null,
+		?RdfValueMapperRegistry $rdfValueMapperRegistry = null,
 	): NeoWikiRegistrar {
 		return new NeoWikiRegistrar(
 			propertyTypeRegistry: $propertyTypeRegistry ?? new PropertyTypeRegistry(),
 			valueBuilderRegistry: $valueBuilderRegistry ?? new Neo4jValueBuilderRegistry(),
 			pagePropertyProviderRegistry: $pagePropertyProviderRegistry ?? new PagePropertyProviderRegistry(),
 			graphDatabasePluginRegistry: $graphDatabasePluginRegistry ?? new GraphDatabasePluginRegistry(),
+			rdfValueMapperRegistry: $rdfValueMapperRegistry ?? new RdfValueMapperRegistry(),
 		);
 	}
 

--- a/tests/phpunit/EntryPoints/NeoWikiRegistrationHookTest.php
+++ b/tests/phpunit/EntryPoints/NeoWikiRegistrationHookTest.php
@@ -42,6 +42,12 @@ class NeoWikiRegistrationHookTest extends MediaWikiIntegrationTestCase {
 		$this->assertTrue( $registry->hasBuilder( 'color' ) );
 	}
 
+	public function testRedHerbRegistersRdfValueMapper(): void {
+		$registry = NeoWikiExtension::getInstance()->getRdfValueMapperRegistry();
+
+		$this->assertTrue( $registry->hasMapper( 'color' ) );
+	}
+
 	public function testRedHerbRegistersGraphDatabasePlugin(): void {
 		$plugins = NeoWikiExtension::getInstance()->getGraphDatabasePluginRegistry()->getPlugins();
 

--- a/tests/phpunit/EntryPoints/REST/ExportPageRdfApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ExportPageRdfApiTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\REST;
+
+use MediaWiki\Rest\RequestData;
+use MediaWiki\Rest\Response;
+use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
+use ProfessionalWiki\NeoWiki\EntryPoints\REST\ExportPageRdfApi;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestStatement;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
+use ProfessionalWiki\NeoWiki\Tests\Domain\Rdf\ParsedRdf;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\REST\ExportPageRdfApi
+ * @group Database
+ */
+class ExportPageRdfApiTest extends NeoWikiIntegrationTestCase {
+	use HandlerTestTrait;
+
+	private const string SCHEMA = 'ExportPageRdfApiTestSchema';
+	private const string SUBJECT_ID = 'sTestERA1111111';
+
+	private int $pageId;
+
+	public function setUp(): void {
+		$this->setUpNeo4j();
+
+		$this->createSchema(
+			self::SCHEMA,
+			<<<JSON
+{
+	"title": "ExportPageRdfApiTestSchema",
+	"propertyDefinitions": {
+		"population": { "type": "text" }
+	}
+}
+JSON
+		);
+
+		$this->pageId = $this->createPageWithSubjects(
+			'ExportPageRdfApiTest_Berlin',
+			mainSubject: TestSubject::build(
+				id: self::SUBJECT_ID,
+				label: new SubjectLabel( 'Berlin' ),
+				schemaName: new SchemaName( self::SCHEMA ),
+				statements: new StatementList( [
+					TestStatement::build( 'population', '3700000' ),
+				] )
+			),
+		)->getPage()->getId();
+	}
+
+	/**
+	 * @param array<string, string> $query
+	 * @param array<string, string> $headers
+	 */
+	private function export( array $query = [], array $headers = [], ?int $pageId = null ): Response {
+		return $this->executeHandler(
+			new ExportPageRdfApi(),
+			new RequestData( [
+				'method' => 'GET',
+				'pathParams' => [ 'pageId' => (string)( $pageId ?? $this->pageId ) ],
+				'queryParams' => $query,
+				'headers' => $headers,
+			] )
+		);
+	}
+
+	public function testDefaultsToTriGWithThePageNamedGraph(): void {
+		$response = $this->export();
+		$body = $response->getBody()->getContents();
+
+		$this->assertSame( 200, $response->getStatusCode() );
+		$this->assertSame( 'application/trig; charset=utf-8', $response->getHeaderLine( 'Content-Type' ) );
+		$this->assertStringContainsString( 'Berlin', $body );
+		$this->assertNotContains( '', $this->graphsIn( $body ), 'Every TriG quad belongs to the page named graph.' );
+	}
+
+	public function testFormatParameterSelectsTurtleWithoutANamedGraph(): void {
+		$response = $this->export( query: [ 'format' => 'turtle' ] );
+		$body = $response->getBody()->getContents();
+
+		$this->assertSame( 200, $response->getStatusCode() );
+		$this->assertSame( 'text/turtle; charset=utf-8', $response->getHeaderLine( 'Content-Type' ) );
+		$this->assertStringContainsString( 'Berlin', $body );
+		$this->assertSame( [ '' ], $this->graphsIn( $body ), 'Turtle drops the named graph.' );
+	}
+
+	public function testFormatParameterOverridesTheAcceptHeader(): void {
+		$response = $this->export( query: [ 'format' => 'trig' ], headers: [ 'Accept' => 'text/turtle' ] );
+
+		$this->assertSame( 200, $response->getStatusCode() );
+		$this->assertSame( 'application/trig; charset=utf-8', $response->getHeaderLine( 'Content-Type' ) );
+	}
+
+	public function testAcceptHeaderSelectsTurtle(): void {
+		$response = $this->export( headers: [ 'Accept' => 'text/turtle' ] );
+
+		$this->assertSame( 200, $response->getStatusCode() );
+		$this->assertSame( 'text/turtle; charset=utf-8', $response->getHeaderLine( 'Content-Type' ) );
+		$this->assertSame( [ '' ], $this->graphsIn( $response->getBody()->getContents() ) );
+	}
+
+	public function testAcceptHeaderSelectsTriG(): void {
+		$response = $this->export( headers: [ 'Accept' => 'application/trig' ] );
+
+		$this->assertSame( 200, $response->getStatusCode() );
+		$this->assertSame( 'application/trig; charset=utf-8', $response->getHeaderLine( 'Content-Type' ) );
+	}
+
+	public function testReturns404ForMissingPage(): void {
+		$response = $this->export( pageId: 999999 );
+
+		$this->assertSame( 404, $response->getStatusCode() );
+	}
+
+	public function testReturns404ForPageWithoutSubjectSlot(): void {
+		$plainPage = $this->insertPage( 'ExportPageRdfApiTest_Plain', 'Just wikitext, no NeoWiki subjects.' );
+
+		$response = $this->export( pageId: $plainPage['id'] );
+
+		$this->assertSame( 404, $response->getStatusCode() );
+	}
+
+	/**
+	 * The graph value (the fourth field of each canonical quad) of every quad in the parsed document.
+	 * Distinguishes TriG (a non-empty page graph on every quad) from Turtle (the empty default graph).
+	 *
+	 * @return list<string>
+	 */
+	private function graphsIn( string $rdf ): array {
+		return array_values( array_unique( array_map(
+			static fn ( string $line ): string => explode( "\t", $line )[3],
+			ParsedRdf::canonicalQuads( $rdf )
+		) ) );
+	}
+
+}

--- a/tests/phpunit/Infrastructure/Rdf/HardfRdfSerializerTest.php
+++ b/tests/phpunit/Infrastructure/Rdf/HardfRdfSerializerTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Infrastructure\Rdf;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\Iri;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\Literal;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\Quad;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\QuadList;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfFormat;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfNamespaces;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
+use ProfessionalWiki\NeoWiki\Infrastructure\Rdf\HardfRdfSerializer;
+use ProfessionalWiki\NeoWiki\Tests\Domain\Rdf\ParsedRdf;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Infrastructure\Rdf\HardfRdfSerializer
+ * @covers \ProfessionalWiki\NeoWiki\Infrastructure\Rdf\HardfRdfStreamWriter
+ */
+class HardfRdfSerializerTest extends TestCase {
+
+	private RdfNamespaces $ns;
+
+	protected function setUp(): void {
+		$this->ns = new RdfNamespaces( 'https://wiki.example' );
+	}
+
+	private function serializer(): HardfRdfSerializer {
+		return new HardfRdfSerializer( $this->ns->prefixMap() );
+	}
+
+	private function personQuads( int $pageId, string $subjectId ): QuadList {
+		$graph = $this->ns->page( new PageId( $pageId ) );
+		$subject = $this->ns->subject( new SubjectId( $subjectId ) );
+
+		return QuadList::fromArray( [
+			new Quad( $subject, $this->ns->rdfType(), $this->ns->schemaClass( new SchemaName( 'Person' ) ), $graph ),
+			new Quad( $subject, $this->ns->rdfsLabel(), new Literal( 'John Doe', $this->ns->xsd( 'string' ) ), $graph ),
+			new Quad( $subject, $this->ns->property( 'Age' ), new Literal( '42', $this->ns->xsd( 'integer' ) ), $graph ),
+			new Quad( $subject, $this->ns->property( 'Active' ), new Literal( 'true', $this->ns->xsd( 'boolean' ) ), $graph ),
+			new Quad( $subject, $this->ns->property( 'Website' ), new Literal( 'https://x', $this->ns->xsd( 'anyURI' ) ), $graph ),
+		] );
+	}
+
+	public function testTriGSerializationRoundTripsToTheSameQuadSetInTheNamedGraph(): void {
+		$output = $this->serializer()->serialize( $this->personQuads( 1, 's1demo8aaaaaab5' ), RdfFormat::TriG );
+
+		$expected = <<<TRIG
+			@prefix neo-subj: <https://wiki.example/entity/> .
+			@prefix neo-prop: <https://wiki.example/prop/> .
+			@prefix neo-schema: <https://wiki.example/schema/> .
+			@prefix neo-page: <https://wiki.example/page/> .
+			@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+			@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+			neo-page:1 {
+				neo-subj:s1demo8aaaaaab5 a neo-schema:Person ;
+					rdfs:label "John Doe" ;
+					neo-prop:Age 42 ;
+					neo-prop:Active true ;
+					neo-prop:Website "https://x"^^xsd:anyURI .
+			}
+			TRIG;
+
+		$this->assertSame( ParsedRdf::canonicalQuads( $expected ), ParsedRdf::canonicalQuads( $output ) );
+	}
+
+	public function testTurtleSerializationEmitsTheSameTriplesWithoutAGraph(): void {
+		$output = $this->serializer()->serialize( $this->personQuads( 1, 's1demo8aaaaaab5' ), RdfFormat::Turtle );
+
+		$expected = <<<TURTLE
+			@prefix neo-subj: <https://wiki.example/entity/> .
+			@prefix neo-prop: <https://wiki.example/prop/> .
+			@prefix neo-schema: <https://wiki.example/schema/> .
+			@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+			@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+			neo-subj:s1demo8aaaaaab5 a neo-schema:Person ;
+				rdfs:label "John Doe" ;
+				neo-prop:Age 42 ;
+				neo-prop:Active true ;
+				neo-prop:Website "https://x"^^xsd:anyURI .
+			TURTLE;
+
+		$this->assertSame( ParsedRdf::canonicalQuads( $expected ), ParsedRdf::canonicalQuads( $output ) );
+	}
+
+	public function testTurtleOutputContainsNoNamedGraph(): void {
+		$output = $this->serializer()->serialize( $this->personQuads( 1, 's1demo8aaaaaab5' ), RdfFormat::Turtle );
+
+		$this->assertStringNotContainsString( 'neo-page:1 {', $output );
+		$this->assertStringNotContainsString( '/page/1', $output );
+	}
+
+	public function testStreamingWriterGroupsQuadsFromEachPageIntoItsOwnGraph(): void {
+		$writer = $this->serializer()->newWriter( RdfFormat::TriG );
+
+		$output = $writer->write( $this->personQuads( 1, 's1demo8aaaaaab5' ) );
+		$output .= $writer->write( $this->personQuads( 2, 's1demo8aaaaaac6' ) );
+		$output .= $writer->finish();
+
+		$quads = ParsedRdf::canonicalQuads( $output );
+
+		$this->assertContains(
+			implode( "\t", [
+				'https://wiki.example/entity/s1demo8aaaaaab5',
+				'http://www.w3.org/2000/01/rdf-schema#label',
+				'"John Doe"',
+				'https://wiki.example/page/1',
+			] ),
+			$quads
+		);
+		$this->assertContains(
+			implode( "\t", [
+				'https://wiki.example/entity/s1demo8aaaaaac6',
+				'http://www.w3.org/2000/01/rdf-schema#label',
+				'"John Doe"',
+				'https://wiki.example/page/2',
+			] ),
+			$quads
+		);
+	}
+
+	public function testOutputUsesReadablePrefixedNames(): void {
+		$output = $this->serializer()->serialize( $this->personQuads( 1, 's1demo8aaaaaab5' ), RdfFormat::TriG );
+
+		$this->assertStringContainsString( '@prefix neo-prop:', $output );
+		$this->assertStringContainsString( 'neo-schema:Person', $output );
+	}
+
+	public function testLiteralWithEmbeddedQuotesIsEscapedInOutputAndStaysOneQuad(): void {
+		$graph = $this->ns->page( new PageId( 3 ) );
+		$subject = $this->ns->subject( new SubjectId( 's1demo8aaaaaab5' ) );
+		$quads = new QuadList(
+			new Quad( $subject, $this->ns->rdfsLabel(), new Literal( 'They said "hi"', $this->ns->xsd( 'string' ) ), $graph )
+		);
+
+		$output = $this->serializer()->serialize( $quads, RdfFormat::TriG );
+
+		// The adapter must let hardf escape the embedded quotes, producing valid Turtle that parses
+		// back to exactly one quad rather than a truncated or malformed literal.
+		$this->assertStringContainsString( '\\"hi\\"', $output );
+		$this->assertCount( 1, ParsedRdf::canonicalQuads( $output ) );
+	}
+
+}

--- a/tests/phpunit/Maintenance/DumpRdfTest.php
+++ b/tests/phpunit/Maintenance/DumpRdfTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Maintenance;
+
+use MediaWiki\Tests\Maintenance\MaintenanceBaseTestCase;
+use ProfessionalWiki\NeoWiki\Maintenance\DumpRdf;
+
+// The maintenance script is not PSR-4 autoloadable (it lives outside src/), so load it explicitly.
+// Its RUN_MAINTENANCE_IF_MAIN guard is a no-op under PHPUnit, so this does not execute the script.
+require_once __DIR__ . '/../../../maintenance/DumpRdf.php';
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Maintenance\DumpRdf
+ * @group Database
+ */
+class DumpRdfTest extends MaintenanceBaseTestCase {
+
+	protected function getMaintenanceClass(): string {
+		return DumpRdf::class;
+	}
+
+	public function testEmitsAnEmptyDocumentWhenNoSubjectSlotRoleExists(): void {
+		// A wiki that has never stored a Subject has no 'neowiki-subjects' slot role, so the role-id
+		// lookup throws NameTableAccessException. Forcing that state (empty table + a store without a
+		// warmed cache) proves the dump degrades to an empty document instead of crashing.
+		$this->truncateTable( 'slot_roles' );
+		$this->getServiceContainer()->resetServiceForTesting( 'SlotRoleStore' );
+
+		ob_start();
+		try {
+			$this->maintenance->execute();
+		} finally {
+			$output = ob_get_clean();
+		}
+
+		// Reaching this point means execute() did not throw on the missing slot role (the N1 fix).
+		// The document is empty: no page named-graph block (which a real dump would open with `{`).
+		$this->assertStringNotContainsString( '{', $output );
+	}
+
+}

--- a/tests/phpunit/NeoWikiConfigFactoryTest.php
+++ b/tests/phpunit/NeoWikiConfigFactoryTest.php
@@ -28,6 +28,8 @@ class NeoWikiConfigFactoryTest extends TestCase {
 	public function testUnsetUrlsProduceNullInsteadOfThrowing(): void {
 		$config = ( new NeoWikiConfigFactory() )->buildFromMediaWikiConfig( new HashConfig( [
 			'NeoWikiEnableDevelopmentUI' => false,
+			'NeoWikiRdfBaseUri' => null,
+			'CanonicalServer' => 'https://wiki.example',
 			'NeoWikiNeo4jInternalWriteUrl' => null,
 			'NeoWikiNeo4jInternalReadUrl' => null,
 		] ) );
@@ -40,6 +42,8 @@ class NeoWikiConfigFactoryTest extends TestCase {
 	public function testConfiguredUrlsArePassedThrough(): void {
 		$config = ( new NeoWikiConfigFactory() )->buildFromMediaWikiConfig( new HashConfig( [
 			'NeoWikiEnableDevelopmentUI' => false,
+			'NeoWikiRdfBaseUri' => null,
+			'CanonicalServer' => 'https://wiki.example',
 			'NeoWikiNeo4jInternalWriteUrl' => 'bolt://write:7687',
 			'NeoWikiNeo4jInternalReadUrl' => 'bolt://read:7687',
 		] ) );
@@ -55,12 +59,38 @@ class NeoWikiConfigFactoryTest extends TestCase {
 
 		$config = ( new NeoWikiConfigFactory() )->buildFromMediaWikiConfig( new HashConfig( [
 			'NeoWikiEnableDevelopmentUI' => false,
+			'NeoWikiRdfBaseUri' => null,
+			'CanonicalServer' => 'https://wiki.example',
 			'NeoWikiNeo4jInternalWriteUrl' => 'bolt://config-write',
 			'NeoWikiNeo4jInternalReadUrl' => 'bolt://config-read',
 		] ) );
 
 		$this->assertSame( 'bolt://env-write', $config->neo4jInternalWriteUrl );
 		$this->assertSame( 'bolt://env-read', $config->neo4jInternalReadUrl );
+	}
+
+	public function testRdfBaseUriDefaultsToTheCanonicalServer(): void {
+		$config = ( new NeoWikiConfigFactory() )->buildFromMediaWikiConfig( new HashConfig( [
+			'NeoWikiEnableDevelopmentUI' => false,
+			'NeoWikiNeo4jInternalWriteUrl' => null,
+			'NeoWikiNeo4jInternalReadUrl' => null,
+			'NeoWikiRdfBaseUri' => null,
+			'CanonicalServer' => 'https://wiki.example',
+		] ) );
+
+		$this->assertSame( 'https://wiki.example', $config->rdfBaseUri );
+	}
+
+	public function testConfiguredRdfBaseUriOverridesTheCanonicalServer(): void {
+		$config = ( new NeoWikiConfigFactory() )->buildFromMediaWikiConfig( new HashConfig( [
+			'NeoWikiEnableDevelopmentUI' => false,
+			'NeoWikiNeo4jInternalWriteUrl' => null,
+			'NeoWikiNeo4jInternalReadUrl' => null,
+			'NeoWikiRdfBaseUri' => 'https://id.example.org/ns',
+			'CanonicalServer' => 'https://wiki.example',
+		] ) );
+
+		$this->assertSame( 'https://id.example.org/ns', $config->rdfBaseUri );
 	}
 
 }

--- a/tests/phpunit/NeoWikiConfigTest.php
+++ b/tests/phpunit/NeoWikiConfigTest.php
@@ -42,6 +42,7 @@ class NeoWikiConfigTest extends TestCase {
 			neo4jInternalWriteUrl: $writeUrl,
 			neo4jInternalReadUrl: $readUrl,
 			wikiId: 'testwiki',
+			rdfBaseUri: 'https://wiki.example',
 		);
 	}
 


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/1025

Implements the store-agnostic native RDF projection specified in
[NativeRdfProjection.md](https://github.com/ProfessionalWiki/NeoWiki/blob/master/docs/planning/NativeRdfProjection.md),
split out from #586 so the SPARQL store plugin can consume it as a finished layer.

## What exists now

- **Term model** (`Domain/Rdf`): immutable `Iri`, `Literal`, `Quad`, `QuadList` behind our own interfaces. The
  third-party serializer (`pietercolpaert/hardf`, pinned to `0.6.2`) is wrapped in a single adapter
  (`Infrastructure/Rdf`); its array term-shapes never leak out.
- **IRI/namespace scheme** (`RdfNamespaces`) per the spec's table (`neo`, `neo-subj`, `neo-prop`, `neo-schema`,
  `neo-rel`, `neo-page`), plus new wiki-level config `$wgNeoWikiRdfBaseUri` (defaults to the wiki's canonical URL).
  User-authored names (Property, Schema and Relation-Type names, and Relation-property keys) are encoded into their
  IRI local part — see **Security: IRI escaping** below.
- **Value → typed-literal mapping** (`RdfValueMapperRegistry` + `RdfLiteralFactory`) with a registry seam mirroring
  `Neo4jValueBuilderRegistry`: `NeoWikiRegistrar::addRdfValueMapper`. Covers text/select→`xsd:string`,
  `url`→`xsd:anyURI`, number→`xsd:decimal`/`xsd:integer`, boolean, date→`xsd:date`, date-time→`xsd:dateTime`.
  RedHerb registers a mapper for its `color` type as the worked example.
- **Projector** (`RdfPageProjector`): `Page` → quads — page metadata, one resource per Subject (`rdf:type` from the
  Schema, `rdfs:label`, one predicate per Statement value), and the two-layer relation reification (direct triple +
  `neo:Relation` node with `source`/`target`/`relationType` and Relation properties). Every quad goes in the page's
  named graph. **Golden tests** encode the spec's "Complete Example" and compare quad *sets* parsed with hardf.
- **REST endpoint**: `GET /neowiki/v0/page/{pageId}/rdf` → TriG (default) or Turtle, chosen by the `format`
  parameter or the `Accept` header. Registered as a general (non-graph-gated) route, so it works with no graph
  backend configured. `404` when the page has no NeoWiki data.
- **Bulk dump**: `maintenance/DumpRdf.php` streams TriG for every subject page to stdout (progress on stderr).
- **Docs**: `docs/reference/rdf-export.md` (config, IRI scheme, endpoint, script) + an `addRdfValueMapper` note in
  `extending.md`.

## Security: IRI escaping (adversarial review round 2)

A second adversarial AI review round found that `RdfNamespaces::localName()` only substituted space→underscore, so a
user-authored name entered its IRI otherwise unescaped. This was empirically exploitable: a Property named `Rev>2020`
closed the `IRIREF` early (making the whole page document unparseable), and a crafted name such as
`p><evil-s>.<evil-s2><evil-p2><evil-o2>.<evil-s3><evil-p3` forged attacker-controlled triples — one Statement became
three quads.

Fix: one Domain function (`RdfNamespaces::localName`, which every IRI-minting call site already routes through) now
encodes every user-authored string entering an IRI:

1. space → underscore (keeps the readable `neo-prop:Has_author` convention; the `Has_author`/`Has author` collision
   stays a documented caveat);
2. percent-encode `%`, the IRIREF-illegal ASCII specials `< > " { } | ^ \`, backtick, and control characters
   (`0x00`–`0x1F`, `0x7F`);
3. everything else — including non-ASCII Unicode — passes through raw, so multilingual names stay readable.

The admin-configured base URI is trusted config and is out of scope. Covered by adversarial tests: `RdfNamespacesTest`
asserts the exact encoded IRIs, and `RdfPageProjectorTest::testUserAuthoredNamesCannotBreakOutOfTheirIri` projects a
page for each illegal character and the two confirmed repro strings, asserting (via the hardf-parsing `ParsedRdf`
helper) that the output parses to *exactly* the intended quads — the injection string yields one quad, not three.

## Missing-Schema degradation: aligned to the Neo4j projection (review round 2)

Previously the projector kept a Subject's type/label/Statements when its Schema was unavailable and skipped only its
relations, while `Neo4jSubjectUpdater` skips the whole Subject. These now match: a Subject whose Schema is unavailable
is **omitted entirely** (no type, label, Statements, relations, or page `hasSubject`/`mainSubject` reference) and
logged with the same "Schema not found" wording. Rationale: sibling projections (native, ontology-mapped, Neo4j) must
hold the same entity set — the invariant the SPARQL store (#586) depends on — and the revision slot remains the source
of truth. Revisit both projections together if partial projection is ever wanted.

## Usage

```sh
curl 'https://wiki.example/rest.php/neowiki/v0/page/48/rdf'                 # TriG (default)
curl 'https://wiki.example/rest.php/neowiki/v0/page/48/rdf?format=turtle'   # Turtle (no named graph)
php maintenance/run.php NeoWiki:DumpRdf > dump.trig                         # bulk dump
```

## Sample output (real, trimmed — page 48 "Birth of Johann Sebastian Bach")

```trig
<http://localhost:8489/page/48> {
<http://localhost:8489/page/48> a neo:Page;
    neo:pageName "Birth of Johann Sebastian Bach";
    dcterms:created "2026-07-11T14:33:05Z"^^xsd:dateTime;
    neo:mainSubject neo-subj:s1bachaaaaaaab2;
    neo:hasSubject neo-subj:s1bachaaaaaaab2.
neo-subj:s1bachaaaaaaab2 a neo-schema:Birth;
    rdfs:label "Birth of Johann Sebastian Bach";
    neo-prop:Date "1685-03-21"^^xsd:date;
    neo-prop:Brought_into_life neo-subj:s1bachaaaaaaaa3.
neo-rel:r1bachaaaaaaaa3 a neo:Relation;
    neo:source neo-subj:s1bachaaaaaaab2;
    neo:target neo-subj:s1bachaaaaaaaa3;
    neo:relationType neo-prop:Brought_into_life.
}
```

Verified live on the demo wiki: both formats and content types (`application/trig`, `text/turtle`), `Accept`
negotiation, the `404` path, and the dump script (75 pages → 75 named graphs). The endpoint and dump script now also
have automated tests (`ExportPageRdfApiTest`, `DumpRdfTest`).

## Spec resolutions followed

Flat property predicate namespace (Q1), minimal standard vocabulary (Q2), writer's-schema omitted from the native
projection (Q8), multi-value ordering loss accepted (Q9), spaces→underscores for property/schema local names (Q7).

## Open questions (contract-level judgment calls)

- **Q7 underscore collision (unresolved in the spec).** Space→underscore substitution means a name that already
  contains an underscore collides with the space form (`Has author` and `Has_author` share `neo-prop:Has_author`).
  Documented in `RdfNamespaces::localName` and `rdf-export.md`. Fine for the native projection; flagging for the
  eventual convention decision (CamelCase was the other suggestion).
- **Projector placement.** Value objects, IRI scheme and value mappers are in `Domain/Rdf`; the projector, which
  needs the `SchemaLookup` port to resolve Relation types, is in `Application/Rdf`. Domain currently never imports
  Application and I kept it that way.
- **Endpoint shape.** `GET /page/{pageId}/rdf`, integer page id like the sibling `/page/{pageId}/subjects`, TriG
  default (it carries the named graph; Turtle is the reduced form), `format` param overriding `Accept`. Reasonable
  but not the only option.
- **Date/date-time are validated and invalid parts dropped** to keep the RDF well-typed, mirroring how the Neo4j
  path drops unparseable `dateTime`s. This is slightly stricter than the Neo4j `date` builder, which stores `date`
  strings unvalidated.
- **Page metadata scope.** Only the documented core Page Properties (`name`, `creationTime`, `lastUpdated`,
  `lastEditor`, `categories`) are projected; extension-contributed Page Properties are not yet mapped to RDF (no
  IRIs defined for them in the spec).
- **Revision visibility is not filtered.** The export and dump read the current revision slot with no filtering of
  deleted/suppressed (RevisionDelete) content — matching the sibling `/page/{pageId}/subjects` endpoint. Subject-level
  access control and server-side ACL query filtering are a separate, later deliverable.
- **Tiny-decimal lexical form.** `xsd:decimal` literals are formatted with `%.15F` then trailing-zero-trimmed, so a
  magnitude below ~`1e-15` rounds to `0.0`. Acceptable for the native projection; noted for the mapping layer.

## Out of scope (owned elsewhere)

SPARQL store + sync (#586), ontology mappings (#1026), RDFS/OWL schema self-description (spec Q10), RDF import (#306).

## Follow-ups

- Project extension-contributed Page Properties once their IRI scheme is decided.
- RDFS/OWL self-description of Schemas (spec Q10) — takin asked for this as mapping input.
- `RebuildGraphDatabases.php` has the same unguarded `getSlotRoleStore()->getId()` that `DumpRdf` had; give it the
  same `NameTableAccessException` guard. Left out here to keep the change scoped.

---

> Scope specified in issue #1025 (drafted in an orchestrating Claude session, approved by @JeroenDeDauw) and
> implemented autonomously. A second adversarial AI review round (same orchestrating session) then found the
> IRI-injection blocker empirically — a crafted Property name forging triples — and its decisions drove the round-2
> commits (IRI escaping, missing-Schema alignment, endpoint/dump-script tests, doc + RedHerb-example hardening). Not
> yet human-reviewed. I explored the codebase layering and the spec's worked examples, wrote the fixes test-first
> (watched the injection tests fail, then pass), added data-driven adversarial and endpoint tests, ran
> `make phpunit`/`make cs`, merged the latest `master` (resolving the #1028 graph-wiring conflict), and live-verified
> the endpoint and dump script on a demo wiki.
> Context: NativeRdfProjection.md and its resolutions, the Neo4j projection as the mirror to follow, the TriG/Turtle
> IRIREF grammar, and `pietercolpaert/hardf`.
> <sub>Written by Claude Code, `Opus 4.8 (max)`</sub>
