### PR TITLE
Add a View RDF link to the page-tools sidebar

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -42,6 +42,7 @@
 	"neowiki-page-tools-view-subjects": "View subjects",
 	"neowiki-page-tools-edit-json": "View or edit JSON",
 	"neowiki-page-tools-view-json": "View JSON",
+	"neowiki-page-tools-rdf": "View RDF",
 
 	"neowiki-property-editor-name": "Name",
 	"neowiki-property-editor-type": "Type",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -43,6 +43,7 @@
 	"neowiki-page-tools-view-subjects": "Read-only counterpart of neowiki-page-tools-manage-subjects: label for the sidebar link to the Subject management page, shown to users who lack edit permission.",
 	"neowiki-page-tools-edit-json": "Label for the sidebar link that navigates to Special:NeoJson for the current page. Only visible when development UIs are enabled.",
 	"neowiki-page-tools-view-json": "Read-only counterpart of neowiki-page-tools-edit-json: label for the sidebar link to Special:NeoJson, shown to users who lack edit permission. Only visible when development UIs are enabled.",
+	"neowiki-page-tools-rdf": "Label for the sidebar link that opens the current page's RDF export (Turtle serialization of the page's Subjects), served by the per-page RDF REST endpoint. Only shown when the page has NeoWiki Subjects.",
 
 	"neowiki-subject-creator-creating-schema": "Subtitle shown in the subject creator dialog header when the user is creating a new schema.",
 	"neowiki-subject-creator-create-schema": "Label for the button that creates a new schema in the subject creator dialog.",

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -269,11 +269,16 @@ class NeoWikiHooks {
 		$hints = $extension->newSubjectPermissionHints( $skin->getAuthority() );
 		$pageId = new PageId( $title->getArticleID() );
 
+		$isContentNamespace = MediaWikiServices::getInstance()
+			->getNamespaceInfo()
+			->isContent( $title->getNamespace() );
+
 		$neoWikiTools = ( new PageToolsBuilder() )->build(
 			title: $title,
-			isContentNamespace: MediaWikiServices::getInstance()
-				->getNamespaceInfo()
-				->isContent( $title->getNamespace() ),
+			pageId: $title->getArticleID(),
+			isContentNamespace: $isContentNamespace,
+			hasSubjects: $isContentNamespace
+				&& $extension->newPageSubjectsLookup()->pageHasSubjects( $pageId ),
 			canCreateMainSubject: $hints->canCreateMainSubject( $pageId ),
 			canEditSubject: $hints->canEditSubject( $pageId ),
 			isLatestRevision: self::pageIsLatestRevision( $skin->getOutput() ),

--- a/src/Presentation/PageToolsBuilder.php
+++ b/src/Presentation/PageToolsBuilder.php
@@ -15,7 +15,9 @@ class PageToolsBuilder {
 	 */
 	public function build(
 		Title $title,
+		int $pageId,
 		bool $isContentNamespace,
+		bool $hasSubjects,
 		bool $canCreateMainSubject,
 		bool $canEditSubject,
 		bool $isLatestRevision,
@@ -46,6 +48,15 @@ class PageToolsBuilder {
 				)->text(),
 				'href' => $title->getLocalURL( [ 'action' => SubjectsAction::ACTION_NAME ] ),
 				'id' => 't-neowiki-manage-subjects',
+			];
+		}
+
+		if ( $hasSubjects ) {
+			$items[] = [
+				'text' => wfMessage( 'neowiki-page-tools-rdf' )->text(),
+				'href' => wfScript( 'rest' ) . '/neowiki/v0/page/'
+					. $pageId . '/rdf?format=turtle',
+				'id' => 't-neowiki-rdf',
 			];
 		}
 

--- a/tests/phpunit/Presentation/PageToolsBuilderTest.php
+++ b/tests/phpunit/Presentation/PageToolsBuilderTest.php
@@ -15,6 +15,7 @@ use ProfessionalWiki\NeoWiki\Presentation\PageToolsBuilder;
 class PageToolsBuilderTest extends MediaWikiIntegrationTestCase {
 
 	private const PAGE_NAME = 'PageToolsBuilderTestPage';
+	private const PAGE_ID = 42;
 
 	public function testReturnsNoItemsOutsideContentNamespace(): void {
 		$this->assertSame(
@@ -28,9 +29,32 @@ class PageToolsBuilderTest extends MediaWikiIntegrationTestCase {
 			[
 				$this->createSubjectItem(),
 				$this->manageSubjectsItem(),
+				$this->rdfItem(),
 				$this->editJsonItem(),
 			],
-			$this->build()
+			$this->build( hasSubjects: true )
+		);
+	}
+
+	public function testShowsRdfLinkWhenPageHasSubjects(): void {
+		$this->assertSame(
+			[ $this->manageSubjectsItem(), $this->rdfItem() ],
+			$this->build(
+				hasSubjects: true,
+				canCreateMainSubject: false,
+				devUiEnabled: false
+			)
+		);
+	}
+
+	public function testHidesRdfLinkWhenPageHasNoSubjects(): void {
+		$this->assertSame(
+			[ $this->manageSubjectsItem() ],
+			$this->build(
+				hasSubjects: false,
+				canCreateMainSubject: false,
+				devUiEnabled: false
+			)
 		);
 	}
 
@@ -101,6 +125,7 @@ class PageToolsBuilderTest extends MediaWikiIntegrationTestCase {
 	 */
 	private function build(
 		bool $isContentNamespace = true,
+		bool $hasSubjects = false,
 		bool $canCreateMainSubject = true,
 		bool $canEditSubject = true,
 		bool $isLatestRevision = true,
@@ -109,7 +134,9 @@ class PageToolsBuilderTest extends MediaWikiIntegrationTestCase {
 	): array {
 		return ( new PageToolsBuilder() )->build(
 			title: Title::newFromText( self::PAGE_NAME ),
+			pageId: self::PAGE_ID,
 			isContentNamespace: $isContentNamespace,
+			hasSubjects: $hasSubjects,
 			canCreateMainSubject: $canCreateMainSubject,
 			canEditSubject: $canEditSubject,
 			isLatestRevision: $isLatestRevision,
@@ -140,6 +167,18 @@ class PageToolsBuilderTest extends MediaWikiIntegrationTestCase {
 			'text' => wfMessage( $messageKey )->text(),
 			'href' => Title::newFromText( self::PAGE_NAME )->getLocalURL( [ 'action' => 'subjects' ] ),
 			'id' => 't-neowiki-manage-subjects',
+		];
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	private function rdfItem(): array {
+		return [
+			'text' => wfMessage( 'neowiki-page-tools-rdf' )->text(),
+			'href' => wfScript( 'rest' ) . '/neowiki/v0/page/'
+				. self::PAGE_ID . '/rdf?format=turtle',
+			'id' => 't-neowiki-rdf',
 		];
 	}
 


### PR DESCRIPTION
The per-page RDF export (GET /rest.php/neowiki/v0/page/{pageId}/rdf) was only
reachable by hand-constructing the URL. Add a "View RDF" link to the NeoWiki
page-tools sidebar section, next to "View JSON", pointing at the current page's
Turtle export.

It is shown only when the page has Subjects, so it never points at the
endpoint's 404-on-empty response. It uses ?format=turtle so the result renders
as readable text in the browser instead of downloading a TriG file, and targets
the native projection. Per-ontology projection links and a per-subject RDF
endpoint (#1087) are out of scope here.

Relates to #1023

> <sub>AI-authored — Claude Code, `Opus 4.8 (max)`; @JeroenDeDauw asked for this sidebar link and to build it via the fix-issue workflow (no revisions during implementation); not yet human-reviewed; new PageToolsBuilder tests + full `make cs` (phpcs + phpstan) green, and verified live on the demo wiki — "View RDF" renders on a Subject page and its target returns `text/turtle`, and is absent on a Subject-less page. Full local PHPUnit is green apart from two pre-existing SPARQL end-to-end tests that need the QLever service (absent from this dev stack, unrelated to this change); CI covers them.</sub>
