### PR TITLE
Add batch Subject-ID minting and client-supplied create IDs

### DIFF
--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -52,6 +52,7 @@ Read, change, and validate Subjects. New Subjects are created on a page — see
 | `DELETE /neowiki/v0/subject/{subjectId}` | Delete a Subject. |
 | `POST /neowiki/v0/subject/validate` | Check whether a new Subject is valid, without saving it. |
 | `POST /neowiki/v0/subject/{subjectId}/validate` | Check whether a change to a Subject is valid, without saving it. |
+| `POST /neowiki/v0/subject-ids` | Mint a batch of unused Subject IDs to assign on create, e.g. to wire relations across an interlinked import. Body `count` (1–1000). |
 | `GET /neowiki/v0/subject-labels` | Find Subjects of a Schema by label; returns `id`/`label` pairs. |
 
 ### Pages and Subjects

--- a/docs/api/subject-format.md
+++ b/docs/api/subject-format.md
@@ -198,6 +198,23 @@ Returns the same statement format as storage, with additional fields:
   (e.g. `Help:Installation`); `pageNamespaceId` is the page's canonical MediaWiki namespace ID (e.g. `0`
   for the main namespace, `12` for Help), which is stable regardless of the wiki's content language.
 
+### Creating Subjects
+
+`POST /rest.php/neowiki/v0/page/{pageId}/mainSubject`
+`POST /rest.php/neowiki/v0/page/{pageId}/childSubjects`
+
+Create a Subject on a page from a [Subject object](#subject-object) (`label`, `schema`, `statements`),
+with an optional `comment` edit summary.
+
+The Subject ID is normally minted server-side. To set it yourself — for example to wire relations across
+a batch before the target Subjects exist — pass an optional `id`:
+
+| Field | Required | Notes |
+|---|---|---|
+| `id` | No | Subject ID to assign. Must be well-formed (`400` otherwise) and unused (`409` otherwise). Omit to have the server mint one. Pre-mint a batch of IDs with `POST /neowiki/v0/subject-ids`. |
+
+After creation the ID is immutable; the replace endpoint below ignores it.
+
 ### Writing Subjects
 
 `PUT /rest.php/neowiki/v0/subject/{subjectId}`

--- a/extension.json
+++ b/extension.json
@@ -285,6 +285,11 @@
 			"factory": "ProfessionalWiki\\NeoWiki\\NeoWikiExtension::newGetSchemaSummariesApi"
 		},
 		{
+			"path": "/neowiki/v0/subject-ids",
+			"method": [ "POST" ],
+			"factory": "ProfessionalWiki\\NeoWiki\\NeoWikiExtension::newMintSubjectIdsApi"
+		},
+		{
 			"path": "/neowiki/v0/subject/validate",
 			"method": [ "POST" ],
 			"factory": "ProfessionalWiki\\NeoWiki\\NeoWikiExtension::newValidateSubjectApi"

--- a/src/Application/Actions/CreateSubject/CreateSubjectAction.php
+++ b/src/Application/Actions/CreateSubject/CreateSubjectAction.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Application\Actions\CreateSubject;
 
 use InvalidArgumentException;
+use ProfessionalWiki\NeoWiki\Application\PageIdentifiersLookup;
 use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
 use ProfessionalWiki\NeoWiki\Application\SelectStatementResolver;
 use ProfessionalWiki\NeoWiki\Application\StatementListBuilder;
@@ -14,6 +15,7 @@ use ProfessionalWiki\NeoWiki\Application\Validation\ProposedSubjectValidator;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
 use ProfessionalWiki\NeoWiki\Infrastructure\IdGenerator;
@@ -30,6 +32,7 @@ readonly class CreateSubjectAction {
 		private SchemaLookup $schemaLookup,
 		private SelectStatementResolver $selectStatementResolver,
 		private ProposedSubjectValidator $proposedSubjectValidator,
+		private PageIdentifiersLookup $pageIdentifiersLookup,
 		private bool $validationEnforced,
 	) {
 	}
@@ -46,6 +49,11 @@ readonly class CreateSubjectAction {
 		}
 
 		$subject = $this->buildSubject( $request );
+
+		if ( $request->id !== null && $this->subjectIdIsInUse( $subject->id ) ) {
+			$this->presenter->presentSubjectAlreadyExists();
+			return;
+		}
 
 		$pageSubjects = $this->subjectRepository->getSubjectsByPageId( $pageId );
 
@@ -84,15 +92,34 @@ readonly class CreateSubjectAction {
 
 	private function buildSubject( CreateSubjectRequest $request ): Subject {
 		$schemaName = new SchemaName( $request->schemaName );
-
-		return Subject::createNew(
-			idGenerator: $this->idGenerator,
-			label: new SubjectLabel( $request->label ),
-			schemaName: $schemaName,
-			statements: $this->statementListBuilder->build(
-				$this->resolveSelectValues( $schemaName, $request->statements )
-			)
+		$label = new SubjectLabel( $request->label );
+		$statements = $this->statementListBuilder->build(
+			$this->resolveSelectValues( $schemaName, $request->statements )
 		);
+
+		if ( $request->id === null ) {
+			return Subject::createNew(
+				idGenerator: $this->idGenerator,
+				label: $label,
+				schemaName: $schemaName,
+				statements: $statements,
+			);
+		}
+
+		return new Subject(
+			id: new SubjectId( $request->id ),
+			label: $label,
+			schemaName: $schemaName,
+			statements: $statements,
+		);
+	}
+
+	/**
+	 * Best-effort global uniqueness check: the subject -> page index lags slot writes, so this can
+	 * miss a very recently created Subject; ID entropy carries the rest (same posture as relation IDs).
+	 */
+	private function subjectIdIsInUse( SubjectId $id ): bool {
+		return $this->pageIdentifiersLookup->getPageIdOfSubject( $id ) !== null;
 	}
 
 	/**

--- a/src/Application/Actions/CreateSubject/CreateSubjectRequest.php
+++ b/src/Application/Actions/CreateSubject/CreateSubjectRequest.php
@@ -20,6 +20,11 @@ readonly class CreateSubjectRequest {
 		public array $statements,
 
 		public ?string $comment = null,
+
+		/**
+		 * Client-supplied Subject ID. Must be well-formed and unused; when null the server mints one.
+		 */
+		public ?string $id = null,
 	) {
 	}
 

--- a/src/Application/SubjectIdMinter.php
+++ b/src/Application/SubjectIdMinter.php
@@ -1,0 +1,35 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application;
+
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
+use ProfessionalWiki\NeoWiki\Infrastructure\IdGenerator;
+
+/**
+ * Mints batches of fresh, mutually distinct Subject IDs for client-side wiring of interlinked
+ * imports. Generation stays server-owned so the ID scheme can evolve without breaking importers.
+ */
+readonly class SubjectIdMinter {
+
+	public function __construct(
+		private IdGenerator $idGenerator,
+	) {
+	}
+
+	/**
+	 * @return list<SubjectId> exactly $count distinct ids
+	 */
+	public function mint( int $count ): array {
+		$ids = [];
+
+		while ( count( $ids ) < $count ) {
+			$id = SubjectId::createNew( $this->idGenerator );
+			$ids[$id->text] = $id;
+		}
+
+		return array_values( $ids );
+	}
+
+}

--- a/src/Domain/Page/PageSubjects.php
+++ b/src/Domain/Page/PageSubjects.php
@@ -91,15 +91,23 @@ class PageSubjects {
 			throw new RuntimeException( 'Main subject already exists' );
 		}
 
+		if ( $this->childSubjects->hasSubject( $subject->id ) ) {
+			throw new RuntimeException( 'Subject already exists' );
+		}
+
 		$this->mainSubject = $subject;
 	}
 
 	public function createChildSubject( Subject $subject ): void {
-		if ( $this->childSubjects->hasSubject( $subject->id ) ) {
-			throw new RuntimeException( 'Child subject already exists' );
+		if ( $this->hasSubjectWithId( $subject->id ) ) {
+			throw new RuntimeException( 'Subject already exists' );
 		}
 
 		$this->childSubjects->addOrUpdateSubject( $subject );
+	}
+
+	private function hasSubjectWithId( SubjectId $id ): bool {
+		return $this->isMainSubject( $id ) || $this->childSubjects->hasSubject( $id );
 	}
 
 	/**

--- a/src/EntryPoints/REST/CreateSubjectApi.php
+++ b/src/EntryPoints/REST/CreateSubjectApi.php
@@ -7,6 +7,7 @@ namespace ProfessionalWiki\NeoWiki\EntryPoints\REST;
 use MediaWiki\Rest\Response;
 use MediaWiki\Rest\SimpleHandler;
 use ProfessionalWiki\NeoWiki\Application\Actions\CreateSubject\CreateSubjectRequest;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Presentation\CsrfValidator;
 use ProfessionalWiki\NeoWiki\Presentation\RestCreateSubjectPresenter;
@@ -25,6 +26,15 @@ class CreateSubjectApi extends SimpleHandler {
 
 		$body = $this->getValidatedBody();
 
+		$id = $body['id'] ?? null;
+
+		if ( $id !== null && !SubjectId::isValid( $id ) ) {
+			return $this->getResponseFactory()->createHttpError( 400, [
+				'status' => 'error',
+				'message' => "Subject ID has the wrong format: '$id'",
+			] );
+		}
+
 		$presenter = new RestCreateSubjectPresenter();
 
 		try {
@@ -36,6 +46,7 @@ class CreateSubjectApi extends SimpleHandler {
 					schemaName: $body['schema'],
 					statements: $body['statements'],
 					comment: $body['comment'] ?? null,
+					id: $id,
 				)
 			);
 		} catch ( \InvalidArgumentException $e ) {
@@ -91,6 +102,14 @@ class CreateSubjectApi extends SimpleHandler {
 				ParamValidator::PARAM_TYPE => 'string',
 				ParamValidator::PARAM_REQUIRED => false,
 				self::PARAM_DESCRIPTION => 'Optional edit summary.',
+			],
+			'id' => [
+				self::PARAM_SOURCE => 'body',
+				ParamValidator::PARAM_TYPE => 'string',
+				ParamValidator::PARAM_REQUIRED => false,
+				self::PARAM_DESCRIPTION => 'Optional Subject ID to assign. Must be a well-formed, unused '
+					. 'Subject ID (malformed is rejected with 400, in-use with 409). When omitted, the server '
+					. 'mints one. Pre-mint IDs with POST /neowiki/v0/subject-ids to wire relations across a batch.',
 			],
 		];
 	}

--- a/src/EntryPoints/REST/MintSubjectIdsApi.php
+++ b/src/EntryPoints/REST/MintSubjectIdsApi.php
@@ -1,0 +1,61 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\EntryPoints\REST;
+
+use MediaWiki\Rest\Response;
+use MediaWiki\Rest\SimpleHandler;
+use ProfessionalWiki\NeoWiki\Application\SubjectIdMinter;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
+use Wikimedia\ParamValidator\ParamValidator;
+
+/**
+ * Mints a batch of unused Subject IDs so an importer can wire relations between interlinked Subjects
+ * before creating them. Stateless: no reservation, no graph dependency. See docs/api/subject-format.md.
+ */
+class MintSubjectIdsApi extends SimpleHandler {
+
+	private const int MIN_COUNT = 1;
+	private const int MAX_COUNT = 1000;
+
+	public function __construct(
+		private readonly SubjectIdMinter $subjectIdMinter,
+	) {
+	}
+
+	public function run(): Response {
+		$count = $this->getValidatedBody()['count'];
+
+		if ( $count < self::MIN_COUNT || $count > self::MAX_COUNT ) {
+			return $this->getResponseFactory()->createHttpError( 400, [
+				'status' => 'error',
+				'message' => 'count must be between ' . self::MIN_COUNT . ' and ' . self::MAX_COUNT . '.',
+			] );
+		}
+
+		return $this->getResponseFactory()->createJson( [
+			'subjectIds' => array_map(
+				static fn ( SubjectId $id ): string => $id->text,
+				$this->subjectIdMinter->mint( $count )
+			),
+		] );
+	}
+
+	public function getBodyParamSettings(): array {
+		return [
+			'count' => [
+				self::PARAM_SOURCE => 'body',
+				ParamValidator::PARAM_TYPE => 'integer',
+				ParamValidator::PARAM_REQUIRED => true,
+				self::PARAM_DESCRIPTION => 'Number of Subject IDs to mint, between '
+					. self::MIN_COUNT . ' and ' . self::MAX_COUNT . ' inclusive.',
+			],
+		];
+	}
+
+	public function needsWriteAccess(): bool {
+		return false;
+	}
+
+}

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -59,6 +59,7 @@ use ProfessionalWiki\NeoWiki\Application\SubjectPermissionHints;
 use ProfessionalWiki\NeoWiki\Application\PageReadAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\SubjectWriteAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\SubjectPageRebuilder;
+use ProfessionalWiki\NeoWiki\Application\SubjectIdMinter;
 use ProfessionalWiki\NeoWiki\Application\SubjectRepository;
 use ProfessionalWiki\NeoWiki\Application\MappingLookup;
 use ProfessionalWiki\NeoWiki\Application\Mappings;
@@ -89,6 +90,7 @@ use ProfessionalWiki\NeoWiki\EntryPoints\REST\GetSchemaNamesApi;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\GetSchemaSummariesApi;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\GetSubjectApi;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\GetSubjectLabelsApi;
+use ProfessionalWiki\NeoWiki\EntryPoints\REST\MintSubjectIdsApi;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\REST\CypherQueryApi;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\REST\Neo4jRouteRegistration;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\ReplaceSubjectApi;
@@ -754,8 +756,13 @@ class NeoWikiExtension {
 			schemaLookup: $this->getSchemaLookup(),
 			selectStatementResolver: $this->getSelectStatementResolver(),
 			proposedSubjectValidator: $this->getProposedSubjectValidator(),
+			pageIdentifiersLookup: $this->getPageIdentifiersLookup(),
 			validationEnforced: $this->isValidationEnforced(),
 		);
+	}
+
+	public function newSubjectIdMinter(): SubjectIdMinter {
+		return new SubjectIdMinter( $this->getIdGenerator() );
 	}
 
 	public function getSelectStatementResolver(): SelectStatementResolver {
@@ -1027,6 +1034,12 @@ class NeoWikiExtension {
 	public static function newValidateSubjectApi(): ValidateSubjectApi {
 		return new ValidateSubjectApi(
 			query: self::getInstance()->newValidateSubjectQuery(),
+		);
+	}
+
+	public static function newMintSubjectIdsApi(): MintSubjectIdsApi {
+		return new MintSubjectIdsApi(
+			subjectIdMinter: self::getInstance()->newSubjectIdMinter(),
 		);
 	}
 

--- a/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
@@ -13,6 +13,7 @@ use ProfessionalWiki\NeoWiki\Application\StatementListBuilder;
 use ProfessionalWiki\NeoWiki\Application\Validation\ProposedSubjectValidator;
 use ProfessionalWiki\NeoWiki\Application\Validation\SubjectValidator;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageIdentifiers;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\SelectOption;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\SelectProperty;
@@ -31,6 +32,7 @@ use ProfessionalWiki\NeoWiki\Infrastructure\IdGenerator;
 use ProfessionalWiki\NeoWiki\Application\SubjectWriteAuthorizer;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestRelation;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestStatement;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemoryPageIdentifiersLookup;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySchemaLookup;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectRepository;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpySubjectWriteAuthorizer;
@@ -44,12 +46,14 @@ class CreateSubjectActionTest extends TestCase {
 
 	private const string STUB_ID = 'EVNrDCjgVpv9oC';
 	private const string SELECT_SCHEMA_NAME = 'StatusSchema';
+	private const string SUPPLIED_ID = 'sABCDEF12345678';
 
 	private InMemorySubjectRepository $subjectRepository;
 	private IdGenerator $idGenerator;
 	private CreateSubjectPresenterSpy $presenterSpy;
 	private SubjectWriteAuthorizer $authorizer;
 	private InMemorySchemaLookup $schemaLookup;
+	private InMemoryPageIdentifiersLookup $pageIdentifiersLookup;
 
 	public function setUp(): void {
 		$this->subjectRepository = new InMemorySubjectRepository();
@@ -57,6 +61,7 @@ class CreateSubjectActionTest extends TestCase {
 		$this->presenterSpy = new CreateSubjectPresenterSpy();
 		$this->authorizer = new SpySubjectWriteAuthorizer( allowed: true );
 		$this->schemaLookup = new InMemorySchemaLookup();
+		$this->pageIdentifiersLookup = new InMemoryPageIdentifiersLookup();
 	}
 
 	private function newCreateSubjectAction( bool $validationEnforced = false ): CreateSubjectAction {
@@ -76,6 +81,7 @@ class CreateSubjectActionTest extends TestCase {
 				schemaLookup: $this->schemaLookup,
 				subjectValidator: new SubjectValidator( propertyTypeLookup: $registry ),
 			),
+			$this->pageIdentifiersLookup,
 			$validationEnforced,
 		);
 	}
@@ -613,6 +619,88 @@ class CreateSubjectActionTest extends TestCase {
 
 		$this->assertSame( 'presentSubjectAlreadyExists', $this->presenterSpy->result );
 		$this->assertFalse( $this->presenterSpy->validationFailed );
+	}
+
+	public function testCreateWithSuppliedIdUsesThatIdInsteadOfMinting(): void {
+		$this->subjectRepository->savePageSubjects( PageSubjects::newEmpty(), new PageId( 1 ) );
+
+		$this->newCreateSubjectAction()->createSubject(
+			new CreateSubjectRequest(
+				pageId: 1,
+				isMainSubject: false,
+				label: 'Some Label',
+				schemaName: 'some-schema',
+				statements: [],
+				id: self::SUPPLIED_ID,
+			)
+		);
+
+		$this->assertSame( self::SUPPLIED_ID, $this->presenterSpy->result );
+	}
+
+	public function testCreateWithSuppliedIdKeepsTheStatements(): void {
+		$this->subjectRepository->savePageSubjects( PageSubjects::newEmpty(), new PageId( 1 ) );
+
+		$this->newCreateSubjectAction()->createSubject(
+			new CreateSubjectRequest(
+				pageId: 1,
+				isMainSubject: false,
+				label: 'Some Label',
+				schemaName: 'some-schema',
+				statements: [
+					'animal' => [ 'propertyType' => 'text', 'value' => 'bunny' ],
+				],
+				id: self::SUPPLIED_ID,
+			)
+		);
+
+		$this->assertEquals(
+			new StatementList( [ TestStatement::build( property: 'animal', value: 'bunny' ) ] ),
+			$this->subjectRepository->getSubject( new SubjectId( self::SUPPLIED_ID ) )->getStatements()
+		);
+	}
+
+	public function testCreateWithSuppliedIdAlreadyUsedElsewherePresentsAlreadyExists(): void {
+		$this->pageIdentifiersLookup->addIdentifiers(
+			new SubjectId( self::SUPPLIED_ID ),
+			new PageIdentifiers( new PageId( 2 ), 'Other Page', 0 )
+		);
+		$this->subjectRepository->savePageSubjects( PageSubjects::newEmpty(), new PageId( 1 ) );
+
+		$this->newCreateSubjectAction()->createSubject(
+			new CreateSubjectRequest(
+				pageId: 1,
+				isMainSubject: false,
+				label: 'Some Label',
+				schemaName: 'some-schema',
+				statements: [],
+				id: self::SUPPLIED_ID,
+			)
+		);
+
+		$this->assertSame( 'presentSubjectAlreadyExists', $this->presenterSpy->result );
+	}
+
+	public function testCreateWithoutSuppliedIdSkipsTheGraphInUseCheck(): void {
+		// The id the server will mint is already registered in the graph. A no-id create must still
+		// succeed, proving the graph is only consulted when the caller supplies an id.
+		$this->pageIdentifiersLookup->addIdentifiers(
+			new SubjectId( 's' . self::STUB_ID ),
+			new PageIdentifiers( new PageId( 2 ), 'Other Page', 0 )
+		);
+		$this->subjectRepository->savePageSubjects( PageSubjects::newEmpty(), new PageId( 1 ) );
+
+		$this->newCreateSubjectAction()->createSubject(
+			new CreateSubjectRequest(
+				pageId: 1,
+				isMainSubject: true,
+				label: 'Some Label',
+				schemaName: 'some-schema',
+				statements: [],
+			)
+		);
+
+		$this->assertSame( 's' . self::STUB_ID, $this->presenterSpy->result );
 	}
 
 }

--- a/tests/phpunit/Application/SubjectIdMinterTest.php
+++ b/tests/phpunit/Application/SubjectIdMinterTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Application;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\SubjectIdMinter;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
+use ProfessionalWiki\NeoWiki\Infrastructure\IdGenerator;
+use ProfessionalWiki\NeoWiki\Infrastructure\ProductionIdGenerator;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\IncrementalIdGenerator;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SequenceIdGenerator;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Application\SubjectIdMinter
+ */
+class SubjectIdMinterTest extends TestCase {
+
+	public function testMintsTheRequestedNumberOfIds(): void {
+		$ids = $this->newMinter( new IncrementalIdGenerator() )->mint( 5 );
+
+		$this->assertCount( 5, $ids );
+	}
+
+	public function testMintedIdsAreWellFormedSubjectIds(): void {
+		$ids = $this->newMinter( new ProductionIdGenerator() )->mint( 20 );
+
+		foreach ( $ids as $id ) {
+			$this->assertTrue( SubjectId::isValid( $id->text ), "Minted id '{$id->text}' is not a valid Subject ID" );
+		}
+	}
+
+	public function testMintedIdsAreDistinct(): void {
+		$ids = $this->newMinter( new ProductionIdGenerator() )->mint( 500 );
+
+		$texts = array_map( static fn ( SubjectId $id ): string => $id->text, $ids );
+
+		$this->assertCount( 500, array_unique( $texts ) );
+	}
+
+	public function testRegeneratesOnCollisionSoOutputStaysDistinct(): void {
+		// The generator hands out 'aa…' twice before 'bb…'; minting two ids must discard the
+		// duplicate and keep generating until two distinct ids exist.
+		$minter = $this->newMinter(
+			new SequenceIdGenerator( 'aaaaaaaaaaaaaa', 'aaaaaaaaaaaaaa', 'bbbbbbbbbbbbbb' )
+		);
+
+		$ids = $minter->mint( 2 );
+
+		$texts = array_map( static fn ( SubjectId $id ): string => $id->text, $ids );
+
+		$this->assertSame( [ 'saaaaaaaaaaaaaa', 'sbbbbbbbbbbbbbb' ], $texts );
+	}
+
+	private function newMinter( IdGenerator $idGenerator ): SubjectIdMinter {
+		return new SubjectIdMinter( $idGenerator );
+	}
+
+}

--- a/tests/phpunit/Domain/Page/PageSubjectsTest.php
+++ b/tests/phpunit/Domain/Page/PageSubjectsTest.php
@@ -12,6 +12,7 @@ use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectMap;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
+use RuntimeException;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects
@@ -188,6 +189,57 @@ class PageSubjectsTest extends TestCase {
 		$this->expectException( InvalidArgumentException::class );
 		// Same id appearing as main AND in the child ordering is illegal.
 		$data->setOrdering( $oldMain->id, [ $first->id, $oldMain->id ] );
+	}
+
+	public function testCreateChildSubjectAddsTheSubject(): void {
+		$data = new PageSubjects( TestSubject::build( TestSubject::uniqueId() ), new SubjectMap() );
+
+		$newChild = TestSubject::build( TestSubject::uniqueId() );
+		$data->createChildSubject( $newChild );
+
+		$this->assertEquals( new SubjectMap( $newChild ), $data->getChildSubjects() );
+	}
+
+	public function testCreateChildSubjectThrowsWhenIdMatchesAnExistingChild(): void {
+		$existingChild = TestSubject::build( TestSubject::uniqueId() );
+		$data = new PageSubjects( null, new SubjectMap( $existingChild ) );
+
+		$this->expectException( RuntimeException::class );
+		$data->createChildSubject( TestSubject::build( $existingChild->id ) );
+	}
+
+	public function testCreateChildSubjectThrowsWhenIdMatchesTheMainSubject(): void {
+		$main = TestSubject::build( TestSubject::uniqueId() );
+		$data = new PageSubjects( $main, new SubjectMap() );
+
+		$this->expectException( RuntimeException::class );
+		// Regression: the guard previously checked only sibling children, missing the main Subject.
+		$data->createChildSubject( TestSubject::build( $main->id ) );
+	}
+
+	public function testCreateMainSubjectSetsTheMainSubject(): void {
+		$data = new PageSubjects( null, new SubjectMap() );
+
+		$newMain = TestSubject::build( TestSubject::uniqueId() );
+		$data->createMainSubject( $newMain );
+
+		$this->assertSame( $newMain, $data->getMainSubject() );
+	}
+
+	public function testCreateMainSubjectThrowsWhenMainAlreadyExists(): void {
+		$data = new PageSubjects( TestSubject::build( TestSubject::uniqueId() ), new SubjectMap() );
+
+		$this->expectException( RuntimeException::class );
+		$data->createMainSubject( TestSubject::build( TestSubject::uniqueId() ) );
+	}
+
+	public function testCreateMainSubjectThrowsWhenIdMatchesAnExistingChild(): void {
+		$existingChild = TestSubject::build( TestSubject::uniqueId() );
+		$data = new PageSubjects( null, new SubjectMap( $existingChild ) );
+
+		$this->expectException( RuntimeException::class );
+		// Regression: a main Subject must not reuse an id already held by a child.
+		$data->createMainSubject( TestSubject::build( $existingChild->id ) );
 	}
 
 }

--- a/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
@@ -8,11 +8,13 @@ use MediaWiki\MediaWikiServices;
 use MediaWiki\Page\PageIdentity;
 use MediaWiki\Rest\HttpException;
 use MediaWiki\Rest\RequestData;
+use MediaWiki\Rest\Response;
 use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
 use MediaWiki\Tests\Unit\Permissions\MockAuthorityTrait;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectMap;
 use ProfessionalWiki\NeoWiki\Domain\Value\NumberValue;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\CreateSubjectApi;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
@@ -30,6 +32,13 @@ use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
 class CreateSubjectApiTest extends NeoWikiIntegrationTestCase {
 	use HandlerTestTrait;
 	use MockAuthorityTrait;
+
+	protected function setUp(): void {
+		parent::setUp();
+		// Clear the graph so the client-supplied-id tests, which use fixed ids, start from a clean
+		// subject -> page index rather than nodes projected by earlier tests or runs.
+		$this->setUpNeo4j();
+	}
 
 	public function testCreatesSubject(): void {
 		$this->createSchema( 'Employee' );
@@ -277,6 +286,165 @@ class CreateSubjectApiTest extends NeoWikiIntegrationTestCase {
 		$this->assertSame( 'Validation failed', $responseData['message'] );
 		$this->assertSame( 'Required', $responseData['violations'][0]['propertyName'] );
 		$this->assertSame( 'required', $responseData['violations'][0]['code'] );
+	}
+
+	public function testCreatesChildSubjectWithSuppliedId(): void {
+		$this->createSchema( 'Employee' );
+		$suppliedId = 'sMintAAAAAAAAA1';
+
+		$body = $this->validBody();
+		$body['id'] = $suppliedId;
+
+		$response = $this->executeCreate( $this->getIdOfExistingPage(), $body, isMainSubject: false );
+
+		$responseData = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertSame( 201, $response->getStatusCode() );
+		$this->assertSame( $suppliedId, $responseData['subjectId'] );
+
+		$subject = NeoWikiExtension::getInstance()->newSubjectRepository()->getSubject( new SubjectId( $suppliedId ) );
+		$this->assertSame( $suppliedId, $subject->getId()->text );
+	}
+
+	public function testCreatesMainSubjectWithSuppliedId(): void {
+		$this->createSchema( 'Employee' );
+		$suppliedId = 'sMintEEEEEEEEE5';
+
+		$body = $this->validBody();
+		$body['id'] = $suppliedId;
+
+		$response = $this->executeCreate( $this->getIdOfExistingPage(), $body, isMainSubject: true );
+
+		$responseData = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertSame( 201, $response->getStatusCode() );
+		$this->assertSame( $suppliedId, $responseData['subjectId'] );
+	}
+
+	public function testMalformedSuppliedIdReturns400(): void {
+		$this->createSchema( 'Employee' );
+
+		$body = $this->validBody();
+		$body['id'] = 'not-a-valid-subject-id';
+
+		$response = $this->executeCreate( $this->getIdOfExistingPage(), $body, isMainSubject: false );
+
+		$this->assertSame( 400, $response->getStatusCode() );
+	}
+
+	public function testSuppliedIdAlreadyUsedOnAnotherPageReturns409(): void {
+		$this->createSchema( 'Employee' );
+		$suppliedId = 'sMintBBBBBBBBB2';
+
+		// Create the Subject on one page through the API, so it is projected into the graph.
+		$firstBody = $this->validBody();
+		$firstBody['id'] = $suppliedId;
+		$firstResponse = $this->executeCreate( $this->pageIdOfNewPage( 'CreateSubjectApiTestOtherPage' ), $firstBody, isMainSubject: false );
+		$this->assertSame( 201, $firstResponse->getStatusCode() );
+
+		// Reusing it on a different page is rejected via the graph's subject -> page index.
+		$secondBody = $this->validBody();
+		$secondBody['id'] = $suppliedId;
+		$secondResponse = $this->executeCreate( $this->getIdOfExistingPage(), $secondBody, isMainSubject: false );
+
+		$responseData = json_decode( $secondResponse->getBody()->getContents(), true );
+
+		$this->assertSame( 409, $secondResponse->getStatusCode() );
+		$this->assertSame( 'Subject already exists', $responseData['message'] );
+	}
+
+	public function testSuppliedIdMatchingAnExistingChildReturns409(): void {
+		$this->createSchema( 'Employee' );
+		$suppliedId = 'sMintCCCCCCCCC3';
+		$pageTitle = 'CreateSubjectApiTestExistingChild';
+
+		$this->createPageWithSubjects(
+			$pageTitle,
+			childSubjects: new SubjectMap( TestSubject::build( id: $suppliedId ) )
+		);
+
+		$body = $this->validBody();
+		$body['id'] = $suppliedId;
+
+		$response = $this->executeCreate( $this->pageIdOf( $pageTitle ), $body, isMainSubject: false );
+
+		$this->assertSame( 409, $response->getStatusCode() );
+	}
+
+	public function testSuppliedIdMatchingThePageMainSubjectReturns409(): void {
+		$this->createSchema( 'Employee' );
+		$suppliedId = 'sMintDDDDDDDDD4';
+		$pageTitle = 'CreateSubjectApiTestMainCollision';
+
+		$this->createPageWithSubjects(
+			$pageTitle,
+			mainSubject: TestSubject::build( id: $suppliedId )
+		);
+
+		$body = $this->validBody();
+		$body['id'] = $suppliedId;
+
+		// Creating a child Subject whose id equals the page's main Subject must be rejected
+		// (regression: the child guard previously ignored the main Subject).
+		$response = $this->executeCreate( $this->pageIdOf( $pageTitle ), $body, isMainSubject: false );
+
+		$this->assertSame( 409, $response->getStatusCode() );
+	}
+
+	public function testInterlinkedSubjectsCanBeCreatedInAnyOrder(): void {
+		$this->createSchema( 'Employee' );
+		$idA = 'sMintFFFFFFFFF6';
+		$idB = 'sMintGGGGGGGGG7';
+		$pageId = $this->getIdOfExistingPage();
+
+		// Subject B references A before A exists (relation targets are not validated on create).
+		$responseB = $this->executeCreate( $pageId, [
+			'label' => 'Subject B',
+			'schema' => 'Employee',
+			'id' => $idB,
+			'statements' => [
+				'Has colleague' => [
+					'propertyType' => 'relation',
+					'value' => [ [ 'target' => $idA ] ],
+				],
+			],
+		], isMainSubject: false );
+		$this->assertSame( 201, $responseB->getStatusCode() );
+
+		// Now create A with its pre-chosen id.
+		$responseA = $this->executeCreate( $pageId, [
+			'label' => 'Subject A',
+			'schema' => 'Employee',
+			'id' => $idA,
+			'statements' => [],
+		], isMainSubject: false );
+		$this->assertSame( 201, $responseA->getStatusCode() );
+
+		$repository = NeoWikiExtension::getInstance()->newSubjectRepository();
+		$this->assertSame( $idA, $repository->getSubject( new SubjectId( $idA ) )->getId()->text );
+		$this->assertSame( $idB, $repository->getSubject( new SubjectId( $idB ) )->getId()->text );
+	}
+
+	private function executeCreate( int $pageId, array $body, bool $isMainSubject = false ): Response {
+		return $this->executeHandler(
+			$this->newCreateSubjectApi( $isMainSubject ),
+			new RequestData( [
+				'method' => 'POST',
+				'pathParams' => [ 'pageId' => $pageId ],
+				'bodyContents' => json_encode( $body ),
+				'headers' => [ 'Content-Type' => 'application/json' ],
+			] )
+		);
+	}
+
+	private function pageIdOf( string $title ): int {
+		return MediaWikiServices::getInstance()->getWikiPageFactory()
+			->newFromTitle( Title::newFromText( $title ) )->getId();
+	}
+
+	private function pageIdOfNewPage( string $title ): int {
+		$this->editPage( Title::newFromText( $title ), 'Whatever wikitext' );
+		return $this->pageIdOf( $title );
 	}
 
 }

--- a/tests/phpunit/EntryPoints/REST/MintSubjectIdsApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/MintSubjectIdsApiTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\REST;
+
+use MediaWiki\Rest\RequestData;
+use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
+use MediaWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Application\SubjectIdMinter;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
+use ProfessionalWiki\NeoWiki\EntryPoints\REST\MintSubjectIdsApi;
+use ProfessionalWiki\NeoWiki\Infrastructure\ProductionIdGenerator;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\REST\MintSubjectIdsApi
+ * @covers \ProfessionalWiki\NeoWiki\Application\SubjectIdMinter
+ */
+class MintSubjectIdsApiTest extends MediaWikiIntegrationTestCase {
+
+	use HandlerTestTrait;
+
+	public function testReturnsRequestedNumberOfDistinctValidIds(): void {
+		$response = $this->executeHandler( $this->newHandler(), $this->requestWithCount( 3 ) );
+
+		$body = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertSame( 200, $response->getStatusCode() );
+		$this->assertCount( 3, $body['subjectIds'] );
+		$this->assertCount( 3, array_unique( $body['subjectIds'] ) );
+
+		foreach ( $body['subjectIds'] as $id ) {
+			$this->assertTrue( SubjectId::isValid( $id ), "Returned id '$id' is not a valid Subject ID" );
+		}
+	}
+
+	public function testCountOfOneReturnsOneId(): void {
+		$response = $this->executeHandler( $this->newHandler(), $this->requestWithCount( 1 ) );
+
+		$body = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertSame( 200, $response->getStatusCode() );
+		$this->assertCount( 1, $body['subjectIds'] );
+	}
+
+	public function testMaximumCountReturnsThatManyDistinctIds(): void {
+		$response = $this->executeHandler( $this->newHandler(), $this->requestWithCount( 1000 ) );
+
+		$body = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertSame( 200, $response->getStatusCode() );
+		$this->assertCount( 1000, $body['subjectIds'] );
+		$this->assertCount( 1000, array_unique( $body['subjectIds'] ) );
+	}
+
+	public function testZeroCountIsRejectedWith400(): void {
+		$response = $this->executeHandler( $this->newHandler(), $this->requestWithCount( 0 ) );
+
+		$this->assertSame( 400, $response->getStatusCode() );
+	}
+
+	public function testCountAboveMaximumIsRejectedWith400(): void {
+		$response = $this->executeHandler( $this->newHandler(), $this->requestWithCount( 1001 ) );
+
+		$this->assertSame( 400, $response->getStatusCode() );
+	}
+
+	public function testNeedsWriteAccessReturnsFalse(): void {
+		$this->assertFalse( $this->newHandler()->needsWriteAccess() );
+	}
+
+	private function newHandler(): MintSubjectIdsApi {
+		return new MintSubjectIdsApi( new SubjectIdMinter( new ProductionIdGenerator() ) );
+	}
+
+	private function requestWithCount( int $count ): RequestData {
+		return new RequestData( [
+			'method' => 'POST',
+			'bodyContents' => json_encode( [ 'count' => $count ] ),
+			'headers' => [ 'Content-Type' => 'application/json' ],
+		] );
+	}
+
+}

--- a/tests/phpunit/TestDoubles/SequenceIdGenerator.php
+++ b/tests/phpunit/TestDoubles/SequenceIdGenerator.php
@@ -1,0 +1,34 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\TestDoubles;
+
+use LogicException;
+use ProfessionalWiki\NeoWiki\Infrastructure\IdGenerator;
+
+/**
+ * Returns a scripted sequence of ids, one per generate() call. Lets a test force a collision by
+ * scripting the same id twice. Throws once the script is exhausted so an over-generating bug fails
+ * loudly instead of hanging.
+ */
+class SequenceIdGenerator implements IdGenerator {
+
+	/** @var string[] */
+	private array $ids;
+
+	public function __construct( string ...$ids ) {
+		$this->ids = $ids;
+	}
+
+	public function generate(): string {
+		$id = array_shift( $this->ids );
+
+		if ( $id === null ) {
+			throw new LogicException( 'SequenceIdGenerator ran out of scripted ids' );
+		}
+
+		return $id;
+	}
+
+}


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/1100

Importing many interlinked Subjects needs their IDs known before the Subjects exist, so relation statements can be wired client-side and the Subjects created in any order. Two additions cover this:

- `POST /neowiki/v0/subject-ids` mints a batch of fresh, distinct, format-valid Subject IDs. Body `count` (1-1000). Stateless: no reservation and no graph dependency. Access model matches the validate endpoint (no write access, no CSRF, no page authorization). A small application-layer `SubjectIdMinter` holds the dedupe/regenerate loop; the handler enforces the count range.
- The create endpoints (`POST …/mainSubject` and `…/childSubjects`) accept an optional `id`. When present it is format-checked at the request boundary (`400`) and rejected when already in use (`409`), both against the page's own Subjects and, best-effort, the graph's subject→page index. When absent the server mints as before, and the default create path gains no new graph dependency.

Also closes a duplicate-guard gap that client-supplied IDs make reachable: the page-local create guards now consider every Subject on the page (main and children), not just the sibling collection.

Global Subject-ID uniqueness stays best-effort — the subject→page index lags slot writes and ID entropy carries the rest, the same posture already used for client-supplied relation IDs (#351).

## Testing

- Unit: `SubjectIdMinter` (count honored, all valid, all distinct, dedupe proven with a duplicate-forcing generator); `PageSubjects` create guards (main/child collisions, including the fixed gap).
- Integration: mint handler (200 + shape, count 1/1000 boundaries, 0/1001 → 400); create-with-id (round-trip read, malformed → 400, in-use on another page → 409, id equal to an existing child or the page's main → 409, main-subject route with a supplied id, and an interlinked pair created back-to-front).
- Live-verified end-to-end via curl on the dev wiki: mint 3 (no CSRF), create a child with a minted id → 201, repeat → 409, GET round-trip; mint 0/1001 → 400, mint 1000 → 1000 distinct, malformed create id → 400.
- Full PHPUnit suite + phpcs + phpstan green locally; each new test confirmed red without its production change; CI green.

> <sub>AI-authored — Claude Code, `Opus 4.8 (max)`; detailed spec from @JeroenDeDauw, executed autonomously with no human revisions mid-implementation; AI-reviewed by three independent read-only passes (correctness, security, design) with no blockers, not yet human-reviewed; TDD — full PHPUnit + phpcs + phpstan green and each new test confirmed red without its fix, live-verified end-to-end via curl, CI green.</sub>
