### PR TITLE
Correct the relation-target resolution docs and pin part indices

### DIFF
--- a/docs/api/validation-codes.md
+++ b/docs/api/validation-codes.md
@@ -208,11 +208,12 @@ Emitted by `SubjectValidator`.
 `propertyName`: the relation property.
 
 A relation targets a Subject that exists but whose own Schema is not the Property's declared
-`targetSchema`. The target is resolved through the canonical revision-slot-backed Subject lookup (the
-same one the read path uses), so the check reflects the target's stored writer's-schema rather than the
-secondary graph projection. This is a blocking `error` (ADR 26): it is rejected at write time when
-`$wgNeoWikiEnforceValidation` is enabled. The subject editor's picker filters candidates by target
-Schema, so this is normally only reachable through the API — for example a bulk import.
+`targetSchema`. The Schema compared is the target's own stored writer's-schema, read from its revision
+slot rather than from a graph node property. Reaching that slot still resolves the target ID through
+the subject-to-page index, which lives only in the graph projection, so this check only runs for
+targets the graph currently knows about. This is a blocking `error` (ADR 26): it is rejected at write
+time when `$wgNeoWikiEnforceValidation` is enabled. The subject editor's picker filters candidates by
+target Schema, so this is normally only reachable through the API — for example a bulk import.
 
 ### `relation-target-not-found`
 
@@ -227,13 +228,23 @@ hardcoded non-blocking set, so it never rejects a write even under enforcement. 
 pointing at a not-yet-created Subject is wiki-native red-link behavior, and an import may legitimately
 mint the target later.
 
+Resolution goes through the subject-to-page index, which lives only in the graph projection, so a
+target that exists in revision slots but is missing from the graph is reported as not found. An
+import populates the slots without updating the projection
+([#1022](https://github.com/ProfessionalWiki/NeoWiki/issues/1022)), so imported targets warn until
+[the graph is rebuilt](../operations/maintenance.md#rebuilding-the-graph). Being non-blocking, this
+misreport never costs a write.
+
 ## Known limitations (Foundation round)
 
-The PHP `SubjectValidator` performs two Subject-level checks:
+The PHP `SubjectValidator` performs these Subject-level checks:
 
 - **`required`** — PHP iterates the Schema's properties to catch absent-required cases.
 - **`type-mismatch`** — PHP compares the Statement's writer's-schema type against the Schema's
   current type and surfaces drift per ADR 11 / ADR 12.
+- **[`relation-target-schema-mismatch`](#relation-target-schema-mismatch)** and
+  **[`relation-target-not-found`](#relation-target-not-found)** — documented above; both need a
+  Subject lookup, which `PropertyType::validate()` has no access to.
 
 ### Deliberate behavior, not a gap
 

--- a/src/Application/Validation/SubjectValidator.php
+++ b/src/Application/Validation/SubjectValidator.php
@@ -93,9 +93,14 @@ readonly class SubjectValidator {
 	 *
 	 * A missing target is a non-blocking `relation-target-not-found` warning (red-link philosophy:
 	 * the target may be minted later, e.g. during import); a resolvable target whose own Schema is
-	 * not the declared targetSchema is a blocking `relation-target-schema-mismatch` error. Targets
-	 * are resolved through the canonical revision-slot-backed lookup the read path uses, never the
-	 * secondary graph projection.
+	 * not the declared targetSchema is a blocking `relation-target-schema-mismatch` error.
+	 *
+	 * The Schema compared is the target's own writer's-schema, read from its revision slot rather
+	 * than from a graph node property. Reaching that slot still resolves the target id through the
+	 * subject -> page index, which lives only in the graph projection (see
+	 * {@see \ProfessionalWiki\NeoWiki\NeoWikiExtension::getPageIdentifiersLookup()}), so an
+	 * unrebuilt or stale graph reports an existing target as not found. That is the same
+	 * degradation the read path has, and the reason not-found is non-blocking.
 	 *
 	 * @return Violation[]
 	 */

--- a/tests/phpunit/Application/Validation/SubjectValidatorTest.php
+++ b/tests/phpunit/Application/Validation/SubjectValidatorTest.php
@@ -501,6 +501,43 @@ class SubjectValidatorTest extends TestCase {
 		$this->assertSame( 1, $violations[1]->valuePartIndex );
 	}
 
+	public function testRelationTargetViolationCarriesItsArrayPositionNotAViolationCounter(): void {
+		$schema = $this->newSchema( [ 'Links' => $this->newRelationProperty( multiple: true ) ] );
+
+		$violations = $this->validator->validate(
+			new SubjectLabel( 'X' ),
+			new StatementList( [
+				$this->newRelationStatement( self::MATCHING_TARGET_ID, self::MISMATCHING_TARGET_ID ),
+			] ),
+			$schema,
+		);
+
+		// The valid target at index 0 emits nothing, so the sole violation belongs to the target at
+		// index 1. Pinning the position here is what the all-targets-invalid case above cannot do:
+		// there, the array position and the ordinal of the violation itself agree, so a counter-based
+		// implementation would pass it. ViolationDiff keys on valuePartIndex, so the difference
+		// decides whether an edit's violations line up with the pre-existing ones.
+		$this->assertCount( 1, $violations );
+		$this->assertSame( 'relation-target-schema-mismatch', $violations[0]->code );
+		$this->assertSame( 1, $violations[0]->valuePartIndex );
+	}
+
+	public function testNonexistentRelationTargetCarriesItsArrayPosition(): void {
+		$schema = $this->newSchema( [ 'Links' => $this->newRelationProperty( multiple: true ) ] );
+
+		$violations = $this->validator->validate(
+			new SubjectLabel( 'X' ),
+			new StatementList( [
+				$this->newRelationStatement( self::MATCHING_TARGET_ID, self::NONEXISTENT_TARGET_ID ),
+			] ),
+			$schema,
+		);
+
+		$this->assertCount( 1, $violations );
+		$this->assertSame( 'relation-target-not-found', $violations[0]->code );
+		$this->assertSame( 1, $violations[0]->valuePartIndex );
+	}
+
 	// --- Helpers ---
 
 	private function newRelationProperty( bool $multiple = true ): RelationProperty {

--- a/tests/phpunit/Domain/PropertyType/Types/RelationTypeTest.php
+++ b/tests/phpunit/Domain/PropertyType/Types/RelationTypeTest.php
@@ -61,10 +61,35 @@ class RelationTypeTest extends TestCase {
 		$this->assertSame( 'required', $violations[0]->code );
 	}
 
+	public function testPropertyOmittingMultipleWithTwoTargetsReturnsSingleValueOnly(): void {
+		// `multiple` is optional in the Schema JSON and defaults to false, so a relation property
+		// authored or imported without the key is single-valued. Since single-value-only blocks,
+		// a Subject that already holds two targets on such a property stops saving under
+		// enforcement. Pinned here because the default is what decides that, not the validation.
+		$violations = ( new RelationType() )->validate(
+			new RelationValue(
+				TestRelation::build( targetId: 'srt111111111aaa' ),
+				TestRelation::build( targetId: 'srt111111111bbb' ),
+			),
+			$this->newRelationPropertyWithoutMultipleKey(),
+		);
+
+		$this->assertCount( 1, $violations );
+		$this->assertSame( 'single-value-only', $violations[0]->code );
+		$this->assertTrue( $violations[0]->isBlocking() );
+	}
+
 	private function newRelationProperty( bool $multiple, bool $required = false ): RelationProperty {
 		return RelationProperty::fromPartialJson(
 			new PropertyCore( description: '', required: $required, default: null ),
 			[ 'relation' => 'has', 'targetSchema' => 'Person', 'multiple' => $multiple ],
+		);
+	}
+
+	private function newRelationPropertyWithoutMultipleKey(): RelationProperty {
+		return RelationProperty::fromPartialJson(
+			new PropertyCore( description: '', required: false, default: null ),
+			[ 'relation' => 'has', 'targetSchema' => 'Person' ],
 		);
 	}
 


### PR DESCRIPTION
Review follow-up for #1082, based on its branch so it can be merged straight in.

## Docs correction

The docblock on `validateRelationTargets()` and both new sections of `docs/api/validation-codes.md` state that relation targets are resolved "never [through] the secondary graph projection". Only half of that is true:

* The Schema compared **is** canonical — it is the target's own writer's-schema, read from its revision slot, not a graph node property.
* Reaching that slot resolves the target id through the subject → page index, and that index lives **only** in the graph projection (`MediaWikiSubjectRepository::getPageIdForSubject()` → `Neo4jPageIdentifiersLookup`, the sole production implementation).

As written the claim also contradicts two places that already say the opposite: the comment above `NeoWikiExtension::getPageIdentifiersLookup()` ("the subject -> page reverse index lives only in Neo4j") and `docs/operations/maintenance.md` ("Subjects are resolved to their page through an index that lives only in Neo4j").

The practical consequence is worth stating, so the docs now do: a target that exists in revision slots but is missing from the graph reports as `relation-target-not-found`. That is exactly the state [#1022](https://github.com/ProfessionalWiki/NeoWiki/issues/1022) leaves behind — an import populates the slots without updating the projection — so imported targets warn until a rebuild. Because the code is non-blocking, the misreport never costs a write. It does mean the blocking schema-mismatch check silently does not run for those targets.

`Known limitations` also still said `SubjectValidator` performs exactly two Subject-level checks; #1082 makes it four.

## Tests

Three additions, all passing against #1082 as it stands — regression guards, not bug reports.

`testMultiValueRelationReportsEachTargetViolationAtItsOwnPartIndex` uses two *equally* invalid targets, so the array position and the ordinal of the violation itself agree (0 and 1 either way) and a counter-based implementation would pass it. The replacement puts a valid target at index 0 so the two disagree, and a second test covers the `relation-target-not-found` branch, which asserted no index at all despite 122712bc existing to add one. Verified by mutation: swapping `(int)$index` for `count( $violations )` fails both, and only those two.

The third pins that a relation property whose Schema JSON omits `multiple` defaults to single-valued (`$property['multiple'] ?? false`), which combined with the newly-enforced `single-value-only` makes a second target a blocking violation.

## Worth a decision, not changed here

`single-value-only` enforcement is new in #1082 — pre-PR `RelationType::validate()` returned `[]` after the required check. Combined with the `?? false` default, any Schema authored or imported without an explicit `multiple` key is single-valued, so a Subject already holding two targets on such a property now fails to save under `$wgNeoWikiEnforceValidation`. The third test pins the behaviour; whether that default is right is a product question.

## Testing

```
make phpunit filter=SubjectValidatorTest   # 31 tests, 87 assertions, OK
make phpunit filter=RelationTypeTest       # 6 tests, 11 assertions, OK
make cs                                    # phpcs 554 files clean; phpstan [OK] No errors
```

No production behaviour changes — docs, comments and tests only.

> <sub>AI-authored — Claude Code, `Opus 4.8 (1M context)`; findings from a multi-agent review of #1082, verified against the code by hand; not yet human-reviewed.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)