### PR TITLE
Render view error output as HTML instead of wikitext

### DIFF
--- a/src/EntryPoints/ViewParserFunction.php
+++ b/src/EntryPoints/ViewParserFunction.php
@@ -25,7 +25,7 @@ class ViewParserFunction {
 		$parsed = $this->parseArgs( $parser, $args );
 
 		if ( is_string( $parsed ) ) {
-			return $parsed;
+			return $this->asHtml( $parsed );
 		}
 
 		[ $explicitSubjectId, $layoutName ] = $parsed;
@@ -36,11 +36,7 @@ class ViewParserFunction {
 			return '';
 		}
 
-		return [
-			ViewHtmlBuilder::viewPlaceholderHtml( $resolvedSubjectId, $layoutName ),
-			'noparse' => true,
-			'isHTML' => true,
-		];
+		return $this->asHtml( ViewHtmlBuilder::viewPlaceholderHtml( $resolvedSubjectId, $layoutName ) );
 	}
 
 	/**
@@ -144,6 +140,19 @@ class ViewParserFunction {
 			->getMainSubject();
 
 		return $subject?->getId()->text;
+	}
+
+	/**
+	 * Hands the HTML to the parser as HTML rather than wikitext. Without this the text is parsed as
+	 * wikitext, which autolinks any URL it happens to hold: the URL is swallowed into a link and its
+	 * trailing quote percent-encoded, corrupting the error box. The error messages echo the offending
+	 * user-supplied argument, which can itself carry a URL, so they need this treatment. The
+	 * subject placeholder is armoured the same way.
+	 *
+	 * @return array{0: string, noparse: true, isHTML: true}
+	 */
+	private function asHtml( string $html ): array {
+		return [ $html, 'noparse' => true, 'isHTML' => true ];
 	}
 
 }

--- a/tests/phpunit/EntryPoints/ViewParserFunctionParsingTest.php
+++ b/tests/phpunit/EntryPoints/ViewParserFunctionParsingTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints;
+
+use MediaWiki\Parser\Parser;
+use MediaWiki\Parser\ParserOptions;
+use MediaWiki\Title\Title;
+use MediaWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\EntryPoints\ViewParserFunction;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectContentRepository;
+
+/**
+ * What a reader ends up with, rather than what the parser function returns: the corruption this
+ * guards against happens in MediaWiki's parser, after the function has handed its text back, so it
+ * is invisible to a test that only inspects the return value.
+ *
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\ViewParserFunction
+ * @group Database
+ */
+class ViewParserFunctionParsingTest extends MediaWikiIntegrationTestCase {
+
+	private const string URL = 'https://example.com/x';
+
+	private function parseView(): string {
+		$parser = $this->getServiceContainer()->getParserFactory()->create();
+
+		$parser->setFunctionHook(
+			'view',
+			static function ( Parser $parser, string ...$args ): string|array {
+				return ( new ViewParserFunction( new InMemorySubjectContentRepository() ) )->handle( $parser, ...$args );
+			}
+		);
+
+		return $parser->parse(
+			'{{#view: Foo | "' . self::URL . '" }}',
+			Title::makeTitle( NS_MAIN, 'ViewParsingTest' ),
+			ParserOptions::newFromAnon()
+		)->getText();
+	}
+
+	public function testErrorUrlSurvivesParsingUnchanged(): void {
+		$html = html_entity_decode( $this->parseView() );
+
+		$this->assertStringContainsString( '"' . self::URL . '"', $html );
+	}
+
+	public function testErrorUrlIsNotTurnedIntoLink(): void {
+		$html = $this->parseView();
+
+		$this->assertStringNotContainsString( '<a ', $html );
+		$this->assertStringNotContainsString( '%22', $html );
+	}
+
+}

--- a/tests/phpunit/EntryPoints/ViewParserFunctionTest.php
+++ b/tests/phpunit/EntryPoints/ViewParserFunctionTest.php
@@ -129,6 +129,14 @@ class ViewParserFunctionTest extends TestCase {
 		$this->assertRendersError( $result, 'neowiki-view-error-unknown-arg', '=Finances' );
 	}
 
+	public function testErrorIsArmouredAgainstWikitextTransformation(): void {
+		$result = $this->callView( self::EXPLICIT_SUBJECT_ID, 'https://example.com' );
+
+		$this->assertIsArray( $result, 'Error detail echoes the offending argument, which can carry a URL, so it needs the same armour.' );
+		$this->assertTrue( $result['isHTML'] );
+		$this->assertTrue( $result['noparse'] );
+	}
+
 	private function callView( string ...$args ): string|array {
 		return ( new ViewParserFunction( $this->repositoryWithMainSubject() ) )
 			->handle( $this->createMockParser(), ...$args );
@@ -165,7 +173,7 @@ class ViewParserFunctionTest extends TestCase {
 		$this->assertTrue( $result['isHTML'] );
 		$this->assertTrue( $result['noparse'] );
 
-		$html = $result[0];
+		$html = $this->html( $result );
 		$this->assertStringContainsString( 'data-mw-neowiki-subject-id="' . $subjectId . '"', $html );
 
 		if ( $layoutName === null ) {
@@ -179,13 +187,24 @@ class ViewParserFunctionTest extends TestCase {
 	 * @param string|array{0: string, noparse: true, isHTML: true} $result
 	 */
 	private function assertRendersError( string|array $result, string $messageKey, ?string $insertion = null ): void {
-		$this->assertIsString( $result, 'Expected an error HTML string; got a placeholder array.' );
-		$this->assertStringContainsString( 'class="error"', $result );
-		$this->assertStringContainsString( $messageKey, $result );
+		$this->assertIsArray( $result, 'Expected an armoured error array; got an error string or empty string.' );
+		$html = $this->html( $result );
+
+		$this->assertStringContainsString( 'class="error"', $html );
+		$this->assertStringContainsString( $messageKey, $html );
 
 		if ( $insertion !== null ) {
-			$this->assertStringContainsString( $insertion, $result );
+			$this->assertStringContainsString( $insertion, $html );
 		}
+	}
+
+	/**
+	 * The HTML the parser function hands back, from either its result or its error shape.
+	 *
+	 * @param array{0: string, noparse: true, isHTML: true} $result
+	 */
+	private function html( array $result ): string {
+		return $result[0];
 	}
 
 }


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1069.

The `{{#view}}` error box was returned as a bare parser-function string, which MediaWiki treats as wikitext. When an error message interpolates the offending user-supplied argument and that argument holds a URL, the parser autolinks it: the URL is wrapped in an anchor, and a trailing quote is swallowed into the link and percent-encoded, corrupting the surrounding markup.

Wrap the error output in the same `isHTML`/`noparse` array the success placeholder and `cypher_raw` already use, so the parser leaves it alone. The wrapping happens at the `handle()` boundary rather than inside `renderError()`: the internal `parseArgs()`/`classifyArgs()` plumbing distinguishes an error string from a parsed argument tuple by type, so an armoured array there would be indistinguishable from the tuple.

> <sub>AI-authored — Claude Code, `Fable 5 (max)`; one-line ask from @malberts after the bug surfaced in an AI review of #1069; no revisions; diff not yet human-reviewed; parser-level regression test seen failing before the fix and passing after, full PHPUnit suite + PHPCS + PHPStan green locally, and both error and success paths verified in a browser on a live dev wiki.</sub>

<details><summary>Production notes</summary>

Spec and review by `Fable 5 (max)`; implementation and tests by an `Opus 4.8 (max)` subagent. Browser verification was automated (Playwright) against the bundled demo data, not human-clicked.

</details>