### PR TITLE
Correct the documented cypher_raw output wrapper

### DIFF
--- a/docs/authoring/parser-functions.md
+++ b/docs/authoring/parser-functions.md
@@ -150,7 +150,7 @@ custom result formatting in templates.
 - Errors (rejected queries, syntax errors, the database being unavailable, etc.) render as a
   styled error message in place of the result.
 - Output is HTML-escaped, so query results containing `<`, `>`, `&`, etc. display safely.
-- The output is wrapped in `<pre><code class="json">` and the error message in
+- The output is wrapped in `<div class="mw-neowiki-cypher-result"><pre>` and the error message in
   `<div class="error">`, so you can target either with CSS.
 
 ### Examples


### PR DESCRIPTION
The cypher_raw notes said the output is wrapped in `<pre><code class="json">`, but the code emits `<div class="mw-neowiki-cypher-result"><pre>` with no `code` element, so CSS targeting the documented wrapper matches nothing. Document the actual wrapper, phrased like the sparql_raw section, which already documents its wrapper correctly.

The bullet was accurate when written: the original parser function (1aee8285) emitted `<pre><code class="json">`. The wrapper changed to its current form in #817 without the doc following.

> <sub>AI-authored — Claude Code, `Fable 5 (max)`; one-line ask from @malberts after the drift surfaced in an AI review of #1069, one requested addition; diff not yet human-reviewed; wrapper confirmed against the emitting code, a live dev-wiki render, and an adversarial `Opus 4.8` subagent re-check.</sub>