### PR TITLE
Extract Neo4j node-label read/remove into a shared helper

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -196,16 +196,6 @@ parameters:
 			path: src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jQueryStore.php
 
 		-
-			message: "#^Cannot call method get\\(\\) on mixed\\.$#"
-			count: 1
-			path: src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectUpdater.php
-
-		-
-			message: "#^Method ProfessionalWiki\\\\NeoWiki\\\\GraphDatabasePlugins\\\\Neo4j\\\\Persistence\\\\Neo4jSubjectUpdater\\:\\:getNodeLabels\\(\\) should return array\\<string\\> but returns array\\<int, mixed\\>\\.$#"
-			count: 1
-			path: src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectUpdater.php
-
-		-
 			message: "#^Cannot access property \\$page_title on array\\|stdClass\\|false\\.$#"
 			count: 1
 			path: src/Persistence/MediaWiki/DatabaseLayoutNameLookup.php

--- a/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jNodeLabels.php
+++ b/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jNodeLabels.php
@@ -1,0 +1,52 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence;
+
+use Laudis\Neo4j\Contracts\TransactionInterface;
+use Laudis\Neo4j\Databags\SummarizedResult;
+
+/**
+ * Reads and removes the labels of a Neo4j node identified by its id, within a given transaction.
+ *
+ * Shared by Neo4jSubjectUpdater (reconciling a subject's labels with its schema) and
+ * Neo4jProjectionStore (stripping a subject down to a stub). Those classes hold their transaction
+ * differently, so the transaction is passed in per call rather than owned here.
+ */
+class Neo4jNodeLabels {
+
+	/**
+	 * @return string[]
+	 */
+	public static function read( TransactionInterface $transaction, string $nodeId ): array {
+		/**
+		 * @var SummarizedResult $result
+		 */
+		$result = $transaction->run(
+			'MATCH (n {id: $id}) RETURN labels(n) AS labels',
+			[ 'id' => $nodeId ]
+		);
+
+		if ( $result->isEmpty() ) {
+			return [];
+		}
+
+		return $result->first()->get( 'labels' )->toArray();
+	}
+
+	/**
+	 * @param string[] $labels
+	 */
+	public static function remove( TransactionInterface $transaction, string $nodeId, array $labels ): void {
+		if ( $labels === [] ) {
+			return;
+		}
+
+		$transaction->run(
+			'MATCH (n {id: $id}) REMOVE n:' . Cypher::buildLabelList( $labels ),
+			[ 'id' => $nodeId ]
+		);
+	}
+
+}

--- a/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStore.php
+++ b/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStore.php
@@ -217,38 +217,11 @@ readonly class Neo4jProjectionStore implements GraphDatabasePlugin {
 	}
 
 	private function removeNonStubLabels( TransactionInterface $transaction, SubjectId $subjectId ): void {
-		$labelsToRemove = array_diff(
-			$this->getSubjectLabels( $transaction, $subjectId ),
-			[ 'Subject' ]
+		Neo4jNodeLabels::remove(
+			$transaction,
+			$subjectId->text,
+			array_diff( Neo4jNodeLabels::read( $transaction, $subjectId->text ), [ 'Subject' ] )
 		);
-
-		if ( $labelsToRemove === [] ) {
-			return;
-		}
-
-		$transaction->run(
-			'MATCH (subject {id: $subjectId}) REMOVE subject:' . Cypher::buildLabelList( $labelsToRemove ),
-			[ 'subjectId' => $subjectId->text ]
-		);
-	}
-
-	/**
-	 * @return string[]
-	 */
-	private function getSubjectLabels( TransactionInterface $transaction, SubjectId $subjectId ): array {
-		/**
-		 * @var SummarizedResult $result
-		 */
-		$result = $transaction->run(
-			'MATCH (subject {id: $subjectId}) RETURN labels(subject) AS labels',
-			[ 'subjectId' => $subjectId->text ]
-		);
-
-		if ( $result->isEmpty() ) {
-			return [];
-		}
-
-		return $result->first()->get( 'labels' )->toArray();
 	}
 
 	private function subjectHasIncomingRelations( TransactionInterface $transaction, SubjectId $subjectId ): bool {

--- a/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectUpdater.php
+++ b/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectUpdater.php
@@ -5,15 +5,12 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence;
 
 use Laudis\Neo4j\Contracts\TransactionInterface;
-use Laudis\Neo4j\Databags\SummarizedResult;
-use Laudis\Neo4j\Types\CypherList;
 use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
 use ProfessionalWiki\NeoWiki\Domain\Statement;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
-use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use Psr\Log\LoggerInterface;
 
 class Neo4jSubjectUpdater {
@@ -124,17 +121,10 @@ class Neo4jSubjectUpdater {
 	}
 
 	private function updateNodeLabels( Subject $subject ): void {
-		$oldLabels = $this->getNodeLabels( $subject->id );
+		$oldLabels = Neo4jNodeLabels::read( $this->transaction, $subject->id->text );
 		$newLabels = [ 'Subject', $subject->getSchemaName()->getText() ];
 
-		$labelsToRemove = array_diff( $oldLabels, $newLabels );
-
-		if ( $labelsToRemove !== [] ) {
-			$this->transaction->run(
-				'MATCH (n {id: $id}) REMOVE n:' . Cypher::buildLabelList( $labelsToRemove ),
-				[ 'id' => $subject->id->text ]
-			);
-		}
+		Neo4jNodeLabels::remove( $this->transaction, $subject->id->text, array_diff( $oldLabels, $newLabels ) );
 
 		$labelsToAdd = array_diff( $newLabels, $oldLabels );
 
@@ -144,30 +134,6 @@ class Neo4jSubjectUpdater {
 				[ 'id' => $subject->id->text ]
 			);
 		}
-	}
-
-	/**
-	 * @return string[]
-	 */
-	private function getNodeLabels( SubjectId $id ): array {
-		/**
-		 * @var SummarizedResult $result
-		 */
-		$result = $this->transaction->run(
-			'MATCH (n) WHERE n.id = $id RETURN labels(n)',
-			[ 'id' => $id->text ]
-		);
-
-		if ( $result->isEmpty() ) {
-			return [];
-		}
-
-		/**
-		 * @var CypherList $labels
-		 */
-		$labels = $result->first()->get( 'labels(n)' );
-
-		return $labels->toArray();
 	}
 
 	private function updateRelations( Subject $subject, Schema $schema ): void {

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStoreTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStoreTest.php
@@ -33,6 +33,7 @@ use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySchemaLookup;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jProjectionStore
+ * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jNodeLabels
  * @group Database
  */
 class Neo4jProjectionStoreTest extends NeoWikiIntegrationTestCase {


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1080

The stub reduction added in #1080 gave `Neo4jProjectionStore` a `getSubjectLabels()` and `removeNonStubLabels()` that near-verbatim duplicated `Neo4jSubjectUpdater`'s `getNodeLabels()` and the remove branch of `updateNodeLabels()`: the same read-labels query, the same empty guard, and the same `array_diff` + `Cypher::buildLabelList` + `MATCH … REMOVE` orchestration.

Both operations now live in a small stateless `Neo4jNodeLabels` helper (`read()` and `remove()`), which the Store's `removeNonStubLabels()` and the Updater's `updateNodeLabels()` both call. The Updater still reads its labels once and keeps its add branch inline, since that branch is not duplicated anywhere.

**Why this clears the original "grows beyond a safe move" objection:** the two classes hold their transaction differently — the Updater receives it in its constructor, the Store threads it through its methods from `writeTransaction()` — but neither needs to *own* the transaction to run these queries. `Neo4jNodeLabels` takes the `TransactionInterface` as a parameter, so it is agnostic to ownership, and as a static utility (like the sibling `Cypher` class) it is not a DI collaborator: nothing to inject or wire.

No behavior change and no test-expectation edits. `Neo4jProjectionStoreTest` gains a `@covers` for the new helper — it exercises it through both the stub path and, via `savePage`, the Updater path; the Updater unit test mocks the transaction and never runs the label queries, so it does not claim coverage. The now-dead `getNodeLabels` phpstan-baseline entries are dropped.

> <sub>AI-authored — Claude Code, `Opus 4.8 (max)`; follow-up from the Relations Phase 1 batch, directed by @JeroenDeDauw; detailed spec, worked autonomously (no human steering); diff not yet human-reviewed; ran the affected test classes, the full PHPUnit suite (1799 pass, 4 pre-existing skips) and `make cs` (phpcs + phpstan), plus a mutation check confirming the stub tests fail when the shared label-strip is broken.</sub>
