### PR TITLE
Resolve schema references through their Source

### DIFF
--- a/docs/api/schema-format.md
+++ b/docs/api/schema-format.md
@@ -189,9 +189,10 @@ References to other Subjects.
 
 `targetSchema` uses the same reference form as a Subject's `schema`: a bare name string for a local
 Schema, or an object `{ "source", "name" }` for a Schema from another Source. Schema save validation
-currently accepts only the bare string form; the object form becomes saveable when sourced schemas
-arrive. Normalization of references naming the local Source happens on the subject `schema` field
-only, so a `targetSchema` is stored as given.
+currently accepts only the bare string form; saving the object form, and presenting a Subject that
+references a Schema from another Source, are part of the deferred sourced-Schema work (see
+[Schema References](subject-format.md#schema-references)). Normalization of references naming the
+local Source happens on the subject `schema` field only, so a `targetSchema` is stored as given.
 
 Example:
 

--- a/docs/api/schema-format.md
+++ b/docs/api/schema-format.md
@@ -188,8 +188,10 @@ References to other Subjects.
 | `multiple` | boolean | No | `false` | Allow multiple relations |
 
 `targetSchema` uses the same reference form as a Subject's `schema`: a bare name string for a local
-Schema, or an object `{ "source", "name" }` for a Schema from another Source. A reference naming the
-local Source normalizes to the bare form.
+Schema, or an object `{ "source", "name" }` for a Schema from another Source. Schema save validation
+currently accepts only the bare string form; the object form becomes saveable when sourced schemas
+arrive. Normalization of references naming the local Source happens on the subject `schema` field
+only, so a `targetSchema` is stored as given.
 
 Example:
 

--- a/docs/api/schema-format.md
+++ b/docs/api/schema-format.md
@@ -184,8 +184,12 @@ References to other Subjects.
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `relation` | string | Yes | - | The relation type name (used in Neo4j as relationship type) |
-| `targetSchema` | string | Yes | - | Name of the schema that target subjects must follow |
+| `targetSchema` | string or object | Yes | - | Reference to the schema that target subjects must follow. See [Schema References](subject-format.md#schema-references). |
 | `multiple` | boolean | No | `false` | Allow multiple relations |
+
+`targetSchema` uses the same reference form as a Subject's `schema`: a bare name string for a local
+Schema, or an object `{ "source", "name" }` for a Schema from another Source. A reference naming the
+local Source normalizes to the bare form.
 
 Example:
 

--- a/docs/api/subject-format.md
+++ b/docs/api/subject-format.md
@@ -220,6 +220,12 @@ that names the local Source is equivalent to its bare form and is normalized to 
 is never referenced under two identities; a relation property's `targetSchema` currently accepts
 only the bare string form at schema save time. Source keys are compared byte-for-byte.
 
+Graceful degradation of an unresolvable reference (a foreign, offline, or removed Schema) currently
+applies to the resolution, validation, and projection paths: resolution yields null with one logged
+warning and the Subject is skipped. Presenting a Subject whose schema reference is unresolvable is
+not supported on the read/View path yet: the surrounding page still renders, but that Subject's own
+View does not. This is part of the deferred sourced-Schema rendering work.
+
 ## REST API
 
 ### Reading Subjects

--- a/docs/api/subject-format.md
+++ b/docs/api/subject-format.md
@@ -50,7 +50,7 @@ Each subject in the `subjects` map has the following structure:
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `label` | string | Yes | Human-readable label for the subject |
-| `schema` | string | Yes | Name of the Schema this subject follows (page name in the Schema namespace) |
+| `schema` | string or object | Yes | Reference to the Schema this subject follows. See [Schema References](#schema-references). |
 | `statements` | object | No | Map of property names to statement objects. If omitted, the subject has no statements. |
 
 ## Statement Object
@@ -196,6 +196,28 @@ Relation IDs follow the same format as subject IDs but start with `r`.
 Example: `r1demo5rrrrrrr1`
 
 See [ADR 014](../adr/014-improved-id-format.md) for details on the ID format.
+
+## Schema References
+
+A Subject's `schema` field (and a relation property's `targetSchema` in the
+[Schema Format](schema-format.md)) is a reference to a Schema, resolved through the Schema's own
+Source ([ADR 23](../adr/023-subject-sources.md)). A Schema's Source is independent of the Subject's
+Source.
+
+- **Local form**: a bare name string, the Schema's page name in the local Schema namespace
+  ([ADR 17](../adr/017-names-as-identifiers.md)). Local references are always stored in this form.
+
+  Example: `"schema": "Company"`
+
+- **Foreign form**: an object `{ "source": "...", "name": "..." }` referencing a Schema from another
+  Source.
+
+  Example: `"schema": { "source": "otherwiki", "name": "Company" }`
+
+Schema names are page titles and may contain colons, so the source and name are kept as separate
+object fields rather than concatenated into one string. An object that names the local Source is
+equivalent to its bare form and is normalized to it, so one Schema is never referenced under two
+identities. Source keys are compared byte-for-byte.
 
 ## REST API
 

--- a/docs/api/subject-format.md
+++ b/docs/api/subject-format.md
@@ -215,9 +215,10 @@ Source.
   Example: `"schema": { "source": "otherwiki", "name": "Company" }`
 
 Schema names are page titles and may contain colons, so the source and name are kept as separate
-object fields rather than concatenated into one string. An object that names the local Source is
-equivalent to its bare form and is normalized to it, so one Schema is never referenced under two
-identities. Source keys are compared byte-for-byte.
+object fields rather than concatenated into one string. On the subject `schema` field, an object
+that names the local Source is equivalent to its bare form and is normalized to it, so one Schema
+is never referenced under two identities; a relation property's `targetSchema` currently accepts
+only the bare string form at schema save time. Source keys are compared byte-for-byte.
 
 ## REST API
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -89,6 +89,11 @@ A Schema ([ADR 6](adr/006-schemas.md)) defines a type of Subject. Examples: Pers
 
 Schemas have a name, description, and a list of Property Definitions
 
+A Schema is referenced as a `(source, name)` pair resolved through its [Source](#source)
+([ADR 23](adr/023-subject-sources.md)), independent of the referring Subject's Source; a bare name
+means the local Source, where the name is the Schema's page title in the Schema namespace
+([ADR 17](adr/017-names-as-identifiers.md)).
+
 ### Property Definition
 
 They always have a Property Name and a Property Type. Depending on the Type, they might have additional information.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -92,7 +92,10 @@ Schemas have a name, description, and a list of Property Definitions
 A Schema is referenced as a `(source, name)` pair resolved through its [Source](#source)
 ([ADR 23](adr/023-subject-sources.md)), independent of the referring Subject's Source; a bare name
 means the local Source, where the name is the Schema's page title in the Schema namespace
-([ADR 17](adr/017-names-as-identifiers.md)).
+([ADR 17](adr/017-names-as-identifiers.md)). When such a reference cannot be resolved, the
+validation and projection paths degrade gracefully (null plus a logged warning, Subject skipped);
+presenting a Subject whose schema reference is unresolvable is not supported on the read/View path
+yet (deferred sourced-Schema rendering).
 
 ### Property Definition
 

--- a/resources/ext.neowiki/src/domain/SchemaReference.ts
+++ b/resources/ext.neowiki/src/domain/SchemaReference.ts
@@ -1,0 +1,26 @@
+import type { SchemaName } from '@/domain/Schema';
+
+/**
+ * A reference to a Schema from a Source other than the local wiki (ADR 23). Schema names are page
+ * titles and may contain colons, so the source and name are kept as separate fields rather than
+ * concatenated into one string.
+ */
+export interface ForeignSchemaReference {
+	readonly source: string;
+	readonly name: SchemaName;
+}
+
+/**
+ * A reference to a Schema, resolved through its own Source. A bare name string is a local reference;
+ * an object is a reference to a Schema from another Source. Local references stay plain strings end
+ * to end.
+ */
+export type SchemaReference = SchemaName | ForeignSchemaReference;
+
+/**
+ * The Schema's name, regardless of Source. A local reference is already its name; an object
+ * reference (including one naming the local Source) reduces to its name.
+ */
+export function schemaReferenceName( reference: SchemaReference ): SchemaName {
+	return typeof reference === 'string' ? reference : reference.name;
+}

--- a/resources/ext.neowiki/src/domain/propertyTypes/Relation.ts
+++ b/resources/ext.neowiki/src/domain/propertyTypes/Relation.ts
@@ -2,6 +2,7 @@ import type { PropertyDefinition } from '@/domain/PropertyDefinition';
 import { PropertyName } from '@/domain/PropertyDefinition';
 import { newRelation, RelationValue, ValueType } from '@/domain/Value';
 import { BasePropertyType } from '@/domain/PropertyType';
+import { schemaReferenceName } from '@/domain/SchemaReference';
 
 export interface RelationProperty extends PropertyDefinition {
 
@@ -34,7 +35,7 @@ export class RelationType extends BasePropertyType<RelationProperty, RelationVal
 		return {
 			...base,
 			relation: json.relation,
-			targetSchema: json.targetSchema,
+			targetSchema: schemaReferenceName( json.targetSchema ),
 			multiple: json.multiple ?? false,
 		} as RelationProperty;
 	}

--- a/resources/ext.neowiki/src/persistence/SubjectDeserializer.ts
+++ b/resources/ext.neowiki/src/persistence/SubjectDeserializer.ts
@@ -3,6 +3,7 @@ import { PageIdentifiers } from '@/domain/PageIdentifiers';
 import { StatementList } from '@/domain/StatementList';
 import { StatementDeserializer } from '@/persistence/StatementDeserializer';
 import { SubjectWithContext } from '@/domain/SubjectWithContext';
+import { schemaReferenceName } from '@/domain/SchemaReference';
 
 export class SubjectDeserializer {
 
@@ -14,7 +15,7 @@ export class SubjectDeserializer {
 	public deserialize( json: any ): SubjectWithContext {
 		const id = new SubjectId( json.id );
 		const label = json.label;
-		const schema = json.schema;
+		const schema = schemaReferenceName( json.schema );
 
 		const pageIdentifiers = new PageIdentifiers( json.pageId, json.pageTitle );
 		const statementList = this.deserializeStatements( json.statements );

--- a/resources/ext.neowiki/src/persistence/__tests__/SubjectDeserializer.spec.ts
+++ b/resources/ext.neowiki/src/persistence/__tests__/SubjectDeserializer.spec.ts
@@ -35,6 +35,27 @@ describe( 'SubjectDeserializer', () => {
 		) );
 	} );
 
+	it( 'reduces a foreign schema reference to its name', () => {
+		const json = {
+			id: 's13333333333337',
+			label: 'SubjectDeserializer',
+			schema: { source: 'otherwiki', name: 'SDSchema' },
+			statements: {},
+			pageId: 42,
+			pageTitle: 'SDPageTitle',
+		};
+
+		const subject = deserializer.deserialize( json );
+
+		expect( subject ).toEqual( new SubjectWithContext(
+			new SubjectId( 's13333333333337' ),
+			'SubjectDeserializer',
+			'SDSchema',
+			new StatementList( [] ),
+			new PageIdentifiers( 42, 'SDPageTitle' ),
+		) );
+	} );
+
 	it( 'deserializes Subject with Statements', () => {
 		const json = {
 			id: 's13333333333337',

--- a/resources/ext.neowiki/tests/domain/PropertyDefinitionDeserializer.unit.spec.ts
+++ b/resources/ext.neowiki/tests/domain/PropertyDefinitionDeserializer.unit.spec.ts
@@ -110,6 +110,18 @@ it( 'creates a relation property definition with all fields', () => {
 	expect( property.multiple ).toBe( true );
 } );
 
+it( 'reduces a foreign target schema reference to its name', () => {
+	const json = {
+		type: 'relation',
+		relation: 'Employer',
+		targetSchema: { source: 'otherwiki', name: 'Company' },
+	};
+
+	const property = serializer.propertyDefinitionFromJson( 'test', json ) as RelationProperty;
+
+	expect( property.targetSchema ).toBe( 'Company' );
+} );
+
 it( 'degrades gracefully to a placeholder definition for an unregistered type', () => {
 	const json = {
 		type: 'color',

--- a/resources/ext.neowiki/tests/domain/SchemaReference.unit.spec.ts
+++ b/resources/ext.neowiki/tests/domain/SchemaReference.unit.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { schemaReferenceName } from '@/domain/SchemaReference';
+
+describe( 'schemaReferenceName', () => {
+
+	it( 'returns a local reference unchanged', () => {
+		expect( schemaReferenceName( 'Person' ) ).toBe( 'Person' );
+	} );
+
+	it( 'returns a local name that contains a colon unchanged', () => {
+		expect( schemaReferenceName( 'Namespace:Person' ) ).toBe( 'Namespace:Person' );
+	} );
+
+	it( 'reduces a foreign reference to its name', () => {
+		expect( schemaReferenceName( { source: 'otherwiki', name: 'Person' } ) ).toBe( 'Person' );
+	} );
+
+	it( 'reduces a foreign name that contains a colon to its name', () => {
+		expect( schemaReferenceName( { source: 'otherwiki', name: 'Namespace:Person' } ) ).toBe( 'Namespace:Person' );
+	} );
+
+} );

--- a/src/Application/Actions/ReplaceSubject/ReplaceSubjectAction.php
+++ b/src/Application/Actions/ReplaceSubject/ReplaceSubjectAction.php
@@ -6,7 +6,7 @@ namespace ProfessionalWiki\NeoWiki\Application\Actions\ReplaceSubject;
 
 use InvalidArgumentException;
 use ProfessionalWiki\NeoWiki\Application\PageIdentifiersLookup;
-use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
+use ProfessionalWiki\NeoWiki\Application\SchemaReferenceResolver;
 use ProfessionalWiki\NeoWiki\Application\SelectStatementResolver;
 use ProfessionalWiki\NeoWiki\Application\StatementListBuilder;
 use ProfessionalWiki\NeoWiki\Application\Subject\Exception\SubjectEditNotAuthorizedException;
@@ -26,7 +26,7 @@ readonly class ReplaceSubjectAction {
 		private SubjectRepository $subjectRepository,
 		private SubjectWriteAuthorizer $writeAuthorizer,
 		private StatementListBuilder $statementListBuilder,
-		private SchemaLookup $schemaLookup,
+		private SchemaReferenceResolver $schemaReferenceResolver,
 		private SelectStatementResolver $selectStatementResolver,
 		private ProposedSubjectValidator $proposedSubjectValidator,
 		private ReplaceSubjectPresenter $presenter,
@@ -88,7 +88,7 @@ readonly class ReplaceSubjectAction {
 	 * @return array<string, mixed>
 	 */
 	private function resolveStatements( Subject $subject, array $statements ): array {
-		$schema = $this->schemaLookup->getSchema( $subject->getSchemaName() );
+		$schema = $this->schemaReferenceResolver->resolve( $subject->getSchemaReference() );
 
 		if ( $schema === null ) {
 			return $statements;

--- a/src/Application/Queries/ValidateSubjectUpdate/ValidateSubjectUpdateQuery.php
+++ b/src/Application/Queries/ValidateSubjectUpdate/ValidateSubjectUpdateQuery.php
@@ -4,7 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Application\Queries\ValidateSubjectUpdate;
 
-use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
+use ProfessionalWiki\NeoWiki\Application\SchemaReferenceResolver;
 use ProfessionalWiki\NeoWiki\Application\SelectStatementResolver;
 use ProfessionalWiki\NeoWiki\Application\StatementListBuilder;
 use ProfessionalWiki\NeoWiki\Application\Subject\Exception\SubjectNotFoundException;
@@ -18,7 +18,7 @@ readonly class ValidateSubjectUpdateQuery {
 
 	public function __construct(
 		private SubjectRepository $subjectRepository,
-		private SchemaLookup $schemaLookup,
+		private SchemaReferenceResolver $schemaReferenceResolver,
 		private SubjectValidator $subjectValidator,
 		private StatementListBuilder $statementListBuilder,
 		private SelectStatementResolver $selectStatementResolver,
@@ -42,7 +42,7 @@ readonly class ValidateSubjectUpdateQuery {
 			throw SubjectNotFoundException::forId( $id );
 		}
 
-		$schema = $this->schemaLookup->getSchema( $subject->getSchemaName() );
+		$schema = $this->schemaReferenceResolver->resolve( $subject->getSchemaReference() );
 
 		if ( $schema === null ) {
 			return [

--- a/src/Application/Rdf/RdfPageProjector.php
+++ b/src/Application/Rdf/RdfPageProjector.php
@@ -6,7 +6,7 @@ namespace ProfessionalWiki\NeoWiki\Application\Rdf;
 
 use DateTimeImmutable;
 use DateTimeZone;
-use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
+use ProfessionalWiki\NeoWiki\Application\SchemaReferenceResolver;
 use ProfessionalWiki\NeoWiki\Domain\Page\Page;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageValue;
@@ -47,7 +47,7 @@ class RdfPageProjector implements PageProjector {
 	public function __construct(
 		private readonly RdfValueMapperRegistry $valueMappers,
 		private readonly RdfNamespaces $namespaces,
-		private readonly SchemaLookup $schemaLookup,
+		private readonly SchemaReferenceResolver $schemaReferenceResolver,
 		private readonly LoggerInterface $logger,
 	) {
 	}
@@ -80,7 +80,7 @@ class RdfPageProjector implements PageProjector {
 		$resolved = [];
 
 		foreach ( $subjects as $subject ) {
-			$schema = $this->schemaLookup->getSchema( $subject->getSchemaName() );
+			$schema = $this->schemaReferenceResolver->resolve( $subject->getSchemaReference() );
 
 			if ( $schema === null ) {
 				$this->logger->warning( 'Schema not found: ' . $subject->getSchemaName()->getText() );

--- a/src/Application/SchemaReferenceResolver.php
+++ b/src/Application/SchemaReferenceResolver.php
@@ -1,0 +1,19 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application;
+
+use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaReference;
+
+/**
+ * Resolves a SchemaReference to its Schema through the reference's own Source (ADR 23), or null when
+ * it cannot be resolved. The name-parameterized {@see SchemaLookup} stays the local, name-keyed seam;
+ * this one is for schema references carried by Subjects, whose source may differ from the subject's.
+ */
+interface SchemaReferenceResolver {
+
+	public function resolve( SchemaReference $reference ): ?Schema;
+
+}

--- a/src/Application/SourceRoutingSchemaReferenceResolver.php
+++ b/src/Application/SourceRoutingSchemaReferenceResolver.php
@@ -1,0 +1,40 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application;
+
+use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaReference;
+use ProfessionalWiki\NeoWiki\Domain\Source\SourceRegistry;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Resolves a SchemaReference through the Source its key resolves to. A reference whose source key is
+ * not registered degrades to not-found (null) plus one logged warning, never fatally (ADR 27),
+ * mirroring {@see SourceRoutingSubjectLookup}. A local reference routes through the local Source and
+ * behaves exactly as a direct name-keyed schema lookup.
+ */
+readonly class SourceRoutingSchemaReferenceResolver implements SchemaReferenceResolver {
+
+	public function __construct(
+		private SourceRegistry $sourceRegistry,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	public function resolve( SchemaReference $reference ): ?Schema {
+		$source = $this->sourceRegistry->getSourceForSchemaReference( $reference );
+
+		if ( $source === null ) {
+			$this->logger->warning(
+				'Schema resolution for an unregistered Source key.',
+				[ 'sourceKey' => $reference->getSource(), 'schemaName' => $reference->getName()->getText() ]
+			);
+			return null;
+		}
+
+		return $source->getSchema( $reference->getName() );
+	}
+
+}

--- a/src/Application/Validation/ProposedSubjectValidator.php
+++ b/src/Application/Validation/ProposedSubjectValidator.php
@@ -4,7 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Application\Validation;
 
-use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
+use ProfessionalWiki\NeoWiki\Application\SchemaReferenceResolver;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
 
@@ -24,7 +24,7 @@ use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
 readonly class ProposedSubjectValidator {
 
 	public function __construct(
-		private SchemaLookup $schemaLookup,
+		private SchemaReferenceResolver $schemaReferenceResolver,
 		private SubjectValidator $subjectValidator,
 	) {
 	}
@@ -33,7 +33,7 @@ readonly class ProposedSubjectValidator {
 	 * @return Violation[]
 	 */
 	public function validate( Subject $subject ): array {
-		$schema = $this->schemaLookup->getSchema( $subject->getSchemaName() );
+		$schema = $this->schemaReferenceResolver->resolve( $subject->getSchemaReference() );
 
 		if ( $schema === null ) {
 			return [

--- a/src/Domain/Schema/Property/RelationProperty.php
+++ b/src/Domain/Schema/Property/RelationProperty.php
@@ -8,6 +8,7 @@ use ProfessionalWiki\NeoWiki\Domain\Relation\RelationType;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinition;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaReference;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\Types\RelationType as RelationPropertyType;
 
 class RelationProperty extends PropertyDefinition {
@@ -15,7 +16,7 @@ class RelationProperty extends PropertyDefinition {
 	public function __construct(
 		PropertyCore $core,
 		private readonly RelationType $relationType,
-		private readonly SchemaName $targetSchema,
+		private readonly SchemaReference $targetSchema,
 		private readonly bool $multiple
 
 	) {
@@ -31,6 +32,10 @@ class RelationProperty extends PropertyDefinition {
 	}
 
 	public function getTargetSchema(): SchemaName {
+		return $this->targetSchema->getName();
+	}
+
+	public function getTargetSchemaReference(): SchemaReference {
 		return $this->targetSchema;
 	}
 
@@ -42,7 +47,7 @@ class RelationProperty extends PropertyDefinition {
 		return new self(
 			core: $core,
 			relationType: new RelationType( $property['relation'] ?? null ), // Required field, constructor throws on null
-			targetSchema: new SchemaName( $property['targetSchema'] ?? null ), // Required field, constructor throws on null
+			targetSchema: SchemaReference::fromSerializedValue( $property['targetSchema'] ?? '' ), // Required; empty throws
 			multiple: $property['multiple'] ?? false,
 		);
 	}
@@ -50,7 +55,7 @@ class RelationProperty extends PropertyDefinition {
 	public function nonCoreToJson(): array {
 		return [
 			'relation' => $this->relationType->getText(),
-			'targetSchema' => $this->targetSchema->getText(),
+			'targetSchema' => $this->targetSchema->toSerializedValue(),
 			'multiple' => $this->multiple,
 		];
 	}

--- a/src/Domain/Schema/SchemaReference.php
+++ b/src/Domain/Schema/SchemaReference.php
@@ -18,10 +18,15 @@ use InvalidArgumentException;
  */
 readonly class SchemaReference {
 
+	private const string SOURCE_KEY_PATTERN = '/^[A-Za-z0-9+_-]+\z/';
+
 	public function __construct(
 		private ?string $source,
 		private SchemaName $name,
 	) {
+		if ( $source !== null && preg_match( self::SOURCE_KEY_PATTERN, $source ) !== 1 ) {
+			throw new InvalidArgumentException( "Schema reference source key has the wrong format: '$source'" );
+		}
 	}
 
 	public static function local( SchemaName $name ): self {

--- a/src/Domain/Schema/SchemaReference.php
+++ b/src/Domain/Schema/SchemaReference.php
@@ -1,0 +1,73 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\Schema;
+
+use InvalidArgumentException;
+
+/**
+ * A reference to a Schema, resolved through its Source (ADR 23, "Schemas come from Sources"). The
+ * source is independent of any Subject's source. A null source means the local wiki; the SchemaName
+ * stays intact underneath, since locally a Schema name is a page title in the Schema namespace
+ * (ADR 17) and a source-qualified reference is not a valid title.
+ *
+ * The serialized form is a bare name string for a local reference and a `{ source, name }` object
+ * for a foreign one. Names are page titles and may legitimately contain colons, so a
+ * string-concatenation grammar would be ambiguous; the object form keeps source and name separate.
+ */
+readonly class SchemaReference {
+
+	public function __construct(
+		private ?string $source,
+		private SchemaName $name,
+	) {
+	}
+
+	public static function local( SchemaName $name ): self {
+		return new self( null, $name );
+	}
+
+	/**
+	 * @param string|array<string, mixed> $value A bare name (local) or a `{ source, name }` object (foreign).
+	 *
+	 * @throws InvalidArgumentException
+	 */
+	public static function fromSerializedValue( string|array $value ): self {
+		if ( is_string( $value ) ) {
+			return self::local( new SchemaName( $value ) );
+		}
+
+		if ( !is_string( $value['source'] ?? null ) || !is_string( $value['name'] ?? null ) ) {
+			throw new InvalidArgumentException( 'A foreign Schema reference needs a string source and name.' );
+		}
+
+		return new self( $value['source'], new SchemaName( $value['name'] ) );
+	}
+
+	public function getSource(): ?string {
+		return $this->source;
+	}
+
+	public function getName(): SchemaName {
+		return $this->name;
+	}
+
+	/**
+	 * @return string|array{source: string, name: string} A bare name for a local reference, a
+	 *  `{ source, name }` object for a foreign one.
+	 */
+	public function toSerializedValue(): string|array {
+		if ( $this->source === null ) {
+			return $this->name->getText();
+		}
+
+		return [ 'source' => $this->source, 'name' => $this->name->getText() ];
+	}
+
+	public function equals( self $other ): bool {
+		return $this->source === $other->source
+			&& $this->name->getText() === $other->name->getText();
+	}
+
+}

--- a/src/Domain/Schema/SchemaReferenceParser.php
+++ b/src/Domain/Schema/SchemaReferenceParser.php
@@ -1,0 +1,35 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\Schema;
+
+/**
+ * Parses serialized Schema references at persistence boundaries. A reference that explicitly names
+ * the local source canonicalizes to the bare local form, so one Schema is never referenced under two
+ * identities. Mirrors {@see \ProfessionalWiki\NeoWiki\Domain\Subject\SubjectIdParser}; source keys
+ * compare byte-for-byte (ADR 27).
+ */
+class SchemaReferenceParser {
+
+	public function __construct(
+		private readonly string $localSourceKey
+	) {
+	}
+
+	/**
+	 * @param string|array<string, mixed> $value
+	 *
+	 * @throws \InvalidArgumentException
+	 */
+	public function parse( string|array $value ): SchemaReference {
+		$reference = SchemaReference::fromSerializedValue( $value );
+
+		if ( $reference->getSource() === $this->localSourceKey ) {
+			return SchemaReference::local( $reference->getName() );
+		}
+
+		return $reference;
+	}
+
+}

--- a/src/Domain/Source/SourceRegistry.php
+++ b/src/Domain/Source/SourceRegistry.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Domain\Source;
 
 use LogicException;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaReference;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 
 class SourceRegistry {
@@ -39,6 +40,14 @@ class SourceRegistry {
 	 */
 	public function getSourceForId( SubjectId $id ): ?Source {
 		return $this->getSource( $id->getSource() ?? $this->localSourceKey );
+	}
+
+	/**
+	 * Maps a local reference (source null) to the local Source; null for unknown keys. A schema's
+	 * source is independent of any subject's source (ADR 23).
+	 */
+	public function getSourceForSchemaReference( SchemaReference $reference ): ?Source {
+		return $this->getSource( $reference->getSource() ?? $this->localSourceKey );
 	}
 
 }

--- a/src/Domain/Subject/Subject.php
+++ b/src/Domain/Subject/Subject.php
@@ -7,6 +7,7 @@ namespace ProfessionalWiki\NeoWiki\Domain\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Relation\TypedRelationList;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaReference;
 use ProfessionalWiki\NeoWiki\Infrastructure\IdGenerator;
 
 class Subject {
@@ -14,7 +15,7 @@ class Subject {
 	public function __construct(
 		public readonly SubjectId $id,
 		public SubjectLabel $label,
-		private readonly SchemaName $schemaName,
+		private readonly SchemaReference $schemaReference,
 		private StatementList $statements,
 	) {
 	}
@@ -28,7 +29,7 @@ class Subject {
 		return new self(
 			id: SubjectId::createNew( $idGenerator ),
 			label: $label,
-			schemaName: $schemaName,
+			schemaReference: SchemaReference::local( $schemaName ),
 			statements: $statements ?? new StatementList( [] ),
 		);
 	}
@@ -37,7 +38,7 @@ class Subject {
 		return new self(
 			id: $id,
 			label: $label,
-			schemaName: $schemaName,
+			schemaReference: SchemaReference::local( $schemaName ),
 			statements: new StatementList( [] ),
 		);
 	}
@@ -55,7 +56,11 @@ class Subject {
 	}
 
 	public function getSchemaName(): SchemaName {
-		return $this->schemaName;
+		return $this->schemaReference->getName();
+	}
+
+	public function getSchemaReference(): SchemaReference {
+		return $this->schemaReference;
 	}
 
 	public function getStatements(): StatementList {

--- a/src/GraphDatabasePlugins/Neo4j/Neo4jPlugin.php
+++ b/src/GraphDatabasePlugins/Neo4j/Neo4jPlugin.php
@@ -6,7 +6,7 @@ namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j;
 
 use Laudis\Neo4j\Contracts\ClientInterface;
 use MediaWiki\Parser\Parser;
-use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
+use ProfessionalWiki\NeoWiki\Application\SchemaReferenceResolver;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphDatabasePlugin;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\CompositeCypherQueryValidator;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\ExplainCypherQueryValidator;
@@ -37,7 +37,7 @@ readonly class Neo4jPlugin {
 	public function __construct(
 		ClientInterface $client,
 		ClientInterface $readOnlyClient,
-		SchemaLookup $schemaLookup,
+		SchemaReferenceResolver $schemaReferenceResolver,
 		Neo4jValueBuilderRegistry $valueBuilderRegistry,
 		LoggerInterface $logger,
 		string $wikiId,
@@ -45,7 +45,7 @@ readonly class Neo4jPlugin {
 		$this->projectionStore = new Neo4jProjectionStore(
 			client: $client,
 			subjectUpdaterFactory: new Neo4jSubjectUpdaterFactory(
-				schemaLookup: $schemaLookup,
+				schemaReferenceResolver: $schemaReferenceResolver,
 				valueBuilderRegistry: $valueBuilderRegistry,
 				logger: $logger,
 				wikiId: $wikiId,

--- a/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectUpdater.php
+++ b/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectUpdater.php
@@ -7,7 +7,7 @@ namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence;
 use Laudis\Neo4j\Contracts\TransactionInterface;
 use Laudis\Neo4j\Databags\SummarizedResult;
 use Laudis\Neo4j\Types\CypherList;
-use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
+use ProfessionalWiki\NeoWiki\Application\SchemaReferenceResolver;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
 use ProfessionalWiki\NeoWiki\Domain\Statement;
@@ -21,7 +21,7 @@ class Neo4jSubjectUpdater {
 	public function __construct(
 		private readonly TransactionInterface $transaction,
 		private readonly PageId $pageId,
-		private readonly SchemaLookup $schemaRepository,
+		private readonly SchemaReferenceResolver $schemaReferenceResolver,
 		private readonly Neo4jValueBuilderRegistry $valueBuilderRegistry,
 		private readonly LoggerInterface $logger,
 		private readonly string $wikiId,
@@ -30,7 +30,7 @@ class Neo4jSubjectUpdater {
 
 	public function updateSubject( Subject $subject, bool $isMainSubject ): void {
 		// TODO: we should make sure this schema retrieval is cached
-		$schema = $this->schemaRepository->getSchema( $subject->getSchemaName() );
+		$schema = $this->schemaReferenceResolver->resolve( $subject->getSchemaReference() );
 
 		if ( $schema === null ) {
 			$this->logger->warning( 'Schema not found: ' . $subject->getSchemaName()->getText() );

--- a/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectUpdaterFactory.php
+++ b/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectUpdaterFactory.php
@@ -5,14 +5,14 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence;
 
 use Laudis\Neo4j\Contracts\TransactionInterface;
-use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
+use ProfessionalWiki\NeoWiki\Application\SchemaReferenceResolver;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use Psr\Log\LoggerInterface;
 
 class Neo4jSubjectUpdaterFactory {
 
 	public function __construct(
-		private readonly SchemaLookup $schemaLookup,
+		private readonly SchemaReferenceResolver $schemaReferenceResolver,
 		private readonly Neo4jValueBuilderRegistry $valueBuilderRegistry,
 		private readonly LoggerInterface $logger,
 		private readonly string $wikiId,
@@ -23,7 +23,7 @@ class Neo4jSubjectUpdaterFactory {
 		return new Neo4jSubjectUpdater(
 			$transaction,
 			$pageId,
-			$this->schemaLookup,
+			$this->schemaReferenceResolver,
 			$this->valueBuilderRegistry,
 			$this->logger,
 			$this->wikiId,

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -64,6 +64,8 @@ use ProfessionalWiki\NeoWiki\Application\SubjectLookup;
 use ProfessionalWiki\NeoWiki\Application\SubjectRepository;
 use ProfessionalWiki\NeoWiki\Application\LazySchemaLookup;
 use ProfessionalWiki\NeoWiki\Application\LazySubjectLookup;
+use ProfessionalWiki\NeoWiki\Application\SchemaReferenceResolver;
+use ProfessionalWiki\NeoWiki\Application\SourceRoutingSchemaReferenceResolver;
 use ProfessionalWiki\NeoWiki\Application\SourceRoutingSubjectLookup;
 use ProfessionalWiki\NeoWiki\Application\MappingLookup;
 use ProfessionalWiki\NeoWiki\Application\Mappings;
@@ -263,6 +265,18 @@ class NeoWikiExtension {
 		return new SchemaReferenceParser( $this->config->wikiId );
 	}
 
+	/**
+	 * Resolves a Subject's schema reference through the reference's own Source (ADR 27). A local
+	 * reference routes through the local Source's schema lookup and behaves exactly as before; an
+	 * unresolvable reference degrades to null (schema-not-found), never fatally.
+	 */
+	public function getSchemaReferenceResolver(): SchemaReferenceResolver {
+		return new SourceRoutingSchemaReferenceResolver(
+			sourceRegistry: $this->getSourceRegistry(),
+			logger: LoggerFactory::getInstance( 'NeoWiki' ),
+		);
+	}
+
 	public function getPagePropertyProviderRegistry(): PagePropertyProviderRegistry {
 		if ( !isset( $this->pagePropertyProviderRegistry ) ) {
 			$this->pagePropertyProviderRegistry = new PagePropertyProviderRegistry();
@@ -319,7 +333,7 @@ class NeoWikiExtension {
 		return new RdfPageProjector(
 			$this->getRdfValueMapperRegistry(),
 			$this->getRdfNamespaces(),
-			$this->getSchemaLookup(),
+			$this->getSchemaReferenceResolver(),
 			LoggerFactory::getInstance( 'NeoWiki' ),
 		);
 	}
@@ -516,7 +530,7 @@ class NeoWikiExtension {
 		}
 
 		if ( $this->neo4jPlugin === null ) {
-			$this->neo4jPlugin = $this->buildNeo4jPlugin( $this->getSchemaLookup() );
+			$this->neo4jPlugin = $this->buildNeo4jPlugin( $this->getSchemaReferenceResolver() );
 		}
 
 		return $this->neo4jPlugin;
@@ -533,17 +547,17 @@ class NeoWikiExtension {
 		return $plugin;
 	}
 
-	// Test seam: lets tests build a projection store with a custom SchemaLookup.
+	// Test seam: lets tests build a projection store with a custom schema resolver.
 	// This is a hack; we should have a proper test environment.
-	public function newNeo4jProjectionStore( SchemaLookup $schemaLookup ): GraphDatabasePlugin {
-		return $this->buildNeo4jPlugin( $schemaLookup )->getGraphDatabasePlugin();
+	public function newNeo4jProjectionStore( SchemaReferenceResolver $schemaReferenceResolver ): GraphDatabasePlugin {
+		return $this->buildNeo4jPlugin( $schemaReferenceResolver )->getGraphDatabasePlugin();
 	}
 
-	private function buildNeo4jPlugin( SchemaLookup $schemaLookup ): Neo4jPlugin {
+	private function buildNeo4jPlugin( SchemaReferenceResolver $schemaReferenceResolver ): Neo4jPlugin {
 		return new Neo4jPlugin(
 			client: $this->getNeo4jClient(),
 			readOnlyClient: $this->getReadOnlyNeo4jClient(),
-			schemaLookup: $schemaLookup,
+			schemaReferenceResolver: $schemaReferenceResolver,
 			valueBuilderRegistry: $this->getValueBuilderRegistry(),
 			logger: LoggerFactory::getInstance( 'NeoWiki' ),
 			wikiId: $this->config->wikiId,
@@ -924,7 +938,7 @@ class NeoWikiExtension {
 			subjectRepository: $this->getSubjectRepository(),
 			writeAuthorizer: $this->newSubjectWriteAuthorizer( $authority ),
 			statementListBuilder: $this->getStatementListBuilder(),
-			schemaLookup: $this->getSchemaLookup(),
+			schemaReferenceResolver: $this->getSchemaReferenceResolver(),
 			selectStatementResolver: $this->getSelectStatementResolver(),
 			proposedSubjectValidator: $this->getProposedSubjectValidator(),
 			presenter: $presenter,
@@ -948,7 +962,7 @@ class NeoWikiExtension {
 
 	public function getProposedSubjectValidator(): ProposedSubjectValidator {
 		return new ProposedSubjectValidator(
-			schemaLookup: $this->getSchemaLookup(),
+			schemaReferenceResolver: $this->getSchemaReferenceResolver(),
 			subjectValidator: $this->getSubjectValidator(),
 		);
 	}
@@ -965,7 +979,7 @@ class NeoWikiExtension {
 	public function newValidateSubjectUpdateQuery(): ValidateSubjectUpdateQuery {
 		return new ValidateSubjectUpdateQuery(
 			subjectRepository: $this->getSubjectRepository(),
-			schemaLookup: $this->getSchemaLookup(),
+			schemaReferenceResolver: $this->getSchemaReferenceResolver(),
 			subjectValidator: $this->getSubjectValidator(),
 			statementListBuilder: $this->getStatementListBuilder(),
 			selectStatementResolver: $this->getSelectStatementResolver(),

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -81,6 +81,7 @@ use ProfessionalWiki\NeoWiki\Infrastructure\Rdf\HardfRdfSerializer;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\ExportPageRdfApi;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jWriteQueryEngine;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeLookup;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaReferenceParser;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectIdParser;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeRegistry;
 use ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiRegistrar;
@@ -249,12 +250,17 @@ class NeoWikiExtension {
 	public function newSubjectContentDataDeserializer(): SubjectContentDataDeserializer {
 		return new SubjectContentDataDeserializer(
 			new StatementDeserializer( $this->getPropertyTypeLookup(), $this->getSubjectIdParser() ),
-			$this->getSubjectIdParser()
+			$this->getSubjectIdParser(),
+			$this->getSchemaReferenceParser()
 		);
 	}
 
 	public function getSubjectIdParser(): SubjectIdParser {
 		return new SubjectIdParser( $this->config->wikiId );
+	}
+
+	public function getSchemaReferenceParser(): SchemaReferenceParser {
+		return new SchemaReferenceParser( $this->config->wikiId );
 	}
 
 	public function getPagePropertyProviderRegistry(): PagePropertyProviderRegistry {

--- a/src/Persistence/MediaWiki/Subject/SubjectContentDataDeserializer.php
+++ b/src/Persistence/MediaWiki/Subject/SubjectContentDataDeserializer.php
@@ -6,6 +6,7 @@ namespace ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject;
 
 use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaReference;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectIdParser;
@@ -58,7 +59,7 @@ class SubjectContentDataDeserializer {
 		return new Subject(
 			id: $this->subjectIdParser->parse( $id ),
 			label: new SubjectLabel( $jsonArray['label'] ),
-			schemaName: new SchemaName( $jsonArray['schema'] ),
+			schemaReference: SchemaReference::local( new SchemaName( $jsonArray['schema'] ) ),
 			statements: $this->buildStatementList( $jsonArray ),
 		);
 	}

--- a/src/Persistence/MediaWiki/Subject/SubjectContentDataDeserializer.php
+++ b/src/Persistence/MediaWiki/Subject/SubjectContentDataDeserializer.php
@@ -5,8 +5,7 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject;
 
 use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
-use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
-use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaReference;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaReferenceParser;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectIdParser;
@@ -18,6 +17,7 @@ class SubjectContentDataDeserializer {
 	public function __construct(
 		private readonly StatementDeserializer $statementDeserializer,
 		private readonly SubjectIdParser $subjectIdParser,
+		private readonly SchemaReferenceParser $schemaReferenceParser,
 	) {
 	}
 
@@ -59,7 +59,7 @@ class SubjectContentDataDeserializer {
 		return new Subject(
 			id: $this->subjectIdParser->parse( $id ),
 			label: new SubjectLabel( $jsonArray['label'] ),
-			schemaReference: SchemaReference::local( new SchemaName( $jsonArray['schema'] ) ),
+			schemaReference: $this->schemaReferenceParser->parse( $jsonArray['schema'] ),
 			statements: $this->buildStatementList( $jsonArray ),
 		);
 	}

--- a/src/Persistence/MediaWiki/Subject/SubjectContentDataSerializer.php
+++ b/src/Persistence/MediaWiki/Subject/SubjectContentDataSerializer.php
@@ -30,7 +30,7 @@ class SubjectContentDataSerializer {
 		foreach ( $subjectMap->asArray() as $subject ) {
 			$serializedSubjects[$subject->id->text] = [
 				'label' => $subject->label->text,
-				'schema' => $subject->getSchemaName()->getText(),
+				'schema' => $subject->getSchemaReference()->toSerializedValue(),
 				'statements' => $this->serializeStatementList( $subject->getStatements() ),
 			];
 		}

--- a/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
@@ -75,7 +75,7 @@ class CreateSubjectActionTest extends TestCase {
 			$this->schemaLookup,
 			new SelectStatementResolver( new SelectValueResolver() ),
 			new ProposedSubjectValidator(
-				schemaLookup: $this->schemaLookup,
+				schemaReferenceResolver: $this->schemaLookup,
 				subjectValidator: new SubjectValidator( propertyTypeLookup: $registry ),
 			),
 			$validationEnforced,

--- a/tests/phpunit/Application/Actions/ReplaceSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/ReplaceSubjectActionTest.php
@@ -72,10 +72,10 @@ class ReplaceSubjectActionTest extends TestCase {
 			subjectRepository: $this->subjectRepository,
 			writeAuthorizer: $authorizer ?? new SpySubjectWriteAuthorizer( allowed: true ),
 			statementListBuilder: $builder,
-			schemaLookup: $this->schemaLookup,
+			schemaReferenceResolver: $this->schemaLookup,
 			selectStatementResolver: new SelectStatementResolver( new SelectValueResolver() ),
 			proposedSubjectValidator: new ProposedSubjectValidator(
-				schemaLookup: $this->schemaLookup,
+				schemaReferenceResolver: $this->schemaLookup,
 				subjectValidator: new SubjectValidator( propertyTypeLookup: $registry ),
 			),
 			presenter: $this->presenterSpy,

--- a/tests/phpunit/Application/SourceRoutingSchemaReferenceResolverTest.php
+++ b/tests/phpunit/Application/SourceRoutingSchemaReferenceResolverTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Application;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\SourceRoutingSchemaReferenceResolver;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinitions;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaReference;
+use ProfessionalWiki\NeoWiki\Domain\Source\SourceRegistry;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpyLogger;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubSource;
+use Psr\Log\LogLevel;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Application\SourceRoutingSchemaReferenceResolver
+ */
+class SourceRoutingSchemaReferenceResolverTest extends TestCase {
+
+	private const string LOCAL_KEY = 'localwiki';
+
+	public function testResolvesLocalReferenceThroughTheLocalSource(): void {
+		$schema = $this->newSchema( 'Person' );
+
+		$result = $this->newResolver( localSource: new StubSource( schema: $schema ) )
+			->resolve( SchemaReference::local( new SchemaName( 'Person' ) ) );
+
+		$this->assertSame( $schema, $result );
+	}
+
+	public function testResolvesForeignReferenceThroughItsSource(): void {
+		$foreignSchema = $this->newSchema( 'Person' );
+		$registry = new SourceRegistry( self::LOCAL_KEY );
+		$registry->register( self::LOCAL_KEY, new StubSource( schema: $this->newSchema( 'Local' ) ) );
+		$registry->register( 'otherwiki', new StubSource( schema: $foreignSchema ) );
+
+		$result = ( new SourceRoutingSchemaReferenceResolver( $registry, new SpyLogger() ) )
+			->resolve( new SchemaReference( 'otherwiki', new SchemaName( 'Person' ) ) );
+
+		$this->assertSame( $foreignSchema, $result );
+	}
+
+	public function testUnknownSourceReturnsNull(): void {
+		$result = $this->newResolver( localSource: new StubSource() )
+			->resolve( new SchemaReference( 'unknownwiki', new SchemaName( 'Person' ) ) );
+
+		$this->assertNull( $result );
+	}
+
+	public function testUnknownSourceLogsOneDiagnosticWarning(): void {
+		$logger = new SpyLogger();
+
+		$this->newResolver( localSource: new StubSource(), logger: $logger )
+			->resolve( new SchemaReference( 'unknownwiki', new SchemaName( 'Person' ) ) );
+
+		$this->assertCount( 1, $logger->getLogCalls() );
+		$this->assertSame( LogLevel::WARNING, $logger->getLogCalls()[0]['level'] );
+		$this->assertSame( 'unknownwiki', $logger->getLogCalls()[0]['context']['sourceKey'] );
+		$this->assertSame( 'Person', $logger->getLogCalls()[0]['context']['schemaName'] );
+	}
+
+	public function testKnownSourceWithMissingSchemaReturnsNullWithoutLogging(): void {
+		$logger = new SpyLogger();
+
+		$result = $this->newResolver( localSource: new StubSource( schema: null ), logger: $logger )
+			->resolve( SchemaReference::local( new SchemaName( 'Person' ) ) );
+
+		$this->assertNull( $result );
+		$this->assertSame( [], $logger->getLogCalls() );
+	}
+
+	private function newResolver( StubSource $localSource, ?SpyLogger $logger = null ): SourceRoutingSchemaReferenceResolver {
+		$registry = new SourceRegistry( self::LOCAL_KEY );
+		$registry->register( 'otherwiki', new StubSource( schema: $this->newSchema( 'Other' ) ) );
+		$registry->register( self::LOCAL_KEY, $localSource );
+
+		return new SourceRoutingSchemaReferenceResolver( $registry, $logger ?? new SpyLogger() );
+	}
+
+	private function newSchema( string $name ): Schema {
+		return new Schema( new SchemaName( $name ), '', new PropertyDefinitions( [] ) );
+	}
+
+}

--- a/tests/phpunit/Application/SubjectResolverTest.php
+++ b/tests/phpunit/Application/SubjectResolverTest.php
@@ -14,6 +14,7 @@ use ProfessionalWiki\NeoWiki\Domain\Relation\Relation;
 use ProfessionalWiki\NeoWiki\Domain\Relation\RelationId;
 use ProfessionalWiki\NeoWiki\Domain\Relation\RelationProperties;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaReference;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
@@ -34,7 +35,7 @@ class SubjectResolverTest extends TestCase {
 		return new Subject(
 			id: new SubjectId( $id ),
 			label: new SubjectLabel( $label ),
-			schemaName: new SchemaName( 'TestSchema' ),
+			schemaReference: SchemaReference::local( new SchemaName( 'TestSchema' ) ),
 			statements: new StatementList(),
 		);
 	}

--- a/tests/phpunit/Application/Validation/ProposedSubjectValidatorTest.php
+++ b/tests/phpunit/Application/Validation/ProposedSubjectValidatorTest.php
@@ -32,7 +32,7 @@ class ProposedSubjectValidatorTest extends TestCase {
 
 	private function newValidator(): ProposedSubjectValidator {
 		return new ProposedSubjectValidator(
-			schemaLookup: $this->schemaLookup,
+			schemaReferenceResolver: $this->schemaLookup,
 			subjectValidator: new SubjectValidator( propertyTypeLookup: PropertyTypeRegistry::withCoreTypes() ),
 		);
 	}

--- a/tests/phpunit/Data/TestData.php
+++ b/tests/phpunit/Data/TestData.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Tests\Data;
 
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaReferenceParser;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectIdParser;
 
 class TestData {
@@ -16,6 +17,10 @@ class TestData {
 
 	public static function newSubjectIdParser(): SubjectIdParser {
 		return new SubjectIdParser( self::LOCAL_SOURCE_KEY );
+	}
+
+	public static function newSchemaReferenceParser(): SchemaReferenceParser {
+		return new SchemaReferenceParser( self::LOCAL_SOURCE_KEY );
 	}
 
 }

--- a/tests/phpunit/Data/TestProperty.php
+++ b/tests/phpunit/Data/TestProperty.php
@@ -13,6 +13,7 @@ use ProfessionalWiki\NeoWiki\Domain\Schema\Property\TextProperty;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\UrlProperty;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaReference;
 
 class TestProperty {
 
@@ -50,7 +51,7 @@ class TestProperty {
 				default: $default
 			),
 			relationType: $relationType instanceof RelationType ? $relationType : new RelationType( $relationType ),
-			targetSchema: $targetSchema instanceof SchemaName ? $targetSchema : new SchemaName( $targetSchema ),
+			targetSchema: SchemaReference::local( $targetSchema instanceof SchemaName ? $targetSchema : new SchemaName( $targetSchema ) ),
 			multiple: $multiple
 		);
 	}

--- a/tests/phpunit/Data/TestSubject.php
+++ b/tests/phpunit/Data/TestSubject.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Tests\Data;
 
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaReference;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
@@ -26,7 +27,7 @@ class TestSubject {
 		return new Subject(
 			id: $id instanceof SubjectId ? $id : new SubjectId( $id ),
 			label: $label instanceof SubjectLabel ? $label : new SubjectLabel( $label ),
-			schemaName: $schemaName ?? new SchemaName( self::DEFAULT_SCHEMA_ID ),
+			schemaReference: SchemaReference::local( $schemaName ?? new SchemaName( self::DEFAULT_SCHEMA_ID ) ),
 			statements: $statements ?? new StatementList( [] ),
 		);
 	}

--- a/tests/phpunit/Domain/Schema/Property/RelationPropertyTest.php
+++ b/tests/phpunit/Domain/Schema/Property/RelationPropertyTest.php
@@ -11,6 +11,7 @@ use ProfessionalWiki\NeoWiki\Domain\Schema\Property\RelationProperty;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinition;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaReference;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\Domain\Relation\RelationType
@@ -27,7 +28,7 @@ class RelationPropertyTest extends PropertyTestCase {
 				default: null
 			),
 			relationType: new RelationType( 'Type' ),
-			targetSchema: new SchemaName( 'Schema' ),
+			targetSchema: SchemaReference::local( new SchemaName( 'Schema' ) ),
 			multiple: true
 		);
 
@@ -94,6 +95,41 @@ JSON
 }
 JSON
 		);
+	}
+
+	public function testForeignTargetSchemaRoundTripsAsObject(): void {
+		$this->assertSerializationDoesNotChange(
+			<<<JSON
+{
+	"type": "relation",
+	"description": "",
+	"required": false,
+	"default": null,
+	"relation": "type",
+	"targetSchema": {
+		"source": "otherwiki",
+		"name": "Person"
+	},
+	"multiple": false
+}
+JSON
+		);
+	}
+
+	public function testGetTargetSchemaReferenceExposesTheForeignSource(): void {
+		$property = new RelationProperty(
+			core: new PropertyCore(
+				description: '',
+				required: false,
+				default: null
+			),
+			relationType: new RelationType( 'Type' ),
+			targetSchema: new SchemaReference( 'otherwiki', new SchemaName( 'Person' ) ),
+			multiple: false
+		);
+
+		$this->assertSame( 'otherwiki', $property->getTargetSchemaReference()->getSource() );
+		$this->assertSame( 'Person', $property->getTargetSchema()->getText() );
 	}
 
 	public function testExceptionOnMissingRelationType(): void {

--- a/tests/phpunit/Domain/Schema/SchemaReferenceParserTest.php
+++ b/tests/phpunit/Domain/Schema/SchemaReferenceParserTest.php
@@ -14,12 +14,12 @@ use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaReferenceParser;
 class SchemaReferenceParserTest extends TestCase {
 
 	/**
-	 * @dataProvider vectorProvider
+	 * @dataProvider validVectorProvider
 	 *
 	 * @param string|array<string, string> $input
 	 * @param string|array<string, string> $serialized
 	 */
-	public function testParsesVector( string|array $input, string|array $serialized, ?string $source, string $schemaName ): void {
+	public function testParsesValidVector( string|array $input, string|array $serialized, ?string $source, string $schemaName ): void {
 		$reference = $this->newParser()->parse( $input );
 
 		$this->assertSame( $source, $reference->getSource() );
@@ -28,7 +28,7 @@ class SchemaReferenceParserTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider vectorProvider
+	 * @dataProvider validVectorProvider
 	 *
 	 * @param string|array<string, string> $input
 	 * @param string|array<string, string> $serialized
@@ -37,22 +37,39 @@ class SchemaReferenceParserTest extends TestCase {
 		$this->assertSame( $serialized, $this->newParser()->parse( $serialized )->toSerializedValue() );
 	}
 
-	public function testAcceptsLocalSourceKeyOutsideTheSchemaNameGrammar(): void {
+	/**
+	 * @dataProvider invalidVectorProvider
+	 *
+	 * @param string|array<string, string> $input
+	 */
+	public function testRejectsInvalidVector( string|array $input ): void {
+		$this->expectException( \InvalidArgumentException::class );
+		$this->newParser()->parse( $input );
+	}
+
+	public function testAcceptsLocalSourceKeyOutsideTheKeyGrammar(): void {
 		$parser = new SchemaReferenceParser( 'weird~key' );
 
-		$reference = $parser->parse( [ 'source' => 'weird~key', 'name' => 'Person' ] );
-
-		$this->assertNull( $reference->getSource() );
-		$this->assertSame( 'Person', $reference->getName()->getText() );
+		$this->assertSame( 'Person', $parser->parse( 'Person' )->toSerializedValue() );
 	}
 
 	private function newParser(): SchemaReferenceParser {
 		return new SchemaReferenceParser( self::vectors()['localSourceKey'] );
 	}
 
-	public static function vectorProvider(): iterable {
+	public static function validVectorProvider(): iterable {
 		foreach ( self::vectors()['cases'] as $case ) {
-			yield $case['name'] => [ $case['input'], $case['serialized'], $case['source'], $case['schemaName'] ];
+			if ( $case['valid'] ) {
+				yield $case['name'] => [ $case['input'], $case['serialized'], $case['source'], $case['schemaName'] ];
+			}
+		}
+	}
+
+	public static function invalidVectorProvider(): iterable {
+		foreach ( self::vectors()['cases'] as $case ) {
+			if ( !$case['valid'] ) {
+				yield $case['name'] => [ $case['input'] ];
+			}
 		}
 	}
 

--- a/tests/phpunit/Domain/Schema/SchemaReferenceParserTest.php
+++ b/tests/phpunit/Domain/Schema/SchemaReferenceParserTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Domain\Schema;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaReferenceParser;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Domain\Schema\SchemaReferenceParser
+ * @covers \ProfessionalWiki\NeoWiki\Domain\Schema\SchemaReference
+ */
+class SchemaReferenceParserTest extends TestCase {
+
+	/**
+	 * @dataProvider vectorProvider
+	 *
+	 * @param string|array<string, string> $input
+	 * @param string|array<string, string> $serialized
+	 */
+	public function testParsesVector( string|array $input, string|array $serialized, ?string $source, string $schemaName ): void {
+		$reference = $this->newParser()->parse( $input );
+
+		$this->assertSame( $source, $reference->getSource() );
+		$this->assertSame( $schemaName, $reference->getName()->getText() );
+		$this->assertSame( $serialized, $reference->toSerializedValue() );
+	}
+
+	/**
+	 * @dataProvider vectorProvider
+	 *
+	 * @param string|array<string, string> $input
+	 * @param string|array<string, string> $serialized
+	 */
+	public function testSerializedFormParsesToItself( string|array $input, string|array $serialized ): void {
+		$this->assertSame( $serialized, $this->newParser()->parse( $serialized )->toSerializedValue() );
+	}
+
+	public function testAcceptsLocalSourceKeyOutsideTheSchemaNameGrammar(): void {
+		$parser = new SchemaReferenceParser( 'weird~key' );
+
+		$reference = $parser->parse( [ 'source' => 'weird~key', 'name' => 'Person' ] );
+
+		$this->assertNull( $reference->getSource() );
+		$this->assertSame( 'Person', $reference->getName()->getText() );
+	}
+
+	private function newParser(): SchemaReferenceParser {
+		return new SchemaReferenceParser( self::vectors()['localSourceKey'] );
+	}
+
+	public static function vectorProvider(): iterable {
+		foreach ( self::vectors()['cases'] as $case ) {
+			yield $case['name'] => [ $case['input'], $case['serialized'], $case['source'], $case['schemaName'] ];
+		}
+	}
+
+	private static function vectors(): array {
+		return json_decode( file_get_contents( __DIR__ . '/schema-reference-vectors.json' ), true );
+	}
+
+}

--- a/tests/phpunit/Domain/Schema/SchemaReferenceTest.php
+++ b/tests/phpunit/Domain/Schema/SchemaReferenceTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Domain\Schema;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaReference;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Domain\Schema\SchemaReference
+ */
+class SchemaReferenceTest extends TestCase {
+
+	public function testLocalReferenceHasNoSource(): void {
+		$reference = SchemaReference::local( new SchemaName( 'Person' ) );
+
+		$this->assertNull( $reference->getSource() );
+		$this->assertSame( 'Person', $reference->getName()->getText() );
+	}
+
+	public function testForeignReferenceKeepsItsSource(): void {
+		$reference = new SchemaReference( 'otherwiki', new SchemaName( 'Person' ) );
+
+		$this->assertSame( 'otherwiki', $reference->getSource() );
+		$this->assertSame( 'Person', $reference->getName()->getText() );
+	}
+
+	public function testLocalReferenceSerializesToBareName(): void {
+		$this->assertSame(
+			'Person',
+			SchemaReference::local( new SchemaName( 'Person' ) )->toSerializedValue()
+		);
+	}
+
+	public function testForeignReferenceSerializesToObject(): void {
+		$this->assertSame(
+			[ 'source' => 'otherwiki', 'name' => 'Person' ],
+			( new SchemaReference( 'otherwiki', new SchemaName( 'Person' ) ) )->toSerializedValue()
+		);
+	}
+
+	public function testDeserializesBareNameAsLocal(): void {
+		$reference = SchemaReference::fromSerializedValue( 'Person' );
+
+		$this->assertNull( $reference->getSource() );
+		$this->assertSame( 'Person', $reference->getName()->getText() );
+	}
+
+	public function testDeserializesObjectAsForeign(): void {
+		$reference = SchemaReference::fromSerializedValue( [ 'source' => 'otherwiki', 'name' => 'Person' ] );
+
+		$this->assertSame( 'otherwiki', $reference->getSource() );
+		$this->assertSame( 'Person', $reference->getName()->getText() );
+	}
+
+	public function testDeserializingObjectWithoutSourceKeyIsRejected(): void {
+		$this->expectException( InvalidArgumentException::class );
+		SchemaReference::fromSerializedValue( [ 'name' => 'Person' ] );
+	}
+
+	public function testDeserializingObjectWithNonStringNameIsRejected(): void {
+		$this->expectException( InvalidArgumentException::class );
+		SchemaReference::fromSerializedValue( [ 'source' => 'otherwiki', 'name' => 42 ] );
+	}
+
+	public function testLocalReferencesWithTheSameNameAreEqual(): void {
+		$this->assertTrue(
+			SchemaReference::local( new SchemaName( 'Person' ) )
+				->equals( SchemaReference::local( new SchemaName( 'Person' ) ) )
+		);
+	}
+
+	public function testReferencesWithDifferentSourcesAreNotEqual(): void {
+		$this->assertFalse(
+			SchemaReference::local( new SchemaName( 'Person' ) )
+				->equals( new SchemaReference( 'otherwiki', new SchemaName( 'Person' ) ) )
+		);
+	}
+
+	public function testForeignReferencesDifferingByNameAreNotEqual(): void {
+		$this->assertFalse(
+			( new SchemaReference( 'otherwiki', new SchemaName( 'Person' ) ) )
+				->equals( new SchemaReference( 'otherwiki', new SchemaName( 'Company' ) ) )
+		);
+	}
+
+}

--- a/tests/phpunit/Domain/Schema/SchemaReferenceTest.php
+++ b/tests/phpunit/Domain/Schema/SchemaReferenceTest.php
@@ -28,6 +28,23 @@ class SchemaReferenceTest extends TestCase {
 		$this->assertSame( 'Person', $reference->getName()->getText() );
 	}
 
+	/**
+	 * @dataProvider invalidSourceKeyProvider
+	 */
+	public function testForeignReferenceWithInvalidSourceKeyIsRejected( string $sourceKey ): void {
+		$this->expectException( InvalidArgumentException::class );
+		new SchemaReference( $sourceKey, new SchemaName( 'Person' ) );
+	}
+
+	public static function invalidSourceKeyProvider(): iterable {
+		yield 'empty' => [ '' ];
+		yield 'whitespace only' => [ '   ' ];
+		yield 'space' => [ 'other wiki' ];
+		yield 'slash' => [ 'other/wiki' ];
+		yield 'tilde' => [ 'weird~key' ];
+		yield 'non-ASCII' => [ 'wikiä' ];
+	}
+
 	public function testLocalReferenceSerializesToBareName(): void {
 		$this->assertSame(
 			'Person',
@@ -64,6 +81,11 @@ class SchemaReferenceTest extends TestCase {
 	public function testDeserializingObjectWithNonStringNameIsRejected(): void {
 		$this->expectException( InvalidArgumentException::class );
 		SchemaReference::fromSerializedValue( [ 'source' => 'otherwiki', 'name' => 42 ] );
+	}
+
+	public function testDeserializingObjectWithInvalidSourceKeyIsRejected(): void {
+		$this->expectException( InvalidArgumentException::class );
+		SchemaReference::fromSerializedValue( [ 'source' => 'other wiki', 'name' => 'Person' ] );
 	}
 
 	public function testLocalReferencesWithTheSameNameAreEqual(): void {

--- a/tests/phpunit/Domain/Schema/schema-reference-vectors.json
+++ b/tests/phpunit/Domain/Schema/schema-reference-vectors.json
@@ -1,0 +1,47 @@
+{
+	"localSourceKey": "mywiki",
+	"cases": [
+		{
+			"name": "bare name is local",
+			"input": "Person",
+			"serialized": "Person",
+			"source": null,
+			"schemaName": "Person"
+		},
+		{
+			"name": "local name may contain a colon",
+			"input": "Namespace:Person",
+			"serialized": "Namespace:Person",
+			"source": null,
+			"schemaName": "Namespace:Person"
+		},
+		{
+			"name": "foreign object keeps its source",
+			"input": { "source": "otherwiki", "name": "Person" },
+			"serialized": { "source": "otherwiki", "name": "Person" },
+			"source": "otherwiki",
+			"schemaName": "Person"
+		},
+		{
+			"name": "foreign name may contain a colon",
+			"input": { "source": "otherwiki", "name": "Namespace:Person" },
+			"serialized": { "source": "otherwiki", "name": "Namespace:Person" },
+			"source": "otherwiki",
+			"schemaName": "Namespace:Person"
+		},
+		{
+			"name": "object naming the local source canonicalizes to bare",
+			"input": { "source": "mywiki", "name": "Person" },
+			"serialized": "Person",
+			"source": null,
+			"schemaName": "Person"
+		},
+		{
+			"name": "source key comparison is byte exact, so a different case stays foreign",
+			"input": { "source": "MyWiki", "name": "Person" },
+			"serialized": { "source": "MyWiki", "name": "Person" },
+			"source": "MyWiki",
+			"schemaName": "Person"
+		}
+	]
+}

--- a/tests/phpunit/Domain/Schema/schema-reference-vectors.json
+++ b/tests/phpunit/Domain/Schema/schema-reference-vectors.json
@@ -4,6 +4,7 @@
 		{
 			"name": "bare name is local",
 			"input": "Person",
+			"valid": true,
 			"serialized": "Person",
 			"source": null,
 			"schemaName": "Person"
@@ -11,6 +12,7 @@
 		{
 			"name": "local name may contain a colon",
 			"input": "Namespace:Person",
+			"valid": true,
 			"serialized": "Namespace:Person",
 			"source": null,
 			"schemaName": "Namespace:Person"
@@ -18,6 +20,7 @@
 		{
 			"name": "foreign object keeps its source",
 			"input": { "source": "otherwiki", "name": "Person" },
+			"valid": true,
 			"serialized": { "source": "otherwiki", "name": "Person" },
 			"source": "otherwiki",
 			"schemaName": "Person"
@@ -25,6 +28,7 @@
 		{
 			"name": "foreign name may contain a colon",
 			"input": { "source": "otherwiki", "name": "Namespace:Person" },
+			"valid": true,
 			"serialized": { "source": "otherwiki", "name": "Namespace:Person" },
 			"source": "otherwiki",
 			"schemaName": "Namespace:Person"
@@ -32,6 +36,7 @@
 		{
 			"name": "object naming the local source canonicalizes to bare",
 			"input": { "source": "mywiki", "name": "Person" },
+			"valid": true,
 			"serialized": "Person",
 			"source": null,
 			"schemaName": "Person"
@@ -39,9 +44,48 @@
 		{
 			"name": "source key comparison is byte exact, so a different case stays foreign",
 			"input": { "source": "MyWiki", "name": "Person" },
+			"valid": true,
 			"serialized": { "source": "MyWiki", "name": "Person" },
 			"source": "MyWiki",
 			"schemaName": "Person"
+		},
+		{
+			"name": "underscore, hyphen and plus are legal source-key characters",
+			"input": { "source": "wiki_en-farm+1", "name": "Person" },
+			"valid": true,
+			"serialized": { "source": "wiki_en-farm+1", "name": "Person" },
+			"source": "wiki_en-farm+1",
+			"schemaName": "Person"
+		},
+		{
+			"name": "empty source key",
+			"input": { "source": "", "name": "Person" },
+			"valid": false
+		},
+		{
+			"name": "whitespace source key",
+			"input": { "source": "   ", "name": "Person" },
+			"valid": false
+		},
+		{
+			"name": "space in source key",
+			"input": { "source": "my wiki", "name": "Person" },
+			"valid": false
+		},
+		{
+			"name": "slash in source key",
+			"input": { "source": "en/wiki", "name": "Person" },
+			"valid": false
+		},
+		{
+			"name": "tilde in source key",
+			"input": { "source": "weird~key", "name": "Person" },
+			"valid": false
+		},
+		{
+			"name": "non-ASCII source key",
+			"input": { "source": "wikiä", "name": "Person" },
+			"valid": false
 		}
 	]
 }

--- a/tests/phpunit/Domain/Source/SourceRegistryTest.php
+++ b/tests/phpunit/Domain/Source/SourceRegistryTest.php
@@ -6,6 +6,8 @@ namespace ProfessionalWiki\NeoWiki\Tests\Domain\Source;
 
 use LogicException;
 use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaReference;
 use ProfessionalWiki\NeoWiki\Domain\Source\SourceRegistry;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubSource;
@@ -77,6 +79,39 @@ class SourceRegistryTest extends TestCase {
 		$registry->register( self::LOCAL_KEY, new StubSource() );
 
 		$this->assertNull( $registry->getSourceForId( new SubjectId( 'LOCALWIKI:s11111111111111' ) ) );
+	}
+
+	public function testLocalSchemaReferenceMapsToTheLocalSource(): void {
+		$localSource = new StubSource();
+		$registry = new SourceRegistry( self::LOCAL_KEY );
+		$registry->register( 'otherwiki', new StubSource() );
+		$registry->register( self::LOCAL_KEY, $localSource );
+
+		$this->assertSame(
+			$localSource,
+			$registry->getSourceForSchemaReference( SchemaReference::local( new SchemaName( 'Person' ) ) )
+		);
+	}
+
+	public function testForeignSchemaReferenceMapsToItsSource(): void {
+		$otherSource = new StubSource();
+		$registry = new SourceRegistry( self::LOCAL_KEY );
+		$registry->register( self::LOCAL_KEY, new StubSource() );
+		$registry->register( 'otherwiki', $otherSource );
+
+		$this->assertSame(
+			$otherSource,
+			$registry->getSourceForSchemaReference( new SchemaReference( 'otherwiki', new SchemaName( 'Person' ) ) )
+		);
+	}
+
+	public function testSchemaReferenceWithUnregisteredSourceMapsToNull(): void {
+		$registry = new SourceRegistry( self::LOCAL_KEY );
+		$registry->register( self::LOCAL_KEY, new StubSource() );
+
+		$this->assertNull(
+			$registry->getSourceForSchemaReference( new SchemaReference( 'unknownwiki', new SchemaName( 'Person' ) ) )
+		);
 	}
 
 	public function testRegisteringAnAlreadyTakenKeyThrows(): void {

--- a/tests/phpunit/EntryPoints/NeoWikiValueParserFunctionTest.php
+++ b/tests/phpunit/EntryPoints/NeoWikiValueParserFunctionTest.php
@@ -16,6 +16,7 @@ use ProfessionalWiki\NeoWiki\Domain\Relation\RelationId;
 use ProfessionalWiki\NeoWiki\Domain\Relation\RelationProperties;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyName;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaReference;
 use ProfessionalWiki\NeoWiki\Domain\Statement;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
@@ -52,7 +53,7 @@ class NeoWikiValueParserFunctionTest extends TestCase {
 		return new Subject(
 			id: new SubjectId( self::SUBJECT_ID ),
 			label: new SubjectLabel( 'Test Subject' ),
-			schemaName: new SchemaName( 'TestSchema' ),
+			schemaReference: SchemaReference::local( new SchemaName( 'TestSchema' ) ),
 			statements: new StatementList( $statements ),
 		);
 	}
@@ -207,7 +208,7 @@ class NeoWikiValueParserFunctionTest extends TestCase {
 		$targetSubject = new Subject(
 			id: new SubjectId( self::TARGET_SUBJECT_ID ),
 			label: new SubjectLabel( 'Sarah Naumann' ),
-			schemaName: new SchemaName( 'Person' ),
+			schemaReference: SchemaReference::local( new SchemaName( 'Person' ) ),
 			statements: new StatementList(),
 		);
 
@@ -258,13 +259,13 @@ class NeoWikiValueParserFunctionTest extends TestCase {
 		$target1 = new Subject(
 			id: new SubjectId( 's1test5bbbbbbbb' ),
 			label: new SubjectLabel( 'Alice' ),
-			schemaName: new SchemaName( 'Person' ),
+			schemaReference: SchemaReference::local( new SchemaName( 'Person' ) ),
 			statements: new StatementList(),
 		);
 		$target2 = new Subject(
 			id: new SubjectId( 's1test5cccccccc' ),
 			label: new SubjectLabel( 'Bob' ),
-			schemaName: new SchemaName( 'Person' ),
+			schemaReference: SchemaReference::local( new SchemaName( 'Person' ) ),
 			statements: new StatementList(),
 		);
 
@@ -382,7 +383,7 @@ class NeoWikiValueParserFunctionTest extends TestCase {
 		$targetSubject = new Subject(
 			id: new SubjectId( self::TARGET_SUBJECT_ID ),
 			label: new SubjectLabel( 'Other Subject' ),
-			schemaName: new SchemaName( 'TestSchema' ),
+			schemaReference: SchemaReference::local( new SchemaName( 'TestSchema' ) ),
 			statements: new StatementList( [
 				new Statement( new PropertyName( 'City' ), 'text', new StringValue( 'Munich' ) ),
 			] ),
@@ -423,7 +424,7 @@ class NeoWikiValueParserFunctionTest extends TestCase {
 		$subjectViaId = new Subject(
 			id: new SubjectId( self::TARGET_SUBJECT_ID ),
 			label: new SubjectLabel( 'Via ID' ),
-			schemaName: new SchemaName( 'TestSchema' ),
+			schemaReference: SchemaReference::local( new SchemaName( 'TestSchema' ) ),
 			statements: new StatementList( [
 				new Statement( new PropertyName( 'City' ), 'text', new StringValue( 'FromSubject' ) ),
 			] ),

--- a/tests/phpunit/EntryPoints/Scribunto/NeoWikiLibraryTestBase.php
+++ b/tests/phpunit/EntryPoints/Scribunto/NeoWikiLibraryTestBase.php
@@ -16,6 +16,7 @@ use MediaWiki\Title\Title;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyName;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaReference;
 use ProfessionalWiki\NeoWiki\Domain\Statement;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
@@ -90,7 +91,7 @@ abstract class NeoWikiLibraryTestBase extends LuaEngineTestBase {
 			mainSubject: new Subject(
 				id: new SubjectId( 's1test5aaaaaaaa' ),
 				label: new SubjectLabel( 'Test Company' ),
-				schemaName: new SchemaName( 'Company' ),
+				schemaReference: SchemaReference::local( new SchemaName( 'Company' ) ),
 				statements: new StatementList( [
 					new Statement( new PropertyName( 'City' ), 'text', new StringValue( 'Berlin' ) ),
 					new Statement( new PropertyName( 'Tags' ), 'text', new StringValue( 'alpha', 'beta', 'gamma' ) ),
@@ -104,14 +105,14 @@ abstract class NeoWikiLibraryTestBase extends LuaEngineTestBase {
 			mainSubject: new Subject(
 				id: new SubjectId( 's1test5cccccccc' ),
 				label: new SubjectLabel( 'Parent' ),
-				schemaName: new SchemaName( 'Company' ),
+				schemaReference: SchemaReference::local( new SchemaName( 'Company' ) ),
 				statements: new StatementList(),
 			),
 			childSubjects: new SubjectMap(
 				new Subject(
 					id: new SubjectId( 's1test5dddddddd' ),
 					label: new SubjectLabel( 'Child Entry' ),
-					schemaName: new SchemaName( 'Entry' ),
+					schemaReference: SchemaReference::local( new SchemaName( 'Entry' ) ),
 					statements: new StatementList( [
 						new Statement( new PropertyName( 'Note' ), 'text', new StringValue( 'A child subject' ) ),
 					] ),

--- a/tests/phpunit/EntryPoints/Scribunto/SchemaLuaSerializerTest.php
+++ b/tests/phpunit/EntryPoints/Scribunto/SchemaLuaSerializerTest.php
@@ -17,6 +17,7 @@ use ProfessionalWiki\NeoWiki\Domain\Schema\Property\TextProperty;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\UrlProperty;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaReference;
 use ProfessionalWiki\NeoWiki\EntryPoints\Scribunto\SchemaLuaSerializer;
 
 /**
@@ -181,7 +182,7 @@ class SchemaLuaSerializerTest extends TestCase {
 			'Employer' => new RelationProperty(
 				$this->coreOptional(),
 				new RelationType( 'Works for' ),
-				new SchemaName( 'Company' ),
+				SchemaReference::local( new SchemaName( 'Company' ) ),
 				multiple: false
 			),
 		] );

--- a/tests/phpunit/EntryPoints/Scribunto/SubjectDataLookupTest.php
+++ b/tests/phpunit/EntryPoints/Scribunto/SubjectDataLookupTest.php
@@ -14,6 +14,7 @@ use ProfessionalWiki\NeoWiki\Domain\Relation\RelationId;
 use ProfessionalWiki\NeoWiki\Domain\Relation\RelationProperties;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyName;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaReference;
 use ProfessionalWiki\NeoWiki\Domain\Statement;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
@@ -46,7 +47,7 @@ class SubjectDataLookupTest extends TestCase {
 		return new Subject(
 			id: new SubjectId( self::SUBJECT_ID ),
 			label: new SubjectLabel( 'Test Subject' ),
-			schemaName: new SchemaName( 'TestSchema' ),
+			schemaReference: SchemaReference::local( new SchemaName( 'TestSchema' ) ),
 			statements: new StatementList( $statements ),
 		);
 	}
@@ -160,7 +161,7 @@ class SubjectDataLookupTest extends TestCase {
 		$targetSubject = new Subject(
 			id: new SubjectId( self::TARGET_SUBJECT_ID ),
 			label: new SubjectLabel( 'Sarah Naumann' ),
-			schemaName: new SchemaName( 'Person' ),
+			schemaReference: SchemaReference::local( new SchemaName( 'Person' ) ),
 			statements: new StatementList(),
 		);
 
@@ -191,7 +192,7 @@ class SubjectDataLookupTest extends TestCase {
 		$target1 = new Subject(
 			id: new SubjectId( 's1test5bbbbbbbb' ),
 			label: new SubjectLabel( 'Alice' ),
-			schemaName: new SchemaName( 'Person' ),
+			schemaReference: SchemaReference::local( new SchemaName( 'Person' ) ),
 			statements: new StatementList(),
 		);
 
@@ -282,7 +283,7 @@ class SubjectDataLookupTest extends TestCase {
 		$targetSubject = new Subject(
 			id: new SubjectId( self::TARGET_SUBJECT_ID ),
 			label: new SubjectLabel( 'Other Subject' ),
-			schemaName: new SchemaName( 'TestSchema' ),
+			schemaReference: SchemaReference::local( new SchemaName( 'TestSchema' ) ),
 			statements: new StatementList( [
 				new Statement( new PropertyName( 'City' ), 'text', new StringValue( 'Munich' ) ),
 			] ),
@@ -365,13 +366,13 @@ class SubjectDataLookupTest extends TestCase {
 		$target1 = new Subject(
 			id: new SubjectId( 's1test5bbbbbbbb' ),
 			label: new SubjectLabel( 'Alice' ),
-			schemaName: new SchemaName( 'Person' ),
+			schemaReference: SchemaReference::local( new SchemaName( 'Person' ) ),
 			statements: new StatementList(),
 		);
 		$target2 = new Subject(
 			id: new SubjectId( 's1test5cccccccc' ),
 			label: new SubjectLabel( 'Bob' ),
-			schemaName: new SchemaName( 'Person' ),
+			schemaReference: SchemaReference::local( new SchemaName( 'Person' ) ),
 			statements: new StatementList(),
 		);
 
@@ -464,7 +465,7 @@ class SubjectDataLookupTest extends TestCase {
 		$subject = new Subject(
 			id: new SubjectId( self::TARGET_SUBJECT_ID ),
 			label: new SubjectLabel( 'ACME Corp' ),
-			schemaName: new SchemaName( 'Company' ),
+			schemaReference: SchemaReference::local( new SchemaName( 'Company' ) ),
 			statements: new StatementList( [
 				new Statement( new PropertyName( 'Founded' ), 'number', new NumberValue( 1985 ) ),
 			] ),
@@ -497,14 +498,14 @@ class SubjectDataLookupTest extends TestCase {
 		$targetSubject = new Subject(
 			id: new SubjectId( self::TARGET_SUBJECT_ID ),
 			label: new SubjectLabel( 'Jane Doe' ),
-			schemaName: new SchemaName( 'Person' ),
+			schemaReference: SchemaReference::local( new SchemaName( 'Person' ) ),
 			statements: new StatementList(),
 		);
 
 		$subject = new Subject(
 			id: new SubjectId( self::SUBJECT_ID ),
 			label: new SubjectLabel( 'ACME Corp' ),
-			schemaName: new SchemaName( 'Company' ),
+			schemaReference: SchemaReference::local( new SchemaName( 'Company' ) ),
 			statements: new StatementList( [
 				new Statement(
 					new PropertyName( 'CEO' ),
@@ -539,13 +540,13 @@ class SubjectDataLookupTest extends TestCase {
 		$child1 = new Subject(
 			id: new SubjectId( self::TARGET_SUBJECT_ID ),
 			label: new SubjectLabel( 'Child One' ),
-			schemaName: new SchemaName( 'ChildSchema' ),
+			schemaReference: SchemaReference::local( new SchemaName( 'ChildSchema' ) ),
 			statements: new StatementList(),
 		);
 		$child2 = new Subject(
 			id: new SubjectId( self::CHILD_SUBJECT_ID ),
 			label: new SubjectLabel( 'Child Two' ),
-			schemaName: new SchemaName( 'ChildSchema' ),
+			schemaReference: SchemaReference::local( new SchemaName( 'ChildSchema' ) ),
 			statements: new StatementList(),
 		);
 

--- a/tests/phpunit/EntryPoints/ViewParserFunctionTest.php
+++ b/tests/phpunit/EntryPoints/ViewParserFunctionTest.php
@@ -10,6 +10,7 @@ use MediaWiki\Title\Title;
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaReference;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
@@ -138,7 +139,7 @@ class ViewParserFunctionTest extends TestCase {
 		$mainSubject = new Subject(
 			id: new SubjectId( self::MAIN_SUBJECT_ID ),
 			label: new SubjectLabel( 'Main' ),
-			schemaName: new SchemaName( 'TestSchema' ),
+			schemaReference: SchemaReference::local( new SchemaName( 'TestSchema' ) ),
 			statements: new StatementList(),
 		);
 

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStoreTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStoreTest.php
@@ -15,6 +15,7 @@ use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinitions;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\RelationProperty;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaReference;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectMap;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
@@ -379,7 +380,7 @@ class Neo4jProjectionStoreTest extends NeoWikiIntegrationTestCase {
 						$relationPropertyName => new RelationProperty(
 							core: new PropertyCore( description: '', required: false, default: null ),
 							relationType: new RelationType( $relationType ),
-							targetSchema: new SchemaName( TestSubject::DEFAULT_SCHEMA_ID ),
+							targetSchema: SchemaReference::local( new SchemaName( TestSubject::DEFAULT_SCHEMA_ID ) ),
 							multiple: false,
 						),
 					] ),

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStoreTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStoreTest.php
@@ -67,7 +67,7 @@ class Neo4jProjectionStoreTest extends NeoWikiIntegrationTestCase {
 		return new Neo4jProjectionStore(
 			client: $extension->getNeo4jClient(),
 			subjectUpdaterFactory: new Neo4jSubjectUpdaterFactory(
-				schemaLookup: new InMemorySchemaLookup(
+				schemaReferenceResolver: new InMemorySchemaLookup(
 					TestSchema::build( name: TestSubject::DEFAULT_SCHEMA_ID )
 				),
 				valueBuilderRegistry: $extension->getValueBuilderRegistry(),

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectUpdaterTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectUpdaterTest.php
@@ -8,6 +8,7 @@ use Laudis\Neo4j\Contracts\TransactionInterface;
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaReference;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
@@ -47,7 +48,7 @@ class Neo4jSubjectUpdaterTest extends TestCase {
 		$this->subject = new Subject(
 			$subjectId,
 			new SubjectLabel( 'Test Label' ),
-			new SchemaName( self::SCHEMA_NAME ),
+			SchemaReference::local( new SchemaName( self::SCHEMA_NAME ) ),
 			new StatementList( [] )
 		);
 	}

--- a/tests/phpunit/Persistence/MediaWiki/Subject/SubjectContentDataSerializerTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/Subject/SubjectContentDataSerializerTest.php
@@ -12,8 +12,10 @@ use ProfessionalWiki\NeoWiki\Domain\Relation\RelationId;
 use ProfessionalWiki\NeoWiki\Domain\Relation\RelationProperties;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyName;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaReference;
 use ProfessionalWiki\NeoWiki\Domain\Statement;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
+use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectMap;
@@ -133,6 +135,74 @@ class SubjectContentDataSerializerTest extends TestCase {
 		);
 	}
 
+	private const string FOREIGN_SCHEMA_PAGE_JSON = '{
+    "mainSubject": null,
+    "subjects": {
+        "sTestSCDST11116": {
+            "label": "Foreign schema subject",
+            "schema": {
+                "source": "otherwiki",
+                "name": "Person"
+            },
+            "statements": {}
+        }
+    }
+}';
+
+	public function testForeignSchemaReferenceSerializesAsObject(): void {
+		$serializer = new SubjectContentDataSerializer();
+
+		$this->assertSame(
+			self::FOREIGN_SCHEMA_PAGE_JSON,
+			$serializer->serialize( new PageSubjects(
+				null,
+				new SubjectMap(
+					new Subject(
+						id: new SubjectId( 'sTestSCDST11116' ),
+						label: new SubjectLabel( 'Foreign schema subject' ),
+						schemaReference: new SchemaReference( 'otherwiki', new SchemaName( 'Person' ) ),
+						statements: new StatementList( [] ),
+					)
+				)
+			) )
+		);
+	}
+
+	public function testForeignSchemaReferenceRoundTripsByteIdentically(): void {
+		$this->assertSame(
+			self::FOREIGN_SCHEMA_PAGE_JSON,
+			$this->roundTrip( self::FOREIGN_SCHEMA_PAGE_JSON )
+		);
+	}
+
+	public function testSchemaObjectNamingTheLocalSourceCanonicalizesToBareName(): void {
+		$objectForm = '{
+    "mainSubject": null,
+    "subjects": {
+        "sTestSCDST11117": {
+            "label": "Local schema subject",
+            "schema": {
+                "source": "testwiki",
+                "name": "Person"
+            },
+            "statements": {}
+        }
+    }
+}';
+		$bareForm = '{
+    "mainSubject": null,
+    "subjects": {
+        "sTestSCDST11117": {
+            "label": "Local schema subject",
+            "schema": "Person",
+            "statements": {}
+        }
+    }
+}';
+
+		$this->assertSame( $bareForm, $this->roundTrip( $objectForm ) );
+	}
+
 	public function testLocalOnlyPageSlotJsonRoundTripsByteIdentically(): void {
 		$deserializer = NeoWikiExtension::getInstance()->newSubjectContentDataDeserializer();
 		$serializer = new SubjectContentDataSerializer();
@@ -240,7 +310,8 @@ class SubjectContentDataSerializerTest extends TestCase {
 	private function roundTrip( string $contentJson ): string {
 		$deserializer = new SubjectContentDataDeserializer(
 			new StatementDeserializer( PropertyTypeRegistry::withCoreTypes(), TestData::newSubjectIdParser() ),
-			TestData::newSubjectIdParser()
+			TestData::newSubjectIdParser(),
+			TestData::newSchemaReferenceParser()
 		);
 
 		return ( new SubjectContentDataSerializer() )->serialize( $deserializer->deserialize( $contentJson ) );

--- a/tests/phpunit/TestDoubles/InMemorySchemaLookup.php
+++ b/tests/phpunit/TestDoubles/InMemorySchemaLookup.php
@@ -6,9 +6,16 @@ namespace ProfessionalWiki\NeoWiki\Tests\TestDoubles;
 
 use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
 use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
+use ProfessionalWiki\NeoWiki\Application\SchemaReferenceResolver;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaReference;
 
-class InMemorySchemaLookup implements SchemaLookup {
+/**
+ * Serves both the name-keyed SchemaLookup and the reference-keyed SchemaReferenceResolver: test
+ * references are local, so resolving one is just a name lookup. Letting one double satisfy both
+ * keeps consumers that hold a lookup and a resolver on the same seam sharing a single instance.
+ */
+class InMemorySchemaLookup implements SchemaLookup, SchemaReferenceResolver {
 
 	/**
 	 * @var array<string, ?Schema>
@@ -21,6 +28,10 @@ class InMemorySchemaLookup implements SchemaLookup {
 
 	public function getSchema( SchemaName $schemaName ): ?Schema {
 		return $this->schemas[$schemaName->getText()] ?? null;
+	}
+
+	public function resolve( SchemaReference $reference ): ?Schema {
+		return $this->getSchema( $reference->getName() );
 	}
 
 	public function updateSchema( Schema $schema ): void {

--- a/tests/phpunit/TestDoubles/StubSource.php
+++ b/tests/phpunit/TestDoubles/StubSource.php
@@ -14,6 +14,7 @@ class StubSource implements Source {
 
 	public function __construct(
 		private readonly ?Subject $subject = null,
+		private readonly ?Schema $schema = null,
 	) {
 	}
 
@@ -22,7 +23,7 @@ class StubSource implements Source {
 	}
 
 	public function getSchema( SchemaName $schemaName ): ?Schema {
-		return null;
+		return $this->schema;
 	}
 
 	public function isEditable(): bool {


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/NeoWiki/issues/993 (work order T3). Builds on the T2 Source
contract PR and targets its branch, so the diff shows only this track.

Schema references become `(source, name)`, resolved through the schema's own Source and degrading
gracefully when unresolvable. Reference plumbing only; no non-local schema source exists yet.

Design calls recorded here:

- **A distinct `SchemaReference` value object** with `SchemaName` intact underneath, per the work
  order's own lean: locally the name IS the page title in the Schema namespace, and a
  source-qualified reference is not a valid title.
- **Foreign references serialize as a JSON object `{ "source": ..., "name": ... }`, not a
  `source:Name` string.** Schema names are page titles and may legitimately contain colons, so a
  string-concatenation grammar is ambiguous; subject ids avoid that only because the bare nanoid
  alphabet excludes the separator. Local references stay bare name strings, byte-identical to
  before (regression-pinned on both persisted spots).
- **Canonicalization**: on the subject `schema` field, an object naming the local Source normalizes
  to the bare form at parse time (mirroring `SubjectIdParser`), so one Schema is never referenced
  under two identities. A relation property's `targetSchema` is deliberately not at full parity
  yet: schema save validation still accepts only the bare string form, so the object form has no
  ingress there, and normalization is omitted where it can never run. Widening the schema-save
  contract and canonicalizing that path belongs with sourced-schema authoring; flip it in review if
  you prefer parity now.
- **Resolution** routes through the T2 registry via `SourceRoutingSchemaReferenceResolver`,
  mirroring the subject routing semantics exactly: unknown source keys degrade to null plus one
  logged warning, and unresolvable references land in the pre-existing `schema-not-found` /
  null-schema handling in all five converted consumers (validators, replace action, RDF projector,
  Neo4j updater), never fatally. Name-parameterized paths (REST schema APIs, new-subject creation)
  stay name-based.
- **The Neo4j schema-name node label stays local-only** (work-order constraint), and the frontend
  reduces string-or-object references to the bare name: sourced rendering is deferred by ADR 23, so
  the TS domain keeps plain names end to end.

Docs: `docs/api/subject-format.md` gains the Schema References section, `docs/api/schema-format.md`
documents the `targetSchema` forms and their current acceptance honestly, and the glossary Schema
entry notes the reference form.

> <sub>AI-authored — Claude Code, `Fable 5 (max)`; standing directive from @malberts to complete the #993 tracks without blocking on inter-track human review, design calls delegated; diff not yet human-reviewed; TDD with watched failures per behavior, two adversarial AI review lenses with live probes (hook-ordering re-trace across five accessor orders, byte-identity on seeded content, ingress enumeration for the canonicalization asymmetry), `make ci` and `make ts-ci` green locally, branch CI pending at posting time.</sub>

<details><summary>Production notes</summary>

Design and review adjudication by `Fable 5 (max)`; implementation by an `Opus 4.8 (max)` subagent;
two `Opus 4.8 (max)` review lenses (runtime correctness with container probes, tests/conventions/
docs) stood in for the usual pre-PR human review at @malberts' direction. The review confirmed the
targetSchema asymmetry is unreachable through every current ingress and found only docs overclaims,
which the final commit scopes to shipped behavior.

</details>
