### PR TITLE
Bring the RDF demo pages up to date with the SPARQL store and #1053

### DIFF
--- a/DemoData/Page/RDF_and_ontology_mappings.wikitext
+++ b/DemoData/Page/RDF_and_ontology_mappings.wikitext
@@ -3,7 +3,7 @@ Every NeoWiki page's Subjects are available as '''RDF'''. The same data is offer
 * A '''native projection''' in NeoWiki's own vocabulary. Lossless, always available, no setup.
 * '''Ontology projections''' that re-express the data in an established vocabulary such as the [https://pro.europeana.eu/page/edm-documentation Europeana Data Model] (EDM). Each one is defined by a '''Mapping''' page.
 
-Each export is produced on demand from the page's current data and downloads as a Turtle or TriG file. Loading a projection into a SPARQL store for live querying is upcoming; the export surface linked below is what exists today.
+Each export is produced on demand from the page's current data and downloads as a Turtle or TriG file. A projection can also be kept in a SPARQL store and queried live — see [[SPARQL queries]] on wikis that have a store configured, such as the NeoWiki development stack.
 
 == The Mapping pages ==
 

--- a/DemoData/SparqlPage/SPARQL_queries.wikitext
+++ b/DemoData/SparqlPage/SPARQL_queries.wikitext
@@ -1,4 +1,4 @@
-NeoWiki keeps [https://github.com/ProfessionalWiki/NeoWiki/blob/master/docs/operations/installation.md#optional-sparql-graph-stores SPARQL 1.1 graph stores] such as [https://qlever.dev/ QLever] in sync with the wiki's structured data: every page becomes a named graph of RDF triples, updated on each edit and dropped on deletion. This page demonstrates the three ways to query that RDF projection. It is imported only into wikis that have a SPARQL store configured, like the NeoWiki development stack.
+NeoWiki keeps [https://github.com/ProfessionalWiki/NeoWiki/blob/master/docs/operations/installation.md#optional-sparql-graph-stores SPARQL 1.1 graph stores] such as [https://qlever.dev/ QLever] in sync with the wiki's structured data: each page becomes a named graph of RDF triples — one per [[RDF and ontology mappings|projection]] the store holds — updated on each edit and dropped on deletion. This wiki's store holds the native projection. This page demonstrates the three ways to query it. It is imported only into wikis that have a SPARQL store configured, like the NeoWiki development stack.
 
 == Query with a parser function ==
 
@@ -14,15 +14,15 @@ Result:
 
 {{#sparql_raw:SELECT ?museum ?visitors WHERE { ?m <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <{{SERVER}}/schema/Museum> . ?m <http://www.w3.org/2000/01/rdf-schema#label> ?museum . ?m <{{SERVER}}/prop/Annual_visitors> ?visitors } ORDER BY DESC(?visitors) LIMIT 5}}
 
-Every page is its own named graph, so results can carry page provenance. This query lists people together with the graph (page) each one comes from:
+Each graph is named for the projection and the page it holds — <code>{{SERVER}}/graph/native/page/&lt;pageid&gt;</code> — so results can carry provenance, and one store can hold several projections without a page's triples in one overwriting the other's. This query lists people together with the graph each one comes from:
 
 <syntaxhighlight lang="mediawiki">
-{{#sparql_raw:SELECT ?page ?person WHERE { GRAPH ?page { ?p <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <{{SERVER}}/schema/Person> . ?p <http://www.w3.org/2000/01/rdf-schema#label> ?person } } ORDER BY ?person LIMIT 5}}
+{{#sparql_raw:SELECT ?graph ?person WHERE { GRAPH ?graph { ?p <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <{{SERVER}}/schema/Person> . ?p <http://www.w3.org/2000/01/rdf-schema#label> ?person } } ORDER BY ?person LIMIT 5}}
 </syntaxhighlight>
 
 Result:
 
-{{#sparql_raw:SELECT ?page ?person WHERE { GRAPH ?page { ?p <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <{{SERVER}}/schema/Person> . ?p <http://www.w3.org/2000/01/rdf-schema#label> ?person } } ORDER BY ?person LIMIT 5}}
+{{#sparql_raw:SELECT ?graph ?person WHERE { GRAPH ?graph { ?p <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <{{SERVER}}/schema/Person> . ?p <http://www.w3.org/2000/01/rdf-schema#label> ?person } } ORDER BY ?person LIMIT 5}}
 
 == Query from Lua ==
 


### PR DESCRIPTION
Two demo pages fell behind yesterday's merges, in opposite directions: the RDF page does not know the SPARQL store shipped (#1051), and the SPARQL page does not know graph IRIs became projection-qualified (#1053 / #1055).

**`RDF_and_ontology_mappings`** still said loading a projection into a SPARQL store for live querying "is upcoming; the export surface linked below is what exists today". It shipped, along with a page demonstrating it, which this page never linked to.

**`SPARQL_queries`** described the scheme #1053 replaced — "every page becomes a named graph", "Every page is its own named graph" — and bound the graph to a variable named `?page`. On the demo wiki that query now returns:

```json
"page": { "type": "uri", "value": "http://localhost:8484/graph/native/page/43" }
```

A variable called `?page` holding a graph IRI. Renamed to `?graph`, with the IRI shape given and a note on what the projection segment buys — this page is the only place on the demo wiki that trace is visible, and it is what partners testing the RDF output will read.

Verified by rendering both pages against a dev stack with QLever populated (`RebuildGraphDatabases` backfills into `.../graph/native/page/{id}`): the prose matches what the queries return, both new links resolve, no redlinks. Full `make phpunit` green (1750 tests, 4 skipped) with the live-QLever system tests running.

Two things deliberately left out, for your call:

- **Nothing demos the multi-projection capability.** #1053's point is that one store can hold several projections, but the dev stack configures only `native`, so the docs claim it and nothing shows it. Adding an `edm` store entry against the same QLever would demonstrate it directly — that is a dev-stack config change, not demo data.
- **A fresh dev stack renders this page with empty results.** Demo data is imported before the store is reachable, so nothing syncs and the queries return `"bindings": []` until someone runs `RebuildGraphDatabases`. A first-run visitor sees an empty demo. Seeding order, not demo content.

> <sub>AI-authored — Claude Code, `Opus 4.8 (max)`; found while checking demo-data currency after #1051 and #1055 merged; verified as described above; not yet human-reviewed.</sub>