### PR TITLE
Pin denial on a warm Schema and Mapping cache

### DIFF
--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -21,6 +21,26 @@ permissions might be required depending on the wiki configuration.
 You can find all endpoints in [the OpenAPI 3.0 description](#full-specification) exposed via the REST API itself.
 Demo wiki example: [neowiki.dev/w/rest.php/specs/v0/module/-](https://neowiki.dev/w/rest.php/specs/v0/module/-)
 
+## Permissions
+
+Read endpoints enforce the caller's per-page `read` permission (page protection, restricted namespaces, read
+whitelists, and permission extensions), not just the wiki-global `read` right. The one exception is
+`GET /subject-labels`, which does not yet apply a per-page filter and can expose the labels of Subjects on
+restricted pages.
+
+A denied read is deliberately indistinguishable from absent data: `GET /subject/{subjectId}`,
+`GET /schema/{schemaName}`, and `GET /layout/{layoutName}` answer `200` with a null value (`{"subject": null}`
+and so on), `GET /page/{pageId}/subjects` answers `200` with an empty subject map (plus the echoed `pageId`
+and a null `mainSubjectId`), `GET /page/{pageId}/rdf` and `POST /subject/{subjectId}/validate` answer `404`,
+and list endpoints omit the affected entries (their `totalRows` counts are currently unfiltered). For a
+per-page denial there is no `403`: page and revision IDs are sequential, so any distinguishable denial would
+let a caller enumerate which pages are restricted. A caller who lacks the wiki-global `read` right entirely
+still receives MediaWiki's standard `403` before any of this applies. Denials are logged server-side to the
+`NeoWiki` logging channel.
+
+Subject write endpoints enforce per-page `edit` permission and answer `403` on denial; a write denial reveals
+nothing, because the caller already knows the page exists.
+
 ## Endpoints
 
 <!-- REST-ENDPOINTS:START — drift-checked against extension.json by

--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -23,24 +23,15 @@ Demo wiki example: [neowiki.dev/w/rest.php/specs/v0/module/-](https://neowiki.de
 
 ## Permissions
 
-Read endpoints enforce the caller's per-page `read` permission (page protection, restricted namespaces, read
-whitelists, and permission extensions), not just the wiki-global `read` right. Two exceptions remain:
-`GET /subject-labels` does not yet apply a per-page filter and can expose the labels of Subjects on restricted
-pages, and the Cypher query endpoint reads the graph with only the `neowiki-query` right (see
+Read endpoints enforce the caller's per-page `read` permission: page protection, restricted namespaces, read
+whitelists, and permission extensions all apply. When you may not read a page, its read endpoints respond as if
+the data were absent — a `null` value, an empty list, or a `404` — rather than with a `403`. Treat a not-found
+response as "not available": it may mean the data does not exist, or that you may not read it.
+
+Subject write endpoints require per-page `edit` permission and answer `403` on denial.
+
+The Cypher query endpoint is gated only by the `neowiki-query` right, with no per-page filtering (see
 [Query API](query-api.md)).
-
-A denied read is deliberately indistinguishable from absent data: `GET /subject/{subjectId}`,
-`GET /schema/{schemaName}`, and `GET /layout/{layoutName}` answer `200` with a null value (`{"subject": null}`
-and so on), `GET /page/{pageId}/subjects` answers `200` with an empty subject map (plus the echoed `pageId`
-and a null `mainSubjectId`), `GET /page/{pageId}/rdf` and `POST /subject/{subjectId}/validate` answer `404`,
-and list endpoints omit the affected entries (their `totalRows` counts are currently unfiltered). For a
-per-page denial there is no `403`: page and revision IDs are sequential, so any distinguishable denial would
-let a caller enumerate which pages are restricted. A caller who lacks the wiki-global `read` right entirely
-still receives MediaWiki's standard `403` before any of this applies. Denials are logged server-side to the
-`NeoWiki` logging channel.
-
-Subject write endpoints enforce per-page `edit` permission and answer `403` on denial. Their page-id-keyed routes
-are not yet enumeration-hardened the way the read endpoints are.
 
 ## Endpoints
 

--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -24,9 +24,10 @@ Demo wiki example: [neowiki.dev/w/rest.php/specs/v0/module/-](https://neowiki.de
 ## Permissions
 
 Read endpoints enforce the caller's per-page `read` permission (page protection, restricted namespaces, read
-whitelists, and permission extensions), not just the wiki-global `read` right. The one exception is
-`GET /subject-labels`, which does not yet apply a per-page filter and can expose the labels of Subjects on
-restricted pages.
+whitelists, and permission extensions), not just the wiki-global `read` right. Two exceptions remain:
+`GET /subject-labels` does not yet apply a per-page filter and can expose the labels of Subjects on restricted
+pages, and the Cypher query endpoint reads the graph with only the `neowiki-query` right (see
+[Query API](query-api.md)).
 
 A denied read is deliberately indistinguishable from absent data: `GET /subject/{subjectId}`,
 `GET /schema/{schemaName}`, and `GET /layout/{layoutName}` answer `200` with a null value (`{"subject": null}`
@@ -38,8 +39,8 @@ let a caller enumerate which pages are restricted. A caller who lacks the wiki-g
 still receives MediaWiki's standard `403` before any of this applies. Denials are logged server-side to the
 `NeoWiki` logging channel.
 
-Subject write endpoints enforce per-page `edit` permission and answer `403` on denial; a write denial reveals
-nothing, because the caller already knows the page exists.
+Subject write endpoints enforce per-page `edit` permission and answer `403` on denial. Their page-id-keyed routes
+are not yet enumeration-hardened the way the read endpoints are.
 
 ## Endpoints
 

--- a/src/Application/Queries/GetPageSubjects/GetPageSubjectsQuery.php
+++ b/src/Application/Queries/GetPageSubjects/GetPageSubjectsQuery.php
@@ -125,9 +125,10 @@ readonly class GetPageSubjectsQuery {
 
 	/**
 	 * A Subject whose page does not resolve in the graph cannot be reached through the
-	 * graph-backed repository at all (the repository returns null before this runs), so null
-	 * only occurs for Subjects whose page was already authorized by the caller. Denying on
-	 * null would instead hide Subjects from readable old revisions after later deletion.
+	 * graph-backed repository at all (the repository returns null before this runs), so the
+	 * null case is unreachable here; treating it as readable keeps the helper uniform with
+	 * the sibling query gates. Denying on null would risk hiding Subjects from readable old
+	 * revisions if a revision-backed lookup is ever wired in.
 	 */
 	private function pageIsReadable( ?PageIdentifiers $pageIdentifiers ): bool {
 		return $pageIdentifiers === null || $this->readAuthorizer->authorizeRead( $pageIdentifiers->getId() );

--- a/src/Application/Queries/GetPageSubjects/GetPageSubjectsQuery.php
+++ b/src/Application/Queries/GetPageSubjects/GetPageSubjectsQuery.php
@@ -8,8 +8,11 @@ use ProfessionalWiki\NeoWiki\Application\PageIdentifiersLookup;
 use ProfessionalWiki\NeoWiki\Application\Queries\GetSubject\GetSubjectResponseItem;
 use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
 use ProfessionalWiki\NeoWiki\Application\SubjectLookup;
+use ProfessionalWiki\NeoWiki\Application\SubjectReadAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\SubjectRepository;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageIdentifiers;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
@@ -24,21 +27,34 @@ readonly class GetPageSubjectsQuery {
 		private SchemaLookup $schemaLookup,
 		private SchemaPresentationSerializer $schemaSerializer,
 		private PageIdentifiersLookup $pageIdentifiersLookup,
+		private SubjectReadAuthorizer $readAuthorizer,
 	) {
 	}
 
 	public function execute( int $pageId, bool $includeSchemas = false, bool $includeReferencedSubjects = false ): void {
-		$pageSubjects = $this->subjectRepository->getSubjectsByPageId( new PageId( $pageId ) );
+		$id = new PageId( $pageId );
+
+		// A denied page takes exactly the path a page without Subjects takes, so the response
+		// is byte-identical to absence and cannot be used to probe page readability (#1046).
+		$pageSubjects = $this->readAuthorizer->authorizeRead( $id )
+			? $this->subjectRepository->getSubjectsByPageId( $id )
+			: PageSubjects::newEmpty();
 
 		$mainSubject = $pageSubjects->getMainSubject();
 		$subjectItems = [];
 
 		if ( $mainSubject !== null ) {
-			$subjectItems[$mainSubject->id->text] = $this->buildResponseItem( $mainSubject );
+			$subjectItems[$mainSubject->id->text] = $this->buildResponseItem(
+				$mainSubject,
+				$this->pageIdentifiersLookup->getPageIdOfSubject( $mainSubject->id )
+			);
 		}
 
 		foreach ( $pageSubjects->getChildSubjects()->asArray() as $childSubject ) {
-			$subjectItems[$childSubject->id->text] = $this->buildResponseItem( $childSubject );
+			$subjectItems[$childSubject->id->text] = $this->buildResponseItem(
+				$childSubject,
+				$this->pageIdentifiersLookup->getPageIdOfSubject( $childSubject->id )
+			);
 		}
 
 		$referencedSubjectItems = null;
@@ -62,9 +78,7 @@ readonly class GetPageSubjectsQuery {
 		);
 	}
 
-	private function buildResponseItem( Subject $subject ): GetSubjectResponseItem {
-		$pageIdentifiers = $this->pageIdentifiersLookup->getPageIdOfSubject( $subject->id );
-
+	private function buildResponseItem( Subject $subject, ?PageIdentifiers $pageIdentifiers ): GetSubjectResponseItem {
 		return new GetSubjectResponseItem(
 			id: $subject->id->text,
 			label: $subject->label->text,
@@ -92,13 +106,31 @@ readonly class GetPageSubjectsQuery {
 
 				$referencedSubject = $this->subjectLookup->getSubject( $referencedId );
 
-				if ( $referencedSubject !== null ) {
-					$referenced[$referencedId->text] = $this->buildResponseItem( $referencedSubject );
+				if ( $referencedSubject === null ) {
+					continue;
 				}
+
+				$pageIdentifiers = $this->pageIdentifiersLookup->getPageIdOfSubject( $referencedSubject->id );
+
+				if ( !$this->pageIsReadable( $pageIdentifiers ) ) {
+					continue;
+				}
+
+				$referenced[$referencedId->text] = $this->buildResponseItem( $referencedSubject, $pageIdentifiers );
 			}
 		}
 
 		return $referenced;
+	}
+
+	/**
+	 * A Subject whose page does not resolve in the graph cannot be reached through the
+	 * graph-backed repository at all (the repository returns null before this runs), so null
+	 * only occurs for Subjects whose page was already authorized by the caller. Denying on
+	 * null would instead hide Subjects from readable old revisions after later deletion.
+	 */
+	private function pageIsReadable( ?PageIdentifiers $pageIdentifiers ): bool {
+		return $pageIdentifiers === null || $this->readAuthorizer->authorizeRead( $pageIdentifiers->getId() );
 	}
 
 	/**

--- a/src/Application/Queries/GetPageSubjects/GetPageSubjectsQuery.php
+++ b/src/Application/Queries/GetPageSubjects/GetPageSubjectsQuery.php
@@ -126,12 +126,14 @@ readonly class GetPageSubjectsQuery {
 	/**
 	 * A Subject whose page does not resolve in the graph cannot be reached through the
 	 * graph-backed repository at all (the repository returns null before this runs), so the
-	 * null case is unreachable here; treating it as readable keeps the helper uniform with
-	 * the sibling query gates. Denying on null would risk hiding Subjects from readable old
-	 * revisions if a revision-backed lookup is ever wired in.
+	 * null case is unreachable today. It fails closed regardless: if a SubjectLookup that
+	 * bypasses the graph is ever wired into this query, unresolvable pages are omitted (this
+	 * endpoint's normal absence shape) instead of served ungated. GetSubjectQuery's helper
+	 * deliberately differs — its revision branch reaches null for Subjects from a revision
+	 * the handler already authorized, which must stay readable.
 	 */
 	private function pageIsReadable( ?PageIdentifiers $pageIdentifiers ): bool {
-		return $pageIdentifiers === null || $this->readAuthorizer->authorizeRead( $pageIdentifiers->getId() );
+		return $pageIdentifiers !== null && $this->readAuthorizer->authorizeRead( $pageIdentifiers->getId() );
 	}
 
 	/**

--- a/src/Application/Queries/GetSubject/GetSubjectQuery.php
+++ b/src/Application/Queries/GetSubject/GetSubjectQuery.php
@@ -6,6 +6,8 @@ namespace ProfessionalWiki\NeoWiki\Application\Queries\GetSubject;
 
 use ProfessionalWiki\NeoWiki\Application\PageIdentifiersLookup;
 use ProfessionalWiki\NeoWiki\Application\SubjectLookup;
+use ProfessionalWiki\NeoWiki\Application\SubjectReadAuthorizer;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageIdentifiers;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
@@ -16,6 +18,7 @@ readonly class GetSubjectQuery {
 		private GetSubjectPresenter $presenter,
 		private SubjectLookup $subjectLookup,
 		private PageIdentifiersLookup $pageIdentifiersLookup,
+		private SubjectReadAuthorizer $readAuthorizer,
 	) {
 	}
 
@@ -31,17 +34,35 @@ readonly class GetSubjectQuery {
 			return;
 		}
 
+		$pageIdentifiers = $this->pageIdentifiersLookup->getPageIdOfSubject( $subject->id );
+
+		if ( !$this->pageIsReadable( $pageIdentifiers ) ) {
+			// Denial takes exactly the absent-Subject path, so harvested Subject ids cannot
+			// be confirmed to exist on restricted pages (#1046).
+			$this->presenter->presentSubjectNotFound();
+			return;
+		}
+
 		$response = [
-			$subject->getId()->text => $this->createResponse( $subject, $includePageIdentifiers )
+			$subject->getId()->text => $this->createResponse( $subject, $includePageIdentifiers, $pageIdentifiers )
 		];
 
 		if ( $includeReferencedSubjects ) {
 			foreach ( $subject->getReferencedSubjects()->asArray() as $id ) {
 				$referencedSubject = $this->subjectLookup->getSubject( $id );
 
-				if ( $referencedSubject !== null ) {
-					$response[$referencedSubject->getId()->text] = $this->createResponse( $referencedSubject, $includePageIdentifiers );
+				if ( $referencedSubject === null ) {
+					continue;
 				}
+
+				$referencedPageIdentifiers = $this->pageIdentifiersLookup->getPageIdOfSubject( $referencedSubject->id );
+
+				if ( !$this->pageIsReadable( $referencedPageIdentifiers ) ) {
+					continue;
+				}
+
+				$response[$referencedSubject->getId()->text] =
+					$this->createResponse( $referencedSubject, $includePageIdentifiers, $referencedPageIdentifiers );
 			}
 		}
 
@@ -53,17 +74,33 @@ readonly class GetSubjectQuery {
 		);
 	}
 
-	private function createResponse( Subject $subject, bool $includePageIdentifiers ): GetSubjectResponseItem {
-		$pageIdentifiers = $includePageIdentifiers ? $this->pageIdentifiersLookup->getPageIdOfSubject( $subject->id ) : null;
+	/**
+	 * A Subject whose page does not resolve in the graph can only have come from a revision
+	 * the caller supplied, and GetSubjectApi authorizes read on that revision's page before
+	 * constructing this query. Reads through the graph-backed repository always resolve the
+	 * owning page (the repository returns null otherwise), so null never bypasses the gate
+	 * there. Denying on null would instead hide Subjects from readable old revisions after
+	 * the Subject was later deleted.
+	 */
+	private function pageIsReadable( ?PageIdentifiers $pageIdentifiers ): bool {
+		return $pageIdentifiers === null || $this->readAuthorizer->authorizeRead( $pageIdentifiers->getId() );
+	}
+
+	private function createResponse(
+		Subject $subject,
+		bool $includePageIdentifiers,
+		?PageIdentifiers $pageIdentifiers
+	): GetSubjectResponseItem {
+		$includedIdentifiers = $includePageIdentifiers ? $pageIdentifiers : null;
 
 		return new GetSubjectResponseItem(
 			id: $subject->id->text,
 			label: $subject->label->text,
 			schemaName: $subject->getSchemaName()->getText(),
 			statements: $this->arrayifyStatements( $subject->getStatements() ),
-			pageId: $pageIdentifiers?->getId()->id,
-			pageTitle: $pageIdentifiers?->getTitle(),
-			pageNamespaceId: $pageIdentifiers?->getNamespaceId(),
+			pageId: $includedIdentifiers?->getId()->id,
+			pageTitle: $includedIdentifiers?->getTitle(),
+			pageNamespaceId: $includedIdentifiers?->getNamespaceId(),
 		);
 	}
 

--- a/src/Application/Queries/ValidateSubjectUpdate/ValidateSubjectUpdateQuery.php
+++ b/src/Application/Queries/ValidateSubjectUpdate/ValidateSubjectUpdateQuery.php
@@ -4,12 +4,15 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Application\Queries\ValidateSubjectUpdate;
 
+use ProfessionalWiki\NeoWiki\Application\PageIdentifiersLookup;
 use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
 use ProfessionalWiki\NeoWiki\Application\SelectStatementResolver;
 use ProfessionalWiki\NeoWiki\Application\StatementListBuilder;
 use ProfessionalWiki\NeoWiki\Application\Subject\Exception\SubjectNotFoundException;
+use ProfessionalWiki\NeoWiki\Application\SubjectReadAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\SubjectRepository;
 use ProfessionalWiki\NeoWiki\Application\Validation\SubjectValidator;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageIdentifiers;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
@@ -22,6 +25,8 @@ readonly class ValidateSubjectUpdateQuery {
 		private SubjectValidator $subjectValidator,
 		private StatementListBuilder $statementListBuilder,
 		private SelectStatementResolver $selectStatementResolver,
+		private PageIdentifiersLookup $pageIdentifiersLookup,
+		private SubjectReadAuthorizer $readAuthorizer,
 	) {
 	}
 
@@ -31,13 +36,19 @@ readonly class ValidateSubjectUpdateQuery {
 	 * @return Violation[]
 	 *
 	 * @throws \InvalidArgumentException when the subject id format is invalid.
-	 * @throws SubjectNotFoundException when the subject does not exist.
+	 * @throws SubjectNotFoundException when the subject does not exist or the caller may not read its page.
 	 */
 	public function validate( string $subjectId, string $label, array $statements ): array {
 		$id = new SubjectId( $subjectId );
 		$subject = $this->subjectRepository->getSubject( $id );
 
 		if ( $subject === null ) {
+			throw SubjectNotFoundException::forId( $id );
+		}
+
+		if ( !$this->pageIsReadable( $this->pageIdentifiersLookup->getPageIdOfSubject( $id ) ) ) {
+			// Denial is shaped exactly like absence: this endpoint previously oracled Subject
+			// existence via its 404, so denied and absent must stay indistinguishable (#1046).
 			throw SubjectNotFoundException::forId( $id );
 		}
 
@@ -60,6 +71,16 @@ readonly class ValidateSubjectUpdateQuery {
 			),
 			$schema,
 		);
+	}
+
+	/**
+	 * MediaWikiSubjectRepository::getSubject() resolves the page through the same
+	 * PageIdentifiersLookup before returning non-null, so null cannot occur here once the
+	 * absence check above has passed. Treat null as readable for uniformity with the sibling
+	 * gates (GetSubjectQuery, GetPageSubjectsQuery), which do encounter it.
+	 */
+	private function pageIsReadable( ?PageIdentifiers $pageIdentifiers ): bool {
+		return $pageIdentifiers === null || $this->readAuthorizer->authorizeRead( $pageIdentifiers->getId() );
 	}
 
 }

--- a/src/Application/Queries/ValidateSubjectUpdate/ValidateSubjectUpdateQuery.php
+++ b/src/Application/Queries/ValidateSubjectUpdate/ValidateSubjectUpdateQuery.php
@@ -12,7 +12,6 @@ use ProfessionalWiki\NeoWiki\Application\Subject\Exception\SubjectNotFoundExcept
 use ProfessionalWiki\NeoWiki\Application\SubjectReadAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\SubjectRepository;
 use ProfessionalWiki\NeoWiki\Application\Validation\SubjectValidator;
-use ProfessionalWiki\NeoWiki\Domain\Page\PageIdentifiers;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
@@ -40,15 +39,22 @@ readonly class ValidateSubjectUpdateQuery {
 	 */
 	public function validate( string $subjectId, string $label, array $statements ): array {
 		$id = new SubjectId( $subjectId );
-		$subject = $this->subjectRepository->getSubject( $id );
+		$pageIdentifiers = $this->pageIdentifiersLookup->getPageIdOfSubject( $id );
 
-		if ( $subject === null ) {
+		if ( $pageIdentifiers === null ) {
+			// No owning page in the graph means the repository cannot load the Subject either.
 			throw SubjectNotFoundException::forId( $id );
 		}
 
-		if ( !$this->pageIsReadable( $this->pageIdentifiersLookup->getPageIdOfSubject( $id ) ) ) {
+		if ( !$this->readAuthorizer->authorizeRead( $pageIdentifiers->getId() ) ) {
 			// Denial is shaped exactly like absence: this endpoint previously oracled Subject
 			// existence via its 404, so denied and absent must stay indistinguishable (#1046).
+			throw SubjectNotFoundException::forId( $id );
+		}
+
+		$subject = $this->subjectRepository->getSubject( $id );
+
+		if ( $subject === null ) {
 			throw SubjectNotFoundException::forId( $id );
 		}
 
@@ -71,16 +77,6 @@ readonly class ValidateSubjectUpdateQuery {
 			),
 			$schema,
 		);
-	}
-
-	/**
-	 * MediaWikiSubjectRepository::getSubject() resolves the page through the same
-	 * PageIdentifiersLookup before returning non-null, so null cannot occur here once the
-	 * absence check above has passed. Treat null as readable for uniformity with the sibling
-	 * gates (GetSubjectQuery, GetPageSubjectsQuery), which do encounter it.
-	 */
-	private function pageIsReadable( ?PageIdentifiers $pageIdentifiers ): bool {
-		return $pageIdentifiers === null || $this->readAuthorizer->authorizeRead( $pageIdentifiers->getId() );
 	}
 
 }

--- a/src/Application/SubjectReadAuthorizer.php
+++ b/src/Application/SubjectReadAuthorizer.php
@@ -1,0 +1,21 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ProfessionalWiki\NeoWiki\Application;
+
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+
+/**
+ * The binding per-page authorization for reading Subject data. Unlike SubjectPermissionHints this
+ * is not advisory, and unlike SubjectWriteAuthorizer it is side-effect-free apart from rate-limit
+ * accounting (no 'read' rate-limit bucket exists in a default MediaWiki install).
+ *
+ * Callers present a denial exactly like absent data (the endpoint's existing not-found shape),
+ * never as an error, so that restricted pages cannot be enumerated through these endpoints.
+ */
+interface SubjectReadAuthorizer {
+
+	public function authorizeRead( PageId $pageId ): bool;
+
+}

--- a/src/EntryPoints/Content/MappingContentHandler.php
+++ b/src/EntryPoints/Content/MappingContentHandler.php
@@ -71,6 +71,9 @@ class MappingContentHandler extends JsonContentHandler {
 			return;
 		}
 
+		// getAllMappings() runs through the per-page read gate, so a conflicting Mapping on a
+		// page the saving editor cannot read escapes this uniqueness check. Accepted: shadowed
+		// conflicts surface at projection time, and read-restricted Mapping pages are rare.
 		$conflict = ( new Mappings( $extension->getMappingLookup()->getAllMappings() ) )
 			->conflictFor( $mapping->schema, $mapping->target, $mapping->name );
 

--- a/src/EntryPoints/REST/ExportPageRdfApi.php
+++ b/src/EntryPoints/REST/ExportPageRdfApi.php
@@ -39,19 +39,32 @@ class ExportPageRdfApi extends SimpleHandler {
 			] );
 		}
 
+		$page = new PageId( $pageId );
+
+		// Denial reuses the exact no-data response so unreadable pages are indistinguishable
+		// from pages without NeoWiki data. The gate lives here rather than in RdfPageLoader
+		// because maintenance/DumpRdf.php shares the loader and must stay unfiltered.
+		if ( !$extension->newSubjectReadAuthorizer( $this->getAuthority() )->authorizeRead( $page ) ) {
+			return $this->noDataResponse( $pageId );
+		}
+
 		$format = $this->resolveFormat();
 
 		$document = $extension
 			->newRdfPageExporterForProjection( $resolution->projection )
-			->exportByPageId( new PageId( $pageId ), $format );
+			->exportByPageId( $page, $format );
 
 		if ( $document === null ) {
-			return $this->getResponseFactory()->createHttpError( 404, [
-				'message' => 'No NeoWiki data found for page: ' . $pageId,
-			] );
+			return $this->noDataResponse( $pageId );
 		}
 
 		return $this->rdfResponse( $document, $format );
+	}
+
+	private function noDataResponse( int $pageId ): Response {
+		return $this->getResponseFactory()->createHttpError( 404, [
+			'message' => 'No NeoWiki data found for page: ' . $pageId,
+		] );
 	}
 
 	private function resolveFormat(): RdfFormat {

--- a/src/EntryPoints/REST/GetPageSubjectsApi.php
+++ b/src/EntryPoints/REST/GetPageSubjectsApi.php
@@ -20,7 +20,7 @@ class GetPageSubjectsApi extends SimpleHandler {
 
 		$expandOptions = explode( '|', $this->getRequest()->getQueryParams()['expand'] ?? '' );
 
-		NeoWikiExtension::getInstance()->newGetPageSubjectsQuery( $presenter )->execute(
+		NeoWikiExtension::getInstance()->newGetPageSubjectsQuery( $presenter, $this->getAuthority() )->execute(
 			pageId: $pageId,
 			includeSchemas: in_array( self::EXPAND_SCHEMAS, $expandOptions, true ),
 			includeReferencedSubjects: in_array( self::EXPAND_RELATIONS, $expandOptions, true ),

--- a/src/EntryPoints/REST/GetSubjectApi.php
+++ b/src/EntryPoints/REST/GetSubjectApi.php
@@ -9,6 +9,7 @@ use MediaWiki\Rest\Response;
 use MediaWiki\Rest\SimpleHandler;
 use MediaWiki\Revision\RevisionRecord;
 use ProfessionalWiki\NeoWiki\Application\Queries\GetSubject\GetSubjectQuery;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Presentation\RestGetSubjectPresenter;
 use Wikimedia\ParamValidator\ParamValidator;
@@ -41,18 +42,27 @@ class GetSubjectApi extends SimpleHandler {
 
 	private function newGetSubjectQuery( RestGetSubjectPresenter $presenter, ?int $revisionId ): GetSubjectQuery|Response {
 		if ( $revisionId === null ) {
-			return NeoWikiExtension::getInstance()->newGetSubjectQuery( $presenter );
+			return NeoWikiExtension::getInstance()->newGetSubjectQuery( $presenter, $this->getAuthority() );
 		}
 
 		$revision = MediaWikiServices::getInstance()->getRevisionLookup()->getRevisionById( $revisionId );
 
-		if ( $revision === null ) {
+		// A revision on an unreadable page answers exactly like a nonexistent revision:
+		// revision ids are sequential, so any distinguishable answer is a sweepable
+		// existence oracle over restricted pages (#1046).
+		if ( $revision === null || !$this->revisionPageIsReadable( $revision->getPageId() ) ) {
 			return $this->getResponseFactory()->createHttpError( 404, [
 				'message' => 'Revision not found: ' . $revisionId,
 			] );
 		}
 
-		return NeoWikiExtension::getInstance()->newGetSubjectQueryForRevision( $presenter, $revision );
+		return NeoWikiExtension::getInstance()->newGetSubjectQueryForRevision( $presenter, $revision, $this->getAuthority() );
+	}
+
+	private function revisionPageIsReadable( int $pageId ): bool {
+		return NeoWikiExtension::getInstance()
+			->newSubjectReadAuthorizer( $this->getAuthority() )
+			->authorizeRead( new PageId( $pageId ) );
 	}
 
 	public function getParamSettings(): array {

--- a/src/EntryPoints/REST/ValidateSubjectUpdateApi.php
+++ b/src/EntryPoints/REST/ValidateSubjectUpdateApi.php
@@ -7,23 +7,19 @@ namespace ProfessionalWiki\NeoWiki\EntryPoints\REST;
 use InvalidArgumentException;
 use MediaWiki\Rest\Response;
 use MediaWiki\Rest\SimpleHandler;
-use ProfessionalWiki\NeoWiki\Application\Queries\ValidateSubjectUpdate\ValidateSubjectUpdateQuery;
 use ProfessionalWiki\NeoWiki\Application\Subject\Exception\SubjectNotFoundException;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Presentation\ViolationSerializer;
 use Wikimedia\ParamValidator\ParamValidator;
 
 class ValidateSubjectUpdateApi extends SimpleHandler {
 
-	public function __construct(
-		private readonly ValidateSubjectUpdateQuery $query,
-	) {
-	}
-
 	public function run( string $subjectId ): Response {
+		$query = NeoWikiExtension::getInstance()->newValidateSubjectUpdateQuery( $this->getAuthority() );
 		$body = $this->getValidatedBody();
 
 		try {
-			$violations = $this->query->validate(
+			$violations = $query->validate(
 				$subjectId,
 				is_string( $body['label'] ) ? $body['label'] : '',
 				$body['statements'],

--- a/src/Infrastructure/AuthorityBasedSubjectAuthorizer.php
+++ b/src/Infrastructure/AuthorityBasedSubjectAuthorizer.php
@@ -69,7 +69,7 @@ class AuthorityBasedSubjectAuthorizer implements SubjectPermissionHints, Subject
 		// authorizeRead runs the full per-title check (RIGOR_FULL), including the expensive
 		// permission hook that extension ACLs use and that the quick checks skip.
 		if ( !$this->authority->authorizeRead( 'read', $title ) ) {
-			$this->logger->info( 'NeoWiki: denied read of page {page} to {user}', [
+			$this->logger->info( 'Denied read of page {page} to {user}', [
 				'page' => $title->getPrefixedDBkey(),
 				'user' => $this->authority->getUser()->getName(),
 			] );

--- a/src/Infrastructure/AuthorityBasedSubjectAuthorizer.php
+++ b/src/Infrastructure/AuthorityBasedSubjectAuthorizer.php
@@ -8,14 +8,17 @@ use MediaWiki\Permissions\Authority;
 use MediaWiki\Title\Title;
 use MediaWiki\Title\TitleFactory;
 use ProfessionalWiki\NeoWiki\Application\SubjectPermissionHints;
+use ProfessionalWiki\NeoWiki\Application\SubjectReadAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\SubjectWriteAuthorizer;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+use Psr\Log\LoggerInterface;
 
-class AuthorityBasedSubjectAuthorizer implements SubjectPermissionHints, SubjectWriteAuthorizer {
+class AuthorityBasedSubjectAuthorizer implements SubjectPermissionHints, SubjectWriteAuthorizer, SubjectReadAuthorizer {
 
 	public function __construct(
 		private Authority $authority,
-		private TitleFactory $titleFactory
+		private TitleFactory $titleFactory,
+		private LoggerInterface $logger
 	) {
 	}
 
@@ -54,11 +57,34 @@ class AuthorityBasedSubjectAuthorizer implements SubjectPermissionHints, Subject
 		return $this->authority->authorizeWrite( 'edit', $title );
 	}
 
+	public function authorizeRead( PageId $pageId ): bool {
+		$title = $this->newTitle( $pageId );
+
+		if ( $title === null ) {
+			// Unlike writes, reads have no global-right fallback: content is only reachable
+			// through a resolved page, so an unresolvable one has nothing to authorize.
+			return false;
+		}
+
+		// authorizeRead runs the full per-title check (RIGOR_FULL), including the expensive
+		// permission hook that extension ACLs use and that the quick checks skip.
+		if ( !$this->authority->authorizeRead( 'read', $title ) ) {
+			$this->logger->info( 'NeoWiki: denied read of page {page} to {user}', [
+				'page' => $title->getPrefixedDBkey(),
+				'user' => $this->authority->getUser()->getName(),
+			] );
+			return false;
+		}
+
+		return true;
+	}
+
 	/**
 	 * Null when there is no page, or when the page could not be resolved (for instance because the
-	 * Subject is not indexed). Callers then fall back to the wiki-global edit right, so that
-	 * authorization never fails open. Such writes are a no-op, so page protection cannot be
-	 * bypassed by suppressing the page.
+	 * Subject is not indexed). The write-side callers then fall back to the wiki-global edit
+	 * right, so that authorization never fails open; such writes are a no-op, so page protection
+	 * cannot be bypassed by suppressing the page. authorizeRead has no such fallback: content is
+	 * only reachable through a resolved page, so an unresolvable one denies.
 	 */
 	private function newTitle( ?PageId $pageId ): ?Title {
 		return $pageId === null ? null : $this->titleFactory->newFromID( $pageId->id );

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -804,7 +804,9 @@ class NeoWikiExtension {
 	public function getSchemaNameLookup(): SchemaNameLookup {
 		return new DatabaseSchemaNameLookup(
 			db: $this->getDbConnection(),
-			searchEngine: MediaWikiServices::getInstance()->newSearchEngine()
+			searchEngine: MediaWikiServices::getInstance()->newSearchEngine(),
+			authority: $this->getRequestAuthority(),
+			titleFactory: MediaWikiServices::getInstance()->getTitleFactory(),
 		);
 	}
 

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -56,6 +56,7 @@ use ProfessionalWiki\NeoWiki\Application\SubjectLabelLookup;
 use ProfessionalWiki\NeoWiki\Application\NullSubjectLabelLookup;
 use ProfessionalWiki\NeoWiki\Application\LayoutLookup;
 use ProfessionalWiki\NeoWiki\Application\SubjectPermissionHints;
+use ProfessionalWiki\NeoWiki\Application\SubjectReadAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\SubjectWriteAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\SubjectPageRebuilder;
 use ProfessionalWiki\NeoWiki\Application\SubjectRepository;
@@ -734,10 +735,15 @@ class NeoWikiExtension {
 		return $this->newAuthorityBasedSubjectAuthorizer( $authority );
 	}
 
+	public function newSubjectReadAuthorizer( Authority $authority ): SubjectReadAuthorizer {
+		return $this->newAuthorityBasedSubjectAuthorizer( $authority );
+	}
+
 	private function newAuthorityBasedSubjectAuthorizer( Authority $authority ): AuthorityBasedSubjectAuthorizer {
 		return new AuthorityBasedSubjectAuthorizer(
 			authority: $authority,
-			titleFactory: MediaWikiServices::getInstance()->getTitleFactory()
+			titleFactory: MediaWikiServices::getInstance()->getTitleFactory(),
+			logger: LoggerFactory::getInstance( 'NeoWiki' ),
 		);
 	}
 

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -841,15 +841,16 @@ class NeoWikiExtension {
 		);
 	}
 
-	public function newGetSubjectQuery( RestGetSubjectPresenter $presenter ): GetSubjectQuery {
+	public function newGetSubjectQuery( RestGetSubjectPresenter $presenter, Authority $authority ): GetSubjectQuery {
 		return new GetSubjectQuery(
 			presenter: $presenter,
 			subjectLookup: $this->getSubjectRepository(),
 			pageIdentifiersLookup: $this->getPageIdentifiersLookup(),
+			readAuthorizer: $this->newSubjectReadAuthorizer( $authority ),
 		);
 	}
 
-	public function newGetSubjectQueryForRevision( RestGetSubjectPresenter $presenter, RevisionRecord $revision ): GetSubjectQuery {
+	public function newGetSubjectQueryForRevision( RestGetSubjectPresenter $presenter, RevisionRecord $revision, Authority $authority ): GetSubjectQuery {
 		return new GetSubjectQuery(
 			presenter: $presenter,
 			subjectLookup: new PointInTimeSubjectLookup(
@@ -859,6 +860,7 @@ class NeoWikiExtension {
 				primaryRevision: $revision,
 			),
 			pageIdentifiersLookup: $this->getPageIdentifiersLookup(),
+			readAuthorizer: $this->newSubjectReadAuthorizer( $authority ),
 		);
 	}
 

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -791,7 +791,9 @@ class NeoWikiExtension {
 		return new WikiPageLayoutLookup(
 			pageContentFetcher: $this->getPageContentFetcher(),
 			authority: $this->getRequestAuthority(),
-			layoutDeserializer: $this->getLayoutPersistenceDeserializer()
+			layoutDeserializer: $this->getLayoutPersistenceDeserializer(),
+			titleFactory: MediaWikiServices::getInstance()->getTitleFactory(),
+			logger: LoggerFactory::getInstance( 'NeoWiki' )
 		);
 	}
 

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -829,7 +829,7 @@ class NeoWikiExtension {
 		return $db;
 	}
 
-	public function newGetPageSubjectsQuery( GetPageSubjectsPresenter $presenter ): GetPageSubjectsQuery {
+	public function newGetPageSubjectsQuery( GetPageSubjectsPresenter $presenter, Authority $authority ): GetPageSubjectsQuery {
 		return new GetPageSubjectsQuery(
 			presenter: $presenter,
 			subjectRepository: $this->getSubjectRepository(),
@@ -837,6 +837,7 @@ class NeoWikiExtension {
 			schemaLookup: $this->getSchemaLookup(),
 			schemaSerializer: $this->getSchemaPresentationSerializer(),
 			pageIdentifiersLookup: $this->getPageIdentifiersLookup(),
+			readAuthorizer: $this->newSubjectReadAuthorizer( $authority ),
 		);
 	}
 

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -415,6 +415,7 @@ class NeoWikiExtension {
 			titleFactory: MediaWikiServices::getInstance()->getTitleFactory(),
 			authority: $this->getRequestAuthority(),
 			connectionProvider: MediaWikiServices::getInstance()->getConnectionProvider(),
+			logger: LoggerFactory::getInstance( 'NeoWiki' ),
 		);
 	}
 
@@ -773,7 +774,8 @@ class NeoWikiExtension {
 			cache: MediaWikiServices::getInstance()->getMainWANObjectCache(),
 			titleFactory: MediaWikiServices::getInstance()->getTitleFactory(),
 			authority: $this->getRequestAuthority(),
-			connectionProvider: MediaWikiServices::getInstance()->getConnectionProvider()
+			connectionProvider: MediaWikiServices::getInstance()->getConnectionProvider(),
+			logger: LoggerFactory::getInstance( 'NeoWiki' ),
 		);
 	}
 

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -907,13 +907,15 @@ class NeoWikiExtension {
 		);
 	}
 
-	public function newValidateSubjectUpdateQuery(): ValidateSubjectUpdateQuery {
+	public function newValidateSubjectUpdateQuery( Authority $authority ): ValidateSubjectUpdateQuery {
 		return new ValidateSubjectUpdateQuery(
 			subjectRepository: $this->getSubjectRepository(),
 			schemaLookup: $this->getSchemaLookup(),
 			subjectValidator: $this->getSubjectValidator(),
 			statementListBuilder: $this->getStatementListBuilder(),
 			selectStatementResolver: $this->getSelectStatementResolver(),
+			pageIdentifiersLookup: $this->getPageIdentifiersLookup(),
+			readAuthorizer: $this->newSubjectReadAuthorizer( $authority ),
 		);
 	}
 
@@ -924,9 +926,7 @@ class NeoWikiExtension {
 	}
 
 	public static function newValidateSubjectUpdateApi(): ValidateSubjectUpdateApi {
-		return new ValidateSubjectUpdateApi(
-			query: self::getInstance()->newValidateSubjectUpdateQuery(),
-		);
+		return new ValidateSubjectUpdateApi();
 	}
 
 	public static function newCreateMainSubjectApi(): CreateSubjectApi {

--- a/src/Persistence/MediaWiki/CachingMappingLookup.php
+++ b/src/Persistence/MediaWiki/CachingMappingLookup.php
@@ -12,6 +12,7 @@ use ProfessionalWiki\NeoWiki\Domain\Mapping\Mapping;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\MappingName;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Persistence\MappingNameLookup;
+use Psr\Log\LoggerInterface;
 use Wikimedia\ObjectCache\WANObjectCache;
 use Wikimedia\Rdbms\Database;
 use Wikimedia\Rdbms\IConnectionProvider;
@@ -33,6 +34,7 @@ class CachingMappingLookup implements MappingLookup {
 		private readonly TitleFactory $titleFactory,
 		private readonly Authority $authority,
 		private readonly IConnectionProvider $connectionProvider,
+		private readonly LoggerInterface $logger,
 	) {
 	}
 
@@ -43,9 +45,15 @@ class CachingMappingLookup implements MappingLookup {
 			return null;
 		}
 
-		// Repeat the inner lookup's per-user read check before the cache, so a cache hit cannot serve a
-		// Mapping to a user who may not read its page.
-		if ( !$this->authority->probablyCan( 'read', $title ) ) {
+		// The inner lookup applies no per-title read check (its revision audience check filters
+		// revision deletion only), so this is the sole read gate on the Mapping read path. It
+		// must also run before the cache: the cached value is user-independent mapping content,
+		// and a cache hit must not serve a Mapping whose page the user may not read (#1046).
+		if ( !$this->authority->authorizeRead( 'read', $title ) ) {
+			$this->logger->info( 'NeoWiki: denied read of page {page} to {user}', [
+				'page' => $title->getPrefixedDBkey(),
+				'user' => $this->authority->getUser()->getName(),
+			] );
 			return null;
 		}
 

--- a/src/Persistence/MediaWiki/CachingMappingLookup.php
+++ b/src/Persistence/MediaWiki/CachingMappingLookup.php
@@ -50,7 +50,7 @@ class CachingMappingLookup implements MappingLookup {
 		// must also run before the cache: the cached value is user-independent mapping content,
 		// and a cache hit must not serve a Mapping whose page the user may not read (#1046).
 		if ( !$this->authority->authorizeRead( 'read', $title ) ) {
-			$this->logger->info( 'NeoWiki: denied read of page {page} to {user}', [
+			$this->logger->info( 'Denied read of page {page} to {user}', [
 				'page' => $title->getPrefixedDBkey(),
 				'user' => $this->authority->getUser()->getName(),
 			] );

--- a/src/Persistence/MediaWiki/CachingSchemaLookup.php
+++ b/src/Persistence/MediaWiki/CachingSchemaLookup.php
@@ -11,6 +11,7 @@ use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+use Psr\Log\LoggerInterface;
 use Wikimedia\ObjectCache\WANObjectCache;
 use Wikimedia\Rdbms\Database;
 use Wikimedia\Rdbms\IConnectionProvider;
@@ -31,6 +32,7 @@ class CachingSchemaLookup implements SchemaLookup {
 		private readonly TitleFactory $titleFactory,
 		private readonly Authority $authority,
 		private readonly IConnectionProvider $connectionProvider,
+		private readonly LoggerInterface $logger,
 	) {
 	}
 
@@ -41,11 +43,15 @@ class CachingSchemaLookup implements SchemaLookup {
 			return null;
 		}
 
-		// The cached value is user-independent schema content; the inner lookup
-		// also applies a per-user read check while loading. Repeat it here,
-		// before the cache, so a cache hit cannot serve a Schema to a user who
-		// may not read its page.
-		if ( !$this->authority->probablyCan( 'read', $title ) ) {
+		// The inner lookup applies no per-title read check (its revision audience check filters
+		// revision deletion only), so this is the sole read gate on the Schema read path. It
+		// must also run before the cache: the cached value is user-independent schema content,
+		// and a cache hit must not serve a Schema whose page the user may not read (#1046).
+		if ( !$this->authority->authorizeRead( 'read', $title ) ) {
+			$this->logger->info( 'NeoWiki: denied read of page {page} to {user}', [
+				'page' => $title->getPrefixedDBkey(),
+				'user' => $this->authority->getUser()->getName(),
+			] );
 			return null;
 		}
 

--- a/src/Persistence/MediaWiki/CachingSchemaLookup.php
+++ b/src/Persistence/MediaWiki/CachingSchemaLookup.php
@@ -48,7 +48,7 @@ class CachingSchemaLookup implements SchemaLookup {
 		// must also run before the cache: the cached value is user-independent schema content,
 		// and a cache hit must not serve a Schema whose page the user may not read (#1046).
 		if ( !$this->authority->authorizeRead( 'read', $title ) ) {
-			$this->logger->info( 'NeoWiki: denied read of page {page} to {user}', [
+			$this->logger->info( 'Denied read of page {page} to {user}', [
 				'page' => $title->getPrefixedDBkey(),
 				'user' => $this->authority->getUser()->getName(),
 			] );

--- a/src/Persistence/MediaWiki/DatabaseSchemaNameLookup.php
+++ b/src/Persistence/MediaWiki/DatabaseSchemaNameLookup.php
@@ -2,6 +2,8 @@
 
 namespace ProfessionalWiki\NeoWiki\Persistence\MediaWiki;
 
+use MediaWiki\Permissions\Authority;
+use MediaWiki\Title\TitleFactory;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Persistence\SchemaNameLookup;
 use RuntimeException;
@@ -16,7 +18,9 @@ class DatabaseSchemaNameLookup implements SchemaNameLookup {
 
 	public function __construct(
 		private readonly IDatabase $db,
-		private readonly SearchEngine $searchEngine
+		private readonly SearchEngine $searchEngine,
+		private readonly Authority $authority,
+		private readonly TitleFactory $titleFactory,
 	) {
 	}
 
@@ -25,10 +29,28 @@ class DatabaseSchemaNameLookup implements SchemaNameLookup {
 	 */
 	public function getSchemaNamesMatching( string $search, int $limit, int $offset = 0 ): array {
 		if ( trim( $search ) === '' ) {
-			return $this->getFirstSchemaNames( $limit, $offset );
+			return $this->filterReadable( $this->getFirstSchemaNames( $limit, $offset ) );
 		}
 
-		return $this->searchSuggestionsToTitleArray( $this->getSearchSuggestions( $search, $limit, $offset ) );
+		return $this->filterReadable(
+			$this->searchSuggestionsToTitleArray( $this->getSearchSuggestions( $search, $limit, $offset ) )
+		);
+	}
+
+	/**
+	 * The search engine applies its own visibility rules inconsistently across engines, and the
+	 * raw DB branch applies none, so both branches share this binding per-title read filter.
+	 * Filtered names are simply absent, like Schemas that do not exist (#1046).
+	 *
+	 * @param TitleValue[] $titles
+	 * @return TitleValue[]
+	 */
+	private function filterReadable( array $titles ): array {
+		return array_values( array_filter(
+			$titles,
+			fn ( TitleValue $titleValue ): bool =>
+				$this->authority->authorizeRead( 'read', $this->titleFactory->newFromLinkTarget( $titleValue ) )
+		) );
 	}
 
 	public function getSchemaCount(): int {

--- a/src/Persistence/MediaWiki/DatabaseSchemaNameLookup.php
+++ b/src/Persistence/MediaWiki/DatabaseSchemaNameLookup.php
@@ -40,7 +40,9 @@ class DatabaseSchemaNameLookup implements SchemaNameLookup {
 	/**
 	 * The search engine applies its own visibility rules inconsistently across engines, and the
 	 * raw DB branch applies none, so both branches share this binding per-title read filter.
-	 * Filtered names are simply absent, like Schemas that do not exist (#1046).
+	 * Filtered names are simply absent, like Schemas that do not exist (#1046). Filtering here
+	 * deliberately does not log per-name denials: enumeration filtering would log proportionally
+	 * to list size, unlike the single-page content gates.
 	 *
 	 * @param TitleValue[] $titles
 	 * @return TitleValue[]

--- a/src/Persistence/MediaWiki/WikiPageLayoutLookup.php
+++ b/src/Persistence/MediaWiki/WikiPageLayoutLookup.php
@@ -6,11 +6,14 @@ namespace ProfessionalWiki\NeoWiki\Persistence\MediaWiki;
 
 use InvalidArgumentException;
 use MediaWiki\Permissions\Authority;
+use MediaWiki\Title\Title;
+use MediaWiki\Title\TitleFactory;
 use ProfessionalWiki\NeoWiki\Application\LayoutLookup;
 use ProfessionalWiki\NeoWiki\Domain\Layout\Layout;
 use ProfessionalWiki\NeoWiki\Domain\Layout\LayoutName;
 use ProfessionalWiki\NeoWiki\EntryPoints\Content\LayoutContent;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+use Psr\Log\LoggerInterface;
 
 class WikiPageLayoutLookup implements LayoutLookup {
 
@@ -18,11 +21,30 @@ class WikiPageLayoutLookup implements LayoutLookup {
 		private readonly PageContentFetcher $pageContentFetcher,
 		private readonly Authority $authority,
 		private readonly LayoutPersistenceDeserializer $layoutDeserializer,
+		private readonly TitleFactory $titleFactory,
+		private readonly LoggerInterface $logger,
 	) {
 	}
 
 	public function getLayout( LayoutName $layoutName ): ?Layout {
-		$content = $this->getContent( $layoutName );
+		$title = $this->titleFactory->newFromText( $layoutName->getText(), NeoWikiExtension::NS_LAYOUT );
+
+		if ( $title === null || !$title->exists() ) {
+			return null;
+		}
+
+		// The audience check inside the content fetcher filters revision deletion only; this
+		// is the sole per-title read gate on the Layout read path. Denial is null, the same
+		// as an absent Layout (#1046).
+		if ( !$this->authority->authorizeRead( 'read', $title ) ) {
+			$this->logger->info( 'NeoWiki: denied read of page {page} to {user}', [
+				'page' => $title->getPrefixedDBkey(),
+				'user' => $this->authority->getUser()->getName(),
+			] );
+			return null;
+		}
+
+		$content = $this->getContent( $title );
 
 		if ( $content === null ) {
 			return null;
@@ -36,9 +58,9 @@ class WikiPageLayoutLookup implements LayoutLookup {
 		}
 	}
 
-	private function getContent( LayoutName $layoutName ): ?LayoutContent {
+	private function getContent( Title $title ): ?LayoutContent {
 		$content = $this->pageContentFetcher->getPageContent(
-			$layoutName->getText(),
+			$title,
 			$this->authority,
 			NeoWikiExtension::NS_LAYOUT
 		);

--- a/src/Persistence/MediaWiki/WikiPageLayoutLookup.php
+++ b/src/Persistence/MediaWiki/WikiPageLayoutLookup.php
@@ -37,7 +37,7 @@ class WikiPageLayoutLookup implements LayoutLookup {
 		// is the sole per-title read gate on the Layout read path. Denial is null, the same
 		// as an absent Layout (#1046).
 		if ( !$this->authority->authorizeRead( 'read', $title ) ) {
-			$this->logger->info( 'NeoWiki: denied read of page {page} to {user}', [
+			$this->logger->info( 'Denied read of page {page} to {user}', [
 				'page' => $title->getPrefixedDBkey(),
 				'user' => $this->authority->getUser()->getName(),
 			] );

--- a/tests/phpunit/Application/Queries/GetPageSubjects/GetPageSubjectsQueryTest.php
+++ b/tests/phpunit/Application/Queries/GetPageSubjects/GetPageSubjectsQueryTest.php
@@ -12,6 +12,7 @@ use ProfessionalWiki\NeoWiki\Application\PageIdentifiersLookup;
 use ProfessionalWiki\NeoWiki\Application\Queries\GetSubject\GetSubjectResponseItem;
 use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
 use ProfessionalWiki\NeoWiki\Application\SubjectLookup;
+use ProfessionalWiki\NeoWiki\Application\SubjectReadAuthorizer;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageIdentifiers;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
@@ -355,6 +356,11 @@ class GetPageSubjectsQueryTest extends TestCase {
 			schemaLookup: $schemaLookup ?? new InMemorySchemaLookup(),
 			schemaSerializer: new SchemaPresentationSerializer(),
 			pageIdentifiersLookup: $pageIdentifiersLookup ?? new InMemoryPageIdentifiersLookup(),
+			readAuthorizer: new class implements SubjectReadAuthorizer {
+				public function authorizeRead( PageId $pageId ): bool {
+					return true;
+				}
+			},
 		);
 	}
 

--- a/tests/phpunit/Application/Queries/GetPageSubjects/GetPageSubjectsQueryTest.php
+++ b/tests/phpunit/Application/Queries/GetPageSubjects/GetPageSubjectsQueryTest.php
@@ -212,10 +212,16 @@ class GetPageSubjectsQueryTest extends TestCase {
 
 		$referenced = TestSubject::build( id: 's11111111111tar', label: new SubjectLabel( 'target subject' ) );
 		$subjectLookup = new InMemorySubjectLookup( $referenced );
+		// The gate omits referenced Subjects whose page does not resolve, so the lookup must
+		// honor the production invariant: a returned Subject always has a resolvable page.
+		$pageIdentifiersLookup = new InMemoryPageIdentifiersLookup( [
+			[ $referenced->id, new PageIdentifiers( new PageId( 137 ), 'Target Page', 0 ) ],
+		] );
 
 		$presenter = $this->newSpyPresenter();
 
-		$this->newQuery( $presenter, $repository, subjectLookup: $subjectLookup )->execute( 42, includeReferencedSubjects: true );
+		$this->newQuery( $presenter, $repository, subjectLookup: $subjectLookup, pageIdentifiersLookup: $pageIdentifiersLookup )
+			->execute( 42, includeReferencedSubjects: true );
 
 		$this->assertNotNull( $presenter->response->referencedSubjects );
 		$this->assertArrayHasKey( 's11111111111tar', $presenter->response->referencedSubjects );
@@ -284,13 +290,16 @@ class GetPageSubjectsQueryTest extends TestCase {
 			new PageId( 42 )
 		);
 
-		$subjectLookup = new InMemorySubjectLookup(
-			TestSubject::build( id: 's11111111111tar', label: new SubjectLabel( 'shared target' ) )
-		);
+		$referenced = TestSubject::build( id: 's11111111111tar', label: new SubjectLabel( 'shared target' ) );
+		$subjectLookup = new InMemorySubjectLookup( $referenced );
+		$pageIdentifiersLookup = new InMemoryPageIdentifiersLookup( [
+			[ $referenced->id, new PageIdentifiers( new PageId( 137 ), 'Target Page', 0 ) ],
+		] );
 
 		$presenter = $this->newSpyPresenter();
 
-		$this->newQuery( $presenter, $repository, subjectLookup: $subjectLookup )->execute( 42, includeReferencedSubjects: true );
+		$this->newQuery( $presenter, $repository, subjectLookup: $subjectLookup, pageIdentifiersLookup: $pageIdentifiersLookup )
+			->execute( 42, includeReferencedSubjects: true );
 
 		$this->assertSame(
 			[ 's11111111111tar' ],

--- a/tests/phpunit/Application/Queries/GetSubject/GetSubjectQueryTest.php
+++ b/tests/phpunit/Application/Queries/GetSubject/GetSubjectQueryTest.php
@@ -9,6 +9,7 @@ use ProfessionalWiki\NeoWiki\Application\Queries\GetSubject\GetSubjectPresenter;
 use ProfessionalWiki\NeoWiki\Application\Queries\GetSubject\GetSubjectQuery;
 use ProfessionalWiki\NeoWiki\Application\Queries\GetSubject\GetSubjectResponse;
 use ProfessionalWiki\NeoWiki\Application\Queries\GetSubject\GetSubjectResponseItem;
+use ProfessionalWiki\NeoWiki\Application\SubjectReadAuthorizer;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageIdentifiers;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
@@ -56,6 +57,7 @@ class GetSubjectQueryTest extends TestCase {
 				),
 			),
 			new InMemoryPageIdentifiersLookup(),
+			$this->newAllowAllReadAuthorizer(),
 		);
 
 		$query->execute(
@@ -128,6 +130,7 @@ class GetSubjectQueryTest extends TestCase {
 			$spyPresenter,
 			new InMemorySubjectLookup(),
 			new InMemoryPageIdentifiersLookup(),
+			$this->newAllowAllReadAuthorizer(),
 		);
 
 		$query->execute(
@@ -150,6 +153,7 @@ class GetSubjectQueryTest extends TestCase {
 				[ new SubjectId( TestSubject::ZERO_GUID ), new PageIdentifiers( new PageId( 1 ), 'wrong title', 0 ) ],
 				[ $subject->id, new PageIdentifiers( new PageId( 42 ), 'right title', 12 ) ],
 			] ),
+			$this->newAllowAllReadAuthorizer(),
 		);
 
 		$query->execute(
@@ -198,6 +202,7 @@ class GetSubjectQueryTest extends TestCase {
 				[ $subject->id, new PageIdentifiers( new PageId( 42 ), 'subject title', 0 ) ],
 				[ $referencedSubject->id, new PageIdentifiers( new PageId( 1337 ), 'referenced title', 12 ) ],
 			] ),
+			$this->newAllowAllReadAuthorizer(),
 		);
 
 		$query->execute(
@@ -214,6 +219,14 @@ class GetSubjectQueryTest extends TestCase {
 		$this->assertSame( 1337, $response->subjects[$referencedSubject->id->text]->pageId );
 		$this->assertSame( 'referenced title', $response->subjects[$referencedSubject->id->text]->pageTitle );
 		$this->assertSame( 12, $response->subjects[$referencedSubject->id->text]->pageNamespaceId );
+	}
+
+	private function newAllowAllReadAuthorizer(): SubjectReadAuthorizer {
+		return new class implements SubjectReadAuthorizer {
+			public function authorizeRead( PageId $pageId ): bool {
+				return true;
+			}
+		};
 	}
 
 }

--- a/tests/phpunit/EntryPoints/REST/ExportPageRdfApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ExportPageRdfApiTest.php
@@ -4,12 +4,10 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\REST;
 
-use MediaWiki\Page\PageIdentity;
 use MediaWiki\Permissions\Authority;
 use MediaWiki\Rest\RequestData;
 use MediaWiki\Rest\Response;
 use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
-use MediaWiki\Tests\Unit\Permissions\MockAuthorityTrait;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
@@ -18,6 +16,7 @@ use ProfessionalWiki\NeoWiki\Tests\Data\TestStatement;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
 use ProfessionalWiki\NeoWiki\Tests\Domain\Rdf\ParsedRdf;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiMockAuthorityTrait;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\EntryPoints\REST\ExportPageRdfApi
@@ -25,7 +24,7 @@ use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
  */
 class ExportPageRdfApiTest extends NeoWikiIntegrationTestCase {
 	use HandlerTestTrait;
-	use MockAuthorityTrait;
+	use NeoWikiMockAuthorityTrait;
 
 	private const string SCHEMA = 'ExportPageRdfApiTestSchema';
 	private const string SUBJECT_ID = 'sTestERA1111111';
@@ -182,13 +181,6 @@ JSON
 		);
 
 		$this->assertSame( 400, $response->getStatusCode() );
-	}
-
-	private function authorityWithGlobalReadButNoPageRead(): Authority {
-		$canReadGloballyButNotPerPage = static fn ( string $permission, ?PageIdentity $page = null ): bool =>
-			$permission === 'read' && $page === null;
-
-		return $this->mockRegisteredAuthority( $canReadGloballyButNotPerPage );
 	}
 
 	public function testProjectionNativeIsTheDefaultAndUnchanged(): void {

--- a/tests/phpunit/EntryPoints/REST/ExportPageRdfApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ExportPageRdfApiTest.php
@@ -4,9 +4,12 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\REST;
 
+use MediaWiki\Page\PageIdentity;
+use MediaWiki\Permissions\Authority;
 use MediaWiki\Rest\RequestData;
 use MediaWiki\Rest\Response;
 use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
+use MediaWiki\Tests\Unit\Permissions\MockAuthorityTrait;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
@@ -22,6 +25,7 @@ use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
  */
 class ExportPageRdfApiTest extends NeoWikiIntegrationTestCase {
 	use HandlerTestTrait;
+	use MockAuthorityTrait;
 
 	private const string SCHEMA = 'ExportPageRdfApiTestSchema';
 	private const string SUBJECT_ID = 'sTestERA1111111';
@@ -60,7 +64,7 @@ JSON
 	 * @param array<string, string> $query
 	 * @param array<string, string> $headers
 	 */
-	private function export( array $query = [], array $headers = [], ?int $pageId = null ): Response {
+	private function export( array $query = [], array $headers = [], ?int $pageId = null, ?Authority $authority = null ): Response {
 		return $this->executeHandler(
 			new ExportPageRdfApi(),
 			new RequestData( [
@@ -68,7 +72,8 @@ JSON
 				'pathParams' => [ 'pageId' => (string)( $pageId ?? $this->pageId ) ],
 				'queryParams' => $query,
 				'headers' => $headers,
-			] )
+			] ),
+			authority: $authority
 		);
 	}
 
@@ -126,6 +131,64 @@ JSON
 		$response = $this->export( pageId: $plainPage['id'] );
 
 		$this->assertSame( 404, $response->getStatusCode() );
+	}
+
+	public function testAbsentAndDeniedPagesProduceByteIdenticalResponses(): void {
+		$plainPage = $this->insertPage( 'ExportPageRdfApiTest_PlainForByteIdentity', 'Just wikitext, no NeoWiki subjects.' );
+
+		$absentResponse = $this->export( pageId: $plainPage['id'] );
+		$deniedResponse = $this->export(
+			pageId: $plainPage['id'],
+			authority: $this->authorityWithGlobalReadButNoPageRead()
+		);
+
+		$this->assertSame( $absentResponse->getStatusCode(), $deniedResponse->getStatusCode() );
+		$this->assertSame(
+			$absentResponse->getBody()->getContents(),
+			$deniedResponse->getBody()->getContents()
+		);
+		$this->assertSame(
+			$absentResponse->getHeaderLine( 'Content-Type' ),
+			$deniedResponse->getHeaderLine( 'Content-Type' )
+		);
+	}
+
+	public function testUnreadablePageIsIndistinguishableFromAPageWithoutData(): void {
+		$response = $this->export( authority: $this->authorityWithGlobalReadButNoPageRead() );
+
+		$this->assertSame( 404, $response->getStatusCode() );
+		$this->assertStringContainsString(
+			'No NeoWiki data found for page: ' . $this->pageId,
+			$response->getBody()->getContents()
+		);
+	}
+
+	public function testPageReadableByANonUltimateAuthorityIsExported(): void {
+		$response = $this->export(
+			authority: $this->mockRegisteredAuthority(
+				static fn ( string $permission ): bool => $permission === 'read'
+			)
+		);
+
+		$this->assertSame( 200, $response->getStatusCode() );
+	}
+
+	public function testUnknownProjectionStillReturns400ForAnUnreadablePage(): void {
+		// The projection check runs before the read gate, so a denied caller sees the same
+		// 400 as anyone else and cannot use it to probe page readability.
+		$response = $this->export(
+			query: [ 'projection' => 'no-such-projection' ],
+			authority: $this->authorityWithGlobalReadButNoPageRead()
+		);
+
+		$this->assertSame( 400, $response->getStatusCode() );
+	}
+
+	private function authorityWithGlobalReadButNoPageRead(): Authority {
+		$canReadGloballyButNotPerPage = static fn ( string $permission, ?PageIdentity $page = null ): bool =>
+			$permission === 'read' && $page === null;
+
+		return $this->mockRegisteredAuthority( $canReadGloballyButNotPerPage );
 	}
 
 	public function testProjectionNativeIsTheDefaultAndUnchanged(): void {

--- a/tests/phpunit/EntryPoints/REST/GetPageSubjectsApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/GetPageSubjectsApiTest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\REST;
 
+use MediaWiki\Page\PageIdentity;
 use MediaWiki\Rest\RequestData;
 use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
@@ -11,9 +12,11 @@ use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectMap;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\GetPageSubjectsApi;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestRelation;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestStatement;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiMockAuthorityTrait;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\EntryPoints\REST\GetPageSubjectsApi
@@ -23,6 +26,7 @@ use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
  */
 class GetPageSubjectsApiTest extends NeoWikiIntegrationTestCase {
 	use HandlerTestTrait;
+	use NeoWikiMockAuthorityTrait;
 
 	public function setUp(): void {
 		$this->setUpNeo4j();
@@ -134,7 +138,7 @@ JSON
 				schemaName: new SchemaName( 'GetPageSubjectsApiTestRelationSchema' ),
 				statements: new StatementList( [
 					TestStatement::buildRelation( 'partner', [
-						\ProfessionalWiki\NeoWiki\Tests\Data\TestRelation::build(
+						TestRelation::build(
 							id: 'rTestGPS1111aa2',
 							targetId: 'sTestGPS1111aa1',
 						),
@@ -197,6 +201,96 @@ JSON
 
 		$this->assertNull( $body['mainSubjectId'] );
 		$this->assertSame( [ 'sTestGPS1111121' ], array_keys( $body['subjects'] ) );
+	}
+
+	public function testSubjectsOnAnUnreadablePageAreAbsent(): void {
+		$restrictedPageId = $this->createPageWithSubjects(
+			'GetPageSubjectsApiTest_Restricted',
+			mainSubject: TestSubject::build( id: 'sTestGPS1111141' )
+		)->getPage()->getId();
+
+		$emptyPageId = $this->insertPage(
+			'GetPageSubjectsApiTest_NoSubjects',
+			'Just wikitext, no NeoWiki subjects.'
+		)['id'];
+
+		$denied = json_decode( $this->executeHandler(
+			new GetPageSubjectsApi(),
+			new RequestData( [
+				'method' => 'GET',
+				'pathParams' => [ 'pageId' => (string)$restrictedPageId ],
+				'queryParams' => [ 'expand' => 'schemas|relations' ],
+			] ),
+			authority: $this->authorityWithGlobalReadButNoPageRead()
+		)->getBody()->getContents(), true );
+
+		$empty = json_decode( $this->executeHandler(
+			new GetPageSubjectsApi(),
+			new RequestData( [
+				'method' => 'GET',
+				'pathParams' => [ 'pageId' => (string)$emptyPageId ],
+				'queryParams' => [ 'expand' => 'schemas|relations' ],
+			] )
+		)->getBody()->getContents(), true );
+
+		// Only the echoed page id may differ between "denied" and "has no Subjects".
+		$empty['pageId'] = $restrictedPageId;
+		$this->assertSame( $empty, $denied );
+	}
+
+	public function testReferencedSubjectOnAnUnreadablePageIsOmitted(): void {
+		$this->createSchema(
+			'GetPageSubjectsApiTestRelationSchema2',
+			<<<JSON
+{
+	"title": "GetPageSubjectsApiTestRelationSchema2",
+	"propertyDefinitions": {
+		"MyRelation": {
+			"type": "relation",
+			"relation": "MyRelation",
+			"targetSchema": "GetPageSubjectsApiTestSchema"
+		}
+	}
+}
+JSON
+		);
+
+		$this->createPageWithSubjects(
+			'GetPageSubjectsApiTest_RestrictedTarget',
+			mainSubject: TestSubject::build(
+				id: 'sTestGPS1111151',
+				schemaName: new SchemaName( 'GetPageSubjectsApiTestSchema' ),
+			)
+		);
+
+		$sourcePageId = $this->createPageWithSubjects(
+			'GetPageSubjectsApiTest_Source',
+			mainSubject: TestSubject::build(
+				id: 'sTestGPS1111152',
+				schemaName: new SchemaName( 'GetPageSubjectsApiTestRelationSchema2' ),
+				statements: new StatementList( [
+					TestStatement::buildRelation( 'MyRelation', [
+						TestRelation::build( id: 'rTestGPS1111152', targetId: 'sTestGPS1111151' ),
+					] ),
+				] )
+			)
+		)->getPage()->getId();
+
+		$denyTargetPage = static fn ( string $permission, ?PageIdentity $page = null ): bool =>
+			$page === null || $page->getDBkey() !== 'GetPageSubjectsApiTest_RestrictedTarget';
+
+		$body = json_decode( $this->executeHandler(
+			new GetPageSubjectsApi(),
+			new RequestData( [
+				'method' => 'GET',
+				'pathParams' => [ 'pageId' => (string)$sourcePageId ],
+				'queryParams' => [ 'expand' => 'relations' ],
+			] ),
+			authority: $this->mockRegisteredAuthority( $denyTargetPage )
+		)->getBody()->getContents(), true );
+
+		$this->assertArrayHasKey( 'sTestGPS1111152', $body['subjects'] );
+		$this->assertSame( [], $body['referencedSubjects'] );
 	}
 
 }

--- a/tests/phpunit/EntryPoints/REST/GetSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/GetSubjectApiTest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\REST;
 
+use MediaWiki\Page\PageIdentity;
 use MediaWiki\Rest\RequestData;
 use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
@@ -15,14 +16,17 @@ use ProfessionalWiki\NeoWiki\Tests\Data\TestRelation;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestStatement;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiMockAuthorityTrait;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\EntryPoints\REST\GetSubjectApi
  * @covers \ProfessionalWiki\NeoWiki\Presentation\RestGetSubjectPresenter
+ * @covers \ProfessionalWiki\NeoWiki\Application\Queries\GetSubject\GetSubjectQuery
  * @group Database
  */
 class GetSubjectApiTest extends NeoWikiIntegrationTestCase {
 	use HandlerTestTrait;
+	use NeoWikiMockAuthorityTrait;
 
 	public function setUp(): void {
 		$this->setUpNeo4j();
@@ -260,6 +264,155 @@ JSON,
 			$response->getBody()->getContents()
 		);
 		$this->assertSame( 200, $response->getStatusCode() );
+	}
+
+	public function testSubjectOnAnUnreadablePageIsIndistinguishableFromAnAbsentSubject(): void {
+		$this->createPageWithSubjects(
+			'GetSubjectApiTest_Restricted',
+			mainSubject: TestSubject::build(
+				id: 'sTestGSA1111244',
+				schemaName: new SchemaName( 'GetSubjectApiTestSchema' )
+			)
+		);
+
+		$denied = $this->executeHandler(
+			new GetSubjectApi(),
+			new RequestData( [ 'method' => 'GET', 'pathParams' => [ 'subjectId' => 'sTestGSA1111244' ] ] ),
+			authority: $this->authorityWithGlobalReadButNoPageRead()
+		);
+
+		$absent = $this->executeHandler(
+			new GetSubjectApi(),
+			new RequestData( [ 'method' => 'GET', 'pathParams' => [ 'subjectId' => 'sTestGSA9999999' ] ] )
+		);
+
+		$this->assertSame( 200, $denied->getStatusCode() );
+		$this->assertSame( $absent->getBody()->getContents(), $denied->getBody()->getContents() );
+	}
+
+	public function testRevisionOnAnUnreadablePageIsIndistinguishableFromAnAbsentRevision(): void {
+		$revisionId = $this->createPageWithSubjects(
+			'GetSubjectApiTest_RestrictedRevision',
+			mainSubject: TestSubject::build(
+				id: 'sTestGSA1111245',
+				schemaName: new SchemaName( 'GetSubjectApiTestSchema' )
+			)
+		)->getId();
+
+		$deniedResponse = $this->executeHandler(
+			new GetSubjectApi(),
+			new RequestData( [
+				'method' => 'GET',
+				'pathParams' => [ 'subjectId' => 'sTestGSA1111245' ],
+				'queryParams' => [ 'revisionId' => (string)$revisionId ],
+			] ),
+			authority: $this->authorityWithGlobalReadButNoPageRead()
+		);
+
+		$absentResponse = $this->executeHandler(
+			new GetSubjectApi(),
+			new RequestData( [
+				'method' => 'GET',
+				'pathParams' => [ 'subjectId' => 'sTestGSA1111245' ],
+				'queryParams' => [ 'revisionId' => '999999999' ],
+			] ),
+			authority: $this->authorityWithGlobalReadButNoPageRead()
+		);
+
+		$this->assertSame( 404, $deniedResponse->getStatusCode() );
+		$this->assertSame( $absentResponse->getStatusCode(), $deniedResponse->getStatusCode() );
+
+		$denied = json_decode( $deniedResponse->getBody()->getContents(), true );
+		$absent = json_decode( $absentResponse->getBody()->getContents(), true );
+
+		// Only the revision id embedded in the message may differ between "denied" and "nonexistent".
+		$absent['message'] = str_replace( '999999999', (string)$revisionId, $absent['message'] );
+		$this->assertSame( $absent, $denied );
+	}
+
+	public function testReferencedSubjectOnAnUnreadablePageIsOmitted(): void {
+		$this->createPageWithSubjects(
+			'GetSubjectApiTest_HiddenTarget',
+			mainSubject: TestSubject::build(
+				id: 'sTestGSA1111246',
+				schemaName: new SchemaName( 'GetSubjectApiTestSchema' )
+			)
+		);
+
+		$this->createPageWithSubjects(
+			'GetSubjectApiTest_VisibleSource',
+			mainSubject: TestSubject::build(
+				id: 'sTestGSA1111247',
+				schemaName: new SchemaName( 'GetSubjectApiTestSchema' ),
+				statements: new StatementList( [
+					TestStatement::buildRelation( 'MyRelation', [
+						TestRelation::build( id: 'rTestGSA1111rr9', targetId: 'sTestGSA1111246' ),
+					] ),
+				] )
+			)
+		);
+
+		$denyTargetPage = static fn ( string $permission, ?PageIdentity $page = null ): bool =>
+			$page === null || $page->getDBkey() !== 'GetSubjectApiTest_HiddenTarget';
+
+		$body = json_decode( $this->executeHandler(
+			new GetSubjectApi(),
+			new RequestData( [
+				'method' => 'GET',
+				'pathParams' => [ 'subjectId' => 'sTestGSA1111247' ],
+				'queryParams' => [ 'expand' => 'relations' ],
+			] ),
+			authority: $this->mockRegisteredAuthority( $denyTargetPage )
+		)->getBody()->getContents(), true );
+
+		$this->assertArrayHasKey( 'sTestGSA1111247', $body['subjects'] );
+		$this->assertArrayNotHasKey( 'sTestGSA1111246', $body['subjects'] );
+	}
+
+	/**
+	 * PointInTimeSubjectLookup::getSubjectFromOtherPage() resolves a requested Subject via the
+	 * graph and reads a DIFFERENT page's revision content when the Subject isn't in the primary
+	 * (caller-supplied) revision. The handler's revision gate only authorizes the primary
+	 * revision's page, so a caller can name a revision on a page they CAN read while asking for
+	 * a Subject that actually lives on a page they CANNOT read. GetSubjectQuery::pageIsReadable()
+	 * is the only thing standing between that request and the restricted page's data.
+	 *
+	 * The denial here must be selective (deny only the restricted page, not global read) -
+	 * authorityWithGlobalReadButNoPageRead() would be stopped at the handler's revision gate
+	 * (on the readable page) and this test would pass without ever reaching the query gate.
+	 */
+	public function testCrossPageRevisionCannotLeakSubjectFromARestrictedPage(): void {
+		$this->createPageWithSubjects(
+			'GetSubjectApiTest_CrossPageRestricted',
+			mainSubject: TestSubject::build(
+				id: 'sTestGSA1111248',
+				schemaName: new SchemaName( 'GetSubjectApiTestSchema' )
+			)
+		);
+
+		$readableRevisionId = $this->createPageWithSubjects(
+			'GetSubjectApiTest_CrossPageReadable',
+			mainSubject: TestSubject::build(
+				id: 'sTestGSA1111249',
+				schemaName: new SchemaName( 'GetSubjectApiTestSchema' )
+			)
+		)->getId();
+
+		$denyRestrictedPage = static fn ( string $permission, ?PageIdentity $page = null ): bool =>
+			$page === null || $page->getDBkey() !== 'GetSubjectApiTest_CrossPageRestricted';
+
+		$response = $this->executeHandler(
+			new GetSubjectApi(),
+			new RequestData( [
+				'method' => 'GET',
+				'pathParams' => [ 'subjectId' => 'sTestGSA1111248' ],
+				'queryParams' => [ 'revisionId' => (string)$readableRevisionId ],
+			] ),
+			authority: $this->mockRegisteredAuthority( $denyRestrictedPage )
+		);
+
+		$this->assertSame( 200, $response->getStatusCode() );
+		$this->assertSame( '{"subject":null}', $response->getBody()->getContents() );
 	}
 
 }

--- a/tests/phpunit/EntryPoints/REST/ValidateSubjectUpdateApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ValidateSubjectUpdateApiTest.php
@@ -6,7 +6,7 @@ namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\REST;
 
 use MediaWiki\Rest\RequestData;
 use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
-use MediaWiki\Tests\Unit\Permissions\MockAuthorityTrait;
+use ProfessionalWiki\NeoWiki\Application\Subject\Exception\SubjectNotFoundException;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
@@ -14,6 +14,7 @@ use ProfessionalWiki\NeoWiki\EntryPoints\REST\ValidateSubjectUpdateApi;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiMockAuthorityTrait;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\EntryPoints\REST\ValidateSubjectUpdateApi
@@ -22,7 +23,7 @@ use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
 class ValidateSubjectUpdateApiTest extends NeoWikiIntegrationTestCase {
 
 	use HandlerTestTrait;
-	use MockAuthorityTrait;
+	use NeoWikiMockAuthorityTrait;
 
 	public function testHappyPathReturns200WithEmptyViolations(): void {
 		$this->createPages();
@@ -100,6 +101,41 @@ class ValidateSubjectUpdateApiTest extends NeoWikiIntegrationTestCase {
 		$this->assertStringContainsString( 'not found', $responseBody['message'] );
 	}
 
+	public function testSubjectOnAnUnreadablePageIsIndistinguishableFromAnAbsentSubject(): void {
+		$this->createPages();
+
+		$response = $this->executeHandler(
+			$this->newValidateSubjectUpdateApi(),
+			$this->createRequestData( 'sTestSU11111111', $this->validBody() ),
+			authority: $this->authorityWithGlobalReadButNoPageRead()
+		);
+
+		$body = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertSame( 404, $response->getStatusCode() );
+		$this->assertSame(
+			SubjectNotFoundException::forId( new SubjectId( 'sTestSU11111111' ) )->getMessage(),
+			$body['message']
+		);
+	}
+
+	public function testSubjectReadableByANonUltimateAuthorityIsValidated(): void {
+		$this->createPages();
+
+		$response = $this->executeHandler(
+			$this->newValidateSubjectUpdateApi(),
+			$this->createRequestData( 'sTestSU11111111', $this->validBody() ),
+			authority: $this->mockRegisteredAuthority(
+				static fn ( string $permission ): bool => $permission === 'read'
+			)
+		);
+
+		$body = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertSame( 200, $response->getStatusCode() );
+		$this->assertSame( [], $body['violations'] );
+	}
+
 	public function testMalformedSubjectIdReturns400(): void {
 		$response = $this->executeHandler(
 			$this->newValidateSubjectUpdateApi(),
@@ -166,9 +202,7 @@ class ValidateSubjectUpdateApiTest extends NeoWikiIntegrationTestCase {
 	}
 
 	private function newValidateSubjectUpdateApi(): ValidateSubjectUpdateApi {
-		return new ValidateSubjectUpdateApi(
-			query: NeoWikiExtension::getInstance()->newValidateSubjectUpdateQuery(),
-		);
+		return new ValidateSubjectUpdateApi();
 	}
 
 	private function createRequestData( string $subjectId, array $body ): RequestData {

--- a/tests/phpunit/Infrastructure/AuthorityBasedSubjectAuthorizerTest.php
+++ b/tests/phpunit/Infrastructure/AuthorityBasedSubjectAuthorizerTest.php
@@ -9,9 +9,12 @@ use MediaWiki\Permissions\Authority;
 use MediaWiki\Tests\Unit\Permissions\MockAuthorityTrait;
 use MediaWiki\Title\Title;
 use MediaWiki\Title\TitleFactory;
+use MediaWiki\User\UserIdentityValue;
 use MediaWikiIntegrationTestCase;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Infrastructure\AuthorityBasedSubjectAuthorizer;
+use Psr\Log\NullLogger;
+use TestLogger;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\Infrastructure\AuthorityBasedSubjectAuthorizer
@@ -49,7 +52,8 @@ class AuthorityBasedSubjectAuthorizerTest extends MediaWikiIntegrationTestCase {
 	public function testFallsBackToGlobalEditRightWhenThePageCannotBeResolved(): void {
 		$authorizer = new AuthorityBasedSubjectAuthorizer(
 			$this->authorityThatCanEditEveryPage(),
-			$this->titleFactoryReturningNull()
+			$this->titleFactoryReturningNull(),
+			new NullLogger()
 		);
 
 		$this->assertTrue( $authorizer->canEditSubject( new PageId( self::PAGE_ID ) ) );
@@ -58,7 +62,8 @@ class AuthorityBasedSubjectAuthorizerTest extends MediaWikiIntegrationTestCase {
 	public function testDeniesUnresolvablePageWhenUserLacksGlobalEditRight(): void {
 		$authorizer = new AuthorityBasedSubjectAuthorizer(
 			$this->authorityWithoutAnyPermissions(),
-			$this->titleFactoryReturningNull()
+			$this->titleFactoryReturningNull(),
+			new NullLogger()
 		);
 
 		$this->assertFalse( $authorizer->canEditSubject( new PageId( self::PAGE_ID ) ) );
@@ -85,7 +90,8 @@ class AuthorityBasedSubjectAuthorizerTest extends MediaWikiIntegrationTestCase {
 	public function testAuthorizeFallsBackToGlobalEditRightWhenThePageCannotBeResolved(): void {
 		$authorizer = new AuthorityBasedSubjectAuthorizer(
 			$this->authorityThatCanEditEveryPage(),
-			$this->titleFactoryReturningNull()
+			$this->titleFactoryReturningNull(),
+			new NullLogger()
 		);
 
 		$this->assertTrue( $authorizer->authorize( new PageId( self::PAGE_ID ) ) );
@@ -94,7 +100,8 @@ class AuthorityBasedSubjectAuthorizerTest extends MediaWikiIntegrationTestCase {
 	public function testAuthorizeDeniesUnresolvablePageWhenUserLacksGlobalEditRight(): void {
 		$authorizer = new AuthorityBasedSubjectAuthorizer(
 			$this->authorityWithoutAnyPermissions(),
-			$this->titleFactoryReturningNull()
+			$this->titleFactoryReturningNull(),
+			new NullLogger()
 		);
 
 		$this->assertFalse( $authorizer->authorize( new PageId( self::PAGE_ID ) ) );
@@ -111,15 +118,82 @@ class AuthorityBasedSubjectAuthorizerTest extends MediaWikiIntegrationTestCase {
 		$authority->method( 'authorizeWrite' )->willReturn( false );
 		$authority->method( 'definitelyCan' )->willReturn( true );
 
-		$authorizer = new AuthorityBasedSubjectAuthorizer( $authority, $titleFactory );
+		$authorizer = new AuthorityBasedSubjectAuthorizer( $authority, $titleFactory, new NullLogger() );
 		$pageId = new PageId( self::PAGE_ID );
 
 		$this->assertFalse( $authorizer->authorize( $pageId ) );
 		$this->assertTrue( $authorizer->canEditSubject( $pageId ) );
 	}
 
+	public function testAuthorizeReadIsDeniedWhenThePageCannotBeRead(): void {
+		$authorizer = $this->newAuthorizer( $this->authorityWithGlobalReadButNoPageRead() );
+
+		$this->assertFalse( $authorizer->authorizeRead( new PageId( self::PAGE_ID ) ) );
+	}
+
+	public function testAuthorizeReadIsAllowedWhenThePageCanBeRead(): void {
+		// Also asserts logger silence, so a future edit that moves the logger->info call outside
+		// the denial branch fails this test.
+		$logger = new TestLogger( true );
+		$authorizer = new AuthorityBasedSubjectAuthorizer(
+			$this->authorityThatCanEditEveryPage(),
+			$this->titleFactoryReturningPage(),
+			$logger
+		);
+
+		$this->assertTrue( $authorizer->authorizeRead( new PageId( self::PAGE_ID ) ) );
+		$this->assertSame( [], $logger->getBuffer() );
+	}
+
+	public function testAuthorizeReadDeniesWhenThePageCannotBeResolved(): void {
+		// Unlike the write side there is no global-right fallback: content is only reachable
+		// through a resolved page, so an unresolvable one has nothing to authorize.
+		$authorizer = new AuthorityBasedSubjectAuthorizer(
+			$this->authorityThatCanEditEveryPage(),
+			$this->titleFactoryReturningNull(),
+			new NullLogger()
+		);
+
+		$this->assertFalse( $authorizer->authorizeRead( new PageId( self::PAGE_ID ) ) );
+	}
+
+	public function testAuthorizeReadUsesBindingAuthorizeRead(): void {
+		// Pin the verb: authorizeRead runs the full per-title check including the expensive ACL
+		// hook that quick checks skip. Reverting to a hint verb fails this test.
+		$title = Title::makeTitle( NS_MAIN, 'Target page' );
+		$titleFactory = $this->createStub( TitleFactory::class );
+		$titleFactory->method( 'newFromID' )->willReturn( $title );
+
+		$authority = $this->createMock( Authority::class );
+		$authority->method( 'probablyCan' )->willReturn( true );
+		$authority->method( 'definitelyCan' )->willReturn( true );
+		$authority->method( 'authorizeRead' )->willReturn( false );
+		$authority->method( 'getUser' )->willReturn( new UserIdentityValue( 9999, 'Petr' ) );
+
+		$authorizer = new AuthorityBasedSubjectAuthorizer( $authority, $titleFactory, new NullLogger() );
+
+		$this->assertFalse( $authorizer->authorizeRead( new PageId( self::PAGE_ID ) ) );
+	}
+
+	public function testDeniedReadIsLogged(): void {
+		$logger = new TestLogger( true, null, true );
+		$authorizer = new AuthorityBasedSubjectAuthorizer(
+			$this->authorityWithoutAnyPermissions(),
+			$this->titleFactoryReturningPage(),
+			$logger
+		);
+
+		$authorizer->authorizeRead( new PageId( self::PAGE_ID ) );
+
+		$this->assertSame(
+			[ [ 'info', 'NeoWiki: denied read of page {page} to {user}',
+				[ 'page' => 'Protected_page', 'user' => 'Petr' ] ] ],
+			$logger->getBuffer()
+		);
+	}
+
 	private function newAuthorizer( Authority $authority ): AuthorityBasedSubjectAuthorizer {
-		return new AuthorityBasedSubjectAuthorizer( $authority, $this->titleFactoryReturningPage() );
+		return new AuthorityBasedSubjectAuthorizer( $authority, $this->titleFactoryReturningPage(), new NullLogger() );
 	}
 
 	/**
@@ -131,6 +205,17 @@ class AuthorityBasedSubjectAuthorizerTest extends MediaWikiIntegrationTestCase {
 			$permission === 'edit' && $page === null;
 
 		return $this->mockRegisteredAuthority( $canEditGloballyButNotPerPage );
+	}
+
+	/**
+	 * Holds the wiki-global 'read' right, but cannot read any specific page
+	 * (as under a restricted namespace, $wgWhitelistRead, or an ACL extension).
+	 */
+	private function authorityWithGlobalReadButNoPageRead(): Authority {
+		$canReadGloballyButNotPerPage = static fn ( string $permission, ?PageIdentity $page = null ): bool =>
+			$permission === 'read' && $page === null;
+
+		return $this->mockRegisteredAuthority( $canReadGloballyButNotPerPage );
 	}
 
 	private function authorityThatCanEditEveryPage(): Authority {

--- a/tests/phpunit/Infrastructure/AuthorityBasedSubjectAuthorizerTest.php
+++ b/tests/phpunit/Infrastructure/AuthorityBasedSubjectAuthorizerTest.php
@@ -6,13 +6,13 @@ namespace ProfessionalWiki\NeoWiki\Tests\Infrastructure;
 
 use MediaWiki\Page\PageIdentity;
 use MediaWiki\Permissions\Authority;
-use MediaWiki\Tests\Unit\Permissions\MockAuthorityTrait;
 use MediaWiki\Title\Title;
 use MediaWiki\Title\TitleFactory;
 use MediaWiki\User\UserIdentityValue;
 use MediaWikiIntegrationTestCase;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Infrastructure\AuthorityBasedSubjectAuthorizer;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiMockAuthorityTrait;
 use Psr\Log\NullLogger;
 use TestLogger;
 
@@ -21,7 +21,7 @@ use TestLogger;
  */
 class AuthorityBasedSubjectAuthorizerTest extends MediaWikiIntegrationTestCase {
 
-	use MockAuthorityTrait;
+	use NeoWikiMockAuthorityTrait;
 
 	private const int PAGE_ID = 42;
 
@@ -223,17 +223,6 @@ class AuthorityBasedSubjectAuthorizerTest extends MediaWikiIntegrationTestCase {
 			$permission === 'edit' && $page === null;
 
 		return $this->mockRegisteredAuthority( $canEditGloballyButNotPerPage );
-	}
-
-	/**
-	 * Holds the wiki-global 'read' right, but cannot read any specific page
-	 * (as under a restricted namespace, $wgWhitelistRead, or an ACL extension).
-	 */
-	private function authorityWithGlobalReadButNoPageRead(): Authority {
-		$canReadGloballyButNotPerPage = static fn ( string $permission, ?PageIdentity $page = null ): bool =>
-			$permission === 'read' && $page === null;
-
-		return $this->mockRegisteredAuthority( $canReadGloballyButNotPerPage );
 	}
 
 	private function authorityThatCanEditEveryPage(): Authority {

--- a/tests/phpunit/Infrastructure/AuthorityBasedSubjectAuthorizerTest.php
+++ b/tests/phpunit/Infrastructure/AuthorityBasedSubjectAuthorizerTest.php
@@ -175,6 +175,24 @@ class AuthorityBasedSubjectAuthorizerTest extends MediaWikiIntegrationTestCase {
 		$this->assertFalse( $authorizer->authorizeRead( new PageId( self::PAGE_ID ) ) );
 	}
 
+	public function testAuthorizeReadChecksTheReadAction(): void {
+		// An authority that permits only the 'read' action: a gate asking for any other
+		// action (e.g. 'edit') is denied, pinning the permission string end-to-end.
+		$title = Title::makeTitle( NS_MAIN, 'Target page' );
+		$titleFactory = $this->createStub( TitleFactory::class );
+		$titleFactory->method( 'newFromID' )->willReturn( $title );
+
+		$authority = $this->createMock( Authority::class );
+		$authority->method( 'authorizeRead' )->willReturnCallback(
+			static fn ( string $action ): bool => $action === 'read'
+		);
+		$authority->method( 'getUser' )->willReturn( new UserIdentityValue( 9999, 'Petr' ) );
+
+		$authorizer = new AuthorityBasedSubjectAuthorizer( $authority, $titleFactory, new NullLogger() );
+
+		$this->assertTrue( $authorizer->authorizeRead( new PageId( self::PAGE_ID ) ) );
+	}
+
 	public function testDeniedReadIsLogged(): void {
 		$logger = new TestLogger( true, null, true );
 		$authorizer = new AuthorityBasedSubjectAuthorizer(

--- a/tests/phpunit/Infrastructure/AuthorityBasedSubjectAuthorizerTest.php
+++ b/tests/phpunit/Infrastructure/AuthorityBasedSubjectAuthorizerTest.php
@@ -204,7 +204,7 @@ class AuthorityBasedSubjectAuthorizerTest extends MediaWikiIntegrationTestCase {
 		$authorizer->authorizeRead( new PageId( self::PAGE_ID ) );
 
 		$this->assertSame(
-			[ [ 'info', 'NeoWiki: denied read of page {page} to {user}',
+			[ [ 'info', 'Denied read of page {page} to {user}',
 				[ 'page' => 'Protected_page', 'user' => 'Petr' ] ] ],
 			$logger->getBuffer()
 		);

--- a/tests/phpunit/NeoWikiMockAuthorityTrait.php
+++ b/tests/phpunit/NeoWikiMockAuthorityTrait.php
@@ -1,0 +1,31 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests;
+
+use MediaWiki\Page\PageIdentity;
+use MediaWiki\Permissions\Authority;
+use MediaWiki\Tests\Unit\Permissions\MockAuthorityTrait;
+
+/**
+ * NeoWiki-specific Authority fixtures on top of core's MockAuthorityTrait. Use this trait
+ * INSTEAD of MockAuthorityTrait (it re-exposes all of its methods); using both in one class
+ * is a trait-method collision.
+ */
+trait NeoWikiMockAuthorityTrait {
+
+	use MockAuthorityTrait;
+
+	/**
+	 * Holds the wiki-global 'read' right, but cannot read any specific page
+	 * (as under a restricted namespace, $wgWhitelistRead, or an ACL extension).
+	 */
+	private function authorityWithGlobalReadButNoPageRead(): Authority {
+		$canReadGloballyButNotPerPage = static fn ( string $permission, ?PageIdentity $page = null ): bool =>
+			$permission === 'read' && $page === null;
+
+		return $this->mockRegisteredAuthority( $canReadGloballyButNotPerPage );
+	}
+
+}

--- a/tests/phpunit/Persistence/MediaWiki/CachingMappingLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/CachingMappingLookupTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Persistence\MediaWiki;
+
+use MediaWiki\Permissions\Authority;
+use MediaWiki\User\UserIdentityValue;
+use ProfessionalWiki\NeoWiki\Application\MappingLookup;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\MappingName;
+use ProfessionalWiki\NeoWiki\Persistence\MappingNameLookup;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\CachingMappingLookup;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+use Psr\Log\NullLogger;
+use Wikimedia\ObjectCache\HashBagOStuff;
+use Wikimedia\ObjectCache\WANObjectCache;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Persistence\MediaWiki\CachingMappingLookup
+ * @group Database
+ */
+class CachingMappingLookupTest extends NeoWikiIntegrationTestCase {
+
+	public function testGateUsesBindingAuthorizeRead(): void {
+		// The mapping page must exist so the gate (which runs after the existence check) is
+		// reached. probablyCan=true + authorizeRead=false must deny: probablyCan is a UI-hint
+		// check that skips the expensive ACL hook extensions use for read restrictions.
+		$this->createMapping( 'CachingGateMapping', $this->personToEdm() );
+
+		$inner = $this->createMock( MappingLookup::class );
+		$inner->expects( $this->never() )->method( 'getMapping' );
+
+		$authority = $this->createMock( Authority::class );
+		$authority->method( 'probablyCan' )->willReturn( true );
+		$authority->method( 'authorizeRead' )->willReturnCallback( function ( string $action ) {
+			$this->assertSame( 'read', $action );
+			return false;
+		} );
+		$authority->method( 'getUser' )->willReturn( new UserIdentityValue( 9999, 'Petr' ) );
+
+		$lookup = new CachingMappingLookup(
+			$inner,
+			$this->createMock( MappingNameLookup::class ),
+			new WANObjectCache( [ 'cache' => new HashBagOStuff() ] ),
+			$this->getServiceContainer()->getTitleFactory(),
+			$authority,
+			$this->getServiceContainer()->getConnectionProvider(),
+			new NullLogger(),
+		);
+
+		$this->assertNull( $lookup->getMapping( new MappingName( 'CachingGateMapping' ) ) );
+	}
+
+	private function personToEdm(): string {
+		return <<<JSON
+			{
+				"version": 1,
+				"schema": "Person",
+				"target": "edm",
+				"prefixes": {
+					"edm": "http://www.europeana.eu/schemas/edm/",
+					"dc": "http://purl.org/dc/elements/1.1/"
+				},
+				"subject": { "class": "edm:ProvidedCHO" },
+				"properties": {
+					"Name": { "predicate": "dc:title", "lang": "en" }
+				}
+			}
+			JSON;
+	}
+
+}

--- a/tests/phpunit/Persistence/MediaWiki/CachingMappingLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/CachingMappingLookupTest.php
@@ -10,13 +10,18 @@ use MediaWiki\Title\TitleFactory;
 use MediaWiki\User\UserIdentityValue;
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Application\MappingLookup;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\Mapping;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\MappingName;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\PropertyMappings;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Persistence\MappingNameLookup;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\CachingMappingLookup;
+use Psr\Log\NullLogger;
 use TestLogger;
 use Wikimedia\ObjectCache\HashBagOStuff;
 use Wikimedia\ObjectCache\WANObjectCache;
 use Wikimedia\Rdbms\IConnectionProvider;
+use Wikimedia\Rdbms\IReadableDatabase;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\Persistence\MediaWiki\CachingMappingLookup
@@ -65,6 +70,89 @@ class CachingMappingLookupTest extends TestCase {
 				[ 'page' => 'Mapping:CachingGateMapping', 'user' => 'Petr' ] ] ],
 			$logger->getBuffer()
 		);
+	}
+
+	public function testDeniedUserGetsNullEvenWhenTheMappingIsAlreadyCached(): void {
+		$cache = $this->newCache();
+
+		$allowed = new CachingMappingLookup(
+			$this->newSpyLookup(),
+			$this->createMock( MappingNameLookup::class ),
+			$cache,
+			$this->newTitleFactory( 1, 100 ),
+			$this->newAuthority(),
+			$this->newConnectionProvider(),
+			new NullLogger(),
+		);
+		$allowed->getMapping( new MappingName( 'Person' ) );
+
+		$denied = new CachingMappingLookup(
+			$this->newSpyLookup(),
+			$this->createMock( MappingNameLookup::class ),
+			$cache,
+			$this->newTitleFactory( 1, 100 ),
+			$this->newAuthority( canRead: false ),
+			$this->newConnectionProvider(),
+			new NullLogger(),
+		);
+
+		$this->assertNull( $denied->getMapping( new MappingName( 'Person' ) ) );
+	}
+
+	private function newSpyLookup(): MappingLookup {
+		return new class() implements MappingLookup {
+			public Mapping $mapping;
+
+			public function __construct() {
+				$this->mapping = new Mapping(
+					name: new MappingName( 'Person' ),
+					schema: new SchemaName( 'Person' ),
+					target: 'http://example.org/target',
+					prefixes: [],
+					subjectClass: 'http://example.org/Class',
+					properties: new PropertyMappings( [] ),
+				);
+			}
+
+			public function getMapping( MappingName $name ): ?Mapping {
+				return $this->mapping;
+			}
+
+			public function getAllMappings(): array {
+				return [ $this->mapping ];
+			}
+		};
+	}
+
+	private function newTitleFactory( int $articleId, int ...$revIds ): TitleFactory {
+		$title = $this->createMock( Title::class );
+		$title->method( 'exists' )->willReturn( true );
+		$title->method( 'getArticleID' )->willReturn( $articleId );
+		$title->method( 'getLatestRevID' )->willReturnOnConsecutiveCalls( ...$revIds );
+
+		$factory = $this->createMock( TitleFactory::class );
+		$factory->method( 'newFromText' )->willReturn( $title );
+		return $factory;
+	}
+
+	private function newCache(): WANObjectCache {
+		return new WANObjectCache( [ 'cache' => new HashBagOStuff() ] );
+	}
+
+	private function newAuthority( bool $canRead = true ): Authority {
+		$authority = $this->createMock( Authority::class );
+		$authority->method( 'authorizeRead' )->willReturn( $canRead );
+		$authority->method( 'getUser' )->willReturn( new UserIdentityValue( 1, 'TestUser' ) );
+		return $authority;
+	}
+
+	private function newConnectionProvider(): IConnectionProvider {
+		$replica = $this->createMock( IReadableDatabase::class );
+		$replica->method( 'getSessionLagStatus' )->willReturn( [ 'lag' => 0, 'since' => INF ] );
+
+		$provider = $this->createMock( IConnectionProvider::class );
+		$provider->method( 'getReplicaDatabase' )->willReturn( $replica );
+		return $provider;
 	}
 
 }

--- a/tests/phpunit/Persistence/MediaWiki/CachingMappingLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/CachingMappingLookupTest.php
@@ -5,27 +5,34 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Tests\Persistence\MediaWiki;
 
 use MediaWiki\Permissions\Authority;
+use MediaWiki\Title\Title;
+use MediaWiki\Title\TitleFactory;
 use MediaWiki\User\UserIdentityValue;
+use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Application\MappingLookup;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\MappingName;
 use ProfessionalWiki\NeoWiki\Persistence\MappingNameLookup;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\CachingMappingLookup;
-use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
-use Psr\Log\NullLogger;
+use TestLogger;
 use Wikimedia\ObjectCache\HashBagOStuff;
 use Wikimedia\ObjectCache\WANObjectCache;
+use Wikimedia\Rdbms\IConnectionProvider;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\Persistence\MediaWiki\CachingMappingLookup
- * @group Database
  */
-class CachingMappingLookupTest extends NeoWikiIntegrationTestCase {
+class CachingMappingLookupTest extends TestCase {
 
 	public function testGateUsesBindingAuthorizeRead(): void {
-		// The mapping page must exist so the gate (which runs after the existence check) is
-		// reached. probablyCan=true + authorizeRead=false must deny: probablyCan is a UI-hint
-		// check that skips the expensive ACL hook extensions use for read restrictions.
-		$this->createMapping( 'CachingGateMapping', $this->personToEdm() );
+		// probablyCan is a UI-hint check that skips the expensive ACL hook that extensions use
+		// for read restrictions; the gate must use the binding authorizeRead with the 'read'
+		// action. Reverting to a hint verb, or a different action, fails this test.
+		$title = $this->createMock( Title::class );
+		$title->method( 'exists' )->willReturn( true );
+		$title->method( 'getPrefixedDBkey' )->willReturn( 'Mapping:CachingGateMapping' );
+
+		$factory = $this->createMock( TitleFactory::class );
+		$factory->method( 'newFromText' )->willReturn( $title );
 
 		$inner = $this->createMock( MappingLookup::class );
 		$inner->expects( $this->never() )->method( 'getMapping' );
@@ -38,35 +45,26 @@ class CachingMappingLookupTest extends NeoWikiIntegrationTestCase {
 		} );
 		$authority->method( 'getUser' )->willReturn( new UserIdentityValue( 9999, 'Petr' ) );
 
+		$logger = new TestLogger( true, null, true );
+
 		$lookup = new CachingMappingLookup(
 			$inner,
 			$this->createMock( MappingNameLookup::class ),
 			new WANObjectCache( [ 'cache' => new HashBagOStuff() ] ),
-			$this->getServiceContainer()->getTitleFactory(),
+			$factory,
 			$authority,
-			$this->getServiceContainer()->getConnectionProvider(),
-			new NullLogger(),
+			$this->createMock( IConnectionProvider::class ),
+			$logger,
 		);
 
 		$this->assertNull( $lookup->getMapping( new MappingName( 'CachingGateMapping' ) ) );
-	}
 
-	private function personToEdm(): string {
-		return <<<JSON
-			{
-				"version": 1,
-				"schema": "Person",
-				"target": "edm",
-				"prefixes": {
-					"edm": "http://www.europeana.eu/schemas/edm/",
-					"dc": "http://purl.org/dc/elements/1.1/"
-				},
-				"subject": { "class": "edm:ProvidedCHO" },
-				"properties": {
-					"Name": { "predicate": "dc:title", "lang": "en" }
-				}
-			}
-			JSON;
+		// Mirrors AuthorityBasedSubjectAuthorizerTest::testDeniedReadIsLogged.
+		$this->assertSame(
+			[ [ 'info', 'Denied read of page {page} to {user}',
+				[ 'page' => 'Mapping:CachingGateMapping', 'user' => 'Petr' ] ] ],
+			$logger->getBuffer()
+		);
 	}
 
 }

--- a/tests/phpunit/Persistence/MediaWiki/CachingSchemaLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/CachingSchemaLookupTest.php
@@ -78,6 +78,31 @@ class CachingSchemaLookupTest extends TestCase {
 		$this->assertSame( 0, $inner->calls );
 	}
 
+	public function testDeniedUserGetsNullEvenWhenTheSchemaIsAlreadyCached(): void {
+		$cache = $this->newCache();
+
+		$allowed = new CachingSchemaLookup(
+			$this->newSpyLookup(),
+			$cache,
+			$this->newTitleFactory( 1, 100 ),
+			$this->newAuthority(),
+			$this->newConnectionProvider(),
+			new NullLogger()
+		);
+		$allowed->getSchema( new SchemaName( 'Person' ) );
+
+		$denied = new CachingSchemaLookup(
+			$this->newSpyLookup(),
+			$cache,
+			$this->newTitleFactory( 1, 100 ),
+			$this->newAuthority( canRead: false ),
+			$this->newConnectionProvider(),
+			new NullLogger()
+		);
+
+		$this->assertNull( $denied->getSchema( new SchemaName( 'Person' ) ) );
+	}
+
 	public function testGateUsesBindingAuthorizeRead(): void {
 		// probablyCan is a UI-hint check that skips the expensive ACL hook that extensions use
 		// for read restrictions; the gate must use the binding authorizeRead. Reverting to a hint

--- a/tests/phpunit/Persistence/MediaWiki/CachingSchemaLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/CachingSchemaLookupTest.php
@@ -108,7 +108,7 @@ class CachingSchemaLookupTest extends TestCase {
 
 		// Mirrors AuthorityBasedSubjectAuthorizerTest::testDeniedReadIsLogged.
 		$this->assertSame(
-			[ [ 'info', 'NeoWiki: denied read of page {page} to {user}',
+			[ [ 'info', 'Denied read of page {page} to {user}',
 				[ 'page' => 'Schema:CachingGateSchema', 'user' => 'Petr' ] ] ],
 			$logger->getBuffer()
 		);

--- a/tests/phpunit/Persistence/MediaWiki/CachingSchemaLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/CachingSchemaLookupTest.php
@@ -7,12 +7,15 @@ namespace ProfessionalWiki\NeoWiki\Tests\Persistence\MediaWiki;
 use MediaWiki\Permissions\Authority;
 use MediaWiki\Title\Title;
 use MediaWiki\Title\TitleFactory;
+use MediaWiki\User\UserIdentityValue;
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinitions;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\CachingSchemaLookup;
+use Psr\Log\NullLogger;
+use TestLogger;
 use Wikimedia\ObjectCache\HashBagOStuff;
 use Wikimedia\ObjectCache\WANObjectCache;
 use Wikimedia\Rdbms\IConnectionProvider;
@@ -26,7 +29,7 @@ class CachingSchemaLookupTest extends TestCase {
 	public function testCachesSchemaSoTheInnerLookupRunsOnce(): void {
 		$inner = $this->newSpyLookup();
 
-		$lookup = new CachingSchemaLookup( $inner, $this->newCache(), $this->newTitleFactory( 1, 100, 100 ), $this->newAuthority(), $this->newConnectionProvider() );
+		$lookup = new CachingSchemaLookup( $inner, $this->newCache(), $this->newTitleFactory( 1, 100, 100 ), $this->newAuthority(), $this->newConnectionProvider(), new NullLogger() );
 		$first = $lookup->getSchema( new SchemaName( 'Person' ) );
 		$second = $lookup->getSchema( new SchemaName( 'Person' ) );
 
@@ -38,7 +41,7 @@ class CachingSchemaLookupTest extends TestCase {
 	public function testReloadsWhenTheSchemaRevisionChanges(): void {
 		$inner = $this->newSpyLookup();
 
-		$lookup = new CachingSchemaLookup( $inner, $this->newCache(), $this->newTitleFactory( 1, 100, 101 ), $this->newAuthority(), $this->newConnectionProvider() );
+		$lookup = new CachingSchemaLookup( $inner, $this->newCache(), $this->newTitleFactory( 1, 100, 101 ), $this->newAuthority(), $this->newConnectionProvider(), new NullLogger() );
 		$lookup->getSchema( new SchemaName( 'Person' ) );
 		$lookup->getSchema( new SchemaName( 'Person' ) );
 
@@ -53,7 +56,7 @@ class CachingSchemaLookupTest extends TestCase {
 		$factory = $this->createMock( TitleFactory::class );
 		$factory->method( 'newFromText' )->willReturn( $title );
 
-		$lookup = new CachingSchemaLookup( $inner, $this->newCache(), $factory, $this->newAuthority(), $this->newConnectionProvider() );
+		$lookup = new CachingSchemaLookup( $inner, $this->newCache(), $factory, $this->newAuthority(), $this->newConnectionProvider(), new NullLogger() );
 
 		$this->assertNull( $lookup->getSchema( new SchemaName( 'Missing' ) ) );
 		$this->assertSame( 0, $inner->calls );
@@ -67,11 +70,48 @@ class CachingSchemaLookupTest extends TestCase {
 			$this->newCache(),
 			$this->newTitleFactory( 1, 100, 100 ),
 			$this->newAuthority( canRead: false ),
-			$this->newConnectionProvider()
+			$this->newConnectionProvider(),
+			new NullLogger()
 		);
 
 		$this->assertNull( $lookup->getSchema( new SchemaName( 'Person' ) ) );
 		$this->assertSame( 0, $inner->calls );
+	}
+
+	public function testGateUsesBindingAuthorizeRead(): void {
+		// probablyCan is a UI-hint check that skips the expensive ACL hook that extensions use
+		// for read restrictions; the gate must use the binding authorizeRead. Reverting to a hint
+		// verb fails this test.
+		$title = $this->createMock( Title::class );
+		$title->method( 'exists' )->willReturn( true );
+		$title->method( 'getPrefixedDBkey' )->willReturn( 'Schema:CachingGateSchema' );
+
+		$factory = $this->createMock( TitleFactory::class );
+		$factory->method( 'newFromText' )->willReturn( $title );
+
+		$inner = $this->newSpyLookup();
+
+		$authority = $this->createMock( Authority::class );
+		$authority->method( 'probablyCan' )->willReturn( true );
+		$authority->method( 'authorizeRead' )->willReturnCallback( function ( string $action ) {
+			$this->assertSame( 'read', $action );
+			return false;
+		} );
+		$authority->method( 'getUser' )->willReturn( new UserIdentityValue( 9999, 'Petr' ) );
+
+		$logger = new TestLogger( true, null, true );
+
+		$lookup = new CachingSchemaLookup( $inner, $this->newCache(), $factory, $authority, $this->newConnectionProvider(), $logger );
+
+		$this->assertNull( $lookup->getSchema( new SchemaName( 'CachingGateSchema' ) ) );
+		$this->assertSame( 0, $inner->calls );
+
+		// Mirrors AuthorityBasedSubjectAuthorizerTest::testDeniedReadIsLogged.
+		$this->assertSame(
+			[ [ 'info', 'NeoWiki: denied read of page {page} to {user}',
+				[ 'page' => 'Schema:CachingGateSchema', 'user' => 'Petr' ] ] ],
+			$logger->getBuffer()
+		);
 	}
 
 	public function testCachesANullResultForTheSameRevision(): void {
@@ -86,7 +126,7 @@ class CachingSchemaLookupTest extends TestCase {
 			}
 		};
 
-		$lookup = new CachingSchemaLookup( $inner, $this->newCache(), $this->newTitleFactory( 1, 100, 100 ), $this->newAuthority(), $this->newConnectionProvider() );
+		$lookup = new CachingSchemaLookup( $inner, $this->newCache(), $this->newTitleFactory( 1, 100, 100 ), $this->newAuthority(), $this->newConnectionProvider(), new NullLogger() );
 		$this->assertNull( $lookup->getSchema( new SchemaName( 'Broken' ) ) );
 		$this->assertNull( $lookup->getSchema( new SchemaName( 'Broken' ) ) );
 
@@ -129,7 +169,8 @@ class CachingSchemaLookupTest extends TestCase {
 
 	private function newAuthority( bool $canRead = true ): Authority {
 		$authority = $this->createMock( Authority::class );
-		$authority->method( 'probablyCan' )->willReturn( $canRead );
+		$authority->method( 'authorizeRead' )->willReturn( $canRead );
+		$authority->method( 'getUser' )->willReturn( new UserIdentityValue( 1, 'TestUser' ) );
 		return $authority;
 	}
 

--- a/tests/phpunit/Persistence/MediaWiki/DatabaseSchemaNameLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/DatabaseSchemaNameLookupTest.php
@@ -141,4 +141,27 @@ class DatabaseSchemaNameLookupTest extends NeoWikiIntegrationTestCase {
 		);
 	}
 
+	public function testGateUsesBindingAuthorizeRead(): void {
+		// probablyCan is a UI-hint check that skips the expensive ACL hook; the filter must
+		// use the binding authorizeRead with the 'read' action. Reverting fails this test.
+		$this->createSchema( 'GatePinSchema' );
+
+		$authority = $this->createMock( Authority::class );
+		$authority->method( 'probablyCan' )->willReturn( true );
+		$authority->method( 'authorizeRead' )->willReturnCallback(
+			function ( string $action ): bool {
+				$this->assertSame( 'read', $action );
+				return false;
+			}
+		);
+
+		$names = array_map(
+			static fn ( TitleValue $title ): string => $title->getText(),
+			$this->getLookup( $authority )->getSchemaNamesMatching( '', 50 )
+		);
+
+		$this->assertNotContains( 'GatePinSchema', $names );
+		$this->assertSame( [], $names );
+	}
+
 }

--- a/tests/phpunit/Persistence/MediaWiki/DatabaseSchemaNameLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/DatabaseSchemaNameLookupTest.php
@@ -4,9 +4,12 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Tests\Persistence\MediaWiki;
 
+use MediaWiki\Page\PageIdentity;
+use MediaWiki\Permissions\Authority;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\DatabaseSchemaNameLookup;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiMockAuthorityTrait;
 use MediaWiki\Title\TitleValue;
 
 /**
@@ -14,6 +17,8 @@ use MediaWiki\Title\TitleValue;
  * @group Database
  */
 class DatabaseSchemaNameLookupTest extends NeoWikiIntegrationTestCase {
+
+	use NeoWikiMockAuthorityTrait;
 
 	public function setUp(): void {
 		$this->tablesUsed[] = 'page';
@@ -40,8 +45,13 @@ class DatabaseSchemaNameLookupTest extends NeoWikiIntegrationTestCase {
 		);
 	}
 
-	private function getLookup(): DatabaseSchemaNameLookup {
-		return NeoWikiExtension::getInstance()->getSchemaNameLookup();
+	private function getLookup( ?Authority $authority = null ): DatabaseSchemaNameLookup {
+		return new DatabaseSchemaNameLookup(
+			db: $this->getDb(),
+			searchEngine: $this->getServiceContainer()->newSearchEngine(),
+			authority: $authority ?? $this->mockRegisteredUltimateAuthority(),
+			titleFactory: $this->getServiceContainer()->getTitleFactory(),
+		);
 	}
 
 	public static function emptyInputProvider(): array {
@@ -100,6 +110,35 @@ class DatabaseSchemaNameLookupTest extends NeoWikiIntegrationTestCase {
 
 	public function testGetSchemaCount(): void {
 		$this->assertSame( 4, $this->getLookup()->getSchemaCount() );
+	}
+
+	public function testUnreadableSchemaNamesAreOmitted(): void {
+		// GateHiddenSchema is created before GateVisibleSchema so the denied row sits mid-list
+		// (not last), which is what makes the assertion below sensitive to a missing
+		// array_values() reindex: dropping the array_values would leave a gap in the array
+		// keys, and json_encode() (used by GetSchemaNamesApi) would serialize the result as a
+		// JSON object instead of an array.
+		$this->createSchema( 'GateHiddenSchema' );
+		$this->createSchema( 'GateVisibleSchema' );
+
+		$denyHidden = static fn ( string $permission, ?PageIdentity $page = null ): bool =>
+			$page === null || $page->getDBkey() !== 'GateHiddenSchema';
+
+		$names = array_map(
+			static fn ( TitleValue $title ): string => $title->getText(),
+			$this->getLookup( $this->mockRegisteredAuthority( $denyHidden ) )->getSchemaNamesMatching( '', 10 )
+		);
+
+		$this->assertSame(
+			[
+				'SchemaNameLookupTest1',
+				'SchemaNameLookupTest21',
+				'SchemaNameLookupTest22',
+				'SchemaNameLookupTest3',
+				'GateVisibleSchema',
+			],
+			$names
+		);
 	}
 
 }

--- a/tests/phpunit/Persistence/MediaWiki/WikiPageLayoutLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/WikiPageLayoutLookupTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Persistence\MediaWiki;
+
+use MediaWiki\Permissions\Authority;
+use MediaWiki\Title\Title;
+use MediaWiki\Title\TitleFactory;
+use MediaWiki\User\UserIdentityValue;
+use MediaWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Domain\Layout\LayoutName;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\LayoutPersistenceDeserializer;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\PageContentFetcher;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\WikiPageLayoutLookup;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiMockAuthorityTrait;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use TestLogger;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Persistence\MediaWiki\WikiPageLayoutLookup
+ */
+class WikiPageLayoutLookupTest extends MediaWikiIntegrationTestCase {
+
+	use NeoWikiMockAuthorityTrait;
+
+	public function testUnreadableLayoutPageIsNullAndContentIsNeverFetched(): void {
+		$fetcher = $this->createMock( PageContentFetcher::class );
+		$fetcher->expects( $this->never() )->method( 'getPageContent' );
+
+		$lookup = $this->newLookup( $this->mockRegisteredAuthority( static fn () => false ), $fetcher );
+
+		$this->assertNull( $lookup->getLayout( new LayoutName( 'Person card' ) ) );
+	}
+
+	public function testReadableLayoutPageDelegatesToTheContentFetcher(): void {
+		$fetcher = $this->createMock( PageContentFetcher::class );
+		$fetcher->expects( $this->once() )->method( 'getPageContent' )->willReturn( null );
+
+		$lookup = $this->newLookup( $this->mockRegisteredAuthority( static fn () => true ), $fetcher );
+
+		$this->assertNull( $lookup->getLayout( new LayoutName( 'Person card' ) ) );
+	}
+
+	public function testGateUsesBindingAuthorizeRead(): void {
+		// probablyCan is a UI-hint check that skips the expensive ACL hook; the gate must
+		// use the binding authorizeRead. Reverting fails this test.
+		$authority = $this->createMock( Authority::class );
+		$authority->method( 'probablyCan' )->willReturn( true );
+		$authority->method( 'authorizeRead' )->willReturn( false );
+		$authority->method( 'getUser' )->willReturn( new UserIdentityValue( 9999, 'Petr' ) );
+
+		$fetcher = $this->createMock( PageContentFetcher::class );
+		$fetcher->expects( $this->never() )->method( 'getPageContent' );
+
+		$logger = new TestLogger( true, null, true );
+
+		$this->assertNull(
+			$this->newLookup( $authority, $fetcher, $logger )->getLayout( new LayoutName( 'Person card' ) )
+		);
+
+		// Mirrors AuthorityBasedSubjectAuthorizerTest::testDeniedReadIsLogged.
+		$this->assertSame(
+			[ [ 'info', 'NeoWiki: denied read of page {page} to {user}',
+				[ 'page' => 'Layout:Person_card', 'user' => 'Petr' ] ] ],
+			$logger->getBuffer()
+		);
+	}
+
+	private function newLookup(
+		Authority $authority,
+		PageContentFetcher $fetcher,
+		LoggerInterface $logger = new NullLogger()
+	): WikiPageLayoutLookup {
+		$title = $this->createMock( Title::class );
+		$title->method( 'exists' )->willReturn( true );
+		$title->method( 'getPrefixedDBkey' )->willReturn( 'Layout:Person_card' );
+
+		$titleFactory = $this->createStub( TitleFactory::class );
+		$titleFactory->method( 'newFromText' )->with( 'Person card', NeoWikiExtension::NS_LAYOUT )->willReturn( $title );
+
+		return new WikiPageLayoutLookup(
+			pageContentFetcher: $fetcher,
+			authority: $authority,
+			layoutDeserializer: new LayoutPersistenceDeserializer(),
+			titleFactory: $titleFactory,
+			logger: $logger,
+		);
+	}
+
+}

--- a/tests/phpunit/Persistence/MediaWiki/WikiPageLayoutLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/WikiPageLayoutLookupTest.php
@@ -49,7 +49,10 @@ class WikiPageLayoutLookupTest extends MediaWikiIntegrationTestCase {
 		// use the binding authorizeRead. Reverting fails this test.
 		$authority = $this->createMock( Authority::class );
 		$authority->method( 'probablyCan' )->willReturn( true );
-		$authority->method( 'authorizeRead' )->willReturn( false );
+		$authority->method( 'authorizeRead' )->willReturnCallback( function ( string $action ) {
+			$this->assertSame( 'read', $action );
+			return false;
+		} );
 		$authority->method( 'getUser' )->willReturn( new UserIdentityValue( 9999, 'Petr' ) );
 
 		$fetcher = $this->createMock( PageContentFetcher::class );

--- a/tests/phpunit/Persistence/MediaWiki/WikiPageLayoutLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/WikiPageLayoutLookupTest.php
@@ -66,7 +66,7 @@ class WikiPageLayoutLookupTest extends MediaWikiIntegrationTestCase {
 
 		// Mirrors AuthorityBasedSubjectAuthorizerTest::testDeniedReadIsLogged.
 		$this->assertSame(
-			[ [ 'info', 'NeoWiki: denied read of page {page} to {user}',
+			[ [ 'info', 'Denied read of page {page} to {user}',
 				[ 'page' => 'Layout:Person_card', 'user' => 'Petr' ] ] ],
 			$logger->getBuffer()
 		);


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1058

Review fix from an AI review of that PR, complementing the fixes in
https://github.com/ProfessionalWiki/NeoWiki/pull/1071: the gate-before-cache ordering in
`CachingSchemaLookup` and `CachingMappingLookup` was only ever tested against a cold cache, so a
refactor that consults the shared revision-keyed cache before the gate would serve cached content to
denied callers with the suite staying green. The new tests warm the cache as an allowed caller and
assert a denied caller still gets null.

Both tests were proven load-bearing by mutation: moving the gate after the cache read turns them red
while the pre-existing tests stay green.

> <sub>AI-authored — Claude Code, `Opus 4.8 (max)`; review-fix delivery from a multi-agent review of
> PR #1058 for @malberts, no steering after launch; diff not yet human-reviewed; tests proven
> load-bearing by mutation, caching suites and phpcs+phpstan green locally on this branch, full suite
> green with these tests on the pre-split branch.</sub>

<details><summary>Production notes</summary>

Review and finding verification by `Fable 5 (max)` with adversarial verifier subagents; implementation by
`Opus 4.8 (max)`. Context: the full PR #1058 diff, the NeoWiki test suite, and a live dev-stack
reproduction of the PR's denial matrix.

</details>
