### PR TITLE
Test that the graph rebuild reconciles deleted pages

### DIFF
--- a/tests/phpunit/Maintenance/RebuildGraphDatabasesTest.php
+++ b/tests/phpunit/Maintenance/RebuildGraphDatabasesTest.php
@@ -25,6 +25,7 @@ class RebuildGraphDatabasesTest extends NeoWikiIntegrationTestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
+		$this->setUpNeo4j();
 		$this->createSchema( TestSubject::DEFAULT_SCHEMA_ID );
 		$this->markPageTableAsUsed();
 	}

--- a/tests/phpunit/Maintenance/RebuildGraphDatabasesTest.php
+++ b/tests/phpunit/Maintenance/RebuildGraphDatabasesTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Maintenance;
+
+use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+use ProfessionalWiki\NeoWiki\Maintenance\RebuildGraphDatabases;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpyGraphDatabasePlugin;
+
+// The maintenance script is not PSR-4 autoloadable (it lives outside src/), so load it explicitly.
+// Its RUN_MAINTENANCE_IF_MAIN guard is a no-op under PHPUnit, so this does not execute the script.
+require_once __DIR__ . '/../../../maintenance/RebuildGraphDatabases.php';
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Maintenance\RebuildGraphDatabases
+ * @group Database
+ */
+class RebuildGraphDatabasesTest extends NeoWikiIntegrationTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->createSchema( TestSubject::DEFAULT_SCHEMA_ID );
+		$this->markPageTableAsUsed();
+	}
+
+	protected function tearDown(): void {
+		parent::tearDown();
+		// The test rebuilds the singleton with a spy plugin registered; reset it so later tests get a
+		// clean instance rebuilt without the temporary hook.
+		NeoWikiExtension::resetInstance();
+	}
+
+	public function testRebuildRemovesADeletedSubjectPageFromTheGraph(): void {
+		$this->createPageWithSubjects( 'Surviving page before', TestSubject::build() );
+		$deleted = $this->createPageWithSubjects( 'Deleted during outage', TestSubject::build() );
+		$this->createPageWithSubjects( 'Surviving page after', TestSubject::build() );
+
+		$this->deletePageByName( 'Deleted during outage' );
+
+		$spy = new SpyGraphDatabasePlugin();
+		$this->registerGraphDatabasePlugins( $spy );
+
+		$this->runRebuild();
+
+		$this->assertSame(
+			[ $deleted->getPageId() ],
+			array_map( static fn ( PageId $pageId ) => $pageId->id, $spy->deletedPageIds ),
+			'the rebuild should remove exactly the page MediaWiki no longer has'
+		);
+	}
+
+	private function runRebuild(): void {
+		ob_start();
+		try {
+			( new RebuildGraphDatabases() )->execute();
+		} finally {
+			ob_end_clean();
+		}
+	}
+
+	private function deletePageByName( string $pageName ): void {
+		$page = MediaWikiServices::getInstance()->getWikiPageFactory()->newFromTitle( Title::newFromText( $pageName ) );
+		$deletePage = MediaWikiServices::getInstance()->getDeletePageFactory()->newDeletePage(
+			$page,
+			$this->getTestSysop()->getUser()
+		);
+
+		$this->assertStatusGood( $deletePage->deleteUnsafe( 'test deletion' ) );
+	}
+
+}


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1038

`RebuildGraphDatabases::execute()` reconciles pages MediaWiki no longer has, but that wiring was untested. `DatabaseDeletedSubjectPageIdsLookup` and the Neo4j `deletePage` are each covered in isolation, yet nothing drove `execute()` to assert a deleted subject page is actually removed from the graph on rebuild; deleting the `removeDeletedPages()` call left the whole suite green.

Drive the maintenance script through `execute()` with a spy backend registered: surviving subject pages either side of one that is then deleted, then assert the spy receives `deletePage` for exactly the deleted page. Verified to fail when the `removeDeletedPages()` call is removed.

Targets the #1038 branch so it lands with that work.

> <sub>AI-authored — Claude Code, `Opus 4.8 (1M context)`; created by @malberts while AI-reviewing #1038, one blocking test-gap fix; diff not yet human-reviewed; test written TDD-style (verified to fail when the guarded call is reverted), full PHPUnit suite + phpcs + phpstan green locally.</sub>