### PR TITLE
Extract server-violation clearing into a shared composable

### DIFF
--- a/resources/ext.neowiki/src/components/Value/RelationInput.vue
+++ b/resources/ext.neowiki/src/components/Value/RelationInput.vue
@@ -47,7 +47,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch, computed } from 'vue';
+import { ref, watch, computed, toRef } from 'vue';
 import { CdxField, CdxIcon, ValidationMessages } from '@wikimedia/codex';
 import { cdxIconInfo } from '@wikimedia/codex-icons';
 import NeoMultiLookupInput from '@/components/common/NeoMultiLookupInput.vue';
@@ -56,7 +56,7 @@ import { ValueInputEmits, ValueInputProps, ValueInputExposes } from '@/component
 import { RelationProperty, RelationType } from '@/domain/propertyTypes/Relation.ts';
 import { Value, ValueType, RelationValue, newRelation, relationValuesHaveSameTargets } from '@/domain/Value';
 import { NeoWikiServices } from '@/NeoWikiServices.ts';
-import { SubjectViolation } from '@/domain/SubjectViolation.ts';
+import { useServerViolations } from '@/composables/useServerViolations.ts';
 
 const props = withDefaults(
 	defineProps<ValueInputProps<RelationProperty>>(),
@@ -73,27 +73,18 @@ const emit = defineEmits<ValueInputEmits>();
 const internalValue = ref<RelationValue | undefined>( undefined );
 const singleHasUnmatchedText = ref( false );
 
-function relevantServerViolations(): readonly SubjectViolation[] {
-	const name = props.property.name.toString();
-	return ( props.serverViolations ?? [] ).filter( ( v ) => v.propertyName === name );
-}
+const { firstMessage, emitClears } = useServerViolations(
+	toRef( props, 'property' ),
+	toRef( props, 'serverViolations' ),
+	emit
+);
 
-// Field-level server violation (NeoMultiLookupInput has no per-index slot).
-function serverFieldMessages(): ValidationMessages {
-	const hit = relevantServerViolations()[ 0 ];
-	if ( hit ) {
-		return {
-			error: mw.message( `neowiki-field-${ hit.code }`, ...( hit.args as string[] ) ).text()
-		};
-	}
-	return {};
-}
-
+// One aggregate error for the whole property (NeoMultiLookupInput has no per-index slot).
 const displayedFieldMessages = computed( (): ValidationMessages => {
-	if ( singleHasUnmatchedText.value ) {
+	if ( singleHasUnmatchedText.value || firstMessage.value === null ) {
 		return {};
 	}
-	return serverFieldMessages();
+	return { error: firstMessage.value };
 } );
 
 const fieldStatus = computed( (): 'error' | 'default' => {
@@ -102,15 +93,6 @@ const fieldStatus = computed( (): 'error' | 'default' => {
 	}
 	return displayedFieldMessages.value.error !== undefined ? 'error' : 'default';
 } );
-
-function emitClearIfServerViolationPresent(): void {
-	if ( relevantServerViolations().length > 0 ) {
-		emit( 'clear-server-violation', {
-			propertyName: props.property.name.toString(),
-			valuePartIndex: null
-		} );
-	}
-}
 
 function initializeInternalValue( value: Value | undefined ): void {
 	if ( value && value.type === ValueType.Relation ) {
@@ -156,7 +138,7 @@ function onSingleSelectionChanged( id: string | null ): void {
 	}
 
 	emit( 'update:modelValue', newRelationValue );
-	emitClearIfServerViolationPresent();
+	emitClears( 'all' );
 }
 
 function onSingleBlur( hasUnmatchedText: boolean ): void {
@@ -179,7 +161,7 @@ function onSelectionsChanged( ids: ( string | null )[] ): void {
 	}
 
 	emit( 'update:modelValue', newRelationValue );
-	emitClearIfServerViolationPresent();
+	emitClears( 'all' );
 }
 
 defineExpose<ValueInputExposes>( {

--- a/resources/ext.neowiki/src/components/Value/SelectInput.vue
+++ b/resources/ext.neowiki/src/components/Value/SelectInput.vue
@@ -42,14 +42,14 @@ import type { Value } from '@/domain/Value';
 </script>
 
 <script setup lang="ts">
-import { ref, watch, computed, nextTick } from 'vue';
+import { ref, watch, computed, nextTick, toRef } from 'vue';
 import { CdxField, CdxIcon, CdxMultiselectLookup, CdxSelect } from '@wikimedia/codex';
 import type { ChipInputItem, MenuItemData } from '@wikimedia/codex';
 import { cdxIconInfo } from '@wikimedia/codex-icons';
 import { newStringValue, StringValue, ValueType } from '@/domain/Value';
 import { resolveSelectLabel, SelectProperty } from '@/domain/propertyTypes/Select.ts';
 import { ValueInputEmits, ValueInputExposes, ValueInputProps } from '@/components/Value/ValueInputContract.ts';
-import { SubjectViolation } from '@/domain/SubjectViolation.ts';
+import { useServerViolations } from '@/composables/useServerViolations.ts';
 
 const props = withDefaults(
 	defineProps<ValueInputProps<SelectProperty>>(),
@@ -61,19 +61,13 @@ const props = withDefaults(
 
 const emit = defineEmits<ValueInputEmits>();
 
-function relevantServerViolations(): readonly SubjectViolation[] {
-	const name = props.property.name.toString();
-	return ( props.serverViolations ?? [] ).filter( ( v ) => v.propertyName === name );
-}
-
-const validationError = computed<string | null>( () => {
-	// For Select (both single and multi), show the first relevant server violation.
-	const hit = relevantServerViolations()[ 0 ];
-	if ( hit ) {
-		return mw.message( `neowiki-field-${ hit.code }`, ...( hit.args as string[] ) ).text();
-	}
-	return null;
-} );
+// For Select (single and multi) the field shows one aggregate error — the first
+// relevant server violation — so an edit clears every held violation ('all').
+const { firstMessage: validationError, emitClears } = useServerViolations(
+	toRef( props, 'property' ),
+	toRef( props, 'serverViolations' ),
+	emit
+);
 
 const selectPlaceholder = computed( () =>
 	mw.message( 'neowiki-select-placeholder' ).text()
@@ -119,20 +113,11 @@ function getFilteredOptions(): MenuItemData[] {
 		.map( ( option ) => ( { value: option.id, label: option.label } ) );
 }
 
-function emitClearIfServerViolationPresent(): void {
-	if ( relevantServerViolations().length > 0 ) {
-		emit( 'clear-server-violation', {
-			propertyName: props.property.name.toString(),
-			valuePartIndex: null
-		} );
-	}
-}
-
 function onSingleSelect( selected: string ): void {
 	selection.value = selected ? [ selected ] : [];
 	emit( 'update:modelValue', selection.value.length > 0 ?
 		newStringValue( selection.value ) : undefined );
-	emitClearIfServerViolationPresent();
+	emitClears( 'all' );
 }
 
 function onInput(): void {
@@ -159,7 +144,7 @@ watch( chips, () => {
 		inputValue.value = '';
 		menuItems.value = [];
 		emit( 'update:modelValue', parts.length > 0 ? newStringValue( parts ) : undefined );
-		emitClearIfServerViolationPresent();
+		emitClears( 'all' );
 	} );
 }, { deep: true } );
 

--- a/resources/ext.neowiki/src/composables/useFieldServerViolation.ts
+++ b/resources/ext.neowiki/src/composables/useFieldServerViolation.ts
@@ -1,7 +1,8 @@
-import { computed, ComputedRef, Ref } from 'vue';
+import { ComputedRef, Ref } from 'vue';
 import { SubjectViolation } from '@/domain/SubjectViolation.ts';
 import { PropertyDefinition } from '@/domain/PropertyDefinition.ts';
 import { ValueInputEmitFunction } from '@/components/Value/ValueInputContract.ts';
+import { useServerViolations } from '@/composables/useServerViolations.ts';
 
 interface FieldServerViolation {
 	validationError: ComputedRef<string | null>;
@@ -9,16 +10,12 @@ interface FieldServerViolation {
 }
 
 /**
- * Field-level server-violation handling shared by the single-value inputs
- * (Boolean, Number, Date, DateTime). Merges a server-sourced violation for
- * this property as the displayed error and clears it when the user edits the
- * field.
- *
- * Only field-level violations (valuePartIndex null/undefined) are handled;
- * single-value inputs have no per-index slot. Text and Url (via
- * useStringValueInput) merge per-index violations into their per-input slots;
- * Select and Relation do their own inline lookup, surfacing the first
- * violation for the property at field level.
+ * Field-level server-violation handling for the single-value inputs (Boolean,
+ * Number, Date, DateTime). A thin adapter over useServerViolations: these
+ * inputs have no per-part slot, so only the field-level violation (valuePartIndex
+ * null/undefined) is displayed, and clearing passes an empty touched-index set
+ * so exactly that violation is dropped — a per-index violation is neither shown
+ * nor cleared here.
  *
  * @param property The field's Property Definition; violations are matched on its name.
  * @param serverViolations The violations passed to this input.
@@ -31,31 +28,10 @@ export function useFieldServerViolation<P extends PropertyDefinition>(
 	emit: ValueInputEmitFunction,
 	formatArg: ( arg: string ) => string = ( arg ) => arg,
 ): FieldServerViolation {
-	const fieldLevelHit = (): SubjectViolation | undefined =>
-		( serverViolations.value ?? [] ).find(
-			( v ) => v.propertyName === property.value.name.toString() &&
-				( v.valuePartIndex === null || v.valuePartIndex === undefined ),
-		);
+	const { fieldLevelMessage, emitClears } = useServerViolations( property, serverViolations, emit, formatArg );
 
-	const validationError = computed<string | null>( () => {
-		const hit = fieldLevelHit();
-		if ( hit ) {
-			return mw.message(
-				`neowiki-field-${ hit.code }`,
-				...( hit.args as string[] ).map( formatArg ),
-			).text();
-		}
-		return null;
-	} );
-
-	function clearServerViolation(): void {
-		if ( fieldLevelHit() ) {
-			emit( 'clear-server-violation', {
-				propertyName: property.value.name.toString(),
-				valuePartIndex: null,
-			} );
-		}
-	}
-
-	return { validationError, clearServerViolation };
+	return {
+		validationError: fieldLevelMessage,
+		clearServerViolation: () => emitClears( [] ),
+	};
 }

--- a/resources/ext.neowiki/src/composables/useServerViolations.ts
+++ b/resources/ext.neowiki/src/composables/useServerViolations.ts
@@ -1,0 +1,103 @@
+import { computed, ComputedRef, Ref } from 'vue';
+import { SubjectViolation } from '@/domain/SubjectViolation.ts';
+import { PropertyDefinition } from '@/domain/PropertyDefinition.ts';
+import { ValueInputEmitFunction } from '@/components/Value/ValueInputContract.ts';
+
+/**
+ * Which on-screen surfaces an edit could have resolved, so the matching stale
+ * server violations can be optimistically cleared:
+ *
+ * - `'all'` — the input renders one aggregate error for the whole property with
+ *   no per-part slot (Select, Relation), so every held violation is stale on any
+ *   edit. Each is cleared by its own index (numeric or null).
+ * - a list of value-part indices — the input renders an independent slot per
+ *   part (multi Text/Url), so only the edited slots are cleared, and the shared
+ *   field-level summary slot is cleared alongside them. A single-value or
+ *   field-level input passes `[]` to clear only that summary slot.
+ */
+export type ClearScope = 'all' | readonly number[];
+
+export interface UseServerViolationsReturn {
+	relevant: () => readonly SubjectViolation[];
+	format: ( violation: SubjectViolation ) => string;
+	firstMessage: ComputedRef<string | null>;
+	fieldLevelMessage: ComputedRef<string | null>;
+	emitClears: ( touched: ClearScope ) => void;
+}
+
+function isFieldLevel( violation: SubjectViolation ): boolean {
+	return violation.valuePartIndex === null || violation.valuePartIndex === undefined;
+}
+
+/**
+ * Shared server-violation handling for the value inputs. Centralises the
+ * property-name filter and the `neowiki-field-` message formatter (each was
+ * copied across four/five inputs) and, crucially, the optimistic
+ * clear-on-edit logic — which differs only by how each input DISPLAYS its
+ * violations. Display stays in the individual inputs, because the aggregate,
+ * per-part-plus-summary, and field-level models genuinely differ.
+ *
+ * The parent dialog drops violations by exact (propertyName, valuePartIndex)
+ * match, so every clear must carry the held violation's own index; a single
+ * null clear never removes a part-indexed one.
+ *
+ * @param property The field's Property Definition; violations match on its name.
+ * @param serverViolations The violations passed to this input (may be undefined).
+ * @param emit The component's emit function; used for clear-server-violation.
+ * @param formatArg Per-arg formatter; Date/DateTime format their bounds for display.
+ */
+export function useServerViolations<P extends PropertyDefinition>(
+	property: Ref<P>,
+	serverViolations: Ref<readonly SubjectViolation[] | undefined>,
+	emit: ValueInputEmitFunction,
+	formatArg: ( arg: string ) => string = ( arg ) => arg,
+): UseServerViolationsReturn {
+	function propertyName(): string {
+		return property.value.name.toString();
+	}
+
+	function relevant(): readonly SubjectViolation[] {
+		const name = propertyName();
+		return ( serverViolations.value ?? [] ).filter( ( v ) => v.propertyName === name );
+	}
+
+	function format( violation: SubjectViolation ): string {
+		return mw.message(
+			`neowiki-field-${ violation.code }`,
+			...( violation.args as string[] ).map( formatArg ),
+		).text();
+	}
+
+	const firstMessage = computed<string | null>( () => {
+		const hit = relevant()[ 0 ];
+		return hit ? format( hit ) : null;
+	} );
+
+	const fieldLevelMessage = computed<string | null>( () => {
+		const hit = relevant().find( isFieldLevel );
+		return hit ? format( hit ) : null;
+	} );
+
+	function emitClears( touched: ClearScope ): void {
+		const held = relevant();
+		const name = propertyName();
+
+		if ( touched === 'all' ) {
+			for ( const violation of held ) {
+				emit( 'clear-server-violation', { propertyName: name, valuePartIndex: violation.valuePartIndex } );
+			}
+			return;
+		}
+
+		for ( const index of touched ) {
+			if ( held.some( ( v ) => v.valuePartIndex === index ) ) {
+				emit( 'clear-server-violation', { propertyName: name, valuePartIndex: index } );
+			}
+		}
+		if ( held.some( isFieldLevel ) ) {
+			emit( 'clear-server-violation', { propertyName: name, valuePartIndex: null } );
+		}
+	}
+
+	return { relevant, format, firstMessage, fieldLevelMessage, emitClears };
+}

--- a/resources/ext.neowiki/src/composables/useStringValueInput.ts
+++ b/resources/ext.neowiki/src/composables/useStringValueInput.ts
@@ -7,6 +7,8 @@ import { MultiStringProperty } from '@/domain/PropertyDefinition.ts';
 import { PropertyType } from '@/domain/PropertyType.ts';
 import { NeoWikiServices } from '@/NeoWikiServices.ts';
 import { SubjectViolation } from '@/domain/SubjectViolation.ts';
+import { ValueInputEmitFunction } from '@/components/Value/ValueInputContract.ts';
+import { useServerViolations } from '@/composables/useServerViolations.ts';
 
 interface UseStringValueInputReturn {
 	displayValues: ComputedRef<string[]>;
@@ -20,10 +22,7 @@ interface UseStringValueInputReturn {
 export function useStringValueInput<P extends MultiStringProperty>(
 	modelValue: Ref<Value | undefined>,
 	property: Ref<P>,
-	emit: {
-		( e: 'update:modelValue', value: Value | undefined ): void;
-		( e: 'clear-server-violation', payload: { propertyName: string; valuePartIndex: number | null } ): void;
-	},
+	emit: ValueInputEmitFunction,
 	propertyType: PropertyType,
 	serverViolations?: Ref<readonly SubjectViolation[] | undefined>,
 ): UseStringValueInputReturn {
@@ -58,18 +57,15 @@ export function useStringValueInput<P extends MultiStringProperty>(
 		return internalValue.value ? internalValue.value.parts : [];
 	} );
 
-	function relevantViolations(): readonly SubjectViolation[] {
-		const all = serverViolations?.value;
-		if ( !all ) {
-			return [];
-		}
-		const name = property.value.name.toString();
-		return all.filter( ( v ) => v.propertyName === name );
-	}
+	const { relevant, format, emitClears } = useServerViolations(
+		property,
+		serverViolations ?? ref<readonly SubjectViolation[] | undefined>( undefined ),
+		emit,
+	);
 
 	function mergeServerIntoInputMessages( baseMessages: ValidationMessages[] ): ValidationMessages[] {
 		const merged = [ ...baseMessages ];
-		for ( const v of relevantViolations() ) {
+		for ( const v of relevant() ) {
 			if ( typeof v.valuePartIndex !== 'number' ) {
 				continue;
 			}
@@ -79,12 +75,7 @@ export function useStringValueInput<P extends MultiStringProperty>(
 			}
 			const existing = merged[ i ];
 			if ( !existing || Object.keys( existing ).length === 0 ) {
-				merged[ i ] = {
-					error: mw.message(
-						`neowiki-field-${ v.code }`,
-						...( v.args as string[] ),
-					).text(),
-				};
+				merged[ i ] = { error: format( v ) };
 			}
 		}
 		return merged;
@@ -95,7 +86,7 @@ export function useStringValueInput<P extends MultiStringProperty>(
 		// per-input slot to attach to, so we surface it through the field-level
 		// summary regardless of multi/single — otherwise something like a
 		// "required" violation on a multi-value property would silently vanish.
-		const fieldLevel = relevantViolations().find(
+		const fieldLevel = relevant().find(
 			( v ) => v.valuePartIndex === null || v.valuePartIndex === undefined,
 		);
 
@@ -103,12 +94,7 @@ export function useStringValueInput<P extends MultiStringProperty>(
 			// For multi: per-input server violations stay in their slots; only a
 			// server-sourced field-level violation surfaces in the summary slot.
 			if ( fieldLevel ) {
-				return {
-					error: mw.message(
-						`neowiki-field-${ fieldLevel.code }`,
-						...( fieldLevel.args as string[] ),
-					).text(),
-				};
+				return { error: format( fieldLevel ) };
 			}
 			return {};
 		}
@@ -121,12 +107,7 @@ export function useStringValueInput<P extends MultiStringProperty>(
 		}
 
 		if ( fieldLevel ) {
-			return {
-				error: mw.message(
-					`neowiki-field-${ fieldLevel.code }`,
-					...( fieldLevel.args as string[] ),
-				).text(),
-			};
+			return { error: format( fieldLevel ) };
 		}
 
 		return {};
@@ -145,24 +126,21 @@ export function useStringValueInput<P extends MultiStringProperty>(
 
 		updateValidationMessages( currentInputValues );
 
-		// Emit clear-server-violation for the index that just changed, if a server
-		// violation existed there for this property.
-		const name = property.value.name.toString();
-		const relevant = relevantViolations();
-		if ( relevant.length > 0 ) {
-			if ( property.value.multiple ) {
-				// Identify which index changed by diffing against the previous values.
-				const len = Math.max( currentInputValues.length, previousInputValues.length );
-				for ( let i = 0; i < len; i++ ) {
-					if ( currentInputValues[ i ] !== previousInputValues[ i ] ) {
-						if ( relevant.some( ( v ) => v.valuePartIndex === i ) ) {
-							emit( 'clear-server-violation', { propertyName: name, valuePartIndex: i } );
-						}
-					}
+		// Optimistically clear the server violations this edit could have resolved:
+		// on a multi-value field, the value parts whose input changed plus the
+		// shared field-level summary; on a single-value field, only the summary.
+		// useServerViolations emits only for indices it actually holds.
+		if ( property.value.multiple ) {
+			const len = Math.max( currentInputValues.length, previousInputValues.length );
+			const changedIndices: number[] = [];
+			for ( let i = 0; i < len; i++ ) {
+				if ( currentInputValues[ i ] !== previousInputValues[ i ] ) {
+					changedIndices.push( i );
 				}
-			} else if ( relevant.some( ( v ) => v.valuePartIndex === null || v.valuePartIndex === undefined ) ) {
-				emit( 'clear-server-violation', { propertyName: name, valuePartIndex: null } );
 			}
+			emitClears( changedIndices );
+		} else {
+			emitClears( [] );
 		}
 
 		// Emit every non-empty entry, including ones that are invalid. The

--- a/resources/ext.neowiki/tests/components/Value/RelationInput.spec.ts
+++ b/resources/ext.neowiki/tests/components/Value/RelationInput.spec.ts
@@ -290,4 +290,100 @@ describe( 'RelationInput', () => {
 			expect( currentValue.relations[ 0 ].target.text ).toBe( 's1demo1aaaaaaa1' );
 		} );
 	} );
+
+	describe( 'clearing server violations', () => {
+		it( 'clears a part-indexed violation using its own index', async () => {
+			const wrapper = newWrapper( {
+				property: newRelationProperty( { name: 'Owner', targetSchema: 'Company' } ),
+				serverViolations: [
+					{
+						propertyName: 'Owner',
+						code: 'relation-target-schema-mismatch',
+						args: [ 'Company', 'Person' ],
+						valuePartIndex: 0,
+					},
+				],
+			} );
+
+			wrapper.findComponent( SubjectLookup ).vm.$emit( 'update:selected', 's1demo1aaaaaaa1' );
+			await wrapper.vm.$nextTick();
+
+			// The parent drops violations by exact valuePartIndex match, so a null here would
+			// never match index 0 and the error would outlive the fix the user just made.
+			expect( wrapper.emitted( 'clear-server-violation' ) ).toEqual( [
+				[ { propertyName: 'Owner', valuePartIndex: 0 } ],
+			] );
+		} );
+
+		it( 'clears every violation on the property, one emit per index', async () => {
+			const wrapper = newWrapper( {
+				property: newRelationProperty( { name: 'Owners', targetSchema: 'Company', multiple: true } ),
+				serverViolations: [
+					{ propertyName: 'Owners', code: 'relation-target-not-found', args: [ 'x' ], valuePartIndex: 0 },
+					{ propertyName: 'Owners', code: 'relation-target-schema-mismatch', args: [], valuePartIndex: 1 },
+				],
+			} );
+
+			wrapper.findComponent( NeoMultiLookupInput ).vm.$emit( 'update:modelValue', [ 's1demo1aaaaaaa1' ] );
+			await wrapper.vm.$nextTick();
+
+			// This field shows one aggregate error, so clearing only the displayed violation
+			// would strand the rest with nothing on screen to explain them.
+			expect( wrapper.emitted( 'clear-server-violation' ) ).toEqual( [
+				[ { propertyName: 'Owners', valuePartIndex: 0 } ],
+				[ { propertyName: 'Owners', valuePartIndex: 1 } ],
+			] );
+		} );
+
+		it( 'does not emit when the property has no violation', async () => {
+			const wrapper = newWrapper( {
+				property: newRelationProperty( { name: 'Owner', targetSchema: 'Company' } ),
+				serverViolations: [
+					{ propertyName: 'Other', code: 'required', args: [], valuePartIndex: null },
+				],
+			} );
+
+			wrapper.findComponent( SubjectLookup ).vm.$emit( 'update:selected', 's1demo1aaaaaaa1' );
+			await wrapper.vm.$nextTick();
+
+			expect( wrapper.emitted( 'clear-server-violation' ) ).toBeUndefined();
+		} );
+
+		it( 'clears a field-level (null-index) violation on the property', async () => {
+			const wrapper = newWrapper( {
+				property: newRelationProperty( { name: 'Owner', targetSchema: 'Company' } ),
+				serverViolations: [
+					{ propertyName: 'Owner', code: 'required', args: [], valuePartIndex: null },
+				],
+			} );
+
+			wrapper.findComponent( SubjectLookup ).vm.$emit( 'update:selected', 's1demo1aaaaaaa1' );
+			await wrapper.vm.$nextTick();
+
+			// A required violation carries valuePartIndex: null; the parent drops by exact match,
+			// so the clear must carry null too or the stale error outlives the user's fix.
+			expect( wrapper.emitted( 'clear-server-violation' ) ).toEqual( [
+				[ { propertyName: 'Owner', valuePartIndex: null } ],
+			] );
+		} );
+
+		it( 'uses the violation index rather than the array position on a gapped multi', async () => {
+			const wrapper = newWrapper( {
+				property: newRelationProperty( { name: 'Owners', targetSchema: 'Company', multiple: true } ),
+				serverViolations: [
+					{ propertyName: 'Owners', code: 'relation-target-not-found', args: [ 'x' ], valuePartIndex: 0 },
+					{ propertyName: 'Owners', code: 'relation-target-schema-mismatch', args: [], valuePartIndex: 2 },
+				],
+			} );
+
+			wrapper.findComponent( NeoMultiLookupInput ).vm.$emit( 'update:modelValue', [ 's1demo1aaaaaaa1' ] );
+			await wrapper.vm.$nextTick();
+
+			// Gapped indices 0 and 2: a positional counter would emit 0 and 1, stranding index 2.
+			expect( wrapper.emitted( 'clear-server-violation' ) ).toEqual( [
+				[ { propertyName: 'Owners', valuePartIndex: 0 } ],
+				[ { propertyName: 'Owners', valuePartIndex: 2 } ],
+			] );
+		} );
+	} );
 } );

--- a/resources/ext.neowiki/tests/components/Value/SelectInput.spec.ts
+++ b/resources/ext.neowiki/tests/components/Value/SelectInput.spec.ts
@@ -1,6 +1,6 @@
-import { VueWrapper } from '@vue/test-utils';
+import { flushPromises, VueWrapper } from '@vue/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { CdxField } from '@wikimedia/codex';
+import { CdxField, CdxMultiselectLookup, CdxSelect } from '@wikimedia/codex';
 import SelectInput from '@/components/Value/SelectInput.vue';
 import { newSelectProperty, SelectProperty } from '@/domain/propertyTypes/Select';
 import { ValueInputProps } from '@/components/Value/ValueInputContract.ts';
@@ -45,5 +45,84 @@ describe( 'SelectInput', () => {
 
 		expect( wrapper.findComponent( CdxField ).props( 'status' ) ).toBe( 'error' );
 		expect( wrapper.findComponent( CdxField ).props( 'messages' ) ).toHaveProperty( 'error', 'neowiki-field-required' );
+	} );
+
+	describe( 'clearing server violations', () => {
+		it( 'clears a part-indexed violation using its own index', async () => {
+			const wrapper = newWrapper( {
+				serverViolations: [
+					{ propertyName: 'Status', code: 'invalid-option', args: [ 'bogus' ], valuePartIndex: 0 },
+				],
+			} );
+
+			wrapper.findComponent( CdxSelect ).vm.$emit( 'update:selected', 'open' );
+			await wrapper.vm.$nextTick();
+
+			// SelectType emits invalid-option per part, and the parent drops violations by exact
+			// valuePartIndex match, so a null here would never clear an indexed one.
+			expect( wrapper.emitted( 'clear-server-violation' ) ).toEqual( [
+				[ { propertyName: 'Status', valuePartIndex: 0 } ],
+			] );
+		} );
+
+		it( 'does not emit when the property has no violation', async () => {
+			const wrapper = newWrapper( {
+				serverViolations: [
+					{ propertyName: 'Other', code: 'required', args: [], valuePartIndex: null },
+				],
+			} );
+
+			wrapper.findComponent( CdxSelect ).vm.$emit( 'update:selected', 'open' );
+			await wrapper.vm.$nextTick();
+
+			expect( wrapper.emitted( 'clear-server-violation' ) ).toBeUndefined();
+		} );
+
+		it( 'clears a field-level (null-index) violation on the property', async () => {
+			const wrapper = newWrapper( {
+				serverViolations: [
+					{ propertyName: 'Status', code: 'required', args: [], valuePartIndex: null },
+				],
+			} );
+
+			wrapper.findComponent( CdxSelect ).vm.$emit( 'update:selected', 'open' );
+			await wrapper.vm.$nextTick();
+
+			// A required violation carries valuePartIndex: null; the parent drops by exact match,
+			// so the clear must carry null too or the stale error outlives the user's fix.
+			expect( wrapper.emitted( 'clear-server-violation' ) ).toEqual( [
+				[ { propertyName: 'Status', valuePartIndex: null } ],
+			] );
+		} );
+
+		it( 'clears every violation on a multi-select via the chips path, each by its own index', async () => {
+			const wrapper = newWrapper( {
+				property: newSelectProperty( {
+					name: 'Status',
+					multiple: true,
+					options: [
+						{ id: 'open', label: 'Open' },
+						{ id: 'closed', label: 'Closed' },
+						{ id: 'archived', label: 'Archived' },
+					],
+				} ),
+				serverViolations: [
+					{ propertyName: 'Status', code: 'invalid-option', args: [ 'a' ], valuePartIndex: 0 },
+					{ propertyName: 'Status', code: 'invalid-option', args: [ 'b' ], valuePartIndex: 2 },
+				],
+			} );
+
+			wrapper.findComponent( CdxMultiselectLookup ).vm.$emit(
+				'update:input-chips', [ { value: 'open', label: 'Open' } ],
+			);
+			await flushPromises();
+
+			// The multi path clears through the chips watcher (nextTick + emitPending guard).
+			// Gapped indices 0 and 2: a positional counter would emit 0 and 1, stranding index 2.
+			// v-model:input-chips is two-way and may echo, so assert presence rather than exact order.
+			const cleared = wrapper.emitted( 'clear-server-violation' );
+			expect( cleared ).toContainEqual( [ { propertyName: 'Status', valuePartIndex: 0 } ] );
+			expect( cleared ).toContainEqual( [ { propertyName: 'Status', valuePartIndex: 2 } ] );
+		} );
 	} );
 } );

--- a/resources/ext.neowiki/tests/composables/useServerViolations.spec.ts
+++ b/resources/ext.neowiki/tests/composables/useServerViolations.spec.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { ref, shallowRef, type Ref } from 'vue';
+import { useServerViolations } from '@/composables/useServerViolations.ts';
+import { SubjectViolation } from '@/domain/SubjectViolation.ts';
+import { PropertyDefinition, PropertyName } from '@/domain/PropertyDefinition.ts';
+
+vi.stubGlobal( 'mw', {
+	message: vi.fn( ( key: string, ...params: string[] ) => ( {
+		text: () => [ key, ...params ].join( '|' ),
+	} ) ),
+} );
+
+const PROPERTY_NAME = 'Status';
+
+function newProperty(): PropertyDefinition {
+	return {
+		name: new PropertyName( PROPERTY_NAME ),
+		type: 'text',
+		description: '',
+		required: false,
+	};
+}
+
+function violation( overrides: Partial<SubjectViolation> = {} ): SubjectViolation {
+	return {
+		propertyName: PROPERTY_NAME,
+		code: 'invalid-option',
+		args: [],
+		valuePartIndex: null,
+		...overrides,
+	};
+}
+
+function setup( violations: SubjectViolation[], formatArg?: ( arg: string ) => string ): {
+	composable: ReturnType<typeof useServerViolations>;
+	serverViolations: Ref<readonly SubjectViolation[] | undefined>;
+	emit: Mock;
+} {
+	const serverViolations = ref<readonly SubjectViolation[] | undefined>( violations );
+	const emit = vi.fn();
+	const composable = useServerViolations( shallowRef( newProperty() ), serverViolations, emit, formatArg );
+	return { composable, serverViolations, emit };
+}
+
+describe( 'useServerViolations', () => {
+	beforeEach( () => {
+		vi.clearAllMocks();
+	} );
+
+	describe( 'relevant', () => {
+		it( 'returns only the violations for this property, preserving order', () => {
+			const { composable } = setup( [
+				violation( { valuePartIndex: 0 } ),
+				violation( { propertyName: 'Other', valuePartIndex: 1 } ),
+				violation( { valuePartIndex: 2 } ),
+			] );
+
+			expect( composable.relevant().map( ( v ) => v.valuePartIndex ) ).toEqual( [ 0, 2 ] );
+		} );
+
+		it( 'is empty when serverViolations is undefined', () => {
+			const serverViolations = ref<readonly SubjectViolation[] | undefined>( undefined );
+			const composable = useServerViolations( shallowRef( newProperty() ), serverViolations, vi.fn() );
+
+			expect( composable.relevant() ).toEqual( [] );
+		} );
+	} );
+
+	describe( 'format', () => {
+		it( 'builds the neowiki-field message with args', () => {
+			const { composable } = setup( [] );
+
+			expect( composable.format( violation( { code: 'type-mismatch', args: [ 'url', 'number' ] } ) ) )
+				.toBe( 'neowiki-field-type-mismatch|url|number' );
+		} );
+
+		it( 'applies the arg formatter', () => {
+			const { composable } = setup( [], ( arg ) => `f(${ arg })` );
+
+			expect( composable.format( violation( { code: 'min-value', args: [ '42' ] } ) ) )
+				.toBe( 'neowiki-field-min-value|f(42)' );
+		} );
+	} );
+
+	describe( 'firstMessage', () => {
+		it( 'is the first relevant violation, even when it is part-indexed', () => {
+			const { composable } = setup( [ violation( { code: 'invalid-option', args: [ 'x' ], valuePartIndex: 1 } ) ] );
+
+			expect( composable.firstMessage.value ).toBe( 'neowiki-field-invalid-option|x' );
+		} );
+
+		it( 'is null when there are no relevant violations', () => {
+			const { composable } = setup( [ violation( { propertyName: 'Other' } ) ] );
+
+			expect( composable.firstMessage.value ).toBeNull();
+		} );
+	} );
+
+	describe( 'fieldLevelMessage', () => {
+		it( 'is the null-index violation, ignoring part-indexed ones', () => {
+			const { composable } = setup( [
+				violation( { code: 'invalid-option', valuePartIndex: 0 } ),
+				violation( { code: 'required', valuePartIndex: null } ),
+			] );
+
+			expect( composable.fieldLevelMessage.value ).toBe( 'neowiki-field-required' );
+		} );
+
+		it( 'is null when only part-indexed violations exist', () => {
+			const { composable } = setup( [ violation( { valuePartIndex: 2 } ) ] );
+
+			expect( composable.fieldLevelMessage.value ).toBeNull();
+		} );
+	} );
+
+	describe( 'emitClears( "all" )', () => {
+		it( 'clears every held violation by its own index, null and numeric alike', () => {
+			const { composable, emit } = setup( [
+				violation( { valuePartIndex: 0 } ),
+				violation( { valuePartIndex: 2 } ),
+				violation( { code: 'required', valuePartIndex: null } ),
+			] );
+
+			composable.emitClears( 'all' );
+
+			expect( emit.mock.calls ).toEqual( [
+				[ 'clear-server-violation', { propertyName: PROPERTY_NAME, valuePartIndex: 0 } ],
+				[ 'clear-server-violation', { propertyName: PROPERTY_NAME, valuePartIndex: 2 } ],
+				[ 'clear-server-violation', { propertyName: PROPERTY_NAME, valuePartIndex: null } ],
+			] );
+		} );
+
+		it( 'does not emit when there is no violation for the property', () => {
+			const { composable, emit } = setup( [ violation( { propertyName: 'Other' } ) ] );
+
+			composable.emitClears( 'all' );
+
+			expect( emit ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'emitClears( indices )', () => {
+		it( 'clears only the touched indices that carry a violation', () => {
+			const { composable, emit } = setup( [
+				violation( { valuePartIndex: 1 } ),
+				violation( { valuePartIndex: 3 } ),
+			] );
+
+			composable.emitClears( [ 0, 1 ] );
+
+			expect( emit.mock.calls ).toEqual( [
+				[ 'clear-server-violation', { propertyName: PROPERTY_NAME, valuePartIndex: 1 } ],
+			] );
+		} );
+
+		it( 'also clears the shared field-level slot when a null-index violation is held', () => {
+			const { composable, emit } = setup( [
+				violation( { code: 'invalid-url', valuePartIndex: 1 } ),
+				violation( { code: 'required', valuePartIndex: null } ),
+			] );
+
+			composable.emitClears( [ 1 ] );
+
+			expect( emit.mock.calls ).toEqual( [
+				[ 'clear-server-violation', { propertyName: PROPERTY_NAME, valuePartIndex: 1 } ],
+				[ 'clear-server-violation', { propertyName: PROPERTY_NAME, valuePartIndex: null } ],
+			] );
+		} );
+
+		it( 'clears the field-level slot on any edit even when no numeric index was touched (item 4)', () => {
+			const { composable, emit } = setup( [ violation( { code: 'required', valuePartIndex: null } ) ] );
+
+			composable.emitClears( [] );
+
+			expect( emit.mock.calls ).toEqual( [
+				[ 'clear-server-violation', { propertyName: PROPERTY_NAME, valuePartIndex: null } ],
+			] );
+		} );
+
+		it( 'does not clear the field-level slot when only part-indexed violations are held', () => {
+			const { composable, emit } = setup( [ violation( { valuePartIndex: 1 } ) ] );
+
+			composable.emitClears( [] );
+
+			expect( emit ).not.toHaveBeenCalled();
+		} );
+
+		it( 'leaves an untouched part-indexed violation in place when clearing the field-level slot', () => {
+			const { composable, emit } = setup( [
+				violation( { code: 'invalid-url', valuePartIndex: 1 } ),
+				violation( { code: 'unique', valuePartIndex: null } ),
+			] );
+
+			composable.emitClears( [ 0 ] );
+
+			// Editing part 0 clears the shared field-level slot but must NOT sweep the
+			// still-invalid part 1: exactly one emit, the null clear, never index 1.
+			expect( emit.mock.calls ).toEqual( [
+				[ 'clear-server-violation', { propertyName: PROPERTY_NAME, valuePartIndex: null } ],
+			] );
+		} );
+	} );
+
+	describe( 'reactivity', () => {
+		it( 'recomputes the display messages when serverViolations changes after creation', () => {
+			const { composable, serverViolations } = setup( [] );
+			expect( composable.firstMessage.value ).toBeNull();
+			expect( composable.fieldLevelMessage.value ).toBeNull();
+
+			// A failed save sets serverViolations on an already-mounted input; the display
+			// computeds must recompute from the live ref, not a snapshot taken at creation.
+			serverViolations.value = [ violation( { code: 'required', valuePartIndex: null } ) ];
+
+			expect( composable.firstMessage.value ).toBe( 'neowiki-field-required' );
+			expect( composable.fieldLevelMessage.value ).toBe( 'neowiki-field-required' );
+		} );
+	} );
+} );

--- a/resources/ext.neowiki/tests/composables/useStringValueInput.spec.ts
+++ b/resources/ext.neowiki/tests/composables/useStringValueInput.spec.ts
@@ -311,6 +311,19 @@ describe( 'useStringValueInput', () => {
 			);
 		} );
 
+		it( 'does not clear a per-index violation on a single-value field edit', () => {
+			const { onInput } = createComposableWithViolations(
+				[ violation( { code: 'min-length', args: [ '10' ], valuePartIndex: 0 } ) ],
+				{ name: new PropertyName( 'testProp' ), multiple: false },
+			);
+
+			onInput( 'some longer text' );
+
+			// Single-value inputs have no per-part slot, so a per-index violation is not
+			// optimistically cleared on edit — only a field-level (null-index) one would be.
+			expect( mockEmit ).not.toHaveBeenCalledWith( 'clear-server-violation', expect.anything() );
+		} );
+
 		it( 'does not emit clear-server-violation when no violation exists for the property', () => {
 			const { onInput } = createComposableWithViolations(
 				[],
@@ -357,6 +370,28 @@ describe( 'useStringValueInput', () => {
 			onInput( [ 'changed', 'bad' ] );
 
 			expect( mockEmit ).not.toHaveBeenCalledWith( 'clear-server-violation', expect.anything() );
+		} );
+
+		it( 'clears a field-level (null-index) violation on edit of a multi-value field', async () => {
+			const modelValueRef = ref<Value | undefined>( newStringValue( 'a', 'b' ) );
+			const propertyRef = ref( createMockPropertyDefinition( {
+				name: new PropertyName( 'testProp' ),
+				multiple: true,
+			} ) ) as Ref<MultiStringProperty>;
+			const serverViolationsRef = ref<SubjectViolation[]>( [ violation( { code: 'unique-items', valuePartIndex: null } ) ] );
+
+			const { onInput } = useStringValueInput( modelValueRef, propertyRef, mockEmit, mockPropertyType, serverViolationsRef );
+			await nextTick();
+			mockEmit.mockClear();
+
+			onInput( [ 'a', 'c' ] );
+
+			// The field-level summary slot is shown for multi too, so an edit must clear it —
+			// on master the multi branch only cleared numeric indices, leaving it stranded.
+			expect( mockEmit ).toHaveBeenCalledWith(
+				'clear-server-violation',
+				{ propertyName: 'testProp', valuePartIndex: null },
+			);
 		} );
 
 		it( 'recomputes messages when the serverViolations ref changes', async () => {


### PR DESCRIPTION
This PR began as a narrow fix for part-indexed server-violation clearing in Select and Relation inputs (the `0 !== null` exact-match bug). Rather than ship that as one input-specific patch and refactor later, it now generalises the whole clear-on-edit path into a shared composable, and fixes the sibling gap in multi-value Text/Url in the same change.

## The problem

When the subject editor validates, the backend returns `SubjectViolation[]` to the dialog, which drops a violation by exact `(propertyName, valuePartIndex)` match when the user edits the field. Three inputs handled this three different ways, with the property-name filter copied four times and the `neowiki-field-` formatter five times:

- **Select / Relation** emitted a single clear with `valuePartIndex: null`. But `SelectType` (`invalid-option`) and the relation-target codes carry a *numeric* index, so `0 === null` never matched — the optimistic clear was a silent no-op and a stale error lingered until the next dry-run validate.
- **Text / Url** cleared per changed numeric index, but its multi branch never cleared a field-level (`required` / `unique`) violation shown in the summary slot — that error lingered on edit.
- **Boolean / Number / Date / DateTime** cleared the field-level violation correctly.

## The change

A single `useServerViolations` composable centralises the filter, the formatter, the display computeds (`firstMessage` / `fieldLevelMessage`), and the clear logic via `emitClears( 'all' | number[] )`:

- `'all'` — emit one clear per held violation, each by its **own** index. The aggregate inputs (Select, Relation) render one error for the whole property with no per-part slot, so on any edit every held violation is stale. This is the part-indexed clearing this PR set out to deliver, now shared.
- a touched-index list — clear the edited parts that carry a violation, **plus** the shared field-level summary slot. Multi Text/Url passes its changed indices (the summary clear is the multi-value fix); single-value and field-level inputs pass `[]`.

`useFieldServerViolation` becomes a thin adapter over the composable. **Display stays per-input** — the aggregate, per-part-plus-summary, and field-level display models genuinely differ and cannot collapse.

The **wire contract and both dialogs' `handleClearViolation` are byte-identical**, so a half-migration would stay correct — no runtime mismatch. That is why this was preferred over the alternative of a discriminated-union clear payload: the union is more type-safe (it would make an un-migrated emitter a compile error) but rewrites a working contract, both consumers, six emit sites, and ~10 test files for a robustness win rather than a correctness one.

## Behaviour changes (both intended)

1. Select / Relation now actually clear their part-indexed violations on edit (previously a no-op).
2. Multi Text/Url now clears the field-level summary violation on edit.

Both follow the established optimistic-clear model: the field shows one aggregate/summary error, editing clears it, and the next dry-run re-adds it if still invalid. Save integrity is unaffected — the backend 422 is authoritative. Known trade-off: on a multi field with several violations, editing one part clears the shared summary even if another part is still invalid; it re-appears on the next validate (~debounce), or, in blur-only validation mode, on blur. Untouched *per-part* (numeric-index) violations are never wiped.

## Testing

```
make ts-test filter=composables   # useServerViolations 16, useFieldServerViolation 12, useStringValueInput 27
make ts-test filter=Input         # Relation 28, Select 6, Text 32, Url 14, Number 7, Boolean 17, Date 15, DateTime 16
make ts-test filter=Dialog        # SubjectEditorDialog 24, SubjectCreatorDialog 57 (parent side unchanged)
make ts-build                     # vue-tsc + vite, clean
make ts-lint                      # clean
```

Mutation-verified the load-bearing cases: emitting a positional counter instead of the violation's own index, coercing/skipping the null index, and letting the field-level clear sweep untouched numeric indices each fail exactly the test that targets them and nothing else.

## Manual Browser Check

Uses the bundled **Validation Demo** schema (open **Validation Clean** → *Data* tab → *Edit* on the subject):

1. **Field-level clear** — set **Score** to `999`. After ~1s the field shows *"Maximum value is 100."* Change it to `50`: the error clears immediately, before the re-validate returns.
2. **Per-index clear** — change one **Tags** (multi-url) entry to a non-http value, e.g. `not a url`. The entry shows *"Please enter a valid URL."* Fix it: the error clears immediately.
3. **Aggregate clear (Select/Relation)** — on any subject with a required Select, the stale error clears the moment you pick a valid option rather than after the next validate round-trip.
4. Confirm no field's error survives the edit that resolves it, and that a *different* still-invalid field keeps its own error.

> <sub>AI-authored — Claude Code, `Opus 4.8 (1M context)`. Started as the narrow Select/Relation fix found during a multi-agent review of #1082, then generalised into the shared composable. Verified by unit + mutation tests, an adversarial multi-agent review, and instrumented in-browser measurement of the optimistic clear (error gone at ~80&nbsp;ms with zero intervening validate calls). Not yet human-reviewed.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
