### PR TITLE
Add Ontology Mapping v1: Mapping pages and term-substitution projection

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ Key docs:
 * [Query API](reference/query-api.md) - REST endpoint for read-only Cypher queries against the graph backend
 * [REST API](reference/rest-api.md) - The complete `/neowiki/v0/*` endpoint reference, plus the generated OpenAPI spec served at `/rest.php/specs/v0/module/-`
 * [RDF Export](reference/rdf-export.md) - Native RDF projection: config, IRI scheme, the per-page export endpoint, and the bulk dump script
+* [Ontology Mapping](reference/ontology-mapping.md) - Projecting Subjects into standard ontologies (EDM, Dublin Core, …) via Mapping pages
 * [Extending NeoWiki](reference/extending.md) - How other extensions add property types, contribute graph data, and reuse NeoWiki's UI
 * [Installation & Maintenance](operations/installation.md) - Sysadmin guide to installing and maintaining NeoWiki
 * [Architecture Decision Records](adr/001-domain-centric-architecture.md) - Numbered, dated architectural decisions

--- a/docs/reference/ontology-mapping.md
+++ b/docs/reference/ontology-mapping.md
@@ -1,0 +1,139 @@
+---
+title: Ontology Mapping
+order: 9
+---
+# Ontology Mapping
+
+NeoWiki stores data in its own native Schemas and projects it to RDF. The **native projection**
+([RDF export](rdf-export.md)) uses NeoWiki-native vocabulary. An **ontology mapping** projects the
+same data into an established cultural-heritage ontology instead (EDM, Dublin Core, …), so the RDF is
+directly interoperable. The native projection and each ontology mapping are **sibling projections** of
+the same source data, selected per request (or, later, per SPARQL store).
+
+The design and its open questions are in
+[planning/OntologyMapping.md](../planning/OntologyMapping.md); this page is the as-built reference for
+the shipped v1.
+
+> **v1 is deliberately minimal and the stored format is provisional.** v1 covers only the *near-1:1
+> tier* — term substitution: a target class for the Subject and one target predicate per mapped
+> property. It does **not** synthesize the intermediate event nodes that CIDOC-CRM-style ontologies
+> need. The mapping-formalism question is still open
+> ([OntologyMapping.md Q1](../planning/OntologyMapping.md#open-questions), [#995](https://github.com/ProfessionalWiki/NeoWiki/issues/995)),
+> so the `"version": 1` format may change. It is versioned precisely so a later tier can supersede it.
+
+## Mappings are wiki pages
+
+A Mapping is a page in the **`Mapping:` namespace** with content model `NeoWikiMapping` (JSON), edited
+like a Schema or Layout page and gated by the `neowiki-mapping-edit` right. Each Mapping binds **one
+Schema** to **one target ontology**. A Schema can have several Mappings (one per target); the Schema is
+never changed to fit an ontology.
+
+**One Mapping per (Schema, target).** Saving a Mapping whose `(schema, target)` pair another Mapping
+page already claims is rejected. (The check is lookup-based, so a concurrent double-save could still
+slip a duplicate through before production; if that happens, the projector picks the alphabetically
+first Mapping page and logs a warning.)
+
+## Format (version 1)
+
+```json
+{
+    "version": 1,
+    "schema": "Person",
+    "target": "edm",
+    "prefixes": {
+        "edm": "http://www.europeana.eu/schemas/edm/",
+        "dc": "http://purl.org/dc/elements/1.1/"
+    },
+    "subject": { "class": "edm:ProvidedCHO" },
+    "properties": {
+        "Name":    { "predicate": "dc:title", "lang": "en" },
+        "Website": { "predicate": "edm:isShownAt" },
+        "Author":  { "predicate": "dc:creator" }
+    }
+}
+```
+
+| Field | Required | Meaning |
+|---|---|---|
+| `version` | yes | Format version. Must be `1`. |
+| `schema` | yes | Name of the native Schema this Mapping applies to. |
+| `target` | yes | Short identifier of the target ontology/profile (`[A-Za-z][A-Za-z0-9_-]*`). This is the value passed to the `projection` parameter below. |
+| `prefixes` | no | Prefix label → namespace IRI, used to expand the CURIEs below. |
+| `subject.class` | yes | The `rdf:type` given to each Subject of the Schema. A CURIE or an absolute IRI. |
+| `properties` | yes | NeoWiki property name → how to project it (see below). May be empty. |
+
+Each **property** entry:
+
+| Key | Required | Meaning |
+|---|---|---|
+| `predicate` | yes | Target predicate for the property's values. A CURIE or an absolute IRI. |
+| `lang` | no | Language tag applied to the produced literal **when it is a plain string** (text/select values). Ignored for typed literals (numbers, dates, …). Mutually exclusive with `datatype`. |
+| `datatype` | no | Absolute IRI or CURIE that overrides the literal's datatype. Mutually exclusive with `lang`. |
+
+### CURIEs, IRIs, and safety
+
+A `class`, `predicate`, or `datatype` is either a **CURIE** `prefix:local` whose prefix is declared in
+`prefixes`, or an **absolute IRI** containing `://`. A CURIE with an undeclared prefix is rejected (it
+is a typo, not a bare IRI). Non-authority IRI schemes (`urn:`, `mailto:`, …) are out of scope for v1.
+
+Terms are expanded to exact ontology IRIs and are **never percent-encoded** — a Mapping must reproduce
+the ontology's terms verbatim. A term (or a declared prefix namespace) that would expand to an IRI
+containing an IRIREF-illegal character (`< > " { } | ^ \` backtick, space, control characters) is
+**rejected at save time**, so a Mapping can never corrupt the projected document.
+
+## What gets emitted
+
+For each Subject on a page whose Schema has a Mapping for the requested target:
+
+- `rdf:type <subject.class>`.
+- `rdfs:label "<label>"` — always, so every projected entity is labelled.
+- One triple per mapped property **value** (multi-valued properties repeat the predicate). Unmapped
+  properties are **absent** — conformant output is the point.
+- A **relation** value becomes a direct triple to the target Subject's IRI. No `neo:Relation`
+  reification node and no relation qualifiers are projected (native-vocabulary constructs with no v1
+  mapping).
+
+Deliberate v1 boundaries:
+
+- **Subject IRIs stay native** (`neo-subj:` under the wiki's RDF base URI): the entity is the wiki's
+  own; only the *vocabulary* comes from the target ontology. Cross-linking to external entities
+  (`owl:sameAs`, reconciliation) is later work.
+- A **Subject whose Schema has no Mapping** for the target is absent entirely. Its IRI can still appear
+  as the target of a relation from a mapped Subject — untyped — exactly as a missing Schema behaves in
+  the native projection.
+- **No page-metadata triples** are emitted (no page node, `neo:hasSubject`, etc.).
+- Quads are placed in the **per-page named graph**, like the native projection, so the same per-page
+  sync infrastructure works for an ontology store.
+
+## Selecting a projection
+
+The RDF export surfaces take an optional `projection`:
+
+`GET /rest.php/neowiki/v0/page/{pageId}/rdf?projection=edm`
+
+- `projection` is `native` (the default, unchanged behaviour) or a target that some Mapping page
+  declares.
+- An unknown target returns **`400`** listing the known projections.
+
+```sh
+# Native (default):
+curl 'https://wiki.example/rest.php/neowiki/v0/page/42/rdf'
+# EDM ontology projection:
+curl 'https://wiki.example/rest.php/neowiki/v0/page/42/rdf?projection=edm&format=turtle'
+```
+
+The bulk dump takes the same option:
+
+```sh
+php maintenance/run.php NeoWiki:DumpRdf --projection=edm > dump.trig
+```
+
+## Authoring a Mapping
+
+1. Create a page in the `Mapping:` namespace (any title — the title is just the Mapping's name).
+2. Declare the `prefixes` you will use, set the `schema` and `target`, and give the Subject a
+   `subject.class`.
+3. Map the properties you want to publish. Only listed properties are projected.
+4. Save. Structural errors, unresolvable/unsafe terms, and a duplicate `(schema, target)` are reported
+   on save.
+5. Export a page of that Schema with `?projection=<target>` to see the result.

--- a/docs/reference/ontology-mapping.md
+++ b/docs/reference/ontology-mapping.md
@@ -67,7 +67,7 @@ Each **property** entry:
 | Key | Required | Meaning |
 |---|---|---|
 | `predicate` | yes | Target predicate for the property's values. A CURIE or an absolute IRI. |
-| `lang` | no | Language tag applied to the produced literal **when it is a plain string** (text/select values). Ignored for typed literals (numbers, dates, …). Mutually exclusive with `datatype`. |
+| `lang` | no | BCP-47-shaped language tag (`^[A-Za-z]{1,8}(-[A-Za-z0-9]{1,8})*$`, e.g. `en`, `pt-BR`) applied to the produced literal **when it is a plain string** (text/select values). Ignored for typed literals (numbers, dates, …). Mutually exclusive with `datatype`. |
 | `datatype` | no | Absolute IRI or CURIE that overrides the literal's datatype. Mutually exclusive with `lang`. |
 
 ### CURIEs, IRIs, and safety
@@ -79,7 +79,13 @@ is a typo, not a bare IRI). Non-authority IRI schemes (`urn:`, `mailto:`, …) a
 Terms are expanded to exact ontology IRIs and are **never percent-encoded** — a Mapping must reproduce
 the ontology's terms verbatim. A term (or a declared prefix namespace) that would expand to an IRI
 containing an IRIREF-illegal character (`< > " { } | ^ \` backtick, space, control characters) is
-**rejected at save time**, so a Mapping can never corrupt the projected document.
+**rejected at save time**. The `lang` tag is constrained the same way — it must be BCP-47-shaped, so it
+cannot smuggle a datatype or a stray `"` into the serialized literal.
+
+Both checks are re-applied at **projection time**, so a Mapping stored before validation existed (or
+loaded via `importDump`) still cannot corrupt the output: a class, predicate, datatype, or prefix that
+does not re-expand safely is dropped, and an invalid language tag falls back to a plain literal — each
+with a logged warning. A bad stored Mapping degrades the projection rather than aborting the export.
 
 ## What gets emitted
 

--- a/docs/reference/rdf-export.md
+++ b/docs/reference/rdf-export.md
@@ -57,8 +57,12 @@ describe the same set of entities. A warning is logged for each omitted Subject.
 
 `GET /rest.php/neowiki/v0/page/{pageId}/rdf`
 
-Returns the page's native projection. The format is chosen by the `format` query parameter, falling
-back to the `Accept` header, then to TriG:
+Returns the page's projection. The `projection` query parameter selects the vocabulary: `native` (the
+default, described here) or an ontology target declared by a Mapping page — see
+[Ontology Mapping](ontology-mapping.md). An unknown target returns `400`.
+
+The format is chosen by the `format` query parameter, falling back to the `Accept` header, then to
+TriG:
 
 | `format` | `Accept` | Content-Type | Named graph |
 |---|---|---|---|
@@ -73,16 +77,18 @@ curl 'https://wiki.example/rest.php/neowiki/v0/page/42/rdf?format=turtle'
 
 ## Bulk dump
 
-`maintenance/DumpRdf.php` streams the native projection of **every** subject page to stdout as TriG,
-one named graph per page. Progress goes to stderr so stdout stays a clean RDF document.
+`maintenance/DumpRdf.php` streams the projection of **every** subject page to stdout as TriG, one named
+graph per page. Progress goes to stderr so stdout stays a clean RDF document. It defaults to the native
+projection; `--projection=<target>` selects an ontology projection (see
+[Ontology Mapping](ontology-mapping.md)).
 
 ```sh
 php maintenance/run.php NeoWiki:DumpRdf > dump.trig
+php maintenance/run.php NeoWiki:DumpRdf --projection=edm > dump-edm.trig
 ```
 
 ## Not covered here
 
 - SPARQL store and live sync (the projection feeds them, but they are a separate concern).
-- Ontology mappings (CIDOC-CRM, EDM, …), which project into standard-ontology terms instead.
 - RDF import.
 - RDFS/OWL self-description of Schemas.

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -49,7 +49,7 @@ Subjects and arrange them.
 | Endpoint | Description |
 |---|---|
 | `GET /neowiki/v0/page/{pageId}/subjects` | List a page's main and child Subjects. `expand` with `schemas` or `relations`. |
-| `GET /neowiki/v0/page/{pageId}/rdf` | Export the page's Subjects and metadata as RDF. `format` is `trig` (default) or `turtle`. See [RDF export](rdf-export.md). |
+| `GET /neowiki/v0/page/{pageId}/rdf` | Export the page's Subjects and metadata as RDF. `format` is `trig` (default) or `turtle`; `projection` is `native` (default) or an ontology target. See [RDF export](rdf-export.md) and [Ontology Mapping](ontology-mapping.md). |
 | `POST /neowiki/v0/page/{pageId}/mainSubject` | Create the page's main Subject. |
 | `PUT /neowiki/v0/page/{pageId}/mainSubject` | Promote a child Subject to main, or clear it. |
 | `POST /neowiki/v0/page/{pageId}/childSubjects` | Create a child Subject on the page. |

--- a/extension.json
+++ b/extension.json
@@ -60,7 +60,8 @@
 	"ContentHandlers": {
 		"NeoWikiSubject": "ProfessionalWiki\\NeoWiki\\EntryPoints\\Content\\SubjectContentHandler",
 		"NeoWikiSchema": "ProfessionalWiki\\NeoWiki\\EntryPoints\\Content\\SchemaContentHandler",
-		"NeoWikiLayout": "ProfessionalWiki\\NeoWiki\\EntryPoints\\Content\\LayoutContentHandler"
+		"NeoWikiLayout": "ProfessionalWiki\\NeoWiki\\EntryPoints\\Content\\LayoutContentHandler",
+		"NeoWikiMapping": "ProfessionalWiki\\NeoWiki\\EntryPoints\\Content\\MappingContentHandler"
 	},
 
 	"namespaces": [
@@ -93,12 +94,28 @@
 			"id": 7477,
 			"constant": "NS_NEOWIKI_LAYOUT_TALK",
 			"name": "Layout_talk"
+		},
+		{
+			"id": 7478,
+			"constant": "NS_NEOWIKI_MAPPING",
+			"name": "Mapping",
+			"defaultcontentmodel": "NeoWikiMapping",
+			"subpages": false,
+			"content": false,
+			"movable": false,
+			"protection": "neowiki-mapping-edit"
+		},
+		{
+			"id": 7479,
+			"constant": "NS_NEOWIKI_MAPPING_TALK",
+			"name": "Mapping_talk"
 		}
 	],
 
 	"AvailableRights": [
 		"neowiki-schema-edit",
 		"neowiki-layout-edit",
+		"neowiki-mapping-edit",
 		"neowiki-query"
 	],
 
@@ -108,7 +125,8 @@
 		},
 		"user": {
 			"neowiki-schema-edit": true,
-			"neowiki-layout-edit": true
+			"neowiki-layout-edit": true,
+			"neowiki-mapping-edit": true
 		}
 	},
 
@@ -118,7 +136,8 @@
 		},
 		"editpage": {
 			"neowiki-schema-edit": true,
-			"neowiki-layout-edit": true
+			"neowiki-layout-edit": true,
+			"neowiki-mapping-edit": true
 		}
 	},
 

--- a/i18n/_Namespaces.php
+++ b/i18n/_Namespaces.php
@@ -9,4 +9,6 @@ $namespaceNames['en'] = [
 	NeoWikiExtension::NS_SCHEMA + 1 => 'Schema_talk',
 	NeoWikiExtension::NS_LAYOUT => 'Layout',
 	NeoWikiExtension::NS_LAYOUT + 1 => 'Layout_talk',
+	NeoWikiExtension::NS_MAPPING => 'Mapping',
+	NeoWikiExtension::NS_MAPPING + 1 => 'Mapping_talk',
 ];

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -12,6 +12,7 @@
 
 	"right-neowiki-schema-edit": "Create and edit NeoWiki schemas",
 	"right-neowiki-layout-edit": "Create and edit NeoWiki layouts",
+	"right-neowiki-mapping-edit": "Create and edit NeoWiki ontology mappings",
 	"right-neowiki-query": "Run NeoWiki queries",
 
 	"specialpages-group-neowiki": "NeoWiki",
@@ -201,6 +202,10 @@
 	"neowiki-layout-invalid": "Layout content is invalid ({{PLURAL:$1|$1 error|$1 errors}}):",
 	"neowiki-layout-invalid-detail": "$1: $2",
 	"neowiki-layout-name-invalid": "Invalid layout name: $1",
+	"neowiki-mapping-invalid": "Mapping content is invalid ({{PLURAL:$1|$1 error|$1 errors}}):",
+	"neowiki-mapping-invalid-detail": "$1: $2",
+	"neowiki-mapping-name-invalid": "Invalid mapping name: $1",
+	"neowiki-mapping-duplicate-target": "The schema \"$1\" is already mapped to target \"$2\" by mapping \"$3\". There can only be one mapping per schema and target.",
 
 	"neowiki-edit-layout": "Edit layout",
 	"neowiki-layout-display-schema": "Schema",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -11,6 +11,7 @@
 	"neowiki-description": "{{Desc|name=NeoWiki|url=https://github.com/ProfessionalWiki/NeoWiki}}",
 	"right-neowiki-schema-edit": "{{doc-right|neowiki-schema-edit}}\nName of the user right required to create and edit pages in the NeoWiki Schema namespace.",
 	"right-neowiki-layout-edit": "{{doc-right|neowiki-layout-edit}}\nName of the user right required to create and edit pages in the NeoWiki Layout namespace.",
+	"right-neowiki-mapping-edit": "{{doc-right|neowiki-mapping-edit}}\nName of the user right required to create and edit pages in the NeoWiki Mapping namespace.",
 	"right-neowiki-query": "{{doc-right|neowiki-query}}\nName of the user right required to run NeoWiki queries, such as via the Cypher query API.",
 	"specialpages-group-neowiki": "Group heading for NeoWiki special pages on [[Special:SpecialPages]].",
 	"neowiki-special-schemas": "Title and description of the [[Special:Schemas]] page.",
@@ -101,6 +102,10 @@
 	"neowiki-layout-invalid": "Error message shown when saving an invalid Layout. Parameters:\n* $1 - number of validation errors",
 	"neowiki-layout-invalid-detail": "One line of detail for a single Layout validation error. Parameters:\n* $1 - JSON pointer to the location of the error\n* $2 - the validation error message",
 	"neowiki-layout-name-invalid": "Error message shown when a Layout page title is not a valid layout name (empty). Parameters:\n* $1 - the reason the name is invalid",
+	"neowiki-mapping-invalid": "Error message shown when saving a structurally or semantically invalid ontology Mapping. Parameters:\n* $1 - number of validation errors",
+	"neowiki-mapping-invalid-detail": "One line of detail for a single Mapping validation error. Parameters:\n* $1 - JSON pointer to the location of the error\n* $2 - the validation error message",
+	"neowiki-mapping-name-invalid": "Error message shown when a Mapping page title is not a valid mapping name (empty). Parameters:\n* $1 - the reason the name is invalid",
+	"neowiki-mapping-duplicate-target": "Error message shown when saving a Mapping whose (schema, target) pair is already claimed by another Mapping page. Parameters:\n* $1 - the schema name\n* $2 - the target ontology name\n* $3 - the name of the existing Mapping page that already claims the pair",
 
 	"neowiki-edit-layout": "Aria label for the edit button on a Layout page.",
 	"neowiki-layout-display-schema": "Label for the schema field in the layout display.",

--- a/maintenance/DumpRdf.php
+++ b/maintenance/DumpRdf.php
@@ -7,8 +7,8 @@ namespace ProfessionalWiki\NeoWiki\Maintenance;
 use Maintenance;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Storage\NameTableAccessException;
+use ProfessionalWiki\NeoWiki\Application\Rdf\PageProjector;
 use ProfessionalWiki\NeoWiki\Application\Rdf\RdfPageLoader;
-use ProfessionalWiki\NeoWiki\Application\Rdf\RdfPageProjector;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfFormat;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfStreamWriter;
@@ -26,16 +26,34 @@ class DumpRdf extends Maintenance {
 
 		$this->requireExtension( 'NeoWiki' );
 		$this->addDescription(
-			'Streams the native RDF projection of every subject page to stdout as TriG, one named '
-			. 'graph per page. Progress is written to stderr so stdout stays a clean RDF document.'
+			'Streams an RDF projection of every subject page to stdout as TriG, one named graph per '
+			. 'page. Progress is written to stderr so stdout stays a clean RDF document.'
+		);
+		$this->addOption(
+			'projection',
+			'RDF projection to produce: "native" (default) or an ontology target declared by a Mapping '
+			. 'page (e.g. "edm").',
+			false,
+			true
 		);
 	}
 
 	public function execute(): void {
 		$extension = NeoWikiExtension::getInstance();
+
+		$projectionName = $this->getOption( 'projection', NeoWikiExtension::PROJECTION_NATIVE );
+		$projection = $extension->newRdfProjection( $projectionName );
+
+		if ( $projection === null ) {
+			$this->fatalError(
+				'Unknown RDF projection: "' . $projectionName . '". Known projections: '
+				. implode( ', ', $extension->getRdfProjectionNames() ) . '.'
+			);
+		}
+
 		$loader = $extension->newRdfPageLoader();
-		$projector = $extension->newRdfPageProjector();
-		$writer = $extension->getRdfSerializer()->newWriter( RdfFormat::TriG );
+		$projector = $projection->projector;
+		$writer = $projection->serializer->newWriter( RdfFormat::TriG );
 
 		$pageIds = $this->getSubjectPageIds();
 		$this->error( 'Dumping RDF for ' . count( $pageIds ) . ' subject pages...' );
@@ -55,7 +73,7 @@ class DumpRdf extends Maintenance {
 	private function dumpPage(
 		int $pageId,
 		RdfPageLoader $loader,
-		RdfPageProjector $projector,
+		PageProjector $projector,
 		RdfStreamWriter $writer
 	): bool {
 		$page = $loader->loadByPageId( new PageId( $pageId ) );

--- a/src/Application/MappingLookup.php
+++ b/src/Application/MappingLookup.php
@@ -1,0 +1,22 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application;
+
+use ProfessionalWiki\NeoWiki\Domain\Mapping\Mapping;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\MappingName;
+
+interface MappingLookup {
+
+	public function getMapping( MappingName $name ): ?Mapping;
+
+	/**
+	 * Every valid Mapping across all Mapping pages. Structurally invalid Mapping pages are omitted.
+	 * Used to select the Mappings for a projection target and to detect duplicate (Schema, target) pairs.
+	 *
+	 * @return Mapping[]
+	 */
+	public function getAllMappings(): array;
+
+}

--- a/src/Application/Mappings.php
+++ b/src/Application/Mappings.php
@@ -1,0 +1,68 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application;
+
+use ProfessionalWiki\NeoWiki\Domain\Mapping\Mapping;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\MappingName;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+
+/**
+ * A set of {@see Mapping}s with the derivations the projection selection and duplicate-detection
+ * need: the distinct targets, the Mappings for one target, and whether a (Schema, target) pair is
+ * already claimed by another Mapping page. Pure, so it is unit-tested without a wiki.
+ */
+readonly class Mappings {
+
+	/**
+	 * @param Mapping[] $mappings
+	 */
+	public function __construct(
+		private array $mappings,
+	) {
+	}
+
+	/**
+	 * @return Mapping[]
+	 */
+	public function forTarget( string $target ): array {
+		return array_values(
+			array_filter(
+				$this->mappings,
+				static fn ( Mapping $mapping ): bool => $mapping->target === $target
+			)
+		);
+	}
+
+	/**
+	 * @return string[] Distinct targets, sorted, so the known-projection list is stable.
+	 */
+	public function targets(): array {
+		$targets = array_values( array_unique(
+			array_map( static fn ( Mapping $mapping ): string => $mapping->target, $this->mappings )
+		) );
+
+		sort( $targets );
+
+		return $targets;
+	}
+
+	/**
+	 * The Mapping, other than $excluding, that already claims the given (Schema, target) pair, or null
+	 * when the pair is free. Used at save time to reject a duplicate; $excluding is the page being
+	 * saved, so editing a Mapping in place does not collide with its own stored revision.
+	 */
+	public function conflictFor( SchemaName $schema, string $target, MappingName $excluding ): ?Mapping {
+		foreach ( $this->mappings as $mapping ) {
+			$isSelf = $mapping->name->getText() === $excluding->getText();
+
+			if ( !$isSelf && $mapping->target === $target && $mapping->schema->getText() === $schema->getText() ) {
+				return $mapping;
+			}
+		}
+
+		return null;
+	}
+
+}

--- a/src/Application/Rdf/OntologyMappingProjector.php
+++ b/src/Application/Rdf/OntologyMappingProjector.php
@@ -173,7 +173,7 @@ class OntologyMappingProjector implements PageProjector {
 			return $this->projectRelationStatement( $statement, $predicate, $subjectIri, $graph );
 		}
 
-		return $this->projectLiteralStatement( $statement, $propertyMapping, $predicate, $expander, $subjectIri, $graph );
+		return $this->projectLiteralStatement( $statement, $propertyMapping, $predicate, $expander, $subjectIri, $graph, $mapping );
 	}
 
 	/**
@@ -208,7 +208,8 @@ class OntologyMappingProjector implements PageProjector {
 		Iri $predicate,
 		CurieExpander $expander,
 		Iri $subjectIri,
-		Iri $graph
+		Iri $graph,
+		Mapping $mapping
 	): array {
 		$literals = $this->valueMappers->mapValue( $statement->getPropertyType(), $statement->getValue() );
 
@@ -219,7 +220,8 @@ class OntologyMappingProjector implements PageProjector {
 		$quads = [];
 
 		foreach ( $literals as $literal ) {
-			$quads[] = new Quad( $subjectIri, $predicate, $this->applyOverrides( $literal, $propertyMapping, $expander ), $graph );
+			$object = $this->applyOverrides( $literal, $propertyMapping, $expander, $mapping, $statement->getPropertyName()->text );
+			$quads[] = new Quad( $subjectIri, $predicate, $object, $graph );
 		}
 
 		return $quads;
@@ -230,8 +232,20 @@ class OntologyMappingProjector implements PageProjector {
 	 * tag (an RDF literal cannot carry both); the validator rejects a Mapping that sets both. A language
 	 * tag applies only to a plain string literal — for a typed literal (number, date, …) it is ignored,
 	 * since the writer's schema already fixed the datatype.
+	 *
+	 * The language tag is re-validated here as well as at save time: a Mapping created outside the
+	 * save-time validator (importDump, a page authored before validation existed) could carry a
+	 * malformed tag, which would corrupt the serialized literal. An invalid tag is therefore dropped —
+	 * the plain string literal is emitted and a warning logged — so a bad stored Mapping degrades the
+	 * output instead of aborting the whole export.
 	 */
-	private function applyOverrides( Literal $literal, PropertyMapping $propertyMapping, CurieExpander $expander ): Literal {
+	private function applyOverrides(
+		Literal $literal,
+		PropertyMapping $propertyMapping,
+		CurieExpander $expander,
+		Mapping $mapping,
+		string $propertyName
+	): Literal {
 		if ( $propertyMapping->datatype !== null ) {
 			$datatype = $expander->expand( $propertyMapping->datatype );
 
@@ -239,10 +253,22 @@ class OntologyMappingProjector implements PageProjector {
 		}
 
 		if ( $propertyMapping->language !== null && $this->isPlainString( $literal ) ) {
-			return new Literal( $literal->lexicalForm, $literal->datatype, $propertyMapping->language );
+			return $this->withLanguageTag( $literal, $propertyMapping->language, $mapping, $propertyName );
 		}
 
 		return $literal;
+	}
+
+	private function withLanguageTag( Literal $literal, string $language, Mapping $mapping, string $propertyName ): Literal {
+		if ( !Literal::isValidLanguageTag( $language ) ) {
+			$this->logger->warning(
+				'Mapping "' . $mapping->name->getText() . '" has an invalid language tag "' . $language
+				. '" for property "' . $propertyName . '"; emitting the literal without a language tag.'
+			);
+			return $literal;
+		}
+
+		return new Literal( $literal->lexicalForm, $literal->datatype, $language );
 	}
 
 	private function isPlainString( Literal $literal ): bool {

--- a/src/Application/Rdf/OntologyMappingProjector.php
+++ b/src/Application/Rdf/OntologyMappingProjector.php
@@ -1,0 +1,252 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application\Rdf;
+
+use ProfessionalWiki\NeoWiki\Domain\Mapping\CurieExpander;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\Mapping;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\PropertyMapping;
+use ProfessionalWiki\NeoWiki\Domain\Page\Page;
+use ProfessionalWiki\NeoWiki\Domain\PropertyType\Types\RelationType;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\Iri;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\Literal;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\Quad;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\QuadList;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfLiteralFactory;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfNamespaces;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfValueMapperRegistry;
+use ProfessionalWiki\NeoWiki\Domain\Statement;
+use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
+use ProfessionalWiki\NeoWiki\Domain\Value\RelationValue;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Projects a {@see Page} into a target ontology using the {@see Mapping}s configured for that target
+ * (OntologyMapping.md, v1 near-1:1 term-substitution tier). Per Subject that has a Mapping for the
+ * target it emits `rdf:type <mapped class>`, `rdfs:label` (always), and one triple per mapped property
+ * value — mapping only the vocabulary; the Subject IRI stays native (`neo-subj:`), because the entity
+ * is the wiki's own. Unmapped properties are absent, so the output is conformant to the target
+ * ontology. There is no intermediate-node synthesis and no `neo:Relation` reification in v1; relation
+ * values become a direct triple to the target Subject's native IRI, which may be untyped when that
+ * Subject has no Mapping of its own.
+ *
+ * Every quad is placed in the page's named graph, so the per-page sync used by the native projection
+ * (NativeRdfProjection.md) works for an ontology store too. No page-metadata triples are emitted.
+ */
+class OntologyMappingProjector implements PageProjector {
+
+	/**
+	 * @var array<string, Mapping> Chosen Mapping per Schema name, for the projector's target.
+	 */
+	private readonly array $mappingsBySchema;
+
+	/**
+	 * @param Mapping[] $mappings The Mappings for the store's target (one per Schema after tie-breaking).
+	 */
+	public function __construct(
+		private readonly string $target,
+		array $mappings,
+		private readonly RdfNamespaces $namespaces,
+		private readonly RdfValueMapperRegistry $valueMappers,
+		private readonly LoggerInterface $logger,
+	) {
+		$this->mappingsBySchema = $this->resolveMappingsBySchema( $mappings );
+	}
+
+	/**
+	 * @param Mapping[] $mappings
+	 * @return array<string, Mapping>
+	 */
+	private function resolveMappingsBySchema( array $mappings ): array {
+		$grouped = [];
+
+		foreach ( $mappings as $mapping ) {
+			$grouped[$mapping->schema->getText()][] = $mapping;
+		}
+
+		$resolved = [];
+
+		foreach ( $grouped as $schemaName => $candidates ) {
+			$resolved[$schemaName] = $this->pickMapping( $schemaName, $candidates );
+		}
+
+		return $resolved;
+	}
+
+	/**
+	 * The v1 guarantee is one Mapping per (Schema, target), enforced at save time. Should duplicate
+	 * pages exist anyway (pre-production race), the projection stays deterministic: pick the
+	 * alphabetically first page title and log, rather than depend on enumeration order.
+	 *
+	 * @param Mapping[] $candidates
+	 */
+	private function pickMapping( string $schemaName, array $candidates ): Mapping {
+		if ( count( $candidates ) === 1 ) {
+			return $candidates[0];
+		}
+
+		usort(
+			$candidates,
+			static fn ( Mapping $a, Mapping $b ): int => strcmp( $a->name->getText(), $b->name->getText() )
+		);
+
+		$this->logger->warning(
+			'Multiple Mappings claim Schema "' . $schemaName . '" for target "' . $this->target
+			. '"; using "' . $candidates[0]->name->getText() . '".'
+		);
+
+		return $candidates[0];
+	}
+
+	public function projectPage( Page $page ): QuadList {
+		$graph = $this->namespaces->page( $page->getId() );
+		$quads = [];
+
+		foreach ( $page->getSubjects()->getAllSubjects()->asArray() as $subject ) {
+			$mapping = $this->mappingsBySchema[$subject->getSchemaName()->getText()] ?? null;
+
+			if ( $mapping !== null ) {
+				$quads = array_merge( $quads, $this->projectSubject( $subject, $mapping, $graph ) );
+			}
+		}
+
+		return QuadList::fromArray( $quads );
+	}
+
+	/**
+	 * @return Quad[]
+	 */
+	private function projectSubject( Subject $subject, Mapping $mapping, Iri $graph ): array {
+		$expander = new CurieExpander( $mapping->prefixes );
+		$subjectIri = $this->namespaces->subject( $subject->id );
+
+		$quads = [
+			new Quad( $subjectIri, $this->namespaces->rdfsLabel(), RdfLiteralFactory::typed( $subject->label->text, 'string' ), $graph ),
+		];
+
+		$class = $expander->expand( $mapping->subjectClass );
+		if ( $class === null ) {
+			// Cannot happen for a Mapping that passed save-time validation; guard the projection anyway.
+			$this->logger->warning( 'Mapping "' . $mapping->name->getText() . '" has an unresolvable subject class; skipping the type triple.' );
+		}
+		else {
+			array_unshift( $quads, new Quad( $subjectIri, $this->namespaces->rdfType(), $class, $graph ) );
+		}
+
+		foreach ( $subject->getStatements()->asArray() as $statement ) {
+			$propertyMapping = $mapping->properties->get( $statement->getPropertyName()->text );
+
+			if ( $propertyMapping !== null ) {
+				$quads = array_merge(
+					$quads,
+					$this->projectStatement( $statement, $propertyMapping, $expander, $subjectIri, $graph, $mapping )
+				);
+			}
+		}
+
+		return $quads;
+	}
+
+	/**
+	 * @return Quad[]
+	 */
+	private function projectStatement(
+		Statement $statement,
+		PropertyMapping $propertyMapping,
+		CurieExpander $expander,
+		Iri $subjectIri,
+		Iri $graph,
+		Mapping $mapping
+	): array {
+		$predicate = $expander->expand( $propertyMapping->predicate );
+
+		if ( $predicate === null ) {
+			$this->logger->warning(
+				'Mapping "' . $mapping->name->getText() . '" has an unresolvable predicate for property "'
+				. $statement->getPropertyName()->text . '"; skipping it.'
+			);
+			return [];
+		}
+
+		if ( $statement->getPropertyType() === RelationType::NAME ) {
+			return $this->projectRelationStatement( $statement, $predicate, $subjectIri, $graph );
+		}
+
+		return $this->projectLiteralStatement( $statement, $propertyMapping, $predicate, $expander, $subjectIri, $graph );
+	}
+
+	/**
+	 * A relation value becomes a direct triple to each target Subject's native IRI. No `neo:Relation`
+	 * node and no relation properties are projected: those are native-vocabulary constructs with no v1
+	 * ontology mapping.
+	 *
+	 * @return Quad[]
+	 */
+	private function projectRelationStatement( Statement $statement, Iri $predicate, Iri $subjectIri, Iri $graph ): array {
+		$value = $statement->getValue();
+
+		if ( !$value instanceof RelationValue ) {
+			return [];
+		}
+
+		$quads = [];
+
+		foreach ( $value->relations as $relation ) {
+			$quads[] = new Quad( $subjectIri, $predicate, $this->namespaces->subject( $relation->targetId ), $graph );
+		}
+
+		return $quads;
+	}
+
+	/**
+	 * @return Quad[]
+	 */
+	private function projectLiteralStatement(
+		Statement $statement,
+		PropertyMapping $propertyMapping,
+		Iri $predicate,
+		CurieExpander $expander,
+		Iri $subjectIri,
+		Iri $graph
+	): array {
+		$literals = $this->valueMappers->mapValue( $statement->getPropertyType(), $statement->getValue() );
+
+		if ( $literals === null ) {
+			return [];
+		}
+
+		$quads = [];
+
+		foreach ( $literals as $literal ) {
+			$quads[] = new Quad( $subjectIri, $predicate, $this->applyOverrides( $literal, $propertyMapping, $expander ), $graph );
+		}
+
+		return $quads;
+	}
+
+	/**
+	 * Applies the optional datatype override or language tag. A datatype override wins over a language
+	 * tag (an RDF literal cannot carry both); the validator rejects a Mapping that sets both. A language
+	 * tag applies only to a plain string literal — for a typed literal (number, date, …) it is ignored,
+	 * since the writer's schema already fixed the datatype.
+	 */
+	private function applyOverrides( Literal $literal, PropertyMapping $propertyMapping, CurieExpander $expander ): Literal {
+		if ( $propertyMapping->datatype !== null ) {
+			$datatype = $expander->expand( $propertyMapping->datatype );
+
+			return $datatype === null ? $literal : new Literal( $literal->lexicalForm, $datatype );
+		}
+
+		if ( $propertyMapping->language !== null && $this->isPlainString( $literal ) ) {
+			return new Literal( $literal->lexicalForm, $literal->datatype, $propertyMapping->language );
+		}
+
+		return $literal;
+	}
+
+	private function isPlainString( Literal $literal ): bool {
+		return $literal->datatype->value === RdfNamespaces::XSD . 'string';
+	}
+
+}

--- a/src/Application/Rdf/PageProjector.php
+++ b/src/Application/Rdf/PageProjector.php
@@ -1,0 +1,20 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application\Rdf;
+
+use ProfessionalWiki\NeoWiki\Domain\Page\Page;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\QuadList;
+
+/**
+ * Projects a {@see Page} to RDF quads in some target vocabulary. The native projection
+ * ({@see RdfPageProjector}) and each ontology mapping ({@see OntologyMappingProjector}) are sibling
+ * implementations selected per store (OntologyMapping.md); the SPARQL store plugin (#586) consumes the
+ * projector for its configured projection through this seam.
+ */
+interface PageProjector {
+
+	public function projectPage( Page $page ): QuadList;
+
+}

--- a/src/Application/Rdf/RdfPageExporter.php
+++ b/src/Application/Rdf/RdfPageExporter.php
@@ -16,7 +16,7 @@ readonly class RdfPageExporter {
 
 	public function __construct(
 		private RdfPageLoader $loader,
-		private RdfPageProjector $projector,
+		private PageProjector $projector,
 		private RdfSerializer $serializer,
 	) {
 	}

--- a/src/Application/Rdf/RdfPageProjector.php
+++ b/src/Application/Rdf/RdfPageProjector.php
@@ -29,8 +29,12 @@ use Psr\Log\LoggerInterface;
  * and the two-layer relation reification. Every quad is placed in the page's named graph.
  *
  * Schema resolution mirrors Neo4jSubjectUpdater: a Subject whose Schema is unavailable is skipped
- * entirely (and logged), so the native projection and its sibling projections hold the same set of
- * entities and page metadata never references a Subject that has no projected type or label.
+ * entirely (and logged), so page metadata never references a Subject that has no projected type or
+ * label. That keeps the native projection internally consistent. It does not perfectly align the
+ * entity sets of sibling projections, though: the ontology projection keys off the Mapping (by Schema
+ * name), not the Schema definition, so a Subject whose Schema page is missing is dropped here yet still
+ * projected there. That is a pathological state — a Subject referencing a deleted Schema — accepted for
+ * v1.
  */
 class RdfPageProjector implements PageProjector {
 
@@ -64,8 +68,10 @@ class RdfPageProjector implements PageProjector {
 
 	/**
 	 * Resolves each Subject's Schema up front. A Subject whose Schema is unavailable is dropped from
-	 * the projection entirely — matching Neo4jSubjectUpdater, which skips the whole Subject — so
-	 * sibling projections hold the same entity set (the invariant the SPARQL store, #586, relies on).
+	 * the projection entirely — matching Neo4jSubjectUpdater, which skips the whole Subject — so page
+	 * metadata never references an unprojected Subject. This does not guarantee sibling projections hold
+	 * the identical entity set: the ontology projection is name-keyed on its Mapping and would still
+	 * project a Subject whose Schema page is missing. Pathological, and accepted for v1.
 	 *
 	 * @param Subject[] $subjects
 	 * @return list<array{Subject, Schema}>

--- a/src/Application/Rdf/RdfPageProjector.php
+++ b/src/Application/Rdf/RdfPageProjector.php
@@ -32,7 +32,7 @@ use Psr\Log\LoggerInterface;
  * entirely (and logged), so the native projection and its sibling projections hold the same set of
  * entities and page metadata never references a Subject that has no projected type or label.
  */
-class RdfPageProjector {
+class RdfPageProjector implements PageProjector {
 
 	private const string PROPERTY_NAME = 'name';
 	private const string PROPERTY_CREATION_TIME = 'creationTime';

--- a/src/Application/Rdf/RdfProjection.php
+++ b/src/Application/Rdf/RdfProjection.php
@@ -1,0 +1,24 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application\Rdf;
+
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfSerializer;
+
+/**
+ * A selected projection: the {@see PageProjector} that produces its quads and the {@see RdfSerializer}
+ * configured with the prefix table that renders them readably (native prefixes plus, for an ontology
+ * projection, the Mapping-declared ontology prefixes). Returned by the projection factory so the RDF
+ * export surfaces — and the SPARQL store plugin (#586), which needs only the projector — resolve a
+ * projection name to everything they need.
+ */
+readonly class RdfProjection {
+
+	public function __construct(
+		public PageProjector $projector,
+		public RdfSerializer $serializer,
+	) {
+	}
+
+}

--- a/src/Application/Rdf/RdfProjectionResolution.php
+++ b/src/Application/Rdf/RdfProjectionResolution.php
@@ -1,0 +1,36 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application\Rdf;
+
+/**
+ * The outcome of resolving a projection name: either the {@see RdfProjection}, or — when the name is
+ * neither "native" nor a target any Mapping declares — the list of known projection names for a
+ * helpful error. It lets a caller resolve the projection and list the valid names from a single
+ * enumeration of the Mapping pages, instead of enumerating twice (once to resolve, once to list).
+ */
+readonly class RdfProjectionResolution {
+
+	/**
+	 * @param string[] $knownProjectionNames The valid projection names, populated only when the target
+	 *   is unknown (so the caller can report them); empty when a projection was resolved.
+	 */
+	private function __construct(
+		public ?RdfProjection $projection,
+		public array $knownProjectionNames,
+	) {
+	}
+
+	public static function projection( RdfProjection $projection ): self {
+		return new self( $projection, [] );
+	}
+
+	/**
+	 * @param string[] $knownProjectionNames
+	 */
+	public static function unknownTarget( array $knownProjectionNames ): self {
+		return new self( null, $knownProjectionNames );
+	}
+
+}

--- a/src/Domain/Mapping/CurieExpander.php
+++ b/src/Domain/Mapping/CurieExpander.php
@@ -1,0 +1,85 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\Mapping;
+
+use ProfessionalWiki\NeoWiki\Domain\Rdf\Iri;
+
+/**
+ * Expands a Mapping term — a CURIE (`prefix:local` against the Mapping's declared prefixes) or an
+ * absolute IRI — into an {@see Iri}, or returns null when it cannot be resolved safely.
+ *
+ * This is a security boundary (the #1029 lesson). Mapping terms are user-authored JSON that end up as
+ * class, predicate, and datatype IRIs in the projected RDF. An unsafe term is **rejected**, never
+ * escaped: a Mapping must reproduce the ontology's exact term, so a percent-encoded variant would
+ * silently point at the wrong thing. The expanded IRI must therefore be a syntactically valid absolute
+ * IRI containing none of the IRIREF-illegal characters, or the term is unusable. The same expander is
+ * used by the content validator (to reject bad Mappings at save time) and by the projector (to expand
+ * at projection time), so a stored Mapping can never inject triples into the output document.
+ */
+readonly class CurieExpander {
+
+	// The characters an RDF IRIREF may not contain: the ASCII specials plus backtick and backslash.
+	// Space and the control characters are handled by the code-point check below.
+	private const string ILLEGAL_CHARS = '<>"{}|^`\\';
+
+	/**
+	 * @param array<string, string> $prefixes Prefix label to namespace IRI.
+	 */
+	public function __construct(
+		private array $prefixes,
+	) {
+	}
+
+	public function expand( string $term ): ?Iri {
+		$colon = strpos( $term, ':' );
+
+		if ( $colon === false ) {
+			return null;
+		}
+
+		$prefix = substr( $term, 0, $colon );
+
+		if ( array_key_exists( $prefix, $this->prefixes ) ) {
+			return self::newSafeIri( $this->prefixes[$prefix] . substr( $term, $colon + 1 ) );
+		}
+
+		// Not a declared CURIE. Accept only an explicit absolute IRI with an authority (`scheme://…`);
+		// a bare `prefix:local` with an undeclared prefix is a typo'd CURIE and is rejected, not
+		// silently treated as an IRI. Non-authority schemes (urn:, mailto:) are out of scope for v1.
+		if ( str_contains( $term, '://' ) ) {
+			return self::newSafeIri( $term );
+		}
+
+		return null;
+	}
+
+	private static function newSafeIri( string $iri ): ?Iri {
+		return self::isSafeAbsoluteIri( $iri ) ? new Iri( $iri ) : null;
+	}
+
+	/**
+	 * Whether the string is a syntactically valid absolute IRI safe to place raw in an RDF document:
+	 * it has a scheme and contains no IRIREF-illegal character. Used for prefix namespace IRIs too,
+	 * which reach the serializer's prefix table and so are an injection vector even when unused.
+	 */
+	public static function isSafeAbsoluteIri( string $iri ): bool {
+		if ( preg_match( '/^[A-Za-z][A-Za-z0-9+.\-]*:/', $iri ) !== 1 ) {
+			return false;
+		}
+
+		foreach ( str_split( $iri ) as $byte ) {
+			$code = ord( $byte );
+
+			// Controls (0x00–0x20, incl. space) and DEL are never allowed; nor are the specials. Bytes
+			// >= 0x80 are UTF-8 continuation of raw Unicode and pass through, keeping IRIs readable.
+			if ( $code <= 0x20 || $code === 0x7F || str_contains( self::ILLEGAL_CHARS, $byte ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+}

--- a/src/Domain/Mapping/Mapping.php
+++ b/src/Domain/Mapping/Mapping.php
@@ -1,0 +1,35 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\Mapping;
+
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+
+/**
+ * An ontology mapping: the correspondence between one native NeoWiki Schema and one target ontology
+ * (OntologyMapping.md). A Mapping is a first-class wiki object, separate from the Schema it references
+ * ([ADR 17](../../../docs/adr/017-names-as-identifiers.md)), so the Schema stays clean and can carry
+ * several mappings — one per target — installed independently.
+ *
+ * This is the deliberately minimal v1 shape: term substitution only (a target class for the Subject
+ * and one predicate per mapped property), no intermediate-node synthesis. The stored format is
+ * versioned and provisional; the mapping-formalism question (OntologyMapping.md Q1, #995) stays open.
+ */
+readonly class Mapping {
+
+	/**
+	 * @param array<string, string> $prefixes Prefix label to namespace IRI, for expanding the CURIEs
+	 *   used in $subjectClass and the property predicates/datatypes.
+	 */
+	public function __construct(
+		public MappingName $name,
+		public SchemaName $schema,
+		public string $target,
+		public array $prefixes,
+		public string $subjectClass,
+		public PropertyMappings $properties,
+	) {
+	}
+
+}

--- a/src/Domain/Mapping/MappingName.php
+++ b/src/Domain/Mapping/MappingName.php
@@ -1,0 +1,23 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\Mapping;
+
+use InvalidArgumentException;
+
+readonly class MappingName {
+
+	public function __construct(
+		private string $text,
+	) {
+		if ( trim( $this->text ) === '' ) {
+			throw new InvalidArgumentException( 'Mapping name cannot be empty' );
+		}
+	}
+
+	public function getText(): string {
+		return $this->text;
+	}
+
+}

--- a/src/Domain/Mapping/PropertyMapping.php
+++ b/src/Domain/Mapping/PropertyMapping.php
@@ -1,0 +1,21 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\Mapping;
+
+/**
+ * Maps one NeoWiki property (referenced by name from the Mapping's Schema) to a target-ontology
+ * predicate. The predicate and optional datatype are raw CURIEs or absolute IRIs; they are expanded
+ * against the Mapping's prefixes by a {@see CurieExpander} at validation and projection time.
+ */
+readonly class PropertyMapping {
+
+	public function __construct(
+		public string $predicate,
+		public ?string $language = null,
+		public ?string $datatype = null,
+	) {
+	}
+
+}

--- a/src/Domain/Mapping/PropertyMappings.php
+++ b/src/Domain/Mapping/PropertyMappings.php
@@ -1,0 +1,31 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\Mapping;
+
+/**
+ * The per-property rules of a {@see Mapping}, keyed by NeoWiki property name.
+ */
+readonly class PropertyMappings {
+
+	/**
+	 * @param array<string, PropertyMapping> $mappings Keyed by NeoWiki property name.
+	 */
+	public function __construct(
+		private array $mappings = [],
+	) {
+	}
+
+	public function get( string $propertyName ): ?PropertyMapping {
+		return $this->mappings[$propertyName] ?? null;
+	}
+
+	/**
+	 * @return array<string, PropertyMapping> Keyed by NeoWiki property name.
+	 */
+	public function asArray(): array {
+		return $this->mappings;
+	}
+
+}

--- a/src/Domain/Rdf/Literal.php
+++ b/src/Domain/Rdf/Literal.php
@@ -4,19 +4,39 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Domain\Rdf;
 
+use InvalidArgumentException;
+
 /**
  * An RDF literal: a lexical form plus a datatype IRI, and optionally a language tag.
  *
  * The native projection only mints datatyped literals (the language tag stays null), but the
  * model carries the tag so language-tagged literals remain expressible for future projections.
+ *
+ * The language tag is a domain invariant: a non-null tag must be BCP-47-shaped, so it cannot smuggle
+ * a `"`, a datatype, or other syntax into the serialized `"lexical"@tag` form. Construction sites are
+ * controlled (the native projection never sets a tag; the ontology projector validates before
+ * constructing), so an invalid tag is a programming error and throws.
  */
 readonly class Literal implements RdfTerm {
+
+	// A BCP-47-shaped language tag: hyphen-separated subtags of 1–8 characters, the primary subtag
+	// alphabetic and the rest alphanumeric. Kept in sync with the `lang` pattern in
+	// mappingContentSchema.json (the save-time layer). The `D` modifier pins `$` to the very end of the
+	// string so a trailing newline cannot slip characters past the check.
+	private const string LANGUAGE_TAG_PATTERN = '/^[A-Za-z]{1,8}(-[A-Za-z0-9]{1,8})*$/D';
 
 	public function __construct(
 		public string $lexicalForm,
 		public Iri $datatype,
 		public ?string $languageTag = null,
 	) {
+		if ( $languageTag !== null && !self::isValidLanguageTag( $languageTag ) ) {
+			throw new InvalidArgumentException( 'Invalid RDF language tag: "' . $languageTag . '".' );
+		}
+	}
+
+	public static function isValidLanguageTag( string $tag ): bool {
+		return preg_match( self::LANGUAGE_TAG_PATTERN, $tag ) === 1;
 	}
 
 	public function isLanguageTagged(): bool {

--- a/src/EntryPoints/Content/MappingContent.php
+++ b/src/EntryPoints/Content/MappingContent.php
@@ -1,0 +1,20 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\EntryPoints\Content;
+
+use MediaWiki\Content\JsonContent;
+
+class MappingContent extends JsonContent {
+
+	public const string CONTENT_MODEL_ID = 'NeoWikiMapping';
+
+	public function __construct( string $text, string $modelId = self::CONTENT_MODEL_ID ) {
+		parent::__construct(
+			$text,
+			$modelId
+		);
+	}
+
+}

--- a/src/EntryPoints/Content/MappingContentHandler.php
+++ b/src/EntryPoints/Content/MappingContentHandler.php
@@ -1,0 +1,115 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\EntryPoints\Content;
+
+use InvalidArgumentException;
+use MediaWiki\Content\Content;
+use MediaWiki\Content\JsonContentHandler;
+use MediaWiki\Content\Renderer\ContentParseParams;
+use MediaWiki\Content\ValidationParams;
+use MediaWiki\Parser\ParserOutput;
+use MediaWiki\Title\Title;
+use ProfessionalWiki\NeoWiki\Application\Mappings;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\MappingName;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\MappingContentValidator;
+use StatusValue;
+
+class MappingContentHandler extends JsonContentHandler {
+
+	protected function getContentClass(): string {
+		return MappingContent::class;
+	}
+
+	public function validateSave( Content $content, ValidationParams $validationParams ): StatusValue {
+		$status = parent::validateSave( $content, $validationParams );
+
+		if ( !$status->isOK() ) {
+			return $status;
+		}
+
+		$title = Title::newFromPageIdentity( $validationParams->getPageIdentity() );
+
+		try {
+			new MappingName( $title->getText() );
+		} catch ( InvalidArgumentException $exception ) {
+			$status->fatal( 'neowiki-mapping-name-invalid', $exception->getMessage() );
+		}
+
+		$validator = MappingContentValidator::newInstance();
+
+		if ( !$validator->validate( $content->getText() ) ) {
+			$status->fatal( 'neowiki-mapping-invalid', count( $validator->getErrors() ) );
+
+			foreach ( $validator->getErrors() as $pointer => $message ) {
+				$status->fatal( 'neowiki-mapping-invalid-detail', $pointer, $message );
+			}
+
+			// The duplicate check deserializes the content, so only run it once the content is valid.
+			return $status;
+		}
+
+		$this->rejectDuplicateTarget( $content, $title, $status );
+
+		return $status;
+	}
+
+	/**
+	 * One Mapping per (Schema, target): reject a save whose pair another Mapping page already claims.
+	 * Lookup-based, so a concurrent save could still slip a duplicate through — acceptable pre-production,
+	 * and the projector tie-breaks deterministically if it happens.
+	 */
+	private function rejectDuplicateTarget( Content $content, Title $title, StatusValue $status ): void {
+		$extension = NeoWikiExtension::getInstance();
+
+		try {
+			$mapping = $extension->getMappingPersistenceDeserializer()
+				->deserialize( new MappingName( $title->getText() ), $content->getText() );
+		} catch ( InvalidArgumentException ) {
+			return;
+		}
+
+		$conflict = ( new Mappings( $extension->getMappingLookup()->getAllMappings() ) )
+			->conflictFor( $mapping->schema, $mapping->target, $mapping->name );
+
+		if ( $conflict !== null ) {
+			$status->fatal(
+				'neowiki-mapping-duplicate-target',
+				$mapping->schema->getText(),
+				$mapping->target,
+				$conflict->name->getText()
+			);
+		}
+	}
+
+	protected function fillParserOutput(
+		Content $content,
+		ContentParseParams $cpoParams,
+		ParserOutput &$parserOutput
+	): void {
+		$parserOutput->setRawText( '' );
+	}
+
+	public function makeEmptyContent(): MappingContent {
+		return new MappingContent( <<<JSON
+{
+	"version": 1,
+	"schema": "",
+	"target": "",
+	"prefixes": {},
+	"subject": {
+		"class": ""
+	},
+	"properties": {}
+}
+JSON
+		);
+	}
+
+	public function canBeUsedOn( Title $title ): bool {
+		return $title->getNamespace() === NeoWikiExtension::NS_MAPPING;
+	}
+
+}

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -19,6 +19,7 @@ use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\EntryPoints\Content\SchemaContent;
 use ProfessionalWiki\NeoWiki\EntryPoints\Content\SubjectContent;
 use ProfessionalWiki\NeoWiki\EntryPoints\Content\LayoutContent;
+use ProfessionalWiki\NeoWiki\EntryPoints\Content\MappingContent;
 use ProfessionalWiki\NeoWiki\Application\SubjectResolver;
 use ProfessionalWiki\NeoWiki\EntryPoints\Actions\SubjectsAction;
 use ProfessionalWiki\NeoWiki\EntryPoints\Scribunto\ScribuntoLuaLibrary;
@@ -184,7 +185,7 @@ class NeoWikiHooks {
 	}
 
 	public static function onCodeEditorGetPageLanguage( Title $title, ?string &$lang, ?string $model, ?string $format ): void {
-		if ( in_array( $model, [ SubjectContent::CONTENT_MODEL_ID, SchemaContent::CONTENT_MODEL_ID, LayoutContent::CONTENT_MODEL_ID ] ) ) {
+		if ( in_array( $model, [ SubjectContent::CONTENT_MODEL_ID, SchemaContent::CONTENT_MODEL_ID, LayoutContent::CONTENT_MODEL_ID, MappingContent::CONTENT_MODEL_ID ] ) ) {
 			$lang = 'json';
 		}
 	}
@@ -210,6 +211,10 @@ class NeoWikiHooks {
 
 		if ( $title->getNamespace() === NeoWikiExtension::NS_LAYOUT ) {
 			$ok = $modelId === LayoutContent::CONTENT_MODEL_ID;
+		}
+
+		if ( $title->getNamespace() === NeoWikiExtension::NS_MAPPING ) {
+			$ok = $modelId === MappingContent::CONTENT_MODEL_ID;
 		}
 	}
 

--- a/src/EntryPoints/REST/ExportPageRdfApi.php
+++ b/src/EntryPoints/REST/ExportPageRdfApi.php
@@ -13,9 +13,11 @@ use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use Wikimedia\ParamValidator\ParamValidator;
 
 /**
- * Exports one page's Subjects and metadata as native RDF (NativeRdfProjection.md). The format is
- * chosen by the `format` query parameter, falling back to the Accept header, then to TriG. TriG keeps
- * the per-page named graph; Turtle emits the same triples without it.
+ * Exports one page's Subjects and metadata as RDF. The `projection` query parameter selects the
+ * vocabulary: "native" (default, NativeRdfProjection.md) or an ontology target that a Mapping page
+ * declares (OntologyMapping.md) — an unknown projection is a 400. The `format` query parameter picks
+ * the serialization, falling back to the Accept header, then to TriG. TriG keeps the per-page named
+ * graph; Turtle emits the same triples without it.
  */
 class ExportPageRdfApi extends SimpleHandler {
 
@@ -26,10 +28,21 @@ class ExportPageRdfApi extends SimpleHandler {
 	private const string CONTENT_TYPE_TURTLE = 'text/turtle; charset=utf-8';
 
 	public function run( int $pageId ): Response {
+		$extension = NeoWikiExtension::getInstance();
+		$projectionName = $this->getValidatedParams()['projection'] ?? NeoWikiExtension::PROJECTION_NATIVE;
+		$projection = $extension->newRdfProjection( $projectionName );
+
+		if ( $projection === null ) {
+			return $this->getResponseFactory()->createHttpError( 400, [
+				'message' => 'Unknown RDF projection: "' . $projectionName . '". Known projections: '
+					. implode( ', ', $extension->getRdfProjectionNames() ) . '.',
+			] );
+		}
+
 		$format = $this->resolveFormat();
 
-		$document = NeoWikiExtension::getInstance()
-			->newRdfPageExporter()
+		$document = $extension
+			->newRdfPageExporterForProjection( $projection )
 			->exportByPageId( new PageId( $pageId ), $format );
 
 		if ( $document === null ) {
@@ -93,6 +106,12 @@ class ExportPageRdfApi extends SimpleHandler {
 				],
 				ParamValidator::PARAM_REQUIRED => false,
 				self::PARAM_DESCRIPTION => 'RDF serialization to return: "trig" (default, includes the per-page named graph) or "turtle". Overrides the Accept header.',
+			],
+			'projection' => [
+				self::PARAM_SOURCE => 'query',
+				ParamValidator::PARAM_TYPE => 'string',
+				ParamValidator::PARAM_REQUIRED => false,
+				self::PARAM_DESCRIPTION => 'RDF projection to produce: "native" (default) for NeoWiki-native vocabulary, or an ontology target declared by a Mapping page (e.g. "edm"). An unknown target returns 400.',
 			],
 		];
 	}

--- a/src/EntryPoints/REST/ExportPageRdfApi.php
+++ b/src/EntryPoints/REST/ExportPageRdfApi.php
@@ -30,19 +30,19 @@ class ExportPageRdfApi extends SimpleHandler {
 	public function run( int $pageId ): Response {
 		$extension = NeoWikiExtension::getInstance();
 		$projectionName = $this->getValidatedParams()['projection'] ?? NeoWikiExtension::PROJECTION_NATIVE;
-		$projection = $extension->newRdfProjection( $projectionName );
+		$resolution = $extension->resolveRdfProjection( $projectionName );
 
-		if ( $projection === null ) {
+		if ( $resolution->projection === null ) {
 			return $this->getResponseFactory()->createHttpError( 400, [
 				'message' => 'Unknown RDF projection: "' . $projectionName . '". Known projections: '
-					. implode( ', ', $extension->getRdfProjectionNames() ) . '.',
+					. implode( ', ', $resolution->knownProjectionNames ) . '.',
 			] );
 		}
 
 		$format = $this->resolveFormat();
 
 		$document = $extension
-			->newRdfPageExporterForProjection( $projection )
+			->newRdfPageExporterForProjection( $resolution->projection )
 			->exportByPageId( new PageId( $pageId ), $format );
 
 		if ( $document === null ) {

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -59,9 +59,14 @@ use ProfessionalWiki\NeoWiki\Application\SubjectPermissionHints;
 use ProfessionalWiki\NeoWiki\Application\SubjectWriteAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\SubjectPageRebuilder;
 use ProfessionalWiki\NeoWiki\Application\SubjectRepository;
+use ProfessionalWiki\NeoWiki\Application\MappingLookup;
+use ProfessionalWiki\NeoWiki\Application\Mappings;
+use ProfessionalWiki\NeoWiki\Application\Rdf\OntologyMappingProjector;
 use ProfessionalWiki\NeoWiki\Application\Rdf\RdfPageExporter;
 use ProfessionalWiki\NeoWiki\Application\Rdf\RdfPageLoader;
 use ProfessionalWiki\NeoWiki\Application\Rdf\RdfPageProjector;
+use ProfessionalWiki\NeoWiki\Application\Rdf\RdfProjection;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\CurieExpander;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfNamespaces;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfSerializer;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfValueMapperRegistry;
@@ -99,10 +104,15 @@ use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\MediaWikiSubjectRepos
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\PointInTimeSubjectLookup;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\StatementDeserializer;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\SubjectContentDataDeserializer;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\CachingMappingLookup;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\CachingSchemaLookup;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\DatabaseMappingNameLookup;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\LayoutPersistenceDeserializer;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\MappingPersistenceDeserializer;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\WikiPageMappingLookup;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\WikiPageSchemaLookup;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\WikiPageLayoutLookup;
+use ProfessionalWiki\NeoWiki\Persistence\MappingNameLookup;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jPageIdentifiersLookup;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Neo4jPlugin;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jSubjectLabelLookup;
@@ -122,6 +132,9 @@ class NeoWikiExtension {
 
 	public const int NS_SCHEMA = 7474;
 	public const int NS_LAYOUT = 7476;
+	public const int NS_MAPPING = 7478;
+
+	public const string PROJECTION_NATIVE = 'native';
 
 	private PropertyTypeRegistry $propertyTypeRegistry;
 	private PagePropertyProviderRegistry $pagePropertyProviderRegistry;
@@ -295,12 +308,101 @@ class NeoWikiExtension {
 		);
 	}
 
-	public function newRdfPageExporter(): RdfPageExporter {
+	public function newRdfPageExporterForProjection( RdfProjection $projection ): RdfPageExporter {
 		return new RdfPageExporter(
 			$this->newRdfPageLoader(),
-			$this->newRdfPageProjector(),
-			$this->getRdfSerializer(),
+			$projection->projector,
+			$projection->serializer,
 		);
+	}
+
+	/**
+	 * Resolves a projection name to its projector and serializer, or null when the name is neither
+	 * "native" nor a target that any Mapping page declares. This is the seam the RDF export surfaces
+	 * use to select a projection, and that the SPARQL store plugin (#586) consumes for its own store
+	 * (it needs only {@see RdfProjection::$projector}). Ontology mappings hold only the target
+	 * vocabulary; Subject IRIs stay native, so the native prefixes always seed the serializer.
+	 */
+	public function newRdfProjection( string $projectionName ): ?RdfProjection {
+		if ( $projectionName === self::PROJECTION_NATIVE ) {
+			return new RdfProjection( $this->newRdfPageProjector(), $this->getRdfSerializer() );
+		}
+
+		$mappings = ( new Mappings( $this->getMappingLookup()->getAllMappings() ) )->forTarget( $projectionName );
+
+		if ( $mappings === [] ) {
+			return null;
+		}
+
+		return new RdfProjection(
+			new OntologyMappingProjector(
+				$projectionName,
+				$mappings,
+				$this->getRdfNamespaces(),
+				$this->getRdfValueMapperRegistry(),
+				LoggerFactory::getInstance( 'NeoWiki' ),
+			),
+			new HardfRdfSerializer( $this->ontologyPrefixMap( $mappings ) ),
+		);
+	}
+
+	/**
+	 * The known projection names: "native" plus every target any Mapping page declares. Used to reject
+	 * an unknown projection with a helpful list of the valid ones.
+	 *
+	 * @return string[]
+	 */
+	public function getRdfProjectionNames(): array {
+		return array_merge(
+			[ self::PROJECTION_NATIVE ],
+			( new Mappings( $this->getMappingLookup()->getAllMappings() ) )->targets()
+		);
+	}
+
+	/**
+	 * The native prefixes (Subject IRIs stay native) plus the Mappings' declared ontology prefixes, for
+	 * readable output. Unsafe prefix namespaces are dropped defensively so a Mapping can never inject a
+	 * `@prefix` declaration into the document, even though save-time validation already rejects them.
+	 *
+	 * @param \ProfessionalWiki\NeoWiki\Domain\Mapping\Mapping[] $mappings
+	 * @return array<string, string>
+	 */
+	private function ontologyPrefixMap( array $mappings ): array {
+		$prefixes = $this->getRdfNamespaces()->prefixMap();
+
+		foreach ( $mappings as $mapping ) {
+			foreach ( $mapping->prefixes as $label => $namespace ) {
+				if ( CurieExpander::isSafeAbsoluteIri( $namespace ) ) {
+					$prefixes[$label] = $namespace;
+				}
+			}
+		}
+
+		return $prefixes;
+	}
+
+	public function getMappingLookup(): MappingLookup {
+		return new CachingMappingLookup(
+			mappingLookup: new WikiPageMappingLookup(
+				pageContentFetcher: $this->getPageContentFetcher(),
+				authority: $this->getRequestAuthority(),
+				mappingDeserializer: $this->getMappingPersistenceDeserializer(),
+				mappingNameLookup: $this->getMappingNameLookup(),
+			),
+			mappingNameLookup: $this->getMappingNameLookup(),
+			cache: MediaWikiServices::getInstance()->getMainWANObjectCache(),
+			titleFactory: MediaWikiServices::getInstance()->getTitleFactory(),
+			authority: $this->getRequestAuthority(),
+			connectionProvider: MediaWikiServices::getInstance()->getConnectionProvider(),
+		);
+	}
+
+	public function getMappingNameLookup(): MappingNameLookup {
+		return new DatabaseMappingNameLookup( db: $this->getDbConnection() );
+	}
+
+	public function getMappingPersistenceDeserializer(): MappingPersistenceDeserializer {
+		return new MappingPersistenceDeserializer();
 	}
 
 	public static function newExportPageRdfApi(): ExportPageRdfApi {

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -66,6 +66,7 @@ use ProfessionalWiki\NeoWiki\Application\Rdf\RdfPageExporter;
 use ProfessionalWiki\NeoWiki\Application\Rdf\RdfPageLoader;
 use ProfessionalWiki\NeoWiki\Application\Rdf\RdfPageProjector;
 use ProfessionalWiki\NeoWiki\Application\Rdf\RdfProjection;
+use ProfessionalWiki\NeoWiki\Application\Rdf\RdfProjectionResolution;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\CurieExpander;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfNamespaces;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfSerializer;
@@ -317,32 +318,49 @@ class NeoWikiExtension {
 	}
 
 	/**
-	 * Resolves a projection name to its projector and serializer, or null when the name is neither
-	 * "native" nor a target that any Mapping page declares. This is the seam the RDF export surfaces
-	 * use to select a projection, and that the SPARQL store plugin (#586) consumes for its own store
-	 * (it needs only {@see RdfProjection::$projector}). Ontology mappings hold only the target
-	 * vocabulary; Subject IRIs stay native, so the native prefixes always seed the serializer.
+	 * The projection for a name, or null when the name is neither "native" nor a target any Mapping page
+	 * declares. The seam the SPARQL store plugin (#586) consumes for its own store (it needs only
+	 * {@see RdfProjection::$projector}); the RDF export surfaces use {@see self::resolveRdfProjection()}
+	 * instead, which also reports the known names on the unknown-target path. Ontology mappings hold only
+	 * the target vocabulary; Subject IRIs stay native, so the native prefixes always seed the serializer.
 	 */
 	public function newRdfProjection( string $projectionName ): ?RdfProjection {
+		return $this->resolveRdfProjection( $projectionName )->projection;
+	}
+
+	/**
+	 * Resolves a projection name to its projector and serializer, or — when the name is neither "native"
+	 * nor a declared target — to the known projection names for a 400/usage message. Mapping pages are
+	 * enumerated at most once (the "native" default enumerates nothing), so a caller that needs both the
+	 * resolution and the known-names list on the unknown-target path pays for a single enumeration.
+	 */
+	public function resolveRdfProjection( string $projectionName ): RdfProjectionResolution {
 		if ( $projectionName === self::PROJECTION_NATIVE ) {
-			return new RdfProjection( $this->newRdfPageProjector(), $this->getRdfSerializer() );
+			return RdfProjectionResolution::projection(
+				new RdfProjection( $this->newRdfPageProjector(), $this->getRdfSerializer() )
+			);
 		}
 
-		$mappings = ( new Mappings( $this->getMappingLookup()->getAllMappings() ) )->forTarget( $projectionName );
+		$mappings = new Mappings( $this->getMappingLookup()->getAllMappings() );
+		$forTarget = $mappings->forTarget( $projectionName );
 
-		if ( $mappings === [] ) {
-			return null;
+		if ( $forTarget === [] ) {
+			return RdfProjectionResolution::unknownTarget(
+				array_merge( [ self::PROJECTION_NATIVE ], $mappings->targets() )
+			);
 		}
 
-		return new RdfProjection(
-			new OntologyMappingProjector(
-				$projectionName,
-				$mappings,
-				$this->getRdfNamespaces(),
-				$this->getRdfValueMapperRegistry(),
-				LoggerFactory::getInstance( 'NeoWiki' ),
-			),
-			new HardfRdfSerializer( $this->ontologyPrefixMap( $mappings ) ),
+		return RdfProjectionResolution::projection(
+			new RdfProjection(
+				new OntologyMappingProjector(
+					$projectionName,
+					$forTarget,
+					$this->getRdfNamespaces(),
+					$this->getRdfValueMapperRegistry(),
+					LoggerFactory::getInstance( 'NeoWiki' ),
+				),
+				new HardfRdfSerializer( $this->ontologyPrefixMap( $forTarget ) ),
+			)
 		);
 	}
 

--- a/src/Persistence/MappingNameLookup.php
+++ b/src/Persistence/MappingNameLookup.php
@@ -1,0 +1,18 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Persistence;
+
+use ProfessionalWiki\NeoWiki\Domain\Mapping\MappingName;
+
+interface MappingNameLookup {
+
+	/**
+	 * The names of every Mapping page, used to enumerate all Mappings.
+	 *
+	 * @return MappingName[]
+	 */
+	public function getMappingNames(): array;
+
+}

--- a/src/Persistence/MediaWiki/CachingMappingLookup.php
+++ b/src/Persistence/MediaWiki/CachingMappingLookup.php
@@ -1,0 +1,91 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Persistence\MediaWiki;
+
+use MediaWiki\Permissions\Authority;
+use MediaWiki\Title\Title;
+use MediaWiki\Title\TitleFactory;
+use ProfessionalWiki\NeoWiki\Application\MappingLookup;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\Mapping;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\MappingName;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+use ProfessionalWiki\NeoWiki\Persistence\MappingNameLookup;
+use Wikimedia\ObjectCache\WANObjectCache;
+use Wikimedia\Rdbms\Database;
+use Wikimedia\Rdbms\IConnectionProvider;
+
+/**
+ * Caches deserialized Mappings, mirroring {@see CachingSchemaLookup}. Enumerating all Mappings (for
+ * projection and for duplicate detection) reads every Mapping page; the cache key includes each page's
+ * latest revision id, so a Mapping edit transparently invalidates its entry and a bulk RDF dump reuses
+ * cached Mappings across pages instead of re-parsing them per page.
+ */
+class CachingMappingLookup implements MappingLookup {
+
+	private const CACHE_VERSION = 1;
+
+	public function __construct(
+		private readonly MappingLookup $mappingLookup,
+		private readonly MappingNameLookup $mappingNameLookup,
+		private readonly WANObjectCache $cache,
+		private readonly TitleFactory $titleFactory,
+		private readonly Authority $authority,
+		private readonly IConnectionProvider $connectionProvider,
+	) {
+	}
+
+	public function getMapping( MappingName $name ): ?Mapping {
+		$title = $this->titleFactory->newFromText( $name->getText(), NeoWikiExtension::NS_MAPPING );
+
+		if ( $title === null || !$title->exists() ) {
+			return null;
+		}
+
+		// Repeat the inner lookup's per-user read check before the cache, so a cache hit cannot serve a
+		// Mapping to a user who may not read its page.
+		if ( !$this->authority->probablyCan( 'read', $title ) ) {
+			return null;
+		}
+
+		/** @var Mapping|null $mapping */
+		$mapping = $this->cache->getWithSetCallback(
+			$this->makeCacheKey( $title ),
+			WANObjectCache::TTL_DAY,
+			function ( mixed $oldValue, int &$ttl, array &$setOpts ) use ( $name ): ?Mapping {
+				$setOpts += Database::getCacheSetOptions( $this->connectionProvider->getReplicaDatabase() );
+				return $this->mappingLookup->getMapping( $name );
+			}
+		);
+
+		return $mapping;
+	}
+
+	/**
+	 * @return Mapping[]
+	 */
+	public function getAllMappings(): array {
+		$mappings = [];
+
+		foreach ( $this->mappingNameLookup->getMappingNames() as $name ) {
+			$mapping = $this->getMapping( $name );
+
+			if ( $mapping !== null ) {
+				$mappings[] = $mapping;
+			}
+		}
+
+		return $mappings;
+	}
+
+	private function makeCacheKey( Title $title ): string {
+		return $this->cache->makeKey(
+			'neowiki-mapping',
+			self::CACHE_VERSION,
+			$title->getArticleID(),
+			$title->getLatestRevID()
+		);
+	}
+
+}

--- a/src/Persistence/MediaWiki/DatabaseMappingNameLookup.php
+++ b/src/Persistence/MediaWiki/DatabaseMappingNameLookup.php
@@ -1,0 +1,39 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Persistence\MediaWiki;
+
+use ProfessionalWiki\NeoWiki\Domain\Mapping\MappingName;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+use ProfessionalWiki\NeoWiki\Persistence\MappingNameLookup;
+use Wikimedia\Rdbms\IDatabase;
+
+class DatabaseMappingNameLookup implements MappingNameLookup {
+
+	public function __construct(
+		private readonly IDatabase $db,
+	) {
+	}
+
+	/**
+	 * @return MappingName[]
+	 */
+	public function getMappingNames(): array {
+		$titles = $this->db->newSelectQueryBuilder()
+			->select( 'page_title' )
+			->from( 'page' )
+			->where( [ 'page_namespace' => NeoWikiExtension::NS_MAPPING ] )
+			->orderBy( 'page_id ASC' )
+			->caller( __METHOD__ )
+			->fetchFieldValues();
+
+		// The DB key uses underscores; the display text (spaces) matches Title::getText(), so the name
+		// compares equal to the page identity a MappingContentHandler sees when detecting duplicates.
+		return array_map(
+			static fn ( string $title ): MappingName => new MappingName( str_replace( '_', ' ', $title ) ),
+			$titles
+		);
+	}
+
+}

--- a/src/Persistence/MediaWiki/MappingContentValidator.php
+++ b/src/Persistence/MediaWiki/MappingContentValidator.php
@@ -1,0 +1,184 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Persistence\MediaWiki;
+
+use Opis\JsonSchema\Errors\ErrorFormatter;
+use Opis\JsonSchema\Errors\ValidationError;
+use Opis\JsonSchema\Validator;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\CurieExpander;
+use RuntimeException;
+
+/**
+ * Validates the JSON of a Mapping page against the v1 format, in two stages:
+ *
+ *  1. Structural validation against mappingContentSchema.json (versioned, deliberately minimal).
+ *  2. Semantic IRI-safety validation: every declared prefix namespace, and every class, predicate and
+ *     datatype term, must expand to a valid, safe absolute IRI (the #1029 lesson). A term that cannot
+ *     be resolved against the declared prefixes, or that would break out of its IRI, is rejected here
+ *     rather than percent-encoded — a Mapping must reproduce the ontology's exact terms.
+ *
+ * The duplicate (Schema, target) check is not here: it needs to enumerate the other Mapping pages, so
+ * it lives in {@see \ProfessionalWiki\NeoWiki\EntryPoints\Content\MappingContentHandler}.
+ */
+class MappingContentValidator {
+
+	/**
+	 * @var array<string, string> Pointer to message.
+	 */
+	private array $errors = [];
+
+	public static function newInstance(): self {
+		$json = file_get_contents( __DIR__ . '/mappingContentSchema.json' );
+
+		if ( !is_string( $json ) ) {
+			throw new RuntimeException( 'Could not obtain JSON Schema' );
+		}
+
+		$schema = json_decode( $json );
+
+		if ( !is_object( $schema ) ) {
+			throw new RuntimeException( 'Failed to deserialize JSON Schema' );
+		}
+
+		return new self( $schema );
+	}
+
+	private function __construct(
+		private object $jsonSchema
+	) {
+	}
+
+	public function validate( string $config ): bool {
+		$this->errors = [];
+
+		$structuralErrors = $this->structuralErrors( $config );
+
+		if ( $structuralErrors !== [] ) {
+			$this->errors = $structuralErrors;
+			return false;
+		}
+
+		// The structure is valid, so json_decode yields the expected associative array.
+		/** @var array<string, mixed> $data */
+		$data = json_decode( $config, true );
+		$this->errors = $this->semanticErrors( $data );
+
+		return $this->errors === [];
+	}
+
+	/**
+	 * @return array<string, string>
+	 */
+	private function structuralErrors( string $config ): array {
+		$validator = new Validator();
+		$validator->setMaxErrors( 10 );
+
+		$error = $validator->validate( json_decode( $config ), $this->jsonSchema )->error();
+
+		return $error instanceof ValidationError ? ( new ErrorFormatter() )->format( $error, false ) : [];
+	}
+
+	/**
+	 * The structure has already passed JSON-Schema validation, so the fields are present and well-typed;
+	 * the guards here keep the analyser happy and make a hand-called validator robust to raw input.
+	 *
+	 * @param array<string, mixed> $data
+	 * @return array<string, string>
+	 */
+	private function semanticErrors( array $data ): array {
+		$prefixes = $this->stringMap( $data['prefixes'] ?? [] );
+		$expander = new CurieExpander( $prefixes );
+
+		$errors = $this->prefixErrors( $prefixes );
+
+		$subject = $data['subject'] ?? null;
+		$class = is_array( $subject ) ? $this->stringOrNull( $subject['class'] ?? null ) : null;
+		if ( $class !== null && $expander->expand( $class ) === null ) {
+			$errors['/subject/class'] = $this->unresolvedTermMessage( $class );
+		}
+
+		$properties = is_array( $data['properties'] ?? null ) ? $data['properties'] : [];
+		foreach ( $properties as $name => $entry ) {
+			if ( is_array( $entry ) ) {
+				$errors = array_merge( $errors, $this->propertyErrors( (string)$name, $entry, $expander ) );
+			}
+		}
+
+		return $errors;
+	}
+
+	/**
+	 * @param array<string, string> $prefixes
+	 * @return array<string, string>
+	 */
+	private function prefixErrors( array $prefixes ): array {
+		$errors = [];
+
+		foreach ( $prefixes as $label => $namespace ) {
+			// The namespace also reaches the serializer's prefix table, so an unsafe one could inject a
+			// `@prefix` declaration even when no term uses it. Reject it up front.
+			if ( !CurieExpander::isSafeAbsoluteIri( $namespace ) ) {
+				$errors['/prefixes/' . $label] = 'The prefix namespace "' . $namespace . '" is not a valid, safe absolute IRI.';
+			}
+		}
+
+		return $errors;
+	}
+
+	/**
+	 * @param array<mixed> $entry
+	 * @return array<string, string>
+	 */
+	private function propertyErrors( string $name, array $entry, CurieExpander $expander ): array {
+		$errors = [];
+
+		$predicate = $this->stringOrNull( $entry['predicate'] ?? null );
+		if ( $predicate !== null && $expander->expand( $predicate ) === null ) {
+			$errors['/properties/' . $name . '/predicate'] = $this->unresolvedTermMessage( $predicate );
+		}
+
+		$datatype = $this->stringOrNull( $entry['datatype'] ?? null );
+		if ( $datatype !== null && $expander->expand( $datatype ) === null ) {
+			$errors['/properties/' . $name . '/datatype'] = $this->unresolvedTermMessage( $datatype );
+		}
+
+		return $errors;
+	}
+
+	private function stringOrNull( mixed $value ): ?string {
+		return is_string( $value ) ? $value : null;
+	}
+
+	/**
+	 * @return array<string, string>
+	 */
+	private function stringMap( mixed $value ): array {
+		if ( !is_array( $value ) ) {
+			return [];
+		}
+
+		$map = [];
+
+		foreach ( $value as $key => $entry ) {
+			if ( is_string( $key ) && is_string( $entry ) ) {
+				$map[$key] = $entry;
+			}
+		}
+
+		return $map;
+	}
+
+	private function unresolvedTermMessage( string $term ): string {
+		return 'The term "' . $term . '" is not a declared CURIE or a valid, safe absolute IRI.';
+	}
+
+	/**
+	 * @return array<string, string>
+	 */
+	public function getErrors(): array {
+		return $this->errors;
+	}
+
+}

--- a/src/Persistence/MediaWiki/MappingPersistenceDeserializer.php
+++ b/src/Persistence/MediaWiki/MappingPersistenceDeserializer.php
@@ -1,0 +1,89 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Persistence\MediaWiki;
+
+use InvalidArgumentException;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\Mapping;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\MappingName;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\PropertyMapping;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\PropertyMappings;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+
+class MappingPersistenceDeserializer {
+
+	/**
+	 * @throws InvalidArgumentException When the JSON is missing the fields a Mapping needs. The lookups
+	 *   catch this and treat the page as having no valid Mapping, so a malformed page never breaks a
+	 *   projection.
+	 */
+	public function deserialize( MappingName $name, string $json ): Mapping {
+		$data = json_decode( $json, true );
+
+		if ( !is_array( $data ) ) {
+			throw new InvalidArgumentException( 'Invalid JSON' );
+		}
+
+		$schema = $data['schema'] ?? null;
+		$target = $data['target'] ?? null;
+		$class = $data['subject']['class'] ?? null;
+
+		if ( !is_string( $schema ) || !is_string( $target ) || !is_string( $class ) ) {
+			throw new InvalidArgumentException( 'Mapping is missing required fields' );
+		}
+
+		return new Mapping(
+			name: $name,
+			schema: new SchemaName( $schema ),
+			target: $target,
+			prefixes: $this->prefixesFromJson( $data ),
+			subjectClass: $class,
+			properties: $this->propertyMappingsFromJson( $data ),
+		);
+	}
+
+	/**
+	 * @param array<string, mixed> $data
+	 * @return array<string, string>
+	 */
+	private function prefixesFromJson( array $data ): array {
+		$prefixes = [];
+
+		foreach ( $this->arrayValue( $data, 'prefixes' ) as $label => $namespace ) {
+			if ( is_string( $label ) && is_string( $namespace ) ) {
+				$prefixes[$label] = $namespace;
+			}
+		}
+
+		return $prefixes;
+	}
+
+	/**
+	 * @param array<string, mixed> $data
+	 */
+	private function propertyMappingsFromJson( array $data ): PropertyMappings {
+		$mappings = [];
+
+		foreach ( $this->arrayValue( $data, 'properties' ) as $name => $entry ) {
+			if ( is_string( $name ) && is_array( $entry ) && is_string( $entry['predicate'] ?? null ) ) {
+				$mappings[$name] = new PropertyMapping(
+					predicate: $entry['predicate'],
+					language: is_string( $entry['lang'] ?? null ) ? $entry['lang'] : null,
+					datatype: is_string( $entry['datatype'] ?? null ) ? $entry['datatype'] : null,
+				);
+			}
+		}
+
+		return new PropertyMappings( $mappings );
+	}
+
+	/**
+	 * @param array<string, mixed> $data
+	 * @return array<mixed>
+	 */
+	private function arrayValue( array $data, string $key ): array {
+		return is_array( $data[$key] ?? null ) ? $data[$key] : [];
+	}
+
+}

--- a/src/Persistence/MediaWiki/WikiPageMappingLookup.php
+++ b/src/Persistence/MediaWiki/WikiPageMappingLookup.php
@@ -1,0 +1,77 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Persistence\MediaWiki;
+
+use InvalidArgumentException;
+use LogicException;
+use MediaWiki\Permissions\Authority;
+use ProfessionalWiki\NeoWiki\Application\MappingLookup;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\Mapping;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\MappingName;
+use ProfessionalWiki\NeoWiki\EntryPoints\Content\MappingContent;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+use ProfessionalWiki\NeoWiki\Persistence\MappingNameLookup;
+
+class WikiPageMappingLookup implements MappingLookup {
+
+	public function __construct(
+		private readonly PageContentFetcher $pageContentFetcher,
+		private readonly Authority $authority,
+		private readonly MappingPersistenceDeserializer $mappingDeserializer,
+		private readonly MappingNameLookup $mappingNameLookup,
+	) {
+	}
+
+	public function getMapping( MappingName $name ): ?Mapping {
+		$content = $this->getContent( $name );
+
+		if ( $content === null ) {
+			return null;
+		}
+
+		try {
+			return $this->mappingDeserializer->deserialize( $name, $content->getText() );
+		}
+		catch ( InvalidArgumentException ) {
+			return null;
+		}
+	}
+
+	/**
+	 * @return Mapping[]
+	 */
+	public function getAllMappings(): array {
+		$mappings = [];
+
+		foreach ( $this->mappingNameLookup->getMappingNames() as $name ) {
+			$mapping = $this->getMapping( $name );
+
+			if ( $mapping !== null ) {
+				$mappings[] = $mapping;
+			}
+		}
+
+		return $mappings;
+	}
+
+	private function getContent( MappingName $name ): ?MappingContent {
+		$content = $this->pageContentFetcher->getPageContent(
+			$name->getText(),
+			$this->authority,
+			NeoWikiExtension::NS_MAPPING
+		);
+
+		if ( $content instanceof MappingContent ) {
+			return $content;
+		}
+
+		if ( $content === null ) {
+			return null;
+		}
+
+		throw new LogicException( 'Unexpected content type: not a MappingContent' );
+	}
+
+}

--- a/src/Persistence/MediaWiki/mappingContentSchema.json
+++ b/src/Persistence/MediaWiki/mappingContentSchema.json
@@ -1,0 +1,81 @@
+{
+	"$schema": "https://json-schema.org/draft/2020-12/schema#",
+	"type": "object",
+	"required": [
+		"version",
+		"schema",
+		"target",
+		"subject",
+		"properties"
+	],
+	"properties": {
+		"version": {
+			"const": 1,
+			"$error": "The mapping format version must be 1."
+		},
+		"schema": {
+			"type": "string",
+			"minLength": 1
+		},
+		"target": {
+			"type": "string",
+			"pattern": "^[A-Za-z][A-Za-z0-9_-]*$",
+			"$error": "The target must be a short identifier (letters, digits, hyphen, underscore)."
+		},
+		"prefixes": {
+			"type": "object",
+			"propertyNames": {
+				"pattern": "^[A-Za-z][A-Za-z0-9_-]*$"
+			},
+			"additionalProperties": {
+				"type": "string",
+				"minLength": 1
+			}
+		},
+		"subject": {
+			"type": "object",
+			"required": [
+				"class"
+			],
+			"properties": {
+				"class": {
+					"type": "string",
+					"minLength": 1
+				}
+			},
+			"additionalProperties": false
+		},
+		"properties": {
+			"type": "object",
+			"additionalProperties": {
+				"type": "object",
+				"required": [
+					"predicate"
+				],
+				"properties": {
+					"predicate": {
+						"type": "string",
+						"minLength": 1
+					},
+					"lang": {
+						"type": "string",
+						"minLength": 1
+					},
+					"datatype": {
+						"type": "string",
+						"minLength": 1
+					}
+				},
+				"additionalProperties": false,
+				"not": {
+					"required": [
+						"lang",
+						"datatype"
+					],
+					"$error": "A property mapping cannot set both a language tag and a datatype."
+				}
+			}
+		}
+	},
+	"additionalProperties": false
+}

--- a/src/Persistence/MediaWiki/mappingContentSchema.json
+++ b/src/Persistence/MediaWiki/mappingContentSchema.json
@@ -59,7 +59,8 @@
 					},
 					"lang": {
 						"type": "string",
-						"minLength": 1
+						"pattern": "^[A-Za-z]{1,8}(-[A-Za-z0-9]{1,8})*$",
+						"$error": "The language tag must be BCP-47-shaped (e.g. \"en\" or \"pt-BR\")."
 					},
 					"datatype": {
 						"type": "string",

--- a/tests/phpunit/Application/MappingsTest.php
+++ b/tests/phpunit/Application/MappingsTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Application;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\Mappings;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\Mapping;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\MappingName;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\PropertyMappings;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Application\Mappings
+ */
+class MappingsTest extends TestCase {
+
+	private function mapping( string $name, string $schema, string $target ): Mapping {
+		return new Mapping(
+			name: new MappingName( $name ),
+			schema: new SchemaName( $schema ),
+			target: $target,
+			prefixes: [],
+			subjectClass: 'http://example.org/Class',
+			properties: new PropertyMappings( [] ),
+		);
+	}
+
+	/**
+	 * @param Mapping[] $mappings
+	 * @return string[]
+	 */
+	private function schemaNames( array $mappings ): array {
+		return array_map( static fn ( Mapping $mapping ): string => $mapping->schema->getText(), $mappings );
+	}
+
+	public function testForTargetReturnsOnlyMappingsOfThatTarget(): void {
+		// A matching Mapping is placed before and after a non-matching one, so returning the first or
+		// last element would not pass.
+		$mappings = new Mappings( [
+			$this->mapping( 'A', 'Person', 'edm' ),
+			$this->mapping( 'B', 'City', 'cidoc' ),
+			$this->mapping( 'C', 'Artwork', 'edm' ),
+		] );
+
+		$this->assertSame( [ 'Person', 'Artwork' ], $this->schemaNames( $mappings->forTarget( 'edm' ) ) );
+	}
+
+	public function testForTargetIsEmptyForAnUnknownTarget(): void {
+		$mappings = new Mappings( [ $this->mapping( 'A', 'Person', 'edm' ) ] );
+
+		$this->assertSame( [], $mappings->forTarget( 'bibframe' ) );
+	}
+
+	public function testTargetsAreDistinctAndSorted(): void {
+		$mappings = new Mappings( [
+			$this->mapping( 'A', 'Person', 'edm' ),
+			$this->mapping( 'B', 'City', 'cidoc' ),
+			$this->mapping( 'C', 'Artwork', 'edm' ),
+		] );
+
+		$this->assertSame( [ 'cidoc', 'edm' ], $mappings->targets() );
+	}
+
+	public function testConflictForFindsAnotherPageClaimingTheSamePair(): void {
+		$conflict = $this->mapping( 'Existing', 'Person', 'edm' );
+		$mappings = new Mappings( [
+			$this->mapping( 'Other', 'City', 'edm' ),
+			$conflict,
+		] );
+
+		$this->assertSame(
+			$conflict,
+			$mappings->conflictFor( new SchemaName( 'Person' ), 'edm', new MappingName( 'New page' ) )
+		);
+	}
+
+	public function testConflictForIgnoresTheMappingBeingSaved(): void {
+		// The page being saved keeps its own (Schema, target) pair; it must not conflict with itself.
+		$mappings = new Mappings( [ $this->mapping( 'Person to EDM', 'Person', 'edm' ) ] );
+
+		$this->assertNull(
+			$mappings->conflictFor( new SchemaName( 'Person' ), 'edm', new MappingName( 'Person to EDM' ) )
+		);
+	}
+
+	public function testConflictForReturnsNullWhenTheTargetDiffers(): void {
+		$mappings = new Mappings( [ $this->mapping( 'Person to CIDOC', 'Person', 'cidoc' ) ] );
+
+		$this->assertNull(
+			$mappings->conflictFor( new SchemaName( 'Person' ), 'edm', new MappingName( 'New page' ) )
+		);
+	}
+
+}

--- a/tests/phpunit/Application/Rdf/OntologyMappingProjectorTest.php
+++ b/tests/phpunit/Application/Rdf/OntologyMappingProjectorTest.php
@@ -1,0 +1,288 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Application\Rdf;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\Rdf\OntologyMappingProjector;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\Mapping;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\MappingName;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\PropertyMapping;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\PropertyMappings;
+use ProfessionalWiki\NeoWiki\Domain\Page\Page;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\Iri;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\Quad;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\QuadList;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfFormat;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfLiteralFactory;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfNamespaces;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfValueMapperRegistry;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectMap;
+use ProfessionalWiki\NeoWiki\Domain\Value\NumberValue;
+use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
+use ProfessionalWiki\NeoWiki\Infrastructure\Rdf\HardfRdfSerializer;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestPage;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestRelation;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestStatement;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
+use ProfessionalWiki\NeoWiki\Tests\Domain\Rdf\ParsedRdf;
+use WMDE\PsrLogTestDoubles\LegacyLoggerSpy;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Application\Rdf\OntologyMappingProjector
+ */
+class OntologyMappingProjectorTest extends TestCase {
+
+	private const string PERSON_ID = 's1janeaaaaaaaa2';
+	private const string CITY_ID = 's1cityaaaaaaaa3';
+
+	private const string EDM = 'http://www.europeana.eu/schemas/edm/';
+	private const string DC = 'http://purl.org/dc/elements/1.1/';
+
+	private RdfNamespaces $ns;
+	private LegacyLoggerSpy $logger;
+
+	protected function setUp(): void {
+		$this->ns = new RdfNamespaces( 'https://wiki.example' );
+		$this->logger = new LegacyLoggerSpy();
+	}
+
+	/**
+	 * @param Mapping[] $mappings
+	 */
+	private function newProjector( array $mappings ): OntologyMappingProjector {
+		return new OntologyMappingProjector(
+			'edm',
+			$mappings,
+			$this->ns,
+			RdfValueMapperRegistry::withCoreMappers(),
+			$this->logger,
+		);
+	}
+
+	public function testProjectsMappedVocabularyOnlyWithNativeSubjectIris(): void {
+		$quads = $this->newProjector( [ $this->personMapping(), $this->cityMapping() ] )
+			->projectPage( $this->examplePage() );
+
+		$output = ( new HardfRdfSerializer( $this->serializerPrefixes() ) )->serialize( $quads, RdfFormat::TriG );
+
+		$this->assertSame(
+			ParsedRdf::canonicalQuads( $this->expectedTriG() ),
+			ParsedRdf::canonicalQuads( $output )
+		);
+		$this->logger->assertNoLoggingCallsWhereMade();
+	}
+
+	/**
+	 * The example exercises: rdfs:label always emitted; a language tag on a plain string (Name); a
+	 * datatype override on a number (BirthYear); an unmapped property present on the Subject but absent
+	 * in the output (Height); a relation projected as a direct triple to the target Subject's native
+	 * IRI (BornIn → City); and native (neo-subj:) Subject IRIs throughout.
+	 */
+	private function expectedTriG(): string {
+		return <<<TRIG
+			@prefix neo-subj: <https://wiki.example/entity/> .
+			@prefix neo-page: <https://wiki.example/page/> .
+			@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+			@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+			@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+			@prefix edm: <http://www.europeana.eu/schemas/edm/> .
+			@prefix dc: <http://purl.org/dc/elements/1.1/> .
+
+			neo-page:42 {
+				neo-subj:s1janeaaaaaaaa2 a edm:ProvidedCHO ;
+					rdfs:label "Jane" ;
+					dc:title "Jane"@en ;
+					edm:isShownAt "https://jane.example"^^xsd:anyURI ;
+					dc:date "1990"^^edm:year ;
+					dc:spatial neo-subj:s1cityaaaaaaaa3 .
+
+				neo-subj:s1cityaaaaaaaa3 a edm:Place ;
+					rdfs:label "Berlin" ;
+					dc:title "Berlin" .
+			}
+			TRIG;
+	}
+
+	private function examplePage(): Page {
+		$person = TestSubject::build(
+			id: self::PERSON_ID,
+			label: 'Jane',
+			schemaName: new SchemaName( 'Person' ),
+			statements: new StatementList( [
+				TestStatement::build( 'Name', new StringValue( 'Jane' ), 'text' ),
+				TestStatement::build( 'Homepage', new StringValue( 'https://jane.example' ), 'url' ),
+				TestStatement::build( 'Height', new NumberValue( 170 ), 'number' ),
+				TestStatement::build( 'BirthYear', new NumberValue( 1990 ), 'number' ),
+				TestStatement::buildRelation( 'BornIn', [ TestRelation::build( targetId: self::CITY_ID ) ] ),
+			] )
+		);
+
+		$city = TestSubject::build(
+			id: self::CITY_ID,
+			label: 'Berlin',
+			schemaName: new SchemaName( 'City' ),
+			statements: new StatementList( [
+				TestStatement::build( 'Name', new StringValue( 'Berlin' ), 'text' ),
+			] )
+		);
+
+		return TestPage::build( id: 42, mainSubject: $person, childSubjects: new SubjectMap( $city ) );
+	}
+
+	private function personMapping(): Mapping {
+		return new Mapping(
+			name: new MappingName( 'Person to EDM' ),
+			schema: new SchemaName( 'Person' ),
+			target: 'edm',
+			prefixes: [ 'edm' => self::EDM, 'dc' => self::DC ],
+			subjectClass: 'edm:ProvidedCHO',
+			properties: new PropertyMappings( [
+				'Name' => new PropertyMapping( 'dc:title', 'en', null ),
+				'Homepage' => new PropertyMapping( 'edm:isShownAt' ),
+				'BirthYear' => new PropertyMapping( 'dc:date', null, 'edm:year' ),
+				'BornIn' => new PropertyMapping( 'dc:spatial' ),
+			] )
+		);
+	}
+
+	private function cityMapping(): Mapping {
+		return new Mapping(
+			name: new MappingName( 'City to EDM' ),
+			schema: new SchemaName( 'City' ),
+			target: 'edm',
+			prefixes: [ 'edm' => self::EDM, 'dc' => self::DC ],
+			subjectClass: 'edm:Place',
+			properties: new PropertyMappings( [
+				'Name' => new PropertyMapping( 'dc:title' ),
+			] )
+		);
+	}
+
+	public function testSubjectWhoseSchemaHasNoMappingForTheTargetIsAbsent(): void {
+		$ghost = TestSubject::build(
+			id: self::CITY_ID,
+			label: 'Unmapped',
+			schemaName: new SchemaName( 'Ghost' ),
+			statements: new StatementList( [ TestStatement::build( 'Name', new StringValue( 'Unmapped' ), 'text' ) ] )
+		);
+		$page = TestPage::build(
+			id: 42,
+			mainSubject: $this->examplePersonWithoutRelations(),
+			childSubjects: new SubjectMap( $ghost )
+		);
+
+		$quads = $this->newProjector( [ $this->personMapping() ] )->projectPage( $page );
+
+		$ghostIri = $this->ns->subject( new SubjectId( self::CITY_ID ) );
+		$this->assertFalse(
+			$this->containsSubjectWithPredicate( $quads, $ghostIri, $this->ns->rdfType() ),
+			'A Subject with no Mapping for the target must not be typed.'
+		);
+		$this->assertFalse(
+			$this->containsSubjectWithPredicate( $quads, $ghostIri, $this->ns->rdfsLabel() ),
+			'A Subject with no Mapping for the target must not be labelled.'
+		);
+		$this->assertTrue(
+			$this->containsSubjectWithPredicate( $quads, $this->ns->subject( new SubjectId( self::PERSON_ID ) ), $this->ns->rdfType() ),
+			'The mapped Subject still projects.'
+		);
+	}
+
+	public function testRelationTargetWithoutAMappingIsReferencedButUntyped(): void {
+		$page = TestPage::build(
+			id: 42,
+			mainSubject: TestSubject::build(
+				id: self::PERSON_ID,
+				label: 'Jane',
+				schemaName: new SchemaName( 'Person' ),
+				statements: new StatementList( [
+					TestStatement::buildRelation( 'BornIn', [ TestRelation::build( targetId: self::CITY_ID ) ] ),
+				] )
+			),
+		);
+
+		// Only Person is mapped; the City target Subject is not even on the page.
+		$quads = $this->newProjector( [ $this->personMapping() ] )->projectPage( $page );
+
+		$cityIri = $this->ns->subject( new SubjectId( self::CITY_ID ) );
+		$this->assertTrue(
+			$quads->contains( new Quad(
+				$this->ns->subject( new SubjectId( self::PERSON_ID ) ),
+				new Iri( self::DC . 'spatial' ),
+				$cityIri,
+				$this->ns->page( new PageId( 42 ) )
+			) ),
+			'The relation is a direct triple to the target Subject native IRI.'
+		);
+		$this->assertFalse(
+			$this->containsSubjectWithPredicate( $quads, $cityIri, $this->ns->rdfType() ),
+			'The unmapped relation target stays untyped.'
+		);
+	}
+
+	public function testDuplicateMappingsForASchemaAreTieBrokenAlphabeticallyAndLogged(): void {
+		// Two Mappings claim (Person, edm) with different classes. Passed in reverse alphabetical order,
+		// the projector must still pick "A ..." — proving it sorts rather than takes the first given.
+		$loser = $this->personMappingNamed( 'B mapping', 'edm:ProvidedCHO' );
+		$winner = $this->personMappingNamed( 'A mapping', 'edm:Place' );
+
+		$page = TestPage::build( id: 42, mainSubject: $this->examplePersonWithoutRelations() );
+
+		$quads = $this->newProjector( [ $loser, $winner ] )->projectPage( $page );
+
+		$this->assertTrue(
+			$quads->contains( new Quad(
+				$this->ns->subject( new SubjectId( self::PERSON_ID ) ),
+				$this->ns->rdfType(),
+				new Iri( self::EDM . 'Place' ),
+				$this->ns->page( new PageId( 42 ) )
+			) ),
+			'The alphabetically first Mapping wins the tie-break.'
+		);
+		$this->assertCount( 1, $this->logger->getLogCalls()->getMessages() );
+	}
+
+	private function personMappingNamed( string $name, string $subjectClass ): Mapping {
+		return new Mapping(
+			name: new MappingName( $name ),
+			schema: new SchemaName( 'Person' ),
+			target: 'edm',
+			prefixes: [ 'edm' => self::EDM ],
+			subjectClass: $subjectClass,
+			properties: new PropertyMappings( [] )
+		);
+	}
+
+	private function examplePersonWithoutRelations(): \ProfessionalWiki\NeoWiki\Domain\Subject\Subject {
+		return TestSubject::build(
+			id: self::PERSON_ID,
+			label: 'Jane',
+			schemaName: new SchemaName( 'Person' ),
+			statements: new StatementList( [ TestStatement::build( 'Name', new StringValue( 'Jane' ), 'text' ) ] )
+		);
+	}
+
+	private function containsSubjectWithPredicate( QuadList $quads, Iri $subject, Iri $predicate ): bool {
+		foreach ( $quads->asArray() as $quad ) {
+			if ( $quad->subject->equals( $subject ) && $quad->predicate->equals( $predicate ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * @return array<string, string>
+	 */
+	private function serializerPrefixes(): array {
+		return array_merge( $this->ns->prefixMap(), [ 'edm' => self::EDM, 'dc' => self::DC ] );
+	}
+
+}

--- a/tests/phpunit/Application/Rdf/OntologyMappingProjectorTest.php
+++ b/tests/phpunit/Application/Rdf/OntologyMappingProjectorTest.php
@@ -21,6 +21,7 @@ use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfNamespaces;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfValueMapperRegistry;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
+use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectMap;
 use ProfessionalWiki\NeoWiki\Domain\Value\NumberValue;
@@ -226,6 +227,216 @@ class OntologyMappingProjectorTest extends TestCase {
 		);
 	}
 
+	public function testInvalidStoredLanguageTagIsDroppedAndTheLiteralStaysPlain(): void {
+		// A Mapping constructed directly, simulating one stored before validation (importDump / a
+		// pre-validation page): its "en_US" tag is not BCP-47-shaped.
+		$quads = $this->newProjector( [ $this->personMappingWithNameLang( 'en_US' ) ] )
+			->projectPage( TestPage::build( id: 42, mainSubject: $this->examplePersonWithoutRelations() ) );
+
+		$output = ( new HardfRdfSerializer( $this->serializerPrefixes() ) )->serialize( $quads, RdfFormat::TriG );
+
+		$this->assertSame(
+			ParsedRdf::canonicalQuads( $this->expectedPlainNameTriG() ),
+			ParsedRdf::canonicalQuads( $output ),
+			'The value projects as a plain string literal when the stored language tag is invalid.'
+		);
+		$this->assertCount( 1, $this->logger->getLogCalls()->getMessages() );
+	}
+
+	public function testMaliciousLanguageTagCannotInjectADatatypeIntoTheDocument(): void {
+		$quads = $this->newProjector( [ $this->personMappingWithNameLang( 'en"^^xsd:evil' ) ] )
+			->projectPage( TestPage::build( id: 42, mainSubject: $this->examplePersonWithoutRelations() ) );
+
+		$output = ( new HardfRdfSerializer( $this->serializerPrefixes() ) )->serialize( $quads, RdfFormat::TriG );
+
+		$this->assertStringNotContainsString( 'xsd:evil', $output, 'The attacker-chosen datatype must not reach the document.' );
+		$this->assertSame(
+			ParsedRdf::canonicalQuads( $this->expectedPlainNameTriG() ),
+			ParsedRdf::canonicalQuads( $output ),
+			'The document still parses to only the safe, plain-literal triples.'
+		);
+		$this->assertCount( 1, $this->logger->getLogCalls()->getMessages() );
+	}
+
+	private function personMappingWithNameLang( string $lang ): Mapping {
+		return new Mapping(
+			name: new MappingName( 'Person to EDM' ),
+			schema: new SchemaName( 'Person' ),
+			target: 'edm',
+			prefixes: [ 'dc' => self::DC ],
+			subjectClass: 'http://example.org/CHO',
+			properties: new PropertyMappings( [
+				'Name' => new PropertyMapping( 'dc:title', $lang, null ),
+			] )
+		);
+	}
+
+	private function expectedPlainNameTriG(): string {
+		return <<<TRIG
+			@prefix neo-subj: <https://wiki.example/entity/> .
+			@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+			@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+			@prefix dc: <http://purl.org/dc/elements/1.1/> .
+
+			<https://wiki.example/page/42> {
+				neo-subj:s1janeaaaaaaaa2 a <http://example.org/CHO> ;
+					rdfs:label "Jane" ;
+					dc:title "Jane" .
+			}
+			TRIG;
+	}
+
+	/**
+	 * The projection-time re-expansion defence: even when save-time validation was bypassed, a class,
+	 * predicate, datatype, or prefix that does not re-expand safely is dropped, so no injection term
+	 * reaches the serialized document and it still parses.
+	 */
+	public function testUnsafeTermsAreDroppedAtProjectionTimeWhenSaveValidationWasBypassed(): void {
+		$quads = $this->newProjector( [ $this->adversarialMapping() ] )
+			->projectPage( TestPage::build( id: 42, mainSubject: $this->adversarialSubject() ) );
+
+		$output = ( new HardfRdfSerializer( $this->serializerPrefixes() ) )->serialize( $quads, RdfFormat::TriG );
+
+		$this->assertStringNotContainsString( 'evil', $output, 'No injection term survives to the document.' );
+		$this->assertSame(
+			ParsedRdf::canonicalQuads( $this->expectedSafeAdversarialTriG() ),
+			ParsedRdf::canonicalQuads( $output ),
+			'Only the safe triples remain: the always-emitted label, the safely mapped property, and the '
+				. 'value whose unsafe datatype override was dropped (kept with its native datatype). The '
+				. 'injection class, predicate, and unsafe-prefix CURIE are gone, and there is no rdf:type.'
+		);
+	}
+
+	private function adversarialMapping(): Mapping {
+		return new Mapping(
+			name: new MappingName( 'Adversarial' ),
+			schema: new SchemaName( 'Person' ),
+			target: 'edm',
+			prefixes: [
+				'dc' => self::DC,
+				// A prefix whose namespace breaks out of the prefix table; a CURIE using it must be dropped.
+				'evil' => 'http://evil.example/"> .# ',
+			],
+			// A subject class that would break out of its IRI: it must not produce an rdf:type triple.
+			subjectClass: 'http://x/> <http://evil.example/s> <http://evil.example/p> <http://evil.example/o',
+			properties: new PropertyMappings( [
+				'Name' => new PropertyMapping( 'dc:title' ),
+				// A safe predicate with an injection datatype override: the value keeps its native datatype.
+				'BirthYear' => new PropertyMapping( 'dc:date', null, 'http://x/> <http://evil.example/dt' ),
+				// An injection predicate: the whole statement is dropped.
+				'Bio' => new PropertyMapping( 'http://x/> <http://evil.example/p2> <http://evil.example/o2' ),
+				// A CURIE against the unsafe prefix: dropped.
+				'Homepage' => new PropertyMapping( 'evil:foo' ),
+			] )
+		);
+	}
+
+	private function adversarialSubject(): Subject {
+		return TestSubject::build(
+			id: self::PERSON_ID,
+			label: 'Jane',
+			schemaName: new SchemaName( 'Person' ),
+			statements: new StatementList( [
+				TestStatement::build( 'Name', new StringValue( 'Jane' ), 'text' ),
+				TestStatement::build( 'BirthYear', new NumberValue( 1990 ), 'number' ),
+				TestStatement::build( 'Bio', new StringValue( 'Hi' ), 'text' ),
+				TestStatement::build( 'Homepage', new StringValue( 'http://jane.example' ), 'text' ),
+			] )
+		);
+	}
+
+	private function expectedSafeAdversarialTriG(): string {
+		return <<<TRIG
+			@prefix neo-subj: <https://wiki.example/entity/> .
+			@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+			@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+			@prefix dc: <http://purl.org/dc/elements/1.1/> .
+
+			<https://wiki.example/page/42> {
+				neo-subj:s1janeaaaaaaaa2 rdfs:label "Jane" ;
+					dc:title "Jane" ;
+					dc:date "1990"^^xsd:integer .
+			}
+			TRIG;
+	}
+
+	public function testLanguageTagIsIgnoredForATypedLiteral(): void {
+		$page = TestPage::build( id: 42, mainSubject: $this->personWithBirthYear() );
+
+		$quads = $this->newProjector( [ $this->personBirthYearMappingWithLang( 'en' ) ] )->projectPage( $page );
+
+		$this->assertTrue(
+			$quads->contains( new Quad(
+				$this->ns->subject( new SubjectId( self::PERSON_ID ) ),
+				new Iri( self::DC . 'date' ),
+				RdfLiteralFactory::typed( '1990', 'integer' ),
+				$this->ns->page( new PageId( 42 ) )
+			) ),
+			'A typed literal keeps its datatype; a language tag does not apply to it.'
+		);
+		$this->logger->assertNoLoggingCallsWhereMade();
+	}
+
+	public function testDatatypeAndLanguageOnARelationPropertyAreIgnored(): void {
+		// Constructed directly, bypassing the save-time lang/datatype mutual-exclusion check, to prove
+		// the projector ignores literal overrides on a relation (its object is an IRI, not a literal).
+		$mapping = new Mapping(
+			name: new MappingName( 'Person to EDM' ),
+			schema: new SchemaName( 'Person' ),
+			target: 'edm',
+			prefixes: [ 'dc' => self::DC, 'edm' => self::EDM ],
+			subjectClass: 'http://example.org/CHO',
+			properties: new PropertyMappings( [
+				'BornIn' => new PropertyMapping( 'dc:spatial', 'en', 'edm:year' ),
+			] )
+		);
+		$page = TestPage::build(
+			id: 42,
+			mainSubject: TestSubject::build(
+				id: self::PERSON_ID,
+				label: 'Jane',
+				schemaName: new SchemaName( 'Person' ),
+				statements: new StatementList( [
+					TestStatement::buildRelation( 'BornIn', [ TestRelation::build( targetId: self::CITY_ID ) ] ),
+				] )
+			),
+		);
+
+		$quads = $this->newProjector( [ $mapping ] )->projectPage( $page );
+
+		$this->assertTrue(
+			$quads->contains( new Quad(
+				$this->ns->subject( new SubjectId( self::PERSON_ID ) ),
+				new Iri( self::DC . 'spatial' ),
+				$this->ns->subject( new SubjectId( self::CITY_ID ) ),
+				$this->ns->page( new PageId( 42 ) )
+			) ),
+			'The relation is a plain IRI-to-IRI triple; datatype and language overrides do not apply.'
+		);
+	}
+
+	private function personWithBirthYear(): Subject {
+		return TestSubject::build(
+			id: self::PERSON_ID,
+			label: 'Jane',
+			schemaName: new SchemaName( 'Person' ),
+			statements: new StatementList( [ TestStatement::build( 'BirthYear', new NumberValue( 1990 ), 'number' ) ] )
+		);
+	}
+
+	private function personBirthYearMappingWithLang( string $lang ): Mapping {
+		return new Mapping(
+			name: new MappingName( 'Person to EDM' ),
+			schema: new SchemaName( 'Person' ),
+			target: 'edm',
+			prefixes: [ 'dc' => self::DC ],
+			subjectClass: 'http://example.org/CHO',
+			properties: new PropertyMappings( [
+				'BirthYear' => new PropertyMapping( 'dc:date', $lang, null ),
+			] )
+		);
+	}
+
 	public function testDuplicateMappingsForASchemaAreTieBrokenAlphabeticallyAndLogged(): void {
 		// Two Mappings claim (Person, edm) with different classes. Passed in reverse alphabetical order,
 		// the projector must still pick "A ..." — proving it sorts rather than takes the first given.
@@ -259,7 +470,7 @@ class OntologyMappingProjectorTest extends TestCase {
 		);
 	}
 
-	private function examplePersonWithoutRelations(): \ProfessionalWiki\NeoWiki\Domain\Subject\Subject {
+	private function examplePersonWithoutRelations(): Subject {
 		return TestSubject::build(
 			id: self::PERSON_ID,
 			label: 'Jane',

--- a/tests/phpunit/Domain/Mapping/CurieExpanderTest.php
+++ b/tests/phpunit/Domain/Mapping/CurieExpanderTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Domain\Mapping;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\CurieExpander;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Domain\Mapping\CurieExpander
+ */
+class CurieExpanderTest extends TestCase {
+
+	private function expander(): CurieExpander {
+		return new CurieExpander( [
+			'edm' => 'http://www.europeana.eu/schemas/edm/',
+			'dc' => 'http://purl.org/dc/elements/1.1/',
+		] );
+	}
+
+	public function testExpandsADeclaredCurie(): void {
+		$this->assertSame(
+			'http://www.europeana.eu/schemas/edm/ProvidedCHO',
+			$this->expander()->expand( 'edm:ProvidedCHO' )?->value
+		);
+	}
+
+	public function testAcceptsAnAbsoluteIriWithAnAuthority(): void {
+		$this->assertSame(
+			'http://example.org/ns/creator',
+			$this->expander()->expand( 'http://example.org/ns/creator' )?->value
+		);
+	}
+
+	public function testRejectsAnUndeclaredCuriePrefix(): void {
+		// A typo'd prefix must not be silently reinterpreted as the absolute IRI "crm:E12".
+		$this->assertNull( $this->expander()->expand( 'crm:E12_Production' ) );
+	}
+
+	public function testRejectsATermWithoutAColon(): void {
+		$this->assertNull( $this->expander()->expand( 'title' ) );
+	}
+
+	/**
+	 * The heart of the #1029 lesson: a malicious term must never break out of its IRI to forge
+	 * triples or prefix declarations. Every one of these expands to something containing an
+	 * IRIREF-illegal character, so the expander must reject it rather than emit it.
+	 *
+	 * @dataProvider provideInjectionTerms
+	 */
+	public function testRejectsTermsThatWouldBreakOutOfTheIri( string $term ): void {
+		$this->assertNull( $this->expander()->expand( $term ) );
+	}
+
+	/**
+	 * @return iterable<string, array{string}>
+	 */
+	public static function provideInjectionTerms(): iterable {
+		yield 'CURIE local part closes the IRIREF' => [ 'dc:title> <s> <p> <o> .# ' ];
+		yield 'CURIE local part with a space' => [ 'edm:is Shown At' ];
+		yield 'CURIE local part with a double quote' => [ 'dc:tit"le' ];
+		yield 'absolute IRI closing the IRIREF' => [ 'http://evil.example/> <s> <p> <o' ];
+		yield 'absolute IRI with a space' => [ 'http://evil.example/a b' ];
+		yield 'absolute IRI with a backtick' => [ 'http://evil.example/a`b' ];
+		yield 'absolute IRI with a control character' => [ "http://evil.example/a\x01b" ];
+		yield 'absolute IRI with a brace' => [ 'http://evil.example/a{b}' ];
+	}
+
+	public function testKeepsUnicodeRawInAnAbsoluteIri(): void {
+		$this->assertSame(
+			'http://example.org/persoon/Naïve',
+			$this->expander()->expand( 'http://example.org/persoon/Naïve' )?->value
+		);
+	}
+
+	public function testIsSafeAbsoluteIriRejectsARelativeIri(): void {
+		$this->assertFalse( CurieExpander::isSafeAbsoluteIri( '/relative/path' ) );
+	}
+
+	public function testIsSafeAbsoluteIriRejectsAnIriThatBreaksOutOfThePrefixTable(): void {
+		$this->assertFalse( CurieExpander::isSafeAbsoluteIri( 'http://evil.example/"> .# ' ) );
+	}
+
+	public function testIsSafeAbsoluteIriAcceptsAcleanNamespaceIri(): void {
+		$this->assertTrue( CurieExpander::isSafeAbsoluteIri( 'http://www.europeana.eu/schemas/edm/' ) );
+	}
+
+}

--- a/tests/phpunit/Domain/Rdf/LiteralTest.php
+++ b/tests/phpunit/Domain/Rdf/LiteralTest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Tests\Domain\Rdf;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\Iri;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\Literal;
@@ -48,6 +49,47 @@ class LiteralTest extends TestCase {
 		$this->assertTrue( $tagged->isLanguageTagged() );
 		$this->assertFalse( $plain->isLanguageTagged() );
 		$this->assertFalse( $tagged->equals( $plain ) );
+	}
+
+	/**
+	 * @dataProvider validLanguageTagProvider
+	 */
+	public function testConstructsWithAValidLanguageTag( string $tag ): void {
+		$this->assertSame( $tag, ( new Literal( 'x', $this->xsd( 'string' ), $tag ) )->languageTag );
+	}
+
+	/**
+	 * @return array<string, array{string}>
+	 */
+	public static function validLanguageTagProvider(): array {
+		return [
+			'primary subtag only' => [ 'en' ],
+			'region subtag' => [ 'en-US' ],
+			'lowercase region' => [ 'pt-BR' ],
+		];
+	}
+
+	/**
+	 * A non-null language tag is a domain invariant: an out-of-shape tag (which could smuggle a `"` or a
+	 * datatype into the serialized `"lexical"@tag` form) is rejected at construction.
+	 *
+	 * @dataProvider invalidLanguageTagProvider
+	 */
+	public function testRejectsAnInvalidLanguageTag( string $tag ): void {
+		$this->expectException( InvalidArgumentException::class );
+		new Literal( 'x', $this->xsd( 'string' ), $tag );
+	}
+
+	/**
+	 * @return array<string, array{string}>
+	 */
+	public static function invalidLanguageTagProvider(): array {
+		return [
+			'underscore separator' => [ 'en_US' ],
+			'trailing space' => [ 'en ' ],
+			'empty trailing subtag' => [ 'en-' ],
+			'datatype injection' => [ 'en"^^xsd:evil' ],
+		];
 	}
 
 }

--- a/tests/phpunit/EntryPoints/Content/MappingContentHandlerValidateSaveTest.php
+++ b/tests/phpunit/EntryPoints/Content/MappingContentHandlerValidateSaveTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\Content;
+
+use MediaWiki\Content\ValidationParams;
+use MediaWiki\Title\Title;
+use ProfessionalWiki\NeoWiki\EntryPoints\Content\MappingContent;
+use ProfessionalWiki\NeoWiki\EntryPoints\Content\MappingContentHandler;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+use StatusValue;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\Content\MappingContentHandler
+ * @group Database
+ */
+class MappingContentHandlerValidateSaveTest extends NeoWikiIntegrationTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->setUpNeo4j();
+	}
+
+	private function validate( string $json, string $name = 'Person to EDM' ): StatusValue {
+		$handler = new MappingContentHandler( MappingContent::CONTENT_MODEL_ID );
+		$params = new ValidationParams( Title::makeTitle( NeoWikiExtension::NS_MAPPING, $name )->toPageIdentity(), 0 );
+
+		return $handler->validateSave( new MappingContent( $json ), $params );
+	}
+
+	public function testValidMappingPassesValidation(): void {
+		$this->assertTrue( $this->validate( $this->personToEdm() )->isOK() );
+	}
+
+	public function testStructurallyInvalidMappingFailsValidation(): void {
+		$this->assertFalse( $this->validate( '{ "version": 2, "schema": "Person", "target": "edm", "subject": { "class": "http://x/C" }, "properties": {} }' )->isOK() );
+	}
+
+	public function testUnresolvableCuriePredicateFailsValidation(): void {
+		$this->assertFalse( $this->validate( <<<JSON
+			{
+				"version": 1,
+				"schema": "Person",
+				"target": "edm",
+				"prefixes": { "edm": "http://www.europeana.eu/schemas/edm/" },
+				"subject": { "class": "edm:ProvidedCHO" },
+				"properties": { "Name": { "predicate": "crm:P1_is_identified_by" } }
+			}
+			JSON )->isOK() );
+	}
+
+	public function testDuplicateSchemaAndTargetPairFailsValidation(): void {
+		$this->createMapping( 'Existing Person to EDM', $this->personToEdm() );
+
+		$status = $this->validate( $this->personToEdm(), 'Another Person to EDM' );
+
+		$this->assertFalse( $status->isOK() );
+	}
+
+	public function testSameSchemaWithADifferentTargetPassesValidation(): void {
+		$this->createMapping( 'Person to EDM', $this->personToEdm() );
+
+		$status = $this->validate(
+			<<<JSON
+			{
+				"version": 1,
+				"schema": "Person",
+				"target": "cidoc",
+				"prefixes": { "crm": "http://www.cidoc-crm.org/cidoc-crm/" },
+				"subject": { "class": "crm:E21_Person" },
+				"properties": {}
+			}
+			JSON,
+			'Person to CIDOC'
+		);
+
+		$this->assertTrue( $status->isOK() );
+	}
+
+	public function testEditingAMappingInPlaceDoesNotConflictWithItself(): void {
+		$this->createMapping( 'Person to EDM', $this->personToEdm() );
+
+		// Re-saving the same page with the same (schema, target) must not count as a duplicate of itself.
+		$status = $this->validate( $this->personToEdm(), 'Person to EDM' );
+
+		$this->assertTrue( $status->isOK() );
+	}
+
+	private function personToEdm(): string {
+		return <<<JSON
+			{
+				"version": 1,
+				"schema": "Person",
+				"target": "edm",
+				"prefixes": {
+					"edm": "http://www.europeana.eu/schemas/edm/",
+					"dc": "http://purl.org/dc/elements/1.1/"
+				},
+				"subject": { "class": "edm:ProvidedCHO" },
+				"properties": {
+					"Name": { "predicate": "dc:title", "lang": "en" }
+				}
+			}
+			JSON;
+	}
+
+}

--- a/tests/phpunit/EntryPoints/REST/ExportPageRdfApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ExportPageRdfApiTest.php
@@ -128,6 +128,54 @@ JSON
 		$this->assertSame( 404, $response->getStatusCode() );
 	}
 
+	public function testProjectionNativeIsTheDefaultAndUnchanged(): void {
+		$default = $this->export();
+		$explicit = $this->export( query: [ 'projection' => 'native' ] );
+
+		$this->assertSame( 200, $explicit->getStatusCode() );
+		$this->assertSame(
+			ParsedRdf::canonicalQuads( $default->getBody()->getContents() ),
+			ParsedRdf::canonicalQuads( $explicit->getBody()->getContents() )
+		);
+	}
+
+	public function testUnknownProjectionReturns400(): void {
+		// No Mapping page declares "edm", so it is not a known projection.
+		$response = $this->export( query: [ 'projection' => 'edm' ] );
+
+		$this->assertSame( 400, $response->getStatusCode() );
+	}
+
+	public function testValidTargetProjectsTheMappedVocabularyWithNativeSubjectIris(): void {
+		$this->createMapping( 'BerlinToEdm', <<<JSON
+			{
+				"version": 1,
+				"schema": "{$this->schemaName()}",
+				"target": "edm",
+				"prefixes": {
+					"edm": "http://www.europeana.eu/schemas/edm/",
+					"dc": "http://purl.org/dc/elements/1.1/"
+				},
+				"subject": { "class": "edm:Place" },
+				"properties": {
+					"population": { "predicate": "dc:description" }
+				}
+			}
+			JSON );
+
+		$response = $this->export( query: [ 'projection' => 'edm', 'format' => 'turtle' ] );
+		$body = $response->getBody()->getContents();
+
+		$this->assertSame( 200, $response->getStatusCode() );
+		$this->assertStringContainsString( 'europeana.eu/schemas/edm', $body, 'The mapped ontology vocabulary is used.' );
+		$this->assertStringContainsString( self::SUBJECT_ID, $body, 'The Subject IRI stays native.' );
+		$this->assertStringNotContainsString( self::SCHEMA, $body, 'No native schema class is emitted.' );
+	}
+
+	private function schemaName(): string {
+		return self::SCHEMA;
+	}
+
 	/**
 	 * The graph value (the fourth field of each canonical quad) of every quad in the parsed document.
 	 * Distinguishes TriG (a non-empty page graph on every quad) from Turtle (the empty default graph).

--- a/tests/phpunit/Maintenance/DumpRdfTest.php
+++ b/tests/phpunit/Maintenance/DumpRdfTest.php
@@ -21,6 +21,16 @@ class DumpRdfTest extends MaintenanceBaseTestCase {
 		return DumpRdf::class;
 	}
 
+	public function testFatalErrorOnAnUnknownProjection(): void {
+		// No Mapping page declares "bogus", so it is not a known projection and the run aborts before
+		// touching any page.
+		$this->maintenance->setOption( 'projection', 'bogus' );
+
+		$this->expectCallToFatalError();
+
+		$this->maintenance->execute();
+	}
+
 	public function testEmitsAnEmptyDocumentWhenNoSubjectSlotRoleExists(): void {
 		// A wiki that has never stored a Subject has no 'neowiki-subjects' slot role, so the role-id
 		// lookup throws NameTableAccessException. Forcing that state (empty table + a store without a

--- a/tests/phpunit/NeoWikiIntegrationTestCase.php
+++ b/tests/phpunit/NeoWikiIntegrationTestCase.php
@@ -15,6 +15,7 @@ use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphDatabasePlugin;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectMap;
+use ProfessionalWiki\NeoWiki\EntryPoints\Content\MappingContent;
 use ProfessionalWiki\NeoWiki\EntryPoints\Content\SchemaContent;
 use ProfessionalWiki\NeoWiki\EntryPoints\Content\SubjectContent;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
@@ -71,6 +72,18 @@ class NeoWikiIntegrationTestCase extends MediaWikiIntegrationTestCase {
 				$json ?? '{"title":"' . $name . '","propertyDefinitions":{}}',
 			)
 		);
+
+		return $updater->saveRevision( CommentStoreComment::newUnsavedComment( 'TODO' ) );
+	}
+
+	protected function createMapping( string $name, string $json ): ?RevisionRecord {
+		$wikiPage = MediaWikiServices::getInstance()->getWikiPageFactory()->newFromTitle(
+			Title::newFromText( $name, NeoWikiExtension::NS_MAPPING )
+		);
+
+		$updater = $wikiPage->newPageUpdater( $this->getTestSysop()->getUser() );
+
+		$updater->setContent( 'main', new MappingContent( $json ) );
 
 		return $updater->saveRevision( CommentStoreComment::newUnsavedComment( 'TODO' ) );
 	}

--- a/tests/phpunit/Persistence/MediaWiki/MappingContentValidatorTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/MappingContentValidatorTest.php
@@ -153,6 +153,63 @@ class MappingContentValidatorTest extends TestCase {
 		);
 	}
 
+	/**
+	 * @dataProvider validLanguageTagProvider
+	 */
+	public function testAcceptsABcp47LanguageTag( string $lang ): void {
+		$this->assertValid( $this->mappingWithLang( $lang ) );
+	}
+
+	/**
+	 * @return array<string, array{string}>
+	 */
+	public static function validLanguageTagProvider(): array {
+		return [
+			'primary subtag only' => [ 'en' ],
+			'region subtag' => [ 'en-US' ],
+			'lowercase region' => [ 'pt-BR' ],
+		];
+	}
+
+	/**
+	 * A language tag outside the BCP-47 shape is rejected at save time, so it can never reach the
+	 * serializer and smuggle a datatype or a `"` into the `"lexical"@tag` literal.
+	 *
+	 * @dataProvider invalidLanguageTagProvider
+	 */
+	public function testRejectsANonBcp47LanguageTag( string $lang ): void {
+		$this->assertInvalidAt( $this->mappingWithLang( $lang ), '/properties/Name/lang' );
+	}
+
+	/**
+	 * @return array<string, array{string}>
+	 */
+	public static function invalidLanguageTagProvider(): array {
+		return [
+			'underscore separator' => [ 'en_US' ],
+			'trailing space' => [ 'en ' ],
+			'empty trailing subtag' => [ 'en-' ],
+			'datatype injection' => [ 'en"^^xsd:evil' ],
+		];
+	}
+
+	private function mappingWithLang( string $lang ): string {
+		$encodedLang = json_encode( $lang );
+
+		return <<<JSON
+			{
+				"version": 1,
+				"schema": "Person",
+				"target": "edm",
+				"prefixes": { "dc": "http://purl.org/dc/elements/1.1/" },
+				"subject": { "class": "http://example.org/CHO" },
+				"properties": {
+					"Name": { "predicate": "dc:title", "lang": {$encodedLang} }
+				}
+			}
+			JSON;
+	}
+
 	public function testRejectsAPropertyThatSetsBothLanguageAndDatatype(): void {
 		// An RDF literal cannot carry both a language tag and a datatype.
 		$this->assertInvalidAt(

--- a/tests/phpunit/Persistence/MediaWiki/MappingContentValidatorTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/MappingContentValidatorTest.php
@@ -1,0 +1,195 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Persistence\MediaWiki;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\MappingContentValidator;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Persistence\MediaWiki\MappingContentValidator
+ */
+class MappingContentValidatorTest extends TestCase {
+
+	private function assertValid( string $json ): void {
+		$validator = MappingContentValidator::newInstance();
+		$this->assertTrue( $validator->validate( $json ), 'Expected valid, got: ' . implode( '; ', $validator->getErrors() ) );
+		$this->assertSame( [], $validator->getErrors() );
+	}
+
+	private function assertInvalidAt( string $json, string $expectedErrorPointer ): void {
+		$validator = MappingContentValidator::newInstance();
+		$this->assertFalse( $validator->validate( $json ) );
+		$this->assertArrayHasKey( $expectedErrorPointer, $validator->getErrors() );
+	}
+
+	public function testAcceptsAValidMapping(): void {
+		$this->assertValid( $this->validMapping() );
+	}
+
+	public function testAcceptsAMappingUsingAnAbsoluteIriPredicate(): void {
+		$this->assertValid( <<<JSON
+			{
+				"version": 1,
+				"schema": "Person",
+				"target": "custom",
+				"subject": { "class": "http://example.org/ns/Person" },
+				"properties": {
+					"Name": { "predicate": "http://example.org/ns/name" }
+				}
+			}
+			JSON );
+	}
+
+	public function testRejectsAMissingSchema(): void {
+		$this->assertInvalidAt(
+			<<<JSON
+			{ "version": 1, "target": "edm", "subject": { "class": "edm:X" }, "prefixes": { "edm": "http://europeana.eu/edm/" }, "properties": {} }
+			JSON,
+			'/'
+		);
+	}
+
+	public function testRejectsAMissingSubjectClass(): void {
+		$this->assertInvalidAt(
+			<<<JSON
+			{ "version": 1, "schema": "Person", "target": "edm", "subject": {}, "properties": {} }
+			JSON,
+			'/subject'
+		);
+	}
+
+	public function testRejectsAWrongFormatVersion(): void {
+		$this->assertInvalidAt(
+			<<<JSON
+			{ "version": 2, "schema": "Person", "target": "edm", "subject": { "class": "edm:X" }, "prefixes": { "edm": "http://europeana.eu/edm/" }, "properties": {} }
+			JSON,
+			'/version'
+		);
+	}
+
+	public function testRejectsATargetWithUnsafeCharacters(): void {
+		$this->assertInvalidAt(
+			<<<JSON
+			{ "version": 1, "schema": "Person", "target": "e dm", "subject": { "class": "edm:X" }, "prefixes": { "edm": "http://europeana.eu/edm/" }, "properties": {} }
+			JSON,
+			'/target'
+		);
+	}
+
+	public function testRejectsAPredicateWhoseCurieDoesNotResolve(): void {
+		// The "crm" prefix is not declared, so this predicate cannot be expanded and is rejected rather
+		// than silently reinterpreted.
+		$this->assertInvalidAt(
+			<<<JSON
+			{
+				"version": 1,
+				"schema": "Artwork",
+				"target": "cidoc",
+				"prefixes": { "edm": "http://www.europeana.eu/schemas/edm/" },
+				"subject": { "class": "edm:ProvidedCHO" },
+				"properties": {
+					"Creator": { "predicate": "crm:P14_carried_out_by" }
+				}
+			}
+			JSON,
+			'/properties/Creator/predicate'
+		);
+	}
+
+	public function testRejectsASubjectClassWhoseCurieDoesNotResolve(): void {
+		$this->assertInvalidAt(
+			<<<JSON
+			{
+				"version": 1,
+				"schema": "Artwork",
+				"target": "cidoc",
+				"prefixes": { "edm": "http://www.europeana.eu/schemas/edm/" },
+				"subject": { "class": "crm:E22_Human-Made_Object" },
+				"properties": {}
+			}
+			JSON,
+			'/subject/class'
+		);
+	}
+
+	/**
+	 * The #1029 lesson at the Mapping boundary: a predicate crafted to break out of its IRI must be
+	 * rejected at save time, so no stored Mapping can forge triples in the projected document.
+	 */
+	public function testRejectsAPredicateThatWouldBreakOutOfItsIri(): void {
+		$this->assertInvalidAt(
+			<<<JSON
+			{
+				"version": 1,
+				"schema": "Person",
+				"target": "edm",
+				"prefixes": { "dc": "http://purl.org/dc/elements/1.1/" },
+				"subject": { "class": "http://example.org/CHO" },
+				"properties": {
+					"Name": { "predicate": "dc:title> <http://evil.example/s> <http://evil/p> <http://evil/o" }
+				}
+			}
+			JSON,
+			'/properties/Name/predicate'
+		);
+	}
+
+	public function testRejectsAPrefixNamespaceThatWouldBreakOutOfThePrefixTable(): void {
+		// An unsafe namespace reaches the serializer's @prefix table even if no term uses it.
+		$this->assertInvalidAt(
+			<<<JSON
+			{
+				"version": 1,
+				"schema": "Person",
+				"target": "edm",
+				"prefixes": { "evil": "http://evil.example/\\"> .# " },
+				"subject": { "class": "http://example.org/CHO" },
+				"properties": {}
+			}
+			JSON,
+			'/prefixes/evil'
+		);
+	}
+
+	public function testRejectsAPropertyThatSetsBothLanguageAndDatatype(): void {
+		// An RDF literal cannot carry both a language tag and a datatype.
+		$this->assertInvalidAt(
+			<<<JSON
+			{
+				"version": 1,
+				"schema": "Person",
+				"target": "edm",
+				"prefixes": { "dc": "http://purl.org/dc/elements/1.1/", "xsd": "http://www.w3.org/2001/XMLSchema#" },
+				"subject": { "class": "http://example.org/CHO" },
+				"properties": {
+					"Name": { "predicate": "dc:title", "lang": "en", "datatype": "xsd:string" }
+				}
+			}
+			JSON,
+			'/properties/Name'
+		);
+	}
+
+	private function validMapping(): string {
+		return <<<JSON
+			{
+				"version": 1,
+				"schema": "Person",
+				"target": "edm",
+				"prefixes": {
+					"edm": "http://www.europeana.eu/schemas/edm/",
+					"dc": "http://purl.org/dc/elements/1.1/"
+				},
+				"subject": { "class": "edm:ProvidedCHO" },
+				"properties": {
+					"Name": { "predicate": "dc:title", "lang": "en" },
+					"Website": { "predicate": "edm:isShownAt" },
+					"Author": { "predicate": "dc:creator" }
+				}
+			}
+			JSON;
+	}
+
+}

--- a/tests/phpunit/Persistence/MediaWiki/MappingPersistenceDeserializerTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/MappingPersistenceDeserializerTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Persistence\MediaWiki;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\MappingName;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\MappingPersistenceDeserializer;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Persistence\MediaWiki\MappingPersistenceDeserializer
+ */
+class MappingPersistenceDeserializerTest extends TestCase {
+
+	private function deserialize( string $json ): \ProfessionalWiki\NeoWiki\Domain\Mapping\Mapping {
+		return ( new MappingPersistenceDeserializer() )->deserialize( new MappingName( 'Person to EDM' ), $json );
+	}
+
+	public function testDeserializesTheSchemaTargetAndSubjectClass(): void {
+		$mapping = $this->deserialize( $this->validJson() );
+
+		$this->assertSame( 'Person to EDM', $mapping->name->getText() );
+		$this->assertSame( 'Person', $mapping->schema->getText() );
+		$this->assertSame( 'edm', $mapping->target );
+		$this->assertSame( 'edm:ProvidedCHO', $mapping->subjectClass );
+	}
+
+	public function testDeserializesThePrefixes(): void {
+		$this->assertSame(
+			[
+				'edm' => 'http://www.europeana.eu/schemas/edm/',
+				'dc' => 'http://purl.org/dc/elements/1.1/',
+			],
+			$this->deserialize( $this->validJson() )->prefixes
+		);
+	}
+
+	public function testDeserializesAPropertyWithALanguageTag(): void {
+		$name = $this->deserialize( $this->validJson() )->properties->get( 'Name' );
+
+		$this->assertNotNull( $name );
+		$this->assertSame( 'dc:title', $name->predicate );
+		$this->assertSame( 'en', $name->language );
+		$this->assertNull( $name->datatype );
+	}
+
+	public function testDeserializesAPropertyWithADatatypeOverride(): void {
+		$born = $this->deserialize( $this->validJson() )->properties->get( 'BirthYear' );
+
+		$this->assertNotNull( $born );
+		$this->assertSame( 'dc:date', $born->predicate );
+		$this->assertNull( $born->language );
+		$this->assertSame( 'edm:year', $born->datatype );
+	}
+
+	public function testThrowsWhenTheSchemaIsMissing(): void {
+		$this->expectException( InvalidArgumentException::class );
+		$this->deserialize( '{ "version": 1, "target": "edm", "subject": { "class": "edm:X" }, "properties": {} }' );
+	}
+
+	public function testThrowsOnInvalidJson(): void {
+		$this->expectException( InvalidArgumentException::class );
+		$this->deserialize( 'not json' );
+	}
+
+	private function validJson(): string {
+		return <<<JSON
+			{
+				"version": 1,
+				"schema": "Person",
+				"target": "edm",
+				"prefixes": {
+					"edm": "http://www.europeana.eu/schemas/edm/",
+					"dc": "http://purl.org/dc/elements/1.1/"
+				},
+				"subject": { "class": "edm:ProvidedCHO" },
+				"properties": {
+					"Name": { "predicate": "dc:title", "lang": "en" },
+					"BirthYear": { "predicate": "dc:date", "datatype": "edm:year" }
+				}
+			}
+			JSON;
+	}
+
+}


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/1026

Makes ontology Mappings real, authorable wiki objects and implements the near-1:1 term-substitution projection tier from [OntologyMapping.md](https://github.com/ProfessionalWiki/NeoWiki/blob/master/docs/planning/OntologyMapping.md), so ECHOLOT partners can react to something concrete.

> **v1 is deliberately minimal and the stored format is provisional.** It covers only the near-1:1 tier (term substitution): a target class per Subject and one predicate per mapped property. No intermediate-node synthesis. The mapping-formalism question is still open (OntologyMapping.md Q1, #995), so the `"version": 1` format may change — it is versioned precisely so a later tier can supersede it.

## What's shipped

- **`Mapping:` namespace (7478/7479) + `NeoWikiMapping` content model**, mirroring the Schema/Layout content-model triad: a namespace-restricted content handler, a JSON + IRI-safety validator, a persistence deserializer to a `Mapping` domain object, and a cached lookup. Protected by a new `neowiki-mapping-edit` right.
- **v1 format**: one Mapping per (schema, target); prefix declarations; a subject class; per-property predicate with optional language tag or datatype override. A duplicate (schema, target) pair is rejected at save (lookup-based; pre-production race acceptable), and the projector also tie-breaks duplicates deterministically (alphabetical page title) with a logged warning.
- **`OntologyMappingProjector`** reusing the #1029 projection infrastructure (quad model, IRI scheme, literal factory, value-mapper registry).
- **First consumer + the seam for #586**: the export endpoint and `DumpRdf` gain an optional `projection` parameter. The export endpoint resolves via `resolveRdfProjection(name)`, which enumerates the Mapping pages once to serve both the resolution and — on an unknown target — the known-names list for the `400`. `newRdfProjection(name)` remains the minimal `?RdfProjection` seam #586 consumes.

## Format (as shipped)

```json
{
    "version": 1,
    "schema": "Person",
    "target": "edm",
    "prefixes": {
        "edm": "http://www.europeana.eu/schemas/edm/",
        "dc": "http://purl.org/dc/elements/1.1/"
    },
    "subject": { "class": "edm:ProvidedCHO" },
    "properties": {
        "Name":    { "predicate": "dc:title", "lang": "en" },
        "Website": { "predicate": "edm:isShownAt" },
        "Author":  { "predicate": "dc:creator" }
    }
}
```

## Projection semantics

- **Subject IRIs stay native** (`neo-subj:`); only the vocabulary comes from the target ontology.
- Per mapped Subject: `rdf:type <class>`, `rdfs:label` (always), and one triple per mapped property value (multi-part → repeated predicates; a relation → a direct triple to the target Subject's native IRI). **Only mapped properties are emitted** — conformant output is the point.
- A Subject whose Schema has no Mapping for the target is absent; its IRI can still appear as an **untyped** relation target.
- No `neo:Relation` reification, no page-metadata triples; **per-page named graphs are kept** so the shared per-store sync works for an ontology store.

## Term and language-tag safety (the #1029 lesson)

At save time every CURIE must resolve against the declared prefixes and every expanded/absolute IRI must be a valid absolute IRI with no IRIREF-illegal characters. Such terms (and declared prefix namespaces, which also reach the serializer's `@prefix` table) are **rejected, never percent-encoded** — a Mapping must reproduce the ontology's exact terms.

A property's `lang` tag is constrained the same way: it must be **BCP-47-shaped** (`^[A-Za-z]{1,8}(-[A-Za-z0-9]{1,8})*$`), so it cannot smuggle a `"` or a datatype into the serialized `"lexical"@tag` literal. This is enforced in **three layers**: (1) at save time via the content schema; (2) as a `Literal` domain invariant (an out-of-shape tag throws at construction); (3) at projection time the projector re-validates and, for a Mapping that bypassed save validation (`importDump` / a pre-validation page), drops an invalid tag to a plain literal with a logged warning rather than 500-ing the export. The IRI terms are likewise re-expanded at projection time, so a bypassed unsafe class/predicate/datatype/prefix is dropped there too.

Adversarial tests at **both** the save layer and the projection layer prove a malicious or malformed Mapping cannot forge triples, prefix declarations, datatypes, or language tags — and that a bad stored Mapping degrades the projection instead of aborting it.

## Usage

```sh
# Native (default, unchanged):
curl 'https://wiki.example/rest.php/neowiki/v0/page/42/rdf'
# EDM ontology projection:
curl 'https://wiki.example/rest.php/neowiki/v0/page/42/rdf?projection=edm&format=turtle'
# Bulk dump in a projection:
php maintenance/run.php NeoWiki:DumpRdf --projection=edm > dump-edm.trig
```

An unknown target returns `400` (endpoint) or a script error, listing the known projections.

## Scope adaptation (flagged)

The issue framed the first consumer as **per-store projection selection** for the SPARQL store (#586, owned elsewhere). As that store is not in this slice, the concrete first consumer here is the **export endpoint + dump `projection` parameter**, and `newRdfProjection(name)` in the composition root is the minimal seam #586 will consume (it needs only `RdfProjection::$projector`).

## Live verification

Authored a real EDM Mapping (`Mapping:ArtistToEDM`) against the demo `Artist` schema and exported Claude Monet with `projection=edm`:

```turtle
neo-subj:sEpfwJLo1kFh84j a edm:Agent;
    rdfs:label "Claude Monet";
    rdagr2:dateOfBirth "1840"^^xsd:gYear;      # datatype override on a number
    rdagr2:dateOfDeath "1926"^^xsd:gYear;
    dc:subject "Impressionism"@en;             # language tag on a plain string
    foaf:page "https://en.wikipedia.org/wiki/Claude_Monet"^^xsd:anyURI.
```

Native subject IRI, mapped vocabulary only, `rdfs:label` always, and the unmapped `Nationality`/`Active period` correctly absent. Native export is unchanged; the bulk dump projects all 75 subject pages, and `--projection=bogus` fatal-errors listing `native, edm`. The demo Mapping page is **left in place as seed material for #1027** (as-built reconciliation of the planning doc).

## Open questions (contract-level judgment calls, not silently guessed)

1. **`lang` on non-text properties.** The validator does not reject `lang` on a non-text property, because that would couple Mapping validity to the referenced Schema's existence/type. Instead the projector applies `lang` only to plain-string literals and ignores it for typed literals. Reasonable, but a call worth confirming. **Update:** an adversarial review round found this thread had reasoned about *where* a `lang` applies but not about the *validity of the tag value itself* — an unvalidated tag reached the serializer and could 500 the export or inject a datatype. Now closed by the three-layer BCP-47 validation above.
2. **`lang` + `datatype` are mutually exclusive** (rejected at save). An RDF literal cannot carry both; enforced as a content-level rule.
3. **Absolute IRIs must contain `://`.** This cleanly separates a CURIE with an undeclared (typo'd) prefix — rejected — from a real absolute IRI. Non-authority schemes (`urn:`, `mailto:`) are therefore out of scope for v1. Flagged as a limitation.
4. **`rdfs:label` is emitted as a plain `xsd:string`** (no language tag), matching the native projection. Multilinguality (OntologyMapping.md Q8) is out of scope.
5. **Relations** project only the direct triple; relation qualifiers/properties have no v1 mapping and any `lang`/`datatype` on a relation property mapping is ignored (the object is an IRI).

## Docs

New `docs/reference/ontology-mapping.md` (format reference, authoring guide, duplicate rule, provisional-format/Q1 note, endpoint/script parameter), linked from `rdf-export.md` and `docs/README.md`. The planning doc is intentionally not rewritten (as-built reconciliation is #1027).

> Scope and v1 format shape approved by @JeroenDeDauw in-session as part of the #1023 RDF-milestone plan; this implementation was produced autonomously from the orchestrating architect's spec and was not human-reviewed. Explored the merged #1029 native RDF projection and the Schema/Layout content-model triad; wrote unit + integration tests (TDD, incl. adversarial IRI-injection cases); ran the full PHP suite (`make cs` + `make phpunit`, all green); verified live on the dev wiki (authored an EDM Mapping, exported a page in the EDM projection, ran the bulk dump).
> **Revision (adversarial-review follow-up):** a separate adversarial AI review round found the `lang` tag was unvalidated end-to-end — a stored tag such as `en_US` threw an uncaught hardf exception (HTTP 500 on the export, a fatal in `DumpRdf`), and `en"^^xsd:evil` could inject an attacker-chosen datatype. This revision adds the three-layer BCP-47 validation, projection-time adversarial tests for the IRI and language-tag defences, two claimed-behaviour tests, and a single-enumeration projection resolver (the 400 path no longer enumerates Mappings twice). Produced autonomously from the review spec; not human-reviewed. Full suite green (`make cs` + `make phpunit`); live-checked on the dev wiki — the EDM export still returns 200 (incl. the valid `"Impressionism"@en`), a `lang: "en_US"` save is rejected (`neowiki-mapping-invalid`, page never created), and an unknown projection is a clean 400 (`native, edm`), never a 500.
> Context: the NeoWiki codebase (#1029 RDF foundation, Schema/Layout triads), `docs/planning/OntologyMapping.md`, and issue #1026.
> <sub>Original written by Claude Code, `Opus 4.8 (max)`; this revision by Claude Code, `Opus 4.8 (1M context, max effort)`.</sub>
