### PR TITLE
Document the expand=relations REST response shape

### DIFF
--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -99,15 +99,16 @@ A Layout defines how a Subject is displayed.
 ## The `expand` parameter
 
 The Subject read and page-subjects read endpoints take an optional multi-valued `expand` query parameter (e.g.
-`?expand=page|relations`) that embeds related data so a client can render without follow-up requests. The Subject
-read accepts `page` and `relations`; the page-subjects read accepts `schemas` and `relations`. `page` and
-`schemas` are covered where they are used; this section covers `relations`, which shapes the response differently
-on each endpoint. Per-Subject objects follow [Subject format](subject-format.md) — page fields are trimmed from the
-examples below.
+`?expand=page|relations`) that embeds related data so a client can render without follow-up requests. On the
+Subject read, `page` adds the page fields described in [Subject format](subject-format.md#reading-subjects) to
+each returned Subject. On the page-subjects read, `schemas` adds a top-level `schemas` map from Schema name to the
+[Schema format](schema-format.md) body of every Schema the returned Subjects use. Both endpoints accept
+`relations`, which shapes the response differently on each endpoint. Per-Subject objects follow
+[Subject format](subject-format.md) — page fields are trimmed from the examples below.
 
 `expand=relations` resolves every relation-type Statement value (each holds a `target` Subject ID) to the full
-target Subject. A `target` that does not resolve to an existing Subject is silently omitted. Match a relation
-value's `target` against the resolved Subjects to look it up.
+target Subject; match a relation value's `target` against the resolved Subjects to look one up. A `target` that
+does not resolve to an existing Subject is silently omitted — the relation value itself is unchanged.
 
 On the **Subject read**, the targets are merged into the same `subjects` map as the requested Subject, which
 `requestedId` identifies:
@@ -130,9 +131,7 @@ On the **Subject read**, the targets are merged into the same `subjects` map as 
 ```
 
 On the **page-subjects read**, the page's own Subjects stay in `subjects` and the resolved targets go in a separate
-top-level `referencedSubjects` map keyed by Subject ID. A target already among the page's own Subjects (a relation
-to another Subject on the same page) is not repeated. When `relations` is requested but nothing resolves,
-`referencedSubjects` is an empty array (`[]`):
+top-level `referencedSubjects` map keyed by Subject ID:
 
 ```json
 {
@@ -147,6 +146,10 @@ to another Subject on the same page) is not repeated. When `relations` is reques
   }
 }
 ```
+
+A target already among the page's own Subjects (a relation to another Subject on the same page) is not repeated in
+`referencedSubjects`. When `relations` is requested but nothing resolves, `referencedSubjects` is an empty array
+(`[]`).
 
 ## Stability
 

--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -96,6 +96,58 @@ A Layout defines how a Subject is displayed.
 
 <!-- REST-ENDPOINTS:END -->
 
+## The `expand` parameter
+
+The Subject read and page-subjects read endpoints take an optional multi-valued `expand` query parameter (e.g.
+`?expand=page|relations`) that embeds related data so a client can render without follow-up requests. The Subject
+read accepts `page` and `relations`; the page-subjects read accepts `schemas` and `relations`. `page` and
+`schemas` are covered where they are used; this section covers `relations`, which shapes the response differently
+on each endpoint. Per-Subject objects follow [Subject format](subject-format.md) — page fields are trimmed from the
+examples below.
+
+`expand=relations` resolves every relation-type Statement value (each holds a `target` Subject ID) to the full
+target Subject. A `target` that does not resolve to an existing Subject is silently omitted. Match a relation
+value's `target` against the resolved Subjects to look it up.
+
+On the **Subject read**, the targets are merged into the same `subjects` map as the requested Subject, which
+`requestedId` identifies:
+
+```json
+{
+  "requestedId": "sEpfwJLnxyQy6vR",
+  "subjects": {
+    "sEpfwJLnxyQy6vR": {
+      "id": "sEpfwJLnxyQy6vR",
+      "label": "Rijksmuseum",
+      "schema": "Museum",
+      "statements": {
+        "City": { "type": "relation", "value": [ { "id": "rEpfwJLoEB5UuQS", "target": "sEpfwJLnuwcxvuJ" } ] }
+      }
+    },
+    "sEpfwJLnuwcxvuJ": { "id": "sEpfwJLnuwcxvuJ", "label": "Amsterdam", "schema": "City", "statements": { ... } }
+  }
+}
+```
+
+On the **page-subjects read**, the page's own Subjects stay in `subjects` and the resolved targets go in a separate
+top-level `referencedSubjects` map keyed by Subject ID. A target already among the page's own Subjects (a relation
+to another Subject on the same page) is not repeated. When `relations` is requested but nothing resolves,
+`referencedSubjects` is an empty array (`[]`):
+
+```json
+{
+  "pageId": 93,
+  "mainSubjectId": "sEpfwJLnxyQy6vR",
+  "subjects": {
+    "sEpfwJLnxyQy6vR": { "id": "sEpfwJLnxyQy6vR", "label": "Rijksmuseum", "schema": "Museum", "statements": { ... } },
+    "sEpfwJLAtndAaaA": { ... }
+  },
+  "referencedSubjects": {
+    "sEpfwJLnuwcxvuJ": { "id": "sEpfwJLnuwcxvuJ", "label": "Amsterdam", "schema": "City", "statements": { ... } }
+  }
+}
+```
+
 ## Stability
 
 **Pre-1.0.** Endpoints and payloads may change without notice. Don't build third-party integrations on

--- a/docs/api/subject-format.md
+++ b/docs/api/subject-format.md
@@ -197,6 +197,8 @@ Returns the same statement format as storage, with additional fields:
   `pageTitle`, and `pageNamespaceId`. `pageTitle` is the full page title including the namespace prefix
   (e.g. `Help:Installation`); `pageNamespaceId` is the page's canonical MediaWiki namespace ID (e.g. `0`
   for the main namespace, `12` for Help), which is stable regardless of the wiki's content language.
+- Passing `?expand=relations` also embeds the Subjects targeted by this Subject's relation values; see
+  [REST API](rest-api.md) for the response shape.
 
 ### Writing Subjects
 

--- a/docs/api/subject-format.md
+++ b/docs/api/subject-format.md
@@ -198,7 +198,7 @@ Returns the same statement format as storage, with additional fields:
   (e.g. `Help:Installation`); `pageNamespaceId` is the page's canonical MediaWiki namespace ID (e.g. `0`
   for the main namespace, `12` for Help), which is stable regardless of the wiki's content language.
 - Passing `?expand=relations` also embeds the Subjects targeted by this Subject's relation values; see
-  [REST API](rest-api.md) for the response shape.
+  [REST API](rest-api.md#the-expand-parameter) for the response shape.
 
 ### Writing Subjects
 


### PR DESCRIPTION
docs/api/rest-api.md listed `expand=relations` on the Subject read and page-subjects read endpoints but never
described the expanded response. This documents it: the accepted `expand` values per endpoint, how `relations`
resolves relation-value targets to full Subjects, the two different envelopes (Subject read merges targets into the
`subjects` map; page-subjects read puts them in a separate `referencedSubjects` map), and that unresolved targets
are omitted. Cross-links from subject-format.md's Reading Subjects section.

Part of the Relations Phase 1 batch. Related: https://github.com/ProfessionalWiki/NeoWiki/issues/630

> <sub>AI-authored — Claude Code, `Opus 4.8 (max)`; detailed spec, batch execution of the Relations Phase 1 plan directed by @JeroenDeDauw, executed autonomously with no revisions; diff not yet human-reviewed; response shapes verified against the live worktree API (Rijksmuseum → Amsterdam City relation); CI green.</sub>
