### PR TITLE
Add a meta description to the qualifiers doc

### DIFF
--- a/docs/qualifiers-and-references.md
+++ b/docs/qualifiers-and-references.md
@@ -1,5 +1,6 @@
 ---
 title: Qualifiers and References
+description: How NeoWiki models Wikibase-style qualifiers, references, and rank with Subjects, Relations, and Schemas.
 order: 2
 ---
 # Qualifiers and References


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/961.

Gives the published page a proper meta description and social-card snippet on neowiki.ai instead of the site-wide default.

> <sub>AI-authored — Claude Code, `Fable 5 (max)`; my proposal during a review session with @JeroenDeDauw, approved as asked; no revisions; diff not yet human-reviewed; frontmatter-only change, verified the site's frontmatter parser and OG handling pick up `description`.</sub>