### PR TITLE
Ship the person→EDM ontology-mapping exercise (demo data + walkthrough)

### DIFF
--- a/DemoData/AGENTS.md
+++ b/DemoData/AGENTS.md
@@ -30,8 +30,8 @@ a clean-slate import after renames or deletions.
 Subject, relation, and option IDs:
 
 - 15 characters total, starting with `s` / `r` / `o` respectively.
-- Remaining 14 characters use a base32-ish alphabet that excludes look-alikes: no `0`, `o`, `O`,
-  `l`, `I`.
+- Remaining 14 characters use a base32-ish alphabet that excludes look-alikes: no `0`, `O`, `l`, `I`
+  (lowercase `o` and `i` are allowed; see `SubjectId`/`RelationId`).
 - Existing conventions:
   - Museum corpus uses random base62 (e.g. `sEpfwJLnxyQy6vR`).
   - Older corpora group by prefix (`s1demo1...` ACME, `s1demo7...` ACME structural,

--- a/DemoData/Mapping/CityToEDM.json
+++ b/DemoData/Mapping/CityToEDM.json
@@ -1,0 +1,12 @@
+{
+	"version": 1,
+	"schema": "City",
+	"target": "edm",
+	"prefixes": {
+		"edm": "http://www.europeana.eu/schemas/edm/"
+	},
+	"subject": {
+		"class": "edm:Place"
+	},
+	"properties": {}
+}

--- a/DemoData/Mapping/PersonToEDM.json
+++ b/DemoData/Mapping/PersonToEDM.json
@@ -1,0 +1,19 @@
+{
+	"version": 1,
+	"schema": "Person",
+	"target": "edm",
+	"prefixes": {
+		"edm": "http://www.europeana.eu/schemas/edm/",
+		"rdaGr2": "http://rdvocab.info/ElementsGr2/",
+		"skos": "http://www.w3.org/2004/02/skos/core#"
+	},
+	"subject": {
+		"class": "edm:Agent"
+	},
+	"properties": {
+		"Gender": { "predicate": "rdaGr2:gender" },
+		"Birth date": { "predicate": "rdaGr2:dateOfBirth" },
+		"Birth place": { "predicate": "rdaGr2:placeOfBirth" },
+		"Description": { "predicate": "skos:note", "lang": "en" }
+	}
+}

--- a/DemoData/Schema/Person.json
+++ b/DemoData/Schema/Person.json
@@ -1,14 +1,32 @@
 {
-	"description": "A human being. Maps to CIDOC CRM E21 Person (http://www.cidoc-crm.org/cidoc-crm/E21_Person). Deliberately lean: life events such as birth live on their own Subjects, not as fields here.",
+	"description": "A human being. Maps to CIDOC CRM E21 Person (http://www.cidoc-crm.org/cidoc-crm/E21_Person) and, via the PersonToEDM Mapping, to EDM edm:Agent. Life events such as birth can be modelled richly as their own event Subjects (see the Birth schema), or flatly via the Birth date and Birth place fields here — the flat form is what the near-1:1 EDM projection consumes.",
 	"propertyDefinitions": {
 		"Description": {
 			"type": "text",
-			"description": "Short biography. CIDOC P3 has note."
+			"description": "Short biography. CIDOC P3 has note; EDM skos:note."
 		},
 		"Also known as": {
 			"type": "text",
 			"multiple": true,
 			"description": "Alternative names and appellations. CIDOC P1 is identified by (E41 Appellation)."
+		},
+		"Gender": {
+			"type": "text",
+			"description": "Gender, as a literal (EDM rdaGr2:gender). Kept as text rather than select on purpose: the v1 ontology projection emits a select value's stored option id, not its label, so a controlled-vocabulary select would project an opaque id."
+		},
+		"Birth date": {
+			"type": "date",
+			"description": "Date of birth (EDM rdaGr2:dateOfBirth). Flat alternative to a Birth event Subject."
+		},
+		"Birth place": {
+			"type": "relation",
+			"relation": "Born in",
+			"targetSchema": "City",
+			"description": "Place of birth, as a relation to a City (EDM rdaGr2:placeOfBirth; the City projects as edm:Place)."
+		},
+		"Source": {
+			"type": "text",
+			"description": "Bibliographic source for the data. Deliberately left out of the EDM Mapping, to show that unmapped properties are absent from an ontology projection."
 		}
 	}
 }

--- a/DemoData/Subject/Málaga.json
+++ b/DemoData/Subject/Málaga.json
@@ -1,0 +1,14 @@
+{
+	"mainSubject": "s2birthcity2aa2",
+	"subjects": {
+		"s2birthcity2aa2": {
+			"label": "Málaga",
+			"schema": "City",
+			"statements": {
+				"Country": { "type": "text", "value": [ "Spain" ] },
+				"Population": { "type": "number", "value": 578460 },
+				"Website": { "type": "url", "value": [ "https://www.malaga.eu" ] }
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Málaga.wikitext
+++ b/DemoData/Subject/Málaga.wikitext
@@ -1,0 +1,3 @@
+'''Málaga''' is a city in Andalusia, southern Spain, on the Costa del Sol. It is the birthplace of [[Pablo Picasso]] (Getty TGN 7007942).
+
+Its City Subject projects into EDM as an <code>edm:Place</code> via the [[Mapping:CityToEDM]] ontology mapping, so a person's <code>rdaGr2:placeOfBirth</code> can point at a typed place.

--- a/DemoData/Subject/Málaga.wikitext
+++ b/DemoData/Subject/Málaga.wikitext
@@ -1,3 +1,3 @@
-'''Málaga''' is a city in Andalusia, southern Spain, on the Costa del Sol. It is the birthplace of [[Pablo Picasso]] (Getty TGN 7007942).
+'''Málaga''' (Getty TGN 7007942) is a city in Andalusia, southern Spain, on the Costa del Sol. It is the birthplace of [[Pablo Picasso]].
 
 Its City Subject projects into EDM as an <code>edm:Place</code> via the [[Mapping:CityToEDM]] ontology mapping, so a person's <code>rdaGr2:placeOfBirth</code> can point at a typed place.

--- a/DemoData/Subject/Pablo_Picasso.json
+++ b/DemoData/Subject/Pablo_Picasso.json
@@ -1,0 +1,16 @@
+{
+	"mainSubject": "s2picasso2aaaa2",
+	"subjects": {
+		"s2picasso2aaaa2": {
+			"label": "Pablo Picasso",
+			"schema": "Person",
+			"statements": {
+				"Description": { "type": "text", "value": [ "Spanish painter, sculptor, and printmaker who co-founded the Cubist movement and is regarded as one of the most influential artists of the 20th century." ] },
+				"Gender": { "type": "text", "value": [ "Male" ] },
+				"Birth date": { "type": "date", "value": [ "1881-10-25" ] },
+				"Birth place": { "type": "relation", "value": [ { "id": "r2picasso2city2", "target": "s2birthcity2aa2" } ] },
+				"Source": { "type": "text", "value": [ "A Life of Picasso I: The Prodigy: 1881-1906 by John Richardson (ISBN 978-0375711497)" ] }
+			}
+		}
+	}
+}

--- a/DemoData/Subject/Pablo_Picasso.wikitext
+++ b/DemoData/Subject/Pablo_Picasso.wikitext
@@ -1,0 +1,3 @@
+'''Pablo Picasso''' (1881–1973) was a Spanish painter, sculptor, and printmaker who co-founded the Cubist movement. He was born in [[Málaga]] and spent most of his working life in France.
+
+This page's Person Subject carries the flat toy-model fields (gender, birth date, birth place, description, source) used by the [[Mapping:PersonToEDM]] ontology mapping to project the page into EDM. See the person→EDM walkthrough in the NeoWiki docs.

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Key docs:
 * [REST API](reference/rest-api.md) - The complete `/neowiki/v0/*` endpoint reference, plus the generated OpenAPI spec served at `/rest.php/specs/v0/module/-`
 * [RDF Export](reference/rdf-export.md) - Native RDF projection: config, IRI scheme, the per-page export endpoint, and the bulk dump script
 * [Ontology Mapping](reference/ontology-mapping.md) - Projecting Subjects into standard ontologies (EDM, Dublin Core, …) via Mapping pages
+* [Example: Person to EDM](examples/person-to-edm.md) - End-to-end walkthrough of the ontology-mapping projection, native vs EDM output, and its findings
 * [Extending NeoWiki](reference/extending.md) - How other extensions add property types, contribute graph data, and reuse NeoWiki's UI
 * [Installation & Maintenance](operations/installation.md) - Sysadmin guide to installing and maintaining NeoWiki
 * [Architecture Decision Records](adr/001-domain-centric-architecture.md) - Numbered, dated architectural decisions
@@ -22,6 +23,7 @@ Key docs:
 
 * Explains a domain idea or model → `concepts/`
 * A precise contract (an API or a data format) → `reference/`
+* A worked, end-to-end example → `examples/`
 * A numbered, dated decision → `adr/`
 * Work-in-progress exploration → `planning/` (not published to the website)
 * Sysadmin install, maintenance, or deployment guide → `operations/`

--- a/docs/examples/person-to-edm.md
+++ b/docs/examples/person-to-edm.md
@@ -12,7 +12,8 @@ native projection.
 It implements the EDM column of the shared "Neutral Person to Many Standards" toy model (takin, ECHOLOT
 WP2/WP3) — the first end-to-end proof of the mapping mechanism proposed in
 [planning/OntologyMapping.md](../planning/OntologyMapping.md). Everything here ships as
-[demo data](../../DemoData/), so a fresh wiki with the demo data imported reproduces it exactly.
+[demo data](../../DemoData/), so a fresh wiki with the demo data imported reproduces it — up to
+instance-specific page IDs and base URI (and, in the page metadata, timestamps and last editor).
 
 > **Scope: the near-1:1 tier only.** EDM is flat and property-centric, so the mapping is term
 > substitution. The toy model's CIDOC-CRM column is event-based (birth becomes an `E67_Birth` node
@@ -130,6 +131,9 @@ Real output from the demo wiki (Turtle; shared prefix header trimmed). **Native*
 ```turtle
 <.../page/115> a neo:Page;
     neo:pageName "Pablo Picasso";
+    dcterms:created "2026-07-11T23:22:20Z"^^xsd:dateTime;
+    dcterms:modified "2026-07-11T23:22:20Z"^^xsd:dateTime;
+    neo:lastEditor "NeoWiki";
     neo:mainSubject neo-subj:s2picasso2aaaa2;
     neo:hasSubject neo-subj:s2picasso2aaaa2.
 neo-subj:s2picasso2aaaa2 a neo-schema:Person;

--- a/docs/examples/person-to-edm.md
+++ b/docs/examples/person-to-edm.md
@@ -1,0 +1,248 @@
+---
+title: Person to EDM
+order: 1
+---
+# Worked example: projecting a Person to EDM
+
+This is an end-to-end walkthrough of the [Ontology Mapping](../reference/ontology-mapping.md) v1
+projection: a NeoWiki-native `Person` Schema, an EDM Mapping, and a demo page, projected into
+[Europeana Data Model](https://pro.europeana.eu/page/edm-documentation) (EDM) RDF and compared with the
+native projection.
+
+It implements the EDM column of the shared "Neutral Person to Many Standards" toy model (takin, ECHOLOT
+WP2/WP3) — the first end-to-end proof of the mapping mechanism proposed in
+[planning/OntologyMapping.md](../planning/OntologyMapping.md). Everything here ships as
+[demo data](../../DemoData/), so a fresh wiki with the demo data imported reproduces it exactly.
+
+> **Scope: the near-1:1 tier only.** EDM is flat and property-centric, so the mapping is term
+> substitution. The toy model's CIDOC-CRM column is event-based (birth becomes an `E67_Birth` node
+> between the person and the date/place) and needs the intermediate-node **synthesis** that v1
+> deliberately does not do — see [Known next tier](#known-next-tier-cidoc-crm) below.
+
+## The toy model
+
+| Neutral Person field | Example value | EDM target |
+|---|---|---|
+| Name | "Pablo Picasso" | `foaf:name` — **see the finding below**; v1 emits the name only as `rdfs:label` |
+| Gender | "Male" | `rdaGr2:gender` literal |
+| Birth Date | 1881-10-25 | `rdaGr2:dateOfBirth` (`xsd:date`) |
+| Birth Location | Málaga (Getty TGN 7007942) | `rdaGr2:placeOfBirth` → an `edm:Place` |
+| Description | biography text | `skos:note` literal |
+| Source | "A Life of Picasso I…" (ISBN) | **n/a in EDM** — deliberately unmapped |
+
+Prefixes: `edm: http://www.europeana.eu/schemas/edm/`, `rdaGr2: http://rdvocab.info/ElementsGr2/`,
+`skos: http://www.w3.org/2004/02/skos/core#`.
+
+## 1. The Schemas
+
+The demo `Person` Schema ([`DemoData/Schema/Person.json`](../../DemoData/Schema/Person.json)) carries the
+flat toy-model fields. It is deliberately **not** a parallel schema: the existing rich, event-based Bach
+family data (birth as its own `Birth` Subject) keeps working; the flat `Birth date` / `Birth place`
+fields are the form the near-1:1 EDM projection consumes.
+
+```json
+{
+    "Gender":      { "type": "text" },
+    "Birth date":  { "type": "date" },
+    "Birth place": { "type": "relation", "relation": "Born in", "targetSchema": "City" },
+    "Source":      { "type": "text" },
+    "Description": { "type": "text" }
+}
+```
+
+Birth Location is a **relation** to a `City` Subject. The demo `City` Schema
+([`DemoData/Schema/City.json`](../../DemoData/Schema/City.json)) is used unchanged.
+
+## 2. The Mappings
+
+Two Mapping pages, one per (Schema, target). Each is a page in the `Mapping:` namespace.
+
+**[`Mapping:PersonToEDM`](../../DemoData/Mapping/PersonToEDM.json)** — `Person` → EDM:
+
+```json
+{
+    "version": 1,
+    "schema": "Person",
+    "target": "edm",
+    "prefixes": {
+        "edm": "http://www.europeana.eu/schemas/edm/",
+        "rdaGr2": "http://rdvocab.info/ElementsGr2/",
+        "skos": "http://www.w3.org/2004/02/skos/core#"
+    },
+    "subject": { "class": "edm:Agent" },
+    "properties": {
+        "Gender":      { "predicate": "rdaGr2:gender" },
+        "Birth date":  { "predicate": "rdaGr2:dateOfBirth" },
+        "Birth place": { "predicate": "rdaGr2:placeOfBirth" },
+        "Description": { "predicate": "skos:note", "lang": "en" }
+    }
+}
+```
+
+**[`Mapping:CityToEDM`](../../DemoData/Mapping/CityToEDM.json)** — `City` → EDM. It maps **only the
+class** (`edm:Place`), with no property mappings:
+
+```json
+{
+    "version": 1,
+    "schema": "City",
+    "target": "edm",
+    "prefixes": { "edm": "http://www.europeana.eu/schemas/edm/" },
+    "subject": { "class": "edm:Place" },
+    "properties": {}
+}
+```
+
+For the birthplace use case, all EDM needs from Málaga is a labelled `edm:Place` that
+`rdaGr2:placeOfBirth` can point at. The City's `Country`/`Population`/`Website` have no near-1:1 EDM
+`Place` predicate in the flat tier (place geography would use `wgs84_pos`, outside the toy model), so
+they are deliberately unmapped — see the [findings](#findings).
+
+## 3. The demo page
+
+[`Pablo_Picasso`](../../DemoData/Subject/Pablo_Picasso.json) is a `Person` main Subject with every
+toy-model value, its `Birth place` relation pointing at [`Málaga`](../../DemoData/Subject/Málaga.json)
+(a `City`).
+
+## 4. Running the projection
+
+Per page, via the [RDF export endpoint](../reference/rdf-export.md#endpoint) (the `projection` query
+parameter selects the vocabulary):
+
+```sh
+# native (default):
+curl '.../rest.php/neowiki/v0/page/<id>/rdf?format=turtle'
+# EDM:
+curl '.../rest.php/neowiki/v0/page/<id>/rdf?projection=edm&format=turtle'
+```
+
+In bulk, via the dump script (one named graph per page):
+
+```sh
+php maintenance/run.php NeoWiki:DumpRdf --projection=edm > dump-edm.trig
+```
+
+## 5. Native vs EDM output
+
+Real output from the demo wiki (Turtle; shared prefix header trimmed). **Native** projection of
+`Pablo_Picasso` — NeoWiki's own vocabulary, lossless, with page metadata and the two-layer relation:
+
+```turtle
+<.../page/115> a neo:Page;
+    neo:pageName "Pablo Picasso";
+    neo:mainSubject neo-subj:s2picasso2aaaa2;
+    neo:hasSubject neo-subj:s2picasso2aaaa2.
+neo-subj:s2picasso2aaaa2 a neo-schema:Person;
+    rdfs:label "Pablo Picasso";
+    neo-prop:Description "Spanish painter, sculptor, and printmaker who co-founded the Cubist movement…";
+    neo-prop:Gender "Male";
+    neo-prop:Birth_date "1881-10-25"^^xsd:date;
+    neo-prop:Source "A Life of Picasso I: The Prodigy: 1881-1906 by John Richardson (ISBN 978-0375711497)";
+    neo-prop:Born_in neo-subj:s2birthcity2aa2.
+neo-rel:r2picasso2city2 a neo:Relation;
+    neo:source neo-subj:s2picasso2aaaa2;
+    neo:target neo-subj:s2birthcity2aa2;
+    neo:relationType neo-prop:Born_in.
+```
+
+**EDM** projection of the same page — target vocabulary only, no page metadata, no relation
+reification:
+
+```turtle
+neo-subj:s2picasso2aaaa2 a edm:Agent;
+    rdfs:label "Pablo Picasso";
+    skos:note "Spanish painter, sculptor, and printmaker who co-founded the Cubist movement…"@en;
+    rdaGr2:gender "Male";
+    rdaGr2:dateOfBirth "1881-10-25"^^xsd:date;
+    rdaGr2:placeOfBirth neo-subj:s2birthcity2aa2.
+```
+
+**EDM** projection of `Málaga` (its own page) — typed `edm:Place`:
+
+```turtle
+neo-subj:s2birthcity2aa2 a edm:Place;
+    rdfs:label "Málaga".
+```
+
+What changed, native → EDM:
+
+- The Subject IRI is **unchanged** (`neo-subj:s2picasso2aaaa2`): the entity stays the wiki's own; only
+  the *vocabulary* is EDM. Sibling projections mint identical IRIs.
+- `rdf:type` `neo-schema:Person` → `edm:Agent`; `Málaga` → `edm:Place`.
+- `rdfs:label` is kept verbatim (a standard term EDM also uses).
+- Each mapped property's predicate is substituted: `neo-prop:Gender` → `rdaGr2:gender`, `Birth_date` →
+  `rdaGr2:dateOfBirth`, `Description` → `skos:note` (now carrying `@en`).
+- The **datatype is preserved** by the value mapper, not the Mapping: `"1881-10-25"^^xsd:date` is
+  identical in both projections.
+- The birth-place **relation** becomes a direct triple `rdaGr2:placeOfBirth neo-subj:s2birthcity2aa2`.
+  Note the predicate is keyed on the **property name** `Birth place`, whereas the native predicate
+  (`neo-prop:Born_in`) uses the **relation-type name** `Born in`.
+- **Absent in EDM:** page metadata (`neo:Page`, `neo:hasSubject`), the `neo:Relation` reification node,
+  the `Source` property (unmapped), and any native-only property. Conformant EDM is the point.
+
+### Per-page vs bulk: the relation target's type
+
+In the **per-page** EDM export of `Pablo_Picasso`, `neo-subj:s2birthcity2aa2` (Málaga) appears as the
+object of `rdaGr2:placeOfBirth` but is **untyped** — its `a edm:Place` triple lives in Málaga's own
+page graph. The **bulk** `DumpRdf --projection=edm` contains both named graphs, so across the dataset
+Málaga is a typed `edm:Place`:
+
+```trig
+<.../page/115> { neo-subj:s2picasso2aaaa2 a edm:Agent; … rdaGr2:placeOfBirth neo-subj:s2birthcity2aa2 }
+<.../page/116> { neo-subj:s2birthcity2aa2 a edm:Place; rdfs:label "Málaga" }
+```
+
+(The dump also projects the other demo `Person`/`City` Subjects — Bach persons as `edm:Agent`, the
+other cities as `edm:Place` — since the Mapping applies to every Subject of its Schema.)
+
+## Findings
+
+The point of this exercise is to surface gaps honestly. From doing it:
+
+1. **The name is only `rdfs:label`; `foaf:name` cannot be emitted (v1 format gap).** A NeoWiki Subject's
+   name is its built-in **label**, not a property. The projector always emits it as `rdfs:label`, and
+   v1 has **no facility to map the label to an additional predicate**, so the toy model's
+   `Name → foaf:name` cannot be produced. Adding a redundant "Name" property purely to force `foaf:name`
+   out would duplicate the label and misrepresent the model, so we did not. This is a real limitation of
+   the v1 format: it needs a way to say "also emit the label as `<predicate>`" (and, more generally, to
+   map the label per target). Recorded for the mapping-formalism discussion
+   ([#996](https://github.com/ProfessionalWiki/NeoWiki/discussions/996)).
+2. **A `select` value would project its option id, not its label.** `Gender` is a controlled
+   vocabulary, so a `select` property is the natural model. But a select value is stored as the option
+   **id**, and the v1 value mapper emits that id as the literal — so `rdaGr2:gender` would carry an
+   opaque `o1…` id, not `"Male"`. We used a **text** property to get a meaningful literal. A
+   select→label (or select→`skos:Concept` IRI) projection is future work.
+3. **EDM's flat `Place` vocabulary is thin.** `CityToEDM` maps only the class. Country/Population/Website
+   have no obvious near-1:1 EDM `Place` predicate without stretching semantics; coordinates would need a
+   geo vocabulary (`wgs84_pos`) beyond the toy model. Class-only is the honest v1 result and is exactly
+   what the birthplace reference needs.
+4. **Relation predicates key on the property name, literal predicates likewise.** The mapping's
+   `properties` keys are **property names** (`Birth place`), while the native projection's relation
+   predicate uses the **relation-type name** (`Born in`). Authors of a Mapping must use property names,
+   not relation-type names — worth stating in the format reference if it trips people up.
+5. **Untyped relation targets in a per-page export are expected.** As above; only the bulk dump (or a
+   store holding all graphs) types the target. Consumers that need the target's type must load its graph.
+
+None of these blocked the exercise; the near-1:1 EDM projection works end to end. (1) is the one that is
+a genuine v1 **format** gap rather than a deliberate boundary.
+
+## Querying via SPARQL
+
+v1 ships the projection and the export surfaces (endpoint + dump). It does **not** yet load the RDF into
+a triple store — the pluggable SPARQL store that would let you run EDM SPARQL against this data is
+[#586](https://github.com/ProfessionalWiki/NeoWiki/issues/586), which consumes the
+`newRdfProjection(name)` seam this work exposes. Until then, feed the `DumpRdf --projection=edm` output
+into any SPARQL engine (e.g. a local QLever) to query the EDM projection. Once #586 lands, a store can be
+configured to hold the `edm` projection directly and be queried in EDM terms.
+
+## Known next tier: CIDOC-CRM
+
+The toy model's CIDOC-CRM column is **out of scope for v1**. CIDOC-CRM mediates birth through an event:
+a person's birth date and place hang off a synthesized `E67_Birth` node
+(`E21_Person → P98i_was_born → E67_Birth → P4_has_time-span / P7_took_place_at`). That node has no
+counterpart in NeoWiki's flat data; the mapping must **mint** it, coordinating several flat fields onto
+one shared node. Expressing that path expansion and node synthesis is the hard tier
+([OntologyMapping.md](../planning/OntologyMapping.md) Q2), and the open mapping-formalism question
+([OntologyMapping.md Q1](../planning/OntologyMapping.md#open-questions),
+[#995](https://github.com/ProfessionalWiki/NeoWiki/issues/995)) is precisely about choosing a formalism
+that can. EDM proves the mechanism end to end; CIDOC-CRM is the next tier it must grow into.

--- a/docs/planning/NativeRdfProjection.md
+++ b/docs/planning/NativeRdfProjection.md
@@ -7,7 +7,8 @@ Status: Draft, incorporating feedback from ECHOLOT partners (Bilbao meeting Marc
 Discussion: [#999](https://github.com/ProfessionalWiki/NeoWiki/discussions/999).
 
 > **As-built (2026-07).** The native projection specified here has shipped, together with the shared
-> per-store IRI/namespace regime and per-page named graphs it defines. See the
+> IRI/namespace regime — wiki-level, so subject IRIs are identical across stores — reused by every
+> sibling projection, and the per-page named graphs it defines. See the
 > [RDF Export reference](../reference/rdf-export.md). Ontology (sibling) projections build on this shared
 > infrastructure — see [OntologyMapping.md](OntologyMapping.md) and the worked
 > [Person → EDM example](../examples/person-to-edm.md).

--- a/docs/planning/NativeRdfProjection.md
+++ b/docs/planning/NativeRdfProjection.md
@@ -6,6 +6,12 @@ Status: Draft, incorporating feedback from ECHOLOT partners (Bilbao meeting Marc
 
 Discussion: [#999](https://github.com/ProfessionalWiki/NeoWiki/discussions/999).
 
+> **As-built (2026-07).** The native projection specified here has shipped, together with the shared
+> per-store IRI/namespace regime and per-page named graphs it defines. See the
+> [RDF Export reference](../reference/rdf-export.md). Ontology (sibling) projections build on this shared
+> infrastructure — see [OntologyMapping.md](OntologyMapping.md) and the worked
+> [Person → EDM example](../examples/person-to-edm.md).
+
 ## Purpose
 
 This document specifies how NeoWiki's data model projects to RDF triples for the SPARQL plugin described in

--- a/docs/planning/OntologyMapping.md
+++ b/docs/planning/OntologyMapping.md
@@ -9,6 +9,14 @@ Status: Draft strawman, for discussion with ECHOLOT partners (T2.3 and T3.x).
 
 Discussion: [#996](https://github.com/ProfessionalWiki/NeoWiki/discussions/996).
 
+> **As-built (v1, 2026-07).** The near-1:1 term-substitution tier of this design has shipped: Mappings as
+> pages in a `Mapping:` namespace, and an ontology projection selectable alongside the native one on the
+> RDF export endpoint and `DumpRdf`. See the [Ontology Mapping reference](../reference/ontology-mapping.md)
+> and the worked [Person → EDM example](../examples/person-to-edm.md). The structural / node-synthesis
+> tier and the mapping-formalism question (Q1, [#995](https://github.com/ProfessionalWiki/NeoWiki/issues/995))
+> remain open; the stored `"version": 1` format is provisional. Provisional answers v1 gives to some open
+> questions below are noted inline.
+
 ## Summary
 
 NeoWiki defines its own native Schemas ([ADR 6](../adr/006-schemas.md)). For RDF and SPARQL it projects that data into
@@ -314,9 +322,16 @@ above, since the store has no sync-back to the wiki.
 mapping per Schema? Per-target is more modular and independently installable; combined may reduce duplication for shared
 sub-patterns.
 
+*v1: a separate Mapping per (Schema, target), enforced at save time — a second page claiming the same pair is rejected.
+Combined multi-target mappings stay open for a later format version.*
+
 **Q7: Authoring and distribution.** Where do Mappings live (a dedicated namespace? API-only?), who authors them (data
 modellers) vs installs them (wiki admins), and how are bundles (e.g. "CIDOC-CRM for Person / Place / Object") packaged
 and shared across wikis and a farm?
+
+*v1: Mappings live as pages in a dedicated `Mapping:` namespace, authored like Schemas/Layouts and gated by the
+`neowiki-mapping-edit` right, and seedable as demo/bundle data (the Person→EDM example ships this way). Packaging and
+farm-wide sharing of bundles is not yet addressed.*
 
 **Q8: Multilinguality.** Mapped labels should carry language tags (`@lang`); canonical values used in queries stay
 language-neutral. CH data is heavily multilingual (Basque, the ELB languages, etc.). How much belongs in the mapping vs
@@ -325,6 +340,10 @@ the native projection vs Views?
 **Q9: Multiple projections per wiki.** Should a wiki be able to serve several projections at once (several stores:
 native + one or more ontologies), and is a native projection always available as a baseline? This makes "which
 vocabulary is in the store" a per-store configuration rather than a single global choice.
+
+*v1: yes for export — a wiki serves several projections at once, selected per request via the `projection` parameter,
+with `native` always the baseline and each Mapping page adding its target to the known set. Per-store selection (a store
+configured to hold one projection) is the seam #586 consumes via `newRdfProjection(name)`.*
 
 **Q10: Flat vs nested native modelling.** The [fork above](#flat-vs-nested-native-modelling-open-fork): should
 case-study data live in flat Schemas with the mapping synthesizing intermediate nodes, or in nested Schemas with the

--- a/maintenance/ImportDemoData.php
+++ b/maintenance/ImportDemoData.php
@@ -9,6 +9,7 @@ use Maintenance;
 use MediaWiki\MediaWikiServices;
 use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\ImportPagesAction;
 use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\ImportPresenter;
+use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\MappingContentSource;
 use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\PageContentSource;
 use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\SchemaContentSource;
 use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\SubjectPageSource;
@@ -65,6 +66,10 @@ class ImportDemoData extends Maintenance {
 			),
 			layoutContentSource: new LayoutContentSource(
 				NeoWikiExtension::getInstance()->getNeoWikiRootDirectory() . '/DemoData/Layout',
+				new SimpleFileFetcher()
+			),
+			mappingContentSource: new MappingContentSource(
+				NeoWikiExtension::getInstance()->getNeoWikiRootDirectory() . '/DemoData/Mapping',
 				new SimpleFileFetcher()
 			)
 		);

--- a/src/Application/Actions/ImportPages/ImportPagesAction.php
+++ b/src/Application/Actions/ImportPages/ImportPagesAction.php
@@ -25,6 +25,7 @@ class ImportPagesAction {
 		private readonly PageContentSource $pageContentSource,
 		private readonly PageContentSource $moduleContentSource,
 		private readonly LayoutContentSource $layoutContentSource,
+		private readonly MappingContentSource $mappingContentSource,
 	) {
 	}
 
@@ -43,6 +44,15 @@ class ImportPagesAction {
 				"Layout:$layoutName",
 				[
 					'main' => $layoutContent,
+				]
+			);
+		}
+
+		foreach ( $this->mappingContentSource->getMappings() as $mappingName => $mappingContent ) {
+			$this->createPage(
+				"Mapping:$mappingName",
+				[
+					'main' => $mappingContent,
 				]
 			);
 		}

--- a/src/Application/Actions/ImportPages/MappingContentSource.php
+++ b/src/Application/Actions/ImportPages/MappingContentSource.php
@@ -1,0 +1,46 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application\Actions\ImportPages;
+
+use DirectoryIterator;
+use FileFetcher\FileFetcher;
+use ProfessionalWiki\NeoWiki\EntryPoints\Content\MappingContent;
+
+class MappingContentSource {
+
+	public function __construct(
+		private readonly string $directoryPath,
+		private readonly FileFetcher $fileFetcher,
+	) {
+	}
+
+	/**
+	 * @return array<string, MappingContent>
+	 */
+	public function getMappings(): array {
+		if ( !is_dir( $this->directoryPath ) ) {
+			return [];
+		}
+
+		$mappingContents = [];
+
+		$directoryIterator = new DirectoryIterator( $this->directoryPath );
+
+		/**
+		 * @var DirectoryIterator $fileInfo
+		 */
+		foreach ( $directoryIterator as $fileInfo ) {
+			if ( !$fileInfo->isFile() ) {
+				continue;
+			}
+
+			$mappingName = $fileInfo->getBasename( '.json' );
+			$mappingContents[$mappingName] = new MappingContent( $this->fileFetcher->fetchFile( $fileInfo->getRealPath() ) );
+		}
+
+		return $mappingContents;
+	}
+
+}

--- a/tests/phpunit/Application/Actions/ImportPagesActionTest.php
+++ b/tests/phpunit/Application/Actions/ImportPagesActionTest.php
@@ -7,6 +7,7 @@ namespace ProfessionalWiki\NeoWiki\Tests\Application\Actions;
 use MediaWiki\MediaWikiServices;
 use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\ImportPagesAction;
 use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\ImportPresenter;
+use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\MappingContentSource;
 use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\PageContentSource;
 use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\SchemaContentSource;
 use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\SubjectPageData;
@@ -27,6 +28,7 @@ class ImportPagesActionTest extends \MediaWikiIntegrationTestCase {
 	private PageContentSource $pageContentSource;
 	private PageContentSource $moduleContentSource;
 	private LayoutContentSource $layoutContentSource;
+	private MappingContentSource $mappingContentSource;
 	private ImportPagesAction $importPagesAction;
 
 	protected function setUp(): void {
@@ -36,6 +38,7 @@ class ImportPagesActionTest extends \MediaWikiIntegrationTestCase {
 		$this->pageContentSource = $this->createMock( PageContentSource::class );
 		$this->moduleContentSource = $this->createMock( PageContentSource::class );
 		$this->layoutContentSource = $this->createMock( LayoutContentSource::class );
+		$this->mappingContentSource = $this->createMock( MappingContentSource::class );
 
 		$this->importPagesAction = new ImportPagesAction(
 			$this->presenter,
@@ -48,6 +51,7 @@ class ImportPagesActionTest extends \MediaWikiIntegrationTestCase {
 			$this->pageContentSource,
 			$this->moduleContentSource,
 			$this->layoutContentSource,
+			$this->mappingContentSource,
 		);
 	}
 

--- a/tests/phpunit/Persistence/MediaWiki/MappingContentValidatorTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/MappingContentValidatorTest.php
@@ -6,6 +6,7 @@ namespace ProfessionalWiki\NeoWiki\Tests\Persistence\MediaWiki;
 
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\MappingContentValidator;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestData;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\Persistence\MediaWiki\MappingContentValidator
@@ -247,6 +248,23 @@ class MappingContentValidatorTest extends TestCase {
 				}
 			}
 			JSON;
+	}
+
+	/**
+	 * @dataProvider demoMappingProvider
+	 */
+	public function testDemoDataMappingIsValid( string $json ): void {
+		$this->assertValid( $json );
+	}
+
+	public function demoMappingProvider(): iterable {
+		$dir = new \DirectoryIterator( __DIR__ . '/../../../../DemoData/Mapping' );
+
+		foreach ( $dir as $fileinfo ) {
+			if ( !$fileinfo->isDot() && $fileinfo->getExtension() === 'json' ) {
+				yield $fileinfo->getFilename() => [ TestData::getFileContents( 'Mapping/' . $fileinfo->getFilename() ) ];
+			}
+		}
 	}
 
 }


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/NeoWiki/issues/1027 (partial — the sibling-store SPARQL demo remains blocked on #586).

Implements the export side of the person→EDM end-to-end exercise: the shared "neutral person" toy model (EDM column) as native Schemas, mapped to EDM via Mapping v1 (#1030), projected end to end and documented. This PR is data + docs; the only code is minimal demo-seeding plumbing so Mapping pages seed like Schemas/Layouts.

## What the exercise proves

Projecting the `Pablo_Picasso` Person page with `?projection=edm` yields conformant EDM: `edm:Agent`, `rdfs:label`, `rdaGr2:gender "Male"`, `rdaGr2:dateOfBirth "1881-10-25"^^xsd:date`, `skos:note …@en`, and `rdaGr2:placeOfBirth` → Málaga (typed `edm:Place` on its own page). The unmapped `Source` is absent; the native projection stays complete (page metadata + two-layer relation). `DumpRdf --projection=edm` runs clean over the whole dataset. Real trimmed output is in the walkthrough. Near-1:1 term substitution works end to end; CIDOC-CRM (event synthesis) is the known next tier, out of v1 scope.

## Findings (surfaced by doing it)

1. **`foaf:name` can't be emitted — a v1 format gap.** The name is the Subject label; the projector always emits it as `rdfs:label` and v1 has no way to also map the label to a predicate. Did not add a redundant "Name" property to force it. This is the one genuine format gap; the rest are deliberate boundaries.
2. **A `select` value projects its option id, not its label** — so `Gender` uses a `text` property (else `rdaGr2:gender` would carry an opaque `o1…` id).
3. **EDM's flat `Place` vocabulary is thin** — `CityToEDM` maps only the class; Country/Population/Website have no near-1:1 EDM Place predicate.
4. **Relation mappings key on the property name** (`Birth place`), while the native relation predicate uses the relation-type name (`Born in`).
5. **Per-page exports leave the relation target untyped** — only the bulk dump (or a full store) types it.

## Planning-doc edits (please review the wording)

Small, factual as-built notes only — no rewrites of these partner-linked docs:
- `docs/planning/OntologyMapping.md`: an "As-built (v1)" note after the Discussion line; provisional-answer notes on **Q6** (one Mapping per (Schema, target)), **Q7** (Mapping-namespace pages), **Q9** (per-request `projection` selection + the #586 seam).
- `docs/planning/NativeRdfProjection.md`: a one-paragraph "As-built" note after the Discussion line, pointing to the shipped RDF-export reference.

## Usage

- Per page: `GET /rest.php/neowiki/v0/page/<id>/rdf?projection=edm`
- Bulk: `php maintenance/run.php NeoWiki:DumpRdf --projection=edm`
- New docs: `docs/examples/person-to-edm.md` (linked from `docs/README.md`).

## What remains

The rest of the #1027 scope; none of it blocks this PR's export-side proof:

- **Sibling-store SPARQL demo** — querying the EDM projection in a triple store, with example SPARQL for both the native and EDM sibling stores. Blocked on the pluggable store #586, which consumes the `newRdfProjection(name)` seam this work exposes. Until then, feed the `DumpRdf --projection=edm` output into a SPARQL engine.
- **Feedback-round posts for #996 and #999** — drafted, awaiting human review before posting.
- **Q10 stretch: RDFS export of Schemas** (`NativeRdfProjection.md` Q10) — a separate follow-up.

### Follow-ups (not this PR)

- Pre-existing doc mismatch: `docs/reference/rdf-export.md`'s IRI table shows the page IRI as `neo-page:42`, but the serializer writes numeric-leading local names as full IRIs (e.g. `<…/page/42>`), so that prefixed form is never actually emitted (the walkthrough's native sample already uses the full-IRI form). Doc-only correction, tracked as a follow-up.

---

> Two passes, both Claude Code (`Opus 4.8`, max), to plans @JeroenDeDauw approved; the PR stays draft as the human review point, and neither pass had human correction rounds during execution.
> 1. **Original exercise** — implemented autonomously to the approved #1027 plan plus the toy-model sheet: explored the Mapping v1 (#1030) and native-projection (#1029) code and the ontology-mapping / native-projection planning docs; added the schema/mapping/subject demo data, the walkthrough, and minimal demo-seeding plumbing; ran phpcs + phpstan and the full PHPUnit suite (green); verified end to end on the dev wiki (native + EDM per-page exports and the bulk `DumpRdf --projection=edm`).
> 2. **Mechanical review-fix round (this update)** — a fully-specified, decided list of small fixes, no design latitude, executed autonomously: added a demo-Mapping CI test (TDD — watched it fail on an uncommitted scratch invalid mapping, then go green over the real files), filled the walkthrough's native sample with the real page-metadata triples regrabbed from the dev wiki, and made the ID-alphabet, Getty-TGN, and wiki-level-IRI doc corrections; phpunit + cs green.
> <sub>Written by Claude Code, `Opus 4.8 (max)`</sub>
