### PR TITLE
Disable SPARQL federation on the bundled QLever stores

### DIFF
--- a/.github/workflows/ci-php.yml
+++ b/.github/workflows/ci-php.yml
@@ -115,6 +115,9 @@ jobs:
       # clears it, so keeping updates in memory is enough. The index is built in /tmp rather than the dev
       # stack's /index: the image runs as a non-root user with no /index (the dev stack provides it via a
       # volume), so a bare `docker run` must use an already-writable in-image path.
+      # --service-allowed-iri-prefixes disables SPARQL federation, matching the dev stack (see
+      # Docker/docker-compose.dev.yml): QLever allows every SERVICE IRI unless the option is given, and "-"
+      # is the documented deny-all value (an invalid prefix no IRI matches). No test federates.
       - name: Start QLever
         run: |
           docker run -d --name test_qlever -p 7019:7019 -e QLEVER_ACCESS_TOKEN=neowiki_test_token \
@@ -123,7 +126,7 @@ jobs:
               cd /tmp
               : > data.nt
               qlever-index -i neowiki -F nt -f data.nt
-              exec qlever-server -i neowiki -p 7019 -a "$QLEVER_ACCESS_TOKEN" -m 1G'
+              exec qlever-server -i neowiki -p 7019 -a "$QLEVER_ACCESS_TOKEN" -m 1G --service-allowed-iri-prefixes -'
 
       - name: Run update.php
         run: php maintenance/update.php --quick

--- a/Docker/docker-compose.dev.yml
+++ b/Docker/docker-compose.dev.yml
@@ -83,7 +83,15 @@ services:
         # --persist-updates is mandatory: without it every SPARQL update is lost on
         # restart. With it, updates persist to neowiki.update-triples on the named volume
         # and are reloaded on startup.
-        exec qlever-server -i neowiki -p 7019 -a "$$QLEVER_ACCESS_TOKEN" -m 1G --persist-updates
+        # --service-allowed-iri-prefixes disables SPARQL federation. NeoWiki's query surfaces
+        # let wiki users send arbitrary SPARQL, and SERVICE makes the store issue outbound
+        # requests from its own network position — here, inside the compose network. QLever
+        # allows every IRI when the option is omitted, so this sets the documented deny-all
+        # value: an invalid prefix ("-") that no IRI can match. Drop or narrow it only if you
+        # actually want federation, and then list real prefixes rather than removing the flag.
+        # Keep it last: it takes an arbitrary number of prefixes, so a bare value placed
+        # after it would be read as another prefix.
+        exec qlever-server -i neowiki -p 7019 -a "$$QLEVER_ACCESS_TOKEN" -m 1G --persist-updates --service-allowed-iri-prefixes -
     environment:
       - QLEVER_ACCESS_TOKEN
     volumes:
@@ -129,7 +137,10 @@ services:
           qlever-index -i neowiki -F nt -f data.nt
           touch .neowiki-indexed
         fi
-        exec qlever-server -i neowiki -p 7019 -a "$$QLEVER_ACCESS_TOKEN" -m 1G
+        # --service-allowed-iri-prefixes disables SPARQL federation, as on the demo `qlever`
+        # service above; see the comment there. No test federates, so deny-all is also what
+        # the system test should run against.
+        exec qlever-server -i neowiki -p 7019 -a "$$QLEVER_ACCESS_TOKEN" -m 1G --service-allowed-iri-prefixes -
     volumes:
       - test-qlever-index-data:/index
     stop_grace_period: 2s

--- a/docs/operations/installation.md
+++ b/docs/operations/installation.md
@@ -223,6 +223,33 @@ The bundled development stack ships a working QLever example wired up this way �
 [`Docker/README.md`](../../Docker/README.md#qlever-sparql-store-dev) for the service, its `--persist-updates`
 requirement, and how to query it.
 
+### Restricting federation
+
+Read-only does not mean inert. `SERVICE` is part of the SPARQL query grammar, so a query may ask the store to fetch
+results from another endpoint. The store makes those requests itself, from its own network position — which usually
+reaches more than the wiki's users do, such as services on an internal network. This follows from offering a SPARQL
+query surface at all and is not specific to NeoWiki; the customary mitigation is to restrict federation at the store,
+which is where the outbound request originates.
+
+QLever allows every `SERVICE` IRI when the option is omitted. Pass `--service-allowed-iri-prefixes` to limit federation
+to the endpoints you intend, or to the deny-all value `-` — an invalid prefix that no IRI matches — to disable it:
+
+```sh
+# No federation:
+qlever-server -i neowiki -p 7019 -m 1G --service-allowed-iri-prefixes -
+
+# Or allow only specific endpoints:
+qlever-server -i neowiki -p 7019 -m 1G --service-allowed-iri-prefixes https://sparql.example.org/
+```
+
+The bundled development stack sets the deny-all value, so federation is off unless you change it. This is also a QLever
+runtime parameter, but changing it over the endpoint requires the store's access token, so keep that token secret.
+Other SPARQL stores have their own equivalents — consult their documentation.
+
+Restricting the store is worth combining with restricting who may query it. The query surfaces are gated by the
+`neowiki-query` right, which by default is granted to everyone including anonymous visitors; see
+[Permissions](../api/query-api.md#permissions) for how to narrow it.
+
 ## Production hardening
 
 NeoWiki is pre-release, so this is not needed for an evaluation. It applies later, when NeoWiki is production-ready.

--- a/docs/operations/installation.md
+++ b/docs/operations/installation.md
@@ -225,14 +225,12 @@ requirement, and how to query it.
 
 ### Restricting federation
 
-Read-only does not mean inert. `SERVICE` is part of the SPARQL query grammar, so a query may ask the store to fetch
-results from another endpoint. The store makes those requests itself, from its own network position — which usually
-reaches more than the wiki's users do, such as services on an internal network. This follows from offering a SPARQL
-query surface at all and is not specific to NeoWiki; the customary mitigation is to restrict federation at the store,
-which is where the outbound request originates.
+The query surfaces are read-only, but SPARQL's `SERVICE` clause lets a query direct the store to fetch results
+from another endpoint. The store makes those requests itself, from its own network position — often one that
+reaches internal services the wiki's visitors cannot. Restrict federation at the store unless you mean to offer it.
 
-QLever allows every `SERVICE` IRI when the option is omitted. Pass `--service-allowed-iri-prefixes` to limit federation
-to the endpoints you intend, or to the deny-all value `-` — an invalid prefix that no IRI matches — to disable it:
+QLever allows every `SERVICE` IRI unless `--service-allowed-iri-prefixes` is given. Pass the IRI prefixes you want
+to allow, or the deny-all value `-` (an invalid prefix that no IRI matches):
 
 ```sh
 # No federation:
@@ -242,9 +240,9 @@ qlever-server -i neowiki -p 7019 -m 1G --service-allowed-iri-prefixes -
 qlever-server -i neowiki -p 7019 -m 1G --service-allowed-iri-prefixes https://sparql.example.org/
 ```
 
-The bundled development stack sets the deny-all value, so federation is off unless you change it. This is also a QLever
-runtime parameter, but changing it over the endpoint requires the store's access token, so keep that token secret.
-Other SPARQL stores have their own equivalents — consult their documentation.
+The bundled development stack sets the deny-all value, so federation is off unless you change it. The setting can
+also be changed at runtime through the store's endpoint by anyone holding its access token, so keep that token
+secret. Other SPARQL stores have equivalent settings — consult their documentation.
 
 Restricting the store is worth combining with restricting who may query it. The query surfaces are gated by the
 `neowiki-query` right, which by default is granted to everyone including anonymous visitors; see


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/NeoWiki/issues/586

Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1051

NeoWiki's SPARQL query surfaces are read-only by protocol, and that argument holds. `SERVICE`, however, is part of the
*query* grammar, so a query can make the store issue outbound requests from its own network position. That is inherent
to exposing a SPARQL query surface, not a NeoWiki defect, and the usual mitigation is store-side: QLever allows every
`SERVICE` IRI unless `--service-allowed-iri-prefixes` is given.

Set it to the documented deny-all value (`-`, an invalid prefix no IRI matches) on the dev stack's `qlever` and
`test_qlever` services and on CI's QLever, and document the knob in the SPARQL section of the installation docs as
operational hardening guidance, alongside restricting the `neowiki-query` right.

No federation target is allowlisted: whether federation is wanted at all is a product decision, and this only makes the
shipped default safe and documents the option. No NeoWiki-side query validator either — that would contradict ADR 019
and #1051's rationale.

> <sub>AI-authored — Claude Code, `Opus 4.8 (max)`; follow-up to an AI review of #1051 at @JeroenDeDauw's direction; not human-reviewed; verified against `adfreiburg/qlever:latest` that omitting the option federates and `-` rejects `SERVICE` while normal queries still work, that an anonymous `SERVICE` query via the REST endpoint no longer reaches a listener on the store's network (an unflagged control does, `ua=Boost.Beast/347`), and that the live `QuerySparqlEndToEndTest` plus the full PHPUnit suite and `make cs` pass with the flag set.</sub>