### PR TITLE
Render Mapping pages instead of blanking the Read tab

### DIFF
--- a/src/EntryPoints/Content/MappingContentHandler.php
+++ b/src/EntryPoints/Content/MappingContentHandler.php
@@ -7,9 +7,7 @@ namespace ProfessionalWiki\NeoWiki\EntryPoints\Content;
 use InvalidArgumentException;
 use MediaWiki\Content\Content;
 use MediaWiki\Content\JsonContentHandler;
-use MediaWiki\Content\Renderer\ContentParseParams;
 use MediaWiki\Content\ValidationParams;
-use MediaWiki\Parser\ParserOutput;
 use MediaWiki\Title\Title;
 use ProfessionalWiki\NeoWiki\Application\Mappings;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\MappingName;
@@ -82,14 +80,6 @@ class MappingContentHandler extends JsonContentHandler {
 				$conflict->name->getText()
 			);
 		}
-	}
-
-	protected function fillParserOutput(
-		Content $content,
-		ContentParseParams $cpoParams,
-		ParserOutput &$parserOutput
-	): void {
-		$parserOutput->setRawText( '' );
 	}
 
 	public function makeEmptyContent(): MappingContent {

--- a/tests/phpunit/EntryPoints/Content/MappingContentHandlerParserOutputTest.php
+++ b/tests/phpunit/EntryPoints/Content/MappingContentHandlerParserOutputTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\Content;
+
+use MediaWiki\Content\Renderer\ContentParseParams;
+use MediaWiki\Title\Title;
+use MediaWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\EntryPoints\Content\MappingContent;
+use ProfessionalWiki\NeoWiki\EntryPoints\Content\MappingContentHandler;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\Content\MappingContentHandler
+ * @group Database
+ */
+class MappingContentHandlerParserOutputTest extends MediaWikiIntegrationTestCase {
+
+	private function render( string $json, string $name = 'Person to EDM' ): string {
+		$handler = new MappingContentHandler( MappingContent::CONTENT_MODEL_ID );
+		$page = Title::makeTitle( NeoWikiExtension::NS_MAPPING, $name )->toPageIdentity();
+		$cpoParams = new ContentParseParams( $page, null, null, true );
+
+		return $handler->getParserOutput( new MappingContent( $json ), $cpoParams )->getRawText();
+	}
+
+	public function testMappingJsonIsVisibleOnTheReadTab(): void {
+		$this->assertStringContainsString( 'edm:Agent', $this->render( $this->personToEdm() ) );
+	}
+
+	private function personToEdm(): string {
+		return <<<JSON
+			{
+				"version": 1,
+				"schema": "Person",
+				"target": "edm",
+				"prefixes": {
+					"edm": "http://www.europeana.eu/schemas/edm/",
+					"rdaGr2": "http://rdvocab.info/ElementsGr2/",
+					"skos": "http://www.w3.org/2004/02/skos/core#"
+				},
+				"subject": {
+					"class": "edm:Agent"
+				},
+				"properties": {
+					"Gender": { "predicate": "rdaGr2:gender" },
+					"Birth date": { "predicate": "rdaGr2:dateOfBirth" },
+					"Birth place": { "predicate": "rdaGr2:placeOfBirth" },
+					"Description": { "predicate": "skos:note", "lang": "en" }
+				}
+			}
+			JSON;
+	}
+
+}


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/1048

MappingContentHandler::fillParserOutput() overrode rendering with
setRawText( '' ), copied from the Schema and Layout handlers where the
blank is intentional because a frontend app mounts into the page. No
Mapping UI exists, so for Mapping pages the override just left the Read
tab empty.

Removing the override lets the stock JsonContentHandler rendering
display the mapping JSON. A dedicated Mapping UI can reinstate custom
rendering later.

> <sub>AI-authored — Claude Code, `Opus 4.8 (max)`; fix direction specified by @JeroenDeDauw in the issue and orchestrating session, implemented autonomously with no redirects; diff not yet human-reviewed; TDD regression test (red then green), full MappingContentHandler suite plus phpcs and phpstan green locally, and live-verified on the dev wiki; CI green.</sub>
