### PR TITLE
Gate the Developers SPARQL-queries pointer behind {{#ifexist:}}

### DIFF
--- a/DemoData/Page/Developers.wikitext
+++ b/DemoData/Page/Developers.wikitext
@@ -20,7 +20,7 @@ Result:
 
 {{#cypher_raw:MATCH (m:Museum) RETURN m.name AS name, m.`Annual visitors` AS visitors ORDER BY visitors DESC LIMIT 5}}
 
-On wikis with a configured [https://github.com/ProfessionalWiki/NeoWiki/blob/master/docs/operations/installation.md#optional-sparql-graph-stores SPARQL store], the same structured data is also queryable as RDF: see [[SPARQL queries]] (a page imported only when such a store is configured).
+{{#ifexist:SPARQL queries|On wikis with a configured [https://github.com/ProfessionalWiki/NeoWiki/blob/master/docs/operations/installation.md#optional-sparql-graph-stores SPARQL store], the same structured data is also queryable as RDF: see [[SPARQL queries]].}}
 
 == Read values in wikitext ==
 

--- a/DemoData/Page/Developers.wikitext
+++ b/DemoData/Page/Developers.wikitext
@@ -20,7 +20,7 @@ Result:
 
 {{#cypher_raw:MATCH (m:Museum) RETURN m.name AS name, m.`Annual visitors` AS visitors ORDER BY visitors DESC LIMIT 5}}
 
-{{#ifexist:SPARQL queries|On wikis with a configured [https://github.com/ProfessionalWiki/NeoWiki/blob/master/docs/operations/installation.md#optional-sparql-graph-stores SPARQL store], the same structured data is also queryable as RDF: see [[SPARQL queries]].}}
+{{#ifexist:SPARQL queries|This wiki also projects its structured data to RDF, queryable with SPARQL: see [[SPARQL queries]].}}
 
 == Read values in wikitext ==
 


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1056

DemoData/Page/Developers.wikitext always imports and links `[[SPARQL queries]]`,
but that page is imported only when `$wgNeoWikiSparqlStores` is non-empty
(`ImportDemoData.php::getPageDirectories`). On a wiki with no SPARQL store — e.g.
the public neowiki.dev demo — the conditional import skips the page, so the
pointer renders as a live redlink (it is live there right now).

Wrapping the sentence in `{{#ifexist:SPARQL queries|...}}` makes the pointer
self-gating: it renders only where the target page exists and disappears cleanly
otherwise. The now-redundant "(a page imported only when such a store is
configured)" parenthetical is dropped. ParserFunctions is loaded on all our
stacks, so `{{#ifexist:}}` is available.

`{{#ifexist:}}` registers the target in pagelinks, so MediaWiki re-renders
Developers automatically when the page is later created — if a store is added to
a wiki and the import runs, the pointer reappears without a manual purge.

Verified live in a dev wiki with a SPARQL store configured (import creates the
SPARQL queries page):

- Page present: the sentence renders a normal blue link
  (`<a href="/wiki/SPARQL_queries" title="SPARQL queries">SPARQL queries</a>` —
  no `class="new"`).
- SPARQL queries deleted and Developers purged (simulating neowiki.dev): the
  sentence is gone entirely — no redlink, no anchor, no leftover punctuation
  (the paragraph collapses to an empty `<p><br /></p>`).
- Re-importing restores the page and the normal link.

`make cs` is clean (no PHP changed).

> <sub>AI-authored — Claude Code, `Opus 4.8 (max)`; detailed spec from @JeroenDeDauw, no redirects; diff not yet human-reviewed; verified live in a dev wiki both directions (link renders with the SPARQL page present, disappears with it absent) and `make cs` green.</sub>
