### PR TITLE
Surface data access in the UI: Data tab export links and RDF autodiscovery

### DIFF
--- a/docs/rdf/rdf-export.md
+++ b/docs/rdf/rdf-export.md
@@ -102,6 +102,13 @@ for the requested ontology target projects to an empty graph — a `200`, not a 
 curl 'https://wiki.example/rest.php/neowiki/v0/subject/s1demo8aaaaaab5/rdf?projection=EDM'
 ```
 
+### Finding these exports
+
+These exports are surfaced in the UI: the Data tab (`?action=subjects`) links to each Subject's JSON and
+per-projection Turtle/TriG, and to the same for the whole page. Pages that carry NeoWiki data also
+advertise the page export through `<link rel="alternate">` autodiscovery tags (Turtle and TriG, native
+projection) in the HTML head, so Linked Data tooling can locate the data without reading this reference.
+
 ## Bulk dump
 
 `maintenance/DumpRdf.php` streams the projection of **every** subject page to stdout as TriG, one named

--- a/extension.json
+++ b/extension.json
@@ -591,7 +591,12 @@
 				"neowiki-managesubjects-id-label",
 				"neowiki-managesubjects-id-copy",
 				"neowiki-managesubjects-id-copied",
-				"neowiki-managesubjects-id-copy-error"
+				"neowiki-managesubjects-id-copy-error",
+				"neowiki-managesubjects-export-button",
+				"neowiki-managesubjects-export-json",
+				"neowiki-managesubjects-export-native",
+				"neowiki-managesubjects-export-turtle",
+				"neowiki-managesubjects-export-trig"
 			],
 			"@group:": "TODO: Load code separately while in development. Remove later.",
 			"group": "ext.neowiki"

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -305,5 +305,10 @@
 	"neowiki-managesubjects-id-copy": "Copy subject ID $1",
 	"neowiki-managesubjects-id-copied": "Copied \"$1\" to clipboard.",
 	"neowiki-managesubjects-id-copy-error": "Couldn't copy the subject ID.",
+	"neowiki-managesubjects-export-button": "Export",
+	"neowiki-managesubjects-export-json": "JSON",
+	"neowiki-managesubjects-export-native": "Native",
+	"neowiki-managesubjects-export-turtle": "$1 · Turtle",
+	"neowiki-managesubjects-export-trig": "$1 · TriG",
 	"action-subjects": "manage subjects on this page"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -236,5 +236,10 @@
 	"neowiki-managesubjects-id-copy": "Tooltip on the subject ID button. $1 is the Subject ID. Click copies the ID to the clipboard.",
 	"neowiki-managesubjects-id-copied": "Notification shown after the subject ID was copied. $1 is the Subject ID.",
 	"neowiki-managesubjects-id-copy-error": "Notification shown when copying the subject ID to the clipboard failed.",
+	"neowiki-managesubjects-export-button": "Label and accessible name of the button that opens the data export menu on the Data tab (per Subject, and for the whole page in the header).",
+	"neowiki-managesubjects-export-json": "Export menu item that downloads the raw JSON representation of the Subject or page.",
+	"neowiki-managesubjects-export-native": "Display name of the native (NeoWiki-vocabulary) RDF projection, used as $1 in {{msg-neowiki|neowiki-managesubjects-export-turtle}} and {{msg-neowiki|neowiki-managesubjects-export-trig}}.",
+	"neowiki-managesubjects-export-turtle": "Export menu item for the Turtle serialization of an RDF projection. $1 is the projection name (e.g. the message {{msg-neowiki|neowiki-managesubjects-export-native}}, or an ontology name such as \"EDM\"). \"Turtle\" is the name of the RDF serialization format and is not translated.",
+	"neowiki-managesubjects-export-trig": "Export menu item for the TriG serialization of an RDF projection. $1 is the projection name (e.g. the message {{msg-neowiki|neowiki-managesubjects-export-native}}, or an ontology name such as \"EDM\"). \"TriG\" is the name of the RDF serialization format and is not translated.",
 	"action-subjects": "Description of the Subject management action used by MediaWiki when generating action descriptions."
 }

--- a/resources/ext.neowiki/src/components/SubjectsManager/SubjectsManagerPage.vue
+++ b/resources/ext.neowiki/src/components/SubjectsManager/SubjectsManagerPage.vue
@@ -8,15 +8,28 @@
 				{{ $i18n( 'neowiki-managesubjects-count', subjects.length ).text() }}
 			</span>
 			<span v-else class="ext-neowiki-subjects-manager__count" />
-			<CdxButton
-				v-if="canCreate && !isCompletelyEmpty"
-				weight="primary"
-				action="progressive"
-				@click="onAddClicked"
-			>
-				<CdxIcon :icon="cdxIconAdd" />
-				{{ $i18n( 'neowiki-managesubjects-add-button' ).text() }}
-			</CdxButton>
+			<div class="ext-neowiki-subjects-manager__controls-actions">
+				<CdxMenuButton
+					v-if="!loading && subjects.length > 0"
+					v-model:selected="exportMenuSelection"
+					class="ext-neowiki-subjects-manager__export-menu"
+					:menu-items="pageExportItems"
+					:aria-label="$i18n( 'neowiki-managesubjects-export-button' ).text()"
+					@update:selected="openExport"
+				>
+					<CdxIcon :icon="cdxIconDownload" />
+					{{ $i18n( 'neowiki-managesubjects-export-button' ).text() }}
+				</CdxMenuButton>
+				<CdxButton
+					v-if="canCreate && !isCompletelyEmpty"
+					weight="primary"
+					action="progressive"
+					@click="onAddClicked"
+				>
+					<CdxIcon :icon="cdxIconAdd" />
+					{{ $i18n( 'neowiki-managesubjects-add-button' ).text() }}
+				</CdxButton>
+			</div>
 		</div>
 
 		<p
@@ -174,6 +187,16 @@
 									</data>
 								</button>
 							</span>
+							<CdxMenuButton
+								v-model:selected="exportMenuSelection"
+								class="ext-neowiki-subjects-manager__export-menu"
+								:menu-items="subjectExportItems( mainSubject as Subject )"
+								:aria-label="$i18n( 'neowiki-managesubjects-export-button' ).text()"
+								@update:selected="openExport"
+							>
+								<CdxIcon :icon="cdxIconDownload" />
+								{{ $i18n( 'neowiki-managesubjects-export-button' ).text() }}
+							</CdxMenuButton>
 						</footer>
 					</div>
 				</details>
@@ -320,6 +343,16 @@
 										</data>
 									</button>
 								</span>
+								<CdxMenuButton
+									v-model:selected="exportMenuSelection"
+									class="ext-neowiki-subjects-manager__export-menu"
+									:menu-items="subjectExportItems( subject )"
+									:aria-label="$i18n( 'neowiki-managesubjects-export-button' ).text()"
+									@update:selected="openExport"
+								>
+									<CdxIcon :icon="cdxIconDownload" />
+									{{ $i18n( 'neowiki-managesubjects-export-button' ).text() }}
+								</CdxMenuButton>
 							</footer>
 						</div>
 					</details>
@@ -386,6 +419,7 @@ import type { MenuButtonItemData } from '@wikimedia/codex';
 import {
 	cdxIconAdd,
 	cdxIconCollapse,
+	cdxIconDownload,
 	cdxIconDraggable,
 	cdxIconEdit,
 	cdxIconEllipsis,
@@ -406,8 +440,13 @@ import EditSummary from '@/components/common/EditSummary.vue';
 import I18nSlot from '@/components/common/I18nSlot.vue';
 import SubjectStatementsView from '@/components/SubjectsManager/SubjectStatementsView.vue';
 import { setPendingNotification } from '@/presentation/PendingNotification.ts';
+import { subjectExportMenuItems, pageExportMenuItems } from '@/presentation/DataExportMenu.ts';
 
 const pageId = Number( mw.config.get( 'wgNeoWikiManageSubjectsPageId' ) );
+
+// RDF projections readable by the viewing user (native + ontology mappings), permission-filtered
+// server-side. Drives the export menus; native is always present, so this is never truly empty.
+const rdfProjections = ( mw.config.get( 'wgNeoWikiRdfProjections' ) as string[] | null ) ?? [];
 
 const subjectStore = useSubjectStore();
 const schemaStore = useSchemaStore();
@@ -550,6 +589,26 @@ function dispatchRowAction( value: string | number | null, subject: Subject ): v
 		openEditor( subject );
 	} else if ( value === 'delete' ) {
 		confirmDelete( subject );
+	}
+}
+
+const exportMenuSelection = ref<string | number | null>( null );
+
+function subjectExportItems( subject: Subject ): MenuButtonItemData[] {
+	return subjectExportMenuItems( subject.getId().text, rdfProjections );
+}
+
+const pageExportItems = computed<MenuButtonItemData[]>(
+	() => pageExportMenuItems( pageId, rdfProjections )
+);
+
+// The menu item value is the export endpoint URL; open it in a new tab so the Data tab UI state
+// (expanded rows, edits in progress) survives. Codex 1.14 menu-item anchors cannot set a target,
+// so we navigate on selection rather than rely on the item's `url`.
+function openExport( value: string | number | null ): void {
+	exportMenuSelection.value = null;
+	if ( typeof value === 'string' && value !== '' ) {
+		window.open( value, '_blank', 'noopener' );
 	}
 }
 
@@ -797,6 +856,12 @@ onUnmounted( () => {
 		justify-content: space-between;
 		gap: @spacing-100;
 		margin-bottom: @spacing-150;
+	}
+
+	&__controls-actions {
+		display: flex;
+		align-items: center;
+		gap: @spacing-100;
 	}
 
 	&__count {
@@ -1104,7 +1169,9 @@ onUnmounted( () => {
 
 	&__row-footer {
 		display: flex;
-		justify-content: flex-start;
+		flex-wrap: wrap;
+		align-items: center;
+		justify-content: space-between;
 		gap: @spacing-100;
 		margin-top: @spacing-100;
 		padding-top: @spacing-75;

--- a/resources/ext.neowiki/src/presentation/DataExportMenu.ts
+++ b/resources/ext.neowiki/src/presentation/DataExportMenu.ts
@@ -1,0 +1,67 @@
+import type { MenuButtonItemData } from '@wikimedia/codex';
+
+/**
+ * Builds the export menu items for the Data tab: a JSON entry, then Turtle and TriG entries for each
+ * RDF projection the viewing user may read (native first, then ontology mappings). Item values are the
+ * full endpoint URLs; the menu navigates to them on selection. Kept as pure functions so the URL and
+ * label derivation is unit-tested independently of the Vue component.
+ */
+
+interface RdfFormatOption {
+	format: string;
+	messageKey: string;
+}
+
+const RDF_FORMATS: readonly RdfFormatOption[] = [
+	{ format: 'turtle', messageKey: 'neowiki-managesubjects-export-turtle' },
+	{ format: 'trig', messageKey: 'neowiki-managesubjects-export-trig' },
+];
+
+const NATIVE_PROJECTION = 'native';
+
+function restApiBase(): string {
+	return mw.util.wikiScript( 'rest' );
+}
+
+function projectionLabel( projection: string ): string {
+	return projection === NATIVE_PROJECTION ?
+		mw.msg( 'neowiki-managesubjects-export-native' ) :
+		projection;
+}
+
+function exportMenuItems(
+	jsonUrl: string,
+	rdfEndpoint: string,
+	projections: readonly string[],
+): MenuButtonItemData[] {
+	const items: MenuButtonItemData[] = [
+		{ value: jsonUrl, label: mw.msg( 'neowiki-managesubjects-export-json' ) },
+	];
+
+	for ( const projection of projections ) {
+		for ( const { format, messageKey } of RDF_FORMATS ) {
+			items.push( {
+				value: `${ rdfEndpoint }?projection=${ encodeURIComponent( projection ) }&format=${ format }`,
+				label: mw.msg( messageKey, projectionLabel( projection ) ),
+			} );
+		}
+	}
+
+	return items;
+}
+
+export function subjectExportMenuItems(
+	subjectId: string,
+	projections: readonly string[],
+): MenuButtonItemData[] {
+	const base = `${ restApiBase() }/neowiki/v0/subject/${ encodeURIComponent( subjectId ) }`;
+	return exportMenuItems( base, `${ base }/rdf`, projections );
+}
+
+export function pageExportMenuItems(
+	pageId: number,
+	projections: readonly string[],
+): MenuButtonItemData[] {
+	const base = `${ restApiBase() }/neowiki/v0/page/${ pageId }`;
+	return exportMenuItems( `${ base }/subjects`, `${ base }/rdf`, projections );
+}

--- a/resources/ext.neowiki/tests/presentation/DataExportMenu.spec.ts
+++ b/resources/ext.neowiki/tests/presentation/DataExportMenu.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { subjectExportMenuItems, pageExportMenuItems } from '@/presentation/DataExportMenu';
+
+describe( 'DataExportMenu', () => {
+	beforeEach( () => {
+		vi.stubGlobal( 'mw', {
+			util: { wikiScript: vi.fn( () => '/w/rest.php' ) },
+			msg: vi.fn( ( key: string, ...params: string[] ) =>
+				params.length > 0 ? `[${ key }|${ params.join( ',' ) }]` : `[${ key }]` ),
+		} );
+	} );
+
+	describe( 'subjectExportMenuItems', () => {
+		it( 'lists JSON first, then Turtle and TriG for each projection in order', () => {
+			const items = subjectExportMenuItems( 's2picasso2aaaa2', [ 'native', 'EDM' ] );
+
+			expect( items.map( ( item ) => item.value ) ).toEqual( [
+				'/w/rest.php/neowiki/v0/subject/s2picasso2aaaa2',
+				'/w/rest.php/neowiki/v0/subject/s2picasso2aaaa2/rdf?projection=native&format=turtle',
+				'/w/rest.php/neowiki/v0/subject/s2picasso2aaaa2/rdf?projection=native&format=trig',
+				'/w/rest.php/neowiki/v0/subject/s2picasso2aaaa2/rdf?projection=EDM&format=turtle',
+				'/w/rest.php/neowiki/v0/subject/s2picasso2aaaa2/rdf?projection=EDM&format=trig',
+			] );
+		} );
+
+		it( 'labels JSON, the native projection, and mapping projections distinctly', () => {
+			const items = subjectExportMenuItems( 's2picasso2aaaa2', [ 'native', 'EDM' ] );
+
+			expect( items.map( ( item ) => item.label ) ).toEqual( [
+				'[neowiki-managesubjects-export-json]',
+				'[neowiki-managesubjects-export-turtle|[neowiki-managesubjects-export-native]]',
+				'[neowiki-managesubjects-export-trig|[neowiki-managesubjects-export-native]]',
+				'[neowiki-managesubjects-export-turtle|EDM]',
+				'[neowiki-managesubjects-export-trig|EDM]',
+			] );
+		} );
+
+		it( 'percent-encodes the projection name in the RDF URLs', () => {
+			const items = subjectExportMenuItems( 's1aaaaaaaaaaaa1', [ 'Wikidata items' ] );
+
+			expect( items[ 1 ].value ).toBe(
+				'/w/rest.php/neowiki/v0/subject/s1aaaaaaaaaaaa1/rdf?projection=Wikidata%20items&format=turtle',
+			);
+		} );
+
+		it( 'returns only the JSON entry when there are no readable projections', () => {
+			const items = subjectExportMenuItems( 's1aaaaaaaaaaaa1', [] );
+
+			expect( items ).toHaveLength( 1 );
+			expect( items[ 0 ].value ).toBe( '/w/rest.php/neowiki/v0/subject/s1aaaaaaaaaaaa1' );
+		} );
+	} );
+
+	describe( 'pageExportMenuItems', () => {
+		it( 'targets the page subjects JSON and the page RDF endpoint', () => {
+			const items = pageExportMenuItems( 42, [ 'native', 'EDM' ] );
+
+			expect( items.map( ( item ) => item.value ) ).toEqual( [
+				'/w/rest.php/neowiki/v0/page/42/subjects',
+				'/w/rest.php/neowiki/v0/page/42/rdf?projection=native&format=turtle',
+				'/w/rest.php/neowiki/v0/page/42/rdf?projection=native&format=trig',
+				'/w/rest.php/neowiki/v0/page/42/rdf?projection=EDM&format=turtle',
+				'/w/rest.php/neowiki/v0/page/42/rdf?projection=EDM&format=trig',
+			] );
+		} );
+	} );
+} );

--- a/src/EntryPoints/Actions/SubjectsAction.php
+++ b/src/EntryPoints/Actions/SubjectsAction.php
@@ -45,10 +45,17 @@ class SubjectsAction extends FormlessAction {
 			);
 		}
 
-		NeoWikiExtension::getInstance()->newFrontendModuleLoader()->load( $out, $this->getSkin() );
+		$extension = NeoWikiExtension::getInstance();
+		$extension->newFrontendModuleLoader()->load( $out, $this->getSkin() );
 
 		$out->addJsConfigVars( [
 			'wgNeoWikiManageSubjectsPageId' => $title->getArticleID(),
+			// The export UI (Data tab menus) is driven by this list. Filtered by the viewing user's
+			// read authority so restricted Mapping page titles never reach a reader who cannot see them.
+			'wgNeoWikiRdfProjections' => $extension->filterReadableProjectionNames(
+				$extension->getRdfProjectionNames(),
+				$this->getAuthority()
+			),
 		] );
 
 		return Html::element( 'div', [ 'id' => 'ext-neowiki-manage-subjects' ] );

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -6,6 +6,7 @@ namespace ProfessionalWiki\NeoWiki\EntryPoints;
 
 use MediaWiki\Html\Html;
 use MediaWiki\Logger\LoggerFactory;
+use MediaWiki\MainConfigNames;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Output\OutputPage;
 use MediaWiki\Page\ProperPageIdentity;
@@ -16,6 +17,7 @@ use MediaWiki\Revision\SlotRoleRegistry;
 use MediaWiki\Title\ForeignTitle;
 use MediaWiki\Title\Title;
 use MediaWiki\User\UserIdentity;
+use ProfessionalWiki\NeoWiki\Application\Rdf\RdfPageProjector;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\EntryPoints\Content\SchemaContent;
 use ProfessionalWiki\NeoWiki\EntryPoints\Content\SubjectContent;
@@ -61,6 +63,7 @@ class NeoWikiHooks {
 
 		NeoWikiExtension::getInstance()->newFrontendModuleLoader()->load( $out, $skin );
 		$out->addHtml( self::getNeoWikiAppHtml( $out ) );
+		self::addRdfAutodiscoveryLinks( $out );
 
 		if ( !NeoWikiExtension::getInstance()->shouldAutoRenderMainSubject() ) {
 			return;
@@ -111,6 +114,34 @@ class NeoWikiHooks {
 
 	private static function pageIsLatestRevision( OutputPage $out ): bool {
 		return $out->getRevisionId() === $out->getTitle()->getLatestRevID();
+	}
+
+	/**
+	 * Advertises the page's RDF export (native projection) via `<link rel="alternate">` autodiscovery
+	 * tags — one Turtle, one TriG — so Linked Data tooling finds the data without reading the API docs.
+	 * Emitted only when the page has Subjects, so the advertised endpoint never 404s. Native only; the
+	 * per-projection exports are reachable from the Data tab UI.
+	 */
+	private static function addRdfAutodiscoveryLinks( OutputPage $out ): void {
+		$pageId = $out->getTitle()->getArticleID();
+
+		if ( !NeoWikiExtension::getInstance()->newPageSubjectsLookup()->pageHasSubjects( new PageId( $pageId ) ) ) {
+			return;
+		}
+
+		$services = MediaWikiServices::getInstance();
+		$endpoint = $services->getMainConfig()->get( MainConfigNames::RestPath )
+			. '/neowiki/v0/page/' . $pageId . '/rdf?projection=' . RdfPageProjector::PROJECTION;
+		$urlUtils = $services->getUrlUtils();
+
+		foreach ( [ 'turtle' => 'text/turtle', 'trig' => 'application/trig' ] as $format => $type ) {
+			$href = $endpoint . '&format=' . $format;
+			$out->addLink( [
+				'rel' => 'alternate',
+				'type' => $type,
+				'href' => $urlUtils->expand( $href, PROTO_CANONICAL ) ?? $href,
+			] );
+		}
 	}
 
 	private static function handleSchemaPage( OutputPage $out, Skin $skin ): void {

--- a/tests/phpunit/EntryPoints/Actions/SubjectsActionTest.php
+++ b/tests/phpunit/EntryPoints/Actions/SubjectsActionTest.php
@@ -4,14 +4,22 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\Actions;
 
+use Article;
+use MediaWiki\Context\RequestContext;
+use MediaWiki\Output\OutputPage;
+use MediaWiki\Permissions\Authority;
 use MediaWiki\Title\Title;
-use MediaWikiIntegrationTestCase;
 use ProfessionalWiki\NeoWiki\EntryPoints\Actions\SubjectsAction;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiMockAuthorityTrait;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\EntryPoints\Actions\SubjectsAction
+ * @group Database
  */
-class SubjectsActionTest extends MediaWikiIntegrationTestCase {
+class SubjectsActionTest extends NeoWikiIntegrationTestCase {
+
+	use NeoWikiMockAuthorityTrait;
 
 	public function testNullTitleIsNotEligible(): void {
 		$this->assertFalse( SubjectsAction::isEligibleTitle( null ) );
@@ -41,6 +49,44 @@ class SubjectsActionTest extends MediaWikiIntegrationTestCase {
 		$title->method( 'getNamespace' )->willReturn( NS_MAIN );
 
 		$this->assertTrue( SubjectsAction::isEligibleTitle( $title ) );
+	}
+
+	public function testExposesReadableRdfProjectionsAsConfigVar(): void {
+		$this->createMapping( 'EDM', '{ "version": 1, "schemas": {} }' );
+
+		$out = $this->runOnView( 'SubjectsActionTest projections', $this->getTestSysop()->getAuthority() );
+
+		$this->assertSame(
+			[ 'native', 'EDM' ],
+			$out->getJsConfigVars()['wgNeoWikiRdfProjections']
+		);
+	}
+
+	public function testOmitsRdfProjectionsTheViewingUserCannotRead(): void {
+		$this->createMapping( 'EDM', '{ "version": 1, "schemas": {} }' );
+
+		$out = $this->runOnView(
+			'SubjectsActionTest restricted',
+			$this->authorityWithGlobalReadButNoPageRead()
+		);
+
+		$this->assertSame(
+			[ 'native' ],
+			$out->getJsConfigVars()['wgNeoWikiRdfProjections'],
+			'A read-restricted Mapping page name must not reach a reader who cannot see it.'
+		);
+	}
+
+	private function runOnView( string $pageName, Authority $authority ): OutputPage {
+		$title = $this->getExistingTestPage( $pageName )->getTitle();
+
+		$context = new RequestContext();
+		$context->setTitle( $title );
+		$context->setAuthority( $authority );
+
+		( new SubjectsAction( Article::newFromTitle( $title, $context ), $context ) )->onView();
+
+		return $context->getOutput();
 	}
 
 }

--- a/tests/phpunit/EntryPoints/RdfAutodiscoveryLinksTest.php
+++ b/tests/phpunit/EntryPoints/RdfAutodiscoveryLinksTest.php
@@ -42,6 +42,9 @@ class RdfAutodiscoveryLinksTest extends NeoWikiIntegrationTestCase {
 		$this->assertNotNull( $trig, 'An application/trig alternate link is expected on a page with Subjects.' );
 		$this->assertStringContainsString( "/neowiki/v0/page/{$pageId}/rdf?projection=native&format=turtle", $turtle );
 		$this->assertStringContainsString( "/neowiki/v0/page/{$pageId}/rdf?projection=native&format=trig", $trig );
+		// Absolute (canonical) URLs, not relative paths, so Linked Data tooling can dereference them.
+		$this->assertStringStartsWith( 'http', $turtle );
+		$this->assertStringStartsWith( 'http', $trig );
 	}
 
 	public function testDoesNotAdvertiseExportsForPageWithoutSubjects(): void {

--- a/tests/phpunit/EntryPoints/RdfAutodiscoveryLinksTest.php
+++ b/tests/phpunit/EntryPoints/RdfAutodiscoveryLinksTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints;
+
+use MediaWiki\Context\RequestContext;
+use MediaWiki\Output\OutputPage;
+use MediaWiki\Title\Title;
+use ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiHooks;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiHooks::onBeforePageDisplay
+ * @group Database
+ */
+class RdfAutodiscoveryLinksTest extends NeoWikiIntegrationTestCase {
+
+	private const string SUBJECT_ID = 's1zz2222222azz1';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->setUpNeo4j();
+		$this->createSchema( TestSubject::DEFAULT_SCHEMA_ID );
+		$this->markPageTableAsUsed();
+	}
+
+	public function testAdvertisesTurtleAndTrigExportsForPageWithSubjects(): void {
+		$revision = $this->createPageWithSubjects(
+			'Autodiscovery with subjects',
+			TestSubject::build( id: self::SUBJECT_ID )
+		);
+
+		$out = $this->renderContentPage( 'Autodiscovery with subjects', $revision->getId() );
+		$pageId = $revision->getPageId();
+
+		$turtle = $this->alternateLinkHref( $out, 'text/turtle' );
+		$trig = $this->alternateLinkHref( $out, 'application/trig' );
+
+		$this->assertNotNull( $turtle, 'A text/turtle alternate link is expected on a page with Subjects.' );
+		$this->assertNotNull( $trig, 'An application/trig alternate link is expected on a page with Subjects.' );
+		$this->assertStringContainsString( "/neowiki/v0/page/{$pageId}/rdf?projection=native&format=turtle", $turtle );
+		$this->assertStringContainsString( "/neowiki/v0/page/{$pageId}/rdf?projection=native&format=trig", $trig );
+	}
+
+	public function testDoesNotAdvertiseExportsForPageWithoutSubjects(): void {
+		$this->editPage( 'Autodiscovery without subjects', 'Plain page, no NeoWiki data.' );
+		$revisionId = Title::newFromText( 'Autodiscovery without subjects' )->getLatestRevID();
+
+		$out = $this->renderContentPage( 'Autodiscovery without subjects', $revisionId );
+
+		$this->assertNull( $this->alternateLinkHref( $out, 'text/turtle' ) );
+		$this->assertNull( $this->alternateLinkHref( $out, 'application/trig' ) );
+	}
+
+	private function renderContentPage( string $pageName, int $revisionId ): OutputPage {
+		$context = new RequestContext();
+		$context->setTitle( Title::newFromText( $pageName ) );
+
+		$out = $context->getOutput();
+		$out->setArticleFlag( true );
+		$out->setRevisionId( $revisionId );
+
+		NeoWikiHooks::onBeforePageDisplay( $out, $context->getSkin() );
+
+		return $out;
+	}
+
+	private function alternateLinkHref( OutputPage $out, string $type ): ?string {
+		foreach ( $out->getLinkTags() as $tag ) {
+			if ( ( $tag['rel'] ?? null ) === 'alternate' && ( $tag['type'] ?? null ) === $type ) {
+				return $tag['href'] ?? null;
+			}
+		}
+
+		return null;
+	}
+
+}


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/1095

Stacked on #1090, whose per-subject RDF endpoint these menus link to; based on
`feature/subject-rdf-export` so the diff is only this work. GitHub retargets to
master once #1090 merges.

The REST API served a page's RDF, its Subjects as JSON, a Subject as JSON, and
(via #1090) a Subject's RDF, in native or ontology-mapped projections — none of
it reachable from the UI. This adds three things:

- A per-subject export menu in each expanded Data tab row, beside the ID: JSON,
  then Turtle and TriG for each readable projection.
- A page-level export menu in the Data tab header: page-subjects JSON, then
  per-projection Turtle/TriG of the page RDF. The two menus share one labelling
  scheme so they read as one system.
- `<link rel="alternate">` autodiscovery tags (Turtle + TriG, native projection)
  in the head of pages that carry NeoWiki data.

The menus are driven by the projections the viewing user may read. `SubjectsAction`
exposes that list as the `wgNeoWikiRdfProjections` JS config var, filtered
server-side by `filterReadableProjectionNames()` so a restricted Mapping page title
never reaches a reader who cannot see it. A later per-wiki choice to hide a
projection then becomes a server-side filter with no UI change.

Menu item URLs carry explicit `format=` parameters and percent-encode the projection
name; each opens in a new tab so the Data tab state is not lost (Codex 1.14 menu-item
anchors cannot set a target, so navigation happens on selection). Autodiscovery links
are emitted only when the page has Subjects, so the advertised endpoint never 404s.

Tests: Vitest covers the URL/label derivation (ordering, native-vs-mapping labels,
projection encoding). PHP integration covers the config var and its permission
filtering, and the head tags being present on a page with Subjects and absent on one
without.

UI check: the Data tab (`?action=subjects`) of a page with subjects and an ontology
mapping — e.g. the demo **Pablo Picasso** page. Expand a subject row for the per-row
Export menu; use the header Export for the whole page.

> <sub>AI-authored — Claude Code, `Opus 4.8 (max)`; detailed spec (issue + lead decisions and recon) steered by @JeroenDeDauw, no human revisions mid-task; diff not yet human-reviewed; PHPUnit (1835) + Vitest (1048) + phpcs/phpstan green locally, all export endpoints returned 200 with the expected content-types and both head tags verified live, UI screenshotted headless and reviewed by the lead session; CI green.</sub>

