### PR TITLE
Create Neo4j uniqueness constraints during graph rebuild

### DIFF
--- a/docs/api/graph-model.md
+++ b/docs/api/graph-model.md
@@ -107,9 +107,15 @@ When a Subject is deleted but still has incoming relations from other Subjects, 
 
 ## Constraints
 
-Two uniqueness constraints are intended for the graph — the `(wiki_id, id)` pair is unique on `:Page` nodes
-([ADR 22](../adr/022-multi-wiki-node-identity.md)), and `Subject.id` is unique. These are **not** created
-automatically yet ([#874](https://github.com/ProfessionalWiki/NeoWiki/issues/874)).
+Two node uniqueness constraints are created on the graph: the `(wiki_id, id)` pair is unique on `:Page` nodes
+([ADR 22](../adr/022-multi-wiki-node-identity.md)), and `Subject.id` is unique. They are (re)created by the
+`RebuildGraphDatabases.php` maintenance script — the path that builds the graph from the MediaWiki source of
+truth — and creation is idempotent (`CREATE CONSTRAINT ... IF NOT EXISTS`), so re-running it is safe.
+
+Relation (edge) `id` values are not constrained at the graph level: Neo4j relationship uniqueness constraints
+are per relationship type, and Relations use an open, user-defined set of relationship types, so no single
+constraint can enforce global Relation-`id` uniqueness (see
+[#351](https://github.com/ProfessionalWiki/NeoWiki/issues/351)).
 
 ## Related Documentation
 

--- a/docs/api/graph-model.md
+++ b/docs/api/graph-model.md
@@ -107,10 +107,11 @@ When a Subject is deleted but still has incoming relations from other Subjects, 
 
 ## Constraints
 
-Two node uniqueness constraints are created on the graph: the `(wiki_id, id)` pair is unique on `:Page` nodes
-([ADR 22](../adr/022-multi-wiki-node-identity.md)), and `Subject.id` is unique. They are (re)created by the
-`RebuildGraphDatabases.php` maintenance script — the path that builds the graph from the MediaWiki source of
-truth — and creation is idempotent (`CREATE CONSTRAINT ... IF NOT EXISTS`), so re-running it is safe.
+Two node uniqueness constraints are defined for the graph: the `(wiki_id, id)` pair is unique on `:Page` nodes
+([ADR 22](../adr/022-multi-wiki-node-identity.md)), and `Subject.id` is unique. They are created by running the
+`RebuildGraphDatabases.php` maintenance script, and creation is idempotent (`CREATE CONSTRAINT ... IF NOT EXISTS`),
+so re-running it is safe. The incremental projection that runs on each page edit does not create them, so an
+existing graph gains them only after the rebuild has been run.
 
 Relation (edge) `id` values are not constrained at the graph level: Neo4j relationship uniqueness constraints
 are per relationship type, and Relations use an open, user-defined set of relationship types, so no single

--- a/docs/extending/extending.md
+++ b/docs/extending/extending.md
@@ -151,6 +151,10 @@ NeoWiki currently supports Neo4j only, but the graph projection is an extension 
 ```php
 class MyGraphDatabasePlugin implements GraphDatabasePlugin {
 
+	public function initialize(): void {
+		// Create any store-level structures your backend needs (e.g. constraints or indexes).
+	}
+
 	public function savePage( Page $page ): void {
 		// Project the page and its subjects into your store.
 	}
@@ -167,6 +171,10 @@ Register with `NeoWikiRegistrar::addGraphDatabasePlugin()`. Example:
 
 `savePage` hands you the page with all of its Subjects and runs for every revision, so subject edits, undeletions
 and page moves all reach you as a save. `deletePage` gets only the page id.
+
+`initialize` runs once at the start of a `RebuildGraphDatabases` run, before any page is projected — create the
+store-level structures a fresh store needs there (this is how NeoWiki's own Neo4j backend creates its uniqueness
+constraints). Make it idempotent, since every rebuild calls it; it never runs on an individual edit.
 
 **Signal failure by throwing.** On an edit, delete or undelete, NeoWiki logs the failure and lets the user's
 operation commit, so a backend being down never blocks the wiki or starves the other backends — your projection is

--- a/maintenance/RebuildGraphDatabases.php
+++ b/maintenance/RebuildGraphDatabases.php
@@ -33,7 +33,7 @@ class RebuildGraphDatabases extends Maintenance {
 	}
 
 	public function execute(): void {
-		$this->createGraphConstraints();
+		$this->initializeGraphDatabases();
 
 		$pageIds = $this->getSubjectPageIds();
 
@@ -55,13 +55,14 @@ class RebuildGraphDatabases extends Maintenance {
 	}
 
 	/**
-	 * Creating the constraints before re-projecting guarantees a rebuilt graph carries them. The rebuild
-	 * is the production path that (re)establishes the graph from the MediaWiki source of truth, so it is
-	 * the natural, idempotent point to ensure the uniqueness constraints exist (#874).
+	 * Initializing the backends before re-projecting guarantees a rebuilt graph carries any store-level
+	 * structures they need (e.g. uniqueness constraints). The rebuild is the production path that
+	 * (re)establishes the graph from the MediaWiki source of truth, so it is the natural, idempotent
+	 * point to ensure those structures exist (#874).
 	 */
-	private function createGraphConstraints(): void {
-		$this->outputChanneled( 'Ensuring graph database uniqueness constraints exist...' );
-		NeoWikiExtension::getInstance()->createGraphDatabaseConstraints();
+	private function initializeGraphDatabases(): void {
+		$this->outputChanneled( 'Initializing graph databases...' );
+		NeoWikiExtension::getInstance()->getGraphDatabasePlugin()->initialize();
 	}
 
 	/**

--- a/maintenance/RebuildGraphDatabases.php
+++ b/maintenance/RebuildGraphDatabases.php
@@ -33,6 +33,8 @@ class RebuildGraphDatabases extends Maintenance {
 	}
 
 	public function execute(): void {
+		$this->createGraphConstraints();
+
 		$pageIds = $this->getSubjectPageIds();
 
 		$this->outputChanneled( 'Rebuilding graph databases for ' . count( $pageIds ) . ' subject pages...' );
@@ -50,6 +52,16 @@ class RebuildGraphDatabases extends Maintenance {
 		$this->outputChanneled( "Rebuild finished. Rebuilt $rebuilt of " . count( $pageIds ) . ' pages.' );
 
 		$this->removeDeletedPages();
+	}
+
+	/**
+	 * Creating the constraints before re-projecting guarantees a rebuilt graph carries them. The rebuild
+	 * is the production path that (re)establishes the graph from the MediaWiki source of truth, so it is
+	 * the natural, idempotent point to ensure the uniqueness constraints exist (#874).
+	 */
+	private function createGraphConstraints(): void {
+		$this->outputChanneled( 'Ensuring graph database uniqueness constraints exist...' );
+		NeoWikiExtension::getInstance()->createGraphDatabaseConstraints();
 	}
 
 	/**

--- a/src/Domain/GraphDatabase/CompositeGraphDatabasePlugin.php
+++ b/src/Domain/GraphDatabase/CompositeGraphDatabasePlugin.php
@@ -27,6 +27,12 @@ class CompositeGraphDatabasePlugin implements GraphDatabasePlugin {
 		$this->plugins = $plugins;
 	}
 
+	public function initialize(): void {
+		foreach ( $this->plugins as $plugin ) {
+			$plugin->initialize();
+		}
+	}
+
 	public function savePage( Page $page ): void {
 		foreach ( $this->plugins as $plugin ) {
 			$plugin->savePage( $page );

--- a/src/Domain/GraphDatabase/FailureIsolatingGraphDatabasePlugin.php
+++ b/src/Domain/GraphDatabase/FailureIsolatingGraphDatabasePlugin.php
@@ -42,6 +42,15 @@ class FailureIsolatingGraphDatabasePlugin implements GraphDatabasePlugin {
 	) {
 	}
 
+	/**
+	 * Passed straight through without isolation: this decorator wraps plugins only on the hook-facing
+	 * write path, and that path never initializes — initialize() runs solely on the propagating
+	 * rebuild path (see GraphDatabasePlugin), where a failure must surface rather than be swallowed.
+	 */
+	public function initialize(): void {
+		$this->plugin->initialize();
+	}
+
 	public function savePage( Page $page ): void {
 		try {
 			$this->plugin->savePage( $page );

--- a/src/Domain/GraphDatabase/GraphDatabasePlugin.php
+++ b/src/Domain/GraphDatabase/GraphDatabasePlugin.php
@@ -17,9 +17,19 @@ use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
  *   each plugin (via FailureIsolatingGraphDatabasePlugin), so a throw does not abort the triggering
  *   user operation and one failing backend does not starve the others.
  * - On maintenance rebuilds (RebuildGraphDatabases), the wiring propagates failures so they are
- *   reported truthfully per page instead of being silently swallowed.
+ *   reported truthfully per page instead of being silently swallowed. The rebuild is also the only
+ *   path that calls initialize(), so an initialize() failure propagates like any other rebuild
+ *   failure; the hook path never initializes.
  */
 interface GraphDatabasePlugin {
+
+	/**
+	 * Prepares the backing store for projections by creating the store-level structures the backend
+	 * needs — such as uniqueness constraints — where it supports them. Idempotent, so the rebuild can
+	 * run it every time. The RebuildGraphDatabases maintenance path calls this before bulk re-projection
+	 * so a rebuilt graph carries those structures; the incremental per-edit path does not.
+	 */
+	public function initialize(): void;
 
 	public function savePage( Page $page ): void;
 

--- a/src/GraphDatabasePlugins/Neo4j/Neo4jPlugin.php
+++ b/src/GraphDatabasePlugins/Neo4j/Neo4jPlugin.php
@@ -15,6 +15,7 @@ use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jQuerySe
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jReadQueryEngine;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\ParserFunction\CypherRawParserFunction;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jClientReadQueryEngine;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jConstraintUpdater;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jProjectionStore;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jResultNormalizer;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jSubjectUpdaterFactory;
@@ -42,6 +43,7 @@ readonly class Neo4jPlugin {
 		LoggerInterface $logger,
 		string $wikiId,
 	) {
+		$this->writeQueryEngine = new Neo4jWriteQueryEngine( $client );
 		$this->projectionStore = new Neo4jProjectionStore(
 			client: $client,
 			subjectUpdaterFactory: new Neo4jSubjectUpdaterFactory(
@@ -50,10 +52,11 @@ readonly class Neo4jPlugin {
 				logger: $logger,
 				wikiId: $wikiId,
 			),
+			// Reuse the write engine the plugin already owns so initialize() creates constraints through it.
+			constraintUpdater: new Neo4jConstraintUpdater( $this->writeQueryEngine ),
 			wikiId: $wikiId,
 		);
 		$this->readQueryEngine = new Neo4jClientReadQueryEngine( $readOnlyClient );
-		$this->writeQueryEngine = new Neo4jWriteQueryEngine( $client );
 		$this->readOnlyClient = $readOnlyClient;
 	}
 

--- a/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStore.php
+++ b/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStore.php
@@ -21,8 +21,13 @@ readonly class Neo4jProjectionStore implements GraphDatabasePlugin {
 	public function __construct(
 		private ClientInterface $client,
 		private Neo4jSubjectUpdaterFactory $subjectUpdaterFactory,
+		private Neo4jConstraintUpdater $constraintUpdater,
 		private string $wikiId,
 	) {
+	}
+
+	public function initialize(): void {
+		$this->constraintUpdater->createDefaultConstraints();
 	}
 
 	public function savePage( Page $page ): void {

--- a/src/GraphDatabasePlugins/Sparql/Persistence/SparqlProjectionStore.php
+++ b/src/GraphDatabasePlugins/Sparql/Persistence/SparqlProjectionStore.php
@@ -45,6 +45,11 @@ readonly class SparqlProjectionStore implements GraphDatabasePlugin {
 	) {
 	}
 
+	public function initialize(): void {
+		// Nothing to prepare: a SPARQL graph store has no store-level structures (e.g. uniqueness
+		// constraints) to create up front, unlike Neo4j.
+	}
+
 	public function savePage( Page $page ): void {
 		$projector = $this->resolveProjector();
 		$graph = $this->namespaces->graph( $this->projectionName, $page->getId() );

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -76,7 +76,6 @@ use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfSerializer;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfValueMapperRegistry;
 use ProfessionalWiki\NeoWiki\Infrastructure\Rdf\HardfRdfSerializer;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\ExportPageRdfApi;
-use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jConstraintUpdater;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jWriteQueryEngine;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeLookup;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeRegistry;
@@ -702,19 +701,6 @@ class NeoWikiExtension {
 
 	public function getWriteQueryEngine(): Neo4jWriteQueryEngine {
 		return $this->requireNeo4jPlugin()->getWriteQueryEngine();
-	}
-
-	/**
-	 * Creates the graph-database uniqueness constraints when a Neo4j backend is configured, and is a
-	 * no-op otherwise (SPARQL stores have no constraints to create). Idempotent — the underlying
-	 * CREATE CONSTRAINT statements use IF NOT EXISTS — so it is safe to run on every graph rebuild.
-	 */
-	public function createGraphDatabaseConstraints(): void {
-		$neo4jPlugin = $this->getNeo4jPlugin();
-
-		if ( $neo4jPlugin !== null ) {
-			( new Neo4jConstraintUpdater( $neo4jPlugin->getWriteQueryEngine() ) )->createDefaultConstraints();
-		}
 	}
 
 	public function isDevelopmentUIEnabled(): bool {

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -76,6 +76,7 @@ use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfSerializer;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfValueMapperRegistry;
 use ProfessionalWiki\NeoWiki\Infrastructure\Rdf\HardfRdfSerializer;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\ExportPageRdfApi;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jConstraintUpdater;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jWriteQueryEngine;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeLookup;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeRegistry;
@@ -701,6 +702,19 @@ class NeoWikiExtension {
 
 	public function getWriteQueryEngine(): Neo4jWriteQueryEngine {
 		return $this->requireNeo4jPlugin()->getWriteQueryEngine();
+	}
+
+	/**
+	 * Creates the graph-database uniqueness constraints when a Neo4j backend is configured, and is a
+	 * no-op otherwise (SPARQL stores have no constraints to create). Idempotent — the underlying
+	 * CREATE CONSTRAINT statements use IF NOT EXISTS — so it is safe to run on every graph rebuild.
+	 */
+	public function createGraphDatabaseConstraints(): void {
+		$neo4jPlugin = $this->getNeo4jPlugin();
+
+		if ( $neo4jPlugin !== null ) {
+			( new Neo4jConstraintUpdater( $neo4jPlugin->getWriteQueryEngine() ) )->createDefaultConstraints();
+		}
 	}
 
 	public function isDevelopmentUIEnabled(): bool {

--- a/tests/RedHerb/src/RedHerbGraphDatabasePlugin.php
+++ b/tests/RedHerb/src/RedHerbGraphDatabasePlugin.php
@@ -21,6 +21,11 @@ class RedHerbGraphDatabasePlugin implements GraphDatabasePlugin {
 	/** @var PageId[] */
 	public array $deletedPageIds = [];
 
+	public function initialize(): void {
+		// A real backend would create its store-level structures (e.g. uniqueness constraints) here.
+		// This example store needs none, so initialization is a no-op.
+	}
+
 	public function savePage( Page $page ): void {
 		$this->savedPages[] = $page;
 	}

--- a/tests/phpunit/Domain/GraphDatabase/CompositeGraphDatabasePluginTest.php
+++ b/tests/phpunit/Domain/GraphDatabase/CompositeGraphDatabasePluginTest.php
@@ -22,10 +22,22 @@ class CompositeGraphDatabasePluginTest extends TestCase {
 	public function testEmptyCompositeDoesNotThrow(): void {
 		$composite = new CompositeGraphDatabasePlugin();
 
+		$composite->initialize();
 		$composite->savePage( TestPage::build() );
 		$composite->deletePage( new PageId( 1 ) );
 
 		$this->addToAssertionCount( 1 );
+	}
+
+	public function testInitializeDispatchesToAllPlugins(): void {
+		$spy1 = new SpyGraphDatabasePlugin();
+		$spy2 = new SpyGraphDatabasePlugin();
+		$composite = new CompositeGraphDatabasePlugin( $spy1, $spy2 );
+
+		$composite->initialize();
+
+		$this->assertSame( 1, $spy1->initializeCount );
+		$this->assertSame( 1, $spy2->initializeCount );
 	}
 
 	public function testSavePageDispatchesToAllPlugins(): void {
@@ -64,6 +76,14 @@ class CompositeGraphDatabasePluginTest extends TestCase {
 
 		$this->assertSame( [ $page1, $page2 ], $spy->savedPages );
 		$this->assertCount( 1, $spy->deletedPageIds );
+	}
+
+	public function testInitializePropagatesAPluginFailure(): void {
+		$composite = new CompositeGraphDatabasePlugin( new ThrowingGraphDatabasePlugin() );
+
+		$this->expectExceptionMessage( ThrowingGraphDatabasePlugin::FAILURE_MESSAGE );
+
+		$composite->initialize();
 	}
 
 	public function testSavePagePropagatesAPluginFailure(): void {

--- a/tests/phpunit/Domain/GraphDatabase/FailureIsolatingGraphDatabasePluginTest.php
+++ b/tests/phpunit/Domain/GraphDatabase/FailureIsolatingGraphDatabasePluginTest.php
@@ -51,6 +51,14 @@ class FailureIsolatingGraphDatabasePluginTest extends TestCase {
 		$this->assertSame( [ $pageId ], $spy->deletedPageIds );
 	}
 
+	public function testInitializeIsDelegatedToTheWrappedPlugin(): void {
+		$spy = new SpyGraphDatabasePlugin();
+
+		$this->newDecorator( $spy )->initialize();
+
+		$this->assertSame( 1, $spy->initializeCount );
+	}
+
 	public function testSucceedingProjectionLogsNothing(): void {
 		$this->newDecorator( new SpyGraphDatabasePlugin() )->savePage( TestPage::build( id: 42 ) );
 
@@ -98,12 +106,29 @@ class FailureIsolatingGraphDatabasePluginTest extends TestCase {
 		$decorator->deletePage( new PageId( 1 ) );
 	}
 
+	/**
+	 * initialize() runs only on the propagating rebuild path, never the isolated hook path, so this
+	 * decorator passes it straight through: a failure surfaces rather than being swallowed and logged
+	 * the way a save or delete failure is.
+	 */
+	public function testInitializeFailureIsNotSwallowed(): void {
+		$decorator = $this->newDecorator( new ThrowingGraphDatabasePlugin() );
+
+		$this->expectExceptionMessage( ThrowingGraphDatabasePlugin::FAILURE_MESSAGE );
+
+		$decorator->initialize();
+	}
+
 	private function pluginThrowing( Throwable $error ): GraphDatabasePlugin {
 		return new class( $error ) implements GraphDatabasePlugin {
 
 			public function __construct(
 				private readonly Throwable $error
 			) {
+			}
+
+			public function initialize(): void {
+				throw $this->error;
 			}
 
 			public function savePage( Page $page ): void {

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStoreTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStoreTest.php
@@ -18,8 +18,10 @@ use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectMap;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jConstraintUpdater;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jProjectionStore;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jSubjectUpdaterFactory;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jWriteQueryEngine;
 use Psr\Log\NullLogger;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestPage;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestRelation;
@@ -73,6 +75,7 @@ class Neo4jProjectionStoreTest extends NeoWikiIntegrationTestCase {
 				logger: new NullLogger(),
 				wikiId: $wikiId,
 			),
+			constraintUpdater: new Neo4jConstraintUpdater( new Neo4jWriteQueryEngine( $extension->getNeo4jClient() ) ),
 			wikiId: $wikiId,
 		);
 	}

--- a/tests/phpunit/Maintenance/RebuildGraphDatabasesTest.php
+++ b/tests/phpunit/Maintenance/RebuildGraphDatabasesTest.php
@@ -56,35 +56,24 @@ class RebuildGraphDatabasesTest extends NeoWikiIntegrationTestCase {
 		);
 	}
 
+	/**
+	 * @covers \ProfessionalWiki\NeoWiki\NeoWikiExtension::createGraphDatabaseConstraints
+	 */
 	public function testRebuildCreatesGraphUniquenessConstraints(): void {
 		// setUpNeo4j() dropped any pre-existing constraints, so the graph starts without them.
-		// A subject page is present so the rebuild re-projects real data: the constraints are
-		// created before the re-projection, so this also proves an unchanged re-save does not
-		// violate them.
+		// A subject page is present so the rebuild re-projects real data under the freshly created
+		// constraints. Only the wiring is asserted here (both constraints exist by name); their shape
+		// and enforcement are covered by Neo4jConstraintUpdaterTest.
 		$this->createPageWithSubjects( 'Page with subject', TestSubject::build() );
 
 		$this->runRebuild();
 
 		$this->assertSame(
 			[
-				[
-					'name' => 'Page wiki_id id',
-					'type' => 'NODE_PROPERTY_UNIQUENESS',
-					'entityType' => 'NODE',
-					'labelsOrTypes' => [ 'Page' ],
-					'properties' => [ 'wiki_id', 'id' ],
-				],
-				[
-					'name' => 'Subject id',
-					'type' => 'NODE_PROPERTY_UNIQUENESS',
-					'entityType' => 'NODE',
-					'labelsOrTypes' => [ 'Subject' ],
-					'properties' => [ 'id' ],
-				],
+				[ 'name' => 'Page wiki_id id' ],
+				[ 'name' => 'Subject id' ],
 			],
-			$this->readGraph(
-				'SHOW CONSTRAINTS YIELD name, type, entityType, labelsOrTypes, properties ORDER BY name'
-			)->toRecursiveArray()
+			$this->readGraph( 'SHOW CONSTRAINTS YIELD name ORDER BY name' )->toRecursiveArray()
 		);
 	}
 

--- a/tests/phpunit/Maintenance/RebuildGraphDatabasesTest.php
+++ b/tests/phpunit/Maintenance/RebuildGraphDatabasesTest.php
@@ -56,6 +56,54 @@ class RebuildGraphDatabasesTest extends NeoWikiIntegrationTestCase {
 		);
 	}
 
+	public function testRebuildCreatesGraphUniquenessConstraints(): void {
+		// setUpNeo4j() dropped any pre-existing constraints, so the graph starts without them.
+		// A subject page is present so the rebuild re-projects real data: the constraints are
+		// created before the re-projection, so this also proves an unchanged re-save does not
+		// violate them.
+		$this->createPageWithSubjects( 'Page with subject', TestSubject::build() );
+
+		$this->runRebuild();
+
+		$this->assertSame(
+			[
+				[
+					'name' => 'Page wiki_id id',
+					'type' => 'NODE_PROPERTY_UNIQUENESS',
+					'entityType' => 'NODE',
+					'labelsOrTypes' => [ 'Page' ],
+					'properties' => [ 'wiki_id', 'id' ],
+				],
+				[
+					'name' => 'Subject id',
+					'type' => 'NODE_PROPERTY_UNIQUENESS',
+					'entityType' => 'NODE',
+					'labelsOrTypes' => [ 'Subject' ],
+					'properties' => [ 'id' ],
+				],
+			],
+			$this->readGraph(
+				'SHOW CONSTRAINTS YIELD name, type, entityType, labelsOrTypes, properties ORDER BY name'
+			)->toRecursiveArray()
+		);
+	}
+
+	/**
+	 * The rebuild runs on wikis with no Neo4j backend (e.g. a SPARQL-only install), so ensuring
+	 * constraints must be a no-op there rather than throwing.
+	 *
+	 * @covers \ProfessionalWiki\NeoWiki\NeoWikiExtension::createGraphDatabaseConstraints
+	 */
+	public function testEnsuringConstraintsIsSkippedWhenNeo4jIsNotConfigured(): void {
+		$this->runWithoutGraphBackend( function (): void {
+			$extension = NeoWikiExtension::getInstance();
+			$this->assertNull( $extension->getNeo4jPlugin(), 'precondition: no Neo4j backend is configured' );
+
+			// Must not throw despite there being no Neo4j write engine to target.
+			$extension->createGraphDatabaseConstraints();
+		} );
+	}
+
 	private function runRebuild(): void {
 		ob_start();
 		try {

--- a/tests/phpunit/Maintenance/RebuildGraphDatabasesTest.php
+++ b/tests/phpunit/Maintenance/RebuildGraphDatabasesTest.php
@@ -57,13 +57,14 @@ class RebuildGraphDatabasesTest extends NeoWikiIntegrationTestCase {
 	}
 
 	/**
-	 * @covers \ProfessionalWiki\NeoWiki\NeoWikiExtension::createGraphDatabaseConstraints
+	 * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jProjectionStore::initialize
 	 */
 	public function testRebuildCreatesGraphUniquenessConstraints(): void {
-		// setUpNeo4j() dropped any pre-existing constraints, so the graph starts without them.
-		// A subject page is present so the rebuild re-projects real data under the freshly created
-		// constraints. Only the wiring is asserted here (both constraints exist by name); their shape
-		// and enforcement are covered by Neo4jConstraintUpdaterTest.
+		// setUpNeo4j() dropped any pre-existing constraints, so the graph starts without them. A subject
+		// page is present so the rebuild re-projects real data under the freshly created constraints. This
+		// is the end-to-end proof that the rebuild's initialization step (routed through the graph plugin
+		// system) reaches Neo4j: both constraints exist by name. Their shape and enforcement are covered by
+		// Neo4jConstraintUpdaterTest.
 		$this->createPageWithSubjects( 'Page with subject', TestSubject::build() );
 
 		$this->runRebuild();
@@ -78,18 +79,19 @@ class RebuildGraphDatabasesTest extends NeoWikiIntegrationTestCase {
 	}
 
 	/**
-	 * The rebuild runs on wikis with no Neo4j backend (e.g. a SPARQL-only install), so ensuring
-	 * constraints must be a no-op there rather than throwing.
+	 * The rebuild runs on wikis with no graph backend configured (e.g. a SPARQL-only install with no
+	 * store), so its initialization step must be a no-op there rather than throwing.
 	 *
-	 * @covers \ProfessionalWiki\NeoWiki\NeoWikiExtension::createGraphDatabaseConstraints
+	 * @covers \ProfessionalWiki\NeoWiki\Domain\GraphDatabase\CompositeGraphDatabasePlugin::initialize
 	 */
-	public function testEnsuringConstraintsIsSkippedWhenNeo4jIsNotConfigured(): void {
+	public function testInitializingGraphDatabasesDoesNotThrowWithoutABackend(): void {
 		$this->runWithoutGraphBackend( function (): void {
 			$extension = NeoWikiExtension::getInstance();
 			$this->assertNull( $extension->getNeo4jPlugin(), 'precondition: no Neo4j backend is configured' );
 
-			// Must not throw despite there being no Neo4j write engine to target.
-			$extension->createGraphDatabaseConstraints();
+			// The rebuild's initialization step, resolved through the facade exactly as the script does.
+			// Must not throw despite there being no store to initialize.
+			$extension->getGraphDatabasePlugin()->initialize();
 		} );
 	}
 

--- a/tests/phpunit/TestDoubles/SpyGraphDatabasePlugin.php
+++ b/tests/phpunit/TestDoubles/SpyGraphDatabasePlugin.php
@@ -10,11 +10,17 @@ use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 
 class SpyGraphDatabasePlugin implements GraphDatabasePlugin {
 
+	public int $initializeCount = 0;
+
 	/** @var Page[] */
 	public array $savedPages = [];
 
 	/** @var PageId[] */
 	public array $deletedPageIds = [];
+
+	public function initialize(): void {
+		$this->initializeCount++;
+	}
 
 	public function savePage( Page $page ): void {
 		$this->savedPages[] = $page;

--- a/tests/phpunit/TestDoubles/ThrowingGraphDatabasePlugin.php
+++ b/tests/phpunit/TestDoubles/ThrowingGraphDatabasePlugin.php
@@ -17,6 +17,10 @@ class ThrowingGraphDatabasePlugin implements GraphDatabasePlugin {
 
 	public const string FAILURE_MESSAGE = 'projection backend unreachable';
 
+	public function initialize(): void {
+		throw new RuntimeException( self::FAILURE_MESSAGE );
+	}
+
 	public function savePage( Page $page ): void {
 		throw new RuntimeException( self::FAILURE_MESSAGE );
 	}


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/874

`Neo4jConstraintUpdater::createDefaultConstraints()` could create the `Page (wiki_id, id)` and `Subject.id` uniqueness constraints but was only ever called from tests, so a real install ran Neo4j without them: duplicate-id nodes were possible and id lookups were unindexed.

Constraint creation is now a store-level `initialize()` step on the `GraphDatabasePlugin` interface, run through the same plugin seam every other rebuild step already uses rather than a Neo4j special case on the `NeoWikiExtension` facade. `RebuildGraphDatabases.php` — the production path that (re)builds the graph from the MediaWiki source of truth — calls `getGraphDatabasePlugin()->initialize()` (the propagating composite over every configured backend) before re-projecting. `Neo4jProjectionStore::initialize()` creates the constraints, idempotently (`CREATE CONSTRAINT ... IF NOT EXISTS`), via a `Neo4jConstraintUpdater` the Neo4j composition root injects from the write engine it already owns; `SparqlProjectionStore::initialize()` is a no-op; a wiki with no graph backend is simply an empty fan-out, so the no-op case needs no facade null-check. Creating the constraints before re-projecting means a rebuilt graph always carries them, and an unchanged re-save still succeeds because the projection `MERGE`s nodes by id. The `graph-model.md` claim that the constraints are "not created automatically yet" is corrected (earlier commit), and `extending.md` now documents the `initialize()` method for extension authors.

**Why the rebuild is the wiring point.** It is already the canonical way to (re)build the whole graph from the source of truth, it runs with every backend resolved, and its idempotency makes repeated runs safe. A `LoadExtensionSchemaUpdates` hook was considered but rejected — NeoWiki registers no SQL schema updater today, and coupling external-Neo4j reachability to `update.php` is fragile.

## Limitations and operational notes

- **Constraints are established by running the rebuild, not automatically.** A wiki whose graph is built only by the normal incremental projection (the Subject slot saved on each page edit) carries no constraints until `RebuildGraphDatabases.php` is run at least once — this PR does not add constraint creation to the per-save path, so a never-rebuilt graph stays unconstrained (verified: a demo-seeded graph reports no constraints via `SHOW CONSTRAINTS`).
- **A graph that already holds violating data aborts the rebuild.** `IF NOT EXISTS` suppresses only the "already exists" case, not a data conflict, so duplicate `(wiki_id, id)` Pages or duplicate `Subject.id`s make the rebuild fail fast at the initialization step — before any re-projection — with a Neo4j error naming the conflict. Fail-fast is acceptable (the rebuild never purges, so it could not have resolved the duplicates anyway), but such duplicates must be cleared by hand first.
- **Constraint creation is a schema (DDL) write and is not failure-isolated.** The rebuild runs `initialize()` through the propagating composite, not the hook path's `FailureIsolatingGraphDatabasePlugin`, so a Neo4j account with data-write but no schema/DDL privilege — or an unreachable Neo4j — now aborts the rebuild where it previously ran constraint-free.
- **Pre-existing wrinkle:** on a Neo4j wiki that has never stored a Subject, the constraints are created and the run then exits non-zero on the pre-existing `NameTableAccessException` in `getSubjectPageIds()` (the Subject slot role is not yet in the name table). The throw is after the initialization step and is unrelated to this change.

## Relation ID uniqueness (#351) — not implemented here

Analysis posted on #351. In short: Neo4j relationship uniqueness constraints are **per relationship type** (verified on this stack's Neo4j 2026.05.0 Enterprise — a type-less `FOR ()-[r]->() REQUIRE r.id IS UNIQUE` is a syntax error), and Relations use an open, user-defined set of relationship types, so no single constraint can enforce global Relation-`id` uniqueness across all edges. A hard "reject the save" guarantee would need a graph read in NeoWiki's deliberately graph-free pre-save validation path (there is no SQL index of relation IDs), which is an architecture decision beyond this change. Referenced here as related, not fixed.

## Tests

- `RebuildGraphDatabasesTest::testRebuildCreatesGraphUniquenessConstraints` — after the rebuild runs, `SHOW CONSTRAINTS` reports both node constraints: the end-to-end proof that the rebuild's initialization step reaches Neo4j through the plugin system (verified failing when `Neo4jProjectionStore::initialize()` is stubbed to a no-op). A subject page is seeded so the rebuild also re-projects real data under the freshly-created constraints. Constraint shape and enforcement stay covered by `Neo4jConstraintUpdaterTest`.
- `RebuildGraphDatabasesTest::testInitializingGraphDatabasesDoesNotThrowWithoutABackend` — with no graph backend configured, the rebuild's initialization step (the composite resolved via the facade) is a no-op rather than throwing.
- `CompositeGraphDatabasePluginTest` / `FailureIsolatingGraphDatabasePluginTest` — `initialize()` fan-out and failure-propagation on the composite; delegation and non-swallowed failure on the isolating decorator (which the hook path never calls).

Full `make phpunit` (1807 tests) and `make cs` (phpcs + phpstan) pass locally.

> <sub>AI-authored — Claude Code, `Opus 4.8 (max)`; batch execution of the Relations Phase 1 plan directed by @JeroenDeDauw, run autonomously with no interactive steering; diff not yet human-reviewed; full `make phpunit` (1794 tests) and `make cs` pass locally, the per-type relationship-constraint limitation verified empirically on Neo4j 2026.05.0 Enterprise, CI pending.</sub>

> <sub>Description updated by an automated PR-review pass — Claude Code, `Opus 4.8 (max)`; no interactive steering; not human-reviewed. Added the limitations section, softened the rebuild rationale, and synced the test bullet to two review fixes pushed to the branch (graph-model.md wording tightened; test assertion trimmed to the wiring fact). Targeted `make phpunit` + full `make cs` pass locally; CI green on the branch.</sub>

> <sub>Reworked by Claude Code, `Opus 4.8 (max)` — autonomous rework directed by @JeroenDeDauw through a parent session, no interactive steering: constraint initialization moved off the `NeoWikiExtension` facade into the `GraphDatabasePlugin` system (new `initialize()` seam). Diff not yet human-reviewed. Full `make phpunit` (1807 tests) and `make cs` (phpcs + phpstan) pass locally; the end-to-end wiring test verified failing when the Neo4j store's `initialize()` is stubbed to a no-op; CI green.</sub>
