### PR TITLE
Finish the #895 cleanup: guard the isolation wiring, reconcile deleted pages, fix stale graph-plugin docs

### DIFF
--- a/docs/adr/019-graph-database-architecture.md
+++ b/docs/adr/019-graph-database-architecture.md
@@ -20,8 +20,10 @@ Data ecosystems. At the same time, the existing Neo4j/Cypher stack remains valua
 
 NeoWiki supports multiple graph database backends simultaneously. Each backend is a plugin that:
 
-1. **Receives domain events** (Subject created, updated, deleted; page deleted, moved) and maintains its own
-   projection of the data.
+1. **Receives domain events** (page saved, page deleted) and maintains its own projection of the data. A page
+   save carries the page's subjects, so subject creations, updates and deletions arrive as a save of their page.
+   There is no separate move event: MediaWiki records a move as a null revision, so a move arrives as a save, and
+   the page ID is stable across it.
 2. **Executes user queries** in its native query language and returns tabular results.
 3. **Validates user queries** if needed to ensure they are read-only, using backend-appropriate validation
    (extending [ADR 13](013-restrict-neo4j-access.md)'s approach).
@@ -43,7 +45,7 @@ contract is at the domain event level, not the graph model level.
 
 ### User-facing query language is per-backend
 
-Users write queries in whatever language their wiki's configured backends support. `{{#cypher:...}}` for Neo4j,
+Users write queries in whatever language their wiki's configured backends support. `{{#cypher_raw:...}}` for Neo4j,
 `{{#sparql:...}}` for a triple store. NeoWiki does not provide a query abstraction language. This keeps things
 simple, avoids reinventing SMW's `#ask`, and lets users leverage the full power of each query language.
 
@@ -69,7 +71,7 @@ This is not a near-term priority. The goal is to avoid architectural decisions t
   is used. It warrants its own design document.
 * The RDF mapping also enables RDF export (bulk dumps) at near-zero marginal cost, since the same mapping can
   serialize to a file instead of sending SPARQL Update requests.
-* User-facing query parser functions (`#cypher`, `#sparql`) go through the MediaWiki backend, which validates
+* User-facing query parser functions (`#cypher_raw`, `#sparql`) go through the MediaWiki backend, which validates
   queries and proxies them to the appropriate backend.
 * SPARQL endpoints can optionally be exposed directly to external consumers, which is standard practice in the
   LOD world (public SPARQL endpoints). Whether this is safe depends on the store: QLever supports access tokens

--- a/docs/extending/extending.md
+++ b/docs/extending/extending.md
@@ -143,6 +143,39 @@ the Page node. No new revision is created. `rebuild()` returns a `PageRefreshOut
 
 Genuine failures (such as the graph store being unreachable) throw rather than returning an outcome.
 
+### Graph Database Backends
+
+NeoWiki currently supports Neo4j only, but the graph projection is an extension point: implement
+`GraphDatabasePlugin` and NeoWiki keeps your store in sync alongside Neo4j.
+
+```php
+class MyGraphDatabasePlugin implements GraphDatabasePlugin {
+
+	public function savePage( Page $page ): void {
+		// Project the page and its subjects into your store.
+	}
+
+	public function deletePage( PageId $pageId ): void {
+		// Remove the page from your store.
+	}
+
+}
+```
+
+Register with `NeoWikiRegistrar::addGraphDatabasePlugin()`. Example:
+[`src/RedHerbGraphDatabasePlugin.php`](https://github.com/ProfessionalWiki/NeoWiki/blob/master/tests/RedHerb/src/RedHerbGraphDatabasePlugin.php).
+
+`savePage` hands you the page with all of its Subjects and runs for every revision, so subject edits, undeletions
+and page moves all reach you as a save. `deletePage` gets only the page id.
+
+**Signal failure by throwing.** On an edit, delete or undelete, NeoWiki logs the failure and lets the user's
+operation commit, so a backend being down never blocks the wiki or starves the other backends — your projection is
+simply out of sync until someone runs `RebuildGraphDatabases`. During that rebuild, failures propagate instead, so
+the script can report which pages did not reconcile.
+
+Make `deletePage` idempotent: the rebuild re-issues a delete for every page MediaWiki no longer has, so it will ask
+you to remove pages that are already gone from your store.
+
 ### Reading NeoWiki data and authorization
 
 `NeoWikiExtension::getInstance()` exposes read-side services usable from any MediaWiki extension point
@@ -338,8 +371,9 @@ Custom SVG icons are also supported — pass an SVG string as the `icon`.
 
 These extension points are designed or partially present but not yet open to extensions:
 
-- **Graph database backends.** A `GraphDatabasePlugin` interface exists, but Neo4j is the only backend and
-  is currently hardcoded.
+- **Query surfaces for a graph database backend.** The projection side is extensible (see
+  "Graph Database Backends"), but a backend cannot yet contribute its own parser function, REST route, or
+  `mw.neowiki` Lua function; Neo4j's are wired in core.
 - **A published TypeScript types package.** TypeScript authors get types today by pointing their `tsconfig` at
   NeoWiki's source (see "Authoring in TypeScript" and [ADR 24](../adr/024-frontend-extension-mechanism.md)). A
   published, versioned package is deferred until a consumer needs types without a NeoWiki checkout.

--- a/docs/operations/maintenance.md
+++ b/docs/operations/maintenance.md
@@ -17,15 +17,15 @@ can wipe and rebuild the Neo4j copy from the canonical slots at any time. From t
 php maintenance/run.php NeoWiki:RebuildGraphDatabases
 ```
 
-It re-saves every Subject from each page's latest revision. Run it to:
+It re-saves every Subject from each page's latest revision, and removes the pages MediaWiki no longer has. Run it to:
 
 - Recover after a Neo4j wipe or restore.
 - Fix any drift between the Neo4j copy and the canonical revision slots.
 
 Two things to plan around:
 
-- It does not clear the graph first, so orphan nodes from a drifted projection can survive a rebuild. For a
-  guaranteed-clean result, wipe the Neo4j data volume before rebuilding.
+- It reconciles pages, not stray data. A node the projection never knew about — one written directly to Neo4j, say —
+  is not something the rebuild can find. For a guaranteed-clean result, wipe the Neo4j data volume before rebuilding.
 - It runs as a single sequential process with no batching or resume, so the time scales with the number of pages. Plan
   downtime on large wikis.
 
@@ -44,9 +44,27 @@ so it matches.
 NeoWiki is pre-release, so a new version can change the schema or data format with no migration path. Your evaluation
 data may not survive an upgrade, so be ready to rebuild it from scratch.
 
+## What happens during a Neo4j outage
+
+The graph is a regenerable copy, so NeoWiki never fails an edit because it could not write to it. Ordinary wiki
+editing survives an outage; structured data does not.
+
+- **Editing pages works.** Edits, deletions and undeletions all commit. NeoWiki logs the projection failure on the
+  `NeoWiki` channel and stays out of the way.
+- **Editing and displaying Subjects fails**, along with queries and anything else that reads the graph. Subjects are
+  resolved to their page through an index that lives only in Neo4j.
+
+Once Neo4j is back, [rebuild the graph](#rebuilding-the-graph). It re-saves the pages that still exist and removes the
+ones MediaWiki no longer has, repairing both a failed save and a failed delete, and it names any page it could not
+reconcile.
+
+Route the `NeoWiki` log channel somewhere you read. On a default MediaWiki install it goes nowhere, which leaves the
+rebuild's output as your only sign that anything went wrong.
+
 ## Current limitations
 
 One known limitation while NeoWiki is pre-release:
 
-- **A Neo4j outage blocks writes.** Edits, deletes, and undeletes fail while Neo4j is unreachable; only reads and
-  queries keep working. Tracked in #877.
+- **NeoWiki requires a configured graph backend.** The subject-to-page index lives only in Neo4j, so a wiki with no
+  backend configured cannot create, edit or display Subjects. Tracked in
+  [#895](https://github.com/ProfessionalWiki/NeoWiki/issues/895).

--- a/maintenance/RebuildGraphDatabases.php
+++ b/maintenance/RebuildGraphDatabases.php
@@ -11,6 +11,8 @@ use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
 use ProfessionalWiki\NeoWiki\Application\PageRefreshOutcome;
 use ProfessionalWiki\NeoWiki\Application\SubjectPageRebuilder;
+use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphDatabasePlugin;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\MediaWikiSubjectRepository;
 
@@ -46,6 +48,48 @@ class RebuildGraphDatabases extends Maintenance {
 		}
 
 		$this->outputChanneled( "Rebuild finished. Rebuilt $rebuilt of " . count( $pageIds ) . ' pages.' );
+
+		$this->removeDeletedPages();
+	}
+
+	/**
+	 * Re-saving the pages that still exist cannot undo a projection delete that failed, so a page deleted
+	 * while a backend was unreachable would otherwise stay in the graph for good, its Subjects still
+	 * queryable. Re-issue the delete for every page MediaWiki no longer has. Deleting a page that is
+	 * already absent is a no-op, so this is safe to repeat.
+	 */
+	private function removeDeletedPages(): void {
+		$pageIds = NeoWikiExtension::getInstance()->newDeletedSubjectPageIdsLookup()->getDeletedSubjectPageIds();
+
+		if ( $pageIds === [] ) {
+			return;
+		}
+
+		$this->outputChanneled( 'Removing ' . count( $pageIds ) . ' deleted pages from the graph databases...' );
+
+		$graphDatabasePlugin = NeoWikiExtension::getInstance()->getGraphDatabasePlugin();
+
+		$removed = 0;
+
+		foreach ( $pageIds as $pageId ) {
+			if ( $this->removePage( $pageId, $graphDatabasePlugin ) ) {
+				$removed++;
+			}
+		}
+
+		$this->outputChanneled( "Removed $removed of " . count( $pageIds ) . ' deleted pages.' );
+	}
+
+	private function removePage( int $pageId, GraphDatabasePlugin $graphDatabasePlugin ): bool {
+		try {
+			$graphDatabasePlugin->deletePage( new PageId( $pageId ) );
+		}
+		catch ( Exception $e ) {
+			$this->outputChanneled( "Failed to remove deleted page $pageId: " . $e->getMessage() );
+			return false;
+		}
+
+		return true;
 	}
 
 	private function rebuildPage( int $pageId, SubjectPageRebuilder $rebuilder ): bool {

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -96,6 +96,7 @@ use ProfessionalWiki\NeoWiki\EntryPoints\REST\SetSubjectsOrderingApi;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\ValidateSubjectApi;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\ValidateSubjectUpdateApi;
 use ProfessionalWiki\NeoWiki\Infrastructure\AuthorityBasedSubjectAuthorizer;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\DatabaseDeletedSubjectPageIdsLookup;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\DatabaseSchemaNameLookup;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\PageContentFetcher;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\PageContentSaver;
@@ -118,6 +119,7 @@ use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jPageIde
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Neo4jPlugin;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jSubjectLabelLookup;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jValueBuilderRegistry;
+use ProfessionalWiki\NeoWiki\Persistence\DeletedSubjectPageIdsLookup;
 use ProfessionalWiki\NeoWiki\Persistence\SchemaNameLookup;
 use ProfessionalWiki\NeoWiki\Persistence\LayoutNameLookup;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\DatabaseLayoutNameLookup;
@@ -633,6 +635,13 @@ class NeoWikiExtension {
 		return new SubjectPageRebuilder(
 			$this->newRebuildStoreContentHandler(),
 			MediaWikiServices::getInstance()->getWikiPageFactory()
+		);
+	}
+
+	public function newDeletedSubjectPageIdsLookup(): DeletedSubjectPageIdsLookup {
+		return new DatabaseDeletedSubjectPageIdsLookup(
+			MediaWikiServices::getInstance()->getConnectionProvider()->getReplicaDatabase(),
+			MediaWikiServices::getInstance()->getSlotRoleStore()
 		);
 	}
 

--- a/src/Persistence/DeletedSubjectPageIdsLookup.php
+++ b/src/Persistence/DeletedSubjectPageIdsLookup.php
@@ -1,0 +1,17 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Persistence;
+
+interface DeletedSubjectPageIdsLookup {
+
+	/**
+	 * Page ids that once carried Subjects and no longer exist in MediaWiki, and so should not be
+	 * present in any graph database either.
+	 *
+	 * @return int[]
+	 */
+	public function getDeletedSubjectPageIds(): array;
+
+}

--- a/src/Persistence/MediaWiki/DatabaseDeletedSubjectPageIdsLookup.php
+++ b/src/Persistence/MediaWiki/DatabaseDeletedSubjectPageIdsLookup.php
@@ -1,0 +1,65 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Persistence\MediaWiki;
+
+use MediaWiki\Storage\NameTableAccessException;
+use MediaWiki\Storage\NameTableStore;
+use ProfessionalWiki\NeoWiki\Persistence\DeletedSubjectPageIdsLookup;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\MediaWikiSubjectRepository;
+use Wikimedia\Rdbms\IReadableDatabase;
+
+class DatabaseDeletedSubjectPageIdsLookup implements DeletedSubjectPageIdsLookup {
+
+	public function __construct(
+		private readonly IReadableDatabase $db,
+		private readonly NameTableStore $slotRoleStore,
+	) {
+	}
+
+	/**
+	 * Deleting a page moves its revisions to the archive table while leaving their slot rows in
+	 * place, so the pages that carried Subjects and are now gone are exactly the archived revisions
+	 * with a subject slot whose page has no row in the page table. An undeleted page reappears in
+	 * the page table and drops back out of this set.
+	 *
+	 * @return int[]
+	 */
+	public function getDeletedSubjectPageIds(): array {
+		$roleId = $this->getSubjectSlotRoleId();
+
+		if ( $roleId === null ) {
+			return [];
+		}
+
+		$pageIds = $this->db->newSelectQueryBuilder()
+			->select( 'ar_page_id' )
+			->distinct()
+			->from( 'archive' )
+			->join( 'slots', null, 'slot_revision_id = ar_rev_id' )
+			->leftJoin( 'page', null, 'page_id = ar_page_id' )
+			->where( [
+				'slot_role_id' => $roleId,
+				'page_id' => null,
+			] )
+			->orderBy( 'ar_page_id' )
+			->caller( __METHOD__ )
+			->fetchFieldValues();
+
+		return array_map( 'intval', $pageIds );
+	}
+
+	/**
+	 * A wiki that has never stored a Subject has no subject slot role, and therefore no deleted
+	 * subject pages either.
+	 */
+	private function getSubjectSlotRoleId(): ?int {
+		try {
+			return $this->slotRoleStore->getId( MediaWikiSubjectRepository::SLOT_NAME );
+		} catch ( NameTableAccessException ) {
+			return null;
+		}
+	}
+
+}

--- a/tests/phpunit/Application/RebuildPathPropagatesProjectionFailureTest.php
+++ b/tests/phpunit/Application/RebuildPathPropagatesProjectionFailureTest.php
@@ -5,7 +5,6 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Tests\Application;
 
 use MediaWiki\Title\Title;
-use ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiRegistrar;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
@@ -42,23 +41,13 @@ class RebuildPathPropagatesProjectionFailureTest extends NeoWikiIntegrationTestC
 	public function testRebuildPropagatesBackendFailureSoTheScriptCanReportIt(): void {
 		$this->createPageWithSubjects( 'Rebuild failure page', TestSubject::build() );
 
-		$this->registerThrowingGraphDatabasePlugin();
+		$this->registerGraphDatabasePlugins( new ThrowingGraphDatabasePlugin() );
 		$rebuilder = NeoWikiExtension::getInstance()->newSubjectPageRebuilder();
 
 		$this->expectException( RuntimeException::class );
 		$this->expectExceptionMessage( ThrowingGraphDatabasePlugin::FAILURE_MESSAGE );
 
 		$rebuilder->rebuild( Title::newFromText( 'Rebuild failure page' ) );
-	}
-
-	private function registerThrowingGraphDatabasePlugin(): void {
-		$this->setTemporaryHook(
-			'NeoWikiRegistration',
-			static function ( NeoWikiRegistrar $registrar ): void {
-				$registrar->addGraphDatabasePlugin( new ThrowingGraphDatabasePlugin() );
-			}
-		);
-		NeoWikiExtension::resetInstance();
 	}
 
 }

--- a/tests/phpunit/EntryPoints/HookPathIsolatesProjectionFailureTest.php
+++ b/tests/phpunit/EntryPoints/HookPathIsolatesProjectionFailureTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints;
+
+use MediaWiki\Deferred\DeferredUpdates;
+use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
+use ProfessionalWiki\NeoWiki\Domain\Page\Page;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpyGraphDatabasePlugin;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\ThrowingGraphDatabasePlugin;
+use StatusValue;
+
+/**
+ * Guards the hook-facing write path at the wiring level: an edit and a delete must survive a backend
+ * that is down, and a failing backend must not starve the backends composed after it. Undeletes run
+ * through the same getStoreContentUC() wiring, so they are covered by the same guard.
+ *
+ * The counterpart of RebuildPathPropagatesProjectionFailureTest, which guards the opposite need on
+ * the maintenance path. Both are wiring tests on purpose: the decorator has its own unit tests, but
+ * without these nothing would catch NeoWikiExtension being rewired to the propagating composite,
+ * which would silently restore the outage-hard-fails-the-edit behavior that #1028 removed.
+ *
+ * @covers \ProfessionalWiki\NeoWiki\NeoWikiExtension
+ * @covers \ProfessionalWiki\NeoWiki\Domain\GraphDatabase\FailureIsolatingGraphDatabasePlugin
+ * @group Database
+ */
+class HookPathIsolatesProjectionFailureTest extends NeoWikiIntegrationTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->setUpNeo4j();
+		$this->createSchema( TestSubject::DEFAULT_SCHEMA_ID );
+		$this->markPageTableAsUsed();
+	}
+
+	protected function tearDown(): void {
+		parent::tearDown();
+		// The tests rebuild the singleton with extra plugins registered; reset it so later tests get a
+		// clean instance rebuilt without the temporary hook.
+		NeoWikiExtension::resetInstance();
+	}
+
+	public function testEditCommitsWhenABackendIsDown(): void {
+		$this->registerGraphDatabasePlugins( new ThrowingGraphDatabasePlugin() );
+
+		$revision = $this->createPageWithSubjects( 'Edit during outage', TestSubject::build() );
+
+		$this->assertNotNull( $revision, 'the edit should still commit while a backend is unreachable' );
+	}
+
+	public function testDeleteCommitsWhenABackendIsDown(): void {
+		$this->createPageWithSubjects( 'Delete during outage', TestSubject::build() );
+		$this->registerGraphDatabasePlugins( new ThrowingGraphDatabasePlugin() );
+
+		$status = $this->deletePageByName( 'Delete during outage' );
+
+		$this->assertStatusGood( $status, 'the deletion should still commit while a backend is unreachable' );
+	}
+
+	public function testFailingBackendDoesNotStarveTheBackendsAfterIt(): void {
+		$spy = new SpyGraphDatabasePlugin();
+		$this->registerGraphDatabasePlugins( new ThrowingGraphDatabasePlugin(), $spy );
+
+		$revision = $this->createPageWithSubjects( 'Outage isolation page', TestSubject::build() );
+		$this->assertNotNull( $revision );
+
+		$this->assertSame(
+			[ $revision->getPageId() ],
+			array_map( static fn ( Page $page ) => $page->getId()->id, $spy->savedPages ),
+			'a backend composed after the failing one should still receive savePage'
+		);
+	}
+
+	private function deletePageByName( string $pageName ): StatusValue {
+		$page = MediaWikiServices::getInstance()->getWikiPageFactory()->newFromTitle( Title::newFromText( $pageName ) );
+		$deletePage = MediaWikiServices::getInstance()->getDeletePageFactory()->newDeletePage(
+			$page,
+			$this->getTestSysop()->getUser()
+		);
+
+		$status = $deletePage->deleteUnsafe( 'test deletion' );
+
+		DeferredUpdates::doUpdates();
+
+		return $status;
+	}
+
+}

--- a/tests/phpunit/Maintenance/RebuildGraphDatabasesTest.php
+++ b/tests/phpunit/Maintenance/RebuildGraphDatabasesTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Maintenance;
+
+use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+use ProfessionalWiki\NeoWiki\Maintenance\RebuildGraphDatabases;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpyGraphDatabasePlugin;
+
+// The maintenance script is not PSR-4 autoloadable (it lives outside src/), so load it explicitly.
+// Its RUN_MAINTENANCE_IF_MAIN guard is a no-op under PHPUnit, so this does not execute the script.
+require_once __DIR__ . '/../../../maintenance/RebuildGraphDatabases.php';
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Maintenance\RebuildGraphDatabases
+ * @group Database
+ */
+class RebuildGraphDatabasesTest extends NeoWikiIntegrationTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->setUpNeo4j();
+		$this->createSchema( TestSubject::DEFAULT_SCHEMA_ID );
+		$this->markPageTableAsUsed();
+	}
+
+	protected function tearDown(): void {
+		parent::tearDown();
+		// The test rebuilds the singleton with a spy plugin registered; reset it so later tests get a
+		// clean instance rebuilt without the temporary hook.
+		NeoWikiExtension::resetInstance();
+	}
+
+	public function testRebuildRemovesADeletedSubjectPageFromTheGraph(): void {
+		$this->createPageWithSubjects( 'Surviving page before', TestSubject::build() );
+		$deleted = $this->createPageWithSubjects( 'Deleted during outage', TestSubject::build() );
+		$this->createPageWithSubjects( 'Surviving page after', TestSubject::build() );
+
+		$this->deletePageByName( 'Deleted during outage' );
+
+		$spy = new SpyGraphDatabasePlugin();
+		$this->registerGraphDatabasePlugins( $spy );
+
+		$this->runRebuild();
+
+		$this->assertSame(
+			[ $deleted->getPageId() ],
+			array_map( static fn ( PageId $pageId ) => $pageId->id, $spy->deletedPageIds ),
+			'the rebuild should remove exactly the page MediaWiki no longer has'
+		);
+	}
+
+	private function runRebuild(): void {
+		ob_start();
+		try {
+			( new RebuildGraphDatabases() )->execute();
+		} finally {
+			ob_end_clean();
+		}
+	}
+
+	private function deletePageByName( string $pageName ): void {
+		$page = MediaWikiServices::getInstance()->getWikiPageFactory()->newFromTitle( Title::newFromText( $pageName ) );
+		$deletePage = MediaWikiServices::getInstance()->getDeletePageFactory()->newDeletePage(
+			$page,
+			$this->getTestSysop()->getUser()
+		);
+
+		$this->assertStatusGood( $deletePage->deleteUnsafe( 'test deletion' ) );
+	}
+
+}

--- a/tests/phpunit/NeoWikiIntegrationTestCase.php
+++ b/tests/phpunit/NeoWikiIntegrationTestCase.php
@@ -18,6 +18,7 @@ use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectMap;
 use ProfessionalWiki\NeoWiki\EntryPoints\Content\MappingContent;
 use ProfessionalWiki\NeoWiki\EntryPoints\Content\SchemaContent;
 use ProfessionalWiki\NeoWiki\EntryPoints\Content\SubjectContent;
+use ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiRegistrar;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\MediaWikiSubjectRepository;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSchema;
@@ -92,6 +93,27 @@ class NeoWikiIntegrationTestCase extends MediaWikiIntegrationTestCase {
 		if ( !in_array( 'page', $this->tablesUsed ) ) {
 			$this->tablesUsed[] = 'page';
 		}
+	}
+
+	/**
+	 * Registers extra graph database plugins through the NeoWikiRegistration hook and rebuilds the singleton
+	 * so they are composed into the write paths, letting a test drive the real hook wiring with a backend of
+	 * its choosing (a spy, or one that always throws).
+	 *
+	 * Callers must reset the singleton again in tearDown, so later tests get an instance built without the
+	 * temporary hook.
+	 */
+	protected function registerGraphDatabasePlugins( GraphDatabasePlugin ...$plugins ): void {
+		$this->setTemporaryHook(
+			'NeoWikiRegistration',
+			static function ( NeoWikiRegistrar $registrar ) use ( $plugins ): void {
+				foreach ( $plugins as $plugin ) {
+					$registrar->addGraphDatabasePlugin( $plugin );
+				}
+			}
+		);
+
+		NeoWikiExtension::resetInstance();
 	}
 
 	protected function newProjectionStore(): GraphDatabasePlugin {

--- a/tests/phpunit/Persistence/MediaWiki/DatabaseDeletedSubjectPageIdsLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/DatabaseDeletedSubjectPageIdsLookupTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Persistence\MediaWiki;
+
+use MediaWiki\MediaWikiServices;
+use MediaWiki\Revision\RevisionRecord;
+use MediaWiki\Title\Title;
+use ProfessionalWiki\NeoWiki\Persistence\DeletedSubjectPageIdsLookup;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\DatabaseDeletedSubjectPageIdsLookup;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Persistence\MediaWiki\DatabaseDeletedSubjectPageIdsLookup
+ * @group Database
+ */
+class DatabaseDeletedSubjectPageIdsLookupTest extends NeoWikiIntegrationTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->createSchema( TestSubject::DEFAULT_SCHEMA_ID );
+		$this->markPageTableAsUsed();
+	}
+
+	public function testFindsTheSubjectPageThatNoLongerExists(): void {
+		$this->createPageWithSubjects( 'Surviving page before', TestSubject::build() );
+		$deleted = $this->createPageWithSubjects( 'Deleted page', TestSubject::build() );
+		$this->createPageWithSubjects( 'Surviving page after', TestSubject::build() );
+
+		$this->deletePageByName( 'Deleted page' );
+
+		$this->assertSame( [ $deleted->getPageId() ], $this->newLookup()->getDeletedSubjectPageIds() );
+	}
+
+	public function testUndeletedPageIsNoLongerReported(): void {
+		$this->createPageWithSubjects( 'Restored page', TestSubject::build() );
+
+		$this->deletePageByName( 'Restored page' );
+		$this->undeletePageByName( 'Restored page' );
+
+		$this->assertSame( [], $this->newLookup()->getDeletedSubjectPageIds() );
+	}
+
+	public function testDeletedPageWithoutSubjectsIsNotReported(): void {
+		// The subject page is what registers the subject slot role, without which the lookup short-circuits
+		// and this test would pass no matter what the query selects.
+		$subjectPage = $this->createPageWithSubjects( 'Deleted subject page', TestSubject::build() );
+		$this->editPage( 'Plain page', 'A page carrying no Subjects.' );
+
+		$this->deletePageByName( 'Plain page' );
+		$this->deletePageByName( 'Deleted subject page' );
+
+		$this->assertSame( [ $subjectPage->getPageId() ], $this->newLookup()->getDeletedSubjectPageIds() );
+	}
+
+	/**
+	 * A page can be archived and present at the same time: restoring only some of a deleted page's
+	 * revisions brings the page back while the rest stay in the archive. Purging it from the graph then
+	 * would delete a live page's data, so the lookup must not report it.
+	 */
+	public function testPageThatIsBothArchivedAndPresentIsNotReported(): void {
+		$revision = $this->createPageWithSubjects( 'Partly restored page', TestSubject::build() );
+
+		$this->archiveRevisionOfExistingPage( $revision );
+
+		$this->assertSame( [], $this->newLookup()->getDeletedSubjectPageIds() );
+	}
+
+	private function newLookup(): DeletedSubjectPageIdsLookup {
+		return new DatabaseDeletedSubjectPageIdsLookup(
+			$this->getDb(),
+			MediaWikiServices::getInstance()->getSlotRoleStore()
+		);
+	}
+
+	private function deletePageByName( string $pageName ): void {
+		$page = MediaWikiServices::getInstance()->getWikiPageFactory()->newFromTitle( Title::newFromText( $pageName ) );
+		$deletePage = MediaWikiServices::getInstance()->getDeletePageFactory()->newDeletePage(
+			$page,
+			$this->getTestSysop()->getUser()
+		);
+
+		$this->assertStatusGood( $deletePage->deleteUnsafe( 'test deletion' ) );
+	}
+
+	private function undeletePageByName( string $pageName ): void {
+		$undeletePage = MediaWikiServices::getInstance()->getUndeletePageFactory()->newUndeletePage(
+			MediaWikiServices::getInstance()->getWikiPageFactory()->newFromTitle( Title::newFromText( $pageName ) ),
+			$this->getTestSysop()->getUser()
+		);
+
+		$this->assertStatusGood( $undeletePage->undeleteUnsafe( 'test undeletion' ) );
+	}
+
+	/**
+	 * Archives one revision of a page that still exists, which is the state a partial undeletion leaves
+	 * behind. Written straight to the archive table: MediaWiki only reaches this state through a selective
+	 * restore, which is far more setup than the row it produces.
+	 */
+	private function archiveRevisionOfExistingPage( RevisionRecord $revision ): void {
+		$row = $this->getDb()->newSelectQueryBuilder()
+			->select( [ 'rev_actor', 'rev_comment_id', 'rev_timestamp', 'rev_len', 'rev_sha1' ] )
+			->from( 'revision' )
+			->where( [ 'rev_id' => $revision->getId() ] )
+			->caller( __METHOD__ )
+			->fetchRow();
+
+		$this->getDb()->newInsertQueryBuilder()
+			->insertInto( 'archive' )
+			->row( [
+				'ar_page_id' => $revision->getPageId(),
+				'ar_rev_id' => $revision->getId(),
+				'ar_namespace' => NS_MAIN,
+				'ar_title' => Title::newFromText( 'Partly restored page' )->getDBkey(),
+				'ar_actor' => $row->rev_actor,
+				'ar_comment_id' => $row->rev_comment_id,
+				'ar_timestamp' => $row->rev_timestamp,
+				'ar_len' => $row->rev_len,
+				'ar_sha1' => $row->rev_sha1,
+				'ar_minor_edit' => 0,
+				'ar_deleted' => 0,
+			] )
+			->caller( __METHOD__ )
+			->execute();
+	}
+
+}


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/NeoWiki/issues/895

Closes out the cleanup #895 has left, now that #897 / #978 / #1000 / #1016 / #1028 have landed. One commit per fix.

## Guard the hook path's projection-failure isolation

#1028 made a failing backend never abort the edit that triggered it, but nothing tested that wiring:
`grep getStoreContentUC tests/` returned nothing. Rewiring `NeoWikiExtension` back to the propagating composite would
silently restore the outage-hard-fails-the-edit behavior and leave the suite green. The rebuild path already had such a
guard; its hook-path counterpart did not exist. The new test drives a real edit and deletion through the actual
MediaWiki hooks with a throwing backend, and was verified to fail on the reverted wiring.

## Reconcile deleted pages when rebuilding

`RebuildGraphDatabases` only re-saved the pages that still exist, so it could not undo a projection delete that failed:
a page deleted while a backend was unreachable stayed in the graph for good, its Subjects still queryable, while the
script reported a clean `Rebuilt N of N`. `neowiki-query` is granted to everyone, so a deleted page's structured data
stayed readable, and the only remedy was wiping the backend — drastic when a wiki farm shares one graph.

The rebuild now removes the pages MediaWiki no longer has. It re-issues `GraphDatabasePlugin::deletePage()`, which is
idempotent and backend-agnostic, so a future SPARQL backend inherits it. A page that is archived *and* present (a
partial undeletion) is excluded, since purging it would delete a live page's data.

## Documentation

- `extending.md` listed graph backends as "Not yet extensible ... Neo4j is the only backend and is currently
  hardcoded", which stopped being true when #978 shipped the registry. It now documents the extension point. What
  remains genuinely non-extensible is narrowed to a backend's user-facing query surfaces.
- `maintenance.md` still warned that "a Neo4j outage blocks writes ... Tracked in #877", which #1028 fixed. It now
  describes what actually happens: wiki pages keep working, NeoWiki's own Subject create/edit/display do not.
- ADR 019 listed plugin events that were never built (`Subject created, updated, deleted; page ... moved`) and named a
  parser function that has never existed (`{{#cypher:}}`). Corrections to what it records about the architecture, not
  to its decision.

## Verification

- An edit and a deletion both committed during the outage.
- Before this PR, the rebuild afterwards reported `Rebuilt 76 of 76 pages` while the deleted page's `Page` node and its
  `Subject` were still queryable via Cypher.
- With this PR, it reports `Removed 1 of 1 deleted pages` and the node is gone.

> Assessment of #895 against the code, and the resulting scope, directed by @alistair3149, who also rejected an earlier
> revision that recorded implementation status inside ADR 019 (an ADR is a durable record) and one that only corrected
> the log message for a failed delete instead of fixing the hole. An adversarial multi-agent review of the branch, plus
> mutation testing, caught three defects in earlier cuts: a log-message assertion that had become vacuous, outage docs
> that claimed Subject editing keeps working when it does not, and two new tests that passed for the wrong reasons (one
> short-circuited before reaching the query, one never produced the second revision it needed).
> Context: the NeoWiki codebase, ADR 019, and the merged #897 / #978 / #1000 / #1016 / #1028.
> <sub>Written by Claude Code, `Opus 4.8 (1M context)`</sub>
