### PR TITLE
Include the projection in named-graph IRIs

### DIFF
--- a/docs/examples/person-to-edm.md
+++ b/docs/examples/person-to-edm.md
@@ -192,9 +192,14 @@ page graph. The **bulk** `DumpRdf --projection=edm` contains both named graphs, 
 Málaga is a typed `edm:Place`:
 
 ```trig
-<.../page/115> { neo-subj:s2picasso2aaaa2 a edm:Agent; … rdaGr2:placeOfBirth neo-subj:s2birthcity2aa2 }
-<.../page/116> { neo-subj:s2birthcity2aa2 a edm:Place; rdfs:label "Málaga" }
+<.../graph/edm/page/115> { neo-subj:s2picasso2aaaa2 a edm:Agent; … rdaGr2:placeOfBirth neo-subj:s2birthcity2aa2 }
+<.../graph/edm/page/116> { neo-subj:s2birthcity2aa2 a edm:Place; rdfs:label "Málaga" }
 ```
+
+The named graph is qualified by projection (`.../graph/edm/page/{id}`,
+[#1053](https://github.com/ProfessionalWiki/NeoWiki/issues/1053)); the native projection of these pages lands in the
+sibling `.../graph/native/page/{id}` graphs, so both can share one triple store. The Subject *resource* IRIs
+(`neo-subj:…`) are identical across projections — that is what lets an EDM query and a native query join.
 
 (The dump also projects the other demo `Person`/`City` Subjects — Bach persons as `edm:Agent`, the
 other cities as `edm:Place` — since the Mapping applies to every Subject of its Schema.)

--- a/docs/examples/person-to-edm.md
+++ b/docs/examples/person-to-edm.md
@@ -196,10 +196,8 @@ Málaga is a typed `edm:Place`:
 <.../graph/edm/page/116> { neo-subj:s2birthcity2aa2 a edm:Place; rdfs:label "Málaga" }
 ```
 
-The named graph is qualified by projection (`.../graph/edm/page/{id}`,
-[#1053](https://github.com/ProfessionalWiki/NeoWiki/issues/1053)); the native projection of these pages lands in the
-sibling `.../graph/native/page/{id}` graphs, so both can share one triple store. The Subject *resource* IRIs
-(`neo-subj:…`) are identical across projections — that is what lets an EDM query and a native query join.
+The native projection of the same pages lands in sibling `.../graph/native/page/{id}` graphs, so both projections can
+share one triple store.
 
 (The dump also projects the other demo `Person`/`City` Subjects — Bach persons as `edm:Agent`, the
 other cities as `edm:Place` — since the Mapping applies to every Subject of its Schema.)

--- a/docs/planning/NativeRdfProjection.md
+++ b/docs/planning/NativeRdfProjection.md
@@ -8,10 +8,12 @@ Discussion: [#999](https://github.com/ProfessionalWiki/NeoWiki/discussions/999).
 
 > **As-built (2026-07).** The native projection specified here has shipped, together with the shared
 > IRI/namespace regime — wiki-level, so subject IRIs are identical across stores — reused by every
-> sibling projection, and the per-page named graphs it defines. See the
-> [RDF Export reference](../rdf/rdf-export.md). Ontology (sibling) projections build on this shared
-> infrastructure — see [OntologyMapping.md](OntologyMapping.md) and the worked
-> [Person → EDM example](../examples/person-to-edm.md).
+> sibling projection, and the per-page named graphs it defines. The named-graph IRIs are **qualified by
+> projection** (`$base/graph/{projection}/page/{id}`, [#1053](https://github.com/ProfessionalWiki/NeoWiki/issues/1053),
+> [discussion #996](https://github.com/ProfessionalWiki/NeoWiki/discussions/996)) so several projections of the same
+> page can share one store; the page *resource* IRI (`neo-page:`) is unchanged. The sections below reflect this. See
+> the [RDF Export reference](../rdf/rdf-export.md). Ontology (sibling) projections build on this shared infrastructure —
+> see [OntologyMapping.md](OntologyMapping.md) and the worked [Person → EDM example](../examples/person-to-edm.md).
 
 ## Purpose
 
@@ -61,7 +63,8 @@ URIs live under this base.
 | `neo-prop:` | `$base/prop/` | Property predicates (direct) | `neo-prop:Website` |
 | `neo-schema:` | `$base/schema/` | Schema classes | `neo-schema:Person` |
 | `neo-rel:` | `$base/relation/` | Relation node IRIs | `neo-rel:r0gje3k4m8n2p1s` |
-| `neo-page:` | `$base/page/` | Page IRIs (also named graph IRIs) | `neo-page:12345` |
+| `neo-page:` | `$base/page/` | Page resource IRIs | `neo-page:12345` |
+| `neo-graph:` | `$base/graph/{projection}/page/` | Named graph IRIs (projection-qualified) | `$base/graph/native/page/12345` |
 
 Standard prefixes used alongside:
 
@@ -136,8 +139,9 @@ round-tripping. Queries that need Relation properties join through the Relation 
 
 ### Pages
 
-Page metadata is emitted as triples about the page resource. The page resource is also used as the named graph
-IRI (see [Named Graphs](#named-graphs) below).
+Page metadata is emitted as triples about the page resource (`neo-page:`). The page's named graph is a separate,
+projection-qualified IRI (`neo-graph:`, see [Named Graphs](#named-graphs) below); the page resource IRI itself stays
+projection-independent and is the subject of these metadata triples.
 
 ```turtle
 neo-page:12345  a                 neo:Page ;
@@ -154,12 +158,17 @@ neo-page:12345  a                 neo:Page ;
 
 ### Named Graphs
 
-All triples from a single wiki page are placed in a named graph identified by the page IRI. This enables:
+All triples from a single wiki page, under a single projection, are placed in a named graph whose IRI is **qualified by
+projection** ([#1053](https://github.com/ProfessionalWiki/NeoWiki/issues/1053)): `$base/graph/{projection}/page/{pageId}`
+— for the native projection `$base/graph/native/page/12345`, abbreviated `neo-graph:12345` below. The page *resource* IRI
+`neo-page:12345` is unchanged and remains the subject of the page-metadata triples. Qualifying the graph lets the native
+projection and an ontology (sibling) projection of the same page coexist in one store, each in its own graph family,
+without one's per-page replace overwriting the other. This enables:
 
-- **Efficient sync:** On page save, `DROP GRAPH <neo-page:12345>` then `INSERT DATA { GRAPH <neo-page:12345> { ... } }`
-  replaces all triples for that page atomically.
-- **Provenance:** The graph IRI tells you which wiki page the data came from.
-- **Page deletion:** `DROP GRAPH <neo-page:12345>` removes all associated triples.
+- **Efficient sync:** On page save, `DROP GRAPH <neo-graph:12345>` then `INSERT DATA { GRAPH <neo-graph:12345> { ... } }`
+  replaces all triples for that page's projection atomically.
+- **Provenance:** The graph IRI tells you which wiki page — and which projection — the data came from.
+- **Page deletion:** `DROP GRAPH <neo-graph:12345>` removes all associated triples for that projection.
 
 The page metadata triples themselves also live in the page's named graph.
 
@@ -169,8 +178,8 @@ A page (ID 42) with a main Subject "ACME Corp" (Company) and a child Subject "Ja
 where Jane is the CEO of ACME:
 
 ```trig
-GRAPH neo-page:42 {
-    # Page metadata
+GRAPH neo-graph:42 {
+    # Page metadata (neo-graph:42 is the native graph $base/graph/native/page/42; neo-page:42 the page resource)
     neo-page:42  a                 neo:Page ;
                  neo:pageName      "ACME Corp" ;
                  dcterms:created   "2024-03-01T09:00:00Z"^^xsd:dateTime ;
@@ -206,11 +215,14 @@ GRAPH neo-page:42 {
 On each page save, the SPARQL plugin:
 
 1. Maps the `Page` domain object to RDF triples (using the projection above).
-2. Issues a SPARQL Update to the configured endpoint:
+2. Issues a SPARQL Update to the configured endpoint, targeting that store's projection-qualified graph
+   ([#1053](https://github.com/ProfessionalWiki/NeoWiki/issues/1053)) — `neo-graph:42` is the native graph
+   `$base/graph/native/page/42`; an ontology store instead targets `$base/graph/edm/page/42`, so the two never
+   overwrite each other:
    ```sparql
-   DROP SILENT GRAPH <neo-page:42> ;
+   DROP SILENT GRAPH <neo-graph:42> ;
    INSERT DATA {
-       GRAPH <neo-page:42> {
+       GRAPH <neo-graph:42> {
            # ... all triples ...
        }
    }
@@ -218,7 +230,7 @@ On each page save, the SPARQL plugin:
 
 On page deletion:
 ```sparql
-DROP SILENT GRAPH <neo-page:42>
+DROP SILENT GRAPH <neo-graph:42>
 ```
 
 `DROP SILENT` avoids errors when the graph does not exist (e.g., first save of a new page).

--- a/docs/planning/NativeRdfProjection.md
+++ b/docs/planning/NativeRdfProjection.md
@@ -8,12 +8,11 @@ Discussion: [#999](https://github.com/ProfessionalWiki/NeoWiki/discussions/999).
 
 > **As-built (2026-07).** The native projection specified here has shipped, together with the shared
 > IRI/namespace regime — wiki-level, so subject IRIs are identical across stores — reused by every
-> sibling projection, and the per-page named graphs it defines. The named-graph IRIs are **qualified by
-> projection** (`$base/graph/{projection}/page/{id}`, [#1053](https://github.com/ProfessionalWiki/NeoWiki/issues/1053),
-> [discussion #996](https://github.com/ProfessionalWiki/NeoWiki/discussions/996)) so several projections of the same
-> page can share one store; the page *resource* IRI (`neo-page:`) is unchanged. The sections below reflect this. See
-> the [RDF Export reference](../rdf/rdf-export.md). Ontology (sibling) projections build on this shared infrastructure —
-> see [OntologyMapping.md](OntologyMapping.md) and the worked [Person → EDM example](../examples/person-to-edm.md).
+> sibling projection, and the per-page named graphs it defines, qualified by projection
+> ([#1053](https://github.com/ProfessionalWiki/NeoWiki/issues/1053)) so sibling projections can share one store. See
+> the [RDF Export reference](../rdf/rdf-export.md). Ontology (sibling) projections build on this shared
+> infrastructure — see [OntologyMapping.md](OntologyMapping.md) and the worked
+> [Person → EDM example](../examples/person-to-edm.md).
 
 ## Purpose
 
@@ -140,8 +139,7 @@ round-tripping. Queries that need Relation properties join through the Relation 
 ### Pages
 
 Page metadata is emitted as triples about the page resource (`neo-page:`). The page's named graph is a separate,
-projection-qualified IRI (`neo-graph:`, see [Named Graphs](#named-graphs) below); the page resource IRI itself stays
-projection-independent and is the subject of these metadata triples.
+projection-qualified IRI — see [Named Graphs](#named-graphs) below.
 
 ```turtle
 neo-page:12345  a                 neo:Page ;
@@ -158,12 +156,10 @@ neo-page:12345  a                 neo:Page ;
 
 ### Named Graphs
 
-All triples from a single wiki page, under a single projection, are placed in a named graph whose IRI is **qualified by
-projection** ([#1053](https://github.com/ProfessionalWiki/NeoWiki/issues/1053)): `$base/graph/{projection}/page/{pageId}`
-— for the native projection `$base/graph/native/page/12345`, abbreviated `neo-graph:12345` below. The page *resource* IRI
-`neo-page:12345` is unchanged and remains the subject of the page-metadata triples. Qualifying the graph lets the native
-projection and an ontology (sibling) projection of the same page coexist in one store, each in its own graph family,
-without one's per-page replace overwriting the other. This enables:
+All triples a projection emits for a single wiki page are placed in a named graph qualified by projection:
+`$base/graph/{projection}/page/{pageId}` — for the native projection `$base/graph/native/page/12345`, abbreviated
+`neo-graph:12345` below. Sibling projections of a page thus write disjoint graphs and can share one triple store.
+This enables:
 
 - **Efficient sync:** On page save, `DROP GRAPH <neo-graph:12345>` then `INSERT DATA { GRAPH <neo-graph:12345> { ... } }`
   replaces all triples for that page's projection atomically.
@@ -179,7 +175,7 @@ where Jane is the CEO of ACME:
 
 ```trig
 GRAPH neo-graph:42 {
-    # Page metadata (neo-graph:42 is the native graph $base/graph/native/page/42; neo-page:42 the page resource)
+    # Page metadata
     neo-page:42  a                 neo:Page ;
                  neo:pageName      "ACME Corp" ;
                  dcterms:created   "2024-03-01T09:00:00Z"^^xsd:dateTime ;
@@ -215,10 +211,7 @@ GRAPH neo-graph:42 {
 On each page save, the SPARQL plugin:
 
 1. Maps the `Page` domain object to RDF triples (using the projection above).
-2. Issues a SPARQL Update to the configured endpoint, targeting that store's projection-qualified graph
-   ([#1053](https://github.com/ProfessionalWiki/NeoWiki/issues/1053)) — `neo-graph:42` is the native graph
-   `$base/graph/native/page/42`; an ontology store instead targets `$base/graph/edm/page/42`, so the two never
-   overwrite each other:
+2. Issues a SPARQL Update to the configured endpoint, targeting the projection's graph for that page:
    ```sparql
    DROP SILENT GRAPH <neo-graph:42> ;
    INSERT DATA {

--- a/docs/planning/NativeRdfProjection.md
+++ b/docs/planning/NativeRdfProjection.md
@@ -26,12 +26,13 @@ It has two jobs:
    when no ontology mapping is configured.
 2. **Specify the projection infrastructure shared by all projections** — the IRI and namespace regime, per-page
    named graphs, and the sync mechanism. An ontology store reuses all of this; only the triples inside each page's
-   graph differ.
+   graph and the projection segment of that graph's IRI differ.
 
 Everything specific to non-native targets — projecting into CIDOC-CRM, EDM, and other standard ontologies — lives in
 [OntologyMapping.md](OntologyMapping.md), which builds on this document. Native and ontology projections are
-siblings: a configured store holds exactly one projection and is queried in that projection's vocabulary, so the
-SPARQL plugin is parameterized by projection rather than hardwired to the native one. Read this document first.
+siblings: a store holds one or more projections, each in its own family of per-page named graphs, and is queried in
+the vocabulary of whichever projection a query targets, so the SPARQL plugin is parameterized by projection rather
+than hardwired to the native one. Read this document first.
 
 This is a strawman proposal. Many decisions here need input from partners with RDF and Linked Open Data expertise,
 particularly regarding ontology alignment and cultural heritage conventions. [Open questions](#open-questions) are

--- a/docs/planning/OntologyMapping.md
+++ b/docs/planning/OntologyMapping.md
@@ -47,19 +47,27 @@ what the projections produce.
 
 ## Projections, not layers
 
-A triple store holds **one projection** of the wiki's data, in one target vocabulary, and SPARQL queries against it are
-written in that vocabulary.
+A triple store holds **one or more projections** of the wiki's data, and SPARQL against it is written in the vocabulary
+of whichever projection a query targets. Each projection lives in its own family of **projection-qualified named graphs**
+(`$base/graph/{projection}/page/{id}`, [#1053](https://github.com/ProfessionalWiki/NeoWiki/issues/1053),
+[discussion #996](https://github.com/ProfessionalWiki/NeoWiki/discussions/996)), so several projections of the same page
+can share one store without their per-page replace syncs overwriting one another.
 
 - The **native projection** ([NativeRdfProjection.md](NativeRdfProjection.md)) is the default target. A wiki with no
   ontology mapping configured still gets RDF and SPARQL, in NeoWiki-native terms.
-- An **ontology mapping** defines an alternative target (CIDOC-CRM, EDM, …). Configure a store with that mapping and it
-  holds ontology RDF; SPARQL against it is written in that ontology.
+- An **ontology mapping** defines an alternative target (CIDOC-CRM, EDM, …). A store can hold that projection — on its
+  own or alongside the native one and other ontology targets — and SPARQL against those graphs is written in that
+  ontology.
 - Projections are **pluggable per store**, consistent with [ADR 19](../adr/019-graph-database-architecture.md) (each
-  backend owns its mapping). A wiki may run several stores with different projections — e.g. a CIDOC-CRM store for CH
-  interoperability alongside a native store for completeness.
+  backend owns its mapping). A store is configured with an endpoint and the **list of projections** to load into it (the
+  [#586](https://github.com/ProfessionalWiki/NeoWiki/issues/586) store config); running several stores with different
+  projection sets stays a **deployment choice** — hard isolation, independent scaling — not a requirement.
 
-This has a deliberate consequence: **a store's query vocabulary is its projection.** Querying CIDOC-CRM means writing
-CIDOC-CRM SPARQL. Wanting the same data in two vocabularies means configuring two stores.
+The earlier "one projection per store, so two vocabularies means two stores" constraint is therefore lifted. Because the
+Subject IRIs are identical across projections (only the vocabulary and the graph family differ), a single store holding
+both the native and an ontology projection can join across them with no `owl:sameAs` machinery; on QLever, unscoped
+queries run against the union of all graphs, so existing queries keep working. Multiple stores remain available for
+isolation, but co-querying no longer forces them.
 
 Why the native projection stays a first-class target rather than always mapping to an ontology: standard ontologies are
 lossy and opinionated, so mapping into one can drop detail that has no place in that ontology. The triple store is a
@@ -342,8 +350,11 @@ native + one or more ontologies), and is a native projection always available as
 vocabulary is in the store" a per-store configuration rather than a single global choice.
 
 *v1: yes for export — a wiki serves several projections at once, selected per request via the `projection` parameter,
-with `native` always the baseline and each Mapping page adding its target to the known set. Per-store selection (a store
-configured to hold one projection) is the seam #586 consumes via `newRdfProjection(name)`.*
+with `native` always the baseline and each Mapping page adding its target to the known set. Since named graphs are now
+qualified by projection ([#1053](https://github.com/ProfessionalWiki/NeoWiki/issues/1053)), a store can hold **one or
+more** projections, each in its own graph family, rather than being limited to one; the #586 store config is therefore
+an endpoint plus a **list of projections**, and multiple stores become a deployment choice (isolation, scaling), not a
+requirement for co-querying two vocabularies. The projector/serializer seam #586 consumes is `newRdfProjection(name)`.*
 
 **Q10: Flat vs nested native modelling.** The [fork above](#flat-vs-nested-native-modelling-open-fork): should
 case-study data live in flat Schemas with the mapping synthesizing intermediate nodes, or in nested Schemas with the

--- a/docs/planning/OntologyMapping.md
+++ b/docs/planning/OntologyMapping.md
@@ -48,26 +48,25 @@ what the projections produce.
 ## Projections, not layers
 
 A triple store holds **one or more projections** of the wiki's data, and SPARQL against it is written in the vocabulary
-of whichever projection a query targets. Each projection lives in its own family of **projection-qualified named graphs**
+of whichever projection a query targets. Each projection writes its own family of named graphs
 (`$base/graph/{projection}/page/{id}`, [#1053](https://github.com/ProfessionalWiki/NeoWiki/issues/1053),
-[discussion #996](https://github.com/ProfessionalWiki/NeoWiki/discussions/996)), so several projections of the same page
-can share one store without their per-page replace syncs overwriting one another.
+[discussion #996](https://github.com/ProfessionalWiki/NeoWiki/discussions/996)), so projections in a shared store never
+overwrite one another.
 
 - The **native projection** ([NativeRdfProjection.md](NativeRdfProjection.md)) is the default target. A wiki with no
   ontology mapping configured still gets RDF and SPARQL, in NeoWiki-native terms.
 - An **ontology mapping** defines an alternative target (CIDOC-CRM, EDM, …). A store can hold that projection — on its
-  own or alongside the native one and other ontology targets — and SPARQL against those graphs is written in that
-  ontology.
+  own or alongside others — and SPARQL against it is written in that ontology.
 - Projections are **pluggable per store**, consistent with [ADR 19](../adr/019-graph-database-architecture.md) (each
   backend owns its mapping). A store is configured with an endpoint and the **list of projections** to load into it (the
   [#586](https://github.com/ProfessionalWiki/NeoWiki/issues/586) store config); running several stores with different
   projection sets stays a **deployment choice** — hard isolation, independent scaling — not a requirement.
 
-The earlier "one projection per store, so two vocabularies means two stores" constraint is therefore lifted. Because the
-Subject IRIs are identical across projections (only the vocabulary and the graph family differ), a single store holding
-both the native and an ontology projection can join across them with no `owl:sameAs` machinery; on QLever, unscoped
-queries run against the union of all graphs, so existing queries keep working. Multiple stores remain available for
-isolation, but co-querying no longer forces them.
+Subject IRIs are identical across projections (only the vocabulary and the graph differ), so queries in a shared store
+join across sibling projections with no `owl:sameAs` machinery. Whether such a query must name the graphs depends on
+the store's default-dataset semantics: QLever always queries the union of all graphs, most other stores offer a
+union-default-graph option, and a spec-strict endpoint needs `FROM`/`GRAPH`. That trait belongs to the per-page
+named-graph design as a whole, not to holding several projections in one store.
 
 Why the native projection stays a first-class target rather than always mapping to an ontology: standard ontologies are
 lossy and opinionated, so mapping into one can drop detail that has no place in that ontology. The triple store is a
@@ -350,11 +349,10 @@ native + one or more ontologies), and is a native projection always available as
 vocabulary is in the store" a per-store configuration rather than a single global choice.
 
 *v1: yes for export — a wiki serves several projections at once, selected per request via the `projection` parameter,
-with `native` always the baseline and each Mapping page adding its target to the known set. Since named graphs are now
-qualified by projection ([#1053](https://github.com/ProfessionalWiki/NeoWiki/issues/1053)), a store can hold **one or
-more** projections, each in its own graph family, rather than being limited to one; the #586 store config is therefore
-an endpoint plus a **list of projections**, and multiple stores become a deployment choice (isolation, scaling), not a
-requirement for co-querying two vocabularies. The projector/serializer seam #586 consumes is `newRdfProjection(name)`.*
+with `native` always the baseline and each Mapping page adding its target to the known set. Named graphs are qualified
+by projection ([#1053](https://github.com/ProfessionalWiki/NeoWiki/issues/1053)), so a single store can likewise hold
+several projections at once — see [Projections, not layers](#projections-not-layers). The projector/serializer seam
+#586 consumes is `newRdfProjection(name)`.*
 
 **Q10: Flat vs nested native modelling.** The [fork above](#flat-vs-nested-native-modelling-open-fork): should
 case-study data live in flat Schemas with the mapping synthesizing intermediate nodes, or in nested Schemas with the

--- a/docs/planning/OntologyMapping.md
+++ b/docs/planning/OntologyMapping.md
@@ -27,9 +27,10 @@ cultural-heritage ontologies such as CIDOC-CRM, EDM, HDTO, and BIBFRAME.
 An **ontology mapping** projects native NeoWiki data **directly into a target ontology**. That ontology RDF is what a
 configured triple store holds and what SPARQL queries run against. The NeoWiki-native projection
 ([NativeRdfProjection.md](NativeRdfProjection.md)) and each target ontology are **sibling projections** of the same
-source data, selected per store rather than stacked: a store is configured with one projection, and different stores
-can hold different projections of the same wiki. The native projection is the default (used when no ontology mapping
-is configured) and the lossless-export target; ontology mappings define the other targets.
+source data, selected per store rather than stacked: a store is configured with one or more projections, each in its
+own family of named graphs, and different stores can hold different projection sets of the same wiki. The native
+projection is the default (used when no ontology mapping is configured) and the lossless-export target; ontology
+mappings define the other targets.
 
 Mappings are first-class, authorable, installable objects, kept separate from Schemas so the native data model is not
 deformed to fit an ontology. A mapping defines the **correspondence** between NeoWiki's model and an ontology, and is

--- a/docs/rdf/ontology-mapping.md
+++ b/docs/rdf/ontology-mapping.md
@@ -115,12 +115,9 @@ Deliberate v1 boundaries:
   as the target of a relation from a mapped Subject — untyped — exactly as a missing Schema behaves in
   the native projection.
 - **No page-metadata triples** are emitted (no page node, `neo:hasSubject`, etc.).
-- Quads are placed in the **per-page named graph for this target** (`$base/graph/{target}/page/{id}`,
-  [#1053](https://github.com/ProfessionalWiki/NeoWiki/issues/1053)), like the native projection, so the same per-page
-  sync infrastructure works for an ontology store. Because the graph is qualified by projection, the native and the
-  ontology projection of a page land in **different** named graphs and can share one triple store without one's
-  per-page replace sync wiping the other's triples. The Subject IRIs inside stay native and identical across
-  projections, which is what makes co-querying work.
+- Quads are placed in the **per-page named graph for this target** (`$base/graph/{target}/page/{id}`), like the
+  native projection, so the same per-page sync infrastructure works for an ontology store — and because the graph
+  is qualified by the target, sibling projections of a page can share one store.
 
 ## Selecting a projection
 

--- a/docs/rdf/ontology-mapping.md
+++ b/docs/rdf/ontology-mapping.md
@@ -115,8 +115,12 @@ Deliberate v1 boundaries:
   as the target of a relation from a mapped Subject — untyped — exactly as a missing Schema behaves in
   the native projection.
 - **No page-metadata triples** are emitted (no page node, `neo:hasSubject`, etc.).
-- Quads are placed in the **per-page named graph**, like the native projection, so the same per-page
-  sync infrastructure works for an ontology store.
+- Quads are placed in the **per-page named graph for this target** (`$base/graph/{target}/page/{id}`,
+  [#1053](https://github.com/ProfessionalWiki/NeoWiki/issues/1053)), like the native projection, so the same per-page
+  sync infrastructure works for an ontology store. Because the graph is qualified by projection, the native and the
+  ontology projection of a page land in **different** named graphs and can share one triple store without one's
+  per-page replace sync wiping the other's triples. The Subject IRIs inside stay native and identical across
+  projections, which is what makes co-querying work.
 
 ## Selecting a projection
 

--- a/docs/rdf/rdf-export.md
+++ b/docs/rdf/rdf-export.md
@@ -40,13 +40,10 @@ All NeoWiki IRIs live under `$base` (`$wgNeoWikiRdfBaseUri`). Standard vocabular
 | `neo-page:` | `$base/page/` | Page resource IRIs (`neo-page:42`) — the subject of the page-metadata triples |
 | `neo-graph:` | `$base/graph/{projection}/page/` | Named-graph IRIs, qualified by projection (`$base/graph/native/page/42`) |
 
-The **named graph** an export puts its quads in is qualified by projection
-([#1053](https://github.com/ProfessionalWiki/NeoWiki/issues/1053)): `$base/graph/{projection}/page/{pageId}`, where
-`{projection}` is `native` or a Mapping target (e.g. `edm`). This is distinct from the page *resource* IRI
-`neo-page:42`, which stays projection-independent and keeps appearing inside the triples. Qualifying the graph lets the
-native and an ontology projection of the same page coexist in one store without one's per-page sync wiping the other's
-triples — see [Ontology Mapping](ontology-mapping.md). The `{projection}` segment is encoded with the same name-encoding
-regime as Property and Schema names below.
+The `{projection}` segment of the named-graph IRI is `native` or a Mapping target (e.g. `edm`), encoded like the
+Property and Schema names below, so sibling projections of a page write disjoint graphs and can share one triple
+store — see [Ontology Mapping](ontology-mapping.md). The page *resource* IRI (`neo-page:42`) stays
+projection-independent and keeps appearing inside the triples.
 
 Property and Schema names form the local part of their IRI: spaces become underscores
 (e.g. `Has author` → `neo-prop:Has_author`), and any character that is illegal in an IRI (`%`, the

--- a/docs/rdf/rdf-export.md
+++ b/docs/rdf/rdf-export.md
@@ -37,7 +37,16 @@ All NeoWiki IRIs live under `$base` (`$wgNeoWikiRdfBaseUri`). Standard vocabular
 | `neo-prop:` | `$base/prop/` | Property and Relation-type predicates (`neo-prop:Has_author`) |
 | `neo-schema:` | `$base/schema/` | Schema classes (`neo-schema:Person`) |
 | `neo-rel:` | `$base/relation/` | Relation node IRIs (`neo-rel:r1demo8aaaaaaD6`) |
-| `neo-page:` | `$base/page/` | Page IRIs, which are also the named-graph IRIs (`neo-page:42`) |
+| `neo-page:` | `$base/page/` | Page resource IRIs (`neo-page:42`) — the subject of the page-metadata triples |
+| `neo-graph:` | `$base/graph/{projection}/page/` | Named-graph IRIs, qualified by projection (`$base/graph/native/page/42`) |
+
+The **named graph** an export puts its quads in is qualified by projection
+([#1053](https://github.com/ProfessionalWiki/NeoWiki/issues/1053)): `$base/graph/{projection}/page/{pageId}`, where
+`{projection}` is `native` or a Mapping target (e.g. `edm`). This is distinct from the page *resource* IRI
+`neo-page:42`, which stays projection-independent and keeps appearing inside the triples. Qualifying the graph lets the
+native and an ontology projection of the same page coexist in one store without one's per-page sync wiping the other's
+triples — see [Ontology Mapping](ontology-mapping.md). The `{projection}` segment is encoded with the same name-encoding
+regime as Property and Schema names below.
 
 Property and Schema names form the local part of their IRI: spaces become underscores
 (e.g. `Has author` → `neo-prop:Has_author`), and any character that is illegal in an IRI (`%`, the

--- a/maintenance/DumpRdf.php
+++ b/maintenance/DumpRdf.php
@@ -9,6 +9,7 @@ use MediaWiki\MediaWikiServices;
 use MediaWiki\Storage\NameTableAccessException;
 use ProfessionalWiki\NeoWiki\Application\Rdf\PageProjector;
 use ProfessionalWiki\NeoWiki\Application\Rdf\RdfPageLoader;
+use ProfessionalWiki\NeoWiki\Application\Rdf\RdfPageProjector;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfFormat;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfStreamWriter;
@@ -41,7 +42,7 @@ class DumpRdf extends Maintenance {
 	public function execute(): void {
 		$extension = NeoWikiExtension::getInstance();
 
-		$projectionName = $this->getOption( 'projection', NeoWikiExtension::PROJECTION_NATIVE );
+		$projectionName = $this->getOption( 'projection', RdfPageProjector::PROJECTION );
 		$projection = $extension->newRdfProjection( $projectionName );
 
 		if ( $projection === null ) {

--- a/src/Application/Rdf/OntologyMappingProjector.php
+++ b/src/Application/Rdf/OntologyMappingProjector.php
@@ -31,8 +31,10 @@ use Psr\Log\LoggerInterface;
  * values become a direct triple to the target Subject's native IRI, which may be untyped when that
  * Subject has no Mapping of its own.
  *
- * Every quad is placed in the page's named graph, so the per-page sync used by the native projection
- * (NativeRdfProjection.md) works for an ontology store too. No page-metadata triples are emitted.
+ * Every quad is placed in the page's named graph for this projection's target (`{$base}/graph/{target}/page/{id}`,
+ * #1053), so the per-page sync used by the native projection (NativeRdfProjection.md) works for an ontology
+ * store too, and the native and ontology projections of a page can share one store without colliding. No
+ * page-metadata triples are emitted.
  */
 class OntologyMappingProjector implements PageProjector {
 
@@ -100,7 +102,7 @@ class OntologyMappingProjector implements PageProjector {
 	}
 
 	public function projectPage( Page $page ): QuadList {
-		$graph = $this->namespaces->page( $page->getId() );
+		$graph = $this->namespaces->graph( $this->target, $page->getId() );
 		$quads = [];
 
 		foreach ( $page->getSubjects()->getAllSubjects()->asArray() as $subject ) {

--- a/src/Application/Rdf/RdfPageProjector.php
+++ b/src/Application/Rdf/RdfPageProjector.php
@@ -26,7 +26,9 @@ use Psr\Log\LoggerInterface;
 /**
  * Projects a {@see Page} to the native RDF quads specified in NativeRdfProjection.md: page metadata,
  * one resource per Subject (rdf:type from the Schema, rdfs:label, one predicate per Statement value),
- * and the two-layer relation reification. Every quad is placed in the page's named graph.
+ * and the two-layer relation reification. Every quad is placed in the page's native named graph
+ * (`{$base}/graph/native/page/{id}`, #1053); the page *resource* IRI (`neo-page:`) that appears inside the
+ * triples stays projection-independent.
  *
  * Schema resolution mirrors Neo4jSubjectUpdater: a Subject whose Schema is unavailable is skipped
  * entirely (and logged), so page metadata never references a Subject that has no projected type or
@@ -37,6 +39,12 @@ use Psr\Log\LoggerInterface;
  * v1.
  */
 class RdfPageProjector implements PageProjector {
+
+	/**
+	 * The name of the native projection, used to qualify its named-graph IRIs (#1053) and as the
+	 * default `projection` selector on the RDF export surfaces.
+	 */
+	public const string PROJECTION = 'native';
 
 	private const string PROPERTY_NAME = 'name';
 	private const string PROPERTY_CREATION_TIME = 'creationTime';
@@ -53,7 +61,7 @@ class RdfPageProjector implements PageProjector {
 	}
 
 	public function projectPage( Page $page ): QuadList {
-		$graph = $this->namespaces->page( $page->getId() );
+		$graph = $this->namespaces->graph( self::PROJECTION, $page->getId() );
 
 		$subjects = $this->resolveSchemas( $page->getSubjects()->getAllSubjects()->asArray() );
 

--- a/src/Domain/Rdf/RdfNamespaces.php
+++ b/src/Domain/Rdf/RdfNamespaces.php
@@ -72,11 +72,7 @@ readonly class RdfNamespaces {
 	 * it runs through the same {@see localName()} encoding as Property and Schema names.
 	 */
 	public function graph( string $projection, PageId $id ): Iri {
-		return new Iri( $this->graphNamespace( $projection ) . $id->id );
-	}
-
-	private function graphNamespace( string $projection ): string {
-		return $this->baseUri . '/graph/' . self::localName( $projection ) . '/page/';
+		return new Iri( $this->baseUri . '/graph/' . self::localName( $projection ) . '/page/' . $id->id );
 	}
 
 	public function term( string $localName ): Iri {
@@ -144,13 +140,13 @@ readonly class RdfNamespaces {
 	}
 
 	/**
-	 * The prefix table for abbreviating a projection's serialized output. A serialization holds exactly
-	 * one projection, so a single `neo-graph` prefix names that projection's graph namespace; `neo-page`
-	 * stays for the page resource IRI, which still appears in the triples.
+	 * The namespaces a serializer may abbreviate. Projection-independent: the graph namespace is left out
+	 * because a graph's local name is a page id, and a prefixed name cannot start with a digit, so no
+	 * graph IRI this mints is abbreviable anyway.
 	 *
 	 * @return array<string, string> Prefix label to namespace IRI, for serializer abbreviation.
 	 */
-	public function prefixMap( string $projection ): array {
+	public function prefixMap(): array {
 		return [
 			'neo' => $this->baseUri . '/ontology/',
 			'neo-subj' => $this->baseUri . '/entity/',
@@ -158,7 +154,6 @@ readonly class RdfNamespaces {
 			'neo-schema' => $this->baseUri . '/schema/',
 			'neo-rel' => $this->baseUri . '/relation/',
 			'neo-page' => $this->baseUri . '/page/',
-			'neo-graph' => $this->graphNamespace( $projection ),
 			'rdf' => self::RDF,
 			'rdfs' => self::RDFS,
 			'xsd' => self::XSD,

--- a/src/Domain/Rdf/RdfNamespaces.php
+++ b/src/Domain/Rdf/RdfNamespaces.php
@@ -61,6 +61,24 @@ readonly class RdfNamespaces {
 		return new Iri( $this->baseUri . '/page/' . $id->id );
 	}
 
+	/**
+	 * The named-graph IRI for a page under a given projection (#1053). Qualifying the graph by
+	 * projection lets several projections of the same page (native, an ontology target, …) live in one
+	 * triple store without the per-page replace sync of one wiping another's triples. The page id stays
+	 * in the IRI so per-page provenance and that sync are unchanged. This is distinct from {@see page()},
+	 * the projection-independent page *resource* IRI that keeps appearing inside the triples.
+	 *
+	 * The projection name is an author-controlled string (a Mapping target, or the native `native`), so
+	 * it runs through the same {@see localName()} encoding as Property and Schema names.
+	 */
+	public function graph( string $projection, PageId $id ): Iri {
+		return new Iri( $this->graphNamespace( $projection ) . $id->id );
+	}
+
+	private function graphNamespace( string $projection ): string {
+		return $this->baseUri . '/graph/' . self::localName( $projection ) . '/page/';
+	}
+
 	public function term( string $localName ): Iri {
 		return new Iri( $this->baseUri . '/ontology/' . $localName );
 	}
@@ -126,9 +144,13 @@ readonly class RdfNamespaces {
 	}
 
 	/**
+	 * The prefix table for abbreviating a projection's serialized output. A serialization holds exactly
+	 * one projection, so a single `neo-graph` prefix names that projection's graph namespace; `neo-page`
+	 * stays for the page resource IRI, which still appears in the triples.
+	 *
 	 * @return array<string, string> Prefix label to namespace IRI, for serializer abbreviation.
 	 */
-	public function prefixMap(): array {
+	public function prefixMap( string $projection ): array {
 		return [
 			'neo' => $this->baseUri . '/ontology/',
 			'neo-subj' => $this->baseUri . '/entity/',
@@ -136,6 +158,7 @@ readonly class RdfNamespaces {
 			'neo-schema' => $this->baseUri . '/schema/',
 			'neo-rel' => $this->baseUri . '/relation/',
 			'neo-page' => $this->baseUri . '/page/',
+			'neo-graph' => $this->graphNamespace( $projection ),
 			'rdf' => self::RDF,
 			'rdfs' => self::RDFS,
 			'xsd' => self::XSD,

--- a/src/EntryPoints/REST/ExportPageRdfApi.php
+++ b/src/EntryPoints/REST/ExportPageRdfApi.php
@@ -7,6 +7,7 @@ namespace ProfessionalWiki\NeoWiki\EntryPoints\REST;
 use MediaWiki\Rest\Response;
 use MediaWiki\Rest\SimpleHandler;
 use MediaWiki\Rest\StringStream;
+use ProfessionalWiki\NeoWiki\Application\Rdf\RdfPageProjector;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfFormat;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
@@ -29,7 +30,7 @@ class ExportPageRdfApi extends SimpleHandler {
 
 	public function run( int $pageId ): Response {
 		$extension = NeoWikiExtension::getInstance();
-		$projectionName = $this->getValidatedParams()['projection'] ?? NeoWikiExtension::PROJECTION_NATIVE;
+		$projectionName = $this->getValidatedParams()['projection'] ?? RdfPageProjector::PROJECTION;
 		$resolution = $extension->resolveRdfProjection( $projectionName );
 
 		if ( $resolution->projection === null ) {

--- a/src/GraphDatabasePlugins/Sparql/Persistence/SparqlProjectionStore.php
+++ b/src/GraphDatabasePlugins/Sparql/Persistence/SparqlProjectionStore.php
@@ -19,8 +19,11 @@ use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlUpdat
 
 /**
  * Keeps a SPARQL 1.1 graph store in sync with wiki page changes, one instance per configured store
- * (NativeRdfProjection.md § Sync Mechanism). Each page is a named graph identified by the page IRI: a
- * save replaces that graph atomically (DROP + INSERT DATA), a delete drops it.
+ * (NativeRdfProjection.md § Sync Mechanism). Each page is a named graph identified by this store's
+ * projection and the page (`{$base}/graph/{projection}/page/{id}`, #1053): a save replaces that graph
+ * atomically (DROP + INSERT DATA), a delete drops it. Qualifying the graph by projection is what lets
+ * two stores with different projections point at one endpoint without each save wiping the other's
+ * triples for that page.
  *
  * The configured projection is resolved lazily on each save through the {@see ProjectionResolver}
  * seam — never at construction — so the store always uses the current Mapping definitions and its
@@ -44,7 +47,7 @@ readonly class SparqlProjectionStore implements GraphDatabasePlugin {
 
 	public function savePage( Page $page ): void {
 		$projector = $this->resolveProjector();
-		$graph = $this->namespaces->page( $page->getId() );
+		$graph = $this->namespaces->graph( $this->projectionName, $page->getId() );
 
 		$this->endpoint->postUpdate(
 			$this->buildSaveUpdate( $graph, $projector->projectPage( $page ) )
@@ -82,15 +85,19 @@ readonly class SparqlProjectionStore implements GraphDatabasePlugin {
 	}
 
 	public function deletePage( PageId $pageId ): void {
-		// No projection resolution here on purpose: a delete only needs the graph IRI, so it keeps
-		// working even when this store's Mapping is broken or missing.
-		$this->endpoint->postUpdate( $this->dropGraph( $this->namespaces->page( $pageId ) ) );
+		// No projection resolution here on purpose: a delete only needs the graph IRI, which this store
+		// can name from its own projection, so it keeps working even when the Mapping is broken or
+		// missing.
+		$this->endpoint->postUpdate(
+			$this->dropGraph( $this->namespaces->graph( $this->projectionName, $pageId ) )
+		);
 	}
 
 	private function dropGraph( Iri $graph ): string {
 		// DROP SILENT so the first save of a new page does not error on a not-yet-existing graph. The
-		// graph IRI is minted from trusted config (the base URI) and an integer page id, so it needs no
-		// escaping to sit inside <...>.
+		// graph IRI is built from trusted config (the base URI), an integer page id, and the projection
+		// name — the one untrusted part, since a Mapping target is author-controlled. RdfNamespaces::graph()
+		// percent-encodes it, `>` included, so it cannot close the <...> early and forge an update clause.
 		return 'DROP SILENT GRAPH <' . $graph->value . '>';
 	}
 

--- a/src/NeoWikiConfigFactory.php
+++ b/src/NeoWikiConfigFactory.php
@@ -6,6 +6,7 @@ namespace ProfessionalWiki\NeoWiki;
 
 use MediaWiki\Config\Config;
 use MediaWiki\WikiMap\WikiMap;
+use ProfessionalWiki\NeoWiki\Application\Rdf\RdfPageProjector;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
@@ -82,7 +83,7 @@ class NeoWikiConfigFactory {
 			updateUrl: $updateUrl,
 			queryUrl: is_string( $queryUrl ) && trim( $queryUrl ) !== '' ? $queryUrl : $updateUrl,
 			accessToken: is_string( $accessToken ) && $accessToken !== '' ? $accessToken : null,
-			projection: is_string( $projection ) && $projection !== '' ? $projection : NeoWikiExtension::PROJECTION_NATIVE,
+			projection: is_string( $projection ) && $projection !== '' ? $projection : RdfPageProjector::PROJECTION,
 		);
 	}
 

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -137,7 +137,7 @@ class NeoWikiExtension {
 	public const int NS_LAYOUT = 7476;
 	public const int NS_MAPPING = 7478;
 
-	public const string PROJECTION_NATIVE = 'native';
+	public const string PROJECTION_NATIVE = RdfPageProjector::PROJECTION;
 
 	private PropertyTypeRegistry $propertyTypeRegistry;
 	private PagePropertyProviderRegistry $pagePropertyProviderRegistry;
@@ -292,7 +292,7 @@ class NeoWikiExtension {
 	}
 
 	public function getRdfSerializer(): RdfSerializer {
-		return new HardfRdfSerializer( $this->getRdfNamespaces()->prefixMap() );
+		return new HardfRdfSerializer( $this->getRdfNamespaces()->prefixMap( self::PROJECTION_NATIVE ) );
 	}
 
 	public function newRdfPageProjector(): RdfPageProjector {
@@ -361,7 +361,7 @@ class NeoWikiExtension {
 					$this->getRdfValueMapperRegistry(),
 					LoggerFactory::getInstance( 'NeoWiki' ),
 				),
-				new HardfRdfSerializer( $this->ontologyPrefixMap( $forTarget ) ),
+				new HardfRdfSerializer( $this->ontologyPrefixMap( $projectionName, $forTarget ) ),
 			)
 		);
 	}
@@ -380,15 +380,16 @@ class NeoWikiExtension {
 	}
 
 	/**
-	 * The native prefixes (Subject IRIs stay native) plus the Mappings' declared ontology prefixes, for
-	 * readable output. Unsafe prefix namespaces are dropped defensively so a Mapping can never inject a
-	 * `@prefix` declaration into the document, even though save-time validation already rejects them.
+	 * The native prefixes (Subject IRIs stay native, and the graph prefix names this target's graph
+	 * family) plus the Mappings' declared ontology prefixes, for readable output. Unsafe prefix
+	 * namespaces are dropped defensively so a Mapping can never inject a `@prefix` declaration into the
+	 * document, even though save-time validation already rejects them.
 	 *
 	 * @param \ProfessionalWiki\NeoWiki\Domain\Mapping\Mapping[] $mappings
 	 * @return array<string, string>
 	 */
-	private function ontologyPrefixMap( array $mappings ): array {
-		$prefixes = $this->getRdfNamespaces()->prefixMap();
+	private function ontologyPrefixMap( string $projection, array $mappings ): array {
+		$prefixes = $this->getRdfNamespaces()->prefixMap( $projection );
 
 		foreach ( $mappings as $mapping ) {
 			foreach ( $mapping->prefixes as $label => $namespace ) {

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -292,7 +292,7 @@ class NeoWikiExtension {
 	}
 
 	public function getRdfSerializer(): RdfSerializer {
-		return new HardfRdfSerializer( $this->getRdfNamespaces()->prefixMap( self::PROJECTION_NATIVE ) );
+		return new HardfRdfSerializer( $this->getRdfNamespaces()->prefixMap() );
 	}
 
 	public function newRdfPageProjector(): RdfPageProjector {
@@ -361,7 +361,7 @@ class NeoWikiExtension {
 					$this->getRdfValueMapperRegistry(),
 					LoggerFactory::getInstance( 'NeoWiki' ),
 				),
-				new HardfRdfSerializer( $this->ontologyPrefixMap( $projectionName, $forTarget ) ),
+				new HardfRdfSerializer( $this->ontologyPrefixMap( $forTarget ) ),
 			)
 		);
 	}
@@ -380,16 +380,15 @@ class NeoWikiExtension {
 	}
 
 	/**
-	 * The native prefixes (Subject IRIs stay native, and the graph prefix names this target's graph
-	 * family) plus the Mappings' declared ontology prefixes, for readable output. Unsafe prefix
-	 * namespaces are dropped defensively so a Mapping can never inject a `@prefix` declaration into the
-	 * document, even though save-time validation already rejects them.
+	 * The native prefixes (Subject IRIs stay native) plus the Mappings' declared ontology prefixes, for
+	 * readable output. Unsafe prefix namespaces are dropped defensively so a Mapping can never inject a
+	 * `@prefix` declaration into the document, even though save-time validation already rejects them.
 	 *
 	 * @param \ProfessionalWiki\NeoWiki\Domain\Mapping\Mapping[] $mappings
 	 * @return array<string, string>
 	 */
-	private function ontologyPrefixMap( string $projection, array $mappings ): array {
-		$prefixes = $this->getRdfNamespaces()->prefixMap( $projection );
+	private function ontologyPrefixMap( array $mappings ): array {
+		$prefixes = $this->getRdfNamespaces()->prefixMap();
 
 		foreach ( $mappings as $mapping ) {
 			foreach ( $mapping->prefixes as $label => $namespace ) {

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -137,8 +137,6 @@ class NeoWikiExtension {
 	public const int NS_LAYOUT = 7476;
 	public const int NS_MAPPING = 7478;
 
-	public const string PROJECTION_NATIVE = RdfPageProjector::PROJECTION;
-
 	private PropertyTypeRegistry $propertyTypeRegistry;
 	private PagePropertyProviderRegistry $pagePropertyProviderRegistry;
 	private Neo4jValueBuilderRegistry $valueBuilderRegistry;
@@ -337,7 +335,7 @@ class NeoWikiExtension {
 	 * resolution and the known-names list on the unknown-target path pays for a single enumeration.
 	 */
 	public function resolveRdfProjection( string $projectionName ): RdfProjectionResolution {
-		if ( $projectionName === self::PROJECTION_NATIVE ) {
+		if ( $projectionName === RdfPageProjector::PROJECTION ) {
 			return RdfProjectionResolution::projection(
 				new RdfProjection( $this->newRdfPageProjector(), $this->getRdfSerializer() )
 			);
@@ -348,7 +346,7 @@ class NeoWikiExtension {
 
 		if ( $forTarget === [] ) {
 			return RdfProjectionResolution::unknownTarget(
-				array_merge( [ self::PROJECTION_NATIVE ], $mappings->targets() )
+				array_merge( [ RdfPageProjector::PROJECTION ], $mappings->targets() )
 			);
 		}
 
@@ -374,7 +372,7 @@ class NeoWikiExtension {
 	 */
 	public function getRdfProjectionNames(): array {
 		return array_merge(
-			[ self::PROJECTION_NATIVE ],
+			[ RdfPageProjector::PROJECTION ],
 			( new Mappings( $this->getMappingLookup()->getAllMappings() ) )->targets()
 		);
 	}

--- a/tests/phpunit/Application/Rdf/OntologyMappingProjectorTest.php
+++ b/tests/phpunit/Application/Rdf/OntologyMappingProjectorTest.php
@@ -493,7 +493,7 @@ class OntologyMappingProjectorTest extends TestCase {
 	 * @return array<string, string>
 	 */
 	private function serializerPrefixes(): array {
-		return array_merge( $this->ns->prefixMap( 'edm' ), [ 'edm' => self::EDM, 'dc' => self::DC ] );
+		return array_merge( $this->ns->prefixMap(), [ 'edm' => self::EDM, 'dc' => self::DC ] );
 	}
 
 }

--- a/tests/phpunit/Application/Rdf/OntologyMappingProjectorTest.php
+++ b/tests/phpunit/Application/Rdf/OntologyMappingProjectorTest.php
@@ -88,14 +88,14 @@ class OntologyMappingProjectorTest extends TestCase {
 	private function expectedTriG(): string {
 		return <<<TRIG
 			@prefix neo-subj: <https://wiki.example/entity/> .
-			@prefix neo-page: <https://wiki.example/page/> .
+			@prefix neo-graph: <https://wiki.example/graph/edm/page/> .
 			@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 			@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 			@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 			@prefix edm: <http://www.europeana.eu/schemas/edm/> .
 			@prefix dc: <http://purl.org/dc/elements/1.1/> .
 
-			neo-page:42 {
+			neo-graph:42 {
 				neo-subj:s1janeaaaaaaaa2 a edm:ProvidedCHO ;
 					rdfs:label "Jane" ;
 					dc:title "Jane"@en ;
@@ -217,7 +217,7 @@ class OntologyMappingProjectorTest extends TestCase {
 				$this->ns->subject( new SubjectId( self::PERSON_ID ) ),
 				new Iri( self::DC . 'spatial' ),
 				$cityIri,
-				$this->ns->page( new PageId( 42 ) )
+				$this->ns->graph( 'edm', new PageId( 42 ) )
 			) ),
 			'The relation is a direct triple to the target Subject native IRI.'
 		);
@@ -278,7 +278,7 @@ class OntologyMappingProjectorTest extends TestCase {
 			@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 			@prefix dc: <http://purl.org/dc/elements/1.1/> .
 
-			<https://wiki.example/page/42> {
+			<https://wiki.example/graph/edm/page/42> {
 				neo-subj:s1janeaaaaaaaa2 a <http://example.org/CHO> ;
 					rdfs:label "Jane" ;
 					dc:title "Jane" .
@@ -352,7 +352,7 @@ class OntologyMappingProjectorTest extends TestCase {
 			@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 			@prefix dc: <http://purl.org/dc/elements/1.1/> .
 
-			<https://wiki.example/page/42> {
+			<https://wiki.example/graph/edm/page/42> {
 				neo-subj:s1janeaaaaaaaa2 rdfs:label "Jane" ;
 					dc:title "Jane" ;
 					dc:date "1990"^^xsd:integer .
@@ -370,7 +370,7 @@ class OntologyMappingProjectorTest extends TestCase {
 				$this->ns->subject( new SubjectId( self::PERSON_ID ) ),
 				new Iri( self::DC . 'date' ),
 				RdfLiteralFactory::typed( '1990', 'integer' ),
-				$this->ns->page( new PageId( 42 ) )
+				$this->ns->graph( 'edm', new PageId( 42 ) )
 			) ),
 			'A typed literal keeps its datatype; a language tag does not apply to it.'
 		);
@@ -409,7 +409,7 @@ class OntologyMappingProjectorTest extends TestCase {
 				$this->ns->subject( new SubjectId( self::PERSON_ID ) ),
 				new Iri( self::DC . 'spatial' ),
 				$this->ns->subject( new SubjectId( self::CITY_ID ) ),
-				$this->ns->page( new PageId( 42 ) )
+				$this->ns->graph( 'edm', new PageId( 42 ) )
 			) ),
 			'The relation is a plain IRI-to-IRI triple; datatype and language overrides do not apply.'
 		);
@@ -452,7 +452,7 @@ class OntologyMappingProjectorTest extends TestCase {
 				$this->ns->subject( new SubjectId( self::PERSON_ID ) ),
 				$this->ns->rdfType(),
 				new Iri( self::EDM . 'Place' ),
-				$this->ns->page( new PageId( 42 ) )
+				$this->ns->graph( 'edm', new PageId( 42 ) )
 			) ),
 			'The alphabetically first Mapping wins the tie-break.'
 		);
@@ -493,7 +493,7 @@ class OntologyMappingProjectorTest extends TestCase {
 	 * @return array<string, string>
 	 */
 	private function serializerPrefixes(): array {
-		return array_merge( $this->ns->prefixMap(), [ 'edm' => self::EDM, 'dc' => self::DC ] );
+		return array_merge( $this->ns->prefixMap( 'edm' ), [ 'edm' => self::EDM, 'dc' => self::DC ] );
 	}
 
 }

--- a/tests/phpunit/Application/Rdf/ProjectionNamedGraphTest.php
+++ b/tests/phpunit/Application/Rdf/ProjectionNamedGraphTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Application\Rdf;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\Rdf\OntologyMappingProjector;
+use ProfessionalWiki\NeoWiki\Application\Rdf\RdfPageProjector;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\Mapping;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\MappingName;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\PropertyMapping;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\PropertyMappings;
+use ProfessionalWiki\NeoWiki\Domain\Page\Page;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\Quad;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\QuadList;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfNamespaces;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfValueMapperRegistry;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinitions;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
+use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestPage;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSchema;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestStatement;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySchemaLookup;
+use WMDE\PsrLogTestDoubles\LegacyLoggerSpy;
+
+/**
+ * Regression test for #1053 (discussion #996): named-graph IRIs are qualified by projection. The same
+ * page projected natively and through an ontology Mapping must land in DIFFERENT named graphs, so two
+ * projections can share one triple store without the per-page replace sync of one wiping the other's
+ * triples. The page RESOURCE IRI that appears inside the triples is unaffected — only the graph moves.
+ *
+ * @covers \ProfessionalWiki\NeoWiki\Application\Rdf\OntologyMappingProjector
+ * @covers \ProfessionalWiki\NeoWiki\Application\Rdf\RdfPageProjector
+ * @covers \ProfessionalWiki\NeoWiki\Domain\Rdf\RdfNamespaces
+ */
+class ProjectionNamedGraphTest extends TestCase {
+
+	private const string PERSON_ID = 's1janeaaaaaaaa2';
+
+	private RdfNamespaces $ns;
+
+	protected function setUp(): void {
+		$this->ns = new RdfNamespaces( 'https://wiki.example' );
+	}
+
+	public function testNativeAndOntologyProjectionsOfTheSamePageUseDifferentNamedGraphs(): void {
+		$page = $this->page();
+
+		$nativeGraph = $this->soleGraph( $this->nativeProjector()->projectPage( $page ) );
+		$ontologyGraph = $this->soleGraph( $this->edmProjector()->projectPage( $page ) );
+
+		$this->assertSame( 'https://wiki.example/graph/native/page/42', $nativeGraph );
+		$this->assertSame( 'https://wiki.example/graph/edm/page/42', $ontologyGraph );
+		$this->assertNotSame(
+			$nativeGraph,
+			$ontologyGraph,
+			'A native and an ontology projection of the same page must not collide in one store.'
+		);
+	}
+
+	public function testThePageResourceIriStaysUnqualifiedWhileItsGraphMoves(): void {
+		$quads = $this->nativeProjector()->projectPage( $this->page() )->asArray();
+
+		$pageTypeTriples = array_values( array_filter(
+			$quads,
+			fn ( Quad $quad ): bool => $quad->subject->value === 'https://wiki.example/page/42'
+				&& $quad->predicate->equals( $this->ns->rdfType() )
+		) );
+
+		$this->assertCount(
+			1,
+			$pageTypeTriples,
+			'The page resource IRI still appears in the triples as https://wiki.example/page/42.'
+		);
+		$this->assertSame(
+			'https://wiki.example/graph/native/page/42',
+			$pageTypeTriples[0]->graph->value,
+			'while that triple now lives in the projection-qualified named graph.'
+		);
+	}
+
+	private function nativeProjector(): RdfPageProjector {
+		return new RdfPageProjector(
+			RdfValueMapperRegistry::withCoreMappers(),
+			$this->ns,
+			new InMemorySchemaLookup(
+				TestSchema::build( name: 'Person', properties: new PropertyDefinitions( [] ) )
+			),
+			new LegacyLoggerSpy(),
+		);
+	}
+
+	private function edmProjector(): OntologyMappingProjector {
+		return new OntologyMappingProjector(
+			'edm',
+			[ $this->personToEdmMapping() ],
+			$this->ns,
+			RdfValueMapperRegistry::withCoreMappers(),
+			new LegacyLoggerSpy(),
+		);
+	}
+
+	private function personToEdmMapping(): Mapping {
+		return new Mapping(
+			name: new MappingName( 'Person to EDM' ),
+			schema: new SchemaName( 'Person' ),
+			target: 'edm',
+			prefixes: [ 'edm' => 'http://www.europeana.eu/schemas/edm/' ],
+			subjectClass: 'edm:Agent',
+			properties: new PropertyMappings( [] )
+		);
+	}
+
+	private function page(): Page {
+		return TestPage::build(
+			id: 42,
+			mainSubject: TestSubject::build(
+				id: self::PERSON_ID,
+				label: 'Jane',
+				schemaName: new SchemaName( 'Person' ),
+				statements: new StatementList( [
+					TestStatement::build( 'Name', new StringValue( 'Jane' ), 'text' ),
+				] )
+			),
+		);
+	}
+
+	private function soleGraph( QuadList $quads ): string {
+		$graphs = array_values( array_unique( array_map(
+			static fn ( Quad $quad ): string => $quad->graph->value,
+			$quads->asArray()
+		) ) );
+
+		$this->assertCount( 1, $graphs, 'A projection places every quad in exactly one named graph.' );
+
+		return $graphs[0];
+	}
+
+}

--- a/tests/phpunit/Application/Rdf/RdfPageProjectorTest.php
+++ b/tests/phpunit/Application/Rdf/RdfPageProjectorTest.php
@@ -74,7 +74,7 @@ class RdfPageProjectorTest extends TestCase {
 		);
 
 		$quads = $this->newProjector( $schemaLookup )->projectPage( $this->completeExamplePage() );
-		$output = ( new HardfRdfSerializer( $this->ns->prefixMap( RdfPageProjector::PROJECTION ) ) )->serialize( $quads, RdfFormat::TriG );
+		$output = ( new HardfRdfSerializer( $this->ns->prefixMap() ) )->serialize( $quads, RdfFormat::TriG );
 
 		$this->assertSame(
 			ParsedRdf::canonicalQuads( $this->completeExampleTriG() ),
@@ -376,7 +376,7 @@ class RdfPageProjectorTest extends TestCase {
 	}
 
 	private function serialize( QuadList $quads ): string {
-		return ( new HardfRdfSerializer( $this->ns->prefixMap( RdfPageProjector::PROJECTION ) ) )->serialize( $quads, RdfFormat::TriG );
+		return ( new HardfRdfSerializer( $this->ns->prefixMap() ) )->serialize( $quads, RdfFormat::TriG );
 	}
 
 	private function companySchema(): Schema {

--- a/tests/phpunit/Application/Rdf/RdfPageProjectorTest.php
+++ b/tests/phpunit/Application/Rdf/RdfPageProjectorTest.php
@@ -74,7 +74,7 @@ class RdfPageProjectorTest extends TestCase {
 		);
 
 		$quads = $this->newProjector( $schemaLookup )->projectPage( $this->completeExamplePage() );
-		$output = ( new HardfRdfSerializer( $this->ns->prefixMap() ) )->serialize( $quads, RdfFormat::TriG );
+		$output = ( new HardfRdfSerializer( $this->ns->prefixMap( RdfPageProjector::PROJECTION ) ) )->serialize( $quads, RdfFormat::TriG );
 
 		$this->assertSame(
 			ParsedRdf::canonicalQuads( $this->completeExampleTriG() ),
@@ -131,12 +131,13 @@ class RdfPageProjectorTest extends TestCase {
 			@prefix neo-schema: <https://wiki.example/schema/> .
 			@prefix neo-rel: <https://wiki.example/relation/> .
 			@prefix neo-page: <https://wiki.example/page/> .
+			@prefix neo-graph: <https://wiki.example/graph/native/page/> .
 			@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 			@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 			@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 			@prefix dcterms: <http://purl.org/dc/terms/> .
 
-			neo-page:42 {
+			neo-graph:42 {
 				neo-page:42 a neo:Page ;
 					neo:pageName "ACME Corp" ;
 					dcterms:created "2024-03-01T09:00:00Z"^^xsd:dateTime ;
@@ -358,7 +359,7 @@ class RdfPageProjectorTest extends TestCase {
 			@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 			@prefix dcterms: <http://purl.org/dc/terms/> .
 
-			<https://wiki.example/page/42> {
+			<https://wiki.example/graph/native/page/42> {
 				<https://wiki.example/page/42> a neo:Page ;
 					neo:pageName "ACME Corp" ;
 					dcterms:created "2024-03-01T09:00:00Z"^^xsd:dateTime ;
@@ -375,7 +376,7 @@ class RdfPageProjectorTest extends TestCase {
 	}
 
 	private function serialize( QuadList $quads ): string {
-		return ( new HardfRdfSerializer( $this->ns->prefixMap() ) )->serialize( $quads, RdfFormat::TriG );
+		return ( new HardfRdfSerializer( $this->ns->prefixMap( RdfPageProjector::PROJECTION ) ) )->serialize( $quads, RdfFormat::TriG );
 	}
 
 	private function companySchema(): Schema {
@@ -388,7 +389,7 @@ class RdfPageProjectorTest extends TestCase {
 	}
 
 	private function quad( Iri $subject, Iri $predicate, Literal|Iri $object ): Quad {
-		return new Quad( $subject, $predicate, $object, $this->ns->page( new PageId( 42 ) ) );
+		return new Quad( $subject, $predicate, $object, $this->ns->graph( RdfPageProjector::PROJECTION, new PageId( 42 ) ) );
 	}
 
 }

--- a/tests/phpunit/Domain/Rdf/RdfNamespacesTest.php
+++ b/tests/phpunit/Domain/Rdf/RdfNamespacesTest.php
@@ -83,6 +83,27 @@ class RdfNamespacesTest extends TestCase {
 		);
 	}
 
+	public function testGraphIriIsQualifiedByTheNativeProjection(): void {
+		$this->assertSame(
+			'https://wiki.example/graph/native/page/42',
+			$this->namespaces()->graph( 'native', new PageId( 42 ) )->value
+		);
+	}
+
+	public function testGraphIriIsQualifiedByAnOntologyTarget(): void {
+		$this->assertSame(
+			'https://wiki.example/graph/edm/page/42',
+			$this->namespaces()->graph( 'edm', new PageId( 42 ) )->value
+		);
+	}
+
+	public function testGraphIriEncodesTheProjectionNameSoAnAuthoredTargetCannotBreakOut(): void {
+		$this->assertSame(
+			'https://wiki.example/graph/a%3Eb/page/42',
+			$this->namespaces()->graph( 'a>b', new PageId( 42 ) )->value
+		);
+	}
+
 	public function testVocabularyTermUsesOntologyPath(): void {
 		$this->assertSame(
 			'https://wiki.example/ontology/hasSubject',
@@ -108,7 +129,7 @@ class RdfNamespacesTest extends TestCase {
 		$this->assertSame( 'http://www.w3.org/2001/XMLSchema#dateTime', $namespaces->xsd( 'dateTime' )->value );
 	}
 
-	public function testPrefixMapCoversEveryNeoAndStandardNamespace(): void {
+	public function testPrefixMapCoversEveryNeoAndStandardNamespaceIncludingTheProjectionGraph(): void {
 		$this->assertSame(
 			[
 				'neo' => 'https://wiki.example/ontology/',
@@ -117,12 +138,20 @@ class RdfNamespacesTest extends TestCase {
 				'neo-schema' => 'https://wiki.example/schema/',
 				'neo-rel' => 'https://wiki.example/relation/',
 				'neo-page' => 'https://wiki.example/page/',
+				'neo-graph' => 'https://wiki.example/graph/native/page/',
 				'rdf' => 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
 				'rdfs' => 'http://www.w3.org/2000/01/rdf-schema#',
 				'xsd' => 'http://www.w3.org/2001/XMLSchema#',
 				'dcterms' => 'http://purl.org/dc/terms/',
 			],
-			$this->namespaces()->prefixMap()
+			$this->namespaces()->prefixMap( 'native' )
+		);
+	}
+
+	public function testPrefixMapGraphNamespaceIsQualifiedByTheProjection(): void {
+		$this->assertSame(
+			'https://wiki.example/graph/edm/page/',
+			$this->namespaces()->prefixMap( 'edm' )['neo-graph']
 		);
 	}
 

--- a/tests/phpunit/Domain/Rdf/RdfNamespacesTest.php
+++ b/tests/phpunit/Domain/Rdf/RdfNamespacesTest.php
@@ -129,7 +129,7 @@ class RdfNamespacesTest extends TestCase {
 		$this->assertSame( 'http://www.w3.org/2001/XMLSchema#dateTime', $namespaces->xsd( 'dateTime' )->value );
 	}
 
-	public function testPrefixMapCoversEveryNeoAndStandardNamespaceIncludingTheProjectionGraph(): void {
+	public function testPrefixMapCoversEveryNeoAndStandardNamespace(): void {
 		$this->assertSame(
 			[
 				'neo' => 'https://wiki.example/ontology/',
@@ -138,20 +138,12 @@ class RdfNamespacesTest extends TestCase {
 				'neo-schema' => 'https://wiki.example/schema/',
 				'neo-rel' => 'https://wiki.example/relation/',
 				'neo-page' => 'https://wiki.example/page/',
-				'neo-graph' => 'https://wiki.example/graph/native/page/',
 				'rdf' => 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
 				'rdfs' => 'http://www.w3.org/2000/01/rdf-schema#',
 				'xsd' => 'http://www.w3.org/2001/XMLSchema#',
 				'dcterms' => 'http://purl.org/dc/terms/',
 			],
-			$this->namespaces()->prefixMap( 'native' )
-		);
-	}
-
-	public function testPrefixMapGraphNamespaceIsQualifiedByTheProjection(): void {
-		$this->assertSame(
-			'https://wiki.example/graph/edm/page/',
-			$this->namespaces()->prefixMap( 'edm' )['neo-graph']
+			$this->namespaces()->prefixMap()
 		);
 	}
 

--- a/tests/phpunit/EntryPoints/REST/ExportPageRdfApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ExportPageRdfApiTest.php
@@ -72,14 +72,18 @@ JSON
 		);
 	}
 
-	public function testDefaultsToTriGWithThePageNamedGraph(): void {
+	public function testDefaultsToTriGWithTheNativeProjectionsPageNamedGraph(): void {
 		$response = $this->export();
 		$body = $response->getBody()->getContents();
 
 		$this->assertSame( 200, $response->getStatusCode() );
 		$this->assertSame( 'application/trig; charset=utf-8', $response->getHeaderLine( 'Content-Type' ) );
 		$this->assertStringContainsString( 'Berlin', $body );
-		$this->assertNotContains( '', $this->graphsIn( $body ), 'Every TriG quad belongs to the page named graph.' );
+		$this->assertStringEndsWith(
+			'/graph/native/page/' . $this->pageId,
+			$this->soleGraphIn( $body ),
+			'Every TriG quad belongs to the page named graph of the native projection.'
+		);
 	}
 
 	public function testFormatParameterSelectsTurtleWithoutANamedGraph(): void {
@@ -147,6 +151,36 @@ JSON
 	}
 
 	public function testValidTargetProjectsTheMappedVocabularyWithNativeSubjectIris(): void {
+		$this->createBerlinToEdmMapping();
+
+		$response = $this->export( query: [ 'projection' => 'edm', 'format' => 'turtle' ] );
+		$body = $response->getBody()->getContents();
+
+		$this->assertSame( 200, $response->getStatusCode() );
+		$this->assertStringContainsString( 'europeana.eu/schemas/edm', $body, 'The mapped ontology vocabulary is used.' );
+		$this->assertStringContainsString( self::SUBJECT_ID, $body, 'The Subject IRI stays native.' );
+		$this->assertStringNotContainsString( self::SCHEMA, $body, 'No native schema class is emitted.' );
+	}
+
+	/**
+	 * The export surface is where the projection name selected by the request reaches both the projector
+	 * that mints the graph and the serializer's prefix table (#1053). Asserting the graph IRI here, rather
+	 * than only on the projector, is what catches the two halves drifting apart.
+	 */
+	public function testOntologyProjectionPlacesItsQuadsInTheTargetsOwnPageNamedGraph(): void {
+		$this->createBerlinToEdmMapping();
+
+		$response = $this->export( query: [ 'projection' => 'edm' ] );
+
+		$this->assertSame( 200, $response->getStatusCode() );
+		$this->assertStringEndsWith(
+			'/graph/edm/page/' . $this->pageId,
+			$this->soleGraphIn( $response->getBody()->getContents() ),
+			'The ontology projection writes the target\'s own named graph, not the native one, so a store can hold both.'
+		);
+	}
+
+	private function createBerlinToEdmMapping(): void {
 		$this->createMapping( 'BerlinToEdm', <<<JSON
 			{
 				"version": 1,
@@ -162,18 +196,21 @@ JSON
 				}
 			}
 			JSON );
-
-		$response = $this->export( query: [ 'projection' => 'edm', 'format' => 'turtle' ] );
-		$body = $response->getBody()->getContents();
-
-		$this->assertSame( 200, $response->getStatusCode() );
-		$this->assertStringContainsString( 'europeana.eu/schemas/edm', $body, 'The mapped ontology vocabulary is used.' );
-		$this->assertStringContainsString( self::SUBJECT_ID, $body, 'The Subject IRI stays native.' );
-		$this->assertStringNotContainsString( self::SCHEMA, $body, 'No native schema class is emitted.' );
 	}
 
 	private function schemaName(): string {
 		return self::SCHEMA;
+	}
+
+	/**
+	 * The single named graph every quad in the document belongs to.
+	 */
+	private function soleGraphIn( string $rdf ): string {
+		$graphs = $this->graphsIn( $rdf );
+
+		$this->assertCount( 1, $graphs, 'A projection places every quad in exactly one named graph.' );
+
+		return $graphs[0];
 	}
 
 	/**

--- a/tests/phpunit/EntryPoints/REST/ExportPageRdfApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ExportPageRdfApiTest.php
@@ -163,9 +163,9 @@ JSON
 	}
 
 	/**
-	 * The export surface is where the projection name selected by the request reaches both the projector
-	 * that mints the graph and the serializer's prefix table (#1053). Asserting the graph IRI here, rather
-	 * than only on the projector, is what catches the two halves drifting apart.
+	 * The export surface is where the projection name selected by the request reaches the projector that
+	 * mints the graph (#1053). Asserting the graph IRI here, rather than only on the projector, is what
+	 * catches that resolution handing the projector the wrong name.
 	 */
 	public function testOntologyProjectionPlacesItsQuadsInTheTargetsOwnPageNamedGraph(): void {
 		$this->createBerlinToEdmMapping();

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/Integration/QuerySparqlEndToEndTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/Integration/QuerySparqlEndToEndTest.php
@@ -10,6 +10,7 @@ use MediaWiki\Http\HttpRequestFactory;
 use MediaWiki\Logger\LoggerFactory;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
+use ProfessionalWiki\NeoWiki\Application\Rdf\RdfPageProjector;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfNamespaces;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryLimits;
@@ -56,7 +57,7 @@ class QuerySparqlEndToEndTest extends NeoWikiIntegrationTestCase {
 		$this->overrideConfigValue( 'NeoWikiSparqlStores', [ [
 			'updateUrl' => $this->storeUrl,
 			'accessToken' => $this->accessToken,
-			'projection' => NeoWikiExtension::PROJECTION_NATIVE,
+			'projection' => RdfPageProjector::PROJECTION,
 		] ] );
 		NeoWikiExtension::resetInstance();
 

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/Persistence/SparqlProjectionStoreTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/Persistence/SparqlProjectionStoreTest.php
@@ -45,8 +45,8 @@ class SparqlProjectionStoreTest extends TestCase {
 	public function testSavePersistsDropThenInsertDataForThePageGraph(): void {
 		$this->newStore( $this->resolverReturning( $this->personQuads() ), 'native' )->savePage( $this->page( 42 ) );
 
-		$expected = "DROP SILENT GRAPH <https://wiki.example/page/42> ;\n"
-			. "INSERT DATA { GRAPH <https://wiki.example/page/42> {\n"
+		$expected = "DROP SILENT GRAPH <https://wiki.example/graph/native/page/42> ;\n"
+			. "INSERT DATA { GRAPH <https://wiki.example/graph/native/page/42> {\n"
 			. "<https://wiki.example/entity/s1demo8aaaaaab5> a <https://wiki.example/schema/Person>;\n"
 			. "    <http://www.w3.org/2000/01/rdf-schema#label> \"John Doe\".\n"
 			. "} }";
@@ -57,13 +57,13 @@ class SparqlProjectionStoreTest extends TestCase {
 	public function testSaveOfEmptyProjectionSendsDropOnly(): void {
 		$this->newStore( $this->resolverReturning( new QuadList() ), 'native' )->savePage( $this->page( 42 ) );
 
-		$this->assertSame( 'DROP SILENT GRAPH <https://wiki.example/page/42>', $this->endpoint->lastUpdate() );
+		$this->assertSame( 'DROP SILENT GRAPH <https://wiki.example/graph/native/page/42>', $this->endpoint->lastUpdate() );
 	}
 
 	public function testDeleteSendsDropOnly(): void {
 		$this->newStore( $this->resolverReturning( $this->personQuads() ), 'native' )->deletePage( new PageId( 42 ) );
 
-		$this->assertSame( 'DROP SILENT GRAPH <https://wiki.example/page/42>', $this->endpoint->lastUpdate() );
+		$this->assertSame( 'DROP SILENT GRAPH <https://wiki.example/graph/native/page/42>', $this->endpoint->lastUpdate() );
 	}
 
 	public function testMaliciousLiteralIsEscapedAndStaysInsideOneInsertDataBlock(): void {
@@ -115,7 +115,11 @@ class SparqlProjectionStoreTest extends TestCase {
 	public function testDeleteWorksEvenWhenProjectionIsUnknown(): void {
 		$this->newStore( $this->unknownProjectionResolver( [ 'native' ] ), 'bogus' )->deletePage( new PageId( 42 ) );
 
-		$this->assertSame( 'DROP SILENT GRAPH <https://wiki.example/page/42>', $this->endpoint->lastUpdate() );
+		$this->assertSame(
+			'DROP SILENT GRAPH <https://wiki.example/graph/bogus/page/42>',
+			$this->endpoint->lastUpdate(),
+			'The store names its own graph, so a delete needs no projection resolution.'
+		);
 	}
 
 	private function newStore( ProjectionResolver $resolver, string $projectionName ): SparqlProjectionStore {

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/SparqlGraphProjectionTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/SparqlGraphProjectionTest.php
@@ -54,7 +54,7 @@ class SparqlGraphProjectionTest extends NeoWikiIntegrationTestCase {
 
 		$update = $this->lastUpdateFor( self::ENDPOINT );
 		$this->assertStringContainsString( 'INSERT DATA', $update );
-		$this->assertStringContainsString( '/page/' . $pageId, $update );
+		$this->assertStringContainsString( '/graph/native/page/' . $pageId, $update );
 		$this->assertStringContainsString( '/entity/' . TestSubject::ZERO_GUID, $update );
 	}
 
@@ -86,7 +86,7 @@ class SparqlGraphProjectionTest extends NeoWikiIntegrationTestCase {
 
 		$update = $this->lastUpdateFor( self::ENDPOINT );
 		$this->assertStringContainsString( 'DROP SILENT GRAPH', $update );
-		$this->assertStringContainsString( '/page/' . $pageId, $update );
+		$this->assertStringContainsString( '/graph/native/page/' . $pageId, $update );
 		$this->assertStringNotContainsString( 'INSERT DATA', $update );
 	}
 
@@ -126,7 +126,7 @@ class SparqlGraphProjectionTest extends NeoWikiIntegrationTestCase {
 	private function assertReceivedInsertForPage( string $endpoint, int $pageId ): void {
 		$update = $this->lastUpdateFor( $endpoint );
 		$this->assertStringContainsString( 'INSERT DATA', $update );
-		$this->assertStringContainsString( '/page/' . $pageId, $update );
+		$this->assertStringContainsString( '/graph/native/page/' . $pageId, $update );
 	}
 
 	private function deletePageByName( string $pageName ): void {

--- a/tests/phpunit/Infrastructure/Rdf/HardfRdfSerializerTest.php
+++ b/tests/phpunit/Infrastructure/Rdf/HardfRdfSerializerTest.php
@@ -30,7 +30,7 @@ class HardfRdfSerializerTest extends TestCase {
 	}
 
 	private function serializer(): HardfRdfSerializer {
-		return new HardfRdfSerializer( $this->ns->prefixMap( 'native' ) );
+		return new HardfRdfSerializer( $this->ns->prefixMap() );
 	}
 
 	private function personQuads( int $pageId, string $subjectId ): QuadList {

--- a/tests/phpunit/Infrastructure/Rdf/HardfRdfSerializerTest.php
+++ b/tests/phpunit/Infrastructure/Rdf/HardfRdfSerializerTest.php
@@ -30,7 +30,7 @@ class HardfRdfSerializerTest extends TestCase {
 	}
 
 	private function serializer(): HardfRdfSerializer {
-		return new HardfRdfSerializer( $this->ns->prefixMap() );
+		return new HardfRdfSerializer( $this->ns->prefixMap( 'native' ) );
 	}
 
 	private function personQuads( int $pageId, string $subjectId ): QuadList {


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/1053

Named-graph IRIs are now qualified by projection: `{$base}/graph/{projection}/page/{pageId}` for
every projection (native's name is `native`; an ontology projection's is its Mapping target, e.g.
`edm`). The page *resource* IRI (`{$base}/page/{pageId}`, `neo-page:`) is unchanged and still appears
inside the triples — only the graph name moves. Subject, Relation, property, and Schema IRIs stay
projection-independent, so the shared Subject IRIs that make co-querying work are untouched.

Previously both projectors placed every quad in the same page-IRI graph, so two projections written
into one store collided: under the per-page replace sync planned for #586 the projection that wrote
a page last wiped the other's triples, and concatenated dumps merged into mixed graphs. Qualifying
the graph by projection lets one triple store hold one *or more* projections, each in its own graph
family, without them overwriting each other.

- `RdfNamespaces`: new `graph(projection, pageId)` method; `page()` remains the resource IRI. The
  projection name is encoded with the same name-encoding regime as Property and Schema names.
  `prefixMap()` is unchanged: a graph's local name is a page id, and a prefixed name cannot start with
  a digit, so a graph IRI is never abbreviable and gets no prefix (`neo-page` stays for the resource
  IRI).
- `RdfPageProjector` (native, `PROJECTION = 'native'`, the one name for the native projection) and
  `OntologyMappingProjector` (its Mapping target) each mint quads in their own projection's graph.
- Docs: as-built (`rdf-export.md`, `ontology-mapping.md`, `person-to-edm.md`) and planning
  (`NativeRdfProjection.md` Named Graphs + Sync + Complete Example; `OntologyMapping.md` "Projections,
  not layers" + Q9 — a store holds one or more projections, the #586 store config becomes endpoint +
  projection list).
- Tests: a regression test that the native and ontology projections of the same page land in
  different named graphs, plus updates to the projector, namespace, and serializer tests.

- `SparqlProjectionStore`: syncs each page into its own projection's graph. #586's per-page replace
  sync merged first (#1051) naming the graph the old way, so without this the live sync and the
  exports would disagree about the graph name, and two stores with different projections against one
  endpoint would still wipe each other.

Breaking change to TriG graph names and to the graphs the SPARQL sync writes; fine pre-production. A
store synced before this lands keeps its triples under the old page-IRI graphs, so re-sync (or drop
the index and rebuild) rather than expecting the new graphs to replace them.

> <sub>AI-authored — Claude Code, `Opus 4.8 (max)`; implemented from issue #1053's spec (written in a Fable 5 design session); diff not yet human-reviewed; verified locally: full `make phpunit` (1672 tests, 6 skipped) green and `make cs` (phpcs + phpstan) clean, after repairing a pre-existing crashed `searchindex` table and installing the missing `hardf` dependency in the dev stack; CI pending at open.</sub>


