### PR TITLE
Cite the public subject-format docs URL in the REST descriptions

### DIFF
--- a/src/EntryPoints/REST/CreateSubjectApi.php
+++ b/src/EntryPoints/REST/CreateSubjectApi.php
@@ -84,7 +84,7 @@ class CreateSubjectApi extends SimpleHandler {
 				self::PARAM_SOURCE => 'body',
 				ParamValidator::PARAM_TYPE => 'array',
 				ParamValidator::PARAM_REQUIRED => true,
-				self::PARAM_DESCRIPTION => 'List of Statements (property/value pairs) for the Subject. Nested shape matches the subject JSON format documented in docs/api/subject-format.md.',
+				self::PARAM_DESCRIPTION => 'List of Statements (property/value pairs) for the Subject. Nested shape matches the subject JSON format documented at https://neowiki.ai/docs/api/subject-format.',
 			],
 			'comment' => [
 				self::PARAM_SOURCE => 'body',

--- a/src/EntryPoints/REST/ReplaceSubjectApi.php
+++ b/src/EntryPoints/REST/ReplaceSubjectApi.php
@@ -85,7 +85,7 @@ class ReplaceSubjectApi extends SimpleHandler {
 				self::PARAM_SOURCE => 'body',
 				ParamValidator::PARAM_TYPE => 'array',
 				ParamValidator::PARAM_REQUIRED => true,
-				self::PARAM_DESCRIPTION => 'Map of property names to Statements. Replaces the Subject\'s statement list entirely; omitted property names are deleted. Pass `{}` to delete all statements. Nested shape matches the subject JSON format documented in docs/api/subject-format.md.',
+				self::PARAM_DESCRIPTION => 'Map of property names to Statements. Replaces the Subject\'s statement list entirely; omitted property names are deleted. Pass `{}` to delete all statements. Nested shape matches the subject JSON format documented at https://neowiki.ai/docs/api/subject-format.',
 			],
 			'comment' => [
 				self::PARAM_SOURCE => 'body',

--- a/src/EntryPoints/REST/ValidateSubjectApi.php
+++ b/src/EntryPoints/REST/ValidateSubjectApi.php
@@ -63,7 +63,7 @@ class ValidateSubjectApi extends SimpleHandler {
 				self::PARAM_SOURCE => 'body',
 				ParamValidator::PARAM_TYPE => 'array',
 				ParamValidator::PARAM_REQUIRED => true,
-				self::PARAM_DESCRIPTION => 'Proposed Statements (property/value pairs). Shape matches docs/api/subject-format.md.',
+				self::PARAM_DESCRIPTION => 'Proposed Statements (property/value pairs). Shape matches the subject JSON format documented at https://neowiki.ai/docs/api/subject-format.',
 			],
 		];
 	}

--- a/src/EntryPoints/REST/ValidateSubjectUpdateApi.php
+++ b/src/EntryPoints/REST/ValidateSubjectUpdateApi.php
@@ -68,7 +68,7 @@ class ValidateSubjectUpdateApi extends SimpleHandler {
 				self::PARAM_SOURCE => 'body',
 				ParamValidator::PARAM_TYPE => 'array',
 				ParamValidator::PARAM_REQUIRED => true,
-				self::PARAM_DESCRIPTION => 'Proposed Statements (property/value pairs) for the proposed update. Shape matches docs/api/subject-format.md.',
+				self::PARAM_DESCRIPTION => 'Proposed Statements (property/value pairs) for the proposed update. Shape matches the subject JSON format documented at https://neowiki.ai/docs/api/subject-format.',
 			],
 			'comment' => [
 				self::PARAM_SOURCE => 'body',

--- a/tests/phpunit/DocsPathReferencesTest.php
+++ b/tests/phpunit/DocsPathReferencesTest.php
@@ -10,11 +10,18 @@ use RecursiveIteratorIterator;
 use SplFileInfo;
 
 /**
- * Guards the docs paths cited in production code against the docs tree.
+ * Guards the documentation references cited in production code against the docs tree.
  *
- * Several REST param descriptions point readers at a documentation file. Those strings are
+ * Some REST param descriptions point readers at NeoWiki documentation. Those strings are
  * user-facing: they are served in the generated OpenAPI spec. Nothing else checks them, so a
  * doc rename silently turns them into dead references.
+ *
+ * Two citation forms are guarded, both resolved offline against the local docs tree:
+ *  - Repo-relative paths (docs/....md), used in developer-facing code comments. A docs/....md
+ *    sequence inside a URL is not such a citation and is ignored.
+ *  - Public docs-site URLs (https://neowiki.ai/docs/...), used in the OpenAPI param descriptions
+ *    because their readers do not have the source tree. Each must map to a doc file that exists
+ *    in this repo (site URL path -> docs/....md).
  *
  * When this fails, either the doc moved (update the citing string) or the path was never right.
  *
@@ -22,11 +29,22 @@ use SplFileInfo;
  */
 class DocsPathReferencesTest extends TestCase {
 
+	private const DOCS_SITE_PREFIX = 'https://neowiki.ai/';
+
 	public function testEveryDocsPathCitedInSourceCodeExists(): void {
 		$this->assertSame(
 			[],
 			$this->danglingDocsReferences(),
 			'These src/ files cite a docs file that does not exist. Point them at the current path.'
+		);
+	}
+
+	public function testEveryDocsSiteUrlCitedInSourceCodeResolvesToADocFile(): void {
+		$this->assertSame(
+			[],
+			$this->danglingDocsSiteUrls(),
+			'These src/ files cite a ' . self::DOCS_SITE_PREFIX . 'docs/... URL with no matching doc file '
+				. 'in the repo. The published page and its docs/....md source must both exist.'
 		);
 	}
 
@@ -40,14 +58,41 @@ class DocsPathReferencesTest extends TestCase {
 			foreach ( $this->citedDocsPaths( $file ) as $line => $paths ) {
 				foreach ( $paths as $path ) {
 					if ( !file_exists( $this->extensionRoot() . '/' . $path ) ) {
-						$relativeFile = substr( $file, strlen( $this->extensionRoot() ) + 1 );
-						$dangling[] = "$relativeFile:$line cites $path";
+						$dangling[] = $this->relativePath( $file ) . ":$line cites $path";
 					}
 				}
 			}
 		}
 
 		return $dangling;
+	}
+
+	/**
+	 * @return list<string> e.g. "src/.../Foo.php:66 cites https://neowiki.ai/docs/x (no docs/x.md)"
+	 */
+	private function danglingDocsSiteUrls(): array {
+		$dangling = [];
+
+		foreach ( $this->sourceFiles() as $file ) {
+			foreach ( $this->citedDocsSiteUrls( $file ) as $line => $urls ) {
+				foreach ( $urls as $url ) {
+					$docFile = $this->docFileForSiteUrl( $url );
+					if ( !file_exists( $this->extensionRoot() . '/' . $docFile ) ) {
+						$dangling[] = $this->relativePath( $file ) . ":$line cites $url (no $docFile)";
+					}
+				}
+			}
+		}
+
+		return $dangling;
+	}
+
+	/**
+	 * Maps a public docs-site URL to its repo source file: strip the site prefix, append .md.
+	 * e.g. https://neowiki.ai/docs/api/subject-format -> docs/api/subject-format.md
+	 */
+	private function docFileForSiteUrl( string $url ): string {
+		return substr( $url, strlen( self::DOCS_SITE_PREFIX ) ) . '.md';
 	}
 
 	/**
@@ -70,23 +115,64 @@ class DocsPathReferencesTest extends TestCase {
 	}
 
 	/**
-	 * @return array<int, list<string>> docs paths cited in the file, keyed by line number.
+	 * Repo-relative docs/....md citations, keyed by line number. Paths that are part of a URL
+	 * (e.g. https://docs.example.com/docs/x.md) are excluded: they are not repo citations.
+	 *
+	 * @return array<int, list<string>>
 	 */
 	private function citedDocsPaths( string $file ): array {
-		$contents = file_get_contents( $file );
-		$this->assertNotFalse( $contents, "Could not read $file" );
-
 		$cited = [];
 
-		foreach ( explode( "\n", $contents ) as $index => $line ) {
-			preg_match_all( '#\bdocs/[A-Za-z0-9._/-]+\.md#', $line, $matches );
+		foreach ( $this->lines( $file ) as $line => $text ) {
+			$outsideUrls = preg_replace( '#https?://\S+#', '', $text );
+			preg_match_all( '#\bdocs/[A-Za-z0-9._/-]+\.md#', $outsideUrls, $matches );
 
 			if ( $matches[0] !== [] ) {
-				$cited[$index + 1] = $matches[0];
+				$cited[$line] = $matches[0];
 			}
 		}
 
 		return $cited;
+	}
+
+	/**
+	 * Public docs-site URLs (https://neowiki.ai/docs/...), keyed by line number. The path stops
+	 * at the first non-slug character, so a trailing sentence period is not captured.
+	 *
+	 * @return array<int, list<string>>
+	 */
+	private function citedDocsSiteUrls( string $file ): array {
+		$cited = [];
+		$pattern = '#' . preg_quote( self::DOCS_SITE_PREFIX, '#' ) . 'docs/[A-Za-z0-9_/-]+#';
+
+		foreach ( $this->lines( $file ) as $line => $text ) {
+			preg_match_all( $pattern, $text, $matches );
+
+			if ( $matches[0] !== [] ) {
+				$cited[$line] = $matches[0];
+			}
+		}
+
+		return $cited;
+	}
+
+	/**
+	 * @return array<int, string> file lines keyed by 1-based line number.
+	 */
+	private function lines( string $file ): array {
+		$contents = file_get_contents( $file );
+		$this->assertNotFalse( $contents, "Could not read $file" );
+
+		$lines = [];
+		foreach ( explode( "\n", $contents ) as $index => $text ) {
+			$lines[$index + 1] = $text;
+		}
+
+		return $lines;
+	}
+
+	private function relativePath( string $file ): string {
+		return substr( $file, strlen( $this->extensionRoot() ) + 1 );
 	}
 
 	private function extensionRoot(): string {


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1037, merging into its branch. Implements the external-link direction from that PR's discussion.

The four subject-writing/validation REST endpoints describe their `statements` body param by pointing at the subject-format documentation. These descriptions are served in the generated OpenAPI spec, so their readers are API consumers (Swagger UI, codegen) who do not have the extension checked out. A repo-relative `docs/api/subject-format.md` is only a name to them; the same page is published at https://neowiki.ai/docs/api/subject-format, which is clickable. Point all four at the public URL, with the citation clause phrased consistently across them.

Caveats discussed on #1037 and accepted for now: version skew (the site serves the current docs while a deployed extension may be older) and availability (an external dependency). At MVP there is effectively one active version tracking the current docs, so drift is negligible. Versioned URLs can follow once the REST API carries an explicit version.

## What changed

- `ValidateSubjectApi`, `ValidateSubjectUpdateApi`, `CreateSubjectApi`, and `ReplaceSubjectApi` now cite `https://neowiki.ai/docs/api/subject-format` instead of the repo path.
- `DocsPathReferencesTest` reworked:
  - New offline check: every `https://neowiki.ai/docs/<path>` URL in `src/` must map to an existing `docs/<path>.md` in the repo (strip the site prefix, append `.md`). No HTTP.
  - The repo-relative `docs/….md` check is retained — it still guards in-code comment citations, e.g. the ADR link in `Mapping.php` — but no longer matches paths inside URLs, closing limitation 2 from the review comment (`https://docs.example.com/docs/x.md` was previously treated as a repo citation).
  - The `../`-prefix-resolved-as-root-relative limitation is intentionally left untouched.

## Verification

Run against the dev stack (MediaWiki container):

- The new URL check was seen failing first: injecting `https://neowiki.ai/docs/nonexistent-probe` into a `src/` file produced

  ```
  src/Domain/Mapping/Mapping.php:15 cites https://neowiki.ai/docs/nonexistent-probe (no docs/nonexistent-probe.md)
  ```

  and the check passes once the probe is reverted.
- URL exclusion confirmed: injecting `https://docs.example.com/docs/nonexistent-guide.md` — which previously false-positived the repo-path check — now keeps the test green.
- Green: `DocsPathReferences` (2 tests, 548 assertions), `ValidateSubjectApi`, `ValidateSubjectUpdateApi`, `CreateSubjectApi`, `ReplaceSubjectApi`, `RestApiDocsCoverage`, and `ModuleSpecHandlerNeoWiki` (7 tests, 465 assertions).
- `make cs` clean: phpcs (498 files) and phpstan both green. The pre-existing `HardfRdfStreamWriter.php` stan errors noted on #1037 did not surface in this worktree.

> <sub>AI-authored — Claude Code, `Opus 4.8 (1M context) (max)`; detailed spec from @JeroenDeDauw, executed without revisions; diff not yet human-reviewed; target PHPUnit classes and `make cs` green locally on the dev stack, including the fail-first evidence above; CI pending at creation.</sub>
