### PR TITLE
Fix the dev-stack QLever crash on rootful Docker

### DIFF
--- a/Docker/docker-compose.dev.yml
+++ b/Docker/docker-compose.dev.yml
@@ -70,6 +70,11 @@ services:
       - -lc
       - |
         set -e
+        # The image runs as the non-root "qlever" user, but on rootful Docker the qlever-index-data
+        # volume mounts empty and root-owned (the image ships no /index for Docker to copy ownership
+        # from), so qlever cannot write the index or persisted updates. Take ownership via the image's
+        # sudo grant. Rootless Podman already makes the fresh volume qlever-owned, so this is a no-op.
+        sudo chown qlever:qlever /index
         cd /index
         # Build an empty index once. The sentinel keeps a container restart from
         # re-indexing, which would wipe the persisted SPARQL updates. NeoWiki fills the
@@ -126,6 +131,10 @@ services:
       - -lc
       - |
         set -e
+        # Same rootful-Docker ownership fix as the demo `qlever` service above: the image runs as
+        # non-root "qlever" and Docker mounts test-qlever-index-data root-owned, so take ownership via
+        # the image's sudo grant. A no-op under rootless Podman.
+        sudo chown qlever:qlever /index
         cd /index
         # Build an empty index once; the sentinel keeps a container restart from re-indexing (which
         # would error on the existing index). NeoWiki fills the store at runtime over the SPARQL 1.1


### PR DESCRIPTION
The `qlever` and `test_qlever` dev-stack services crash-loop on rootful Docker with
`data.nt: Permission denied`. The `adfreiburg/qlever` image runs as the non-root
`qlever` user and ships no `/index` directory, so Docker mounts the index named volume
empty and root-owned and the process cannot write it. Rootless Podman chowns a fresh
volume to the run user, so the dev stack works there and only a Docker host hits this.

Both entrypoints take ownership of `/index` via the image's passwordless sudo grant
(present for reconciling mounted-volume permissions) before building the index. On
Podman the fresh volume is already `qlever`-owned, so the chown is a no-op.

The image's help recommends a bind mount to `/data` (`-w /data` plus `-e UID/GID`, or `-u`), and its default entrypoint requires `-w /data` (it exits unless the working directory is `/data`, checking `pwd`, not the mount); this stack deliberately uses a named volume instead, to avoid host bind-mount / SELinux coupling, and drives the binaries directly, so it reconciles ownership here. Running as root, or baking a
`qlever`-owned `/index` into a wrapper image, are alternatives; `sudo chown` keeps the
server non-root in a one-line change.

> <sub>AI-authored — Claude Code, `Opus 4.8 (1M context)`; diagnosed and steered by @malberts; diff not yet human-reviewed; reproduced fail→pass against a crafted root-owned volume, and the identical service run on podman-compose end-to-end (clean start, healthcheck healthy, query + Bearer-gated update, and an update surviving a container recreation with no re-index); the full dev stack was not run.</sub>


