### PR TITLE
Keep referenced Subjects as stubs instead of deleting them

### DIFF
--- a/docs/api/graph-model.md
+++ b/docs/api/graph-model.md
@@ -78,6 +78,23 @@ Property Name "Founded at" and a number value of `2019` results in a node proper
 Relation-type Statements are not stored as node properties. They are stored as relationships between Subject
 nodes (see below).
 
+### Stub Subject nodes
+
+A Subject node can exist as a *stub*: a node stripped down to only its `id` and `wiki_id` properties and the
+`Subject` label — no `name`, no Schema label, and no Statement-derived properties. A stub keeps a Subject's identity
+available for incoming relations while carrying none of its data.
+
+Stubs arise in two ways:
+
+- **Referenced but removed.** When a Subject is removed from its page (or its page is deleted) but other Subjects
+  still hold relations to it, its node is reduced to a stub rather than deleted, and its `HasSubject` and outgoing
+  relationships are removed. This keeps the incoming references valid.
+- **Referenced but not yet created.** When a Relation targets a Subject that does not exist yet, a stub target node
+  is created so the relationship can be stored.
+
+When the real Subject is later saved, its node is upgraded in place — matched by `id` alone, so the stub gains its
+properties and Schema label without creating a duplicate node.
+
 ## Relationships
 
 ### HasSubject
@@ -102,8 +119,8 @@ backtick-escaped.
 | `id` | string | Relation ID, 15 characters starting with `r` |
 | *(additional)* | scalar | Any properties from the Relation's property map |
 
-When a Subject is deleted but still has incoming relations from other Subjects, its outgoing relationships and
-`HasSubject` relationship are removed, but the node itself is kept so that the incoming references remain valid.
+When a Subject with incoming relations from other Subjects is removed, its node is kept as a
+[stub](#stub-subject-nodes) so those incoming references remain valid.
 
 ## Constraints
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -196,16 +196,6 @@ parameters:
 			path: src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jQueryStore.php
 
 		-
-			message: "#^Cannot call method get\\(\\) on mixed\\.$#"
-			count: 1
-			path: src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectUpdater.php
-
-		-
-			message: "#^Method ProfessionalWiki\\\\NeoWiki\\\\GraphDatabasePlugins\\\\Neo4j\\\\Persistence\\\\Neo4jSubjectUpdater\\:\\:getNodeLabels\\(\\) should return array\\<string\\> but returns array\\<int, mixed\\>\\.$#"
-			count: 1
-			path: src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectUpdater.php
-
-		-
 			message: "#^Cannot access property \\$page_title on array\\|stdClass\\|false\\.$#"
 			count: 1
 			path: src/Persistence/MediaWiki/DatabaseLayoutNameLookup.php

--- a/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jNodeLabels.php
+++ b/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jNodeLabels.php
@@ -1,0 +1,52 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence;
+
+use Laudis\Neo4j\Contracts\TransactionInterface;
+use Laudis\Neo4j\Databags\SummarizedResult;
+
+/**
+ * Reads and removes the labels of a Neo4j node identified by its id, within a given transaction.
+ *
+ * Shared by Neo4jSubjectUpdater (reconciling a subject's labels with its schema) and
+ * Neo4jProjectionStore (stripping a subject down to a stub). Those classes hold their transaction
+ * differently, so the transaction is passed in per call rather than owned here.
+ */
+class Neo4jNodeLabels {
+
+	/**
+	 * @return string[]
+	 */
+	public static function read( TransactionInterface $transaction, string $nodeId ): array {
+		/**
+		 * @var SummarizedResult $result
+		 */
+		$result = $transaction->run(
+			'MATCH (n {id: $id}) RETURN labels(n) AS labels',
+			[ 'id' => $nodeId ]
+		);
+
+		if ( $result->isEmpty() ) {
+			return [];
+		}
+
+		return $result->first()->get( 'labels' )->toArray();
+	}
+
+	/**
+	 * @param string[] $labels
+	 */
+	public static function remove( TransactionInterface $transaction, string $nodeId, array $labels ): void {
+		if ( $labels === [] ) {
+			return;
+		}
+
+		$transaction->run(
+			'MATCH (n {id: $id}) REMOVE n:' . Cypher::buildLabelList( $labels ),
+			[ 'id' => $nodeId ]
+		);
+	}
+
+}

--- a/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStore.php
+++ b/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStore.php
@@ -222,38 +222,11 @@ readonly class Neo4jProjectionStore implements GraphDatabasePlugin {
 	}
 
 	private function removeNonStubLabels( TransactionInterface $transaction, SubjectId $subjectId ): void {
-		$labelsToRemove = array_diff(
-			$this->getSubjectLabels( $transaction, $subjectId ),
-			[ 'Subject' ]
+		Neo4jNodeLabels::remove(
+			$transaction,
+			$subjectId->text,
+			array_diff( Neo4jNodeLabels::read( $transaction, $subjectId->text ), [ 'Subject' ] )
 		);
-
-		if ( $labelsToRemove === [] ) {
-			return;
-		}
-
-		$transaction->run(
-			'MATCH (subject {id: $subjectId}) REMOVE subject:' . Cypher::buildLabelList( $labelsToRemove ),
-			[ 'subjectId' => $subjectId->text ]
-		);
-	}
-
-	/**
-	 * @return string[]
-	 */
-	private function getSubjectLabels( TransactionInterface $transaction, SubjectId $subjectId ): array {
-		/**
-		 * @var SummarizedResult $result
-		 */
-		$result = $transaction->run(
-			'MATCH (subject {id: $subjectId}) RETURN labels(subject) AS labels',
-			[ 'subjectId' => $subjectId->text ]
-		);
-
-		if ( $result->isEmpty() ) {
-			return [];
-		}
-
-		return $result->first()->get( 'labels' )->toArray();
 	}
 
 	private function subjectHasIncomingRelations( TransactionInterface $transaction, SubjectId $subjectId ): bool {

--- a/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStore.php
+++ b/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStore.php
@@ -32,50 +32,63 @@ readonly class Neo4jProjectionStore implements GraphDatabasePlugin {
 
 	public function savePage( Page $page ): void {
 		$this->client->writeTransaction( function ( TransactionInterface $transaction ) use ( $page ): void {
-			$properties = $page->getProperties()->asArray();
-			[ $typedSetClauses, $typedParams, $properties ] = $this->extractTypedValues( $properties );
-
-			$cypher = '
-				// Create or update the page. Page identity is scoped per wiki so that
-				// pages from different wikis sharing the same id do not collide in a shared graph.
-				// The wiki_id is persisted by the MERGE pattern itself.
-				MERGE (page:Page {id: $pageId, wiki_id: $wikiId})
-				SET page += $properties
-				SET page.id = $pageId';
-
-			if ( $typedSetClauses !== '' ) {
-				$cypher .= ',' . $typedSetClauses;
-			}
-
-			$cypher .= '
-
-				// Delete subjects that are no longer present on the page
-				WITH page
-				MATCH (page)-[r:HasSubject]->(subject)
-				WHERE NOT subject.id IN $subjectIds
-				DETACH DELETE subject
-
-				// Remove all existing HasSubject relations
-				WITH page
-				MATCH (page)-[r:HasSubject]->()
-				DELETE r
-				';
-
-			$transaction->run(
-				$cypher,
-				array_merge(
-					[
-						'pageId' => $page->getId()->id,
-						'wikiId' => $this->wikiId,
-						'subjectIds' => $page->getSubjects()->getAllSubjects()->getIdsAsTextArray(),
-						'properties' => new CypherMap( $properties ),
-					],
-					$typedParams,
-				)
-			);
-
+			$this->upsertPageNode( $transaction, $page );
+			$this->removeAbsentSubjects( $transaction, $page );
+			$this->detachSubjectsFromPage( $transaction, $page->getId() );
 			$this->updateSubjects( $transaction, $page );
 		} );
+	}
+
+	private function upsertPageNode( TransactionInterface $transaction, Page $page ): void {
+		$properties = $page->getProperties()->asArray();
+		[ $typedSetClauses, $typedParams, $properties ] = $this->extractTypedValues( $properties );
+
+		// Create or update the page. Page identity is scoped per wiki so that pages from different
+		// wikis sharing the same id do not collide in a shared graph. The wiki_id is persisted by
+		// the MERGE pattern itself.
+		$cypher = '
+			MERGE (page:Page {id: $pageId, wiki_id: $wikiId})
+			SET page += $properties
+			SET page.id = $pageId';
+
+		if ( $typedSetClauses !== '' ) {
+			$cypher .= ',' . $typedSetClauses;
+		}
+
+		$transaction->run(
+			$cypher,
+			array_merge(
+				[
+					'pageId' => $page->getId()->id,
+					'wikiId' => $this->wikiId,
+					'properties' => new CypherMap( $properties ),
+				],
+				$typedParams,
+			)
+		);
+	}
+
+	/**
+	 * Removes the subjects that are attached to the page in the graph but are no longer present on the
+	 * page. This reuses deleteSubject so that a removed subject still referenced by other subjects is
+	 * kept as a stub instead of being deleted, keeping the incoming relations valid.
+	 */
+	private function removeAbsentSubjects( TransactionInterface $transaction, Page $page ): void {
+		$presentSubjectIds = $page->getSubjects()->getAllSubjects()->getIdsAsTextArray();
+
+		foreach ( $this->getSubjectIdsByPageId( $transaction, $page->getId() ) as $attachedSubjectId ) {
+			if ( !in_array( $attachedSubjectId, $presentSubjectIds, true ) ) {
+				$this->deleteSubject( $transaction, new SubjectId( $attachedSubjectId ) );
+			}
+		}
+	}
+
+	private function detachSubjectsFromPage( TransactionInterface $transaction, PageId $pageId ): void {
+		$transaction->run(
+			'MATCH (page:Page {id: $pageId, wiki_id: $wikiId})-[hasSubject:HasSubject]->()
+				DELETE hasSubject',
+			[ 'pageId' => $pageId->id, 'wikiId' => $this->wikiId ]
+		);
 	}
 
 	/**
@@ -157,7 +170,6 @@ readonly class Neo4jProjectionStore implements GraphDatabasePlugin {
 	}
 
 	/**
-	 * FIXME: tests still pass if this function returns an empty array
 	 * @return string[]
 	 */
 	private function getSubjectIdsByPageId( TransactionInterface $transaction, PageId $pageId ): array {
@@ -178,18 +190,7 @@ readonly class Neo4jProjectionStore implements GraphDatabasePlugin {
 
 	private function deleteSubject( TransactionInterface $transaction, SubjectId $subjectId ): void {
 		if ( $this->subjectHasIncomingRelations( $transaction, $subjectId ) ) {
-			// Only remove HasSubject relations and outgoing relations.
-			// Keep the subject node itself because other subjects still reference it.
-			$transaction->run(
-				'
-					MATCH ()-[hsRelation:HasSubject]->(subject {id: $subjectId})
-					OPTIONAL MATCH (subject)-[outgoingSubjectRelation]->(o)
-					DELETE hsRelation, outgoingSubjectRelation
-					',
-				[ 'subjectId' => $subjectId->text ]
-			);
-			// TODO: clear properties?
-			// TODO: clear labels?
+			$this->reduceSubjectToStub( $transaction, $subjectId );
 		}
 		else {
 			$transaction->run(
@@ -198,6 +199,61 @@ readonly class Neo4jProjectionStore implements GraphDatabasePlugin {
 				[ 'subjectId' => $subjectId->text ]
 			);
 		}
+	}
+
+	/**
+	 * Reduces a subject node to a stub: it is detached from its page and its outgoing relations, and
+	 * stripped down to only the id and wiki_id properties and the Subject label. The incoming relations
+	 * from other subjects are kept, so the stub keeps those references valid. The stub is upgraded back
+	 * to a full subject in place if the subject is saved again.
+	 */
+	private function reduceSubjectToStub( TransactionInterface $transaction, SubjectId $subjectId ): void {
+		$transaction->run(
+			'MATCH (subject {id: $subjectId})
+				OPTIONAL MATCH ()-[hasSubject:HasSubject]->(subject)
+				OPTIONAL MATCH (subject)-[outgoingRelation]->()
+				DELETE hasSubject, outgoingRelation
+				SET subject = {id: $subjectId, wiki_id: $wikiId}
+				SET subject:Subject',
+			[ 'subjectId' => $subjectId->text, 'wikiId' => $this->wikiId ]
+		);
+
+		$this->removeNonStubLabels( $transaction, $subjectId );
+	}
+
+	private function removeNonStubLabels( TransactionInterface $transaction, SubjectId $subjectId ): void {
+		$labelsToRemove = array_diff(
+			$this->getSubjectLabels( $transaction, $subjectId ),
+			[ 'Subject' ]
+		);
+
+		if ( $labelsToRemove === [] ) {
+			return;
+		}
+
+		$transaction->run(
+			'MATCH (subject {id: $subjectId}) REMOVE subject:' . Cypher::buildLabelList( $labelsToRemove ),
+			[ 'subjectId' => $subjectId->text ]
+		);
+	}
+
+	/**
+	 * @return string[]
+	 */
+	private function getSubjectLabels( TransactionInterface $transaction, SubjectId $subjectId ): array {
+		/**
+		 * @var SummarizedResult $result
+		 */
+		$result = $transaction->run(
+			'MATCH (subject {id: $subjectId}) RETURN labels(subject) AS labels',
+			[ 'subjectId' => $subjectId->text ]
+		);
+
+		if ( $result->isEmpty() ) {
+			return [];
+		}
+
+		return $result->first()->get( 'labels' )->toArray();
 	}
 
 	private function subjectHasIncomingRelations( TransactionInterface $transaction, SubjectId $subjectId ): bool {

--- a/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStore.php
+++ b/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStore.php
@@ -70,17 +70,18 @@ readonly class Neo4jProjectionStore implements GraphDatabasePlugin {
 
 	/**
 	 * Removes the subjects that are attached to the page in the graph but are no longer present on the
-	 * page. This reuses deleteSubject so that a removed subject still referenced by other subjects is
+	 * page. This reuses removeSubjects so that a removed subject still referenced by other subjects is
 	 * kept as a stub instead of being deleted, keeping the incoming relations valid.
 	 */
 	private function removeAbsentSubjects( TransactionInterface $transaction, Page $page ): void {
 		$presentSubjectIds = $page->getSubjects()->getAllSubjects()->getIdsAsTextArray();
 
-		foreach ( $this->getSubjectIdsByPageId( $transaction, $page->getId() ) as $attachedSubjectId ) {
-			if ( !in_array( $attachedSubjectId, $presentSubjectIds, true ) ) {
-				$this->deleteSubject( $transaction, new SubjectId( $attachedSubjectId ) );
-			}
-		}
+		$absentSubjectIds = array_values( array_filter(
+			$this->getSubjectIdsByPageId( $transaction, $page->getId() ),
+			fn( string $subjectId ) => !in_array( $subjectId, $presentSubjectIds, true )
+		) );
+
+		$this->removeSubjects( $transaction, $absentSubjectIds );
 	}
 
 	private function detachSubjectsFromPage( TransactionInterface $transaction, PageId $pageId ): void {
@@ -153,9 +154,7 @@ readonly class Neo4jProjectionStore implements GraphDatabasePlugin {
 
 	public function deletePage( PageId $pageId ): void {
 		$this->client->writeTransaction( function ( TransactionInterface $transaction ) use ( $pageId ): void {
-			foreach ( $this->getSubjectIdsByPageId( $transaction, $pageId ) as $subjectId ) {
-				$this->deleteSubject( $transaction, new SubjectId( $subjectId ) );
-			}
+			$this->removeSubjects( $transaction, $this->getSubjectIdsByPageId( $transaction, $pageId ) );
 
 			$this->deletePageNode( $transaction, $pageId );
 		} );
@@ -178,7 +177,7 @@ readonly class Neo4jProjectionStore implements GraphDatabasePlugin {
 		 */
 		$results = $transaction->run(
 			'MATCH (page:Page {id: $pageId, wiki_id: $wikiId})-[:HasSubject]->(subject:Subject)
-				RETURN subject.id AS id, subject AS properties, labels(subject) AS labels',
+				RETURN subject.id AS id',
 			[ 'pageId' => $pageId->id, 'wikiId' => $this->wikiId ]
 		);
 
@@ -188,17 +187,68 @@ readonly class Neo4jProjectionStore implements GraphDatabasePlugin {
 		);
 	}
 
-	private function deleteSubject( TransactionInterface $transaction, SubjectId $subjectId ): void {
-		if ( $this->subjectHasIncomingRelations( $transaction, $subjectId ) ) {
-			$this->reduceSubjectToStub( $transaction, $subjectId );
+	/**
+	 * Removes the given subjects from the graph. A subject still referenced by an incoming relation from
+	 * another subject is reduced to a stub so that reference stays valid; the rest are deleted outright.
+	 *
+	 * The referenced/unreferenced split is computed with a single query and the unreferenced subjects are
+	 * deleted with a single query, rather than one round trip per subject.
+	 *
+	 * @param string[] $subjectIds
+	 */
+	private function removeSubjects( TransactionInterface $transaction, array $subjectIds ): void {
+		if ( $subjectIds === [] ) {
+			return;
 		}
-		else {
-			$transaction->run(
-				'MATCH (subject {id: $subjectId})
-				DETACH DELETE subject',
-				[ 'subjectId' => $subjectId->text ]
-			);
+
+		$referencedSubjectIds = $this->subjectIdsWithIncomingRelations( $transaction, $subjectIds );
+
+		$this->deleteSubjects( $transaction, array_values( array_diff( $subjectIds, $referencedSubjectIds ) ) );
+
+		foreach ( $referencedSubjectIds as $subjectId ) {
+			$this->reduceSubjectToStub( $transaction, new SubjectId( $subjectId ) );
 		}
+	}
+
+	/**
+	 * Returns the subset of the given subject ids that still have an incoming relation from a *different*
+	 * subject. HasSubject relations do not count, and neither does a self-loop: a subject whose only
+	 * incoming relation is its own outgoing self-reference has no external referrer, so it is deleted
+	 * rather than kept as an unreachable stub.
+	 *
+	 * @param string[] $subjectIds
+	 * @return string[]
+	 */
+	private function subjectIdsWithIncomingRelations( TransactionInterface $transaction, array $subjectIds ): array {
+		/**
+		 * @var SummarizedResult $result
+		 */
+		$result = $transaction->run(
+			'UNWIND $subjectIds AS subjectId
+				MATCH (subject {id: subjectId})<-[incomingRelation]-(other)
+				WHERE NOT incomingRelation:HasSubject AND other <> subject
+				RETURN DISTINCT subject.id AS id',
+			[ 'subjectIds' => $subjectIds ]
+		);
+
+		return array_map(
+			fn( $record ) => $record->get( 'id' ),
+			$result->toArray()
+		);
+	}
+
+	/**
+	 * @param string[] $subjectIds
+	 */
+	private function deleteSubjects( TransactionInterface $transaction, array $subjectIds ): void {
+		if ( $subjectIds === [] ) {
+			return;
+		}
+
+		$transaction->run(
+			'MATCH (subject) WHERE subject.id IN $subjectIds DETACH DELETE subject',
+			[ 'subjectIds' => $subjectIds ]
+		);
 	}
 
 	/**
@@ -213,6 +263,7 @@ readonly class Neo4jProjectionStore implements GraphDatabasePlugin {
 				OPTIONAL MATCH ()-[hasSubject:HasSubject]->(subject)
 				OPTIONAL MATCH (subject)-[outgoingRelation]->()
 				DELETE hasSubject, outgoingRelation
+				WITH DISTINCT subject
 				SET subject = {id: $subjectId, wiki_id: $wikiId}
 				SET subject:Subject',
 			[ 'subjectId' => $subjectId->text, 'wikiId' => $this->wikiId ]
@@ -227,15 +278,6 @@ readonly class Neo4jProjectionStore implements GraphDatabasePlugin {
 			$subjectId->text,
 			array_diff( Neo4jNodeLabels::read( $transaction, $subjectId->text ), [ 'Subject' ] )
 		);
-	}
-
-	private function subjectHasIncomingRelations( TransactionInterface $transaction, SubjectId $subjectId ): bool {
-		return $transaction->run(
-			'MATCH (subject {id: $subjectId})<-[incomingRelation]-()
-			WHERE NOT incomingRelation:HasSubject
-			RETURN incomingRelation',
-			[ 'subjectId' => $subjectId->text ]
-		)->isEmpty() === false;
 	}
 
 }

--- a/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectRelationUpdater.php
+++ b/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectRelationUpdater.php
@@ -15,6 +15,7 @@ class Neo4jSubjectRelationUpdater {
 		private readonly SubjectId $subjectId,
 		private readonly TypedRelationList $relations,
 		private readonly TransactionInterface $transaction,
+		private readonly string $wikiId,
 	) {
 	}
 
@@ -57,9 +58,14 @@ class Neo4jSubjectRelationUpdater {
 	}
 
 	private function createOrUpdate( TypedRelation $relation ): void {
+		// A relation whose target Subject does not exist yet creates it as a stub: a node with only
+		// the id and wiki_id properties and the Subject label. ON CREATE keeps an already-existing
+		// target (a real Subject or an earlier stub) untouched. The stub is upgraded in place when the
+		// real Subject is later saved, since the save path also matches the node by id alone.
 		$this->transaction->run(
 			'MERGE (subject {id: $subjectId})
 			 MERGE (target {id: $targetId})
+			 ON CREATE SET target:Subject, target.wiki_id = $wikiId
 			 MERGE (subject)-[relation:' . Cypher::escape( $relation->type->text ) . ' {id: $relationId}]->(target)
 			 SET relation = $relationProperties',
 			[
@@ -67,6 +73,7 @@ class Neo4jSubjectRelationUpdater {
 				'relationId' => $relation->id->asString(),
 				'relationProperties' => $this->getPropertiesForNeo4j( $relation ),
 				'targetId' => $relation->targetId->text,
+				'wikiId' => $this->wikiId,
 			]
 		);
 	}

--- a/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectUpdater.php
+++ b/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectUpdater.php
@@ -174,7 +174,8 @@ class Neo4jSubjectUpdater {
 		$updater = new Neo4jSubjectRelationUpdater(
 			$subject->getId(),
 			$subject->getTypedRelations( $schema ),
-			$this->transaction
+			$this->transaction,
+			$this->wikiId
 		);
 		$updater->updateRelations();
 	}

--- a/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectUpdater.php
+++ b/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectUpdater.php
@@ -5,15 +5,12 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence;
 
 use Laudis\Neo4j\Contracts\TransactionInterface;
-use Laudis\Neo4j\Databags\SummarizedResult;
-use Laudis\Neo4j\Types\CypherList;
 use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
 use ProfessionalWiki\NeoWiki\Domain\Statement;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
-use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use Psr\Log\LoggerInterface;
 
 class Neo4jSubjectUpdater {
@@ -124,17 +121,10 @@ class Neo4jSubjectUpdater {
 	}
 
 	private function updateNodeLabels( Subject $subject ): void {
-		$oldLabels = $this->getNodeLabels( $subject->id );
+		$oldLabels = Neo4jNodeLabels::read( $this->transaction, $subject->id->text );
 		$newLabels = [ 'Subject', $subject->getSchemaName()->getText() ];
 
-		$labelsToRemove = array_diff( $oldLabels, $newLabels );
-
-		if ( $labelsToRemove !== [] ) {
-			$this->transaction->run(
-				'MATCH (n {id: $id}) REMOVE n:' . Cypher::buildLabelList( $labelsToRemove ),
-				[ 'id' => $subject->id->text ]
-			);
-		}
+		Neo4jNodeLabels::remove( $this->transaction, $subject->id->text, array_diff( $oldLabels, $newLabels ) );
 
 		$labelsToAdd = array_diff( $newLabels, $oldLabels );
 
@@ -144,30 +134,6 @@ class Neo4jSubjectUpdater {
 				[ 'id' => $subject->id->text ]
 			);
 		}
-	}
-
-	/**
-	 * @return string[]
-	 */
-	private function getNodeLabels( SubjectId $id ): array {
-		/**
-		 * @var SummarizedResult $result
-		 */
-		$result = $this->transaction->run(
-			'MATCH (n) WHERE n.id = $id RETURN labels(n)',
-			[ 'id' => $id->text ]
-		);
-
-		if ( $result->isEmpty() ) {
-			return [];
-		}
-
-		/**
-		 * @var CypherList $labels
-		 */
-		$labels = $result->first()->get( 'labels(n)' );
-
-		return $labels->toArray();
 	}
 
 	private function updateRelations( Subject $subject, Schema $schema ): void {

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStoreTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStoreTest.php
@@ -43,6 +43,7 @@ class Neo4jProjectionStoreTest extends NeoWikiIntegrationTestCase {
 	private const GUID_2 = 'sTestNQS1111112';
 	private const GUID_3 = 'sTestNQS1111113';
 	private const GUID_4 = 'sTestNQS1111114';
+	private const GUID_5 = 'sTestNQS1111115';
 	private const SCHEMA_ID_A = 'sTestNQS111111A';
 	private const SCHEMA_ID_Z = 'sTestNQS111111Z';
 	private const WIKI_ID = 'my_wiki';
@@ -391,6 +392,52 @@ class Neo4jProjectionStoreTest extends NeoWikiIntegrationTestCase {
 		$this->assertRelationExists( self::GUID_2, 'LocatedIn', self::GUID_1 );
 	}
 
+	public function testReducingReferencedSubjectToStubKeepsIncomingRelationsButStripsOutgoingRelationsAndProperties(): void {
+		$store = $this->newProjectionStoreWithLocationRelation();
+
+		// GUID_1 has a scalar property and two outgoing relations (to GUID_3 and GUID_4).
+		$store->savePage( TestPage::build(
+			id: 1,
+			mainSubject: TestSubject::build(
+				id: self::GUID_1,
+				statements: new StatementList( [
+					TestStatement::build( property: 'nickname', value: 'Ada' ),
+					TestStatement::buildRelation(
+						property: 'locatedIn',
+						relations: [
+							TestRelation::build( id: 'rTestNQS1111rrB', targetId: self::GUID_3 ),
+							TestRelation::build( id: 'rTestNQS1111rrE', targetId: self::GUID_4 ),
+						],
+					),
+				] ),
+			),
+		) );
+
+		// GUID_2 and GUID_5, on their own pages, each hold an incoming relation to GUID_1.
+		$store->savePage( TestPage::build(
+			id: 2,
+			mainSubject: $this->buildSubjectWithLocationRelation( self::GUID_2, self::GUID_1, 'rTestNQS1111rCA' ),
+		) );
+		$store->savePage( TestPage::build(
+			id: 3,
+			mainSubject: $this->buildSubjectWithLocationRelation( self::GUID_5, self::GUID_1, 'rTestNQS1111rDA' ),
+		) );
+
+		$this->assertTrue(
+			$this->subjectHasProperty( self::GUID_1, 'nickname' ),
+			'Precondition: the subject has a projected scalar property before being stubbed'
+		);
+		$this->assertOutgoingRelationCount( self::GUID_1, 2, 'Precondition: the subject has two outgoing relations' );
+
+		// Remove GUID_1 from its page while GUID_2 and GUID_5 still reference it.
+		$store->savePage( TestPage::build( id: 1 ) );
+
+		$this->assertSubjectIsStub( self::GUID_1 );
+		$this->assertOutgoingRelationCount( self::GUID_1, 0 );
+		$this->assertRelationExists( self::GUID_2, 'LocatedIn', self::GUID_1 );
+		$this->assertRelationExists( self::GUID_5, 'LocatedIn', self::GUID_1 );
+	}
+
 	private function newProjectionStoreWithLocationRelation( string $wikiId = self::WIKI_ID ): GraphDatabasePlugin {
 		$extension = NeoWikiExtension::getInstance();
 
@@ -414,6 +461,7 @@ class Neo4jProjectionStoreTest extends NeoWikiIntegrationTestCase {
 				logger: new NullLogger(),
 				wikiId: $wikiId,
 			),
+			constraintUpdater: new Neo4jConstraintUpdater( new Neo4jWriteQueryEngine( $extension->getNeo4jClient() ) ),
 			wikiId: $wikiId,
 		);
 	}
@@ -442,6 +490,24 @@ class Neo4jProjectionStoreTest extends NeoWikiIntegrationTestCase {
 			$result->isEmpty(),
 			"Relation {$fromSubjectId}-[{$relationType}]->{$toSubjectId} should exist"
 		);
+	}
+
+	private function subjectHasProperty( string $subjectId, string $property ): bool {
+		$result = $this->readGraph(
+			'MATCH (subject {id: $id}) RETURN $property IN keys(subject) AS hasProperty',
+			[ 'id' => $subjectId, 'property' => $property ]
+		);
+
+		return $result->first()->toRecursiveArray()['hasProperty'];
+	}
+
+	private function assertOutgoingRelationCount( string $subjectId, int $expected, string $message = '' ): void {
+		$result = $this->readGraph(
+			'MATCH ({id: $id})-[relation]->() RETURN count(relation) AS count',
+			[ 'id' => $subjectId ]
+		);
+
+		$this->assertSame( $expected, $result->first()->toRecursiveArray()['count'], $message );
 	}
 
 	private function assertSubjectIsStub( string $subjectId ): void {

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStoreTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStoreTest.php
@@ -305,7 +305,7 @@ class Neo4jProjectionStoreTest extends NeoWikiIntegrationTestCase {
 
 		$store->savePage( TestPage::build( id: 1 ) );
 
-		$this->assertRelationExists( self::GUID_2, 'LocatedIn', self::GUID_1 );
+		$this->assertRelationExists( self::GUID_2, 'LocatedIn', self::GUID_1, 'rTestNQS1111rr1' );
 	}
 
 	public function testSavingPageWithoutAReferencedSubjectReducesItToAStub(): void {
@@ -361,7 +361,7 @@ class Neo4jProjectionStoreTest extends NeoWikiIntegrationTestCase {
 		$store->deletePage( new PageId( 1 ) );
 
 		$this->assertSubjectIsStub( self::GUID_1 );
-		$this->assertRelationExists( self::GUID_2, 'LocatedIn', self::GUID_1 );
+		$this->assertRelationExists( self::GUID_2, 'LocatedIn', self::GUID_1, 'rTestNQS1111rr1' );
 	}
 
 	public function testSavingASubjectUpgradesItsStubInPlace(): void {
@@ -390,7 +390,7 @@ class Neo4jProjectionStoreTest extends NeoWikiIntegrationTestCase {
 
 		$this->assertSame( [ 'Subject', TestSubject::DEFAULT_SCHEMA_ID ], $labels );
 		$this->assertSame( 'Real subject', $row['name'] );
-		$this->assertRelationExists( self::GUID_2, 'LocatedIn', self::GUID_1 );
+		$this->assertRelationExists( self::GUID_2, 'LocatedIn', self::GUID_1, 'rTestNQS1111rr1' );
 	}
 
 	public function testReducingReferencedSubjectToStubKeepsIncomingRelationsButStripsOutgoingRelationsAndProperties(): void {
@@ -435,8 +435,55 @@ class Neo4jProjectionStoreTest extends NeoWikiIntegrationTestCase {
 
 		$this->assertSubjectIsStub( self::GUID_1 );
 		$this->assertOutgoingRelationCount( self::GUID_1, 0 );
-		$this->assertRelationExists( self::GUID_2, 'LocatedIn', self::GUID_1 );
-		$this->assertRelationExists( self::GUID_5, 'LocatedIn', self::GUID_1 );
+		$this->assertRelationExists( self::GUID_2, 'LocatedIn', self::GUID_1, 'rTestNQS1111rCA' );
+		$this->assertRelationExists( self::GUID_5, 'LocatedIn', self::GUID_1, 'rTestNQS1111rDA' );
+	}
+
+	public function testFlippingASubjectBetweenMainAndChildLeavesASingleHasSubjectEdge(): void {
+		$store = $this->newProjectionStore();
+
+		$store->savePage( TestPage::build(
+			id: 42,
+			mainSubject: TestSubject::build( id: self::GUID_1 ),
+			childSubjects: new SubjectMap(
+				TestSubject::build( id: self::GUID_2 ),
+			)
+		) );
+
+		// Swap the roles: GUID_2 becomes the main subject and GUID_1 becomes a child.
+		// The HasSubject relation carries the isMain flag, so re-saving must not leave a
+		// second, stale HasSubject edge behind for either subject.
+		$store->savePage( TestPage::build(
+			id: 42,
+			mainSubject: TestSubject::build( id: self::GUID_2 ),
+			childSubjects: new SubjectMap(
+				TestSubject::build( id: self::GUID_1 ),
+			)
+		) );
+
+		$this->assertPageHasSubjects(
+			[
+				[ 'id' => self::GUID_1, 'hs' => [ 'isMain' => false ] ],
+				[ 'id' => self::GUID_2, 'hs' => [ 'isMain' => true ] ],
+			],
+			42
+		);
+	}
+
+	public function testRemovingASelfReferencingSubjectDeletesItRatherThanStubbingIt(): void {
+		$store = $this->newProjectionStoreWithLocationRelation();
+
+		// GUID_1 holds a relation to itself and nothing else references it.
+		$store->savePage( TestPage::build(
+			id: 1,
+			mainSubject: $this->buildSubjectWithLocationRelation( self::GUID_1, self::GUID_1, 'rTestNQS1111rr1' ),
+		) );
+
+		// Removing it from its page must delete it: a self-loop is not an external reference,
+		// so keeping it as a stub would leave an unreachable orphan node.
+		$store->savePage( TestPage::build( id: 1 ) );
+
+		$this->assertSubjectDoesNotExist( self::GUID_1 );
 	}
 
 	private function newProjectionStoreWithLocationRelation( string $wikiId = self::WIKI_ID ): GraphDatabasePlugin {
@@ -481,9 +528,14 @@ class Neo4jProjectionStoreTest extends NeoWikiIntegrationTestCase {
 		);
 	}
 
-	private function assertRelationExists( string $fromSubjectId, string $relationType, string $toSubjectId ): void {
+	private function assertRelationExists(
+		string $fromSubjectId,
+		string $relationType,
+		string $toSubjectId,
+		?string $expectedRelationId = null
+	): void {
 		$result = $this->readGraph(
-			'MATCH ({id: $from})-[relation:' . $relationType . ']->({id: $to}) RETURN relation',
+			'MATCH ({id: $from})-[relation:' . $relationType . ']->({id: $to}) RETURN relation.id AS id',
 			[ 'from' => $fromSubjectId, 'to' => $toSubjectId ]
 		);
 
@@ -491,6 +543,16 @@ class Neo4jProjectionStoreTest extends NeoWikiIntegrationTestCase {
 			$result->isEmpty(),
 			"Relation {$fromSubjectId}-[{$relationType}]->{$toSubjectId} should exist"
 		);
+
+		// Readers reconcile relations by their id, so a relation that survives by endpoints and type
+		// but loses its id is broken. Assert the id is preserved when the caller pins it down.
+		if ( $expectedRelationId !== null ) {
+			$this->assertSame(
+				$expectedRelationId,
+				$result->first()->toRecursiveArray()['id'],
+				"Relation {$fromSubjectId}-[{$relationType}]->{$toSubjectId} should keep its id"
+			);
+		}
 	}
 
 	private function subjectHasProperty( string $subjectId, string $property ): bool {

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStoreTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStoreTest.php
@@ -16,6 +16,7 @@ use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinitions;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\RelationProperty;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
+use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectMap;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jConstraintUpdater;
@@ -44,6 +45,7 @@ class Neo4jProjectionStoreTest extends NeoWikiIntegrationTestCase {
 	private const GUID_4 = 'sTestNQS1111114';
 	private const SCHEMA_ID_A = 'sTestNQS111111A';
 	private const SCHEMA_ID_Z = 'sTestNQS111111Z';
+	private const WIKI_ID = 'my_wiki';
 
 	public function setUp(): void {
 		$this->setUpNeo4j();
@@ -284,6 +286,185 @@ class Neo4jProjectionStoreTest extends NeoWikiIntegrationTestCase {
 			],
 			42
 		);
+	}
+
+	public function testSavingPageWithoutAReferencedSubjectPreservesIncomingRelations(): void {
+		$store = $this->newProjectionStoreWithLocationRelation();
+
+		$store->savePage( TestPage::build(
+			id: 1,
+			mainSubject: TestSubject::build( id: self::GUID_1 ),
+		) );
+
+		$store->savePage( TestPage::build(
+			id: 2,
+			mainSubject: $this->buildSubjectWithLocationRelation( self::GUID_2, self::GUID_1, 'rTestNQS1111rr1' ),
+		) );
+
+		$store->savePage( TestPage::build( id: 1 ) );
+
+		$this->assertRelationExists( self::GUID_2, 'LocatedIn', self::GUID_1 );
+	}
+
+	public function testSavingPageWithoutAReferencedSubjectReducesItToAStub(): void {
+		$store = $this->newProjectionStoreWithLocationRelation();
+
+		$store->savePage( TestPage::build(
+			id: 1,
+			mainSubject: TestSubject::build( id: self::GUID_1 ),
+		) );
+
+		$store->savePage( TestPage::build(
+			id: 2,
+			mainSubject: $this->buildSubjectWithLocationRelation( self::GUID_2, self::GUID_1, 'rTestNQS1111rr1' ),
+		) );
+
+		$store->savePage( TestPage::build( id: 1 ) );
+
+		$this->assertSubjectIsStub( self::GUID_1 );
+	}
+
+	public function testSavingPageWithoutAnUnreferencedSubjectDeletesIt(): void {
+		$store = $this->newProjectionStoreWithLocationRelation();
+
+		$store->savePage( TestPage::build(
+			id: 1,
+			mainSubject: TestSubject::build( id: self::GUID_1 ),
+			childSubjects: new SubjectMap(
+				TestSubject::build( id: self::GUID_2 ),
+			)
+		) );
+
+		$store->savePage( TestPage::build(
+			id: 1,
+			mainSubject: TestSubject::build( id: self::GUID_1 ),
+		) );
+
+		$this->assertSubjectDoesNotExist( self::GUID_2 );
+	}
+
+	public function testDeletingPageReducesAReferencedSubjectToAStub(): void {
+		$store = $this->newProjectionStoreWithLocationRelation();
+
+		$store->savePage( TestPage::build(
+			id: 1,
+			mainSubject: TestSubject::build( id: self::GUID_1 ),
+		) );
+
+		$store->savePage( TestPage::build(
+			id: 2,
+			mainSubject: $this->buildSubjectWithLocationRelation( self::GUID_2, self::GUID_1, 'rTestNQS1111rr1' ),
+		) );
+
+		$store->deletePage( new PageId( 1 ) );
+
+		$this->assertSubjectIsStub( self::GUID_1 );
+		$this->assertRelationExists( self::GUID_2, 'LocatedIn', self::GUID_1 );
+	}
+
+	public function testSavingASubjectUpgradesItsStubInPlace(): void {
+		$store = $this->newProjectionStoreWithLocationRelation();
+
+		$store->savePage( TestPage::build(
+			id: 2,
+			mainSubject: $this->buildSubjectWithLocationRelation( self::GUID_2, self::GUID_1, 'rTestNQS1111rr1' ),
+		) );
+
+		$store->savePage( TestPage::build(
+			id: 1,
+			mainSubject: TestSubject::build( id: self::GUID_1, label: 'Real subject' ),
+		) );
+
+		$result = $this->readGraph(
+			'MATCH (subject {id: $id}) RETURN subject.name AS name, labels(subject) AS labels',
+			[ 'id' => self::GUID_1 ]
+		);
+
+		$this->assertCount( 1, $result->toArray(), 'Saving the real subject should not create a duplicate node' );
+
+		$row = $result->first()->toRecursiveArray();
+		$labels = $row['labels'];
+		sort( $labels );
+
+		$this->assertSame( [ 'Subject', TestSubject::DEFAULT_SCHEMA_ID ], $labels );
+		$this->assertSame( 'Real subject', $row['name'] );
+		$this->assertRelationExists( self::GUID_2, 'LocatedIn', self::GUID_1 );
+	}
+
+	private function newProjectionStoreWithLocationRelation( string $wikiId = self::WIKI_ID ): GraphDatabasePlugin {
+		$extension = NeoWikiExtension::getInstance();
+
+		return new Neo4jProjectionStore(
+			client: $extension->getNeo4jClient(),
+			subjectUpdaterFactory: new Neo4jSubjectUpdaterFactory(
+				schemaLookup: new InMemorySchemaLookup(
+					TestSchema::build(
+						name: TestSubject::DEFAULT_SCHEMA_ID,
+						properties: new PropertyDefinitions( [
+							'locatedIn' => new RelationProperty(
+								core: new PropertyCore( description: '', required: false, default: null ),
+								relationType: new RelationType( 'LocatedIn' ),
+								targetSchema: new SchemaName( TestSubject::DEFAULT_SCHEMA_ID ),
+								multiple: false,
+							),
+						] ),
+					),
+				),
+				valueBuilderRegistry: $extension->getValueBuilderRegistry(),
+				logger: new NullLogger(),
+				wikiId: $wikiId,
+			),
+			wikiId: $wikiId,
+		);
+	}
+
+	private function buildSubjectWithLocationRelation( string $id, string $targetId, string $relationId ): Subject {
+		return TestSubject::build(
+			id: $id,
+			statements: new StatementList( [
+				TestStatement::buildRelation(
+					property: 'locatedIn',
+					relations: [
+						TestRelation::build( id: $relationId, targetId: $targetId ),
+					],
+				),
+			] ),
+		);
+	}
+
+	private function assertRelationExists( string $fromSubjectId, string $relationType, string $toSubjectId ): void {
+		$result = $this->readGraph(
+			'MATCH ({id: $from})-[relation:' . $relationType . ']->({id: $to}) RETURN relation',
+			[ 'from' => $fromSubjectId, 'to' => $toSubjectId ]
+		);
+
+		$this->assertFalse(
+			$result->isEmpty(),
+			"Relation {$fromSubjectId}-[{$relationType}]->{$toSubjectId} should exist"
+		);
+	}
+
+	private function assertSubjectIsStub( string $subjectId ): void {
+		$result = $this->readGraph(
+			'MATCH (subject {id: $id})
+				RETURN labels(subject) AS labels, subject.id AS id, subject.wiki_id AS wikiId, size(keys(subject)) AS propertyCount',
+			[ 'id' => $subjectId ]
+		);
+
+		$this->assertFalse( $result->isEmpty(), "Stub subject {$subjectId} should exist" );
+
+		$row = $result->first()->toRecursiveArray();
+
+		$this->assertSame( [ 'Subject' ], $row['labels'], "Stub {$subjectId} should keep only the Subject label" );
+		$this->assertSame( $subjectId, $row['id'] );
+		$this->assertSame( self::WIKI_ID, $row['wikiId'], "Stub {$subjectId} should keep its wiki_id" );
+		$this->assertSame( 2, $row['propertyCount'], "Stub {$subjectId} should keep only the id and wiki_id properties" );
+	}
+
+	private function assertSubjectDoesNotExist( string $subjectId ): void {
+		$result = $this->readGraph( 'MATCH (subject {id: $id}) RETURN subject', [ 'id' => $subjectId ] );
+
+		$this->assertTrue( $result->isEmpty(), "Subject {$subjectId} should not exist" );
 	}
 
 	public function testSavingPageAndThenDeletingItLeavesNoTrace(): void {

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStoreTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStoreTest.php
@@ -35,6 +35,7 @@ use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySchemaLookup;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jProjectionStore
+ * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jNodeLabels
  * @group Database
  */
 class Neo4jProjectionStoreTest extends NeoWikiIntegrationTestCase {

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectRelationUpdaterTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectRelationUpdaterTest.php
@@ -25,6 +25,7 @@ class Neo4jSubjectRelationUpdaterTest extends NeoWikiIntegrationTestCase {
 	private const string SUBJECT_ID = 'sTestSRU1111111';
 	private const string TARGET_SUBJECT_1 = 'sTestSRU1111112';
 	private const string TARGET_SUBJECT_2 = 'sTestSRU1111113';
+	private const string WIKI_ID = 'test_wiki';
 
 	public function setUp(): void {
 		$this->setUpNeo4j();
@@ -66,7 +67,8 @@ class Neo4jSubjectRelationUpdaterTest extends NeoWikiIntegrationTestCase {
 		$updater = new Neo4jSubjectRelationUpdater(
 			new SubjectId( self::SUBJECT_ID ),
 			$relations,
-			NeoWikiExtension::getInstance()->getNeo4jClient()
+			NeoWikiExtension::getInstance()->getNeo4jClient(),
+			self::WIKI_ID
 		);
 		$updater->updateRelations();
 	}
@@ -275,6 +277,33 @@ class Neo4jSubjectRelationUpdaterTest extends NeoWikiIntegrationTestCase {
 		);
 
 		$this->assertCount( 1, $result->getResults()->toRecursiveArray() );
+	}
+
+	public function testRelationToNonExistentTargetCreatesStubTarget(): void {
+		$targetId = 'sTestSRU111nope';
+
+		$this->updateRelations(
+			new TypedRelationList( [
+				TestRelation::build(
+					id: 'rTestSRU1111rr1',
+					targetId: $targetId,
+					properties: new RelationProperties( [] ),
+				)->withType( new RelationType( 'RelationType' ) )
+			] )
+		);
+
+		$result = NeoWikiExtension::getInstance()->getNeo4jClient()->run(
+			'MATCH (target {id: $targetId})
+				RETURN labels(target) AS labels, target.id AS id, target.wiki_id AS wikiId, size(keys(target)) AS propertyCount',
+			[ 'targetId' => $targetId ]
+		);
+
+		$row = $result->first()->toRecursiveArray();
+
+		$this->assertSame( [ 'Subject' ], $row['labels'] );
+		$this->assertSame( $targetId, $row['id'] );
+		$this->assertSame( self::WIKI_ID, $row['wikiId'] );
+		$this->assertSame( 2, $row['propertyCount'], 'Stub target should keep only the id and wiki_id properties' );
 	}
 
 }

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectRelationUpdaterTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectRelationUpdaterTest.php
@@ -298,6 +298,8 @@ class Neo4jSubjectRelationUpdaterTest extends NeoWikiIntegrationTestCase {
 			[ 'targetId' => $targetId ]
 		);
 
+		$this->assertFalse( $result->isEmpty(), 'Stub target should exist' );
+
 		$row = $result->first()->toRecursiveArray();
 
 		$this->assertSame( [ 'Subject' ], $row['labels'] );


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/544

`savePage()` DETACH DELETEd Subjects that were removed from a page without checking whether other Subjects still held relations to them, silently breaking those relations. `deleteSubject()` (used by `deletePage`) already guarded against this via `subjectHasIncomingRelations()`. `savePage()` now reuses `deleteSubject()`, so a removed-but-still-referenced Subject is preserved rather than deleted.

This also unifies the three kinds of "referenced but absent" node onto a single stub shape: a node with only the `id` and `wiki_id` properties and the `Subject` label (no `name`, no Schema label, no other properties). The paths:

- `deleteSubject()`'s keep path now strips the node to a stub, resolving the clear-properties / clear-labels TODOs (it previously kept the full stale node).
- `savePage()`'s new keep path, via `deleteSubject()`.
- The placeholder MERGEd by `Neo4jSubjectRelationUpdater` when a relation targets a not-yet-existing Subject now gets the `Subject` label and `wiki_id` on create (it was previously a bare, unlabelled node).

When the real Subject is later saved, the normal save path upgrades the stub in place. All the MERGEs that reach these nodes match by `id` alone, so both the new labelled stubs and any pre-existing bare placeholders upgrade without creating a duplicate node.

Placeholder `wiki_id` is stamped with the current wiki's `wiki_id`, which is correct under Subject Sources v1 where relation targets are restricted to resolvable local sources. The graph is a rebuildable projection and NeoWiki is not in production, so any lingering old-shape placeholder nodes are acceptable; a graph rebuild normalises them and the id-based upgrade path handles them regardless.

`docs/api/graph-model.md` documents the stub shape.

Covered by integration tests (`@group Database`): `savePage` keeping a still-referenced removed Subject as a stub (regression), `savePage` still fully deleting an unreferenced removed Subject, `deleteSubject` producing a stub with cleared properties and Schema labels, the relation placeholder carrying the `Subject` label and `wiki_id`, and a real-Subject save upgrading a stub in place without duplication.

> <sub>AI-authored — Claude Code, `Opus 4.8 (max)`; batch execution of the Relations Phase 1 plan directed by @JeroenDeDauw, autonomous subagent run (no questions asked); diff not yet human-reviewed; TDD regression seen red then green, all new tests confirmed failing on reverted production, full PHPUnit suite (1798 tests) and `make cs` (phpcs + phpstan) green locally, CI green.</sub>


## Review notes (batch pr-review pass)

A fresh-session review pass added the missing stub coverage (63cdc496): a 2-incoming×2-outgoing stub test proving outgoing relations and statement-derived properties are stripped while incoming relations survive, teeth-verified by mutating the production clause and watching it fail. Known limitation, accepted for now: removing two mutually-referencing subjects in one save can leave an orphan stub (order-dependent; harmless — no reader surfaces it — and self-healing on `RebuildGraphDatabases.php`). A robust fix needs cascade sweeping, so it is left for a follow-up.

Accuracy correction to the attribution note above: two of the original tests (`…UnreferencedSubjectDeletesIt`, `…UpgradesItsStubInPlace`) are guard tests that also pass on master; the revert-verification claim holds for the four fix-proving tests.

> <sub>Review-pass notes added by Claude Code, `Fable 5 (max)`, summarizing a fresh-session `Opus 4.8` review agent's verified findings; not yet human-reviewed.</sub>
