### PR TITLE
Guard the sidebar RDF link against a missing graph backend

### DIFF
--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -273,12 +273,17 @@ class NeoWikiHooks {
 			->getNamespaceInfo()
 			->isContent( $title->getNamespace() );
 
+		// Building the Subjects lookup eagerly constructs the Neo4j client, which throws without a
+		// configured backend; guard so content pages still render backend-less (cf. handleContentPage).
+		$hasSubjects = $isContentNamespace
+			&& $extension->getNeo4jPlugin() !== null
+			&& $extension->newPageSubjectsLookup()->pageHasSubjects( $pageId );
+
 		$neoWikiTools = ( new PageToolsBuilder() )->build(
 			title: $title,
 			pageId: $title->getArticleID(),
 			isContentNamespace: $isContentNamespace,
-			hasSubjects: $isContentNamespace
-				&& $extension->newPageSubjectsLookup()->pageHasSubjects( $pageId ),
+			hasSubjects: $hasSubjects,
 			canCreateMainSubject: $hints->canCreateMainSubject( $pageId ),
 			canEditSubject: $hints->canEditSubject( $pageId ),
 			isLatestRevision: self::pageIsLatestRevision( $skin->getOutput() ),

--- a/tests/phpunit/EntryPoints/NeoWikiSidebarLinkTest.php
+++ b/tests/phpunit/EntryPoints/NeoWikiSidebarLinkTest.php
@@ -45,6 +45,17 @@ class NeoWikiSidebarLinkTest extends NeoWikiIntegrationTestCase {
 		$this->assertNull( $this->findLinkById( $sidebar[self::NEOWIKI_SECTION] ?? [], 't-neowiki-layouts' ) );
 	}
 
+	public function testContentPageSidebarBuildsWithoutGraphBackend(): void {
+		$sidebar = $this->runWithoutGraphBackend(
+			fn (): array => $this->buildSidebar( Title::makeTitle( NS_MAIN, 'Sidebar Without Backend' ) )
+		);
+
+		$this->assertNull(
+			$this->findLinkById( $sidebar[self::NEOWIKI_SECTION] ?? [], 't-neowiki-rdf' ),
+			'Building a content-page sidebar must not require a graph backend, and the View RDF link must be omitted without one.'
+		);
+	}
+
 	private function assertAllPagesLinkInNeoWikiSection(
 		int $namespace,
 		string $linkId,


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1088

#1088's new "View RDF" sidebar link gates on `PageToolsBuilder`'s `hasSubjects` flag, which `onSidebarBeforeOutput` computes by building the Subjects lookup. That eagerly constructs the Neo4j client and throws `GraphBackendNotConfiguredException` when no backend is configured, so every content-namespace page view 500s on a backend-less wiki. CI runs with a backend, so it stays green.

Guard the lookup on `getNeo4jPlugin() !== null`, mirroring the no-backend guard #1016 added to `handleContentPage`. A new `NeoWikiSidebarLinkTest` case builds a content page's sidebar under `runWithoutGraphBackend`; it throws without the guard and passes with it.

> <sub>AI-authored — Claude Code, `Opus 4.8 (1M context)`; review of @JeroenDeDauw's #1088 requested by @malberts via /pr-review, blocker found and fixed autonomously (no human steering during the fix); not yet human-reviewed; regression test written failing-first then green, full local PHPUnit (1795 tests) + phpcs + phpstan pass, and the 500 reproduced then confirmed fixed live on a no-backend dev wiki.</sub>