### PR TITLE
Pin the Schema name search read gate and correct the permissions docs

### DIFF
--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -23,8 +23,9 @@ Demo wiki example: [neowiki.dev/w/rest.php/specs/v0/module/-](https://neowiki.de
 
 ## Permissions
 
-Read endpoints enforce the caller's per-page `read` permission: page protection, restricted namespaces, read
-whitelists, and permission extensions all apply. When you may not read a page, its read endpoints respond as if
+The Subject, Schema, Layout, Mapping and RDF read endpoints enforce the caller's per-page `read` permission: read
+whitelists and permission extensions apply. (MediaWiki's `read` action ignores page protection and
+`$wgNamespaceProtection`, so neither restricts these endpoints.) When you may not read a page, they respond as if
 the data were absent — a `null` value, an empty list, or a `404` — rather than with a `403`. Treat a not-found
 response as "not available": it may mean the data does not exist, or that you may not read it.
 

--- a/tests/phpunit/Persistence/MediaWiki/DatabaseSchemaNameLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/DatabaseSchemaNameLookupTest.php
@@ -141,6 +141,19 @@ class DatabaseSchemaNameLookupTest extends NeoWikiIntegrationTestCase {
 		);
 	}
 
+	public function testUnreadableSchemaNamesAreOmittedFromSearchResults(): void {
+		$denyFirstMatch = static fn ( string $permission, ?PageIdentity $page = null ): bool =>
+			$page === null || $page->getDBkey() !== 'SchemaNameLookupTest21';
+
+		$names = array_map(
+			static fn ( TitleValue $title ): string => $title->getText(),
+			$this->getLookup( $this->mockRegisteredAuthority( $denyFirstMatch ) )
+				->getSchemaNamesMatching( 'SchemaNameLookupTest2', 10 )
+		);
+
+		$this->assertSame( [ 'SchemaNameLookupTest22' ], $names );
+	}
+
 	public function testGateUsesBindingAuthorizeRead(): void {
 		// probablyCan is a UI-hint check that skips the expensive ACL hook; the filter must
 		// use the binding authorizeRead with the 'read' action. Reverting fails this test.


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1058

Two fixes from an AI review of #1058. Both are small. The review's more significant findings are deliberately **not** in this branch — they need your call, and are reported separately.

### Test the read gate on the Schema name search branch

Both denial tests in `DatabaseSchemaNameLookupTest` call `getSchemaNamesMatching` with an empty search, so they only cover `getFirstSchemaNames`. Deleting `filterReadable` from the search branch — the one `GET /schema-names/{search}` actually uses — passed the full suite. The production code is correct; the gate was simply unpinned. The new test fails without the gate and passes with it.

### Correct the REST permissions documentation

Two inaccuracies:

* It claimed page protection and restricted namespaces apply to reads. Neither does: for the `read` action MediaWiki runs only `checkPermissionHooks`, `checkReadPermissions` and `checkUserBlock`; `read` is not one of the default `$wgRestrictionTypes`; and `$wgNamespaceProtection` is only consulted by `checkSpecialsAndNSPermissions`, which reads skip. Per-page read restrictions come from `$wgWhitelistRead` or a permission extension.
* It stated without qualification that read endpoints enforce per-page `read`. `GET /subject-labels` applies no per-page filter. Verified on a dev wiki with one page read-denied: `GET /subject/{id}` returns `{"subject":null}` while `GET /subject-labels` still returns that Subject's id and label. `totalRows` likewise still counts rows omitted from the list.

This partially restores caveats that 4cb79db trimmed as "temporary not-yet caveats". Flagging rather than assuming your intent: #1058's description says the deferred gaps are "Documented in the new `docs/api/rest-api.md` Permissions section", and the trim removed exactly that, which left the remaining blanket claim false. If you prefer different wording, the only constraint is that the section not assert a guarantee `/subject-labels` does not provide.

### Verification

`make cs` clean; full suite green (1689 tests). New test proven load-bearing by mutation.

> <sub>AI-authored — Claude Code, `Opus 4.8 (max)`; produced by a `/pr-review` run of #1058 for @JeroenDeDauw, no revisions; diff not yet human-reviewed; new test mutation-tested, `make cs` clean, full PHPUnit suite green locally, docs claims checked against MediaWiki 1.43 core and reproduced live on a dev wiki.</sub>
