### PR TITLE
Fix links to moved docs outside the docs/ tree

### DIFF
--- a/DemoData/Page/Developers.wikitext
+++ b/DemoData/Page/Developers.wikitext
@@ -86,7 +86,7 @@ Oldest museums in this demo:
 
 {{#invoke:LuaExample|oldestMuseums}}
 
-For the full library reference, see the [https://github.com/ProfessionalWiki/NeoWiki/blob/master/docs/reference/lua-api.md Lua API documentation].
+For the full library reference, see the [https://github.com/ProfessionalWiki/NeoWiki/blob/master/docs/authoring/lua-api.md Lua API documentation].
 
 == Reactive UI ==
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ NeoWiki is not production ready yet. We support two installation use cases:
 
 ## Technical Documentation
 
-See [docs/](./docs/), especially [docs/concepts/glossary.md](./docs/concepts/glossary.md).
+See [docs/](./docs/), especially [docs/glossary.md](./docs/glossary.md).
 
 ## Development
 

--- a/tests/RedHerb/README.md
+++ b/tests/RedHerb/README.md
@@ -5,7 +5,7 @@ reference for how to extend NeoWiki. NeoWiki's own tests exercise it, so the exa
 RedHerb does not cover every extension point and grows over time as new examples are added.
 
 The narrative reference for NeoWiki's extension points lives in the published docs:
-**[Extending NeoWiki](../../docs/reference/extending.md)**. This README is just an index mapping each
+**[Extending NeoWiki](../../docs/extending/extending.md)**. This README is just an index mapping each
 extension point to the file that demonstrates it.
 
 > **Stability:** NeoWiki is pre-1.0. Every extension point is alpha and may change without notice.


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1034 (based on its branch).

The docs reorganisation moved `glossary.md` to the docs root and `extending.md` / `lua-api.md` into audience
directories. Three links that live *outside* the `docs/` tree still pointed at the old paths, so the docs-tree
link check did not catch them:

- `README.md` → `docs/concepts/glossary.md`
- `tests/RedHerb/README.md` → `docs/reference/extending.md`
- `DemoData/Page/Developers.wikitext` → `docs/reference/lua-api.md` (an absolute `master` URL, so it 404s only
  after merge; it is a link on the seeded Developers demo page)

Each now points at its new location. An exhaustive resolver over every `docs/…​md` reference in all tracked file
types confirms every target exists, and every `#anchor` link resolves to a real heading.

> <sub>AI-authored — Claude Code, `Opus 4.8 (max)`; review request from @malberts, fixes found and applied autonomously, no revisions; diff not yet human-reviewed; exhaustive doc-link + `#anchor` scan clean, parent branch CI green (incl. RestApiDocsCoverageTest), local PHP unavailable so the coverage test relied on CI.</sub>
