### PR TITLE
Make RDF and ontology mappings explorable on any DemoData wiki

### DIFF
--- a/DemoData/Mapping/ArtistToEDM.json
+++ b/DemoData/Mapping/ArtistToEDM.json
@@ -1,0 +1,19 @@
+{
+	"version": 1,
+	"schema": "Artist",
+	"target": "edm",
+	"prefixes": {
+		"edm": "http://www.europeana.eu/schemas/edm/",
+		"rdaGr2": "http://rdvocab.info/ElementsGr2/",
+		"dc": "http://purl.org/dc/elements/1.1/",
+		"foaf": "http://xmlns.com/foaf/0.1/",
+		"xsd": "http://www.w3.org/2001/XMLSchema#"
+	},
+	"subject": { "class": "edm:Agent" },
+	"properties": {
+		"Born": { "predicate": "rdaGr2:dateOfBirth", "datatype": "xsd:gYear" },
+		"Died": { "predicate": "rdaGr2:dateOfDeath", "datatype": "xsd:gYear" },
+		"Movement": { "predicate": "dc:subject", "lang": "en" },
+		"Wikipedia": { "predicate": "foaf:page" }
+	}
+}

--- a/DemoData/Mapping/ArtworkToEDM.json
+++ b/DemoData/Mapping/ArtworkToEDM.json
@@ -1,0 +1,19 @@
+{
+	"version": 1,
+	"schema": "Artwork",
+	"target": "edm",
+	"prefixes": {
+		"edm": "http://www.europeana.eu/schemas/edm/",
+		"dc": "http://purl.org/dc/elements/1.1/",
+		"dcterms": "http://purl.org/dc/terms/",
+		"xsd": "http://www.w3.org/2001/XMLSchema#"
+	},
+	"subject": { "class": "edm:ProvidedCHO" },
+	"properties": {
+		"Creator": { "predicate": "dc:creator" },
+		"Year": { "predicate": "dcterms:created", "datatype": "xsd:gYear" },
+		"Medium": { "predicate": "dcterms:medium" },
+		"Located at": { "predicate": "edm:currentLocation" },
+		"Image": { "predicate": "edm:isShownBy" }
+	}
+}

--- a/DemoData/Page/Main_Page.wikitext
+++ b/DemoData/Page/Main_Page.wikitext
@@ -12,6 +12,7 @@ This is a public demo of NeoWiki, an early-stage MediaWiki extension. Explore th
 * Structured data, queried in a page: [[Museum collection]] runs live graph queries over linked museums, artworks, and exhibitions.
 * Several Subjects on one page: open the Data tab on [{{fullurl:Rijksmuseum|action=subjects}} Rijksmuseum] to see the museum and its yearly visitor records as separate Subjects.
 * Every Subject is shaped by a [[Special:Schemas|Schema]], and [[Special:Layouts|Layouts]] control how Subjects are displayed.
+* Every Subject's data as RDF: [[RDF and ontology mappings]] shows native and EDM projections of the demo content.
 
 '''Trying it hands-on'''
 

--- a/DemoData/Page/RDF_and_ontology_mappings.wikitext
+++ b/DemoData/Page/RDF_and_ontology_mappings.wikitext
@@ -1,0 +1,32 @@
+Every NeoWiki page's Subjects are available as '''RDF'''. The same data is offered in two ways:
+
+* A '''native projection''' in NeoWiki's own vocabulary. Lossless, always available, no setup.
+* '''Ontology projections''' that re-express the data in an established vocabulary such as the [https://pro.europeana.eu/page/edm-documentation Europeana Data Model] (EDM). Each one is defined by a '''Mapping''' page.
+
+Each export is produced on demand from the page's current data and downloads as a Turtle or TriG file. Loading a projection into a SPARQL store for live querying is upcoming; the export surface linked below is what exists today.
+
+== The Mapping pages ==
+
+Each Mapping binds one Schema to one target ontology. This wiki ships four, all targeting EDM:
+
+* [[Mapping:PersonToEDM]] — the Person Schema
+* [[Mapping:CityToEDM]] — the City Schema
+* [[Mapping:ArtworkToEDM]] — the Artwork Schema
+* [[Mapping:ArtistToEDM]] — the Artist Schema
+
+== Explore the projections ==
+
+Follow these in order; each link downloads the projection so you can read it.
+
+# '''Pablo Picasso''', [{{SERVER}}{{SCRIPTPATH}}/rest.php/neowiki/v0/page/{{PAGEID:Pablo Picasso}}/rdf native] vs [{{SERVER}}{{SCRIPTPATH}}/rest.php/neowiki/v0/page/{{PAGEID:Pablo Picasso}}/rdf?projection=edm EDM]: the native file has everything, including the two-layer "Born in" relation and the page metadata; the EDM file is an <code>edm:Agent</code> carrying only the mapped vocabulary, with the unmapped <code>Source</code> absent.
+# '''Málaga''', [{{SERVER}}{{SCRIPTPATH}}/rest.php/neowiki/v0/page/{{PAGEID:Málaga}}/rdf?projection=edm EDM]: an <code>edm:Place</code> — and the very same entity IRI that Picasso's <code>rdaGr2:placeOfBirth</code> points at, because sibling projections share entity IRIs.
+# '''The Milkmaid''', [{{SERVER}}{{SCRIPTPATH}}/rest.php/neowiki/v0/page/{{PAGEID:The Milkmaid}}/rdf?projection=edm EDM]: an <code>edm:ProvidedCHO</code> whose <code>dc:creator</code> is the IRI of [{{SERVER}}{{SCRIPTPATH}}/rest.php/neowiki/v0/page/{{PAGEID:Johannes Vermeer}}/rdf?projection=edm Vermeer] (an <code>edm:Agent</code>) and whose <code>edm:currentLocation</code> is the Rijksmuseum.
+# '''Johann Sebastian Bach''', [{{SERVER}}{{SCRIPTPATH}}/rest.php/neowiki/v0/page/{{PAGEID:Johann Sebastian Bach}}/rdf?projection=edm EDM]: Bach's birth is modelled as its own Birth Subject instead of flat fields, so his <code>edm:Agent</code> projects sparse — the same Person Schema as Picasso, a different modelling style.
+# '''ACME Inc''', [{{SERVER}}{{SCRIPTPATH}}/rest.php/neowiki/v0/page/{{PAGEID:ACME Inc}}/rdf?projection=edm EDM]: its Company Schema has no EDM Mapping, so the EDM projection comes back empty — a Schema without a Mapping is simply absent, which is how conformant output stays conformant.
+
+== Learn more ==
+
+* [https://github.com/ProfessionalWiki/NeoWiki/blob/master/docs/rdf/rdf-export.md RDF export reference]
+* [https://github.com/ProfessionalWiki/NeoWiki/blob/master/docs/rdf/ontology-mapping.md Ontology mapping reference]
+* [https://github.com/ProfessionalWiki/NeoWiki/blob/master/docs/examples/person-to-edm.md Person-to-EDM worked example]
+* Tell us what you need from RDF and ontology mapping: [https://github.com/ProfessionalWiki/NeoWiki/discussions/996 join the discussion].


### PR DESCRIPTION
Makes NeoWiki's RDF export and ontology mapping explorable on any wiki with the NeoWiki demo data imported, aimed especially at ECHOLOT/GLAM partners evaluating the mapping mechanism.

## Two EDM Mappings for the cultural-heritage schemas

- **ArtworkToEDM**: Artwork → `edm:ProvidedCHO` (`dc:creator`, `dcterms:created` as `xsd:gYear`, `dcterms:medium`, `edm:currentLocation`, `edm:isShownBy`).
- **ArtistToEDM**: Artist → `edm:Agent` (`rdaGr2:dateOfBirth`/`dateOfDeath` as `xsd:gYear`, `dc:subject`@en, `foaf:page`).

Together with the existing `PersonToEDM` and `CityToEDM`, the museum corpus now projects to EDM end to end. The mappings stay honest-EDM: properties with no defensible EDM term (Artwork `Condition`/`Estimated value`, Artist `Nationality`/`Active period`) are deliberately left unmapped, so an ontology projection is conformant. Both are validated automatically by the existing DemoData mapping CI test.

## Partner-facing on-wiki page

Adds `RDF and ontology mappings`, a guided page that walks through the native and EDM projections of the demo content as a ladder (Picasso native vs EDM, Málaga, The Milkmaid + Vermeer, Bach, ACME). Every export link is **instance-portable**, built from `{{SERVER}}{{SCRIPTPATH}}` and `{{PAGEID:...}}`, so it resolves on any wiki with the demo data regardless of page IDs or base URI. Linked from the Main Page.

Part of #1023; related to #1027.

## The Milkmaid EDM projection (live, trimmed)

```turtle
neo-subj:sEpfwJLo8KqKsUP a edm:ProvidedCHO;
    rdfs:label "The Milkmaid";
    dcterms:created "1658"^^xsd:gYear;
    dcterms:medium "Oil on canvas";
    dc:creator neo-subj:sEpfwJLo3dEPj2Z;
    edm:currentLocation neo-subj:sEpfwJLnxyQy6vR;
    edm:isShownBy "https://upload.wikimedia.org/.../Het_melkmeisje...jpg"^^xsd:anyURI.
```

`dc:creator` and `edm:currentLocation` are the shared native entity IRIs of Vermeer and the Rijksmuseum; `Estimated value` (unmapped) is absent.

> <sub>AI-authored — Claude Code, `Opus 4.8 (max)`; one-line ask from @JeroenDeDauw, mapping choices and page structure specced by an orchestrating session, implemented autonomously here; not yet human-reviewed; both EDM mappings pass the DemoData validation CI test, exports and instance-portable links verified live on the demo wiki, `make phpunit` + `make cs` green.</sub>
