### PR TITLE
Add SPARQL query surfaces (parser function, Lua, REST) with a live QLever system test

### DIFF
--- a/.github/workflows/ci-php.yml
+++ b/.github/workflows/ci-php.yml
@@ -33,6 +33,11 @@ jobs:
     env:
       NEO4J_URL_OVERRIDE: bolt://neo4j:password@localhost:7689
       NEO4J_URL_READ_OVERRIDE: bolt://mediawiki_read:mediawiki_read@localhost:7689
+      # Live QLever store for the SPARQL query system test. Overrides the dev-stack hostname in
+      # phpunit.xml.dist (PHPUnit <env> does not override an existing environment variable), so the test
+      # reaches the QLever the "Start QLever" step publishes on the runner's localhost.
+      QLEVER_TEST_URL: http://localhost:7019/
+      QLEVER_TEST_ACCESS_TOKEN: neowiki_test_token
 
     services:
       test_neo:
@@ -103,12 +108,37 @@ jobs:
           resource: http-get://localhost:7689
           timeout: 60000
 
+      # QLever for the SPARQL query system test. It cannot be a `services:` container: its bring-up needs
+      # a multi-step entrypoint (build an empty index, then serve) that a service container cannot express
+      # (no command/args, only an image + options). So it is started explicitly, mirroring the dev stack's
+      # test_qlever and the "Create neo4j user" docker step below. --persist-updates is omitted: the store
+      # is fresh per CI run and the test clears it, so keeping updates in memory is enough.
+      - name: Start QLever
+        run: |
+          docker run -d --name test_qlever -p 7019:7019 -e QLEVER_ACCESS_TOKEN=neowiki_test_token \
+            --entrypoint /bin/bash docker.io/adfreiburg/qlever:latest -lc '
+              set -e
+              cd /index
+              : > data.nt
+              qlever-index -i neowiki -F nt -f data.nt
+              exec qlever-server -i neowiki -p 7019 -a "$QLEVER_ACCESS_TOKEN" -m 1G'
+
       - name: Run update.php
         run: php maintenance/update.php --quick
 
       - name: Create neo4j user
         run: docker exec test_neo bash -c \
           "echo \"CREATE USER mediawiki_read SET PASSWORD 'mediawiki_read' CHANGE NOT REQUIRED; GRANT ROLE reader TO mediawiki_read;\" | cypher-shell -u neo4j -p password -a bolt://localhost:7689"
+
+      - name: Wait for QLever
+        run: |
+          for i in $(seq 1 40); do
+            if curl -fsS -o /dev/null "http://localhost:7019/?query=SELECT%20%2A%20WHERE%20%7B%20%3Fs%20%3Fp%20%3Fo%20%7D%20LIMIT%201"; then
+              echo "QLever is serving"; exit 0
+            fi
+            sleep 2
+          done
+          echo "QLever did not become ready in time; dumping logs:"; docker logs test_qlever; exit 1
 
       - name: Run PHPUnit
         run: php tests/phpunit/phpunit.php -c extensions/NeoWiki/phpunit.xml.dist

--- a/.github/workflows/ci-php.yml
+++ b/.github/workflows/ci-php.yml
@@ -110,15 +110,17 @@ jobs:
 
       # QLever for the SPARQL query system test. It cannot be a `services:` container: its bring-up needs
       # a multi-step entrypoint (build an empty index, then serve) that a service container cannot express
-      # (no command/args, only an image + options). So it is started explicitly, mirroring the dev stack's
-      # test_qlever and the "Create neo4j user" docker step below. --persist-updates is omitted: the store
-      # is fresh per CI run and the test clears it, so keeping updates in memory is enough.
+      # (no command/args, only an image + options). So it is started explicitly, like the "Create neo4j
+      # user" docker step below. --persist-updates is omitted: the store is fresh per CI run and the test
+      # clears it, so keeping updates in memory is enough. The index is built in /tmp rather than the dev
+      # stack's /index: the image runs as a non-root user with no /index (the dev stack provides it via a
+      # volume), so a bare `docker run` must use an already-writable in-image path.
       - name: Start QLever
         run: |
           docker run -d --name test_qlever -p 7019:7019 -e QLEVER_ACCESS_TOKEN=neowiki_test_token \
             --entrypoint /bin/bash docker.io/adfreiburg/qlever:latest -lc '
               set -e
-              cd /index
+              cd /tmp
               : > data.nt
               qlever-index -i neowiki -F nt -f data.nt
               exec qlever-server -i neowiki -p 7019 -a "$QLEVER_ACCESS_TOKEN" -m 1G'

--- a/DemoData/AGENTS.md
+++ b/DemoData/AGENTS.md
@@ -12,6 +12,7 @@ partners, knowledge managers, MediaWiki ecosystem evaluators, and live-demo audi
 | `Subject/<Name>.json` | Subjects (data instances). Optional paired `<Name>.wikitext` for prose. | Main namespace, `<Name>` |
 | `Layout/<Name>.json` | Layouts (curated displays for a Schema) | `Layout:<Name>` |
 | `Page/<Name>.wikitext` | Free-form wiki pages (hubs, references) | Main namespace, `<Name>` |
+| `SparqlPage/<Name>.wikitext` | Pages demoing the SPARQL surfaces. Imported only when `$wgNeoWikiSparqlStores` is non-empty (elsewhere `{{#sparql_raw}}` is unregistered and would render literally). | Main namespace, `<Name>` |
 | `Module/<Name>.lua` | Scribunto modules | `Module:<Name>` |
 
 `ImportDemoData.php` is additive: it creates and updates pages but does NOT delete pages whose

--- a/DemoData/Module/LuaExample.lua
+++ b/DemoData/Module/LuaExample.lua
@@ -6,6 +6,25 @@ function p.foundedYear( frame )
 	return tostring( year or '' )
 end
 
+-- Only invoked from the SPARQL queries demo page, which is imported only into wikis with a
+-- configured SPARQL store; elsewhere mw.neowiki.sparqlQuery is nil and calling this would error.
+function p.largestMuseums( frame )
+	local base = mw.site.server
+	local result = nw.sparqlQuery(
+		'SELECT ?label ?visitors WHERE { ' ..
+		'?m <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <' .. base .. '/schema/Museum> . ' ..
+		'?m <http://www.w3.org/2000/01/rdf-schema#label> ?label . ' ..
+		'?m <' .. base .. '/prop/Annual_visitors> ?visitors ' ..
+		'} ORDER BY DESC(?visitors) LIMIT 3'
+	)
+
+	local list = {}
+	for _, binding in ipairs( result.results.bindings ) do
+		list[#list + 1] = '* ' .. binding.label.value .. ' (' .. binding.visitors.value .. ' visitors)'
+	end
+	return table.concat( list, '\n' )
+end
+
 function p.oldestMuseums( frame )
 	local rows = nw.query(
 		'MATCH (m:Museum) RETURN m.name AS name, m.Founded AS year ORDER BY year LIMIT 3'

--- a/DemoData/Page/Developers.wikitext
+++ b/DemoData/Page/Developers.wikitext
@@ -20,6 +20,8 @@ Result:
 
 {{#cypher_raw:MATCH (m:Museum) RETURN m.name AS name, m.`Annual visitors` AS visitors ORDER BY visitors DESC LIMIT 5}}
 
+On wikis with a configured [https://github.com/ProfessionalWiki/NeoWiki/blob/master/docs/operations/installation.md#optional-sparql-graph-stores SPARQL store], the same structured data is also queryable as RDF: see [[SPARQL queries]] (a page imported only when such a store is configured).
+
 == Read values in wikitext ==
 
 The <code><nowiki>{{#neowiki_value}}</nowiki></code> parser function reads a single property from a subject on a page.

--- a/DemoData/SparqlPage/SPARQL_queries.wikitext
+++ b/DemoData/SparqlPage/SPARQL_queries.wikitext
@@ -1,0 +1,70 @@
+NeoWiki keeps [https://github.com/ProfessionalWiki/NeoWiki/blob/master/docs/operations/installation.md#optional-sparql-graph-stores SPARQL 1.1 graph stores] such as [https://qlever.dev/ QLever] in sync with the wiki's structured data: every page becomes a named graph of RDF triples, updated on each edit and dropped on deletion. This page demonstrates the three ways to query that RDF projection. It is imported only into wikis that have a SPARQL store configured, like the NeoWiki development stack.
+
+== Query with a parser function ==
+
+The <code><nowiki>{{#sparql_raw}}</nowiki></code> parser function runs a read-only SPARQL query against the first configured store and returns the raw [https://www.w3.org/TR/sparql11-results-json/ SPARQL JSON results]. Entity, schema, and property IRIs are minted under the wiki's RDF base URI, which defaults to the wiki's own server URL — the examples below write it as <code><nowiki>{{SERVER}}</nowiki></code> so they work on any wiki.
+
+Source:
+
+<syntaxhighlight lang="mediawiki">
+{{#sparql_raw:SELECT ?museum ?visitors WHERE { ?m <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <{{SERVER}}/schema/Museum> . ?m <http://www.w3.org/2000/01/rdf-schema#label> ?museum . ?m <{{SERVER}}/prop/Annual_visitors> ?visitors } ORDER BY DESC(?visitors) LIMIT 5}}
+</syntaxhighlight>
+
+Result:
+
+{{#sparql_raw:SELECT ?museum ?visitors WHERE { ?m <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <{{SERVER}}/schema/Museum> . ?m <http://www.w3.org/2000/01/rdf-schema#label> ?museum . ?m <{{SERVER}}/prop/Annual_visitors> ?visitors } ORDER BY DESC(?visitors) LIMIT 5}}
+
+Every page is its own named graph, so results can carry page provenance. This query lists people together with the graph (page) each one comes from:
+
+<syntaxhighlight lang="mediawiki">
+{{#sparql_raw:SELECT ?page ?person WHERE { GRAPH ?page { ?p <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <{{SERVER}}/schema/Person> . ?p <http://www.w3.org/2000/01/rdf-schema#label> ?person } } ORDER BY ?person LIMIT 5}}
+</syntaxhighlight>
+
+Result:
+
+{{#sparql_raw:SELECT ?page ?person WHERE { GRAPH ?page { ?p <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <{{SERVER}}/schema/Person> . ?p <http://www.w3.org/2000/01/rdf-schema#label> ?person } } ORDER BY ?person LIMIT 5}}
+
+== Query from Lua ==
+
+<code>mw.neowiki.sparqlQuery</code> returns the same results document as a Lua table, so Scribunto modules can format it. From [[Module:LuaExample]]:
+
+<syntaxhighlight lang="lua">
+function p.largestMuseums( frame )
+	local base = mw.site.server
+	local result = nw.sparqlQuery(
+		'SELECT ?label ?visitors WHERE { ' ..
+		'?m <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <' .. base .. '/schema/Museum> . ' ..
+		'?m <http://www.w3.org/2000/01/rdf-schema#label> ?label . ' ..
+		'?m <' .. base .. '/prop/Annual_visitors> ?visitors ' ..
+		'} ORDER BY DESC(?visitors) LIMIT 3'
+	)
+
+	local list = {}
+	for _, binding in ipairs( result.results.bindings ) do
+		list[#list + 1] = '* ' .. binding.label.value .. ' (' .. binding.visitors.value .. ' visitors)'
+	end
+	return table.concat( list, '\n' )
+end
+</syntaxhighlight>
+
+Invoke it from wikitext:
+
+<syntaxhighlight lang="mediawiki">
+{{#invoke:LuaExample|largestMuseums}}
+</syntaxhighlight>
+
+Result:
+
+{{#invoke:LuaExample|largestMuseums}}
+
+== Query over REST ==
+
+The same queries work over the wiki's REST API, which returns the results document as JSON:
+
+<code>POST {{SERVER}}{{SCRIPTPATH}}/rest.php/neowiki/v0/query/sparql</code>
+
+<syntaxhighlight lang="json">
+{ "query": "SELECT ?label WHERE { ?s <http://www.w3.org/2000/01/rdf-schema#label> ?label } LIMIT 5" }
+</syntaxhighlight>
+
+For details, see the [https://github.com/ProfessionalWiki/NeoWiki/blob/master/docs/reference/query-api.md query API], [https://github.com/ProfessionalWiki/NeoWiki/blob/master/docs/reference/parser-functions.md parser function], and [https://github.com/ProfessionalWiki/NeoWiki/blob/master/docs/reference/lua-api.md Lua] documentation. For querying the property graph with Cypher instead, see [[Developers]].

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -67,6 +67,18 @@ Without the tools overlay, run the same query from inside the stack, e.g.
 `docker compose exec qlever curl ...` or from the `mediawiki` container against
 `http://qlever:7019/`. Writes require the `QLEVER_ACCESS_TOKEN` Bearer token; reads do not.
 
+### `test_qlever` (SPARQL query system test)
+
+A second, dedicated QLever store — `test_qlever` — backs the SPARQL query system test
+(`QuerySparqlEndToEndTest`), isolated from the demo `qlever` store the way `test_neo` is
+isolated from `neo`: the test writes and deletes Subjects, so it must not touch the demo
+data. `phpunit.xml.dist` points the test at it via `QLEVER_TEST_URL=http://test_qlever:7019/`
+(fixed token `neowiki_test_token`); it is reached in-network only, with no host port. Unlike
+the demo store it runs **without** `--persist-updates`: it is ephemeral test scaffolding that
+each run clears (`DROP ALL`), so keeping updates in memory is enough. `make phpunit` brings it
+up as part of the dev stack; in CI it is started explicitly (see `.github/workflows/ci-php.yml`),
+because its multi-step bring-up cannot be expressed as a GitHub Actions service container.
+
 ## Files
 
 - `Dockerfile` — multi-stage build: `production-mw` (MediaWiki + NeoWiki on the

--- a/Docker/docker-compose.dev.yml
+++ b/Docker/docker-compose.dev.yml
@@ -102,6 +102,43 @@ services:
       timeout: 5s
       retries: 20
 
+  # Dedicated QLever store for the SPARQL query system test, isolated from the demo `qlever` service
+  # above the way `test_neo` is isolated from `neo`: the system test writes and deletes Subjects, so it
+  # must not mutate the demo data. It reaches this in-network as http://test_qlever:7019/ (see
+  # QLEVER_TEST_URL in phpunit.xml.dist); no host port is exposed.
+  test_qlever:
+    image: docker.io/adfreiburg/qlever:latest
+    restart: unless-stopped
+    # Fixed access token (intentional, like test_neo's fixed password): the test suite uses this exact
+    # value to authorize its updates. Do not parameterize without updating phpunit.xml.dist.
+    environment:
+      - QLEVER_ACCESS_TOKEN=neowiki_test_token
+    entrypoint:
+      - /bin/bash
+      - -lc
+      - |
+        set -e
+        cd /index
+        # Build an empty index once; the sentinel keeps a container restart from re-indexing (which
+        # would error on the existing index). NeoWiki fills the store at runtime over the SPARQL 1.1
+        # Update endpoint. Unlike the demo `qlever` service, --persist-updates is deliberately omitted:
+        # this store is ephemeral test scaffolding — each test run clears it (DROP ALL) and never relies
+        # on updates surviving a restart — so keeping updates in memory is simpler and lighter.
+        if [ ! -f .neowiki-indexed ]; then
+          : > data.nt
+          qlever-index -i neowiki -F nt -f data.nt
+          touch .neowiki-indexed
+        fi
+        exec qlever-server -i neowiki -p 7019 -a "$$QLEVER_ACCESS_TOKEN" -m 1G
+    volumes:
+      - test-qlever-index-data:/index
+    stop_grace_period: 2s
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "-o", "/dev/null", "http://localhost:7019/?query=SELECT%20%2A%20WHERE%20%7B%20%3Fs%20%3Fp%20%3Fo%20%7D%20LIMIT%201"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
   node:
     image: node:24
     restart: on-failure:3
@@ -132,3 +169,4 @@ services:
 volumes:
   test-neo4j-data:
   qlever-index-data:
+  test-qlever-index-data:

--- a/docs/operations/installation.md
+++ b/docs/operations/installation.md
@@ -168,7 +168,7 @@ These are the settings you are most likely to change. For the full list with des
 | `$wgNeoWikiEnableDevelopmentUI` | Enables development-only UIs | `false` | No |
 | `$wgNeoWikiEnforceValidation` | Rejects writes that introduce new constraint violations | `false` | No |
 | `$wgNeoWikiAutoRenderMainSubject` | Automatically renders a page's Main Subject as an infobox | `true` | No |
-| `$wgNeoWikiSparqlStores` | SPARQL 1.1 graph stores to keep in sync, e.g. QLever | `[]` | No |
+| `$wgNeoWikiSparqlStores` | SPARQL 1.1 graph stores to keep in sync and query, e.g. QLever | `[]` | No |
 
 ¹ Required for NeoWiki's structured-data features. The wiki still loads without them; NeoWiki's features are
 simply disabled until both are set.
@@ -188,9 +188,13 @@ Configure the stores with `$wgNeoWikiSparqlStores`, a list of objects:
 ```php
 $wgNeoWikiSparqlStores = [
 	[
-		// Required: the store's SPARQL 1.1 Update endpoint.
+		// Required: the store's SPARQL 1.1 Update endpoint (the write path posts here).
 		'updateUrl' => 'https://qlever.example/api/neowiki',
-		// Optional: sent as an HTTP Bearer token (e.g. a QLever access token) to authorize writes.
+		// Optional: the store's SPARQL 1.1 Query endpoint (the read path posts here).
+		// Defaults to updateUrl, which is correct for QLever, where the two are the same.
+		'queryUrl' => 'https://qlever.example/api/neowiki',
+		// Optional: sent as an HTTP Bearer token (e.g. a QLever access token) on both update and
+		// query requests — QLever only requires it for updates, but a read-protected store needs it too.
 		'accessToken' => 'SECRET',
 		// Optional: the RDF vocabulary written to this store. Defaults to 'native'; may be any
 		// configured Mapping target, such as 'edm'.
@@ -202,8 +206,18 @@ $wgNeoWikiSparqlStores = [
 A store entry whose `updateUrl` is missing or empty is skipped with a warning rather than failing the wiki. Leaving
 `$wgNeoWikiSparqlStores` empty (the default) configures no SPARQL stores.
 
-This is a write path only: it projects NeoWiki data into the store. Querying a SPARQL store from wiki pages is a
-later addition.
+### Querying a SPARQL store
+
+When at least one store is configured, three read-only query surfaces become available and target the **first**
+configured store (multi-store query addressing is a later addition):
+
+- The [`{{#sparql_raw}}`](../reference/parser-functions.md#sparql_raw) parser function.
+- The [`nw.sparqlQuery()`](../reference/lua-api.md#nwsparqlquerysparql) Lua function.
+- The [`POST /neowiki/v0/query/sparql`](../reference/query-api.md#sparql-query-endpoint) REST endpoint.
+
+Each is read-only *by protocol*: the query is sent as a SPARQL 1.1 *query* operation, whose grammar has no update
+forms, so no read-only validator is needed (unlike the Cypher surfaces). They never post to `updateUrl` — only to
+`queryUrl` — and return the W3C `application/sparql-results+json` document unmodified.
 
 The bundled development stack ships a working QLever example wired up this way — see
 [`Docker/README.md`](../../Docker/README.md#qlever-sparql-store-dev) for the service, its `--persist-updates`

--- a/docs/reference/lua-api.md
+++ b/docs/reference/lua-api.md
@@ -16,6 +16,7 @@ enough.
 | Get a page's Main Subject (label, schema, all properties) | [`nw.getMainSubject`](#nwgetmainsubjectpagename) |
 | Get a Subject by its ID, regardless of which page it's on | [`nw.getSubject`](#nwgetsubjectsubjectid) |
 | Run a read-only Cypher query | [`nw.query`](#nwquerycypher-params) |
+| Run a read-only SPARQL query | [`nw.sparqlQuery`](#nwsparqlquerysparql) |
 | List all Child Subjects on a page | [`nw.getChildSubjects`](#nwgetchildsubjectspagename) |
 | Inspect a Schema | [`nw.getSchema`](#nwgetschemaname) |
 
@@ -230,6 +231,48 @@ local rows = nw.query(
 ```
 
 Integer comparisons need an explicit cast in the query — e.g. `WHERE s.year = toInteger($year)`.
+
+### `nw.sparqlQuery(sparql)`
+
+Runs a read-only SPARQL query against the first configured
+[SPARQL store](../operations/installation.md#optional-sparql-graph-stores) and returns the results as a Lua table.
+The SPARQL counterpart of `nw.query`. It is available only when a SPARQL store is configured; on a wiki
+without one, `mw.neowiki.sparqlQuery` is nil.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `sparql` | string | Required. A SPARQL query (`SELECT` / `ASK` / `CONSTRUCT` / `DESCRIBE`). Read-only by protocol. |
+
+#### Returns
+
+The W3C [`application/sparql-results+json`](https://www.w3.org/TR/sparql11-results-json/) document as a
+Lua table, preserving its standard structure: `head.vars` and `results.bindings` for a `SELECT`, or
+`boolean` for an `ASK`. Every JSON array (`head.vars`, `results.bindings`) is a 1-indexed Lua sequence;
+each binding is a string-keyed table of RDF terms (`{ type, value, datatype?, ['xml:lang']? }`).
+
+#### Errors
+
+Always throws on failure; wrap in `pcall` if you need graceful degradation.
+
+- Empty or whitespace-only `sparql`.
+- A query the store rejects (e.g. a SPARQL syntax error), or the store being unavailable.
+
+#### Expensive
+
+Every call counts as an expensive parser function. Keep an eye on your page's expensive function
+limit if a template calls `nw.sparqlQuery` in a loop.
+
+#### Examples
+
+```lua
+local results = nw.sparqlQuery(
+    'SELECT ?label WHERE { ?s <http://www.w3.org/2000/01/rdf-schema#label> ?label } LIMIT 5'
+)
+
+for _, binding in ipairs( results.results.bindings ) do
+    mw.log( binding.label.value )
+end
+```
 
 ### `nw.getSchema(name)`
 

--- a/docs/reference/lua-api.md
+++ b/docs/reference/lua-api.md
@@ -241,7 +241,7 @@ without one, `mw.neowiki.sparqlQuery` is nil.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `sparql` | string | Required. A SPARQL query (`SELECT` / `ASK` / `CONSTRUCT` / `DESCRIBE`). Read-only by protocol. |
+| `sparql` | string | Required. A SPARQL `SELECT` or `ASK` query. Read-only by protocol. `CONSTRUCT` / `DESCRIBE` are not supported yet (they return an RDF graph, not a results document). |
 
 #### Returns
 

--- a/docs/reference/parser-functions.md
+++ b/docs/reference/parser-functions.md
@@ -11,6 +11,7 @@ NeoWiki provides three parser functions for use in wikitext.
 | Render a Subject visually on the page | [`{{#view}}`](#view) |
 | Insert one property's value inline as text | [`{{#neowiki_value}}`](#neowiki_value) |
 | Run a custom Cypher query and see the raw results | [`{{#cypher_raw}}`](#cypher_raw) |
+| Run a custom SPARQL query and see the raw results | [`{{#sparql_raw}}`](#sparql_raw) |
 
 For programmatic access from Lua modules, see the [Lua API](lua-api.md).
 
@@ -158,6 +159,39 @@ custom result formatting in templates.
 {{#cypher_raw: MATCH (s:Subject) RETURN s.name LIMIT 10}}
 
 {{#cypher_raw: MATCH (s:Subject) WHERE 'Company' IN labels(s) RETURN s.name, s.`Founded at`}}
+```
+
+## `{{#sparql_raw}}`
+
+Executes a read-only SPARQL query against the first configured [SPARQL store](../operations/installation.md#optional-sparql-graph-stores)
+and returns the raw results as JSON in a code block. The SPARQL counterpart of `{{#cypher_raw}}`, mainly
+useful for development and debugging. It is available only when a SPARQL store is configured; on a wiki
+without one, `{{#sparql_raw: …}}` is not registered and renders as ordinary wikitext.
+
+The output is the W3C [`application/sparql-results+json`](https://www.w3.org/TR/sparql11-results-json/)
+document, unmodified — the standard `head` / `results` structure (or `boolean` for an `ASK` query).
+
+### Syntax
+
+```
+{{#sparql_raw: <sparqlQuery>}}
+```
+
+### Notes
+
+- Read-only by protocol, not by a keyword filter: the query is sent as a SPARQL 1.1 *query* operation
+  (`SELECT` / `ASK` / `CONSTRUCT` / `DESCRIBE`), and the SPARQL query grammar contains no update forms, so
+  no read-only validator is needed (unlike Cypher, where one language expresses both reads and writes).
+- Errors (a query the store rejects, the store being unavailable, etc.) render as a styled error message
+  in place of the result.
+- Output is HTML-escaped, so results containing `<`, `>`, `&`, etc. display safely.
+- The output is wrapped in `<div class="mw-neowiki-sparql-result"><pre>` and the error message in
+  `<div class="error">`, so you can target either with CSS.
+
+### Examples
+
+```
+{{#sparql_raw: SELECT ?label WHERE { ?s <http://www.w3.org/2000/01/rdf-schema#label> ?label } LIMIT 10}}
 ```
 
 ## Related Documentation

--- a/docs/reference/query-api.md
+++ b/docs/reference/query-api.md
@@ -313,7 +313,10 @@ Content-Type: application/json
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `query` | string | Yes | A read-only SPARQL 1.1 query (`SELECT`, `ASK`, `CONSTRUCT`, or `DESCRIBE`). |
+| `query` | string | Yes | A read-only SPARQL 1.1 `SELECT` or `ASK` query. |
+
+`CONSTRUCT` and `DESCRIBE` are not supported yet: they return an RDF graph rather than the
+`application/sparql-results+json` document this endpoint negotiates.
 
 ### Successful response (200)
 

--- a/docs/reference/query-api.md
+++ b/docs/reference/query-api.md
@@ -290,11 +290,76 @@ that bypass the application layer are still bounded. A value such as `360s` give
 These settings apply to all connections to the Neo4j instance, not only NeoWiki traffic. Adjust to your
 deployment's needs.
 
+## SPARQL query endpoint
+
+`POST /neowiki/v0/query/sparql` runs a read-only SPARQL query against the first configured
+[SPARQL store](../operations/installation.md#optional-sparql-graph-stores) and returns the results. Like the Cypher
+endpoint, it exists only when a store is configured; on a wiki without one the route is absent and does not appear in
+the OpenAPI spec. Multi-store query addressing is a later addition — for now the endpoint always targets the first
+configured store.
+
+### Request
+
+```
+POST /rest.php/neowiki/v0/query/sparql
+Content-Type: application/json
+```
+
+```json
+{
+    "query": "SELECT ?label WHERE { ?s <http://www.w3.org/2000/01/rdf-schema#label> ?label } LIMIT 10"
+}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `query` | string | Yes | A read-only SPARQL 1.1 query (`SELECT`, `ASK`, `CONSTRUCT`, or `DESCRIBE`). |
+
+### Successful response (200)
+
+The body is the W3C [`application/sparql-results+json`](https://www.w3.org/TR/sparql11-results-json/) document from the
+store, **unmodified** — the standard `head` / `results` structure (or `boolean` for an `ASK`), plus any store-specific
+extras (e.g. QLever's `meta`). NeoWiki wraps no envelope of its own around it.
+
+```json
+{
+    "head": { "vars": ["label"] },
+    "results": { "bindings": [ { "label": { "type": "literal", "value": "Johann Sebastian Bach" } } ] }
+}
+```
+
+### Error response
+
+Same shape as the Cypher endpoint (`{ "errorType", "message" }`); branch on `errorType`, not `message`.
+
+| `errorType` | HTTP | When |
+|---|---|---|
+| `emptyQuery` | 400 | `query` is empty or contains only whitespace. |
+| `sparqlSyntaxError` | 400 | The store rejected the query (a 4xx response, most commonly a SPARQL syntax error). The store's own detail is relayed in `message`. |
+| `sparqlStoreUnavailable` | 503 | The store could not be reached or failed to serve the query (a 5xx response or a transport error). |
+| `internalError` | 500 | The store returned a 2xx response whose body is not a JSON results document, or any other unexpected failure. |
+| `rateLimitExceeded` | 429 | Request frequency exceeded the `neowiki-query` rate limit. |
+| `permissionDenied` | 403 | Caller lacks the `neowiki-query` right. |
+
+### Differences from the Cypher endpoint
+
+- **Read-only by protocol, not by a validator.** The query is sent as a SPARQL 1.1 *query* operation
+  (`Content-Type: application/sparql-query`), and the SPARQL query grammar contains no update forms, so no read-only
+  validator is needed. The endpoint only ever posts to the store's `queryUrl`, never to `updateUrl`.
+- **The result document is returned unmodified, with no envelope**, so there is no `columns` / `rows` / `resultCount`
+  reshaping and no cell normalization — the store's JSON already carries typed RDF terms.
+- **Limits: the per-tier timeout is applied** (as the HTTP client timeout), reusing the same `$wgNeoWikiQueryLimits`
+  tiers and `neowiki-query` right and rate limits as the Cypher endpoint. The `maxRows` cap is **not** applied:
+  truncating `results.bindings` would alter the W3C document, and signaling the truncation would require inventing a
+  field, so neither is done. Bound result size with `LIMIT` in the query.
+
 ## Related
 
 - [REST API](rest-api.md) — OpenAPI spec and how it is generated; how to browse it with Swagger UI.
-- [Lua API](lua-api.md) — `nw.query()` for the same Cypher surface from wikitext templates.
-- [Parser Functions](parser-functions.md) — `{{#cypher_raw}}` for inline Cypher output in wikitext.
+- [Lua API](lua-api.md) — `nw.query()` for the same Cypher surface from wikitext templates, and `nw.sparqlQuery()` for
+  the SPARQL surface.
+- [Parser Functions](parser-functions.md) — `{{#cypher_raw}}` and `{{#sparql_raw}}` for inline query output in
+  wikitext.
 - [Graph Model](graph-model.md) — Neo4j node labels, relationships, and properties; essential reading before
   writing Cypher.
 - [ADR 13: Restrict Neo4j Access](../adr/013-restrict-neo4j-access.md) — Why Neo4j is not exposed directly.

--- a/extension.json
+++ b/extension.json
@@ -196,7 +196,7 @@
 			"value": null
 		},
 		"NeoWikiSparqlStores": {
-			"description": "SPARQL 1.1 graph stores to keep in sync with page changes, in addition to any Neo4j backend. A list of objects, each with: 'updateUrl' (required, the store's SPARQL 1.1 Update endpoint, e.g. a QLever instance); 'accessToken' (optional, sent as an HTTP Bearer token, e.g. for a QLever access token); and 'projection' (optional, the RDF vocabulary written to the store: 'native' by default, or any configured Mapping target). Works with QLever and any SPARQL 1.1 store. Empty by default.",
+			"description": "SPARQL 1.1 graph stores to keep in sync with page changes and to query, in addition to any Neo4j backend. A list of objects, each with: 'updateUrl' (required, the store's SPARQL 1.1 Update endpoint, e.g. a QLever instance); 'queryUrl' (optional, the store's SPARQL 1.1 Query endpoint the read surfaces use; defaults to 'updateUrl', which is correct for QLever where the two are the same); 'accessToken' (optional, sent as an HTTP Bearer token on both update and query requests, e.g. for a QLever access token or a read-protected endpoint); and 'projection' (optional, the RDF vocabulary written to the store: 'native' by default, or any configured Mapping target). The query surfaces (the {{#sparql_raw}} parser function, nw.sparqlQuery() in Lua, and POST /neowiki/v0/query/sparql) target the first configured store. Works with QLever and any SPARQL 1.1 store. Empty by default.",
 			"value": []
 		}
 	},

--- a/i18n/_Magic.php
+++ b/i18n/_Magic.php
@@ -4,6 +4,7 @@ $magicWords = [];
 
 $magicWords['en'] = [
 	'cypher_raw' => [ 0, 'cypher_raw' ],
+	'sparql_raw' => [ 0, 'sparql_raw' ],
 	'view' => [ 0, 'view' ],
 	'neowiki_value' => [ 0, 'neowiki_value' ],
 ];

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -143,6 +143,13 @@
 	"neowiki-cypher-error-backend-unavailable": "The graph database is currently unavailable.",
 	"neowiki-cypher-error-internal": "The Cypher query could not be completed: $1",
 
+	"neowiki-sparql-raw-error-json-encode": "Failed to encode query result as JSON",
+
+	"neowiki-sparql-error-empty-query": "The SPARQL query must not be empty.",
+	"neowiki-sparql-error-syntax": "The SPARQL query was rejected by the store: $1",
+	"neowiki-sparql-error-store-unavailable": "The SPARQL store is currently unavailable.",
+	"neowiki-sparql-error-internal": "The SPARQL query could not be completed: $1",
+
 	"neowiki-view-error-extra-positional": "Unexpected extra positional argument: $1",
 	"neowiki-view-error-conflicting-subject": "Subject specified both positionally and as a named subject argument.",
 	"neowiki-view-error-unknown-arg": "Unknown argument: $1",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -26,6 +26,13 @@
 	"neowiki-cypher-error-backend-unavailable": "Error shown when the graph database backend cannot be reached for a Cypher query run from wikitext. The underlying connection detail is intentionally omitted.",
 	"neowiki-cypher-error-internal": "Generic fallback error shown for a Cypher query run from wikitext that fails for a reason not covered by the more specific cases. $1 is the verbatim underlying detail and is not translatable.",
 
+	"neowiki-sparql-raw-error-json-encode": "Error message shown when JSON encoding of SPARQL query results fails.",
+
+	"neowiki-sparql-error-empty-query": "Error shown on the <code>{{#sparql_raw}}</code> parser function and the <code>nw.sparqlQuery()</code> Lua function when the supplied SPARQL query is empty or only whitespace.",
+	"neowiki-sparql-error-syntax": "Error shown when the SPARQL store rejects a query run from wikitext (a 4xx response, most commonly a syntax error). $1 is the verbatim store-supplied detail and is not translatable.",
+	"neowiki-sparql-error-store-unavailable": "Error shown when the SPARQL store cannot be reached for a query run from wikitext (a 5xx response or a transport error). The underlying connection detail is intentionally omitted.",
+	"neowiki-sparql-error-internal": "Generic fallback error shown for a SPARQL query run from wikitext that fails for a reason not covered by the more specific cases. $1 is the verbatim underlying detail and is not translatable.",
+
 	"neowiki-view-error-extra-positional": "Error shown when {{#view}} is called with more than one positional argument. $1 is the offending extra argument value.",
 	"neowiki-view-error-conflicting-subject": "Error shown when {{#view}} receives a Subject ID as both a positional argument and a named <code>subject=</code> argument.",
 	"neowiki-view-error-unknown-arg": "Error shown when {{#view}} receives an unrecognized named argument. $1 is the offending argument name.",

--- a/maintenance/ImportDemoData.php
+++ b/maintenance/ImportDemoData.php
@@ -53,9 +53,7 @@ class ImportDemoData extends Maintenance {
 				new SimpleFileFetcher()
 			),
 			pageContentSource: new PageContentSource(
-				[
-					NeoWikiExtension::getInstance()->getNeoWikiRootDirectory() . '/DemoData/Page',
-				],
+				$this->getPageDirectories(),
 				new SimpleFileFetcher()
 			),
 			moduleContentSource: new PageContentSource(
@@ -73,6 +71,25 @@ class ImportDemoData extends Maintenance {
 				new SimpleFileFetcher()
 			)
 		);
+	}
+
+	/**
+	 * The SPARQL demo page invokes {{#sparql_raw}}, which only exists on wikis with a configured
+	 * SPARQL store — anywhere else it would render as literal wikitext. So that page is only
+	 * imported when a store is configured (as in the development stack).
+	 *
+	 * @return string[]
+	 */
+	private function getPageDirectories(): array {
+		$directories = [
+			NeoWikiExtension::getInstance()->getNeoWikiRootDirectory() . '/DemoData/Page',
+		];
+
+		if ( $this->getConfig()->get( 'NeoWikiSparqlStores' ) !== [] ) {
+			$directories[] = NeoWikiExtension::getInstance()->getNeoWikiRootDirectory() . '/DemoData/SparqlPage';
+		}
+
+		return $directories;
 	}
 
 	private function getUser(): User {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -14,6 +14,7 @@ parameters:
 		analyse:
 			- src/EntryPoints/
 			- src/GraphDatabasePlugins/Neo4j/EntryPoints/
+			- src/GraphDatabasePlugins/Sparql/EntryPoints/
 	reportUnmatchedIgnoredErrors: false
 	ignoreErrors:
 		- '#no value type specified in iterable type array\.$#'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,5 +8,9 @@
 	<php>
 		<env name="NEO4J_URL_OVERRIDE" value="bolt://neo4j:password@test_neo:7689" />
 		<env name="NEO4J_URL_READ_OVERRIDE" value="bolt://mediawiki_read:mediawiki_read@test_neo:7689" />
+		<!-- Live QLever store for the SPARQL query system test (dev-stack hostname; CI overrides these
+		     via job-level env to reach the runner-published port). -->
+		<env name="QLEVER_TEST_URL" value="http://test_qlever:7019/" />
+		<env name="QLEVER_TEST_ACCESS_TOKEN" value="neowiki_test_token" />
 	</php>
 </phpunit>

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -144,6 +144,7 @@ class NeoWikiHooks {
 
 	public static function onParserFirstCallInit( Parser $parser ): void {
 		NeoWikiExtension::getInstance()->getNeo4jPlugin()?->registerParserFunctions( $parser );
+		NeoWikiExtension::getInstance()->getFirstSparqlPlugin()?->registerParserFunctions( $parser );
 
 		$parser->setFunctionHook(
 			'view',

--- a/src/EntryPoints/Scribunto/ScribuntoLuaLibrary.php
+++ b/src/EntryPoints/Scribunto/ScribuntoLuaLibrary.php
@@ -13,6 +13,9 @@ use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\QueryException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\CypherErrorMessage;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\Lua\CypherQueryRunner;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlQueryException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\EntryPoints\Lua\SparqlQueryRunner;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\EntryPoints\SparqlErrorMessage;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 
 class ScribuntoLuaLibrary extends LibraryBase {
@@ -20,6 +23,7 @@ class ScribuntoLuaLibrary extends LibraryBase {
 	private ?SubjectDataLookup $subjectDataLookup = null;
 	private ?SchemaLuaSerializer $schemaLuaSerializer = null;
 	private ?CypherQueryRunner $cypherQueryRunner = null;
+	private ?SparqlQueryRunner $sparqlQueryRunner = null;
 
 	private function getSubjectDataLookup(): SubjectDataLookup {
 		if ( $this->subjectDataLookup === null ) {
@@ -53,6 +57,16 @@ class ScribuntoLuaLibrary extends LibraryBase {
 		return $this->cypherQueryRunner;
 	}
 
+	private function getSparqlQueryRunner(): SparqlQueryRunner {
+		if ( $this->sparqlQueryRunner === null ) {
+			$this->sparqlQueryRunner = new SparqlQueryRunner(
+				NeoWikiExtension::getInstance()->newSparqlQueryService()
+			);
+		}
+
+		return $this->sparqlQueryRunner;
+	}
+
 	public function register(): array {
 		$lib = [
 			'getValue' => [ $this, 'getValue' ],
@@ -65,6 +79,11 @@ class ScribuntoLuaLibrary extends LibraryBase {
 
 		$neo4jFunctions = NeoWikiExtension::getInstance()->getNeo4jPlugin()?->getLuaLibraryFunctionNames() ?? [];
 		foreach ( $neo4jFunctions as $name ) {
+			$lib[$name] = [ $this, $name ];
+		}
+
+		$sparqlFunctions = NeoWikiExtension::getInstance()->getFirstSparqlPlugin()?->getLuaLibraryFunctionNames() ?? [];
+		foreach ( $sparqlFunctions as $name ) {
 			$lib[$name] = [ $this, $name ];
 		}
 
@@ -135,6 +154,22 @@ class ScribuntoLuaLibrary extends LibraryBase {
 		}
 
 		return [ $rows ];
+	}
+
+	public function sparqlQuery( ?string $sparql = null ): array {
+		$this->checkType( 'mw.neowiki.sparqlQuery', 1, $sparql, 'string' );
+		$this->incrementExpensiveFunctionCount();
+
+		try {
+			$document = $this->getSparqlQueryRunner()->run( $sparql ?? '' );
+		} catch ( SparqlQueryException $e ) {
+			$message = SparqlErrorMessage::for( $e );
+			throw new LuaError( $this->getParser()->msg( $message->key, ...$message->params )->text() );
+		} catch ( Exception $e ) {
+			throw new LuaError( $e->getMessage() );
+		}
+
+		return [ $document ];
 	}
 
 	public function getSchema( ?string $schemaName = null ): array {

--- a/src/EntryPoints/Scribunto/mw.neowiki.lua
+++ b/src/EntryPoints/Scribunto/mw.neowiki.lua
@@ -13,6 +13,11 @@ function neowiki.setupInterface()
 		neowiki.query = nil
 	end
 
+	-- Likewise, sparqlQuery is registered only when a SPARQL store is configured.
+	if not php.sparqlQuery then
+		neowiki.sparqlQuery = nil
+	end
+
 	mw = mw or {}
 	mw.neowiki = neowiki
 
@@ -41,6 +46,10 @@ end
 
 function neowiki.query( cypher, params )
 	return php.query( cypher, params )
+end
+
+function neowiki.sparqlQuery( sparql )
+	return php.sparqlQuery( sparql )
 end
 
 function neowiki.getSchema( name )

--- a/src/GraphDatabasePlugins/Sparql/Application/Exception/EmptySparqlQueryException.php
+++ b/src/GraphDatabasePlugins/Sparql/Application/Exception/EmptySparqlQueryException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception;
+
+class EmptySparqlQueryException extends SparqlQueryException {
+
+	public function errorType(): string {
+		return 'emptyQuery';
+	}
+
+}

--- a/src/GraphDatabasePlugins/Sparql/Application/Exception/InternalSparqlQueryException.php
+++ b/src/GraphDatabasePlugins/Sparql/Application/Exception/InternalSparqlQueryException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception;
+
+/**
+ * A failure not covered by the more specific cases: most notably a 2xx response whose body is not a
+ * decodable JSON results document.
+ */
+class InternalSparqlQueryException extends SparqlQueryException {
+
+	public function errorType(): string {
+		return 'internalError';
+	}
+
+}

--- a/src/GraphDatabasePlugins/Sparql/Application/Exception/SparqlQueryException.php
+++ b/src/GraphDatabasePlugins/Sparql/Application/Exception/SparqlQueryException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception;
+
+use RuntimeException;
+
+/**
+ * Base for the errors the SPARQL query surfaces classify. Mirrors the Neo4j
+ * {@see \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\QueryException}:
+ * each subclass names a stable `errorType()` the REST envelope and the localized wikitext messages
+ * branch on.
+ */
+abstract class SparqlQueryException extends RuntimeException {
+
+	abstract public function errorType(): string;
+
+}

--- a/src/GraphDatabasePlugins/Sparql/Application/Exception/SparqlQueryFailedException.php
+++ b/src/GraphDatabasePlugins/Sparql/Application/Exception/SparqlQueryFailedException.php
@@ -1,0 +1,44 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception;
+
+use RuntimeException;
+
+/**
+ * Thrown by the HTTP query endpoint when a SPARQL query request fails: a non-2xx HTTP response, or a
+ * transport error (which surfaces as HTTP status 0). Carries the HTTP status and a bounded snippet of
+ * the response body so {@see \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryService}
+ * can classify it (4xx client error vs 5xx/transport unavailability) and, for a client error, relay the
+ * store's own detail to the author.
+ *
+ * The sibling of {@see SparqlUpdateFailedException} on the read side; kept separate because the query
+ * service needs the status and snippet as data, not only baked into a message.
+ */
+class SparqlQueryFailedException extends RuntimeException {
+
+	private const int MAX_BODY_SNIPPET_LENGTH = 500;
+
+	public function __construct(
+		public readonly string $endpointUrl,
+		public readonly int $httpStatus,
+		public readonly string $responseBody,
+	) {
+		parent::__construct(
+			'The SPARQL query to <' . $endpointUrl . '> failed with HTTP status ' . $httpStatus
+			. '. Response body: ' . $this->bodySnippet()
+		);
+	}
+
+	public function bodySnippet(): string {
+		$trimmed = trim( $this->responseBody );
+
+		if ( mb_strlen( $trimmed ) <= self::MAX_BODY_SNIPPET_LENGTH ) {
+			return $trimmed;
+		}
+
+		return mb_substr( $trimmed, 0, self::MAX_BODY_SNIPPET_LENGTH ) . '…';
+	}
+
+}

--- a/src/GraphDatabasePlugins/Sparql/Application/Exception/SparqlStoreUnavailableException.php
+++ b/src/GraphDatabasePlugins/Sparql/Application/Exception/SparqlStoreUnavailableException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception;
+
+/**
+ * The store could not be reached or failed to serve the query: a transport error (HTTP status 0) or a
+ * 5xx response. The store's raw detail is intentionally not surfaced to the user.
+ */
+class SparqlStoreUnavailableException extends SparqlQueryException {
+
+	public function errorType(): string {
+		return 'sparqlStoreUnavailable';
+	}
+
+}

--- a/src/GraphDatabasePlugins/Sparql/Application/Exception/SparqlSyntaxException.php
+++ b/src/GraphDatabasePlugins/Sparql/Application/Exception/SparqlSyntaxException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception;
+
+/**
+ * The store rejected the query with a 4xx status: a client problem, most commonly a SPARQL syntax
+ * error. The message carries the store's own response detail so the author can fix the query.
+ */
+class SparqlSyntaxException extends SparqlQueryException {
+
+	public function errorType(): string {
+		return 'sparqlSyntaxError';
+	}
+
+}

--- a/src/GraphDatabasePlugins/Sparql/Application/SparqlQueryEndpoint.php
+++ b/src/GraphDatabasePlugins/Sparql/Application/SparqlQueryEndpoint.php
@@ -1,0 +1,23 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application;
+
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlQueryFailedException;
+
+/**
+ * Sends a SPARQL 1.1 Query operation to a store's query endpoint and returns the raw response body (a
+ * `application/sparql-results+json` document). The read-side sibling of {@see SparqlUpdateEndpoint}.
+ *
+ * @see \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Persistence\HttpSparqlQueryEndpoint for why
+ *      no read-only validator is needed (a query operation cannot express an update).
+ */
+interface SparqlQueryEndpoint {
+
+	/**
+	 * @throws SparqlQueryFailedException on a non-2xx response or a transport error.
+	 */
+	public function runQuery( string $sparql, int $timeoutSeconds ): string;
+
+}

--- a/src/GraphDatabasePlugins/Sparql/Application/SparqlQueryLimits.php
+++ b/src/GraphDatabasePlugins/Sparql/Application/SparqlQueryLimits.php
@@ -1,0 +1,38 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application;
+
+use MediaWiki\MediaWikiServices;
+use MediaWiki\User\User;
+
+/**
+ * Per-tier resource cap for a SPARQL query, read from the shared `NeoWikiQueryLimits` config — the same
+ * config the Neo4j surfaces use. Mirrors
+ * {@see \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jQueryLimits}, but carries
+ * only `timeoutSeconds`: unlike Cypher, the SPARQL surfaces do not apply the `maxRows` cap (see
+ * {@see SparqlQueryService} for why truncating the W3C results document is out of scope here).
+ */
+readonly class SparqlQueryLimits {
+
+	public function __construct(
+		public int $timeoutSeconds,
+	) {
+	}
+
+	public static function forUser( User $user ): self {
+		/** @var array<string, array{timeoutSeconds: int, maxRows: int}> $config */
+		$config = MediaWikiServices::getInstance()->getMainConfig()->get( 'NeoWikiQueryLimits' );
+
+		$tier = MediaWikiServices::getInstance()->getPermissionManager()
+			->userHasRight( $user, 'apihighlimits' )
+				? 'expensive'
+				: 'default';
+
+		return new self(
+			timeoutSeconds: (int)$config[$tier]['timeoutSeconds'],
+		);
+	}
+
+}

--- a/src/GraphDatabasePlugins/Sparql/Application/SparqlQueryRequest.php
+++ b/src/GraphDatabasePlugins/Sparql/Application/SparqlQueryRequest.php
@@ -1,0 +1,15 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application;
+
+readonly class SparqlQueryRequest {
+
+	public function __construct(
+		public string $sparql,
+		public SparqlQueryLimits $limits,
+	) {
+	}
+
+}

--- a/src/GraphDatabasePlugins/Sparql/Application/SparqlQueryResult.php
+++ b/src/GraphDatabasePlugins/Sparql/Application/SparqlQueryResult.php
@@ -1,0 +1,23 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application;
+
+/**
+ * The store's response to a query: the W3C `application/sparql-results+json` document, decoded and
+ * otherwise unmodified. NeoWiki adds no envelope of its own around it (unlike the Cypher surface, whose
+ * result is assembled from non-JSON Bolt records) — every surface renders this document directly.
+ */
+readonly class SparqlQueryResult {
+
+	/**
+	 * @param array<string, mixed> $document The decoded SPARQL results document (`head`, `results`, or
+	 *   `boolean` for an ASK query), plus any store-specific extras (e.g. QLever's `meta`).
+	 */
+	public function __construct(
+		public array $document,
+	) {
+	}
+
+}

--- a/src/GraphDatabasePlugins/Sparql/Application/SparqlQueryService.php
+++ b/src/GraphDatabasePlugins/Sparql/Application/SparqlQueryService.php
@@ -1,0 +1,71 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application;
+
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\EmptySparqlQueryException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\InternalSparqlQueryException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlQueryException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlQueryFailedException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlStoreUnavailableException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlSyntaxException;
+
+/**
+ * Runs a read-only SPARQL query against one store and returns the W3C results document. The read-side
+ * counterpart to {@see \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jQueryService}.
+ *
+ * Two deliberate differences from the Cypher service:
+ *
+ *  - No read-only validator. Cypher can express writes, so it needs one; the query is instead sent as a
+ *    SPARQL 1.1 Protocol *query* operation, and the SPARQL Query grammar contains no update forms (see
+ *    {@see \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Persistence\HttpSparqlQueryEndpoint}).
+ *  - No normalizer and no envelope. Bolt records are not JSON, so the Cypher path assembles rows into an
+ *    envelope; the SPARQL response already *is* the `application/sparql-results+json` document, returned
+ *    unmodified. As a consequence the `maxRows` cap is not applied: truncating `results.bindings` would
+ *    alter that document, and signaling the truncation would require inventing a field. Only the per-tier
+ *    timeout is enforced (as the HTTP client timeout).
+ */
+readonly class SparqlQueryService {
+
+	public function __construct(
+		private SparqlQueryEndpoint $endpoint,
+	) {
+	}
+
+	public function execute( SparqlQueryRequest $request ): SparqlQueryResult {
+		$sparql = trim( $request->sparql );
+
+		if ( $sparql === '' ) {
+			throw new EmptySparqlQueryException( 'Query is empty.' );
+		}
+
+		try {
+			$body = $this->endpoint->runQuery( $sparql, $request->limits->timeoutSeconds );
+		} catch ( SparqlQueryFailedException $e ) {
+			throw $this->translateFailure( $e );
+		}
+
+		$document = json_decode( $body, true );
+
+		if ( !is_array( $document ) ) {
+			throw new InternalSparqlQueryException(
+				'The SPARQL store returned a response that is not a JSON results document.'
+			);
+		}
+
+		return new SparqlQueryResult( $document );
+	}
+
+	private function translateFailure( SparqlQueryFailedException $failure ): SparqlQueryException {
+		// A 4xx means the store rejected the request itself — for a query that is almost always a SPARQL
+		// syntax error. Relay the store's own detail so the author can fix the query.
+		if ( $failure->httpStatus >= 400 && $failure->httpStatus < 500 ) {
+			return new SparqlSyntaxException( $failure->bodySnippet(), 0, $failure );
+		}
+
+		// A 5xx response or a transport error (status 0) means the store is unavailable.
+		return new SparqlStoreUnavailableException( 'The SPARQL store is unavailable.', 0, $failure );
+	}
+
+}

--- a/src/GraphDatabasePlugins/Sparql/EntryPoints/Lua/SparqlQueryRunner.php
+++ b/src/GraphDatabasePlugins/Sparql/EntryPoints/Lua/SparqlQueryRunner.php
@@ -1,0 +1,57 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\EntryPoints\Lua;
+
+use MediaWiki\Context\RequestContext;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryLimits;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryRequest;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryService;
+
+/**
+ * Runs a SPARQL query for nw.sparqlQuery() and returns the W3C results document as a Lua table,
+ * preserving the standard `head` / `results.bindings` structure. The read-side sibling of
+ * {@see \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\Lua\CypherQueryRunner}.
+ */
+class SparqlQueryRunner {
+
+	public function __construct(
+		private readonly SparqlQueryService $queryService,
+	) {
+	}
+
+	/**
+	 * @return array<int|string, mixed> The results document with every JSON array re-indexed for Lua.
+	 */
+	public function run( string $sparql ): array {
+		$result = $this->queryService->execute(
+			new SparqlQueryRequest(
+				sparql: $sparql,
+				limits: SparqlQueryLimits::forUser( RequestContext::getMain()->getUser() ),
+			)
+		);
+
+		return self::toLuaTable( $result->document );
+	}
+
+	/**
+	 * Lua tables are 1-indexed, but json_decode produces 0-indexed lists (head.vars, results.bindings).
+	 * Shift every integer key up by one — recursively, since the lists are nested — while leaving the
+	 * string-keyed objects (bindings, RDF terms) untouched.
+	 *
+	 * @param array<int|string, mixed> $data
+	 * @return array<int|string, mixed>
+	 */
+	private static function toLuaTable( array $data ): array {
+		$result = [];
+
+		foreach ( $data as $key => $value ) {
+			$luaKey = is_int( $key ) ? $key + 1 : $key;
+			$result[$luaKey] = is_array( $value ) ? self::toLuaTable( $value ) : $value;
+		}
+
+		return $result;
+	}
+
+}

--- a/src/GraphDatabasePlugins/Sparql/EntryPoints/ParserFunction/SparqlRawParserFunction.php
+++ b/src/GraphDatabasePlugins/Sparql/EntryPoints/ParserFunction/SparqlRawParserFunction.php
@@ -1,0 +1,57 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\EntryPoints\ParserFunction;
+
+use MediaWiki\Context\RequestContext;
+use MediaWiki\Parser\Parser;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlQueryException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryLimits;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryRequest;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryService;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\EntryPoints\SparqlErrorMessage;
+
+/**
+ * {{#sparql_raw: <query> }} — outputs the W3C `application/sparql-results+json` document as pretty
+ * JSON text, exactly like {{#cypher_raw}} renders its rows. The read-side sibling of
+ * {@see \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\ParserFunction\CypherRawParserFunction}.
+ */
+class SparqlRawParserFunction {
+
+	public function __construct(
+		private readonly SparqlQueryService $queryService,
+	) {
+	}
+
+	public function handle( Parser $parser, string $query ): string {
+		try {
+			$result = $this->queryService->execute(
+				new SparqlQueryRequest(
+					sparql: $query,
+					limits: SparqlQueryLimits::forUser( RequestContext::getMain()->getUser() ),
+				)
+			);
+		} catch ( SparqlQueryException $e ) {
+			$message = SparqlErrorMessage::for( $e );
+			return $this->formatError( $parser->msg( $message->key, ...$message->params )->text() );
+		}
+
+		$json = json_encode( $result->document, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+
+		if ( $json === false ) {
+			return $this->formatError( $parser->msg( 'neowiki-sparql-raw-error-json-encode' )->text() );
+		}
+
+		return $this->formatResult( $json );
+	}
+
+	private function formatResult( string $json ): string {
+		return '<div class="mw-neowiki-sparql-result"><pre>' . htmlspecialchars( $json ) . '</pre></div>';
+	}
+
+	private function formatError( string $message ): string {
+		return '<div class="error">' . htmlspecialchars( $message ) . '</div>';
+	}
+
+}

--- a/src/GraphDatabasePlugins/Sparql/EntryPoints/REST/SparqlQueryApi.php
+++ b/src/GraphDatabasePlugins/Sparql/EntryPoints/REST/SparqlQueryApi.php
@@ -95,7 +95,7 @@ class SparqlQueryApi extends SimpleHandler {
 				self::PARAM_SOURCE => 'body',
 				ParamValidator::PARAM_TYPE => 'string',
 				ParamValidator::PARAM_REQUIRED => true,
-				self::PARAM_DESCRIPTION => 'A read-only SPARQL 1.1 query (SELECT, ASK, CONSTRUCT, or DESCRIBE).',
+				self::PARAM_DESCRIPTION => 'A read-only SPARQL 1.1 SELECT or ASK query.',
 			],
 		];
 	}

--- a/src/GraphDatabasePlugins/Sparql/EntryPoints/REST/SparqlQueryApi.php
+++ b/src/GraphDatabasePlugins/Sparql/EntryPoints/REST/SparqlQueryApi.php
@@ -1,0 +1,107 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\EntryPoints\REST;
+
+use MediaWiki\MediaWikiServices;
+use MediaWiki\Rest\Response;
+use MediaWiki\Rest\SimpleHandler;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\EmptySparqlQueryException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\InternalSparqlQueryException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlQueryException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlStoreUnavailableException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlSyntaxException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryLimits;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryRequest;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryService;
+use Throwable;
+use Wikimedia\ParamValidator\ParamValidator;
+
+/**
+ * POST /neowiki/v0/query/sparql — runs a read-only SPARQL query against the first configured SPARQL
+ * store and returns the W3C `application/sparql-results+json` document unmodified. The read-side sibling
+ * of {@see \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\REST\CypherQueryApi}; it
+ * reuses the same `neowiki-query` right and rate limit, since both are read-only graph queries.
+ */
+class SparqlQueryApi extends SimpleHandler {
+
+	public function __construct(
+		private readonly SparqlQueryService $queryService,
+	) {
+	}
+
+	public function run(): Response {
+		$authority = $this->getAuthority();
+
+		if ( !$authority->isAllowed( 'neowiki-query' ) ) {
+			return $this->errorResponse( 403, 'permissionDenied', 'You do not have permission to run queries.' );
+		}
+
+		$user = MediaWikiServices::getInstance()->getUserFactory()->newFromAuthority( $authority );
+
+		if ( $user->pingLimiter( 'neowiki-query' ) ) {
+			return $this->errorResponse( 429, 'rateLimitExceeded', 'Query rate limit exceeded.' );
+		}
+
+		$body = $this->getValidatedBody();
+
+		try {
+			$limits = SparqlQueryLimits::forUser( $user );
+		} catch ( Throwable $e ) {
+			return $this->errorResponse( 500, 'internalError', $e->getMessage() );
+		}
+
+		try {
+			$result = $this->queryService->execute(
+				new SparqlQueryRequest(
+					sparql: $body['query'],
+					limits: $limits,
+				)
+			);
+		} catch ( SparqlQueryException $e ) {
+			return $this->mapException( $e );
+		}
+
+		// The W3C results document is returned unmodified, with no NeoWiki envelope around it.
+		return $this->getResponseFactory()->createJson( $result->document );
+	}
+
+	private function mapException( SparqlQueryException $e ): Response {
+		$status = match ( true ) {
+			$e instanceof EmptySparqlQueryException => 400,
+			$e instanceof SparqlSyntaxException => 400,
+			$e instanceof SparqlStoreUnavailableException => 503,
+			$e instanceof InternalSparqlQueryException => 500,
+			// Defensive default for any future SparqlQueryException subclass added without updating this map.
+			default => 500,
+		};
+
+		return $this->errorResponse( $status, $e->errorType(), $e->getMessage() );
+	}
+
+	private function errorResponse( int $status, string $errorType, string $message ): Response {
+		$response = $this->getResponseFactory()->createJson( [
+			'errorType' => $errorType,
+			'message' => $message,
+		] );
+		$response->setStatus( $status );
+		return $response;
+	}
+
+	public function getBodyParamSettings(): array {
+		return [
+			'query' => [
+				self::PARAM_SOURCE => 'body',
+				ParamValidator::PARAM_TYPE => 'string',
+				ParamValidator::PARAM_REQUIRED => true,
+				self::PARAM_DESCRIPTION => 'A read-only SPARQL 1.1 query (SELECT, ASK, CONSTRUCT, or DESCRIBE).',
+			],
+		];
+	}
+
+	public function needsWriteAccess(): bool {
+		return false;
+	}
+
+}

--- a/src/GraphDatabasePlugins/Sparql/EntryPoints/REST/SparqlRouteRegistration.php
+++ b/src/GraphDatabasePlugins/Sparql/EntryPoints/REST/SparqlRouteRegistration.php
@@ -1,0 +1,29 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\EntryPoints\REST;
+
+use ProfessionalWiki\NeoWiki\NeoWikiConfig;
+
+/**
+ * The read-side counterpart to
+ * {@see \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\REST\Neo4jRouteRegistration}:
+ * contributes the SPARQL query route only when at least one SPARQL store is configured.
+ */
+class SparqlRouteRegistration {
+
+	/**
+	 * REST route files the SPARQL plugin contributes given the raw `NeoWikiSparqlStores` config.
+	 *
+	 * @return string[]
+	 */
+	public static function routeFiles( mixed $rawStores ): array {
+		if ( !NeoWikiConfig::hasConfiguredSparqlStore( $rawStores ) ) {
+			return [];
+		}
+
+		return [ __DIR__ . '/sparqlRoutes.json' ];
+	}
+
+}

--- a/src/GraphDatabasePlugins/Sparql/EntryPoints/REST/sparqlRoutes.json
+++ b/src/GraphDatabasePlugins/Sparql/EntryPoints/REST/sparqlRoutes.json
@@ -1,0 +1,9 @@
+[
+	{
+		"path": "/neowiki/v0/query/sparql",
+		"method": [
+			"POST"
+		],
+		"factory": "ProfessionalWiki\\NeoWiki\\NeoWikiExtension::newSparqlQueryApi"
+	}
+]

--- a/src/GraphDatabasePlugins/Sparql/EntryPoints/SparqlErrorMessage.php
+++ b/src/GraphDatabasePlugins/Sparql/EntryPoints/SparqlErrorMessage.php
@@ -1,0 +1,35 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\EntryPoints;
+
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlQueryException;
+
+/**
+ * Maps a {@see SparqlQueryException} to the localized message that the wikitext-facing surfaces
+ * ({{#sparql_raw}} and nw.sparqlQuery()) show to users. Returns the message key and its parameters
+ * rather than rendered text, so each surface renders it in its own language context. Mirrors
+ * {@see \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\CypherErrorMessage}.
+ */
+readonly class SparqlErrorMessage {
+
+	/**
+	 * @param string[] $params
+	 */
+	public function __construct(
+		public string $key,
+		public array $params,
+	) {
+	}
+
+	public static function for( SparqlQueryException $error ): self {
+		return match ( $error->errorType() ) {
+			'emptyQuery' => new self( 'neowiki-sparql-error-empty-query', [] ),
+			'sparqlSyntaxError' => new self( 'neowiki-sparql-error-syntax', [ $error->getMessage() ] ),
+			'sparqlStoreUnavailable' => new self( 'neowiki-sparql-error-store-unavailable', [] ),
+			default => new self( 'neowiki-sparql-error-internal', [ $error->getMessage() ] ),
+		};
+	}
+
+}

--- a/src/GraphDatabasePlugins/Sparql/Persistence/HttpSparqlQueryEndpoint.php
+++ b/src/GraphDatabasePlugins/Sparql/Persistence/HttpSparqlQueryEndpoint.php
@@ -1,0 +1,64 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Persistence;
+
+use MediaWiki\Http\HttpRequestFactory;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlQueryFailedException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryEndpoint;
+
+/**
+ * Runs a SPARQL query over HTTP as a SPARQL 1.1 Protocol *query* operation (§ 2.1.3): the query text is
+ * the POST body with a `application/sparql-query` content type, and `application/sparql-results+json` is
+ * requested via the Accept header. A configured access token is sent as an HTTP Bearer token, matching
+ * QLever's access-token scheme (QLever requires the token only for updates, but sending it on reads too
+ * is harmless there and necessary for stores that also protect reads).
+ *
+ * Read-only by protocol, not by a validator. Unlike Cypher — where a single language expresses both
+ * reads and writes, so a read-only validator is required — this class only ever issues a *query*
+ * operation, and the SPARQL Query grammar (SELECT / ASK / CONSTRUCT / DESCRIBE) contains no update
+ * forms. It targets the store's `queryUrl` and never posts an update; for QLever `queryUrl` and
+ * `updateUrl` are the same value, so the real invariant is "only ever a query operation, never an
+ * update", not a distinct URL.
+ *
+ * No connection is attempted at construction, so building the plugin stays I/O-free. Any non-2xx
+ * response or transport failure (HTTP status 0) throws {@see SparqlQueryFailedException}.
+ */
+readonly class HttpSparqlQueryEndpoint implements SparqlQueryEndpoint {
+
+	private const string CONTENT_TYPE = 'application/sparql-query';
+	private const string ACCEPT = 'application/sparql-results+json';
+
+	public function __construct(
+		private HttpRequestFactory $httpRequestFactory,
+		private string $queryUrl,
+		private ?string $accessToken,
+	) {
+	}
+
+	public function runQuery( string $sparql, int $timeoutSeconds ): string {
+		$request = $this->httpRequestFactory->create(
+			$this->queryUrl,
+			[ 'method' => 'POST', 'postData' => $sparql, 'timeout' => $timeoutSeconds ],
+			__METHOD__
+		);
+
+		$request->setHeader( 'Content-Type', self::CONTENT_TYPE );
+		$request->setHeader( 'Accept', self::ACCEPT );
+
+		if ( $this->accessToken !== null ) {
+			$request->setHeader( 'Authorization', 'Bearer ' . $this->accessToken );
+		}
+
+		$request->execute();
+
+		$status = $request->getStatus();
+		if ( $status < 200 || $status >= 300 ) {
+			throw new SparqlQueryFailedException( $this->queryUrl, $status, $request->getContent() );
+		}
+
+		return $request->getContent();
+	}
+
+}

--- a/src/GraphDatabasePlugins/Sparql/SparqlPlugin.php
+++ b/src/GraphDatabasePlugins/Sparql/SparqlPlugin.php
@@ -5,9 +5,13 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql;
 
 use MediaWiki\Http\HttpRequestFactory;
+use MediaWiki\Parser\Parser;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphDatabasePlugin;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfNamespaces;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\ProjectionResolver;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryService;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\EntryPoints\ParserFunction\SparqlRawParserFunction;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Persistence\HttpSparqlQueryEndpoint;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Persistence\HttpSparqlUpdateEndpoint;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Persistence\SparqlProjectionStore;
 use ProfessionalWiki\NeoWiki\Infrastructure\Rdf\HardfRdfSerializer;
@@ -15,8 +19,9 @@ use ProfessionalWiki\NeoWiki\SparqlStoreConfig;
 
 /**
  * Composition root for one SPARQL graph-database backend — one instance per configured store —
- * mirroring {@see \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Neo4jPlugin}. A new backend
- * copies this shape.
+ * mirroring {@see \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Neo4jPlugin}. Owns both the write
+ * path (the projection store) and the read path (the query service and its wikitext surfaces). A new
+ * backend copies this shape.
  *
  * Construction is cheap and never does I/O: no HTTP, no projection resolution, no Mapping lookups. It
  * runs outside the per-plugin failure isolation, so a throw here would break every backend's edit path.
@@ -26,10 +31,10 @@ readonly class SparqlPlugin {
 	private GraphDatabasePlugin $projectionStore;
 
 	public function __construct(
-		SparqlStoreConfig $store,
+		private SparqlStoreConfig $store,
 		ProjectionResolver $projectionResolver,
 		RdfNamespaces $namespaces,
-		HttpRequestFactory $httpRequestFactory,
+		private HttpRequestFactory $httpRequestFactory,
 	) {
 		$this->projectionStore = new SparqlProjectionStore(
 			endpoint: new HttpSparqlUpdateEndpoint(
@@ -50,6 +55,38 @@ readonly class SparqlPlugin {
 
 	public function getGraphDatabasePlugin(): GraphDatabasePlugin {
 		return $this->projectionStore;
+	}
+
+	public function newQueryService(): SparqlQueryService {
+		return new SparqlQueryService(
+			new HttpSparqlQueryEndpoint(
+				httpRequestFactory: $this->httpRequestFactory,
+				queryUrl: $this->store->queryUrl,
+				accessToken: $this->store->accessToken,
+			)
+		);
+	}
+
+	/**
+	 * The Lua library function names this plugin contributes to mw.neowiki. The handler lives on
+	 * ScribuntoLuaLibrary; the plugin's presence is the gate. Only the first configured store's plugin
+	 * contributes these (see NeoWikiExtension::getFirstSparqlPlugin).
+	 *
+	 * @return string[]
+	 */
+	public function getLuaLibraryFunctionNames(): array {
+		return [ 'sparqlQuery' ];
+	}
+
+	public function registerParserFunctions( Parser $parser ): void {
+		$queryService = $this->newQueryService();
+
+		$parser->setFunctionHook(
+			'sparql_raw',
+			static function ( Parser $parser, string $query ) use ( $queryService ): string {
+				return ( new SparqlRawParserFunction( $queryService ) )->handle( $parser, $query );
+			}
+		);
 	}
 
 }

--- a/src/NeoWikiConfig.php
+++ b/src/NeoWikiConfig.php
@@ -27,4 +27,25 @@ readonly class NeoWikiConfig {
 		return $readUrl !== null && $writeUrl !== null;
 	}
 
+	/**
+	 * Whether at least one usable SPARQL store is present in the raw `NeoWikiSparqlStores` config. Used
+	 * at registration time (before the config is parsed into {@see SparqlStoreConfig} objects) to gate
+	 * the SPARQL query surfaces. The acceptance rule — an array entry with a non-empty-string
+	 * `updateUrl` — mirrors {@see NeoWikiConfigFactory::buildSparqlStore}, so the route is present
+	 * exactly when a plugin will be built.
+	 */
+	public static function hasConfiguredSparqlStore( mixed $rawStores ): bool {
+		if ( !is_array( $rawStores ) ) {
+			return false;
+		}
+
+		foreach ( $rawStores as $entry ) {
+			if ( is_array( $entry ) && is_string( $entry['updateUrl'] ?? null ) && trim( $entry['updateUrl'] ) !== '' ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 }

--- a/src/NeoWikiConfigFactory.php
+++ b/src/NeoWikiConfigFactory.php
@@ -73,8 +73,14 @@ class NeoWikiConfigFactory {
 		$accessToken = $entry['accessToken'] ?? null;
 		$projection = $entry['projection'] ?? null;
 
+		// The read surfaces query `queryUrl`; it defaults to `updateUrl` because for QLever the query and
+		// update endpoints are the same value. A store that separates them (e.g. a read replica or a
+		// read-protected endpoint) sets `queryUrl` explicitly.
+		$queryUrl = $entry['queryUrl'] ?? null;
+
 		return new SparqlStoreConfig(
 			updateUrl: $updateUrl,
+			queryUrl: is_string( $queryUrl ) && trim( $queryUrl ) !== '' ? $queryUrl : $updateUrl,
 			accessToken: is_string( $accessToken ) && $accessToken !== '' ? $accessToken : null,
 			projection: is_string( $projection ) && $projection !== '' ? $projection : NeoWikiExtension::PROJECTION_NATIVE,
 		);

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -119,6 +119,9 @@ use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Neo4jPlugin;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jSubjectLabelLookup;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jValueBuilderRegistry;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\CallbackProjectionResolver;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryService;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\EntryPoints\REST\SparqlQueryApi;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\EntryPoints\REST\SparqlRouteRegistration;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\SparqlPlugin;
 use ProfessionalWiki\NeoWiki\Persistence\SchemaNameLookup;
 use ProfessionalWiki\NeoWiki\Persistence\LayoutNameLookup;
@@ -182,7 +185,8 @@ class NeoWikiExtension {
 
 		$GLOBALS['wgRestAPIAdditionalRouteFiles'] = array_merge(
 			$GLOBALS['wgRestAPIAdditionalRouteFiles'] ?? [],
-			Neo4jRouteRegistration::routeFiles( $readUrl, $writeUrl )
+			Neo4jRouteRegistration::routeFiles( $readUrl, $writeUrl ),
+			SparqlRouteRegistration::routeFiles( $GLOBALS['wgNeoWikiSparqlStores'] ?? null )
 		);
 	}
 
@@ -515,6 +519,35 @@ class NeoWikiExtension {
 		}
 
 		return $this->sparqlPlugins;
+	}
+
+	/**
+	 * The first configured SPARQL store's plugin, or null when none is configured. The read surfaces
+	 * (parser function, Lua, REST) target this one store; multi-store query addressing is a follow-up.
+	 */
+	public function getFirstSparqlPlugin(): ?SparqlPlugin {
+		return $this->getSparqlPlugins()[0] ?? null;
+	}
+
+	// Guard for surfaces whose registration is already gated on a configured store, so callers get a
+	// non-null plugin without repeating the null handling.
+	public function requireFirstSparqlPlugin(): SparqlPlugin {
+		$plugin = $this->getFirstSparqlPlugin();
+		if ( $plugin === null ) {
+			throw new LogicException( 'A configured SPARQL store is required here.' );
+		}
+
+		return $plugin;
+	}
+
+	public function newSparqlQueryService(): SparqlQueryService {
+		return $this->requireFirstSparqlPlugin()->newQueryService();
+	}
+
+	public static function newSparqlQueryApi(): SparqlQueryApi {
+		return new SparqlQueryApi(
+			self::getInstance()->newSparqlQueryService()
+		);
 	}
 
 	private function buildSparqlPlugin( SparqlStoreConfig $store ): SparqlPlugin {

--- a/src/SparqlStoreConfig.php
+++ b/src/SparqlStoreConfig.php
@@ -5,8 +5,12 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki;
 
 /**
- * Configuration for a single SPARQL 1.1 graph store the SPARQL plugin (#586) projects into. One is
- * parsed from each `NeoWikiSparqlStores` entry (see {@see NeoWikiConfigFactory}).
+ * Configuration for a single SPARQL 1.1 graph store the SPARQL plugin (#586) projects into and queries.
+ * One is parsed from each `NeoWikiSparqlStores` entry (see {@see NeoWikiConfigFactory}).
+ *
+ * `updateUrl` is the SPARQL 1.1 Update endpoint the write path posts to; `queryUrl` is the SPARQL 1.1
+ * Query endpoint the read surfaces post to, defaulting to `updateUrl` (for QLever the two are the same
+ * value). The `accessToken`, when set, is sent as an HTTP Bearer token on both.
  *
  * The projection names the RDF vocabulary the store holds — "native" or any Mapping target. It is
  * resolved lazily on each save (not here), so a store always tracks the current Mapping definitions.
@@ -15,6 +19,7 @@ readonly class SparqlStoreConfig {
 
 	public function __construct(
 		public string $updateUrl,
+		public string $queryUrl,
 		public ?string $accessToken,
 		public string $projection,
 	) {

--- a/tests/phpunit/EntryPoints/Scribunto/NeoWikiLibraryTestBase.php
+++ b/tests/phpunit/EntryPoints/Scribunto/NeoWikiLibraryTestBase.php
@@ -44,11 +44,23 @@ abstract class NeoWikiLibraryTestBase extends LuaEngineTestBase {
 	protected function setUp(): void {
 		parent::setUp();
 
+		// Configure a SPARQL store so nw.sparqlQuery is registered in the Lua environment. The URL is
+		// never contacted: the only Lua test that calls it (empty query) fails before any HTTP. Resetting
+		// the singleton makes the extension rebuild with the store before the engine loads the library.
+		$this->overrideConfigValue( 'NeoWikiSparqlStores', [ [ 'updateUrl' => 'https://sparql.invalid/store' ] ] );
+		NeoWikiExtension::resetInstance();
+
 		// Suppress NeoWiki's revision handler during test data creation
 		// to avoid graph DB and property type registration dependencies
 		$this->setTemporaryHook( 'RevisionFromEditComplete', static function (): void {
 		} );
 		$this->createTestData();
+	}
+
+	protected function tearDown(): void {
+		// The singleton bakes the store config; reset it so later tests rebuild from restored config.
+		NeoWikiExtension::resetInstance();
+		parent::tearDown();
 	}
 
 	protected function getTestModules(): array {

--- a/tests/phpunit/EntryPoints/Scribunto/NeoWikiLibraryTests.lua
+++ b/tests/phpunit/EntryPoints/Scribunto/NeoWikiLibraryTests.lua
@@ -107,6 +107,18 @@ local function testQueryRejectsWriteQuery()
 	return type( err ) == 'string' and string.find( err, 'read-only Cypher queries are allowed', 1, true ) ~= nil
 end
 
+-- sparqlQuery tests
+
+local function testSparqlQueryRejectsEmptyString()
+	local ok, err = pcall( function()
+		return nw.sparqlQuery( '' )
+	end )
+	if ok then
+		return 'unexpected success'
+	end
+	return type( err ) == 'string' and string.find( err, 'must not be empty', 1, true ) ~= nil
+end
+
 -- getSchema tests
 
 local function testGetSchemaReturnsNameAndPropertyCount()
@@ -213,6 +225,10 @@ local tests = {
 	  func = testQueryRejectsEmptyString, expect = { true } },
 	{ name = 'query rejects write query with localized message',
 	  func = testQueryRejectsWriteQuery, expect = { true } },
+
+	-- sparqlQuery
+	{ name = 'sparqlQuery rejects empty string with localized message',
+	  func = testSparqlQueryRejectsEmptyString, expect = { true } },
 
 	-- getSchema
 	{ name = 'getSchema returns name and property count',

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/Application/SparqlQueryServiceTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/Application/SparqlQueryServiceTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\GraphDatabasePlugins\Sparql\Application;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\EmptySparqlQueryException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\InternalSparqlQueryException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlQueryFailedException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlStoreUnavailableException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlSyntaxException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryLimits;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryRequest;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryResult;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryService;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\FakeSparqlQueryEndpoint;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryService
+ */
+class SparqlQueryServiceTest extends TestCase {
+
+	private const string RESULTS = '{"head":{"vars":["label"]},"results":{"bindings":[{"label":{"type":"literal","value":"Bach"}}]}}';
+
+	public function testReturnsDecodedResultsDocument(): void {
+		$result = $this->execute(
+			FakeSparqlQueryEndpoint::returning( self::RESULTS ),
+			'SELECT ?label WHERE { ?s <http://www.w3.org/2000/01/rdf-schema#label> ?label }'
+		);
+
+		$this->assertSame( [ 'label' ], $result->document['head']['vars'] );
+		$this->assertSame( 'Bach', $result->document['results']['bindings'][0]['label']['value'] );
+	}
+
+	public function testEmptyQueryThrowsEmptySparqlQueryException(): void {
+		$this->expectException( EmptySparqlQueryException::class );
+
+		$this->execute( FakeSparqlQueryEndpoint::returning( self::RESULTS ), '   ' );
+	}
+
+	public function testClientErrorFromStoreBecomesSyntaxExceptionCarryingStoreDetail(): void {
+		try {
+			$this->execute(
+				FakeSparqlQueryEndpoint::failingWith( new SparqlQueryFailedException( 'https://s.example', 400, 'parse error near WHERE' ) ),
+				'INVALID'
+			);
+			$this->fail( 'Expected SparqlSyntaxException' );
+		} catch ( SparqlSyntaxException $exception ) {
+			$this->assertSame( 'sparqlSyntaxError', $exception->errorType() );
+			$this->assertStringContainsString( 'parse error near WHERE', $exception->getMessage() );
+		}
+	}
+
+	public function testServerErrorFromStoreBecomesStoreUnavailableException(): void {
+		$this->expectException( SparqlStoreUnavailableException::class );
+
+		$this->execute(
+			FakeSparqlQueryEndpoint::failingWith( new SparqlQueryFailedException( 'https://s.example', 503, 'overloaded' ) ),
+			'SELECT * WHERE { ?s ?p ?o }'
+		);
+	}
+
+	public function testTransportFailureBecomesStoreUnavailableException(): void {
+		$this->expectException( SparqlStoreUnavailableException::class );
+
+		$this->execute(
+			FakeSparqlQueryEndpoint::failingWith( new SparqlQueryFailedException( 'https://s.example', 0, '' ) ),
+			'SELECT * WHERE { ?s ?p ?o }'
+		);
+	}
+
+	public function testNonJsonResponseBecomesInternalSparqlQueryException(): void {
+		$this->expectException( InternalSparqlQueryException::class );
+
+		$this->execute( FakeSparqlQueryEndpoint::returning( '<html>Gateway Timeout</html>' ), 'SELECT * WHERE { ?s ?p ?o }' );
+	}
+
+	public function testAppliesTierTimeoutToTheEndpoint(): void {
+		$endpoint = FakeSparqlQueryEndpoint::returning( self::RESULTS );
+
+		( new SparqlQueryService( $endpoint ) )->execute(
+			new SparqlQueryRequest( 'SELECT * WHERE { ?s ?p ?o }', new SparqlQueryLimits( 17 ) )
+		);
+
+		$this->assertSame( 17, $endpoint->lastTimeoutSeconds );
+	}
+
+	public function testTrimsQueryBeforeSending(): void {
+		$endpoint = FakeSparqlQueryEndpoint::returning( self::RESULTS );
+
+		$this->execute( $endpoint, "  SELECT * WHERE { ?s ?p ?o }  \n" );
+
+		$this->assertSame( 'SELECT * WHERE { ?s ?p ?o }', $endpoint->lastQuery );
+	}
+
+	private function execute( FakeSparqlQueryEndpoint $endpoint, string $sparql ): SparqlQueryResult {
+		return ( new SparqlQueryService( $endpoint ) )->execute(
+			new SparqlQueryRequest( $sparql, new SparqlQueryLimits( 30 ) )
+		);
+	}
+
+}

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/EntryPoints/Lua/SparqlQueryRunnerTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/EntryPoints/Lua/SparqlQueryRunnerTest.php
@@ -40,6 +40,13 @@ class SparqlQueryRunnerTest extends TestCase {
 		$this->assertTrue( $table['boolean'] );
 	}
 
+	public function testPreservesEmptyBindingsWhileReindexingVars(): void {
+		$table = $this->runViaRunner( '{"head":{"vars":["s"]},"results":{"bindings":[]}}' );
+
+		$this->assertSame( [ 1 => 's' ], $table['head']['vars'] );
+		$this->assertSame( [], $table['results']['bindings'] );
+	}
+
 	public function testEmptyQueryPropagatesEmptySparqlQueryException(): void {
 		$this->expectException( EmptySparqlQueryException::class );
 

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/EntryPoints/Lua/SparqlQueryRunnerTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/EntryPoints/Lua/SparqlQueryRunnerTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\GraphDatabasePlugins\Sparql\EntryPoints\Lua;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\EmptySparqlQueryException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlQueryFailedException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlStoreUnavailableException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryService;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\EntryPoints\Lua\SparqlQueryRunner;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\FakeSparqlQueryEndpoint;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\EntryPoints\Lua\SparqlQueryRunner
+ */
+class SparqlQueryRunnerTest extends TestCase {
+
+	public function testReindexesListsToOneBasedWhilePreservingObjectKeys(): void {
+		$results = '{"head":{"vars":["s","label"]},"results":{"bindings":['
+			. '{"s":{"type":"uri","value":"urn:1"},"label":{"type":"literal","value":"One"}},'
+			. '{"s":{"type":"uri","value":"urn:2"},"label":{"type":"literal","value":"Two"}}]}}';
+
+		$table = $this->runViaRunner( $results );
+
+		// head.vars is a JSON array -> 1-indexed Lua sequence.
+		$this->assertSame( [ 1 => 's', 2 => 'label' ], $table['head']['vars'] );
+
+		// results.bindings is a JSON array -> 1-indexed; each binding is an object keeping string keys.
+		$bindings = $table['results']['bindings'];
+		$this->assertSame( [ 1, 2 ], array_keys( $bindings ) );
+		$this->assertSame( 'urn:1', $bindings[1]['s']['value'] );
+		$this->assertSame( 'Two', $bindings[2]['label']['value'] );
+	}
+
+	public function testPreservesAskBooleanResult(): void {
+		$table = $this->runViaRunner( '{"head":{},"boolean":true}' );
+
+		$this->assertTrue( $table['boolean'] );
+	}
+
+	public function testEmptyQueryPropagatesEmptySparqlQueryException(): void {
+		$this->expectException( EmptySparqlQueryException::class );
+
+		$this->runViaRunner( '{"head":{},"results":{"bindings":[]}}', '   ' );
+	}
+
+	public function testStoreFailurePropagatesAsStoreUnavailableException(): void {
+		$runner = new SparqlQueryRunner(
+			new SparqlQueryService(
+				FakeSparqlQueryEndpoint::failingWith( new SparqlQueryFailedException( 'https://s.example', 500, 'boom' ) )
+			)
+		);
+
+		$this->expectException( SparqlStoreUnavailableException::class );
+		$runner->run( 'SELECT * WHERE { ?s ?p ?o }' );
+	}
+
+	/**
+	 * @return array<int|string, mixed>
+	 */
+	private function runViaRunner( string $results, string $query = 'SELECT * WHERE { ?s ?p ?o }' ): array {
+		$runner = new SparqlQueryRunner(
+			new SparqlQueryService( FakeSparqlQueryEndpoint::returning( $results ) )
+		);
+
+		return $runner->run( $query );
+	}
+
+}

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/EntryPoints/ParserFunction/SparqlRawParserFunctionTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/EntryPoints/ParserFunction/SparqlRawParserFunctionTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\GraphDatabasePlugins\Sparql\EntryPoints\ParserFunction;
+
+use MediaWiki\Message\Message;
+use MediaWiki\Parser\Parser;
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlQueryFailedException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryService;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\EntryPoints\ParserFunction\SparqlRawParserFunction;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\FakeSparqlQueryEndpoint;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\EntryPoints\ParserFunction\SparqlRawParserFunction
+ */
+class SparqlRawParserFunctionTest extends TestCase {
+
+	private const string RESULTS = '{"head":{"vars":["label"]},"results":{"bindings":[{"label":{"type":"literal","value":"Bach"}}]}}';
+
+	/**
+	 * A Parser whose msg() renders any key as "[key]" (params appended as "[key|p1|p2]"), so a test can
+	 * assert which message key the production code selected without a full message-resolution context.
+	 */
+	private function createParser(): Parser {
+		$parser = $this->createMock( Parser::class );
+		$parser->method( 'msg' )->willReturnCallback(
+			function ( string $key, ...$params ): Message {
+				$rendered = $params === [] ? "[$key]" : '[' . $key . '|' . implode( '|', $params ) . ']';
+				$message = $this->createMock( Message::class );
+				$message->method( 'text' )->willReturn( $rendered );
+				return $message;
+			}
+		);
+		return $parser;
+	}
+
+	private function parserFunction( FakeSparqlQueryEndpoint $endpoint ): SparqlRawParserFunction {
+		return new SparqlRawParserFunction( new SparqlQueryService( $endpoint ) );
+	}
+
+	public function testEmptyQueryShowsLocalizedError(): void {
+		$result = $this->parserFunction( FakeSparqlQueryEndpoint::returning( self::RESULTS ) )
+			->handle( $this->createParser(), '   ' );
+
+		$this->assertStringContainsString( '[neowiki-sparql-error-empty-query]', $result );
+	}
+
+	public function testStoreRejectionShowsLocalizedSyntaxErrorWithDetail(): void {
+		$result = $this->parserFunction(
+			FakeSparqlQueryEndpoint::failingWith( new SparqlQueryFailedException( 'https://s.example', 400, 'bad token FOO' ) )
+		)->handle( $this->createParser(), 'FOO' );
+
+		$this->assertStringContainsString( '[neowiki-sparql-error-syntax|', $result );
+		$this->assertStringContainsString( 'bad token FOO', $result );
+	}
+
+	public function testStoreFailureShowsLocalizedStoreUnavailableError(): void {
+		$result = $this->parserFunction(
+			FakeSparqlQueryEndpoint::failingWith( new SparqlQueryFailedException( 'https://s.example', 0, '' ) )
+		)->handle( $this->createParser(), 'SELECT * WHERE { ?s ?p ?o }' );
+
+		$this->assertStringContainsString( '[neowiki-sparql-error-store-unavailable]', $result );
+	}
+
+	public function testValidQueryReturnsFormattedJsonResult(): void {
+		$result = $this->parserFunction( FakeSparqlQueryEndpoint::returning( self::RESULTS ) )
+			->handle( $this->createParser(), 'SELECT ?label WHERE { ?s ?p ?label }' );
+
+		$this->assertStringContainsString( '<div class="mw-neowiki-sparql-result"><pre>', $result );
+		$this->assertStringContainsString( 'Bach', $result );
+		$this->assertStringContainsString( 'bindings', $result );
+	}
+
+	public function testOutputIsHtmlEscaped(): void {
+		$results = '{"head":{"vars":["v"]},"results":{"bindings":[{"v":{"type":"literal","value":"<script>alert(1)</script>"}}]}}';
+
+		$result = $this->parserFunction( FakeSparqlQueryEndpoint::returning( $results ) )
+			->handle( $this->createParser(), 'SELECT ?v WHERE { ?s ?p ?v }' );
+
+		$this->assertStringNotContainsString( '<script>alert', $result );
+		$this->assertStringContainsString( '&lt;script&gt;', $result );
+	}
+
+}

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/EntryPoints/REST/SparqlQueryApiTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/EntryPoints/REST/SparqlQueryApiTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\GraphDatabasePlugins\Sparql\EntryPoints\REST;
+
+use MediaWiki\MainConfigNames;
+use MediaWiki\Permissions\Authority;
+use MediaWiki\Rest\RequestData;
+use MediaWiki\Rest\ResponseInterface;
+use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
+use MediaWiki\Tests\Unit\Permissions\MockAuthorityTrait;
+use MediaWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlQueryFailedException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryService;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\EntryPoints\REST\SparqlQueryApi;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\FakeSparqlQueryEndpoint;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\EntryPoints\REST\SparqlQueryApi
+ * @group Database
+ */
+class SparqlQueryApiTest extends MediaWikiIntegrationTestCase {
+
+	use HandlerTestTrait;
+	use MockAuthorityTrait;
+
+	private const string RESULTS = '{"head":{"vars":["label"]},"results":{"bindings":[{"label":{"type":"literal","value":"Bach"}}]}}';
+
+	public function testReturns200WithUnmodifiedResultsDocument(): void {
+		$response = $this->executeRequest(
+			$this->serviceReturning( self::RESULTS ),
+			[ 'query' => 'SELECT ?label WHERE { ?s ?p ?label }' ]
+		);
+		$body = $this->decodeBody( $response );
+
+		$this->assertSame( 200, $response->getStatusCode() );
+		$this->assertSame( [ 'label' ], $body['head']['vars'] );
+		$this->assertSame( 'Bach', $body['results']['bindings'][0]['label']['value'] );
+	}
+
+	public function testEmptyQueryMapsTo400EmptyQuery(): void {
+		$response = $this->executeRequest( $this->serviceReturning( self::RESULTS ), [ 'query' => '   ' ] );
+		$body = $this->decodeBody( $response );
+
+		$this->assertSame( 400, $response->getStatusCode() );
+		$this->assertSame( 'emptyQuery', $body['errorType'] );
+	}
+
+	public function testStoreRejectionMapsTo400SparqlSyntaxError(): void {
+		$response = $this->executeRequest(
+			$this->serviceFailingWith( new SparqlQueryFailedException( 'https://s.example', 400, 'parse error' ) ),
+			[ 'query' => 'INVALID' ]
+		);
+		$body = $this->decodeBody( $response );
+
+		$this->assertSame( 400, $response->getStatusCode() );
+		$this->assertSame( 'sparqlSyntaxError', $body['errorType'] );
+	}
+
+	public function testStoreFailureMapsTo503StoreUnavailable(): void {
+		$response = $this->executeRequest(
+			$this->serviceFailingWith( new SparqlQueryFailedException( 'https://s.example', 0, '' ) ),
+			[ 'query' => 'SELECT * WHERE { ?s ?p ?o }' ]
+		);
+		$body = $this->decodeBody( $response );
+
+		$this->assertSame( 503, $response->getStatusCode() );
+		$this->assertSame( 'sparqlStoreUnavailable', $body['errorType'] );
+	}
+
+	public function testNonJsonResponseMapsTo500InternalError(): void {
+		$response = $this->executeRequest(
+			$this->serviceReturning( '<html>Bad Gateway</html>' ),
+			[ 'query' => 'SELECT * WHERE { ?s ?p ?o }' ]
+		);
+		$body = $this->decodeBody( $response );
+
+		$this->assertSame( 500, $response->getStatusCode() );
+		$this->assertSame( 'internalError', $body['errorType'] );
+	}
+
+	public function testReturns403WhenUserLacksNeowikiQueryRight(): void {
+		$response = $this->executeRequest(
+			$this->serviceReturning( self::RESULTS ),
+			[ 'query' => 'SELECT * WHERE { ?s ?p ?o }' ],
+			authority: $this->mockAnonAuthorityWithPermissions( [] )
+		);
+		$body = $this->decodeBody( $response );
+
+		$this->assertSame( 403, $response->getStatusCode() );
+		$this->assertSame( 'permissionDenied', $body['errorType'] );
+	}
+
+	public function testRateLimitedReturns429(): void {
+		$this->overrideConfigValue(
+			MainConfigNames::RateLimits,
+			[ 'neowiki-query' => [ 'user' => [ 0, 60 ] ] ]
+		);
+
+		$response = $this->executeRequest(
+			$this->serviceReturning( self::RESULTS ),
+			[ 'query' => 'SELECT * WHERE { ?s ?p ?o }' ],
+			authority: $this->mockUserAuthorityWithPermissions(
+				$this->getTestUser()->getUser(),
+				[ 'neowiki-query' ]
+			)
+		);
+		$body = $this->decodeBody( $response );
+
+		$this->assertSame( 429, $response->getStatusCode() );
+		$this->assertSame( 'rateLimitExceeded', $body['errorType'] );
+	}
+
+	private function executeRequest(
+		SparqlQueryService $service,
+		array $body,
+		?Authority $authority = null
+	): ResponseInterface {
+		return $this->executeHandler(
+			new SparqlQueryApi( $service ),
+			new RequestData( [
+				'method' => 'POST',
+				'bodyContents' => json_encode( $body ),
+				'headers' => [ 'Content-Type' => 'application/json' ],
+			] ),
+			authority: $authority
+		);
+	}
+
+	private function decodeBody( ResponseInterface $response ): array {
+		return json_decode( $response->getBody()->getContents(), true );
+	}
+
+	private function serviceReturning( string $responseBody ): SparqlQueryService {
+		return new SparqlQueryService( FakeSparqlQueryEndpoint::returning( $responseBody ) );
+	}
+
+	private function serviceFailingWith( SparqlQueryFailedException $failure ): SparqlQueryService {
+		return new SparqlQueryService( FakeSparqlQueryEndpoint::failingWith( $failure ) );
+	}
+
+}

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/EntryPoints/REST/SparqlRouteRegistrationTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/EntryPoints/REST/SparqlRouteRegistrationTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\GraphDatabasePlugins\Sparql\EntryPoints\REST;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\EntryPoints\REST\SparqlRouteRegistration;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\EntryPoints\REST\SparqlRouteRegistration
+ */
+class SparqlRouteRegistrationTest extends TestCase {
+
+	public function testReturnsRouteFileWhenAStoreIsConfigured(): void {
+		$files = SparqlRouteRegistration::routeFiles( [ [ 'updateUrl' => 'https://qlever.example/api' ] ] );
+
+		$this->assertCount( 1, $files );
+		$this->assertStringEndsWith( 'sparqlRoutes.json', $files[0] );
+		$this->assertFileExists( $files[0] );
+	}
+
+	public function testReturnsNothingWhenNoStoresConfigured(): void {
+		$this->assertSame( [], SparqlRouteRegistration::routeFiles( [] ) );
+		$this->assertSame( [], SparqlRouteRegistration::routeFiles( null ) );
+	}
+
+	public function testReturnsNothingWhenTheOnlyEntryLacksAnUpdateUrl(): void {
+		$this->assertSame( [], SparqlRouteRegistration::routeFiles( [ [ 'accessToken' => 'secret' ] ] ) );
+	}
+
+	public function testRouteFileDeclaresSparqlRoute(): void {
+		$routes = json_decode( file_get_contents( SparqlRouteRegistration::routeFiles( [ [ 'updateUrl' => 'u' ] ] )[0] ), true );
+
+		$this->assertSame( '/neowiki/v0/query/sparql', $routes[0]['path'] );
+		$this->assertSame( [ 'POST' ], $routes[0]['method'] );
+		$this->assertSame(
+			'ProfessionalWiki\\NeoWiki\\NeoWikiExtension::newSparqlQueryApi',
+			$routes[0]['factory']
+		);
+	}
+
+}

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/Integration/QuerySparqlEndToEndTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/Integration/QuerySparqlEndToEndTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\GraphDatabasePlugins\Sparql\Integration;
+
+use MediaWiki\Config\ServiceOptions;
+use MediaWiki\Deferred\DeferredUpdates;
+use MediaWiki\Http\HttpRequestFactory;
+use MediaWiki\Logger\LoggerFactory;
+use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfNamespaces;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryLimits;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryRequest;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Persistence\HttpSparqlUpdateEndpoint;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+
+/**
+ * The headline write+query loop, exercised against a REAL, live QLever store (the `test_qlever`
+ * dev-stack service) with REAL HTTP — no mocking on either the write or the read side. A page edit that
+ * stores a Subject projects into the store over the SPARQL 1.1 Update endpoint; the new SPARQL query
+ * service reads it back over the SPARQL 1.1 Query endpoint. Proves the surfaces this PR adds work
+ * end-to-end against a real SPARQL 1.1 store, not just against fakes.
+ *
+ * Deliberately does NOT skip when the store is unreachable: a missing QLEVER_TEST_URL fails the test
+ * with a clear message, and an unreachable store surfaces as a loud query/HTTP failure. A silently
+ * skipped system test would leave the headline deliverable unverified.
+ *
+ * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryService
+ * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Persistence\HttpSparqlQueryEndpoint
+ * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\SparqlPlugin
+ * @group Database
+ */
+class QuerySparqlEndToEndTest extends NeoWikiIntegrationTestCase {
+
+	private const string PAGE_NAME = 'Sparql query system test page';
+	private const string LABEL_PREDICATE = 'http://www.w3.org/2000/01/rdf-schema#label';
+
+	private string $storeUrl;
+	private ?string $accessToken;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->storeUrl = $this->requireStoreUrl();
+		$this->accessToken = getenv( 'QLEVER_TEST_ACCESS_TOKEN' ) ?: null;
+
+		// Replace the integration harness's NullHttpRequestFactory (which blocks all outbound HTTP) with a
+		// real one, so both the projection write path and the query read path reach the live store.
+		$this->setService( 'HttpRequestFactory', $this->realHttpRequestFactory() );
+
+		$this->overrideConfigValue( 'NeoWikiSparqlStores', [ [
+			'updateUrl' => $this->storeUrl,
+			'accessToken' => $this->accessToken,
+			'projection' => NeoWikiExtension::PROJECTION_NATIVE,
+		] ] );
+		NeoWikiExtension::resetInstance();
+
+		$this->clearStore();
+		$this->createSchema( TestSubject::DEFAULT_SCHEMA_ID );
+		$this->markPageTableAsUsed();
+	}
+
+	protected function tearDown(): void {
+		NeoWikiExtension::resetInstance();
+		parent::tearDown();
+	}
+
+	public function testSubjectLabelRoundTripsThroughTheSparqlQueryService(): void {
+		$subjectId = TestSubject::uniqueId();
+		$initialLabel = 'System test subject ' . uniqid( '', true );
+
+		// CREATE: a page whose Subject projects into the store.
+		$this->savePageWithSubjectLabel( $subjectId, $initialLabel );
+		$this->assertSame(
+			[ $initialLabel ],
+			$this->queryLabelsOf( $subjectId ),
+			'the created Subject label must come back through the SPARQL query service'
+		);
+
+		// EDIT: the projection is replaced, so the new label is visible and the old one is gone.
+		$editedLabel = 'System test subject edited ' . uniqid( '', true );
+		$this->savePageWithSubjectLabel( $subjectId, $editedLabel );
+		$this->assertSame(
+			[ $editedLabel ],
+			$this->queryLabelsOf( $subjectId ),
+			'the edited Subject label must replace the previous one'
+		);
+
+		// DELETE: the page's named graph is dropped, so the binding disappears.
+		$this->deletePageUnderTest();
+		$this->assertSame(
+			[],
+			$this->queryLabelsOf( $subjectId ),
+			'the deleted Subject must no longer be queryable'
+		);
+	}
+
+	private function savePageWithSubjectLabel( SubjectId $subjectId, string $label ): void {
+		$this->createPageWithSubjects(
+			self::PAGE_NAME,
+			TestSubject::build( id: $subjectId, label: $label )
+		);
+		DeferredUpdates::doUpdates();
+	}
+
+	/**
+	 * @return list<string> The rdfs:label literal values bound to the Subject, via the new query service.
+	 */
+	private function queryLabelsOf( SubjectId $subjectId ): array {
+		$subjectIri = NeoWikiExtension::getInstance()->getRdfNamespaces()->subject( $subjectId )->value;
+
+		$result = NeoWikiExtension::getInstance()->newSparqlQueryService()->execute(
+			new SparqlQueryRequest(
+				sparql: 'SELECT ?label WHERE { <' . $subjectIri . '> <' . self::LABEL_PREDICATE . '> ?label }',
+				limits: new SparqlQueryLimits( 30 ),
+			)
+		);
+
+		return array_map(
+			static fn ( array $binding ): string => $binding['label']['value'],
+			$result->document['results']['bindings']
+		);
+	}
+
+	private function deletePageUnderTest(): void {
+		$page = MediaWikiServices::getInstance()->getWikiPageFactory()->newFromTitle( Title::newFromText( self::PAGE_NAME ) );
+		$deletePage = MediaWikiServices::getInstance()->getDeletePageFactory()->newDeletePage( $page, $this->getTestSysop()->getUser() );
+
+		$this->assertStatusGood( $deletePage->deleteUnsafe( 'system test cleanup' ) );
+		DeferredUpdates::doUpdates();
+	}
+
+	private function clearStore(): void {
+		( new HttpSparqlUpdateEndpoint(
+			MediaWikiServices::getInstance()->getHttpRequestFactory(),
+			$this->storeUrl,
+			$this->accessToken,
+		) )->postUpdate( 'DROP ALL' );
+	}
+
+	private function realHttpRequestFactory(): HttpRequestFactory {
+		return new HttpRequestFactory(
+			new ServiceOptions(
+				HttpRequestFactory::CONSTRUCTOR_OPTIONS,
+				$this->getServiceContainer()->getMainConfig()
+			),
+			LoggerFactory::getInstance( 'http' )
+		);
+	}
+
+	private function requireStoreUrl(): string {
+		$url = getenv( 'QLEVER_TEST_URL' );
+
+		if ( $url === false || trim( $url ) === '' ) {
+			$this->fail(
+				'QLEVER_TEST_URL is not set. This SPARQL query system test requires a live QLever store '
+				. '(the test_qlever dev-stack service). Run it via `make phpunit`, which sets QLEVER_TEST_URL '
+				. 'from phpunit.xml.dist and reaches test_qlever in the dev network. It deliberately fails '
+				. 'rather than skips, so the write+query loop is never silently left unverified.'
+			);
+		}
+
+		return $url;
+	}
+
+}

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/Persistence/HttpSparqlQueryEndpointTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/Persistence/HttpSparqlQueryEndpointTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\GraphDatabasePlugins\Sparql\Persistence;
+
+use MediaWiki\Http\HttpRequestFactory;
+use MWHttpRequest;
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlQueryFailedException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Persistence\HttpSparqlQueryEndpoint;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Persistence\HttpSparqlQueryEndpoint
+ */
+class HttpSparqlQueryEndpointTest extends TestCase {
+
+	private const string URL = 'https://qlever.example/api/neowiki';
+	private const string RESULTS = '{"head":{"vars":["s"]},"results":{"bindings":[]}}';
+
+	/**
+	 * @var array<string, string>
+	 */
+	private array $sentHeaders = [];
+
+	private ?string $requestedUrl = null;
+
+	/**
+	 * @var array<string, mixed>
+	 */
+	private array $requestOptions = [];
+
+	public function testPostsQueryAsSparqlQueryBodyWithHeadersAndTimeout(): void {
+		$factory = $this->httpRequestFactoryReturning( $this->fakeRequest( 200, self::RESULTS ) );
+
+		$body = ( new HttpSparqlQueryEndpoint( $factory, self::URL, 'secret-token' ) )
+			->runQuery( 'SELECT ?s WHERE { ?s ?p ?o }', 42 );
+
+		$this->assertSame( self::RESULTS, $body );
+		$this->assertSame( self::URL, $this->requestedUrl );
+		$this->assertSame( 'POST', $this->requestOptions['method'] );
+		$this->assertSame( 'SELECT ?s WHERE { ?s ?p ?o }', $this->requestOptions['postData'] );
+		$this->assertSame( 42, $this->requestOptions['timeout'] );
+		$this->assertSame( 'application/sparql-query', $this->sentHeaders['Content-Type'] );
+		$this->assertSame( 'application/sparql-results+json', $this->sentHeaders['Accept'] );
+		$this->assertSame( 'Bearer secret-token', $this->sentHeaders['Authorization'] );
+	}
+
+	public function testOmitsAuthorizationHeaderWhenNoAccessTokenIsConfigured(): void {
+		$factory = $this->httpRequestFactoryReturning( $this->fakeRequest( 200, self::RESULTS ) );
+
+		( new HttpSparqlQueryEndpoint( $factory, self::URL, null ) )->runQuery( 'SELECT * WHERE { ?s ?p ?o }', 30 );
+
+		$this->assertArrayNotHasKey( 'Authorization', $this->sentHeaders );
+	}
+
+	public function testNonSuccessResponseThrowsWithUrlStatusAndResponseBody(): void {
+		$factory = $this->httpRequestFactoryReturning( $this->fakeRequest( 400, 'parse error at line 1' ) );
+
+		try {
+			( new HttpSparqlQueryEndpoint( $factory, self::URL, 'secret-token' ) )->runQuery( 'INVALID', 30 );
+			$this->fail( 'Expected SparqlQueryFailedException' );
+		} catch ( SparqlQueryFailedException $exception ) {
+			$this->assertSame( 400, $exception->httpStatus );
+			$this->assertStringContainsString( self::URL, $exception->getMessage() );
+			$this->assertStringContainsString( 'parse error at line 1', $exception->getMessage() );
+		}
+	}
+
+	public function testTransportFailureSurfacesAsStatusZero(): void {
+		$factory = $this->httpRequestFactoryReturning( $this->fakeRequest( 0, '' ) );
+
+		try {
+			( new HttpSparqlQueryEndpoint( $factory, self::URL, null ) )->runQuery( 'SELECT * WHERE { ?s ?p ?o }', 30 );
+			$this->fail( 'Expected SparqlQueryFailedException' );
+		} catch ( SparqlQueryFailedException $exception ) {
+			$this->assertSame( 0, $exception->httpStatus );
+		}
+	}
+
+	private function httpRequestFactoryReturning( MWHttpRequest $request ): HttpRequestFactory {
+		$factory = $this->createMock( HttpRequestFactory::class );
+		$factory->method( 'create' )->willReturnCallback(
+			function ( $url, $options = [] ) use ( $request ): MWHttpRequest {
+				$this->requestedUrl = $url;
+				$this->requestOptions = $options;
+				return $request;
+			}
+		);
+
+		return $factory;
+	}
+
+	private function fakeRequest( int $status, string $body ): MWHttpRequest {
+		$request = $this->createMock( MWHttpRequest::class );
+		$request->method( 'setHeader' )->willReturnCallback(
+			function ( string $name, $value ): void {
+				$this->sentHeaders[$name] = $value;
+			}
+		);
+		$request->method( 'getStatus' )->willReturn( $status );
+		$request->method( 'getContent' )->willReturn( $body );
+
+		return $request;
+	}
+
+}

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/Persistence/HttpSparqlQueryEndpointTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/Persistence/HttpSparqlQueryEndpointTest.php
@@ -78,6 +78,17 @@ class HttpSparqlQueryEndpointTest extends TestCase {
 		}
 	}
 
+	public function testRedirectResponseIsTreatedAsFailureNotSuccess(): void {
+		$factory = $this->httpRequestFactoryReturning( $this->fakeRequest( 302, 'Found' ) );
+
+		try {
+			( new HttpSparqlQueryEndpoint( $factory, self::URL, null ) )->runQuery( 'SELECT * WHERE { ?s ?p ?o }', 30 );
+			$this->fail( 'Expected SparqlQueryFailedException' );
+		} catch ( SparqlQueryFailedException $exception ) {
+			$this->assertSame( 302, $exception->httpStatus );
+		}
+	}
+
 	private function httpRequestFactoryReturning( MWHttpRequest $request ): HttpRequestFactory {
 		$factory = $this->createMock( HttpRequestFactory::class );
 		$factory->method( 'create' )->willReturnCallback(

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/SparqlSurfaceRegistrationTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/SparqlSurfaceRegistrationTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\GraphDatabasePlugins\Sparql;
+
+use MediaWiki\Parser\Parser;
+use ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiHooks;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+
+/**
+ * The wikitext SPARQL surfaces exist only when at least one SPARQL store is configured, and are absent
+ * otherwise — both directions, mirroring the Neo4j conditional-registration tests (#1016). The REST
+ * route's presence is covered by SparqlRouteRegistrationTest and OnExtensionRegistrationTest.
+ *
+ * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\SparqlPlugin
+ * @covers \ProfessionalWiki\NeoWiki\NeoWikiExtension::getFirstSparqlPlugin
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiHooks::onParserFirstCallInit
+ * @group Database
+ */
+class SparqlSurfaceRegistrationTest extends NeoWikiIntegrationTestCase {
+
+	protected function tearDown(): void {
+		// The singleton bakes the store config; reset it so the next test rebuilds from restored config.
+		NeoWikiExtension::resetInstance();
+		parent::tearDown();
+	}
+
+	public function testParserFunctionRegisteredWhenStoreConfigured(): void {
+		$this->configureSparqlStore();
+
+		$parser = $this->recordingParser( $names );
+		NeoWikiHooks::onParserFirstCallInit( $parser );
+
+		$this->assertContains( 'sparql_raw', $names );
+	}
+
+	public function testParserFunctionNotRegisteredWithoutStore(): void {
+		$this->clearSparqlStores();
+
+		$parser = $this->recordingParser( $names );
+		NeoWikiHooks::onParserFirstCallInit( $parser );
+
+		$this->assertNotContains( 'sparql_raw', $names );
+	}
+
+	public function testLuaFunctionOfferedWhenStoreConfigured(): void {
+		$this->configureSparqlStore();
+
+		$names = NeoWikiExtension::getInstance()->getFirstSparqlPlugin()?->getLuaLibraryFunctionNames() ?? [];
+
+		$this->assertContains( 'sparqlQuery', $names );
+	}
+
+	public function testLuaFunctionNotOfferedWithoutStore(): void {
+		$this->clearSparqlStores();
+
+		$this->assertNull( NeoWikiExtension::getInstance()->getFirstSparqlPlugin() );
+	}
+
+	private function configureSparqlStore(): void {
+		$this->overrideConfigValue( 'NeoWikiSparqlStores', [ [ 'updateUrl' => 'https://qlever.example/api' ] ] );
+		NeoWikiExtension::resetInstance();
+	}
+
+	private function clearSparqlStores(): void {
+		$this->overrideConfigValue( 'NeoWikiSparqlStores', [] );
+		NeoWikiExtension::resetInstance();
+	}
+
+	private function recordingParser( ?array &$names ): Parser {
+		$names = [];
+		$parser = $this->createMock( Parser::class );
+		$parser->method( 'setFunctionHook' )->willReturnCallback(
+			static function ( string $name ) use ( &$names ): void {
+				$names[] = $name;
+			}
+		);
+		return $parser;
+	}
+
+}

--- a/tests/phpunit/NeoWikiConfigFactoryTest.php
+++ b/tests/phpunit/NeoWikiConfigFactoryTest.php
@@ -99,6 +99,7 @@ class NeoWikiConfigFactoryTest extends TestCase {
 	public function testFullSparqlStoreEntryIsParsed(): void {
 		$config = $this->buildSparqlConfig( [ [
 			'updateUrl' => 'https://qlever.example/api',
+			'queryUrl' => 'https://qlever.example/query',
 			'accessToken' => 'secret-token',
 			'projection' => 'edm',
 		] ] );
@@ -106,6 +107,7 @@ class NeoWikiConfigFactoryTest extends TestCase {
 		$this->assertCount( 1, $config->sparqlStores );
 		$store = $config->sparqlStores[0];
 		$this->assertSame( 'https://qlever.example/api', $store->updateUrl );
+		$this->assertSame( 'https://qlever.example/query', $store->queryUrl );
 		$this->assertSame( 'secret-token', $store->accessToken );
 		$this->assertSame( 'edm', $store->projection );
 	}
@@ -115,8 +117,18 @@ class NeoWikiConfigFactoryTest extends TestCase {
 
 		$store = $config->sparqlStores[0];
 		$this->assertSame( 'https://qlever.example/api', $store->updateUrl );
+		$this->assertSame( 'https://qlever.example/api', $store->queryUrl );
 		$this->assertNull( $store->accessToken );
 		$this->assertSame( 'native', $store->projection );
+	}
+
+	public function testBlankQueryUrlFallsBackToUpdateUrl(): void {
+		$config = $this->buildSparqlConfig( [ [
+			'updateUrl' => 'https://qlever.example/api',
+			'queryUrl' => '   ',
+		] ] );
+
+		$this->assertSame( 'https://qlever.example/api', $config->sparqlStores[0]->queryUrl );
 	}
 
 	public function testSparqlStoreEntryMissingUpdateUrlIsSkippedWithWarning(): void {

--- a/tests/phpunit/OnExtensionRegistrationTest.php
+++ b/tests/phpunit/OnExtensionRegistrationTest.php
@@ -17,16 +17,19 @@ class OnExtensionRegistrationTest extends TestCase {
 	private mixed $routeFiles;
 	private mixed $writeUrl;
 	private mixed $readUrl;
+	private mixed $sparqlStores;
 
 	protected function setUp(): void {
 		parent::setUp();
 		$this->routeFiles = $GLOBALS['wgRestAPIAdditionalRouteFiles'] ?? null;
 		$this->writeUrl = $GLOBALS['wgNeoWikiNeo4jInternalWriteUrl'] ?? null;
 		$this->readUrl = $GLOBALS['wgNeoWikiNeo4jInternalReadUrl'] ?? null;
+		$this->sparqlStores = $GLOBALS['wgNeoWikiSparqlStores'] ?? null;
 
 		// Clear the CI env overrides so the config-value path is exercised deterministically.
 		$this->snapshotAndClearNeo4jEnvOverrides();
 		$GLOBALS['wgRestAPIAdditionalRouteFiles'] = [];
+		$GLOBALS['wgNeoWikiSparqlStores'] = null;
 	}
 
 	protected function tearDown(): void {
@@ -34,6 +37,7 @@ class OnExtensionRegistrationTest extends TestCase {
 		$GLOBALS['wgRestAPIAdditionalRouteFiles'] = $this->routeFiles;
 		$GLOBALS['wgNeoWikiNeo4jInternalWriteUrl'] = $this->writeUrl;
 		$GLOBALS['wgNeoWikiNeo4jInternalReadUrl'] = $this->readUrl;
+		$GLOBALS['wgNeoWikiSparqlStores'] = $this->sparqlStores;
 		parent::tearDown();
 	}
 
@@ -64,6 +68,37 @@ class OnExtensionRegistrationTest extends TestCase {
 		NeoWikiExtension::onExtensionRegistration();
 
 		$this->assertContains( '/existing/routes.json', $GLOBALS['wgRestAPIAdditionalRouteFiles'] );
+		$this->assertCount( 2, $GLOBALS['wgRestAPIAdditionalRouteFiles'] );
+	}
+
+	public function testAddsSparqlRouteFileWhenStoreConfigured(): void {
+		$GLOBALS['wgNeoWikiNeo4jInternalWriteUrl'] = null;
+		$GLOBALS['wgNeoWikiNeo4jInternalReadUrl'] = null;
+		$GLOBALS['wgNeoWikiSparqlStores'] = [ [ 'updateUrl' => 'https://qlever.example/api' ] ];
+
+		NeoWikiExtension::onExtensionRegistration();
+
+		$this->assertCount( 1, $GLOBALS['wgRestAPIAdditionalRouteFiles'] );
+		$this->assertStringEndsWith( 'sparqlRoutes.json', $GLOBALS['wgRestAPIAdditionalRouteFiles'][0] );
+	}
+
+	public function testAddsNoSparqlRouteFileWithoutStore(): void {
+		$GLOBALS['wgNeoWikiNeo4jInternalWriteUrl'] = null;
+		$GLOBALS['wgNeoWikiNeo4jInternalReadUrl'] = null;
+		$GLOBALS['wgNeoWikiSparqlStores'] = [];
+
+		NeoWikiExtension::onExtensionRegistration();
+
+		$this->assertSame( [], $GLOBALS['wgRestAPIAdditionalRouteFiles'] );
+	}
+
+	public function testAddsBothRouteFilesWhenNeo4jAndSparqlConfigured(): void {
+		$GLOBALS['wgNeoWikiNeo4jInternalWriteUrl'] = 'bolt://write:7687';
+		$GLOBALS['wgNeoWikiNeo4jInternalReadUrl'] = 'bolt://read:7687';
+		$GLOBALS['wgNeoWikiSparqlStores'] = [ [ 'updateUrl' => 'https://qlever.example/api' ] ];
+
+		NeoWikiExtension::onExtensionRegistration();
+
 		$this->assertCount( 2, $GLOBALS['wgRestAPIAdditionalRouteFiles'] );
 	}
 

--- a/tests/phpunit/TestDoubles/FakeSparqlQueryEndpoint.php
+++ b/tests/phpunit/TestDoubles/FakeSparqlQueryEndpoint.php
@@ -1,0 +1,45 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\TestDoubles;
+
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlQueryFailedException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryEndpoint;
+
+/**
+ * A SPARQL query endpoint that returns a canned response body (or throws a canned failure) without any
+ * HTTP, and records the query and timeout it was called with. Lets tests drive the query service and the
+ * surfaces above it deterministically.
+ */
+class FakeSparqlQueryEndpoint implements SparqlQueryEndpoint {
+
+	public ?string $lastQuery = null;
+	public ?int $lastTimeoutSeconds = null;
+
+	private function __construct(
+		private readonly ?string $responseBody,
+		private readonly ?SparqlQueryFailedException $failure,
+	) {
+	}
+
+	public static function returning( string $responseBody ): self {
+		return new self( $responseBody, null );
+	}
+
+	public static function failingWith( SparqlQueryFailedException $failure ): self {
+		return new self( null, $failure );
+	}
+
+	public function runQuery( string $sparql, int $timeoutSeconds ): string {
+		$this->lastQuery = $sparql;
+		$this->lastTimeoutSeconds = $timeoutSeconds;
+
+		if ( $this->failure !== null ) {
+			throw $this->failure;
+		}
+
+		return (string)$this->responseBody;
+	}
+
+}


### PR DESCRIPTION
Add SPARQL query surfaces (parser function, Lua, REST) with a live QLever system test

For https://github.com/ProfessionalWiki/NeoWiki/issues/586

Stacked on #1054 (dev-stack QLever service), which stacks on #1051 (SPARQL projection
write path). Base branch is `qlever-dev-stack`; review only the top commit.

Adds three read-only SPARQL query surfaces, each present only when at least one SPARQL
store is configured (mirroring the Neo4j conditional registration from #1016):

- `{{#sparql_raw: <query> }}` parser function
- `nw.sparqlQuery( <query> )` Lua function
- `POST /neowiki/v0/query/sparql` REST endpoint

All three run through a new `SparqlQueryService` (SPARQL plugin's Application layer, built
by `SparqlPlugin::newQueryService()` like the Neo4j side), which posts to a query-side HTTP
port (`HttpSparqlQueryEndpoint`) next to the existing update endpoint. Config gains an
optional `queryUrl` per store, defaulting to `updateUrl`; `accessToken` is now sent as
Bearer on query requests too.

Design decisions:

- Read-only by protocol, not by a validator. Queries are sent as SPARQL 1.1 query
  operations (Content-Type application/sparql-query, Accept application/sparql-results+json).
  The SPARQL query grammar has no update forms, so — unlike Cypher — no read-only validator
  is needed. The read path only ever posts to `queryUrl`, never `updateUrl` (identical for
  QLever).
- Result shape is the W3C application/sparql-results+json document, unmodified: no
  normalizer, no envelope. REST returns it as JSON (application/json, matching the rest of
  the API); `{{#sparql_raw}}` renders it as pretty JSON text like `{{#cypher_raw}}`; Lua
  decodes it into a table preserving head/results.bindings (JSON arrays re-indexed to 1-based).
- Limits: the per-tier timeout (shared `$wgNeoWikiQueryLimits`) is applied as the HTTP
  client timeout. maxRows is NOT applied — truncating `results.bindings` would alter the
  W3C document and signaling truncation would require inventing a field, both of which
  conflict with returning the document unmodified. Bound size with LIMIT in the query. This
  is the documented divergence from the Cypher envelope's maxRows/truncated.
- Store targeting: the surfaces target the FIRST configured store. No store-addressing
  parameter in this PR — an open follow-up for when someone actually runs multiple stores.
- The REST endpoint reuses the `neowiki-query` right and rate limit (both are read-only
  graph queries).

Live write+query system test (the headline): `QuerySparqlEndToEndTest` configures a store
pointing at a live QLever (`test_qlever`, added to the dev stack with its own volume, no
`--persist-updates` — it is ephemeral test scaffolding that each run clears) with REAL HTTP
(no mocking). It creates a page with a subject, queries the label back through the new query
service, edits and re-queries, deletes and confirms the binding is gone. It fails loudly
(never skips) when the store is unreachable.

CI: QLever cannot be a GitHub Actions `services:` container — its bring-up needs a
multi-step entrypoint (build an empty index, then serve) that a service container cannot
express. So the PHPUnit job starts it with an explicit `docker run` step (mirroring the
existing `docker exec test_neo` step) publishing it on the runner's localhost, so the system
test runs in CI too.

Live verification (running dev stack, demo QLever holding the Bach demo data):

- `POST /w/rest.php/neowiki/v0/query/sparql` for Johann Sebastian Bach's rdfs:label -> 200,
  `{"head":{"vars":["label"]},"results":{"bindings":[{"label":{"type":"literal","value":"Johann Sebastian Bach"}}]},"meta":{...}}`
  (the store's `meta` extra passes through unmodified).
- Empty query -> 400 `emptyQuery`; malformed query -> 400 `sparqlSyntaxError` relaying
  QLever's own detail; store failure -> 503 `sparqlStoreUnavailable`.
- `{{#sparql_raw}}` renders the pretty-printed, HTML-escaped W3C JSON with "Johann Sebastian
  Bach".

Tests: full `make phpunit` green (1715 tests), `make cs` (phpcs + phpstan) green. Covers the
query service, HTTP query endpoint (headers/timeout/bearer/failure), `queryUrl`
parse/default, conditional registration of all three surfaces (both directions), REST
envelope + error mapping, Lua re-indexing and engine-level empty-query message, and the live
system test.

Open for humans: whether to add multi-store query addressing; #586's umbrella also covers
RDF import, which is out of scope here.


> <sub>AI-authored — Claude Code, `Opus 4.8 (max)`; detailed spec from @JeroenDeDauw, executed in one pass; diff not yet human-reviewed; full `make phpunit` (1715 tests) + phpcs + phpstan green locally, and the REST endpoint + `{{#sparql_raw}}` live-verified against a running QLever.</sub>
