### PR TITLE
Bind the context parse to the revision and clarify provider docs

### DIFF
--- a/docs/reference/extending.md
+++ b/docs/reference/extending.md
@@ -87,7 +87,10 @@ class StaticPagePropertyProvider implements PagePropertyProvider {
 ```
 
 Register with `NeoWikiRegistrar::addPagePropertyProvider()`. The context exposes the page id, title,
-creation and modification times, categories, and last editor. Example:
+creation and modification times, categories, and last editor. It also exposes the revision's main slot
+content (plus its content model) and the properties recorded during parsing of that content (MediaWiki
+page properties, e.g. those set by parser hooks via `ParserOutput::setPageProperty`), so providers can
+derive Page Properties from the page content without re-fetching or re-parsing it. Example:
 [`src/StaticPagePropertyProvider.php`](https://github.com/ProfessionalWiki/NeoWiki/blob/master/tests/RedHerb/src/StaticPagePropertyProvider.php).
 
 ### Reading NeoWiki data and authorization

--- a/docs/reference/extending.md
+++ b/docs/reference/extending.md
@@ -87,10 +87,16 @@ class StaticPagePropertyProvider implements PagePropertyProvider {
 ```
 
 Register with `NeoWikiRegistrar::addPagePropertyProvider()`. The context exposes the page id, title,
-creation and modification times, categories, and last editor. It also exposes the revision's main slot
-content (plus its content model) and the properties recorded during parsing of that content (MediaWiki
-page properties, e.g. those set by parser hooks via `ParserOutput::setPageProperty`), so providers can
-derive Page Properties from the page content without re-fetching or re-parsing it. Example:
+creation and modification times, categories, and last editor, so providers can derive Page Properties
+from the page content without re-fetching or re-parsing it.
+
+To derive Page Properties from the content, prefer the parse products: `categories`, and
+`parserProperties` — the MediaWiki page properties recorded during parsing (e.g. those a parser hook
+sets via `ParserOutput::setPageProperty`). These are template-expansion-safe and robust. (Note that
+`parserProperties` are an input from MediaWiki's parse; they are not the NeoWiki Page Properties this
+provider returns.) The raw main slot `content` and its `contentModel` are also exposed, but scraping
+raw wikitext is fragile — reach for them mainly when handling a custom, non-wikitext content model that
+the parse products do not cover. Example:
 [`src/StaticPagePropertyProvider.php`](https://github.com/ProfessionalWiki/NeoWiki/blob/master/tests/RedHerb/src/StaticPagePropertyProvider.php).
 
 ### Reading NeoWiki data and authorization

--- a/docs/reference/extending.md
+++ b/docs/reference/extending.md
@@ -74,7 +74,10 @@ $registrar->addNeo4jValueBuilder( ColorType::NAME, static fn ( $value ) => $valu
 ### Page Property Providers
 
 Page Property Providers contribute key/value metadata to the Page node in the graph (queryable via Cypher;
-Neo4j is currently the only graph backend). Implement `PagePropertyProvider`:
+Neo4j is currently the only graph backend). They run when a revision is stored for a page carrying Subject
+data (including undeletions), and again for such pages when the graph is rebuilt with the
+`RebuildGraphDatabases` maintenance script. Pages without Subject data are not stored in the graph, so
+providers are never invoked for them. Implement `PagePropertyProvider`:
 
 ```php
 class StaticPagePropertyProvider implements PagePropertyProvider {
@@ -87,14 +90,14 @@ class StaticPagePropertyProvider implements PagePropertyProvider {
 ```
 
 Register with `NeoWikiRegistrar::addPagePropertyProvider()`. The context exposes the page id, title,
-creation and modification times, categories, and last editor, so providers can derive Page Properties
-from the page content without re-fetching or re-parsing it.
+creation and modification times, categories, and last editor, as well as the page content and its parse
+products, so providers can derive Page Properties from the page content without re-fetching or re-parsing it.
 
-To derive Page Properties from the content, prefer the parse products: `categories`, and
+To derive Page Properties from the content, prefer the parse products: `categories` and
 `parserProperties` — the MediaWiki page properties recorded during parsing (e.g. those a parser hook
 sets via `ParserOutput::setPageProperty`). These are template-expansion-safe and robust. (Note that
 `parserProperties` are an input from MediaWiki's parse; they are not the NeoWiki Page Properties this
-provider returns.) The raw main slot `content` and its `contentModel` are also exposed, but scraping
+provider returns.) The raw main slot `content` and its `contentModel` are the fallback: scraping
 raw wikitext is fragile — reach for them mainly when handling a custom, non-wikitext content model that
 the parse products do not cover. Example:
 [`src/StaticPagePropertyProvider.php`](https://github.com/ProfessionalWiki/NeoWiki/blob/master/tests/RedHerb/src/StaticPagePropertyProvider.php).

--- a/src/Domain/Page/PagePropertyProviderContext.php
+++ b/src/Domain/Page/PagePropertyProviderContext.php
@@ -13,6 +13,14 @@ readonly class PagePropertyProviderContext {
 	 * @param string $modificationTime In the standard MediaWiki format, ie 20230726163439
 	 * @param string[] $categories
 	 * @param string $lastEditor Plain username of the last editor, e.g. "JohnDoe". Empty string if unknown.
+	 * @param string $content Serialized main slot content of the revision, e.g. the wikitext.
+	 *   Empty string if the content is unavailable.
+	 * @param string $contentModel Content model of the main slot, e.g. "wikitext".
+	 *   Empty string if the content is unavailable.
+	 * @param array<string, int|float|string|bool|null> $parserProperties Properties recorded during parsing of the
+	 *   content (MediaWiki page properties, e.g. "defaultsort" or values set by parser hooks via
+	 *   ParserOutput::setPageProperty). These are inputs from the parse, not to be confused with the NeoWiki
+	 *   Page Properties that providers return.
 	 */
 	public function __construct(
 		public PageId $pageId,
@@ -22,6 +30,9 @@ readonly class PagePropertyProviderContext {
 		public string $modificationTime,
 		public array $categories,
 		public string $lastEditor,
+		public string $content,
+		public string $contentModel,
+		public array $parserProperties,
 	) {
 	}
 

--- a/src/PagePropertiesBuilder.php
+++ b/src/PagePropertiesBuilder.php
@@ -4,8 +4,10 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki;
 
+use MediaWiki\Content\Content;
 use MediaWiki\Content\IContentHandlerFactory;
 use MediaWiki\Content\Renderer\ContentParseParams;
+use MediaWiki\Parser\ParserOutput;
 use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Revision\RevisionStore;
 use MediaWiki\Revision\SlotRecord;
@@ -40,6 +42,8 @@ readonly class PagePropertiesBuilder {
 
 	private function buildContext( RevisionRecord $revision, ?UserIdentity $user ): PagePropertyProviderContext {
 		$linkTarget = $revision->getPageAsLinkTarget();
+		$content = $revision->getContent( SlotRecord::MAIN );
+		$parserOutput = $content === null ? null : $this->parse( $content, $revision );
 
 		return new PagePropertyProviderContext(
 			pageId: new PageId( $revision->getPageId() ),
@@ -47,9 +51,17 @@ readonly class PagePropertiesBuilder {
 			namespaceId: $linkTarget->getNamespace(),
 			creationTime: $this->getCreationTime( $revision ),
 			modificationTime: $this->getModificationTime( $revision ),
-			categories: $this->getCategories( $revision ),
+			categories: $parserOutput === null ? [] : $parserOutput->getCategoryNames(),
 			lastEditor: $user?->getName() ?? '',
+			content: $content === null ? '' : $content->serialize(),
+			contentModel: $content === null ? '' : $content->getModel(),
+			parserProperties: $parserOutput === null ? [] : $parserOutput->getPageProperties(),
 		);
+	}
+
+	private function parse( Content $content, RevisionRecord $revision ): ParserOutput {
+		return $this->contentHandlerFactory->getContentHandler( $content->getModel() )
+			->getParserOutput( $content, new ContentParseParams( $revision->getPage() ) );
 	}
 
 	private function getCreationTime( RevisionRecord $revision ): string {
@@ -70,21 +82,6 @@ readonly class PagePropertiesBuilder {
 		}
 
 		return $time;
-	}
-
-	/**
-	 * @return string[]
-	 */
-	private function getCategories( RevisionRecord $revision ): array {
-		$content = $revision->getContent( SlotRecord::MAIN );
-
-		if ( $content === null ) {
-			return [];
-		}
-
-		return $this->contentHandlerFactory->getContentHandler( $content->getModel() )
-			->getParserOutput( $content, new ContentParseParams( $revision->getPage() ) )
-			->getCategoryNames();
 	}
 
 }

--- a/src/PagePropertiesBuilder.php
+++ b/src/PagePropertiesBuilder.php
@@ -61,7 +61,7 @@ readonly class PagePropertiesBuilder {
 
 	private function parse( Content $content, RevisionRecord $revision ): ParserOutput {
 		return $this->contentHandlerFactory->getContentHandler( $content->getModel() )
-			->getParserOutput( $content, new ContentParseParams( $revision->getPage() ) );
+			->getParserOutput( $content, new ContentParseParams( $revision->getPage(), $revision->getId() ) );
 	}
 
 	private function getCreationTime( RevisionRecord $revision ): string {

--- a/tests/phpunit/PagePropertiesBuilderTest.php
+++ b/tests/phpunit/PagePropertiesBuilderTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests;
+
+use ProfessionalWiki\NeoWiki\Domain\Page\PagePropertyProviderContext;
+use ProfessionalWiki\NeoWiki\Domain\Page\PagePropertyProviderRegistry;
+use ProfessionalWiki\NeoWiki\PagePropertiesBuilder;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpyPagePropertyProvider;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\PagePropertiesBuilder
+ * @group Database
+ */
+class PagePropertiesBuilderTest extends NeoWikiIntegrationTestCase {
+
+	public function testProviderReceivesContent(): void {
+		$context = $this->getContextForNewPageWithContent( 'Some text [[Category:Cats]]' );
+
+		$this->assertSame( 'Some text [[Category:Cats]]', $context->content );
+	}
+
+	public function testProviderReceivesContentModel(): void {
+		$context = $this->getContextForNewPageWithContent( 'Whatever wikitext' );
+
+		$this->assertSame( CONTENT_MODEL_WIKITEXT, $context->contentModel );
+	}
+
+	public function testProviderReceivesParserRecordedProperties(): void {
+		$context = $this->getContextForNewPageWithContent( 'Sorted {{DEFAULTSORT:Zebra}}' );
+
+		$this->assertSame( 'Zebra', $context->parserProperties['defaultsort'] );
+	}
+
+	public function testProviderReceivesCategoriesFromParsedContent(): void {
+		$context = $this->getContextForNewPageWithContent( 'Some text [[Category:Cats]]' );
+
+		$this->assertSame( [ 'Cats' ], $context->categories );
+	}
+
+	private function getContextForNewPageWithContent( string $wikitext ): PagePropertyProviderContext {
+		$revision = $this->editPage( 'PagePropertiesBuilderTestPage', $wikitext )->getNewRevision();
+
+		$spy = new SpyPagePropertyProvider();
+
+		$this->newPagePropertiesBuilder( $spy )->getPagePropertiesFor( $revision, null );
+
+		return $spy->getReceivedContext();
+	}
+
+	private function newPagePropertiesBuilder( SpyPagePropertyProvider $provider ): PagePropertiesBuilder {
+		$registry = new PagePropertyProviderRegistry();
+		$registry->addProvider( $provider );
+
+		$services = $this->getServiceContainer();
+
+		return new PagePropertiesBuilder(
+			revisionStore: $services->getRevisionStore(),
+			contentHandlerFactory: $services->getContentHandlerFactory(),
+			titleFormatter: $services->getTitleFormatter(),
+			providerRegistry: $registry,
+		);
+	}
+
+}

--- a/tests/phpunit/PagePropertiesBuilderTest.php
+++ b/tests/phpunit/PagePropertiesBuilderTest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Tests;
 
+use MediaWiki\Revision\RevisionRecord;
 use ProfessionalWiki\NeoWiki\Domain\Page\PagePropertyProviderContext;
 use ProfessionalWiki\NeoWiki\Domain\Page\PagePropertyProviderRegistry;
 use ProfessionalWiki\NeoWiki\PagePropertiesBuilder;
@@ -39,9 +40,46 @@ class PagePropertiesBuilderTest extends NeoWikiIntegrationTestCase {
 		$this->assertSame( [ 'Cats' ], $context->categories );
 	}
 
-	private function getContextForNewPageWithContent( string $wikitext ): PagePropertyProviderContext {
-		$revision = $this->editPage( 'PagePropertiesBuilderTestPage', $wikitext )->getNewRevision();
+	public function testParseIsBoundToTheProvidedRevision(): void {
+		$revision = $this->editPage( 'PagePropertiesBuilderTestPage', '{{DEFAULTSORT:Rev{{REVISIONID}}}}' )->getNewRevision();
+		$this->editPage( 'PagePropertiesBuilderTestPage', 'Newer revision without a defaultsort' );
 
+		$this->assertSame(
+			'Rev' . $revision->getId(),
+			$this->getContextForRevision( $revision )->parserProperties['defaultsort']
+		);
+	}
+
+	public function testProviderReceivesContentModelOfNonWikitextContent(): void {
+		$revision = $this->editPage( 'MediaWiki:PagePropertiesBuilderTest.json', '{ "answer": 42 }' )->getNewRevision();
+
+		$this->assertSame( CONTENT_MODEL_JSON, $this->getContextForRevision( $revision )->contentModel );
+	}
+
+	public function testContextHasEmptySentinelsWhenContentIsUnavailable(): void {
+		$revision = $this->editPage( 'PagePropertiesBuilderTestPage', 'Hidden [[Category:Cats]] {{DEFAULTSORT:Zebra}}' )->getNewRevision();
+		$this->editPage( 'PagePropertiesBuilderTestPage', 'Newer public revision' );
+		$this->revisionDelete( $revision );
+
+		$context = $this->getContextForRevision( $this->getSuppressedRevision( $revision->getId() ) );
+
+		$this->assertSame( '', $context->content );
+		$this->assertSame( '', $context->contentModel );
+		$this->assertSame( [], $context->parserProperties );
+		$this->assertSame( [], $context->categories );
+	}
+
+	private function getSuppressedRevision( int $revisionId ): RevisionRecord {
+		return $this->getServiceContainer()->getRevisionStore()->getRevisionById( $revisionId );
+	}
+
+	private function getContextForNewPageWithContent( string $wikitext ): PagePropertyProviderContext {
+		return $this->getContextForRevision(
+			$this->editPage( 'PagePropertiesBuilderTestPage', $wikitext )->getNewRevision()
+		);
+	}
+
+	private function getContextForRevision( RevisionRecord $revision ): PagePropertyProviderContext {
 		$spy = new SpyPagePropertyProvider();
 
 		$this->newPagePropertiesBuilder( $spy )->getPagePropertiesFor( $revision, null );

--- a/tests/phpunit/Persistence/CorePagePropertyProviderTest.php
+++ b/tests/phpunit/Persistence/CorePagePropertyProviderTest.php
@@ -82,6 +82,9 @@ class CorePagePropertyProviderTest extends TestCase {
 				modificationTime: $modificationTime,
 				categories: $categories,
 				lastEditor: $lastEditor,
+				content: 'Whatever content',
+				contentModel: 'wikitext',
+				parserProperties: [],
 			)
 		);
 	}

--- a/tests/phpunit/TestDoubles/SpyPagePropertyProvider.php
+++ b/tests/phpunit/TestDoubles/SpyPagePropertyProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\TestDoubles;
+
+use ProfessionalWiki\NeoWiki\Domain\Page\PagePropertyProvider;
+use ProfessionalWiki\NeoWiki\Domain\Page\PagePropertyProviderContext;
+
+class SpyPagePropertyProvider implements PagePropertyProvider {
+
+	private ?PagePropertyProviderContext $receivedContext = null;
+
+	public function getProperties( PagePropertyProviderContext $context ): array {
+		$this->receivedContext = $context;
+		return [];
+	}
+
+	public function getReceivedContext(): PagePropertyProviderContext {
+		if ( $this->receivedContext === null ) {
+			throw new \LogicException( 'getProperties was not called' );
+		}
+
+		return $this->receivedContext;
+	}
+
+}


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/982, delivering review fixes onto that PR's
branch (this diff contains only the fixes).

**Bind the context parse to the stored revision.** The parse that fills `categories` and `parserProperties`
ran without a revision id, i.e. as a preview-like parse: revision-context magic words (`{{REVISIONID}}`,
`{{REVISIONUSER}}`, ...) and parser hooks that read the revision while recording page properties resolved
against nothing, so the recorded values could diverge from what core stored for the same revision. That
mattered little while the parse only fed `categories`, but the PR publishes the parse products to providers
as the recommended derivation path. The fix passes `$revision->getId()` through `ContentParseParams`. The
test pins the behavior with a `{{DEFAULTSORT:Rev{{REVISIONID}}}}` page: it records `Rev` without the fix and
`Rev<id>` with it, and a second stored revision ensures resolving the page's latest revision instead of the
provided one also fails. Verified end to end on a dev stack, where the graph property carries the actual
revision id.

**Pin the remaining documented contracts with tests.** The content-unavailable sentinels (`content`,
`contentModel` empty and `parserProperties`, `categories` empty when the main-slot content is hidden) had no
covering test, so type-clean drift such as switching the builder to `getContentOrThrow` would pass the whole
suite while making undeletion of a page with rev-deleted history fatal in production; the new test suppresses
a real revision and asserts what a provider receives. The `contentModel` test only exercised wikitext, the
one value a hardcode would also produce, so a JSON page now pins that the model comes from the actual
content. Each test was verified against a production mutation that only it catches.

**Docs accuracy in extending.md.** The sentence introducing the context now names the content and parse
products (previously it promised content derivation while enumerating only the pre-existing fields), and the
section states when providers actually run: when a revision is stored for a page carrying Subject data
(including undeletions) and during `RebuildGraphDatabases` runs, with pages whose last Subject was deleted
still qualifying via their subject slot.

> Review-fix delivery directed by @malberts over two rounds: he triaged the initial review's findings and
> scoped the first delivery to them, then requested a deeper re-review that produced the additional tests and
> docs corrections; the history is squashed to one commit and @malberts gave the diff a quick look before requesting review. Findings
> come from multi-agent reviews of #982 (code review, security review, test review, adversarial verification
> of candidate blockers, with MediaWiki 1.43 core-contract claims checked against core source), and a third,
> independent re-review of #982 reproduced the findings these fixes address. All code changes were developed
> test-first or mutation-verified, with the full PHPUnit, phpcs, and phpstan gate run locally and the parse
> binding verified end to end on a running dev stack.
> Context: the NeoWiki codebase, the PR #982 and issue #979 discussions, and MediaWiki 1.43 core source.
> <sub>Written by Claude Code, `Fable 5` (initial fixes at high effort, later additions at max)</sub>


