### PR TITLE
Render cypher_raw output as HTML instead of wikitext

### DIFF
--- a/src/GraphDatabasePlugins/Neo4j/EntryPoints/ParserFunction/CypherRawParserFunction.php
+++ b/src/GraphDatabasePlugins/Neo4j/EntryPoints/ParserFunction/CypherRawParserFunction.php
@@ -63,7 +63,8 @@ class CypherRawParserFunction {
 	 * Hands the HTML to the parser as HTML rather than wikitext. Without this the text is parsed as
 	 * wikitext, which autolinks any URL a returned value happens to hold: the trailing quote of the
 	 * URL is swallowed into the link and percent-encoded, leaving invalid JSON with anchors in it.
-	 * Error detail needs the same treatment, as the store's message can itself carry a URL.
+	 * Error detail needs the same treatment, as the store's message echoes the offending query,
+	 * which can itself contain a URL.
 	 *
 	 * @return array{0: string, noparse: true, isHTML: true}
 	 */

--- a/src/GraphDatabasePlugins/Neo4j/EntryPoints/ParserFunction/CypherRawParserFunction.php
+++ b/src/GraphDatabasePlugins/Neo4j/EntryPoints/ParserFunction/CypherRawParserFunction.php
@@ -19,7 +19,10 @@ class CypherRawParserFunction {
 	) {
 	}
 
-	public function handle( Parser $parser, string $cypherQuery ): string {
+	/**
+	 * @return array{0: string, noparse: true, isHTML: true}
+	 */
+	public function handle( Parser $parser, string $cypherQuery ): array {
 		try {
 			$result = $this->queryService->execute(
 				new Neo4jQueryRequest(
@@ -42,12 +45,30 @@ class CypherRawParserFunction {
 		return $this->formatResult( $json );
 	}
 
-	private function formatResult( string $json ): string {
-		return '<div class="mw-neowiki-cypher-result"><pre>' . htmlspecialchars( $json ) . '</pre></div>';
+	/**
+	 * @return array{0: string, noparse: true, isHTML: true}
+	 */
+	private function formatResult( string $json ): array {
+		return $this->asHtml( '<div class="mw-neowiki-cypher-result"><pre>' . htmlspecialchars( $json ) . '</pre></div>' );
 	}
 
-	private function formatError( string $message ): string {
-		return '<div class="error">' . htmlspecialchars( $message ) . '</div>';
+	/**
+	 * @return array{0: string, noparse: true, isHTML: true}
+	 */
+	private function formatError( string $message ): array {
+		return $this->asHtml( '<div class="error">' . htmlspecialchars( $message ) . '</div>' );
+	}
+
+	/**
+	 * Hands the HTML to the parser as HTML rather than wikitext. Without this the text is parsed as
+	 * wikitext, which autolinks any URL a returned value happens to hold: the trailing quote of the
+	 * URL is swallowed into the link and percent-encoded, leaving invalid JSON with anchors in it.
+	 * Error detail needs the same treatment, as the store's message can itself carry a URL.
+	 *
+	 * @return array{0: string, noparse: true, isHTML: true}
+	 */
+	private function asHtml( string $html ): array {
+		return [ $html, 'noparse' => true, 'isHTML' => true ];
 	}
 
 }

--- a/src/GraphDatabasePlugins/Neo4j/Neo4jPlugin.php
+++ b/src/GraphDatabasePlugins/Neo4j/Neo4jPlugin.php
@@ -84,7 +84,7 @@ readonly class Neo4jPlugin {
 
 		$parser->setFunctionHook(
 			'cypher_raw',
-			static function ( Parser $parser, string $cypherQuery ) use ( $queryService ): string {
+			static function ( Parser $parser, string $cypherQuery ) use ( $queryService ): array {
 				return ( new CypherRawParserFunction( $queryService ) )->handle( $parser, $cypherQuery );
 			}
 		);

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/EntryPoints/ParserFunction/CypherRawParserFunctionParsingTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/EntryPoints/ParserFunction/CypherRawParserFunctionParsingTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\GraphDatabasePlugins\Neo4j\EntryPoints\ParserFunction;
+
+use Laudis\Neo4j\Databags\SummarizedResult;
+use Laudis\Neo4j\Types\CypherMap;
+use MediaWiki\Parser\Parser;
+use MediaWiki\Parser\ParserOptions;
+use MediaWiki\Title\Title;
+use MediaWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\KeywordCypherQueryValidator;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jQueryService;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jReadQueryEngine;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\ParserFunction\CypherRawParserFunction;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jResultNormalizer;
+
+/**
+ * What a reader ends up with, rather than what the parser function returns: the corruption this
+ * guards against happens in MediaWiki's parser, after the function has handed its text back, so it
+ * is invisible to a test that only inspects the return value.
+ *
+ * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\ParserFunction\CypherRawParserFunction
+ * @group Database
+ */
+class CypherRawParserFunctionParsingTest extends MediaWikiIntegrationTestCase {
+
+	private const string WEBSITE = 'https://www.rijksmuseum.nl';
+
+	private function parseCypherRaw(): string {
+		$parser = $this->getServiceContainer()->getParserFactory()->create();
+		$queryService = $this->queryServiceReturningWebsite();
+
+		$parser->setFunctionHook(
+			'cypher_raw',
+			static function ( Parser $parser, string $cypherQuery ) use ( $queryService ): string|array {
+				return ( new CypherRawParserFunction( $queryService ) )->handle( $parser, $cypherQuery );
+			}
+		);
+
+		return $parser->parse(
+			'{{#cypher_raw: MATCH (m:Museum) RETURN m.Website AS site }}',
+			Title::makeTitle( NS_MAIN, 'CypherRawParsingTest' ),
+			ParserOptions::newFromAnon()
+		)->getText();
+	}
+
+	private function queryServiceReturningWebsite(): Neo4jQueryService {
+		// SummarizedResult takes its summary by reference, so it needs a variable.
+		$summary = null;
+
+		$queryEngine = $this->createMock( Neo4jReadQueryEngine::class );
+		$queryEngine->method( 'runReadQuery' )->willReturn(
+			new SummarizedResult( $summary, [ new CypherMap( [ 'site' => self::WEBSITE ] ) ] )
+		);
+
+		return new Neo4jQueryService(
+			$queryEngine,
+			new KeywordCypherQueryValidator(),
+			new Neo4jResultNormalizer(),
+		);
+	}
+
+	public function testUrlValueSurvivesParsingUnchanged(): void {
+		$html = html_entity_decode( $this->parseCypherRaw() );
+
+		$this->assertStringContainsString( '"site": "' . self::WEBSITE . '"', $html );
+	}
+
+	public function testUrlsAreNotTurnedIntoLinks(): void {
+		$html = $this->parseCypherRaw();
+
+		$this->assertStringNotContainsString( '<a ', $html );
+		$this->assertStringNotContainsString( '%22', $html );
+	}
+
+}

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/EntryPoints/ParserFunction/CypherRawParserFunctionTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/EntryPoints/ParserFunction/CypherRawParserFunctionTest.php
@@ -88,12 +88,21 @@ class CypherRawParserFunctionTest extends TestCase {
 		);
 	}
 
+	/**
+	 * The HTML the parser function hands back, from either its result or its error shape.
+	 *
+	 * @param array{0: string, noparse: true, isHTML: true} $result
+	 */
+	private function html( array $result ): string {
+		return $result[0];
+	}
+
 	public function testEmptyQueryShowsLocalizedError(): void {
 		$parserFunction = $this->createParserFunction( $this->createDummyQueryEngine() );
 
 		$result = $parserFunction->handle( $this->createParser(), '' );
 
-		$this->assertStringContainsString( '[neowiki-cypher-error-empty-query]', $result );
+		$this->assertStringContainsString( '[neowiki-cypher-error-empty-query]', $this->html( $result ) );
 	}
 
 	public function testWriteQueryShowsLocalizedError(): void {
@@ -101,7 +110,7 @@ class CypherRawParserFunctionTest extends TestCase {
 
 		$result = $parserFunction->handle( $this->createParser(), "CREATE (n:Person {name: 'Alice'})" );
 
-		$this->assertStringContainsString( '[neowiki-cypher-error-write-query]', $result );
+		$this->assertStringContainsString( '[neowiki-cypher-error-write-query]', $this->html( $result ) );
 	}
 
 	public function testEngineFailureShowsLocalizedBackendError(): void {
@@ -111,7 +120,7 @@ class CypherRawParserFunctionTest extends TestCase {
 
 		$result = $parserFunction->handle( $this->createParser(), 'MATCH (n) RETURN n' );
 
-		$this->assertStringContainsString( '[neowiki-cypher-error-backend-unavailable]', $result );
+		$this->assertStringContainsString( '[neowiki-cypher-error-backend-unavailable]', $this->html( $result ) );
 	}
 
 	public function testSyntaxErrorForwardsNeo4jDetailToLocalizedMessage(): void {
@@ -125,8 +134,8 @@ class CypherRawParserFunctionTest extends TestCase {
 
 		$result = $parserFunction->handle( $this->createParser(), 'MATCH (n) RETURN x' );
 
-		$this->assertStringContainsString( '[neowiki-cypher-error-syntax|', $result );
-		$this->assertStringContainsString( 'Invalid input near RETURN', $result );
+		$this->assertStringContainsString( '[neowiki-cypher-error-syntax|', $this->html( $result ) );
+		$this->assertStringContainsString( 'Invalid input near RETURN', $this->html( $result ) );
 	}
 
 	public function testValidatorFailureShowsLocalizedBackendError(): void {
@@ -140,7 +149,7 @@ class CypherRawParserFunctionTest extends TestCase {
 
 		$result = $parserFunction->handle( $this->createParser(), 'MATCH (n) RETURN n' );
 
-		$this->assertStringContainsString( '[neowiki-cypher-error-backend-unavailable]', $result );
+		$this->assertStringContainsString( '[neowiki-cypher-error-backend-unavailable]', $this->html( $result ) );
 	}
 
 	public function testValidReadQueryReturnsFormattedResult(): void {
@@ -153,9 +162,9 @@ class CypherRawParserFunctionTest extends TestCase {
 
 		$result = $parserFunction->handle( $this->createParser(), 'MATCH (n:Person) RETURN n' );
 
-		$this->assertStringContainsString( '<div class="mw-neowiki-cypher-result"><pre>', $result );
-		$this->assertStringContainsString( 'Alice', $result );
-		$this->assertStringContainsString( 'Bob', $result );
+		$this->assertStringContainsString( '<div class="mw-neowiki-cypher-result"><pre>', $this->html( $result ) );
+		$this->assertStringContainsString( 'Alice', $this->html( $result ) );
+		$this->assertStringContainsString( 'Bob', $this->html( $result ) );
 	}
 
 	public function testTrimWhitespaceFromQuery(): void {
@@ -163,7 +172,7 @@ class CypherRawParserFunctionTest extends TestCase {
 
 		$result = $parserFunction->handle( $this->createParser(), '  MATCH (n) RETURN n  ' );
 
-		$this->assertStringContainsString( '<div class="mw-neowiki-cypher-result"><pre>', $result );
+		$this->assertStringContainsString( '<div class="mw-neowiki-cypher-result"><pre>', $this->html( $result ) );
 	}
 
 	public function testOutputIsHTMLEscaped(): void {
@@ -175,8 +184,8 @@ class CypherRawParserFunctionTest extends TestCase {
 
 		$result = $parserFunction->handle( $this->createParser(), 'MATCH (n) RETURN n' );
 
-		$this->assertStringNotContainsString( '<script>alert', $result );
-		$this->assertStringContainsString( '&lt;script&gt;', $result );
+		$this->assertStringNotContainsString( '<script>alert', $this->html( $result ) );
+		$this->assertStringContainsString( '&lt;script&gt;', $this->html( $result ) );
 	}
 
 }

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/EntryPoints/ParserFunction/CypherRawParserFunctionTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/EntryPoints/ParserFunction/CypherRawParserFunctionTest.php
@@ -188,4 +188,38 @@ class CypherRawParserFunctionTest extends TestCase {
 		$this->assertStringContainsString( '&lt;script&gt;', $this->html( $result ) );
 	}
 
+	public function testResultIsArmouredAgainstWikitextTransformation(): void {
+		$parserFunction = $this->createParserFunction(
+			$this->createQueryEngineWithData( [ [ 'site' => 'https://example.com' ] ] )
+		);
+
+		$result = $parserFunction->handle( $this->createParser(), 'MATCH (n) RETURN n.site AS site' );
+
+		$this->assertIsArray( $result, 'Expected an isHTML array so the parser leaves the JSON alone.' );
+		$this->assertTrue( $result['isHTML'] );
+		$this->assertTrue( $result['noparse'] );
+	}
+
+	public function testErrorIsArmouredAgainstWikitextTransformation(): void {
+		$neo4jException = new Neo4jException( [
+			Neo4jError::fromMessageAndCode(
+				'Neo.ClientError.Statement.SyntaxError',
+				"Invalid input near 'https://example.com'"
+			),
+		] );
+
+		$parserFunction = $this->createParserFunction(
+			$this->createQueryEngineWithException( $neo4jException )
+		);
+
+		$result = $parserFunction->handle(
+			$this->createParser(),
+			"MATCH (n) WHERE n.site = 'https://example.com' RETURN n"
+		);
+
+		$this->assertIsArray( $result, 'Error detail echoes the query, which can carry a URL, so it needs the same armour.' );
+		$this->assertTrue( $result['isHTML'] );
+		$this->assertTrue( $result['noparse'] );
+	}
+
 }


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/1067

`{{#cypher_raw}}` handed its JSON to the parser as wikitext, so any URL in a returned value
got autolinked. The closing quote of the JSON string was swallowed into the link and
percent-encoded, leaving the reader with invalid JSON and `<a>` tags inside the `<pre>`.

Returns the output as HTML instead, the way `#view` and `#neowiki_value` already do, and the
way `{{#sparql_raw}}` was fixed in #1051. `isHTML` is the flag that does the work: it
strip-armours the text so the parser leaves it alone. `noparse` is already the default for a
parser-function return and is included only to match the shape used elsewhere.

The error path gets the same treatment. Unlike the SPARQL side, no Cypher error message
carries the endpoint URL, since `backendUnavailable` passes no params; a URL reaches the
message by being echoed back from the offending query.

Returning an array means changing the `: string` return type to `: array` on
`CypherRawParserFunction::handle()` and on the `cypher_raw` closure in `Neo4jPlugin`, which
would otherwise fatal with a `TypeError`.

## Testing

The existing unit tests could not catch this: they assert on what `handle()` returns, while
the corruption happens afterwards, inside the parser. `CypherRawParserFunctionParsingTest`
parses wikitext through a real `Parser` and asserts on what a reader ends up with, mirroring
`SparqlRawParserFunctionParsingTest`. Verified failing before the fix and passing after.

The second commit closes a gap found in review: the unit tests exercised the returned HTML but
never the flags that carry it, so replacing `asHtml()`'s return with `[ $html ]` — dropping both
flags and reintroducing the corruption — left all eight of them green. It adds the two armour
tests the `sparql_raw` sibling already has; they now fail against exactly that mutation.

> <sub>AI-authored — Claude Code, `Opus 4.8 (max)`; fixing a filed issue at @JeroenDeDauw's direction; not human-reviewed; verified by a parser-level regression test seen failing before the fix and passing after, by the issue's exact query rendered on a live dev wiki before and after, and by mutation-checking the new armour tests; full PHPUnit suite (1749 tests) and `make cs` green.</sub>
