### PR TITLE
Align two ADR 26 statements with its fixed-severity table

### DIFF
--- a/docs/adr/026-validation-severity-levels.md
+++ b/docs/adr/026-validation-severity-levels.md
@@ -99,7 +99,7 @@ because enforcement is off by default and an admin can lift it for the duration 
 
 Every serialized violation gains an always-present `"severity": "error" | "warning"` field, in the dry-run validate
 endpoints' 200 body and in the enforcement 422 body alike. In the domain model, every violation carries its severity,
-stamped at validation time from the configuration of the Constraint it violates.
+stamped at validation time from the violated Constraint's configuration or the fixed classification above.
 
 ## Consequences
 
@@ -117,8 +117,8 @@ Pros:
 
 Cons:
 
-* Enforcement only bites once schema authors mark Constraints as `error`: flipping `$wgNeoWikiEnforceValidation` on
-  has no blocking effect while Schemas are unannotated.
+* Enforcement only bites for authorable Constraints once schema authors mark them `error`: while Schemas are
+  unannotated, flipping `$wgNeoWikiEnforceValidation` on blocks nothing beyond the fixed-`error` conditions.
 * The Schema editor UI must expose a severity control per Constraint.
 * The PHP and TypeScript JSON parsers must handle both the scalar and the object Constraint form.
 * Severity is one more concept schema authors need to understand.


### PR DESCRIPTION
Text review of the validation-severity ADR. Two statements contradicted the ADR's own fixed-severity table:

* The first Con claimed flipping `$wgNeoWikiEnforceValidation` on "has no blocking effect while Schemas are unannotated" — the five fixed-`error` system conditions block regardless of Schema annotation.
* The domain-model paragraph said severity is stamped "from the configuration of the Constraint it violates" — the fixed-severity codes have no backing Constraint; their severity comes from the fixed classification.

> <sub>AI-authored — Claude Code, `Fable 5 (max)`; /text-review skill run on this ADR by @JeroenDeDauw, no steering; diff not yet human-reviewed; both corrected claims cross-checked against the ADR's own tables, ADRs 12/21, and the violation codes in src/.</sub>