### PR TITLE
Validate relation statement targets server-side

### DIFF
--- a/docs/api/validation-codes.md
+++ b/docs/api/validation-codes.md
@@ -208,11 +208,12 @@ Emitted by `SubjectValidator`.
 `propertyName`: the relation property.
 
 A relation targets a Subject that exists but whose own Schema is not the Property's declared
-`targetSchema`. The target is resolved through the canonical revision-slot-backed Subject lookup (the
-same one the read path uses), so the check reflects the target's stored writer's-schema rather than the
-secondary graph projection. This is a blocking `error` (ADR 26): it is rejected at write time when
-`$wgNeoWikiEnforceValidation` is enabled. The subject editor's picker filters candidates by target
-Schema, so this is normally only reachable through the API — for example a bulk import.
+`targetSchema`. The Schema compared is the target's own stored writer's-schema, read from its revision
+slot rather than from a graph node property. Reaching that slot still resolves the target ID through
+the subject-to-page index, which lives only in the graph projection, so this check only runs for
+targets the graph currently knows about. This is a blocking `error` (ADR 26): it is rejected at write
+time when `$wgNeoWikiEnforceValidation` is enabled. The subject editor's picker filters candidates by
+target Schema, so this is normally only reachable through the API — for example a bulk import.
 
 ### `relation-target-not-found`
 
@@ -227,13 +228,23 @@ hardcoded non-blocking set, so it never rejects a write even under enforcement. 
 pointing at a not-yet-created Subject is wiki-native red-link behavior, and an import may legitimately
 mint the target later.
 
+Resolution goes through the subject-to-page index, which lives only in the graph projection, so a
+target that exists in revision slots but is missing from the graph is reported as not found. An
+import populates the slots without updating the projection
+([#1022](https://github.com/ProfessionalWiki/NeoWiki/issues/1022)), so imported targets warn until
+[the graph is rebuilt](../operations/maintenance.md#rebuilding-the-graph). Being non-blocking, this
+misreport never costs a write.
+
 ## Known limitations (Foundation round)
 
-The PHP `SubjectValidator` performs two Subject-level checks:
+The PHP `SubjectValidator` performs these Subject-level checks:
 
 - **`required`** — PHP iterates the Schema's properties to catch absent-required cases.
 - **`type-mismatch`** — PHP compares the Statement's writer's-schema type against the Schema's
   current type and surfaces drift per ADR 11 / ADR 12.
+- **[`relation-target-schema-mismatch`](#relation-target-schema-mismatch)** and
+  **[`relation-target-not-found`](#relation-target-not-found)** — documented above; both need a
+  Subject lookup, which `PropertyType::validate()` has no access to.
 
 ### Deliberate behavior, not a gap
 

--- a/docs/api/validation-codes.md
+++ b/docs/api/validation-codes.md
@@ -204,7 +204,7 @@ Reconciling that asymmetry is left to the enforcement tier (ADR 21).
 Emitted by `SubjectValidator`.
 `args`: `[expectedSchema, actualSchema]` — the target Schema the relation Property declares
 (`targetSchema`), and the Schema the resolved target Subject actually uses.
-`valuePartIndex`: never set.
+`valuePartIndex`: index of the offending relation target within the `RelationValue`.
 `propertyName`: the relation property.
 
 A relation targets a Subject that exists but whose own Schema is not the Property's declared
@@ -218,7 +218,7 @@ Schema, so this is normally only reachable through the API — for example a bul
 
 Emitted by `SubjectValidator`.
 `args`: `[targetId]` — the target Subject ID that did not resolve.
-`valuePartIndex`: never set.
+`valuePartIndex`: index of the offending relation target within the `RelationValue`.
 `propertyName`: the relation property.
 
 A relation targets a Subject ID that does not resolve to any existing Subject. It is a non-blocking

--- a/docs/api/validation-codes.md
+++ b/docs/api/validation-codes.md
@@ -154,11 +154,12 @@ ColorType).
 
 ### `single-value-only`
 
-Emitted by `SelectType`.
+Emitted by `SelectType` and `RelationType`.
 `args`: `[]`.
 `valuePartIndex`: never set (Subject-property-level, not part-level).
 
-The Property's `multiple` flag is false and more than one part was supplied.
+The Property's `multiple` flag is false and more than one value was supplied — more than one part for
+`SelectType`, or more than one relation target for `RelationType`.
 
 ### `invalid-datetime`
 
@@ -197,6 +198,34 @@ Note the create dry-run endpoint (`POST /subject/validate`) instead returns `404
 (`SchemaNotFoundException`) for a missing Schema, because there it is the addressed resource;
 the update dry-run (`POST /subject/{id}/validate`) and both write endpoints surface the violation.
 Reconciling that asymmetry is left to the enforcement tier (ADR 21).
+
+### `relation-target-schema-mismatch`
+
+Emitted by `SubjectValidator`.
+`args`: `[expectedSchema, actualSchema]` — the target Schema the relation Property declares
+(`targetSchema`), and the Schema the resolved target Subject actually uses.
+`valuePartIndex`: never set.
+`propertyName`: the relation property.
+
+A relation targets a Subject that exists but whose own Schema is not the Property's declared
+`targetSchema`. The target is resolved through the canonical revision-slot-backed Subject lookup (the
+same one the read path uses), so the check reflects the target's stored writer's-schema rather than the
+secondary graph projection. This is a blocking `error` (ADR 26): it is rejected at write time when
+`$wgNeoWikiEnforceValidation` is enabled. The subject editor's picker filters candidates by target
+Schema, so this is normally only reachable through the API — for example a bulk import.
+
+### `relation-target-not-found`
+
+Emitted by `SubjectValidator`.
+`args`: `[targetId]` — the target Subject ID that did not resolve.
+`valuePartIndex`: never set.
+`propertyName`: the relation property.
+
+A relation targets a Subject ID that does not resolve to any existing Subject. It is a non-blocking
+`warning` (ADR 26), joining [`schema-not-found`](#schema-not-found) and `unregistered-type` in the
+hardcoded non-blocking set, so it never rejects a write even under enforcement. This is deliberate:
+pointing at a not-yet-created Subject is wiki-native red-link behavior, and an import may legitimately
+mint the target later.
 
 ## Known limitations (Foundation round)
 

--- a/extension.json
+++ b/extension.json
@@ -405,6 +405,8 @@
 				"neowiki-field-schema-not-found",
 				"neowiki-field-unregistered-type",
 				"neowiki-field-label-required",
+				"neowiki-field-relation-target-schema-mismatch",
+				"neowiki-field-relation-target-not-found",
 				"neowiki-select-placeholder",
 				"neowiki-select-no-results",
 				"neowiki-select-unknown-option",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -86,6 +86,8 @@
 	"neowiki-field-schema-not-found": "The schema \"$1\" is missing. Restore it before saving.",
 	"neowiki-field-unregistered-type": "The type \"$1\" is not available on this wiki.",
 	"neowiki-field-label-required": "Please provide a label for the subject.",
+	"neowiki-field-relation-target-schema-mismatch": "This relation must point to a subject using the \"$1\" schema, but the selected subject uses \"$2\".",
+	"neowiki-field-relation-target-not-found": "The subject \"$1\" this relation points to does not exist yet.",
 	"neowiki-select-placeholder": "Select an option",
 	"neowiki-select-no-results": "No matching options.",
 	"neowiki-select-unknown-option": "(unknown option)",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -186,6 +186,8 @@
 	"neowiki-field-min-length": "Validation error shown when a text value is shorter than the property's minimum length. $1 is the minimum number of characters.",
 	"neowiki-field-max-length": "Validation error shown when a text value is longer than the property's maximum length. $1 is the maximum number of characters.",
 	"neowiki-field-label-required": "Form-level error shown when the backend reports the Subject is missing its required display label.",
+	"neowiki-field-relation-target-schema-mismatch": "Validation error shown when a relation points to a subject whose schema is not the relation's declared target schema. $1 is the required target schema; $2 is the schema the target subject actually uses.",
+	"neowiki-field-relation-target-not-found": "Validation warning shown when a relation points to a subject ID that does not resolve to an existing subject. $1 is the target subject ID. Non-blocking: the target may be created later (for example during import), mirroring wiki red links.",
 	"neowiki-select-placeholder": "Placeholder text shown in the select dropdown before any option is chosen.",
 	"neowiki-select-no-results": "Message shown in the multi-select dropdown when the typed text does not match any available option.",
 	"neowiki-field-invalid-datetime": "Validation error shown when the entered date and time value cannot be parsed. DateTime values must be strict ISO 8601 / xsd:dateTime strings with an explicit timezone offset or 'Z' (for example, '2025-06-15T12:00:00Z' or '2025-06-15T12:00:00+02:00'). Partial values such as year-only or date-only are rejected, and min/max bounds are inclusive.",

--- a/src/Application/Validation/SubjectValidator.php
+++ b/src/Application/Validation/SubjectValidator.php
@@ -113,7 +113,7 @@ readonly class SubjectValidator {
 				$relation,
 				$statement->getPropertyName(),
 				$definition->getTargetSchema(),
-				$index
+				(int)$index
 			);
 
 			if ( $violation !== null ) {

--- a/src/Application/Validation/SubjectValidator.php
+++ b/src/Application/Validation/SubjectValidator.php
@@ -93,9 +93,14 @@ readonly class SubjectValidator {
 	 *
 	 * A missing target is a non-blocking `relation-target-not-found` warning (red-link philosophy:
 	 * the target may be minted later, e.g. during import); a resolvable target whose own Schema is
-	 * not the declared targetSchema is a blocking `relation-target-schema-mismatch` error. Targets
-	 * are resolved through the canonical revision-slot-backed lookup the read path uses, never the
-	 * secondary graph projection.
+	 * not the declared targetSchema is a blocking `relation-target-schema-mismatch` error.
+	 *
+	 * The Schema compared is the target's own writer's-schema, read from its revision slot rather
+	 * than from a graph node property. Reaching that slot still resolves the target id through the
+	 * subject -> page index, which lives only in the graph projection (see
+	 * {@see \ProfessionalWiki\NeoWiki\NeoWikiExtension::getPageIdentifiersLookup()}), so an
+	 * unrebuilt or stale graph reports an existing target as not found. That is the same
+	 * degradation the read path has, and the reason not-found is non-blocking.
 	 *
 	 * @return Violation[]
 	 */

--- a/src/Application/Validation/SubjectValidator.php
+++ b/src/Application/Validation/SubjectValidator.php
@@ -4,19 +4,25 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Application\Validation;
 
+use ProfessionalWiki\NeoWiki\Application\SubjectLookup;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeLookup;
+use ProfessionalWiki\NeoWiki\Domain\Relation\Relation;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Property\RelationProperty;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinition;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyName;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Statement;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
+use ProfessionalWiki\NeoWiki\Domain\Value\RelationValue;
 
 readonly class SubjectValidator {
 
 	public function __construct(
 		private PropertyTypeLookup $propertyTypeLookup,
+		private SubjectLookup $subjectLookup,
 	) {
 	}
 
@@ -75,7 +81,72 @@ readonly class SubjectValidator {
 			$violations[] = $rawViolation->withPropertyName( $propertyName );
 		}
 
+		return array_merge( $violations, $this->validateRelationTargets( $statement, $definition ) );
+	}
+
+	/**
+	 * Server-side relation-target checks. Schema-scoped by necessity: both need the writer's-schema
+	 * RelationProperty (for its declared targetSchema) and a Subject lookup, neither of which
+	 * PropertyType::validate() has access to. This runs after the per-type dispatch, so the
+	 * Statement's type still matches the Schema's relation property here; a type-mismatched
+	 * Statement returned earlier and is not treated as a relation.
+	 *
+	 * A missing target is a non-blocking `relation-target-not-found` warning (red-link philosophy:
+	 * the target may be minted later, e.g. during import); a resolvable target whose own Schema is
+	 * not the declared targetSchema is a blocking `relation-target-schema-mismatch` error. Targets
+	 * are resolved through the canonical revision-slot-backed lookup the read path uses, never the
+	 * secondary graph projection.
+	 *
+	 * @return Violation[]
+	 */
+	private function validateRelationTargets( Statement $statement, PropertyDefinition $definition ): array {
+		$value = $statement->getValue();
+
+		if ( !$definition instanceof RelationProperty || !$value instanceof RelationValue ) {
+			return [];
+		}
+
+		$violations = [];
+
+		foreach ( $value->relations as $relation ) {
+			$violation = $this->validateRelationTarget(
+				$relation,
+				$statement->getPropertyName(),
+				$definition->getTargetSchema()
+			);
+
+			if ( $violation !== null ) {
+				$violations[] = $violation;
+			}
+		}
+
 		return $violations;
+	}
+
+	private function validateRelationTarget(
+		Relation $relation,
+		PropertyName $propertyName,
+		SchemaName $targetSchema
+	): ?Violation {
+		$target = $this->subjectLookup->getSubject( $relation->targetId );
+
+		if ( $target === null ) {
+			return new Violation(
+				propertyName: $propertyName,
+				code: 'relation-target-not-found',
+				args: [ $relation->targetId->text ],
+			);
+		}
+
+		if ( $target->getSchemaName()->getText() !== $targetSchema->getText() ) {
+			return new Violation(
+				propertyName: $propertyName,
+				code: 'relation-target-schema-mismatch',
+				args: [ $targetSchema->getText(), $target->getSchemaName()->getText() ],
+			);
+		}
+
+		return null;
 	}
 
 	/**

--- a/src/Application/Validation/SubjectValidator.php
+++ b/src/Application/Validation/SubjectValidator.php
@@ -108,11 +108,12 @@ readonly class SubjectValidator {
 
 		$violations = [];
 
-		foreach ( $value->relations as $relation ) {
+		foreach ( $value->relations as $index => $relation ) {
 			$violation = $this->validateRelationTarget(
 				$relation,
 				$statement->getPropertyName(),
-				$definition->getTargetSchema()
+				$definition->getTargetSchema(),
+				$index
 			);
 
 			if ( $violation !== null ) {
@@ -123,10 +124,16 @@ readonly class SubjectValidator {
 		return $violations;
 	}
 
+	/**
+	 * The target's position in the multi-value RelationValue is carried as valuePartIndex so
+	 * ViolationDiff can tell a newly-added bad target apart from a pre-existing same-code
+	 * violation on the same property, exactly as SelectType/UrlType do for their parts.
+	 */
 	private function validateRelationTarget(
 		Relation $relation,
 		PropertyName $propertyName,
-		SchemaName $targetSchema
+		SchemaName $targetSchema,
+		int $valuePartIndex
 	): ?Violation {
 		$target = $this->subjectLookup->getSubject( $relation->targetId );
 
@@ -135,6 +142,7 @@ readonly class SubjectValidator {
 				propertyName: $propertyName,
 				code: 'relation-target-not-found',
 				args: [ $relation->targetId->text ],
+				valuePartIndex: $valuePartIndex,
 			);
 		}
 
@@ -143,6 +151,7 @@ readonly class SubjectValidator {
 				propertyName: $propertyName,
 				code: 'relation-target-schema-mismatch',
 				args: [ $targetSchema->getText(), $target->getSchemaName()->getText() ],
+				valuePartIndex: $valuePartIndex,
 			);
 		}
 

--- a/src/Domain/PropertyType/Types/RelationType.php
+++ b/src/Domain/PropertyType/Types/RelationType.php
@@ -41,13 +41,19 @@ class RelationType implements PropertyType {
 			return [];
 		}
 
-		$isEmpty = !( $value instanceof RelationValue ) || $value->isEmpty();
+		$relations = $value instanceof RelationValue ? $value->relations : [];
 
-		if ( $definition->isRequired() && $isEmpty ) {
+		if ( $definition->isRequired() && $relations === [] ) {
 			return [ new Violation( propertyName: null, code: 'required' ) ];
 		}
 
-		return [];
+		$violations = [];
+
+		if ( !$definition->allowsMultipleValues() && count( $relations ) > 1 ) {
+			$violations[] = new Violation( propertyName: null, code: 'single-value-only' );
+		}
+
+		return $violations;
 	}
 
 }

--- a/src/Domain/Validation/Violation.php
+++ b/src/Domain/Validation/Violation.php
@@ -13,7 +13,7 @@ readonly class Violation {
 	 * is in a degraded state. They are reported but never reject a write. These are the
 	 * `warning` tier that ADR 26 will make configurable per Constraint.
 	 */
-	private const NON_BLOCKING_CODES = [ 'schema-not-found', 'unregistered-type' ];
+	private const NON_BLOCKING_CODES = [ 'schema-not-found', 'unregistered-type', 'relation-target-not-found' ];
 
 	public function __construct(
 		public ?PropertyName $propertyName,

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -993,6 +993,7 @@ class NeoWikiExtension {
 	public function getSubjectValidator(): SubjectValidator {
 		return new SubjectValidator(
 			propertyTypeLookup: $this->getPropertyTypeLookup(),
+			subjectLookup: $this->getSubjectRepository(),
 		);
 	}
 

--- a/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
@@ -32,6 +32,7 @@ use ProfessionalWiki\NeoWiki\Application\SubjectWriteAuthorizer;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestRelation;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestStatement;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySchemaLookup;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectLookup;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectRepository;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpySubjectWriteAuthorizer;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubIdGenerator;
@@ -74,7 +75,10 @@ class CreateSubjectActionTest extends TestCase {
 			new SelectStatementResolver( new SelectValueResolver() ),
 			new ProposedSubjectValidator(
 				schemaLookup: $this->schemaLookup,
-				subjectValidator: new SubjectValidator( propertyTypeLookup: $registry ),
+				subjectValidator: new SubjectValidator(
+					propertyTypeLookup: $registry,
+					subjectLookup: new InMemorySubjectLookup(),
+				),
 			),
 			$validationEnforced,
 		);

--- a/tests/phpunit/Application/Actions/ReplaceSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/ReplaceSubjectActionTest.php
@@ -35,6 +35,7 @@ use ProfessionalWiki\NeoWiki\Tests\Data\TestStatement;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemoryPageIdentifiersLookup;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySchemaLookup;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectLookup;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectRepository;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpySubjectWriteAuthorizer;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubIdGenerator;
@@ -74,7 +75,10 @@ class ReplaceSubjectActionTest extends TestCase {
 			selectStatementResolver: new SelectStatementResolver( new SelectValueResolver() ),
 			proposedSubjectValidator: new ProposedSubjectValidator(
 				schemaLookup: $this->schemaLookup,
-				subjectValidator: new SubjectValidator( propertyTypeLookup: $registry ),
+				subjectValidator: new SubjectValidator(
+					propertyTypeLookup: $registry,
+					subjectLookup: new InMemorySubjectLookup(),
+				),
 			),
 			presenter: $this->presenterSpy,
 			validationEnforced: $validationEnforced,

--- a/tests/phpunit/Application/Validation/ProposedSubjectValidatorTest.php
+++ b/tests/phpunit/Application/Validation/ProposedSubjectValidatorTest.php
@@ -16,6 +16,7 @@ use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySchemaLookup;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectLookup;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\Application\Validation\ProposedSubjectValidator
@@ -33,7 +34,10 @@ class ProposedSubjectValidatorTest extends TestCase {
 	private function newValidator(): ProposedSubjectValidator {
 		return new ProposedSubjectValidator(
 			schemaLookup: $this->schemaLookup,
-			subjectValidator: new SubjectValidator( propertyTypeLookup: PropertyTypeRegistry::withCoreTypes() ),
+			subjectValidator: new SubjectValidator(
+				propertyTypeLookup: PropertyTypeRegistry::withCoreTypes(),
+				subjectLookup: new InMemorySubjectLookup(),
+			),
 		);
 	}
 

--- a/tests/phpunit/Application/Validation/SubjectValidatorTest.php
+++ b/tests/phpunit/Application/Validation/SubjectValidatorTest.php
@@ -480,6 +480,27 @@ class SubjectValidatorTest extends TestCase {
 		$this->assertEquals( new PropertyName( 'Links' ), $violations[0]->propertyName );
 	}
 
+	public function testMultiValueRelationReportsEachTargetViolationAtItsOwnPartIndex(): void {
+		$schema = $this->newSchema( [ 'Links' => $this->newRelationProperty( multiple: true ) ] );
+
+		$violations = $this->validator->validate(
+			new SubjectLabel( 'X' ),
+			new StatementList( [
+				$this->newRelationStatement( self::MISMATCHING_TARGET_ID, self::MISMATCHING_TARGET_ID ),
+			] ),
+			$schema,
+		);
+
+		// Distinct valuePartIndex per target is what lets ViolationDiff treat a newly-added bad
+		// target as new on the Replace enforcement path, rather than collapsing it into a
+		// pre-existing same-code violation on the same property.
+		$this->assertCount( 2, $violations );
+		$this->assertSame( 'relation-target-schema-mismatch', $violations[0]->code );
+		$this->assertSame( 0, $violations[0]->valuePartIndex );
+		$this->assertSame( 'relation-target-schema-mismatch', $violations[1]->code );
+		$this->assertSame( 1, $violations[1]->valuePartIndex );
+	}
+
 	// --- Helpers ---
 
 	private function newRelationProperty( bool $multiple = true ): RelationProperty {

--- a/tests/phpunit/Application/Validation/SubjectValidatorTest.php
+++ b/tests/phpunit/Application/Validation/SubjectValidatorTest.php
@@ -7,7 +7,9 @@ namespace ProfessionalWiki\NeoWiki\Tests\Application\Validation;
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Application\Validation\SubjectValidator;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeRegistry;
+use ProfessionalWiki\NeoWiki\Domain\Relation\Relation;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\NumberProperty;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Property\RelationProperty;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinition;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinitions;
@@ -18,19 +20,38 @@ use ProfessionalWiki\NeoWiki\Domain\Statement;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
 use ProfessionalWiki\NeoWiki\Domain\Value\NumberValue;
+use ProfessionalWiki\NeoWiki\Domain\Value\RelationValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\UnregisteredTypeValue;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\UnregisteredTypeProperty;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestRelation;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectLookup;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\Application\Validation\SubjectValidator
  */
 class SubjectValidatorTest extends TestCase {
 
+	private const string TARGET_SCHEMA = 'Person';
+	private const string MATCHING_TARGET_ID = 'srt111111111aaa';
+	private const string MISMATCHING_TARGET_ID = 'srt111111111bbb';
+	private const string NONEXISTENT_TARGET_ID = 'srt111111111eee';
+
 	private SubjectValidator $validator;
 
 	protected function setUp(): void {
 		$this->validator = new SubjectValidator(
 			propertyTypeLookup: PropertyTypeRegistry::withCoreTypes(),
+			subjectLookup: $this->newSubjectLookup(),
+		);
+	}
+
+	private function newSubjectLookup(): InMemorySubjectLookup {
+		return new InMemorySubjectLookup(
+			TestSubject::build( id: 'srt111111111ccc', schemaName: new SchemaName( 'DecoySchema' ) ),
+			TestSubject::build( id: self::MATCHING_TARGET_ID, schemaName: new SchemaName( self::TARGET_SCHEMA ) ),
+			TestSubject::build( id: self::MISMATCHING_TARGET_ID, schemaName: new SchemaName( 'Company' ) ),
+			TestSubject::build( id: 'srt111111111ddd', schemaName: new SchemaName( 'DecoySchema' ) ),
 		);
 	}
 
@@ -390,7 +411,92 @@ class SubjectValidatorTest extends TestCase {
 		$this->assertSame( 'unregistered-type', $violations[1]->code );
 	}
 
+	public function testRelationTargetWithMismatchedSchemaReturnsSchemaMismatchError(): void {
+		$schema = $this->newSchema( [ 'Links' => $this->newRelationProperty() ] );
+
+		$violations = $this->validator->validate(
+			new SubjectLabel( 'X' ),
+			new StatementList( [ $this->newRelationStatement( self::MISMATCHING_TARGET_ID ) ] ),
+			$schema,
+		);
+
+		$this->assertCount( 1, $violations );
+		$this->assertSame( 'relation-target-schema-mismatch', $violations[0]->code );
+		$this->assertEquals( new PropertyName( 'Links' ), $violations[0]->propertyName );
+		$this->assertSame( [ self::TARGET_SCHEMA, 'Company' ], $violations[0]->args );
+		$this->assertTrue( $violations[0]->isBlocking() );
+	}
+
+	public function testRelationTargetWithMatchingSchemaReturnsNoViolation(): void {
+		$schema = $this->newSchema( [ 'Links' => $this->newRelationProperty() ] );
+
+		$this->assertSame( [], $this->validator->validate(
+			new SubjectLabel( 'X' ),
+			new StatementList( [ $this->newRelationStatement( self::MATCHING_TARGET_ID ) ] ),
+			$schema,
+		) );
+	}
+
+	public function testNonexistentRelationTargetReturnsNonBlockingNotFoundWarning(): void {
+		$schema = $this->newSchema( [ 'Links' => $this->newRelationProperty() ] );
+
+		$violations = $this->validator->validate(
+			new SubjectLabel( 'X' ),
+			new StatementList( [ $this->newRelationStatement( self::NONEXISTENT_TARGET_ID ) ] ),
+			$schema,
+		);
+
+		$this->assertCount( 1, $violations );
+		$this->assertSame( 'relation-target-not-found', $violations[0]->code );
+		$this->assertEquals( new PropertyName( 'Links' ), $violations[0]->propertyName );
+		$this->assertSame( [ self::NONEXISTENT_TARGET_ID ], $violations[0]->args );
+		$this->assertFalse( $violations[0]->isBlocking() );
+	}
+
+	public function testNonexistentRelationTargetDoesNotAlsoEmitSchemaMismatch(): void {
+		$schema = $this->newSchema( [ 'Links' => $this->newRelationProperty() ] );
+
+		$violations = $this->validator->validate(
+			new SubjectLabel( 'X' ),
+			new StatementList( [ $this->newRelationStatement( self::NONEXISTENT_TARGET_ID ) ] ),
+			$schema,
+		);
+
+		$codes = array_map( static fn ( $v ) => $v->code, $violations );
+		$this->assertNotContains( 'relation-target-schema-mismatch', $codes );
+	}
+
+	public function testSingleValueRelationWithTwoTargetsSurfacesSingleValueOnly(): void {
+		$schema = $this->newSchema( [ 'Links' => $this->newRelationProperty( multiple: false ) ] );
+
+		$violations = $this->validator->validate(
+			new SubjectLabel( 'X' ),
+			new StatementList( [ $this->newRelationStatement( self::MATCHING_TARGET_ID, self::MATCHING_TARGET_ID ) ] ),
+			$schema,
+		);
+
+		$this->assertCount( 1, $violations );
+		$this->assertSame( 'single-value-only', $violations[0]->code );
+		$this->assertEquals( new PropertyName( 'Links' ), $violations[0]->propertyName );
+	}
+
 	// --- Helpers ---
+
+	private function newRelationProperty( bool $multiple = true ): RelationProperty {
+		return RelationProperty::fromPartialJson(
+			new PropertyCore( description: '', required: false, default: null ),
+			[ 'relation' => 'has', 'targetSchema' => self::TARGET_SCHEMA, 'multiple' => $multiple ],
+		);
+	}
+
+	private function newRelationStatement( string ...$targetIds ): Statement {
+		$relations = array_map(
+			static fn ( string $targetId ): Relation => TestRelation::build( targetId: $targetId ),
+			$targetIds,
+		);
+
+		return new Statement( new PropertyName( 'Links' ), 'relation', new RelationValue( ...$relations ) );
+	}
 
 	private function newSchema( array $properties ): Schema {
 		return new Schema(

--- a/tests/phpunit/Application/Validation/SubjectValidatorTest.php
+++ b/tests/phpunit/Application/Validation/SubjectValidatorTest.php
@@ -501,6 +501,43 @@ class SubjectValidatorTest extends TestCase {
 		$this->assertSame( 1, $violations[1]->valuePartIndex );
 	}
 
+	public function testRelationTargetViolationCarriesItsArrayPositionNotAViolationCounter(): void {
+		$schema = $this->newSchema( [ 'Links' => $this->newRelationProperty( multiple: true ) ] );
+
+		$violations = $this->validator->validate(
+			new SubjectLabel( 'X' ),
+			new StatementList( [
+				$this->newRelationStatement( self::MATCHING_TARGET_ID, self::MISMATCHING_TARGET_ID ),
+			] ),
+			$schema,
+		);
+
+		// The valid target at index 0 emits nothing, so the sole violation belongs to the target at
+		// index 1. Pinning the position here is what the all-targets-invalid case above cannot do:
+		// there, the array position and the ordinal of the violation itself agree, so a counter-based
+		// implementation would pass it. ViolationDiff keys on valuePartIndex, so the difference
+		// decides whether an edit's violations line up with the pre-existing ones.
+		$this->assertCount( 1, $violations );
+		$this->assertSame( 'relation-target-schema-mismatch', $violations[0]->code );
+		$this->assertSame( 1, $violations[0]->valuePartIndex );
+	}
+
+	public function testNonexistentRelationTargetCarriesItsArrayPosition(): void {
+		$schema = $this->newSchema( [ 'Links' => $this->newRelationProperty( multiple: true ) ] );
+
+		$violations = $this->validator->validate(
+			new SubjectLabel( 'X' ),
+			new StatementList( [
+				$this->newRelationStatement( self::MATCHING_TARGET_ID, self::NONEXISTENT_TARGET_ID ),
+			] ),
+			$schema,
+		);
+
+		$this->assertCount( 1, $violations );
+		$this->assertSame( 'relation-target-not-found', $violations[0]->code );
+		$this->assertSame( 1, $violations[0]->valuePartIndex );
+	}
+
 	// --- Helpers ---
 
 	private function newRelationProperty( bool $multiple = true ): RelationProperty {

--- a/tests/phpunit/Domain/PropertyType/Types/RelationTypeTest.php
+++ b/tests/phpunit/Domain/PropertyType/Types/RelationTypeTest.php
@@ -6,6 +6,10 @@ namespace ProfessionalWiki\NeoWiki\Tests\Domain\PropertyType\Types;
 
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\Types\RelationType;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Property\RelationProperty;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
+use ProfessionalWiki\NeoWiki\Domain\Value\RelationValue;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestRelation;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\Domain\PropertyType\Types\RelationType
@@ -14,6 +18,54 @@ class RelationTypeTest extends TestCase {
 
 	public function testDisplayAttributeNamesIsEmpty(): void {
 		$this->assertSame( [], ( new RelationType() )->getDisplayAttributeNames() );
+	}
+
+	public function testSingleValuePropertyWithTwoTargetsReturnsSingleValueOnly(): void {
+		$violations = ( new RelationType() )->validate(
+			new RelationValue(
+				TestRelation::build( targetId: 'srt111111111aaa' ),
+				TestRelation::build( targetId: 'srt111111111bbb' ),
+			),
+			$this->newRelationProperty( multiple: false ),
+		);
+
+		$this->assertCount( 1, $violations );
+		$this->assertSame( 'single-value-only', $violations[0]->code );
+		$this->assertNull( $violations[0]->propertyName );
+	}
+
+	public function testMultiValuePropertyWithTwoTargetsReturnsNoViolation(): void {
+		$this->assertSame( [], ( new RelationType() )->validate(
+			new RelationValue(
+				TestRelation::build( targetId: 'srt111111111aaa' ),
+				TestRelation::build( targetId: 'srt111111111bbb' ),
+			),
+			$this->newRelationProperty( multiple: true ),
+		) );
+	}
+
+	public function testSingleValuePropertyWithOneTargetReturnsNoViolation(): void {
+		$this->assertSame( [], ( new RelationType() )->validate(
+			new RelationValue( TestRelation::build( targetId: 'srt111111111aaa' ) ),
+			$this->newRelationProperty( multiple: false ),
+		) );
+	}
+
+	public function testRequiredPropertyWithoutTargetsReturnsRequired(): void {
+		$violations = ( new RelationType() )->validate(
+			new RelationValue(),
+			$this->newRelationProperty( multiple: false, required: true ),
+		);
+
+		$this->assertCount( 1, $violations );
+		$this->assertSame( 'required', $violations[0]->code );
+	}
+
+	private function newRelationProperty( bool $multiple, bool $required = false ): RelationProperty {
+		return RelationProperty::fromPartialJson(
+			new PropertyCore( description: '', required: $required, default: null ),
+			[ 'relation' => 'has', 'targetSchema' => 'Person', 'multiple' => $multiple ],
+		);
 	}
 
 }

--- a/tests/phpunit/Domain/PropertyType/Types/RelationTypeTest.php
+++ b/tests/phpunit/Domain/PropertyType/Types/RelationTypeTest.php
@@ -61,10 +61,35 @@ class RelationTypeTest extends TestCase {
 		$this->assertSame( 'required', $violations[0]->code );
 	}
 
+	public function testPropertyOmittingMultipleWithTwoTargetsReturnsSingleValueOnly(): void {
+		// `multiple` is optional in the Schema JSON and defaults to false, so a relation property
+		// authored or imported without the key is single-valued. Since single-value-only blocks,
+		// a Subject that already holds two targets on such a property stops saving under
+		// enforcement. Pinned here because the default is what decides that, not the validation.
+		$violations = ( new RelationType() )->validate(
+			new RelationValue(
+				TestRelation::build( targetId: 'srt111111111aaa' ),
+				TestRelation::build( targetId: 'srt111111111bbb' ),
+			),
+			$this->newRelationPropertyWithoutMultipleKey(),
+		);
+
+		$this->assertCount( 1, $violations );
+		$this->assertSame( 'single-value-only', $violations[0]->code );
+		$this->assertTrue( $violations[0]->isBlocking() );
+	}
+
 	private function newRelationProperty( bool $multiple, bool $required = false ): RelationProperty {
 		return RelationProperty::fromPartialJson(
 			new PropertyCore( description: '', required: $required, default: null ),
 			[ 'relation' => 'has', 'targetSchema' => 'Person', 'multiple' => $multiple ],
+		);
+	}
+
+	private function newRelationPropertyWithoutMultipleKey(): RelationProperty {
+		return RelationProperty::fromPartialJson(
+			new PropertyCore( description: '', required: false, default: null ),
+			[ 'relation' => 'has', 'targetSchema' => 'Person' ],
 		);
 	}
 


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/1078

`RelationType::validate()` only emitted `required` and `RelationProperty::getTargetSchema()` had no
consumers, so relation statements went unchecked on write. An API write accepted a relation that
points at a Subject that does not exist, at a Subject whose Schema is not the property's
`targetSchema`, or that holds multiple targets on a `multiple: false` property. The subject editor's
picker hides this, but API-driven import does not go through the picker.

This adds three validations, using the severity model of ADR 26 as actually implemented (blocking vs.
`Violation::NON_BLOCKING_CODES`):

- `single-value-only` (`error`) for a `multiple: false` relation holding more than one target, emitted
  by `RelationType::validate()` exactly as `SelectType` does — no lookups needed.
- `relation-target-schema-mismatch` (`error`, new) when the target Subject exists but its own Schema
  is not the property's `targetSchema`.
- `relation-target-not-found` (`warning`, new, non-blocking) when the target id does not resolve.
  Deliberately non-blocking: pointing at a not-yet-created Subject is wiki-native red-link behaviour,
  and an import may mint the target later.

The last two live in `SubjectValidator` (the placement PR #1043 uses), since they need a lookup and
the writer's-schema `RelationProperty`, which `PropertyType::validate()` cannot reach. Targets are
resolved through the canonical revision-slot-backed `SubjectLookup` the read path uses
(`getSubjectRepository()`), never the secondary Neo4j projection; the target's Schema comes from its
own stored Subject. A missing target short-circuits, so it never also reports a schema mismatch.

Enforcement is unchanged: `relation-target-not-found` joins `Violation::NON_BLOCKING_CODES` (the
warning tier as implemented), and the newly-introduced-blocking-violation gate is untouched.

`RelationInput` already renders server violations generically via `neowiki-field-<code>` messages, so
the two new codes get `i18n/en.json`, `i18n/qqq.json`, and `extension.json` entries and no new UI
code. `docs/api/validation-codes.md` documents both codes and notes `RelationType` as a
`single-value-only` emitter.

ADR 26 (Draft) is intentionally not edited: its per-Constraint severity model is not fully
implemented, and PR #1043 set the precedent of not treating it as a living code catalog. Folding
these two fixed-severity system codes (mismatch = fixed `error`, not-found = fixed `warning`) into
ADR 26 is a follow-up for whoever finalizes it.

A textual conflict with open PR #1043 (which also touches `SubjectValidator`, the same three test
files, `validation-codes.md`, and the i18n / extension.json message list) is expected.

> <sub>AI-authored — Claude Code, `Opus 4.8 (max)`; batch execution of the Relations Phase 1 plan directed by @JeroenDeDauw, from a fixed spec with no redirection; not yet human-reviewed; TDD (red then green), full PHPUnit suite (1801 tests) + `make cs` (phpcs + phpstan) green locally, psalm clean on changed files, production-revert test-verification done; CI green (PHPCS, PHPStan, PHPUnit).</sub>


## Review notes (batch pr-review pass)

A fresh-session review pass fixed a blocking enforcement gap (relation-target violations now carry `valuePartIndex`, 122712bc) and verified all three validations end to end (unit + mutation battery + live endpoint). Two architecture-level follow-ups were identified and deliberately left out of this PR pending a decision:

* The validate path resolves relation targets without page-read authorization, so violation responses can disclose whether an unreadable target exists and what its schema is (the read path gates exactly this per #1046). Likely fix: thread the read authorizer into target resolution and collapse unreadable targets into `relation-target-not-found`.
* Target resolution adds one live lookup per relation target on an anonymous, unrate-limited validate endpoint (no relation cap, no id dedup). Consider a cap, dedup/batching, or a ping limiter before ACL/farm deployments.

> <sub>Review-pass notes added by Claude Code, `Fable 5 (max)`, summarizing a fresh-session `Opus 4.8` review agent's verified findings; not yet human-reviewed.</sub>
