### PR TITLE
Point the Validate REST descriptions at the real subject-format doc

### DIFF
--- a/src/EntryPoints/REST/CreateSubjectApi.php
+++ b/src/EntryPoints/REST/CreateSubjectApi.php
@@ -84,7 +84,7 @@ class CreateSubjectApi extends SimpleHandler {
 				self::PARAM_SOURCE => 'body',
 				ParamValidator::PARAM_TYPE => 'array',
 				ParamValidator::PARAM_REQUIRED => true,
-				self::PARAM_DESCRIPTION => 'List of Statements (property/value pairs) for the Subject. Nested shape matches the subject JSON format documented in docs/api/subject-format.md.',
+				self::PARAM_DESCRIPTION => 'List of Statements (property/value pairs) for the Subject. Nested shape matches the subject JSON format documented at https://neowiki.ai/docs/api/subject-format.',
 			],
 			'comment' => [
 				self::PARAM_SOURCE => 'body',

--- a/src/EntryPoints/REST/ReplaceSubjectApi.php
+++ b/src/EntryPoints/REST/ReplaceSubjectApi.php
@@ -85,7 +85,7 @@ class ReplaceSubjectApi extends SimpleHandler {
 				self::PARAM_SOURCE => 'body',
 				ParamValidator::PARAM_TYPE => 'array',
 				ParamValidator::PARAM_REQUIRED => true,
-				self::PARAM_DESCRIPTION => 'Map of property names to Statements. Replaces the Subject\'s statement list entirely; omitted property names are deleted. Pass `{}` to delete all statements. Nested shape matches the subject JSON format documented in docs/api/subject-format.md.',
+				self::PARAM_DESCRIPTION => 'Map of property names to Statements. Replaces the Subject\'s statement list entirely; omitted property names are deleted. Pass `{}` to delete all statements. Nested shape matches the subject JSON format documented at https://neowiki.ai/docs/api/subject-format.',
 			],
 			'comment' => [
 				self::PARAM_SOURCE => 'body',

--- a/src/EntryPoints/REST/ValidateSubjectApi.php
+++ b/src/EntryPoints/REST/ValidateSubjectApi.php
@@ -63,7 +63,7 @@ class ValidateSubjectApi extends SimpleHandler {
 				self::PARAM_SOURCE => 'body',
 				ParamValidator::PARAM_TYPE => 'array',
 				ParamValidator::PARAM_REQUIRED => true,
-				self::PARAM_DESCRIPTION => 'Proposed Statements (property/value pairs). Shape matches docs/api/subject-format.md.',
+				self::PARAM_DESCRIPTION => 'Proposed Statements (property/value pairs). Shape matches the subject JSON format documented at https://neowiki.ai/docs/api/subject-format.',
 			],
 		];
 	}

--- a/src/EntryPoints/REST/ValidateSubjectApi.php
+++ b/src/EntryPoints/REST/ValidateSubjectApi.php
@@ -63,7 +63,7 @@ class ValidateSubjectApi extends SimpleHandler {
 				self::PARAM_SOURCE => 'body',
 				ParamValidator::PARAM_TYPE => 'array',
 				ParamValidator::PARAM_REQUIRED => true,
-				self::PARAM_DESCRIPTION => 'Proposed Statements (property/value pairs). Shape matches docs/SubjectFormat.md.',
+				self::PARAM_DESCRIPTION => 'Proposed Statements (property/value pairs). Shape matches docs/api/subject-format.md.',
 			],
 		];
 	}

--- a/src/EntryPoints/REST/ValidateSubjectUpdateApi.php
+++ b/src/EntryPoints/REST/ValidateSubjectUpdateApi.php
@@ -68,7 +68,7 @@ class ValidateSubjectUpdateApi extends SimpleHandler {
 				self::PARAM_SOURCE => 'body',
 				ParamValidator::PARAM_TYPE => 'array',
 				ParamValidator::PARAM_REQUIRED => true,
-				self::PARAM_DESCRIPTION => 'Proposed Statements (property/value pairs) for the proposed update. Shape matches docs/api/subject-format.md.',
+				self::PARAM_DESCRIPTION => 'Proposed Statements (property/value pairs) for the proposed update. Shape matches the subject JSON format documented at https://neowiki.ai/docs/api/subject-format.',
 			],
 			'comment' => [
 				self::PARAM_SOURCE => 'body',

--- a/src/EntryPoints/REST/ValidateSubjectUpdateApi.php
+++ b/src/EntryPoints/REST/ValidateSubjectUpdateApi.php
@@ -68,7 +68,7 @@ class ValidateSubjectUpdateApi extends SimpleHandler {
 				self::PARAM_SOURCE => 'body',
 				ParamValidator::PARAM_TYPE => 'array',
 				ParamValidator::PARAM_REQUIRED => true,
-				self::PARAM_DESCRIPTION => 'Proposed Statements (property/value pairs) for the proposed update. Shape matches docs/SubjectFormat.md.',
+				self::PARAM_DESCRIPTION => 'Proposed Statements (property/value pairs) for the proposed update. Shape matches docs/api/subject-format.md.',
 			],
 			'comment' => [
 				self::PARAM_SOURCE => 'body',

--- a/tests/phpunit/DocsPathReferencesTest.php
+++ b/tests/phpunit/DocsPathReferencesTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests;
+
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+/**
+ * Guards the docs paths cited in production code against the docs tree.
+ *
+ * Several REST param descriptions point readers at a documentation file. Those strings are
+ * user-facing: they are served in the generated OpenAPI spec. Nothing else checks them, so a
+ * doc rename silently turns them into dead references.
+ *
+ * When this fails, either the doc moved (update the citing string) or the path was never right.
+ *
+ * @coversNothing
+ */
+class DocsPathReferencesTest extends TestCase {
+
+	public function testEveryDocsPathCitedInSourceCodeExists(): void {
+		$this->assertSame(
+			[],
+			$this->danglingDocsReferences(),
+			'These src/ files cite a docs file that does not exist. Point them at the current path.'
+		);
+	}
+
+	/**
+	 * @return list<string> e.g. "src/EntryPoints/REST/ValidateSubjectApi.php:66 cites docs/Foo.md"
+	 */
+	private function danglingDocsReferences(): array {
+		$dangling = [];
+
+		foreach ( $this->sourceFiles() as $file ) {
+			foreach ( $this->citedDocsPaths( $file ) as $line => $paths ) {
+				foreach ( $paths as $path ) {
+					if ( !file_exists( $this->extensionRoot() . '/' . $path ) ) {
+						$relativeFile = substr( $file, strlen( $this->extensionRoot() ) + 1 );
+						$dangling[] = "$relativeFile:$line cites $path";
+					}
+				}
+			}
+		}
+
+		return $dangling;
+	}
+
+	/**
+	 * @return list<string> absolute paths of every PHP file under src/.
+	 */
+	private function sourceFiles(): array {
+		$files = [];
+
+		$directory = new RecursiveDirectoryIterator( $this->extensionRoot() . '/src' );
+		/** @var SplFileInfo $file */
+		foreach ( new RecursiveIteratorIterator( $directory ) as $file ) {
+			if ( $file->isFile() && $file->getExtension() === 'php' ) {
+				$files[] = $file->getPathname();
+			}
+		}
+
+		sort( $files );
+
+		return $files;
+	}
+
+	/**
+	 * @return array<int, list<string>> docs paths cited in the file, keyed by line number.
+	 */
+	private function citedDocsPaths( string $file ): array {
+		$contents = file_get_contents( $file );
+		$this->assertNotFalse( $contents, "Could not read $file" );
+
+		$cited = [];
+
+		foreach ( explode( "\n", $contents ) as $index => $line ) {
+			preg_match_all( '#\bdocs/[A-Za-z0-9._/-]+\.md#', $line, $matches );
+
+			if ( $matches[0] !== [] ) {
+				$cited[$index + 1] = $matches[0];
+			}
+		}
+
+		return $cited;
+	}
+
+	private function extensionRoot(): string {
+		return dirname( __DIR__, 2 );
+	}
+
+}

--- a/tests/phpunit/DocsPathReferencesTest.php
+++ b/tests/phpunit/DocsPathReferencesTest.php
@@ -10,11 +10,18 @@ use RecursiveIteratorIterator;
 use SplFileInfo;
 
 /**
- * Guards the docs paths cited in production code against the docs tree.
+ * Guards the documentation references cited in production code against the docs tree.
  *
- * Several REST param descriptions point readers at a documentation file. Those strings are
+ * Some REST param descriptions point readers at NeoWiki documentation. Those strings are
  * user-facing: they are served in the generated OpenAPI spec. Nothing else checks them, so a
  * doc rename silently turns them into dead references.
+ *
+ * Two citation forms are guarded, both resolved offline against the local docs tree:
+ *  - Repo-relative paths (docs/....md), used in developer-facing code comments. A docs/....md
+ *    sequence inside a URL is not such a citation and is ignored.
+ *  - Public docs-site URLs (https://neowiki.ai/docs/...), used in the OpenAPI param descriptions
+ *    because their readers do not have the source tree. Each must map to a doc file that exists
+ *    in this repo (site URL path -> docs/....md).
  *
  * When this fails, either the doc moved (update the citing string) or the path was never right.
  *
@@ -22,11 +29,22 @@ use SplFileInfo;
  */
 class DocsPathReferencesTest extends TestCase {
 
+	private const DOCS_SITE_PREFIX = 'https://neowiki.ai/';
+
 	public function testEveryDocsPathCitedInSourceCodeExists(): void {
 		$this->assertSame(
 			[],
 			$this->danglingDocsReferences(),
 			'These src/ files cite a docs file that does not exist. Point them at the current path.'
+		);
+	}
+
+	public function testEveryDocsSiteUrlCitedInSourceCodeResolvesToADocFile(): void {
+		$this->assertSame(
+			[],
+			$this->danglingDocsSiteUrls(),
+			'These src/ files cite a ' . self::DOCS_SITE_PREFIX . 'docs/... URL with no matching doc file '
+				. 'in the repo. The published page and its docs/....md source must both exist.'
 		);
 	}
 
@@ -40,14 +58,41 @@ class DocsPathReferencesTest extends TestCase {
 			foreach ( $this->citedDocsPaths( $file ) as $line => $paths ) {
 				foreach ( $paths as $path ) {
 					if ( !file_exists( $this->extensionRoot() . '/' . $path ) ) {
-						$relativeFile = substr( $file, strlen( $this->extensionRoot() ) + 1 );
-						$dangling[] = "$relativeFile:$line cites $path";
+						$dangling[] = $this->relativePath( $file ) . ":$line cites $path";
 					}
 				}
 			}
 		}
 
 		return $dangling;
+	}
+
+	/**
+	 * @return list<string> e.g. "src/.../Foo.php:66 cites https://neowiki.ai/docs/x (no docs/x.md)"
+	 */
+	private function danglingDocsSiteUrls(): array {
+		$dangling = [];
+
+		foreach ( $this->sourceFiles() as $file ) {
+			foreach ( $this->citedDocsSiteUrls( $file ) as $line => $urls ) {
+				foreach ( $urls as $url ) {
+					$docFile = $this->docFileForSiteUrl( $url );
+					if ( !file_exists( $this->extensionRoot() . '/' . $docFile ) ) {
+						$dangling[] = $this->relativePath( $file ) . ":$line cites $url (no $docFile)";
+					}
+				}
+			}
+		}
+
+		return $dangling;
+	}
+
+	/**
+	 * Maps a public docs-site URL to its repo source file: strip the site prefix, append .md.
+	 * e.g. https://neowiki.ai/docs/api/subject-format -> docs/api/subject-format.md
+	 */
+	private function docFileForSiteUrl( string $url ): string {
+		return substr( $url, strlen( self::DOCS_SITE_PREFIX ) ) . '.md';
 	}
 
 	/**
@@ -70,23 +115,64 @@ class DocsPathReferencesTest extends TestCase {
 	}
 
 	/**
-	 * @return array<int, list<string>> docs paths cited in the file, keyed by line number.
+	 * Repo-relative docs/....md citations, keyed by line number. Paths that are part of a URL
+	 * (e.g. https://docs.example.com/docs/x.md) are excluded: they are not repo citations.
+	 *
+	 * @return array<int, list<string>>
 	 */
 	private function citedDocsPaths( string $file ): array {
-		$contents = file_get_contents( $file );
-		$this->assertNotFalse( $contents, "Could not read $file" );
-
 		$cited = [];
 
-		foreach ( explode( "\n", $contents ) as $index => $line ) {
-			preg_match_all( '#\bdocs/[A-Za-z0-9._/-]+\.md#', $line, $matches );
+		foreach ( $this->lines( $file ) as $line => $text ) {
+			$outsideUrls = preg_replace( '#https?://\S+#', '', $text );
+			preg_match_all( '#\bdocs/[A-Za-z0-9._/-]+\.md#', $outsideUrls, $matches );
 
 			if ( $matches[0] !== [] ) {
-				$cited[$index + 1] = $matches[0];
+				$cited[$line] = $matches[0];
 			}
 		}
 
 		return $cited;
+	}
+
+	/**
+	 * Public docs-site URLs (https://neowiki.ai/docs/...), keyed by line number. The path stops
+	 * at the first non-slug character, so a trailing sentence period is not captured.
+	 *
+	 * @return array<int, list<string>>
+	 */
+	private function citedDocsSiteUrls( string $file ): array {
+		$cited = [];
+		$pattern = '#' . preg_quote( self::DOCS_SITE_PREFIX, '#' ) . 'docs/[A-Za-z0-9_/-]+#';
+
+		foreach ( $this->lines( $file ) as $line => $text ) {
+			preg_match_all( $pattern, $text, $matches );
+
+			if ( $matches[0] !== [] ) {
+				$cited[$line] = $matches[0];
+			}
+		}
+
+		return $cited;
+	}
+
+	/**
+	 * @return array<int, string> file lines keyed by 1-based line number.
+	 */
+	private function lines( string $file ): array {
+		$contents = file_get_contents( $file );
+		$this->assertNotFalse( $contents, "Could not read $file" );
+
+		$lines = [];
+		foreach ( explode( "\n", $contents ) as $index => $text ) {
+			$lines[$index + 1] = $text;
+		}
+
+		return $lines;
+	}
+
+	private function relativePath( string $file ): string {
+		return substr( $file, strlen( $this->extensionRoot() ) + 1 );
 	}
 
 	private function extensionRoot(): string {


### PR DESCRIPTION
`ValidateSubjectApi` and `ValidateSubjectUpdateApi` tell API consumers that their `statements` shape "matches docs/SubjectFormat.md". No such file has ever existed — not before the docs reorganisation either — so the generated OpenAPI spec has been serving a dead reference. Their siblings `CreateSubjectApi` and `ReplaceSubjectApi` cite the same document and were corrected to `docs/api/subject-format.md` in #1034, which left two of the four subject-format citations pointing nowhere.

Point both at `docs/api/subject-format.md`, and add `DocsPathReferencesTest` to guard the class of bug: it resolves every `docs/….md` path cited anywhere in `src/` against the docs tree and fails on any that does not exist.

## Why a test for two strings

Nothing checked these strings, which is how a path that never existed could be advertised in the public API spec indefinitely. It also gives the reorganised docs a backstop: `RestApiDocsCoverageTest` already guards the endpoint table against `extension.json`, but nothing guarded code-to-docs citations, and #1034 moved every doc in the tree.

Worth noting for the record: #1035 states that "an exhaustive resolver over every `docs/…md` reference in all tracked file types confirms every target exists". These two references survived it — the resolver matched markdown and wikitext link syntax, not bare paths inside PHP string literals. The test added here is the version of that check that runs in CI.

## Verification

Run against the dev stack (MediaWiki container), not only CI:

- `DocsPathReferencesTest` was seen **failing first**, naming exactly the two offenders:
  ```
  0 => 'src/EntryPoints/REST/ValidateSubjectApi.php:66 cites docs/SubjectFormat.md'
  1 => 'src/EntryPoints/REST/ValidateSubjectUpdateApi.php:71 cites docs/SubjectFormat.md'
  ```
  and passing after the fix: `OK (1 test, 274 assertions)`.
- Green: `ValidateSubjectApi`, `ValidateSubjectUpdateApi`, `CreateSubjectApi`, `ReplaceSubjectApi`, `RestApiDocsCoverage`, and `ModuleSpecHandlerNeoWiki` (the OpenAPI spec test, 465 assertions).
- `make phpcs` clean. `make stan` reports 5 errors, all in `src/Infrastructure/Rdf/HardfRdfStreamWriter.php` (unresolved `hardf` symbols). That file is byte-identical to master, so they are pre-existing and unrelated to this change.

> Result of a review of #1034 and #1035 requested by @alistair3149. The dead reference was surfaced by that review; including the guard test rather than only fixing the two strings was his call.
> Context: the NeoWiki docs tree, the REST entry points, and the running dev stack.
> <sub>Written by Claude Code, `Opus 4.8 (1M context)`</sub>
