### PR TITLE
Scope the relation-target autocomplete to the current wiki

### DIFF
--- a/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectLabelLookup.php
+++ b/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectLabelLookup.php
@@ -13,7 +13,8 @@ use ProfessionalWiki\NeoWiki\Application\SubjectLabelLookupResult;
 class Neo4jSubjectLabelLookup implements SubjectLabelLookup {
 
 	public function __construct(
-		private readonly ClientInterface $client
+		private readonly ClientInterface $client,
+		private readonly string $wikiId,
 	) {
 	}
 
@@ -34,13 +35,15 @@ class Neo4jSubjectLabelLookup implements SubjectLabelLookup {
 					"MATCH (n:Subject)
 					 WHERE toLower(n.name) STARTS WITH toLower(\$search)
 					 AND \$schemaName IN labels(n)
+					 AND n.wiki_id = \$wikiId
 					 RETURN n.id AS id, n.name AS name
 					 ORDER BY n.name
 					 LIMIT \$limit",
 					[
 						'search' => $search,
 						'limit' => (int)$limit,
-						'schemaName' => $schemaName
+						'schemaName' => $schemaName,
+						'wikiId' => $this->wikiId,
 					]
 				);
 

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -917,7 +917,8 @@ class NeoWikiExtension {
 		}
 
 		return new Neo4jSubjectLabelLookup(
-			client: $this->getReadOnlyNeo4jClient()
+			client: $this->getReadOnlyNeo4jClient(),
+			wikiId: $this->config->wikiId,
 		);
 	}
 

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectLabelLookupTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectLabelLookupTest.php
@@ -11,6 +11,7 @@ use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectMap;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Cypher;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jSubjectLabelLookup;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestPage;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestPageProperties;
@@ -111,6 +112,36 @@ class Neo4jSubjectLabelLookupTest extends NeoWikiIntegrationTestCase {
 		$this->assertSame( [], $this->newLookup()->getSubjectLabelsMatching( 'Apple', 10, 'Recipe' ) );
 	}
 
+	public function testExcludesSubjectsFromOtherWikis(): void {
+		$this->saveSubjects( new SubjectMap(
+			TestSubject::build( id: self::SUBJECT_ID_1, label: new SubjectLabel( 'Apple Pie' ) ),
+		) );
+
+		$otherWikiId = $this->currentWikiId() . '-other';
+		$this->createSubjectNode( id: 'sTestSLL2222221', name: 'Apple Crumble', wikiId: $otherWikiId );
+		$this->createSubjectNode( id: 'sTestSLL2222222', name: 'Apple Pie', wikiId: $otherWikiId );
+		$this->createSubjectNode( id: 'sTestSLL2222223', name: 'Apple Tart', wikiId: $otherWikiId );
+
+		$this->assertEquals(
+			[ new SubjectLabelLookupResult( self::SUBJECT_ID_1, 'Apple Pie' ) ],
+			$this->getSubjectLabelsMatching( 'Apple' )
+		);
+	}
+
+	public function testExcludesSubjectsWithoutWikiId(): void {
+		$this->saveSubjects( new SubjectMap(
+			TestSubject::build( id: self::SUBJECT_ID_1, label: new SubjectLabel( 'Apple Pie' ) ),
+		) );
+
+		$this->createSubjectNode( id: 'sTestSLL3333331', name: 'Apple Crumble', wikiId: null );
+		$this->createSubjectNode( id: 'sTestSLL3333332', name: 'Apple Tart', wikiId: null );
+
+		$this->assertEquals(
+			[ new SubjectLabelLookupResult( self::SUBJECT_ID_1, 'Apple Pie' ) ],
+			$this->getSubjectLabelsMatching( 'Apple' )
+		);
+	}
+
 	private function saveSubjects( SubjectMap $subjects ): void {
 		$this->newProjectionStore()->savePage( TestPage::build(
 			id: 1,
@@ -136,7 +167,29 @@ class Neo4jSubjectLabelLookupTest extends NeoWikiIntegrationTestCase {
 
 	private function newLookup( ClientInterface $client = null ): Neo4jSubjectLabelLookup {
 		return new Neo4jSubjectLabelLookup(
-			client: $client ?? $this->getClient()
+			client: $client ?? $this->getClient(),
+			wikiId: $this->currentWikiId(),
+		);
+	}
+
+	private function currentWikiId(): string {
+		return NeoWikiExtension::getInstance()->config->wikiId;
+	}
+
+	/**
+	 * Creates a Subject node directly in the graph, bypassing the projection store, so a test can
+	 * plant a node with a chosen wiki_id (or none at all, as written before wiki_id stamping existed).
+	 */
+	private function createSubjectNode( string $id, string $name, ?string $wikiId ): void {
+		$properties = [ 'id' => $id, 'name' => $name ];
+
+		if ( $wikiId !== null ) {
+			$properties['wiki_id'] = $wikiId;
+		}
+
+		$this->getClient()->run(
+			'CREATE (n:Subject:' . Cypher::escape( TestSubject::DEFAULT_SCHEMA_ID ) . ' $properties)',
+			[ 'properties' => $properties ]
 		);
 	}
 


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/1079

`Neo4jSubjectLabelLookup::getSubjectLabelsMatching()` matched `(n:Subject)` by name prefix and schema label only. In a shared farm graph (ADR 22, `wiki_id` stamped on Subject nodes) it therefore suggested Subjects from every wiki in the farm, letting the picker offer cross-wiki targets the local wiki cannot resolve or display through the normal UI.

Add a `wiki_id` equality predicate for the current wiki to the lookup query. The wiki id comes from the same source of truth the write side uses: it is injected from `NeoWikiConfig::$wikiId` (`WikiMap::getCurrentWikiId()`), mirroring how `Neo4jSubjectUpdater` receives the value it stamps onto Subject nodes.

Filtering is strict: `n.wiki_id = $wikiId` also excludes nodes that have no `wiki_id` (written before stamping existed). That is acceptable because the graph is a rebuildable projection; a `RebuildGraphDatabases.php` run re-stamps them. Operationally, this means a graph projected before `wiki_id` stamping was introduced (ADR 22) returns an empty relation-target picker until `RebuildGraphDatabases.php` has been run.

No API surface change: `GetSubjectLabelsApi` keeps its parameters; the scoping is internal.

> <sub>AI-authored — Claude Code, `Opus 4.8 (max)`; batch execution of the Relations Phase 1 plan directed by @JeroenDeDauw; not yet human-reviewed; regression tests written (observed failing before the fix, passing after), full PHPUnit suite (1794 tests), phpcs and phpstan run locally and all green; CI green.</sub>

> <sub>Review pass — Claude Code, `Opus 4.8 (max)`; automated PR review directed by @JeroenDeDauw; amended this description with the operational note above; the fix itself remains not human-reviewed; independently re-verified — full PHPUnit (1794 tests) + phpcs + phpstan green, and the two new regression tests mutation-checked (predicate removal, `=`→`<>`, and a wiki-id-source mismatch were all caught); CI green.</sub>
