### PR TITLE
Add the Source contract, registry, and LocalSource

### DIFF
--- a/docs/adr/027-source-interface-contract.md
+++ b/docs/adr/027-source-interface-contract.md
@@ -1,0 +1,74 @@
+# Source Interface Contract
+
+Date: 2026-07-15
+
+Status: Draft (frozen when the T2 PR merges)
+
+## Context
+
+ADR 23 decided that Subjects come from pluggable Sources and left the Source interface contract as
+an open question. Issue #993's T2 work order assigns freezing it to the T2 PR. The contract must
+serve the wiki-farm case (more registered Sources), the future on-wiki SMW/Wikibase and federation
+adapters, and T3's schema references, without a per-Source capability matrix (ADR 23 Won'ts).
+
+## Decision
+
+A single `Source` interface (Domain\Source) with exactly five members:
+
+- `getSubject( SubjectId $id ): ?Subject` — by-id resolution; the registry routes, the Source
+  interprets its own localIds.
+- `getSchema( SchemaName $schemaName ): ?Schema` — schemas come from Sources; a schema's source is
+  independent of a subject's source.
+- `isEditable(): bool` — the entire capability surface: local editable + versioned, sourced
+  read-only.
+- `isValidLocalId( string $localId ): bool` — each Source owns its localId grammar; the serialized
+  qualified form additionally restricts localIds to URL-path-safe characters at the wire level.
+- `getBaseUri(): ?string` — IRI projection base for this Source's ids. Native RDF projection mints
+  all IRIs from the per-wiki base (`NeoWikiConfig->rdfBaseUri`, see [RDF Export](../rdf/rdf-export.md)); a
+  per-Source base generalizes this for sourced Subjects. `LocalSource` returns the wiki base; no
+  per-source consumer exists yet.
+
+A `SourceRegistry` maps source key to Source, constructed with the local source key
+(`WikiMap::getCurrentWikiId()`), maps bare ids to the local Source, returns null for unknown keys,
+and throws at registration time on duplicate keys. Keys are compared byte-for-byte: case-insensitive
+comparison is foreclosed because dbnames on Linux MySQL/MariaDB (`lower_case_table_names=0`) can
+differ only in case, making two such wikis distinct, and the graph's `wiki_id` stores the wiki ID
+verbatim (ADR 22), so case-folding would desynchronize the derived pair from stored data. The
+registry may additionally warn at registration when a new key differs from an existing one only by
+case, as an operator-error guard; comparison semantics stay byte-exact. Extensions register Sources through
+`NeoWikiRegistrar::addSource()` in the `NeoWikiRegistration` hook; core registers `LocalSource`
+first.
+
+Sources play no part at query time: queryability is materialisation into the graph (ADR 23). Write
+paths do not consult the registry; sourced Subjects are read-only. An unresolvable source key
+degrades to not-found (null) plus one logged warning, never fatally.
+
+## Consequences
+
+- T3 resolves schema references through the schema's own Source with no contract change; T4 gets
+  per-source target validation via `isValidLocalId`.
+- Write-back, when designed, arrives as a separate `WritableSource` interface extending `Source`
+  (non-breaking for existing implementers), under its own ADR.
+- The local persistence path gains read-side indirection (the routing lookup, the registry,
+  `LocalSource`, and lazy construction wrappers around the local lookups) and is otherwise
+  byte-for-byte unchanged.
+- The RDF projection path (`RdfPageProjector`) consumes `SchemaLookup` directly; when T3 routes
+  schema resolution through Sources, that path becomes part of its surface. The page-scoped RDF
+  export (`ExportPageRdfApi` / `RdfPageExporter`) reads Subjects outside `SubjectLookup` and is
+  outside T2's routing surface.
+
+## Alternatives considered
+
+- **localId-string resolution parameter**: rejected; remote Sources need the full id to construct
+  qualified Subjects.
+- **Result object for unresolvable Sources**: rejected; unknown-source behaves exactly like
+  not-found at every surface, and a result object would rewrite all read signatures for it.
+- **Unused write-capability stub**: rejected in favor of the `WritableSource` evolution path.
+- **Amending ADR 23**: rejected; one decision per ADR.
+
+## Related
+
+- [ADR 23: Subject Sources](023-subject-sources.md) (the model this contract serves)
+- [ADR 22: Multi-wiki Graph Node Identity](022-multi-wiki-node-identity.md) (node identity)
+- [ADR 1: Domain-centric Architecture](001-domain-centric-architecture.md) (layering)
+- [Issue #993](https://github.com/ProfessionalWiki/NeoWiki/issues/993) (the T2 work order)

--- a/docs/adr/027-source-interface-contract.md
+++ b/docs/adr/027-source-interface-contract.md
@@ -45,8 +45,9 @@ degrades to not-found (null) plus one logged warning, never fatally.
 
 ## Consequences
 
-- T3 resolves schema references through the schema's own Source with no contract change; T4 gets
-  per-source target validation via `isValidLocalId`.
+- T3 resolves schema references through the schema's own Source with no contract change. T4 rejects
+  relation targets whose source is not registered, checking Source registration through the
+  registry; `isValidLocalId` is available for per-source localId validation but has no consumer yet.
 - Write-back, when designed, arrives as a separate `WritableSource` interface extending `Source`
   (non-breaking for existing implementers), under its own ADR.
 - The local persistence path gains read-side indirection (the routing lookup, the registry,

--- a/docs/extending/extending.md
+++ b/docs/extending/extending.md
@@ -13,8 +13,8 @@ NeoWiki concepts referenced here — Subject, Schema, Property Type, Page Proper
 
 [RedHerb](https://github.com/ProfessionalWiki/NeoWiki/tree/master/tests/RedHerb) is a minimal, test-backed
 example extension shipped in the NeoWiki repository. NeoWiki's own tests exercise it, so its examples stay
-working. Each extension point below links to the RedHerb file that demonstrates it, so the fastest start is to
-copy the relevant RedHerb file and adapt it.
+working. Most extension points below link to the RedHerb file that demonstrates them, so the fastest start is
+to copy the relevant RedHerb file and adapt it.
 
 ## Stability
 
@@ -142,6 +142,29 @@ the Page node. No new revision is created. `rebuild()` returns a `PageRefreshOut
 - `SkippedMissingSubjectSlot` — the page carries no NeoWiki subject slot, so there was nothing to write.
 
 Genuine failures (such as the graph store being unreachable) throw rather than returning an outcome.
+
+### Sources
+
+A Source supplies Subjects and Schemas from one origin: the local revision slot (the default
+Source), an on-wiki SMW or Wikibase store, another NeoWiki, or an external system
+([ADR 23](../adr/023-subject-sources.md)). Implement the `Source` interface and register it under a
+unique source key:
+
+```php
+$registrar->addSource( 'my-source-key', new MySource() );
+```
+
+The source key namespaces the Subject ids the Source owns: a Subject id is a `source:localId` pair,
+and a bare id means the local Source. Core registers `LocalSource` under the local wiki id before this
+hook runs, so registering a duplicate key (including the local wiki id) throws. A Source is the
+authority for its Subjects' editability, localId grammar, schema resolution, and IRI base URI; the
+frozen contract is in [ADR 27](../adr/027-source-interface-contract.md).
+
+Sources are consulted on by-id resolution: an id whose source key is not registered degrades to
+not-found rather than failing. Rendering sourced Subjects in Views is deferred (ADR 23), so a
+registered Source is reachable by id but not yet shown through the View system.
+
+No example extension registers a Source yet; RedHerb does not demonstrate this extension point.
 
 ### Reading NeoWiki data and authorization
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -67,6 +67,22 @@ Each Relation has
 
 
 
+## Source
+
+The origin a Subject (and its Schema) comes from ([ADR 23](adr/023-subject-sources.md)). The local
+revision slot is the default Source; others can supply Subjects too, such as an on-wiki SMW or Wikibase
+store, another NeoWiki, or an external system. A wiki farm is simply more registered Sources.
+
+Each Subject id is a `(source, localId)` pair; a bare id means the local Source. A **Source registry**
+maps a source key to its Source, and the Source is the authority for its Subjects' editability, localId
+grammar, schema resolution, and IRI base URI. Local Subjects are editable and versioned; sourced
+Subjects are read-only. A Subject is queryable via Cypher only once materialised in the graph,
+independent of its Source.
+
+Extensions register Sources through the `NeoWikiRegistration` hook (see
+[Extending NeoWiki](extending/extending.md)). The interface contract is frozen in
+[ADR 27](adr/027-source-interface-contract.md).
+
 ## Schema
 
 A Schema ([ADR 6](adr/006-schemas.md)) defines a type of Subject. Examples: Person, Company, Product, etc.

--- a/src/Application/LazySchemaLookup.php
+++ b/src/Application/LazySchemaLookup.php
@@ -1,0 +1,30 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application;
+
+use Closure;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+
+/**
+ * Builds the wrapped SchemaLookup on demand rather than at construction. Constructing the real
+ * schema lookup pulls in the property-type registry, which fires the NeoWikiRegistration hook;
+ * seams assembled before that hook may run (see NeoWikiExtension::newLocalSource()) must defer it.
+ */
+readonly class LazySchemaLookup implements SchemaLookup {
+
+	/**
+	 * @param Closure(): SchemaLookup $schemaLookupFactory
+	 */
+	public function __construct(
+		private Closure $schemaLookupFactory
+	) {
+	}
+
+	public function getSchema( SchemaName $schemaName ): ?Schema {
+		return ( $this->schemaLookupFactory )()->getSchema( $schemaName );
+	}
+
+}

--- a/src/Application/LazySubjectLookup.php
+++ b/src/Application/LazySubjectLookup.php
@@ -1,0 +1,31 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application;
+
+use Closure;
+use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
+
+/**
+ * Builds the wrapped SubjectLookup on demand rather than at construction. The local lookup's
+ * construction eagerly requires a configured graph backend, but the SourceRegistry that holds
+ * LocalSource is assembled during extension registration, which also runs on backend-less paths
+ * (edits, parser-function registration). Deferring keeps that assembly backend-free.
+ */
+readonly class LazySubjectLookup implements SubjectLookup {
+
+	/**
+	 * @param Closure(): SubjectLookup $subjectLookupFactory
+	 */
+	public function __construct(
+		private Closure $subjectLookupFactory
+	) {
+	}
+
+	public function getSubject( SubjectId $subjectId ): ?Subject {
+		return ( $this->subjectLookupFactory )()->getSubject( $subjectId );
+	}
+
+}

--- a/src/Application/SourceRoutingSubjectLookup.php
+++ b/src/Application/SourceRoutingSubjectLookup.php
@@ -1,0 +1,39 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application;
+
+use ProfessionalWiki\NeoWiki\Domain\Source\SourceRegistry;
+use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Read-side Subject lookup that routes each id to the Source its key resolves to. An id whose
+ * source key is not registered degrades to not-found (null) plus one logged warning, never
+ * fatally (ADR 27). For bare ids this is the local lookup with the registry indirection in front.
+ */
+readonly class SourceRoutingSubjectLookup implements SubjectLookup {
+
+	public function __construct(
+		private SourceRegistry $sourceRegistry,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	public function getSubject( SubjectId $subjectId ): ?Subject {
+		$source = $this->sourceRegistry->getSourceForId( $subjectId );
+
+		if ( $source === null ) {
+			$this->logger->warning(
+				'Subject lookup for an unregistered Source key.',
+				[ 'sourceKey' => $subjectId->getSource(), 'subjectId' => $subjectId->text ]
+			);
+			return null;
+		}
+
+		return $source->getSubject( $subjectId );
+	}
+
+}

--- a/src/Application/SubjectResolver.php
+++ b/src/Application/SubjectResolver.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Application;
 
 use MediaWiki\Title\Title;
+use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphBackendNotConfiguredException;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
 use ProfessionalWiki\NeoWiki\Domain\Relation\Relation;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
@@ -22,6 +23,8 @@ class SubjectResolver {
 	public function resolveById( string $subjectIdText ): ?Subject {
 		try {
 			return $this->subjectLookup->getSubject( $this->subjectIdParser->parse( $subjectIdText ) );
+		} catch ( GraphBackendNotConfiguredException $e ) {
+			throw $e;
 		} catch ( \Exception ) {
 			return null;
 		}
@@ -54,6 +57,8 @@ class SubjectResolver {
 			if ( $subject !== null ) {
 				return $subject->getLabel()->text;
 			}
+		} catch ( GraphBackendNotConfiguredException $e ) {
+			throw $e;
 		} catch ( \Exception ) {
 			// Fall through to ID
 		}

--- a/src/Domain/Source/Source.php
+++ b/src/Domain/Source/Source.php
@@ -1,0 +1,59 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\Source;
+
+use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
+
+/**
+ * Supplies Subjects from one origin: the local revision slot, an on-wiki
+ * SMW/Wikibase store, another NeoWiki, or an external system (ADR 23).
+ *
+ * Sources play no part at query time: a Subject is Cypher-queryable only once
+ * materialised in the graph. Resolution through a Source is by-id only.
+ */
+interface Source {
+
+	/**
+	 * The Subject with the given id, or null when this Source has no such
+	 * Subject. The registry has already matched the id's source key to this
+	 * Source; how the localId is interpreted is this Source's business.
+	 */
+	public function getSubject( SubjectId $id ): ?Subject;
+
+	/**
+	 * The schema with the given name from this Source, or null when it has
+	 * none ("Schemas come from Sources", ADR 23). A schema's source is
+	 * independent of a subject's source; T3 builds the reference plumbing.
+	 */
+	public function getSchema( SchemaName $schemaName ): ?Schema;
+
+	/**
+	 * Whether Subjects from this Source are editable through NeoWiki.
+	 * Editability is the only capability the model varies: local Subjects
+	 * are editable and versioned, sourced Subjects are read-only (ADR 23).
+	 */
+	public function isEditable(): bool;
+
+	/**
+	 * Whether the localId is well-formed for this Source. Each Source owns
+	 * its localId grammar (ADR 23); the serialized qualified form further
+	 * restricts localIds to URL-path-safe characters at the wire level.
+	 */
+	public function isValidLocalId( string $localId ): bool;
+
+	/**
+	 * Base URI for projecting this Source's ids to IRIs, or null when none
+	 * is configured. Native RDF projection mints all IRIs from the single
+	 * per-wiki base (NeoWikiConfig->rdfBaseUri, consumed by RdfNamespaces);
+	 * a per-Source base URI generalizes that for sourced Subjects. Nothing
+	 * consumes a per-source value yet; cross-wiki linking stays deferred
+	 * (owl:sameAs, NativeRdfProjection Design Principle 5).
+	 */
+	public function getBaseUri(): ?string;
+
+}

--- a/src/Domain/Source/Source.php
+++ b/src/Domain/Source/Source.php
@@ -28,7 +28,7 @@ interface Source {
 	/**
 	 * The schema with the given name from this Source, or null when it has
 	 * none ("Schemas come from Sources", ADR 23). A schema's source is
-	 * independent of a subject's source; T3 builds the reference plumbing.
+	 * independent of a subject's source.
 	 */
 	public function getSchema( SchemaName $schemaName ): ?Schema;
 

--- a/src/Domain/Source/SourceRegistry.php
+++ b/src/Domain/Source/SourceRegistry.php
@@ -1,0 +1,44 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\Source;
+
+use LogicException;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
+
+class SourceRegistry {
+
+	/**
+	 * @var array<string, Source>
+	 */
+	private array $sources = [];
+
+	public function __construct(
+		private readonly string $localSourceKey
+	) {
+	}
+
+	/**
+	 * @throws LogicException when the key is already taken (a config error: fail at registration)
+	 */
+	public function register( string $sourceKey, Source $source ): void {
+		if ( array_key_exists( $sourceKey, $this->sources ) ) {
+			throw new LogicException( "A Source is already registered for the key '$sourceKey'." );
+		}
+
+		$this->sources[$sourceKey] = $source;
+	}
+
+	public function getSource( string $sourceKey ): ?Source {
+		return $this->sources[$sourceKey] ?? null;
+	}
+
+	/**
+	 * Maps a bare id (source null) to the local Source; null for unknown keys.
+	 */
+	public function getSourceForId( SubjectId $id ): ?Source {
+		return $this->getSource( $id->getSource() ?? $this->localSourceKey );
+	}
+
+}

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -162,7 +162,7 @@ class NeoWikiHooks {
 				$parserFunction = new NeoWikiValueParserFunction(
 					new SubjectResolver(
 						$extension->newSubjectContentRepository(),
-						$extension->getSubjectRepository(),
+						$extension->getSubjectLookup(),
 						$extension->getSubjectIdParser(),
 					)
 				);

--- a/src/EntryPoints/NeoWikiRegistrar.php
+++ b/src/EntryPoints/NeoWikiRegistrar.php
@@ -12,6 +12,8 @@ use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyType;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeRegistry;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\Literal;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfValueMapperRegistry;
+use ProfessionalWiki\NeoWiki\Domain\Source\Source;
+use ProfessionalWiki\NeoWiki\Domain\Source\SourceRegistry;
 use ProfessionalWiki\NeoWiki\Domain\Value\NeoValue;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jValueBuilderRegistry;
 
@@ -23,6 +25,7 @@ readonly class NeoWikiRegistrar {
 		private PagePropertyProviderRegistry $pagePropertyProviderRegistry,
 		private GraphDatabasePluginRegistry $graphDatabasePluginRegistry,
 		private RdfValueMapperRegistry $rdfValueMapperRegistry,
+		private SourceRegistry $sourceRegistry,
 	) {
 	}
 
@@ -52,6 +55,14 @@ readonly class NeoWikiRegistrar {
 
 	public function addGraphDatabasePlugin( GraphDatabasePlugin $plugin ): void {
 		$this->graphDatabasePluginRegistry->addPlugin( $plugin );
+	}
+
+	/**
+	 * Registers a Source under its source key. Throws when the key is already taken (including the
+	 * local wiki id, which core registers before this hook runs).
+	 */
+	public function addSource( string $sourceKey, Source $source ): void {
+		$this->sourceRegistry->register( $sourceKey, $source );
 	}
 
 }

--- a/src/EntryPoints/Scribunto/ScribuntoLuaLibrary.php
+++ b/src/EntryPoints/Scribunto/ScribuntoLuaLibrary.php
@@ -28,7 +28,7 @@ class ScribuntoLuaLibrary extends LibraryBase {
 			$this->subjectDataLookup = new SubjectDataLookup(
 				new SubjectResolver(
 					$extension->newSubjectContentRepository(),
-					$extension->getSubjectRepository(),
+					$extension->getSubjectLookup(),
 					$extension->getSubjectIdParser(),
 				),
 			);

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -43,7 +43,9 @@ use ProfessionalWiki\NeoWiki\Application\Queries\ValidateSubjectUpdate\ValidateS
 use ProfessionalWiki\NeoWiki\Infrastructure\IdGenerator;
 use ProfessionalWiki\NeoWiki\Infrastructure\ProductionIdGenerator;
 use ProfessionalWiki\NeoWiki\Persistence\CorePagePropertyProvider;
+use ProfessionalWiki\NeoWiki\Persistence\LocalSource;
 use ProfessionalWiki\NeoWiki\Domain\Page\PagePropertyProviderRegistry;
+use ProfessionalWiki\NeoWiki\Domain\Source\SourceRegistry;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\CompositeGraphDatabasePlugin;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\FailureIsolatingGraphDatabasePlugin;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphBackendNotConfiguredException;
@@ -58,7 +60,11 @@ use ProfessionalWiki\NeoWiki\Application\LayoutLookup;
 use ProfessionalWiki\NeoWiki\Application\SubjectPermissionHints;
 use ProfessionalWiki\NeoWiki\Application\SubjectWriteAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\SubjectPageRebuilder;
+use ProfessionalWiki\NeoWiki\Application\SubjectLookup;
 use ProfessionalWiki\NeoWiki\Application\SubjectRepository;
+use ProfessionalWiki\NeoWiki\Application\LazySchemaLookup;
+use ProfessionalWiki\NeoWiki\Application\LazySubjectLookup;
+use ProfessionalWiki\NeoWiki\Application\SourceRoutingSubjectLookup;
 use ProfessionalWiki\NeoWiki\Application\MappingLookup;
 use ProfessionalWiki\NeoWiki\Application\Mappings;
 use ProfessionalWiki\NeoWiki\Application\Rdf\OntologyMappingProjector;
@@ -142,6 +148,7 @@ class NeoWikiExtension {
 	private PagePropertyProviderRegistry $pagePropertyProviderRegistry;
 	private Neo4jValueBuilderRegistry $valueBuilderRegistry;
 	private RdfValueMapperRegistry $rdfValueMapperRegistry;
+	private SourceRegistry $sourceRegistry;
 	private bool $extensionsRegistered = false;
 	private SubjectRepository $subjectRepository;
 	private CompositeGraphDatabasePlugin $graphDatabasePlugin;
@@ -234,6 +241,7 @@ class NeoWikiExtension {
 				$this->getPagePropertyProviderRegistry(),
 				$this->getGraphDatabasePluginRegistry(),
 				$this->getRdfValueMapperRegistry(),
+				$this->getSourceRegistry(),
 			) ]
 		);
 	}
@@ -679,6 +687,52 @@ class NeoWikiExtension {
 		);
 	}
 
+	/**
+	 * The read-side Subject lookup: resolves each id through its Source (ADR 27). Local ids stay on
+	 * the local repository; an unregistered source key degrades to not-found plus a logged warning.
+	 * Write paths keep using getSubjectRepository() directly, since sourced Subjects are read-only.
+	 */
+	public function getSubjectLookup(): SubjectLookup {
+		return new SourceRoutingSubjectLookup(
+			sourceRegistry: $this->getSourceRegistry(),
+			logger: LoggerFactory::getInstance( 'NeoWiki' ),
+		);
+	}
+
+	/**
+	 * The Source registry, seeded with core's LocalSource under the local wiki id before the
+	 * NeoWikiRegistration hook runs, so an extension colliding with the local key fails fast at
+	 * registration (same core-first ordering as the Neo4j composite plugin). The field is populated
+	 * before ensureExtensionsRegistered() fires: that call builds a NeoWikiRegistrar which re-enters
+	 * this accessor, and the already-set field short-circuits the re-entry instead of looping.
+	 */
+	public function getSourceRegistry(): SourceRegistry {
+		if ( !isset( $this->sourceRegistry ) ) {
+			$this->sourceRegistry = new SourceRegistry( $this->config->wikiId );
+			$this->sourceRegistry->register( $this->config->wikiId, $this->newLocalSource() );
+		}
+
+		$this->ensureExtensionsRegistered();
+
+		return $this->sourceRegistry;
+	}
+
+	/**
+	 * Runs while getSourceRegistry() assembles the registry, before the NeoWikiRegistration hook
+	 * fires, so nothing here may fire that hook: a dependency doing so (getSchemaLookup() does, via
+	 * the property-type registry) would hand handlers the still-empty registry and let an extension
+	 * claim the local key before core registers LocalSource. The subject lookup is deferred for
+	 * another reason too: its construction requires a graph backend, while the registry also
+	 * assembles on backend-less paths.
+	 */
+	private function newLocalSource(): LocalSource {
+		return new LocalSource(
+			subjectLookup: new LazySubjectLookup( fn (): SubjectLookup => $this->getSubjectRepository() ),
+			schemaLookup: new LazySchemaLookup( fn (): SchemaLookup => $this->getSchemaLookup() ),
+			baseUri: $this->config->rdfBaseUri,
+		);
+	}
+
 	private function getIdGenerator(): IdGenerator {
 		return new ProductionIdGenerator();
 	}
@@ -829,7 +883,7 @@ class NeoWikiExtension {
 		return new GetPageSubjectsQuery(
 			presenter: $presenter,
 			subjectRepository: $this->getSubjectRepository(),
-			subjectLookup: $this->getSubjectRepository(),
+			subjectLookup: $this->getSubjectLookup(),
 			schemaLookup: $this->getSchemaLookup(),
 			schemaSerializer: $this->getSchemaPresentationSerializer(),
 			pageIdentifiersLookup: $this->getPageIdentifiersLookup(),
@@ -839,7 +893,7 @@ class NeoWikiExtension {
 	public function newGetSubjectQuery( RestGetSubjectPresenter $presenter ): GetSubjectQuery {
 		return new GetSubjectQuery(
 			presenter: $presenter,
-			subjectLookup: $this->getSubjectRepository(),
+			subjectLookup: $this->getSubjectLookup(),
 			pageIdentifiersLookup: $this->getPageIdentifiersLookup(),
 			subjectIdParser: $this->getSubjectIdParser(),
 		);

--- a/src/Persistence/LocalSource.php
+++ b/src/Persistence/LocalSource.php
@@ -1,0 +1,49 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Persistence;
+
+use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
+use ProfessionalWiki\NeoWiki\Application\SubjectLookup;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Source\Source;
+use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
+
+/**
+ * The default Source: local Subjects and Schemas stored in the wiki's revision slots, resolved
+ * through the existing local persistence. Editable and versioned, with bare-nanoid localIds (ADR 23).
+ */
+readonly class LocalSource implements Source {
+
+	public function __construct(
+		private SubjectLookup $subjectLookup,
+		private SchemaLookup $schemaLookup,
+		private string $baseUri,
+	) {
+	}
+
+	public function getSubject( SubjectId $id ): ?Subject {
+		return $this->subjectLookup->getSubject( $id );
+	}
+
+	public function getSchema( SchemaName $schemaName ): ?Schema {
+		return $this->schemaLookup->getSchema( $schemaName );
+	}
+
+	public function isEditable(): bool {
+		return true;
+	}
+
+	public function isValidLocalId( string $localId ): bool {
+		return SubjectId::isValid( $localId )
+			&& ( new SubjectId( $localId ) )->getSource() === null;
+	}
+
+	public function getBaseUri(): ?string {
+		return $this->baseUri;
+	}
+
+}

--- a/tests/phpunit/Application/LazySchemaLookupTest.php
+++ b/tests/phpunit/Application/LazySchemaLookupTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Application;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\LazySchemaLookup;
+use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSchema;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySchemaLookup;
+use RuntimeException;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Application\LazySchemaLookup
+ */
+class LazySchemaLookupTest extends TestCase {
+
+	public function testGetSchemaReturnsTheSchemaFromTheWrappedLookup(): void {
+		$schema = TestSchema::build( name: 'Person' );
+
+		$lookup = new LazySchemaLookup(
+			static fn (): SchemaLookup => new InMemorySchemaLookup( $schema )
+		);
+
+		$this->assertSame( $schema, $lookup->getSchema( new SchemaName( 'Person' ) ) );
+	}
+
+	public function testTheWrappedLookupIsNotBuiltAtConstructionTime(): void {
+		$lookup = new LazySchemaLookup(
+			static fn (): SchemaLookup => throw new RuntimeException( 'The factory ran at construction time.' )
+		);
+
+		$this->assertInstanceOf( LazySchemaLookup::class, $lookup );
+	}
+
+}

--- a/tests/phpunit/Application/LazySubjectLookupTest.php
+++ b/tests/phpunit/Application/LazySubjectLookupTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Application;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\LazySubjectLookup;
+use ProfessionalWiki\NeoWiki\Application\SubjectLookup;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectLookup;
+use RuntimeException;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Application\LazySubjectLookup
+ */
+class LazySubjectLookupTest extends TestCase {
+
+	public function testGetSubjectReturnsTheSubjectFromTheWrappedLookup(): void {
+		$subject = TestSubject::build( id: 's11111111111111' );
+
+		$lookup = new LazySubjectLookup(
+			static fn (): SubjectLookup => new InMemorySubjectLookup( $subject )
+		);
+
+		$this->assertSame( $subject, $lookup->getSubject( new SubjectId( 's11111111111111' ) ) );
+	}
+
+	public function testTheWrappedLookupIsNotBuiltAtConstructionTime(): void {
+		$lookup = new LazySubjectLookup(
+			static fn (): SubjectLookup => throw new RuntimeException( 'The factory ran at construction time.' )
+		);
+
+		$this->assertInstanceOf( LazySubjectLookup::class, $lookup );
+	}
+
+}

--- a/tests/phpunit/Application/SourceRoutingSubjectLookupTest.php
+++ b/tests/phpunit/Application/SourceRoutingSubjectLookupTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Application;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\SourceRoutingSubjectLookup;
+use ProfessionalWiki\NeoWiki\Domain\Source\SourceRegistry;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpyLogger;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubSource;
+use Psr\Log\LogLevel;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Application\SourceRoutingSubjectLookup
+ */
+class SourceRoutingSubjectLookupTest extends TestCase {
+
+	private const string LOCAL_KEY = 'localwiki';
+
+	public function testRoutesBareIdToTheLocalSource(): void {
+		$localSubject = TestSubject::build( id: 's11111111111111' );
+
+		$result = $this->newLookup( localSource: new StubSource( $localSubject ) )
+			->getSubject( new SubjectId( 's11111111111111' ) );
+
+		$this->assertSame( $localSubject, $result );
+	}
+
+	public function testRoutesLocalQualifiedIdToTheLocalSource(): void {
+		$localSubject = TestSubject::build( id: 's11111111111111' );
+
+		$result = $this->newLookup( localSource: new StubSource( $localSubject ) )
+			->getSubject( new SubjectId( self::LOCAL_KEY . ':s11111111111111' ) );
+
+		$this->assertSame( $localSubject, $result );
+	}
+
+	public function testUnknownSourceReturnsNull(): void {
+		$result = $this->newLookup( localSource: new StubSource() )
+			->getSubject( new SubjectId( 'unknownwiki:s11111111111111' ) );
+
+		$this->assertNull( $result );
+	}
+
+	public function testUnknownSourceLogsOneDiagnosticWarning(): void {
+		$logger = new SpyLogger();
+
+		$this->newLookup( localSource: new StubSource(), logger: $logger )
+			->getSubject( new SubjectId( 'unknownwiki:s11111111111111' ) );
+
+		$this->assertCount( 1, $logger->getLogCalls() );
+		$this->assertSame( LogLevel::WARNING, $logger->getLogCalls()[0]['level'] );
+		$this->assertSame( 'unknownwiki', $logger->getLogCalls()[0]['context']['sourceKey'] );
+		$this->assertSame( 'unknownwiki:s11111111111111', $logger->getLogCalls()[0]['context']['subjectId'] );
+	}
+
+	public function testKnownSourceWithMissingSubjectReturnsNullWithoutLogging(): void {
+		$logger = new SpyLogger();
+
+		$result = $this->newLookup( localSource: new StubSource( subject: null ), logger: $logger )
+			->getSubject( new SubjectId( 's11111111111111' ) );
+
+		$this->assertNull( $result );
+		$this->assertSame( [], $logger->getLogCalls() );
+	}
+
+	private function newLookup( StubSource $localSource, ?SpyLogger $logger = null ): SourceRoutingSubjectLookup {
+		$registry = new SourceRegistry( self::LOCAL_KEY );
+		$registry->register( 'otherwiki', new StubSource( TestSubject::build( id: 's22222222222222' ) ) );
+		$registry->register( self::LOCAL_KEY, $localSource );
+
+		return new SourceRoutingSubjectLookup( $registry, $logger ?? new SpyLogger() );
+	}
+
+}

--- a/tests/phpunit/Application/SubjectResolverTest.php
+++ b/tests/phpunit/Application/SubjectResolverTest.php
@@ -8,6 +8,7 @@ use MediaWiki\Title\Title;
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Application\SubjectLookup;
 use ProfessionalWiki\NeoWiki\Application\SubjectResolver;
+use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphBackendNotConfiguredException;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
 use ProfessionalWiki\NeoWiki\Domain\Relation\Relation;
 use ProfessionalWiki\NeoWiki\Domain\Relation\RelationId;
@@ -79,6 +80,24 @@ class SubjectResolverTest extends TestCase {
 		$resolver = new SubjectResolver( new InMemorySubjectContentRepository(), $lookup, TestData::newSubjectIdParser() );
 
 		$this->assertNull( $resolver->resolveById( self::SUBJECT_ID ) );
+	}
+
+	public function testResolveByIdPropagatesMissingGraphBackend(): void {
+		$resolver = new SubjectResolver(
+			new InMemorySubjectContentRepository(),
+			$this->newLookupWithoutGraphBackend(),
+			TestData::newSubjectIdParser()
+		);
+
+		$this->expectException( GraphBackendNotConfiguredException::class );
+		$resolver->resolveById( self::SUBJECT_ID );
+	}
+
+	private function newLookupWithoutGraphBackend(): SubjectLookup {
+		$lookup = $this->createStub( SubjectLookup::class );
+		$lookup->method( 'getSubject' )->willThrowException( new GraphBackendNotConfiguredException() );
+
+		return $lookup;
 	}
 
 	public function testResolveMainByTitleReturnsMainSubject(): void {
@@ -173,6 +192,23 @@ class SubjectResolverTest extends TestCase {
 		);
 
 		$this->assertSame( self::TARGET_SUBJECT_ID, $resolver->resolveRelationLabel( $relation ) );
+	}
+
+	public function testResolveRelationLabelPropagatesMissingGraphBackend(): void {
+		$resolver = new SubjectResolver(
+			new InMemorySubjectContentRepository(),
+			$this->newLookupWithoutGraphBackend(),
+			TestData::newSubjectIdParser()
+		);
+
+		$relation = new Relation(
+			id: new RelationId( 'r1test5cccccccc' ),
+			targetId: new SubjectId( self::TARGET_SUBJECT_ID ),
+			properties: new RelationProperties( [] ),
+		);
+
+		$this->expectException( GraphBackendNotConfiguredException::class );
+		$resolver->resolveRelationLabel( $relation );
 	}
 
 }

--- a/tests/phpunit/Domain/Source/SourceRegistryTest.php
+++ b/tests/phpunit/Domain/Source/SourceRegistryTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Domain\Source;
+
+use LogicException;
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\Source\SourceRegistry;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubSource;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Domain\Source\SourceRegistry
+ */
+class SourceRegistryTest extends TestCase {
+
+	private const string LOCAL_KEY = 'localwiki';
+
+	public function testRegisteredSourceIsReturnedByItsKey(): void {
+		$source = new StubSource();
+		$registry = new SourceRegistry( self::LOCAL_KEY );
+
+		$registry->register( 'somewiki', $source );
+
+		$this->assertSame( $source, $registry->getSource( 'somewiki' ) );
+	}
+
+	public function testGetSourceReturnsNullForUnregisteredKey(): void {
+		$registry = new SourceRegistry( self::LOCAL_KEY );
+
+		$this->assertNull( $registry->getSource( 'somewiki' ) );
+	}
+
+	public function testBareIdMapsToTheLocalSource(): void {
+		$localSource = new StubSource();
+		$registry = new SourceRegistry( self::LOCAL_KEY );
+		$registry->register( 'otherwiki', new StubSource() );
+		$registry->register( self::LOCAL_KEY, $localSource );
+
+		$this->assertSame( $localSource, $registry->getSourceForId( new SubjectId( 's11111111111111' ) ) );
+	}
+
+	public function testLocalQualifiedIdMapsToTheLocalSource(): void {
+		$localSource = new StubSource();
+		$registry = new SourceRegistry( self::LOCAL_KEY );
+		$registry->register( 'otherwiki', new StubSource() );
+		$registry->register( self::LOCAL_KEY, $localSource );
+
+		$this->assertSame(
+			$localSource,
+			$registry->getSourceForId( new SubjectId( self::LOCAL_KEY . ':s11111111111111' ) )
+		);
+	}
+
+	public function testSourceQualifiedIdMapsToItsSource(): void {
+		$otherSource = new StubSource();
+		$registry = new SourceRegistry( self::LOCAL_KEY );
+		$registry->register( self::LOCAL_KEY, new StubSource() );
+		$registry->register( 'otherwiki', $otherSource );
+
+		$this->assertSame(
+			$otherSource,
+			$registry->getSourceForId( new SubjectId( 'otherwiki:s11111111111111' ) )
+		);
+	}
+
+	public function testIdWithUnregisteredSourceMapsToNull(): void {
+		$registry = new SourceRegistry( self::LOCAL_KEY );
+		$registry->register( self::LOCAL_KEY, new StubSource() );
+
+		$this->assertNull( $registry->getSourceForId( new SubjectId( 'unknownwiki:s11111111111111' ) ) );
+	}
+
+	public function testIdWithCaseVariantOfTheLocalKeyMapsToNull(): void {
+		$registry = new SourceRegistry( self::LOCAL_KEY );
+		$registry->register( self::LOCAL_KEY, new StubSource() );
+
+		$this->assertNull( $registry->getSourceForId( new SubjectId( 'LOCALWIKI:s11111111111111' ) ) );
+	}
+
+	public function testRegisteringAnAlreadyTakenKeyThrows(): void {
+		$registry = new SourceRegistry( self::LOCAL_KEY );
+		$registry->register( self::LOCAL_KEY, new StubSource() );
+
+		$this->expectException( LogicException::class );
+		$registry->register( self::LOCAL_KEY, new StubSource() );
+	}
+
+	public function testSourceKeysAreComparedVerbatim(): void {
+		$lowerSource = new StubSource();
+		$upperSource = new StubSource();
+		$registry = new SourceRegistry( self::LOCAL_KEY );
+
+		$registry->register( 'wiki', $lowerSource );
+		$registry->register( 'WIKI', $upperSource );
+
+		$this->assertSame( $lowerSource, $registry->getSource( 'wiki' ) );
+		$this->assertSame( $upperSource, $registry->getSource( 'WIKI' ) );
+	}
+
+}

--- a/tests/phpunit/EntryPoints/NeoWikiRegistrarTest.php
+++ b/tests/phpunit/EntryPoints/NeoWikiRegistrarTest.php
@@ -10,10 +10,12 @@ use ProfessionalWiki\NeoWiki\Domain\Page\PagePropertyProviderRegistry;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeRegistry;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\Types\TextType;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfValueMapperRegistry;
+use ProfessionalWiki\NeoWiki\Domain\Source\SourceRegistry;
 use ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiRegistrar;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jValueBuilderRegistry;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpyGraphDatabasePlugin;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubPagePropertyProvider;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubSource;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiRegistrar
@@ -67,12 +69,23 @@ class NeoWikiRegistrarTest extends TestCase {
 		$this->assertTrue( $rdfValueMapperRegistry->hasMapper( 'custom' ) );
 	}
 
+	public function testAddSourceRegistersInRegistry(): void {
+		$sourceRegistry = new SourceRegistry( 'localwiki' );
+		$registrar = $this->newRegistrar( sourceRegistry: $sourceRegistry );
+
+		$source = new StubSource();
+		$registrar->addSource( 'somewiki', $source );
+
+		$this->assertSame( $source, $sourceRegistry->getSource( 'somewiki' ) );
+	}
+
 	private function newRegistrar(
 		?PropertyTypeRegistry $propertyTypeRegistry = null,
 		?Neo4jValueBuilderRegistry $valueBuilderRegistry = null,
 		?PagePropertyProviderRegistry $pagePropertyProviderRegistry = null,
 		?GraphDatabasePluginRegistry $graphDatabasePluginRegistry = null,
 		?RdfValueMapperRegistry $rdfValueMapperRegistry = null,
+		?SourceRegistry $sourceRegistry = null,
 	): NeoWikiRegistrar {
 		return new NeoWikiRegistrar(
 			propertyTypeRegistry: $propertyTypeRegistry ?? new PropertyTypeRegistry(),
@@ -80,6 +93,7 @@ class NeoWikiRegistrarTest extends TestCase {
 			pagePropertyProviderRegistry: $pagePropertyProviderRegistry ?? new PagePropertyProviderRegistry(),
 			graphDatabasePluginRegistry: $graphDatabasePluginRegistry ?? new GraphDatabasePluginRegistry(),
 			rdfValueMapperRegistry: $rdfValueMapperRegistry ?? new RdfValueMapperRegistry(),
+			sourceRegistry: $sourceRegistry ?? new SourceRegistry( 'localwiki' ),
 		);
 	}
 

--- a/tests/phpunit/EntryPoints/REST/GetSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/GetSubjectApiTest.php
@@ -101,6 +101,24 @@ JSON,
 		$this->assertSame( 200, $response->getStatusCode() );
 	}
 
+	public function testSubjectWithUnregisteredSourceDegradesToNotFound(): void {
+		$response = $this->executeHandler(
+			new GetSubjectApi(),
+			new RequestData( [
+				'method' => 'GET',
+				'pathParams' => [
+					'subjectId' => 'nonexistentsource:s11111111111111'
+				]
+			] )
+		);
+
+		$this->assertSame(
+			'{"subject":null}',
+			$response->getBody()->getContents()
+		);
+		$this->assertSame( 200, $response->getStatusCode() );
+	}
+
 	public function testReturnsSubjectDataFromSpecificRevision(): void {
 		$originalSubject = TestSubject::build(
 			id: 'sTestGSA1111116',

--- a/tests/phpunit/Persistence/LocalSourceTest.php
+++ b/tests/phpunit/Persistence/LocalSourceTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Persistence;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
+use ProfessionalWiki\NeoWiki\Persistence\LocalSource;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSchema;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySchemaLookup;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectLookup;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Persistence\LocalSource
+ */
+class LocalSourceTest extends TestCase {
+
+	private const string BASE_URI = 'https://example.org/entity/';
+
+	public function testGetSubjectReturnsTheSubjectFromTheLocalLookup(): void {
+		$subject = TestSubject::build( id: 's11111111111111' );
+
+		$source = $this->newLocalSource( subjectLookup: new InMemorySubjectLookup( $subject ) );
+
+		$this->assertSame( $subject, $source->getSubject( new SubjectId( 's11111111111111' ) ) );
+	}
+
+	public function testGetSubjectReturnsNullWhenTheLocalLookupHasNoSuchSubject(): void {
+		$source = $this->newLocalSource( subjectLookup: new InMemorySubjectLookup() );
+
+		$this->assertNull( $source->getSubject( new SubjectId( 's11111111111111' ) ) );
+	}
+
+	public function testGetSchemaReturnsTheSchemaFromTheLocalLookup(): void {
+		$schema = TestSchema::build( name: 'Person' );
+
+		$source = $this->newLocalSource( schemaLookup: new InMemorySchemaLookup( $schema ) );
+
+		$this->assertSame( $schema, $source->getSchema( new SchemaName( 'Person' ) ) );
+	}
+
+	public function testGetSchemaReturnsNullWhenTheLocalLookupHasNoSuchSchema(): void {
+		$source = $this->newLocalSource( schemaLookup: new InMemorySchemaLookup() );
+
+		$this->assertNull( $source->getSchema( new SchemaName( 'Person' ) ) );
+	}
+
+	public function testLocalSubjectsAreEditable(): void {
+		$this->assertTrue( $this->newLocalSource()->isEditable() );
+	}
+
+	public function testBareNanoidIsAValidLocalId(): void {
+		$this->assertTrue( $this->newLocalSource()->isValidLocalId( 's11111111111111' ) );
+	}
+
+	public function testSourceQualifiedIdIsNotAValidLocalId(): void {
+		$this->assertFalse( $this->newLocalSource()->isValidLocalId( 'otherwiki:s11111111111111' ) );
+	}
+
+	public function testGarbageIsNotAValidLocalId(): void {
+		$this->assertFalse( $this->newLocalSource()->isValidLocalId( 'not a subject id' ) );
+	}
+
+	public function testEmptyStringIsNotAValidLocalId(): void {
+		$this->assertFalse( $this->newLocalSource()->isValidLocalId( '' ) );
+	}
+
+	public function testGetBaseUriReturnsTheConfiguredWikiBase(): void {
+		$this->assertSame( self::BASE_URI, $this->newLocalSource()->getBaseUri() );
+	}
+
+	private function newLocalSource(
+		?InMemorySubjectLookup $subjectLookup = null,
+		?InMemorySchemaLookup $schemaLookup = null,
+	): LocalSource {
+		return new LocalSource(
+			subjectLookup: $subjectLookup ?? new InMemorySubjectLookup(),
+			schemaLookup: $schemaLookup ?? new InMemorySchemaLookup(),
+			baseUri: self::BASE_URI,
+		);
+	}
+
+}

--- a/tests/phpunit/TestDoubles/SpyLogger.php
+++ b/tests/phpunit/TestDoubles/SpyLogger.php
@@ -1,0 +1,32 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\TestDoubles;
+
+use Psr\Log\AbstractLogger;
+
+class SpyLogger extends AbstractLogger {
+
+	/**
+	 * @var list<array{level: mixed, message: string, context: array<mixed>}>
+	 */
+	private array $logCalls = [];
+
+	/**
+	 * @param mixed $level
+	 * @param string|\Stringable $message
+	 * @param array<mixed> $context
+	 */
+	public function log( $level, $message, array $context = [] ): void {
+		$this->logCalls[] = [ 'level' => $level, 'message' => (string)$message, 'context' => $context ];
+	}
+
+	/**
+	 * @return list<array{level: mixed, message: string, context: array<mixed>}>
+	 */
+	public function getLogCalls(): array {
+		return $this->logCalls;
+	}
+
+}

--- a/tests/phpunit/TestDoubles/StubSource.php
+++ b/tests/phpunit/TestDoubles/StubSource.php
@@ -1,0 +1,40 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\TestDoubles;
+
+use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Source\Source;
+use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
+
+class StubSource implements Source {
+
+	public function __construct(
+		private readonly ?Subject $subject = null,
+	) {
+	}
+
+	public function getSubject( SubjectId $id ): ?Subject {
+		return $this->subject;
+	}
+
+	public function getSchema( SchemaName $schemaName ): ?Schema {
+		return null;
+	}
+
+	public function isEditable(): bool {
+		return false;
+	}
+
+	public function isValidLocalId( string $localId ): bool {
+		return true;
+	}
+
+	public function getBaseUri(): ?string {
+		return null;
+	}
+
+}


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/NeoWiki/issues/993 (work order T2). Builds on #1005 and targets
its branch, so the diff shows only this track.

This PR freezes the Source interface contract that ADR 23 left open. The contract, its whys, and the
alternatives are recorded in `docs/adr/027-source-interface-contract.md`; the highlights:

- **The `Source` contract** (`Domain\Source`): `getSubject( SubjectId )`, `getSchema( SchemaName )`,
  `isEditable()`, `isValidLocalId( string )`, `getBaseUri()`. Sources play no part at query time:
  queryability is materialisation into the graph (ADR 23). Schema resolution enters the contract now
  because interface additions break third-party implementers and T3 needs it.
- **`SourceRegistry`**: byte-exact key comparison (two Linux MySQL/MariaDB dbnames can differ only in
  case, and the graph's `wiki_id` stores the wiki ID verbatim, so case-folding is foreclosed),
  `LogicException` on duplicate registration, bare ids map to the local source.
- **`LocalSource`** wraps the existing local persistence behind lazily constructed lookups and returns
  the per-wiki RDF base (`NeoWikiConfig->rdfBaseUri`, from the native RDF projection) as its base URI.
- **Read-side routing only**: the `subjectLookup` seams (`GetSubjectQuery`, `GetPageSubjectsQuery`,
  both `SubjectResolver` sites) resolve through the registry; write paths and the revision-scoped
  `PointInTimeSubjectLookup` stay direct, since sourced Subjects are read-only per ADR 23.
- **Registration point**: `NeoWikiRegistrar::addSource()` in the `NeoWikiRegistration` hook, with core
  registering `LocalSource` under the wiki ID before the hook fires, so colliding extension
  registrations fail fast. The lazy construction wrappers (`LazySubjectLookup`, `LazySchemaLookup`)
  are load-bearing here: an eagerly built dependency chain fires the registration hook re-entrantly,
  and the hook would observe an empty registry (probe-verified in both process orders).
- **Unresolvable source keys** degrade to not-found plus one logged warning, never fatally. REST GET
  keeps the pinned not-found contract (HTTP 200 with `{"subject":null}`).
- **Deliberately preserved**: on a wiki with no graph backend, `{{#neowiki_value}}` and Lua keep
  failing loudly (`GraphBackendNotConfiguredException` is rethrown through `SubjectResolver`'s
  catches); the softer degradation belongs to the #895 track, not this one.
- **Deferred by design**: no unused write-capability stub. Write-back, when designed, arrives as a
  `WritableSource extends Source` extension, which is non-breaking for implementers.

> <sub>AI-authored — Claude Code, `Fable 5 (max)`; standing directive from @malberts to complete the #993 tracks without blocking on inter-track human review, design calls delegated; diff not yet human-reviewed; TDD with watched failures, three adversarial AI review lenses with live hook-order and backendless probes, `make ci` and `make ts-ci` green locally, branch CI pending at posting time.</sub>

<details><summary>Production notes</summary>

Design, contract decisions, and review adjudication by `Fable 5 (max)`; implementation and the fix
round by `Opus 4.8 (max)` subagents; three parallel `Opus 4.8 (max)` review lenses (contract
fidelity, runtime correctness, test quality) stood in for the usual pre-PR human review at
@malberts' direction. The correctness lens probe-confirmed the hook-ordering hazard and drove the
lazy-construction fix and the loud-backendless preservation described above.

</details>
