### PR TITLE
Reseed demo data: delete pages whose source files were removed

### DIFF
--- a/DemoData/AGENTS.md
+++ b/DemoData/AGENTS.md
@@ -18,7 +18,8 @@ partners, knowledge managers, MediaWiki ecosystem evaluators, and live-demo audi
 `ImportDemoData.php` reseeds the demo set: it creates and updates pages from these directories, and
 deletes pages a previous import created whose source file is now gone. So renaming or removing a
 file and re-importing is enough — no `make reinstall-db` needed. Only pages the import itself created
-are pruned; pages created by others (such as `Main_Page`) are left alone even when absent here.
+are pruned; a page someone else created — like `Main_Page`, which the installer creates and the
+import merely overwrites — is never deleted, even if its source file is removed.
 
 ## Filename and ID conventions
 
@@ -144,7 +145,7 @@ From the repo root:
 # whose source files are gone. Enough on its own after renames or deletions.
 make load-test-data
 
-# Full clean-slate reset (drops the wiki database first). Rarely needed now.
+# Full clean-slate reset (drops the wiki database first). Rarely needed.
 make reinstall-db && make load-test-data
 
 # Reproject the Neo4j graph if Cypher results look stale.

--- a/DemoData/AGENTS.md
+++ b/DemoData/AGENTS.md
@@ -15,9 +15,10 @@ partners, knowledge managers, MediaWiki ecosystem evaluators, and live-demo audi
 | `SparqlPage/<Name>.wikitext` | Pages demoing the SPARQL surfaces. Imported only when `$wgNeoWikiSparqlStores` is non-empty (elsewhere `{{#sparql_raw}}` is unregistered and would render literally). | Main namespace, `<Name>` |
 | `Module/<Name>.lua` | Scribunto modules | `Module:<Name>` |
 
-`ImportDemoData.php` is additive: it creates and updates pages but does NOT delete pages whose
-source files were removed. Use `make reinstall-db && make load-test-data` from the repo root for
-a clean-slate import after renames or deletions.
+`ImportDemoData.php` reseeds the demo set: it creates and updates pages from these directories, and
+deletes pages a previous import created whose source file is now gone. So renaming or removing a
+file and re-importing is enough — no `make reinstall-db` needed. Only pages the import itself created
+are pruned; pages created by others (such as `Main_Page`) are left alone even when absent here.
 
 ## Filename and ID conventions
 
@@ -139,10 +140,11 @@ the content.
 From the repo root:
 
 ```sh
-# Incremental import (does not delete removed pages).
+# Reseeds the demo set: creates/updates pages and deletes ones the import previously created
+# whose source files are gone. Enough on its own after renames or deletions.
 make load-test-data
 
-# Clean-slate import (drops the wiki database first). Use after renames or deletions.
+# Full clean-slate reset (drops the wiki database first). Rarely needed now.
 make reinstall-db && make load-test-data
 
 # Reproject the Neo4j graph if Cypher results look stale.

--- a/maintenance/ImportDemoData.php
+++ b/maintenance/ImportDemoData.php
@@ -15,6 +15,8 @@ use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\SchemaContentSource
 use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\SubjectPageSource;
 use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\LayoutContentSource;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\FirstRevisionAuthorPageTitlesLookup;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\MediaWikiPageDeleter;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\PageContentSaver;
 use User;
 
@@ -37,11 +39,23 @@ class ImportDemoData extends Maintenance {
 
 	private function newImportAction(): ImportPagesAction {
 		$user = $this->getUser();
+		$services = MediaWikiServices::getInstance();
 
 		return new ImportPagesAction(
 			presenter: $this->newImportPresenter(),
 			pageContentSaver: new PageContentSaver(
-				wikiPageFactory: MediaWikiServices::getInstance()->getWikiPageFactory(),
+				wikiPageFactory: $services->getWikiPageFactory(),
+				performer: $user,
+			),
+			importedPageTitlesLookup: new FirstRevisionAuthorPageTitlesLookup(
+				db: $this->getPrimaryDB(),
+				actorNormalization: $services->getActorNormalization(),
+				revisionLookup: $services->getRevisionLookup(),
+				titleFactory: $services->getTitleFactory(),
+				importer: $user,
+			),
+			pageDeleter: new MediaWikiPageDeleter(
+				deletePageFactory: $services->getDeletePageFactory(),
 				performer: $user,
 			),
 			schemaContentSource: new SchemaContentSource(
@@ -121,6 +135,18 @@ class ImportDemoData extends Maintenance {
 			}
 
 			public function presentImportFailed( string $pageTitle, string $errorMessage ): void {
+				$this->maintenance->outputChanneled( "FAILED: $errorMessage", $pageTitle );
+			}
+
+			public function presentDeletionStarted( string $pageTitle ): void {
+				$this->maintenance->outputChanneled( "Deleting $pageTitle... ", $pageTitle );
+			}
+
+			public function presentDeleted( string $pageTitle ): void {
+				$this->maintenance->outputChanneled( "done", $pageTitle );
+			}
+
+			public function presentDeletionFailed( string $pageTitle, string $errorMessage ): void {
 				$this->maintenance->outputChanneled( "FAILED: $errorMessage", $pageTitle );
 			}
 

--- a/src/Application/Actions/ImportPages/ImportPagesAction.php
+++ b/src/Application/Actions/ImportPages/ImportPagesAction.php
@@ -10,16 +10,29 @@ use MediaWiki\Content\TextContent;
 use MediaWiki\Content\WikitextContent;
 use MediaWiki\Title\Title;
 use ProfessionalWiki\NeoWiki\EntryPoints\Content\SubjectContent;
+use ProfessionalWiki\NeoWiki\Persistence\ImportedPageTitlesLookup;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\PageContentSaver;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\PageContentSavingStatus;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\MediaWikiSubjectRepository;
+use ProfessionalWiki\NeoWiki\Persistence\PageDeleter;
 use RuntimeException;
 
 class ImportPagesAction {
 
+	private const string DELETION_REASON = 'No longer part of the NeoWiki demo data';
+
+	/**
+	 * @var array<string, true> Prefixed DB keys of the pages this run imported, whether or not the
+	 *   save succeeded. Everything the import owns that is not in this set is a page whose source
+	 *   file is gone, and so gets deleted.
+	 */
+	private array $currentTitleKeys = [];
+
 	public function __construct(
 		private readonly ImportPresenter $presenter,
 		private readonly PageContentSaver $pageContentSaver,
+		private readonly ImportedPageTitlesLookup $importedPageTitlesLookup,
+		private readonly PageDeleter $pageDeleter,
 		private readonly SchemaContentSource $schemaContentSource,
 		private readonly SubjectPageSource $subjectPageSource,
 		private readonly PageContentSource $pageContentSource,
@@ -30,6 +43,8 @@ class ImportPagesAction {
 	}
 
 	public function import(): void {
+		$this->currentTitleKeys = [];
+
 		foreach ( $this->schemaContentSource->getSchemas() as $schemaName => $schemaContent ) {
 			$this->createPage(
 				"Schema:$schemaName",
@@ -85,6 +100,8 @@ class ImportPagesAction {
 			);
 		}
 
+		$this->deleteRemovedPages();
+
 		$this->presenter->presentDone();
 	}
 
@@ -117,6 +134,8 @@ class ImportPagesAction {
 			return;
 		}
 
+		$this->currentTitleKeys[$title->getPrefixedDBkey()] = true;
+
 		$savingResult = $this->pageContentSaver->saveContent(
 			page: $title,
 			contentBySlot: $contentBySlot,
@@ -144,6 +163,29 @@ class ImportPagesAction {
 		}
 
 		throw new RuntimeException();
+	}
+
+	private function deleteRemovedPages(): void {
+		foreach ( $this->importedPageTitlesLookup->getImportedPageTitles() as $title ) {
+			if ( !isset( $this->currentTitleKeys[$title->getPrefixedDBkey()] ) ) {
+				$this->deletePage( $title );
+			}
+		}
+	}
+
+	private function deletePage( Title $title ): void {
+		$prefixedTitle = $title->getPrefixedText();
+
+		$this->presenter->presentDeletionStarted( $prefixedTitle );
+
+		$status = $this->pageDeleter->deletePage( $title->toPageIdentity(), self::DELETION_REASON );
+
+		if ( $status->succeeded ) {
+			$this->presenter->presentDeleted( $prefixedTitle );
+			return;
+		}
+
+		$this->presenter->presentDeletionFailed( $prefixedTitle, $status->errorMessage ?? '' );
 	}
 
 }

--- a/src/Application/Actions/ImportPages/ImportPresenter.php
+++ b/src/Application/Actions/ImportPages/ImportPresenter.php
@@ -16,4 +16,10 @@ interface ImportPresenter {
 
 	public function presentImportFailed( string $pageTitle, string $errorMessage ): void;
 
+	public function presentDeletionStarted( string $pageTitle ): void;
+
+	public function presentDeleted( string $pageTitle ): void;
+
+	public function presentDeletionFailed( string $pageTitle, string $errorMessage ): void;
+
 }

--- a/src/Persistence/ImportedPageTitlesLookup.php
+++ b/src/Persistence/ImportedPageTitlesLookup.php
@@ -1,0 +1,19 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Persistence;
+
+use MediaWiki\Title\Title;
+
+interface ImportedPageTitlesLookup {
+
+	/**
+	 * The titles of the pages a prior import created, so it can tell which of them a new run no
+	 * longer covers and should remove.
+	 *
+	 * @return Title[]
+	 */
+	public function getImportedPageTitles(): array;
+
+}

--- a/src/Persistence/MediaWiki/FirstRevisionAuthorPageTitlesLookup.php
+++ b/src/Persistence/MediaWiki/FirstRevisionAuthorPageTitlesLookup.php
@@ -1,0 +1,79 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Persistence\MediaWiki;
+
+use MediaWiki\Revision\RevisionLookup;
+use MediaWiki\Revision\RevisionRecord;
+use MediaWiki\Title\Title;
+use MediaWiki\Title\TitleFactory;
+use MediaWiki\User\ActorNormalization;
+use MediaWiki\User\UserIdentity;
+use ProfessionalWiki\NeoWiki\Persistence\ImportedPageTitlesLookup;
+use Wikimedia\Rdbms\IReadableDatabase;
+
+/**
+ * Finds the pages the import owns by first-revision authorship: a page whose first revision is the
+ * importer's was created by the import, while one the importer merely edited later was not. This is
+ * why the actor-narrowed candidates are confirmed against the first revision rather than trusting
+ * rev_parent_id being zero.
+ */
+class FirstRevisionAuthorPageTitlesLookup implements ImportedPageTitlesLookup {
+
+	public function __construct(
+		private readonly IReadableDatabase $db,
+		private readonly ActorNormalization $actorNormalization,
+		private readonly RevisionLookup $revisionLookup,
+		private readonly TitleFactory $titleFactory,
+		private readonly UserIdentity $importer,
+	) {
+	}
+
+	/**
+	 * @return Title[]
+	 */
+	public function getImportedPageTitles(): array {
+		$actorId = $this->actorNormalization->findActorId( $this->importer, $this->db );
+
+		if ( $actorId === null ) {
+			return [];
+		}
+
+		$titles = [];
+
+		foreach ( $this->getPageIdsAuthoredBy( $actorId ) as $pageId ) {
+			$title = $this->titleFactory->newFromID( $pageId );
+
+			if ( $title !== null && $this->firstRevisionIsByImporter( $title ) ) {
+				$titles[] = $title;
+			}
+		}
+
+		return $titles;
+	}
+
+	/**
+	 * @return int[] Ids of the still-existing pages the importer authored any revision of.
+	 */
+	private function getPageIdsAuthoredBy( int $actorId ): array {
+		$pageIds = $this->db->newSelectQueryBuilder()
+			->select( 'rev_page' )
+			->distinct()
+			->from( 'revision' )
+			->where( [ 'rev_actor' => $actorId ] )
+			->orderBy( 'rev_page' )
+			->caller( __METHOD__ )
+			->fetchFieldValues();
+
+		return array_map( 'intval', $pageIds );
+	}
+
+	private function firstRevisionIsByImporter( Title $title ): bool {
+		$firstRevision = $this->revisionLookup->getFirstRevision( $title );
+
+		return $firstRevision !== null
+			&& $this->importer->equals( $firstRevision->getUser( RevisionRecord::RAW ) );
+	}
+
+}

--- a/src/Persistence/MediaWiki/MediaWikiPageDeleter.php
+++ b/src/Persistence/MediaWiki/MediaWikiPageDeleter.php
@@ -1,0 +1,33 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Persistence\MediaWiki;
+
+use MediaWiki\Page\DeletePageFactory;
+use MediaWiki\Page\ProperPageIdentity;
+use MediaWiki\Permissions\Authority;
+use ProfessionalWiki\NeoWiki\Persistence\PageDeleter;
+use ProfessionalWiki\NeoWiki\Persistence\PageDeletionStatus;
+
+class MediaWikiPageDeleter implements PageDeleter {
+
+	public function __construct(
+		private readonly DeletePageFactory $deletePageFactory,
+		private readonly Authority $performer,
+	) {
+	}
+
+	public function deletePage( ProperPageIdentity $page, string $reason ): PageDeletionStatus {
+		$status = $this->deletePageFactory
+			->newDeletePage( $page, $this->performer )
+			->deleteUnsafe( $reason );
+
+		if ( $status->isGood() ) {
+			return new PageDeletionStatus( true );
+		}
+
+		return new PageDeletionStatus( false, $status->getWikiText() );
+	}
+
+}

--- a/src/Persistence/PageDeleter.php
+++ b/src/Persistence/PageDeleter.php
@@ -1,0 +1,13 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Persistence;
+
+use MediaWiki\Page\ProperPageIdentity;
+
+interface PageDeleter {
+
+	public function deletePage( ProperPageIdentity $page, string $reason ): PageDeletionStatus;
+
+}

--- a/src/Persistence/PageDeletionStatus.php
+++ b/src/Persistence/PageDeletionStatus.php
@@ -1,0 +1,15 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Persistence;
+
+class PageDeletionStatus {
+
+	public function __construct(
+		public readonly bool $succeeded,
+		public readonly ?string $errorMessage = null,
+	) {
+	}
+
+}

--- a/tests/phpunit/Application/Actions/ImportPagesActionTest.php
+++ b/tests/phpunit/Application/Actions/ImportPagesActionTest.php
@@ -13,7 +13,9 @@ use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\SchemaContentSource
 use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\SubjectPageData;
 use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\SubjectPageSource;
 use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\LayoutContentSource;
+use ProfessionalWiki\NeoWiki\Persistence\ImportedPageTitlesLookup;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\PageContentSaver;
+use ProfessionalWiki\NeoWiki\Persistence\PageDeleter;
 use MediaWiki\Content\WikitextContent;
 
 /**
@@ -46,6 +48,8 @@ class ImportPagesActionTest extends \MediaWikiIntegrationTestCase {
 				MediaWikiServices::getInstance()->getWikiPageFactory(),
 				$this->getTestUser()->getUser(),
 			),
+			$this->createMock( ImportedPageTitlesLookup::class ),
+			$this->createMock( PageDeleter::class ),
 			$this->schemaContentSource,
 			$this->subjectPageSource,
 			$this->pageContentSource,
@@ -135,6 +139,18 @@ class ImportPagesActionTest extends \MediaWikiIntegrationTestCase {
 
 			public function presentImportFailed( string $pageTitle, string $errorMessage ): void {
 				$this->messages[] = "Import failed for $pageTitle: $errorMessage";
+			}
+
+			public function presentDeletionStarted( string $pageTitle ): void {
+				$this->messages[] = "Deleting $pageTitle...";
+			}
+
+			public function presentDeleted( string $pageTitle ): void {
+				$this->messages[] = "Deleted $pageTitle";
+			}
+
+			public function presentDeletionFailed( string $pageTitle, string $errorMessage ): void {
+				$this->messages[] = "Deletion failed for $pageTitle: $errorMessage";
 			}
 
 			/**

--- a/tests/phpunit/Application/Actions/ImportPagesDeletionTest.php
+++ b/tests/phpunit/Application/Actions/ImportPagesDeletionTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Application\Actions;
+
+use MediaWiki\CommentStore\CommentStoreComment;
+use MediaWiki\Page\PageIdentity;
+use MediaWiki\Page\ProperPageIdentity;
+use MediaWiki\Page\WikiPageFactory;
+use MediaWiki\Permissions\Authority;
+use MediaWiki\Title\Title;
+use MediaWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\ImportPagesAction;
+use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\ImportPresenter;
+use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\LayoutContentSource;
+use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\MappingContentSource;
+use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\PageContentSource;
+use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\SchemaContentSource;
+use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\SubjectPageSource;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+use ProfessionalWiki\NeoWiki\Persistence\ImportedPageTitlesLookup;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\PageContentSaver;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\PageContentSavingStatus;
+use ProfessionalWiki\NeoWiki\Persistence\PageDeleter;
+use ProfessionalWiki\NeoWiki\Persistence\PageDeletionStatus;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\ImportPresenterSpy;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\PageDeleterSpy;
+
+/**
+ * Covers how the import prunes pages it previously created once their source files are gone. The
+ * managed-set discovery itself lives in FirstRevisionAuthorPageTitlesLookupTest; here that lookup is
+ * a fake so the deletion decision can be tested against controlled managed and current sets.
+ *
+ * @covers \ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\ImportPagesAction
+ * @group Database
+ */
+class ImportPagesDeletionTest extends MediaWikiIntegrationTestCase {
+
+	public function testPageNoLongerInTheSourceIsDeleted(): void {
+		$deleter = $this->newPageDeleterSpy();
+
+		$this->runImport(
+			importedTitles: [ Title::newFromText( 'Kept' ), Title::newFromText( 'Removed' ) ],
+			currentPageFiles: [ 'Kept.wikitext' => 'still here' ],
+			deleter: $deleter,
+		);
+
+		$this->assertSame( [ 'Removed' ], $deleter->deletedKeys );
+	}
+
+	public function testDeletionIsReportedToThePresenter(): void {
+		$presenter = $this->newPresenterSpy();
+
+		$this->runImport(
+			importedTitles: [ Title::newFromText( 'Removed' ) ],
+			currentPageFiles: [],
+			presenter: $presenter,
+		);
+
+		$this->assertSame( [ 'Removed' ], $presenter->deletionsStarted );
+		$this->assertSame( [ 'Removed' ], $presenter->deleted );
+	}
+
+	public function testUnchangedSourceSetDeletesNothing(): void {
+		$deleter = $this->newPageDeleterSpy();
+
+		$this->runImport(
+			importedTitles: [ Title::newFromText( 'First' ), Title::newFromText( 'Second' ) ],
+			currentPageFiles: [ 'First.wikitext' => 'a', 'Second.wikitext' => 'b' ],
+			deleter: $deleter,
+		);
+
+		$this->assertSame( [], $deleter->deletedKeys );
+	}
+
+	public function testPageWhoseImportFailedThisRunIsNotDeleted(): void {
+		$deleter = $this->newPageDeleterSpy();
+		$presenter = $this->newPresenterSpy();
+
+		$this->runImport(
+			importedTitles: [ Title::newFromText( 'Flaky' ) ],
+			currentPageFiles: [ 'Flaky.wikitext' => 'content that fails to save' ],
+			deleter: $deleter,
+			presenter: $presenter,
+			titlesThatFailToSave: [ 'Flaky' ],
+		);
+
+		$this->assertSame( [ 'Flaky' ], $presenter->importFailures, 'the save should have failed' );
+		$this->assertSame( [], $deleter->deletedKeys, 'a failed save must not cascade into a deletion' );
+	}
+
+	public function testDeletionFailureIsReported(): void {
+		$presenter = $this->newPresenterSpy();
+
+		$this->runImport(
+			importedTitles: [ Title::newFromText( 'Removed' ) ],
+			currentPageFiles: [],
+			deleter: $this->newFailingPageDeleter( 'the page could not be deleted' ),
+			presenter: $presenter,
+		);
+
+		$this->assertSame( [ 'Removed' ], $presenter->deletionFailures );
+		$this->assertSame( [], $presenter->deleted );
+	}
+
+	/**
+	 * @param Title[] $importedTitles The managed set the lookup reports.
+	 * @param array<string, string> $currentPageFiles Page source files (name => content) for this run.
+	 * @param string[] $titlesThatFailToSave DB keys whose save the saver should reject.
+	 */
+	private function runImport(
+		array $importedTitles,
+		array $currentPageFiles,
+		?PageDeleter $deleter = null,
+		?ImportPresenter $presenter = null,
+		array $titlesThatFailToSave = [],
+	): void {
+		$pageContentSource = $this->createMock( PageContentSource::class );
+		$pageContentSource->method( 'getPageContentStrings' )->willReturn( $currentPageFiles );
+
+		( new ImportPagesAction(
+			presenter: $presenter ?? $this->newPresenterSpy(),
+			pageContentSaver: $this->newPageContentSaver( ...$titlesThatFailToSave ),
+			importedPageTitlesLookup: $this->newImportedPageTitlesLookup( ...$importedTitles ),
+			pageDeleter: $deleter ?? $this->newPageDeleterSpy(),
+			schemaContentSource: $this->createMock( SchemaContentSource::class ),
+			subjectPageSource: $this->createMock( SubjectPageSource::class ),
+			pageContentSource: $pageContentSource,
+			moduleContentSource: $this->createMock( PageContentSource::class ),
+			layoutContentSource: $this->createMock( LayoutContentSource::class ),
+			mappingContentSource: $this->createMock( MappingContentSource::class ),
+		) )->import();
+	}
+
+	private function newImportedPageTitlesLookup( Title ...$titles ): ImportedPageTitlesLookup {
+		return new class( $titles ) implements ImportedPageTitlesLookup {
+
+			/**
+			 * @param Title[] $titles
+			 */
+			public function __construct(
+				private readonly array $titles
+			) {
+			}
+
+			public function getImportedPageTitles(): array {
+				return $this->titles;
+			}
+
+		};
+	}
+
+	/**
+	 * A saver that persists nothing and simply reports the outcome the test asked for, so the action's
+	 * deletion decision can be exercised without touching the database.
+	 */
+	private function newPageContentSaver( string ...$failingKeys ): PageContentSaver {
+		return new class(
+			$this->createMock( WikiPageFactory::class ),
+			$this->createMock( Authority::class ),
+			$failingKeys
+		) extends PageContentSaver {
+
+			/**
+			 * @param string[] $failingKeys
+			 */
+			public function __construct(
+				WikiPageFactory $wikiPageFactory,
+				Authority $performer,
+				private readonly array $failingKeys
+			) {
+				parent::__construct( $wikiPageFactory, $performer );
+			}
+
+			public function saveContent( PageIdentity|PageId $page, array $contentBySlot, CommentStoreComment $comment ): PageContentSavingStatus {
+				if ( $page instanceof PageIdentity && in_array( $page->getDBkey(), $this->failingKeys, true ) ) {
+					return new PageContentSavingStatus( PageContentSavingStatus::ERROR, 'forced failure' );
+				}
+
+				return new PageContentSavingStatus( PageContentSavingStatus::REVISION_CREATED );
+			}
+
+		};
+	}
+
+	private function newPageDeleterSpy(): PageDeleterSpy {
+		return new PageDeleterSpy();
+	}
+
+	private function newFailingPageDeleter( string $errorMessage ): PageDeleter {
+		return new class( $errorMessage ) implements PageDeleter {
+
+			public function __construct(
+				private readonly string $errorMessage
+			) {
+			}
+
+			public function deletePage( ProperPageIdentity $page, string $reason ): PageDeletionStatus {
+				return new PageDeletionStatus( false, $this->errorMessage );
+			}
+
+		};
+	}
+
+	private function newPresenterSpy(): ImportPresenterSpy {
+		return new ImportPresenterSpy();
+	}
+
+}

--- a/tests/phpunit/Persistence/MediaWiki/FirstRevisionAuthorPageTitlesLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/FirstRevisionAuthorPageTitlesLookupTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Persistence\MediaWiki;
+
+use MediaWiki\CommentStore\CommentStoreComment;
+use MediaWiki\Content\WikitextContent;
+use MediaWiki\Permissions\Authority;
+use MediaWiki\Title\Title;
+use MediaWiki\User\UserIdentity;
+use MediaWiki\User\UserIdentityValue;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\FirstRevisionAuthorPageTitlesLookup;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+use User;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Persistence\MediaWiki\FirstRevisionAuthorPageTitlesLookup
+ * @group Database
+ */
+class FirstRevisionAuthorPageTitlesLookupTest extends NeoWikiIntegrationTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->markPageTableAsUsed();
+	}
+
+	public function testReturnsAPageTheImporterCreated(): void {
+		$this->editAs( $this->importer(), 'Importer page', 'created by the importer' );
+
+		$this->assertSame( [ 'Importer page' ], $this->importedTitleTexts() );
+	}
+
+	public function testExcludesPagesCreatedByAnotherUser(): void {
+		$this->editAs( $this->otherUser(), 'Third party page', 'created by another user' );
+		$this->editAs( $this->importer(), 'Importer page', 'created by the importer' );
+
+		$this->assertSame( [ 'Importer page' ], $this->importedTitleTexts() );
+	}
+
+	public function testExcludesPagesTheImporterOnlyEditedLater(): void {
+		$this->editAs( $this->otherUser(), 'Community page', 'first revision by another user' );
+		$this->editAs( $this->importer(), 'Community page', 'importer edits it afterwards' );
+		$this->editAs( $this->importer(), 'Importer page', 'created by the importer' );
+
+		$this->assertSame( [ 'Importer page' ], $this->importedTitleTexts() );
+	}
+
+	public function testExcludesPagesThatNoLongerExist(): void {
+		$this->editAs( $this->importer(), 'Temporary page', 'created by the importer' );
+		$this->editAs( $this->importer(), 'Surviving page', 'also created by the importer' );
+		$this->deletePageByName( 'Temporary page' );
+
+		$this->assertSame( [ 'Surviving page' ], $this->importedTitleTexts() );
+	}
+
+	public function testReturnsNothingForAnImporterThatHasAuthoredNoPages(): void {
+		$this->editAs( $this->otherUser(), 'Someone elses page', 'created by another user' );
+
+		$ghostImporter = UserIdentityValue::newRegistered( 424242, 'Ghost importer' );
+
+		$this->assertSame( [], $this->newLookup( $ghostImporter )->getImportedPageTitles() );
+	}
+
+	/**
+	 * @return string[]
+	 */
+	private function importedTitleTexts(): array {
+		return array_map(
+			static fn ( Title $title ): string => $title->getPrefixedText(),
+			$this->newLookup( $this->importer() )->getImportedPageTitles()
+		);
+	}
+
+	private function newLookup( UserIdentity $importer ): FirstRevisionAuthorPageTitlesLookup {
+		$services = $this->getServiceContainer();
+
+		return new FirstRevisionAuthorPageTitlesLookup(
+			db: $this->getDb(),
+			actorNormalization: $services->getActorNormalization(),
+			revisionLookup: $services->getRevisionLookup(),
+			titleFactory: $services->getTitleFactory(),
+			importer: $importer,
+		);
+	}
+
+	private function importer(): User {
+		return User::newSystemUser( 'NeoWikiImportTest', [ 'steal' => true ] );
+	}
+
+	private function otherUser(): User {
+		return $this->getTestUser()->getUser();
+	}
+
+	private function editAs( Authority $performer, string $pageName, string $text ): void {
+		$wikiPage = $this->getServiceContainer()->getWikiPageFactory()->newFromTitle( Title::newFromText( $pageName ) );
+
+		$updater = $wikiPage->newPageUpdater( $performer );
+		$updater->setContent( 'main', new WikitextContent( $text ) );
+		$updater->saveRevision( CommentStoreComment::newUnsavedComment( 'test edit' ) );
+	}
+
+	private function deletePageByName( string $pageName ): void {
+		$page = $this->getServiceContainer()->getWikiPageFactory()->newFromTitle( Title::newFromText( $pageName ) );
+
+		$this->getServiceContainer()->getDeletePageFactory()
+			->newDeletePage( $page, $this->getTestSysop()->getUser() )
+			->deleteUnsafe( 'test cleanup' );
+	}
+
+}

--- a/tests/phpunit/Persistence/MediaWiki/MediaWikiPageDeleterTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/MediaWikiPageDeleterTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Persistence\MediaWiki;
+
+use MediaWiki\Title\Title;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\MediaWikiPageDeleter;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Persistence\MediaWiki\MediaWikiPageDeleter
+ * @group Database
+ */
+class MediaWikiPageDeleterTest extends NeoWikiIntegrationTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->markPageTableAsUsed();
+	}
+
+	public function testDeletesAnExistingPage(): void {
+		$title = $this->insertPage( 'Page to delete', 'content' )['title'];
+
+		$status = $this->newDeleter()->deletePage( $title->toPageIdentity(), 'no longer needed' );
+
+		$this->assertTrue( $status->succeeded );
+		$this->assertFalse(
+			$this->getServiceContainer()->getWikiPageFactory()->newFromTitle( $title )->exists(),
+			'the page should be gone after deletion'
+		);
+	}
+
+	public function testReportsFailureWhenThePageCannotBeDeleted(): void {
+		$missingPage = Title::newFromText( 'Never created' )->toPageIdentity();
+
+		$status = $this->newDeleter()->deletePage( $missingPage, 'no longer needed' );
+
+		$this->assertFalse( $status->succeeded );
+		$this->assertNotNull( $status->errorMessage );
+	}
+
+	private function newDeleter(): MediaWikiPageDeleter {
+		return new MediaWikiPageDeleter(
+			$this->getServiceContainer()->getDeletePageFactory(),
+			$this->getTestSysop()->getUser(),
+		);
+	}
+
+}

--- a/tests/phpunit/TestDoubles/ImportPresenterSpy.php
+++ b/tests/phpunit/TestDoubles/ImportPresenterSpy.php
@@ -1,0 +1,74 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\TestDoubles;
+
+use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\ImportPresenter;
+
+class ImportPresenterSpy implements ImportPresenter {
+
+	/**
+	 * @var string[]
+	 */
+	public array $created = [];
+
+	/**
+	 * @var string[]
+	 */
+	public array $noChanges = [];
+
+	/**
+	 * @var string[]
+	 */
+	public array $importFailures = [];
+
+	/**
+	 * @var string[]
+	 */
+	public array $deletionsStarted = [];
+
+	/**
+	 * @var string[]
+	 */
+	public array $deleted = [];
+
+	/**
+	 * @var string[]
+	 */
+	public array $deletionFailures = [];
+
+	public bool $done = false;
+
+	public function presentDone(): void {
+		$this->done = true;
+	}
+
+	public function presentImportStarted( string $pageTitle ): void {
+	}
+
+	public function presentCreatedRevision( string $pageTitle ): void {
+		$this->created[] = $pageTitle;
+	}
+
+	public function presentNoChanges( string $pageTitle ): void {
+		$this->noChanges[] = $pageTitle;
+	}
+
+	public function presentImportFailed( string $pageTitle, string $errorMessage ): void {
+		$this->importFailures[] = $pageTitle;
+	}
+
+	public function presentDeletionStarted( string $pageTitle ): void {
+		$this->deletionsStarted[] = $pageTitle;
+	}
+
+	public function presentDeleted( string $pageTitle ): void {
+		$this->deleted[] = $pageTitle;
+	}
+
+	public function presentDeletionFailed( string $pageTitle, string $errorMessage ): void {
+		$this->deletionFailures[] = $pageTitle;
+	}
+
+}

--- a/tests/phpunit/TestDoubles/PageDeleterSpy.php
+++ b/tests/phpunit/TestDoubles/PageDeleterSpy.php
@@ -1,0 +1,24 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\TestDoubles;
+
+use MediaWiki\Page\ProperPageIdentity;
+use ProfessionalWiki\NeoWiki\Persistence\PageDeleter;
+use ProfessionalWiki\NeoWiki\Persistence\PageDeletionStatus;
+
+class PageDeleterSpy implements PageDeleter {
+
+	/**
+	 * @var string[] DB keys of the pages the action asked to delete, in order.
+	 */
+	public array $deletedKeys = [];
+
+	public function deletePage( ProperPageIdentity $page, string $reason ): PageDeletionStatus {
+		$this->deletedKeys[] = $page->getDBkey();
+
+		return new PageDeletionStatus( true );
+	}
+
+}


### PR DESCRIPTION
`maintenance/ImportDemoData.php` only created and updated pages from the `DemoData/`
file tree. When a source file was removed or renamed, the previously imported wiki page
lingered forever, and the only remedy was a full `make reinstall-db`. The import now also
deletes previously imported pages whose source files no longer exist, so a re-import fully
reseeds the demo set — renames included.

## Managed set: first-revision authorship

The pages the import may delete are exactly those whose *first* revision was authored by
the `NeoWiki` system user the maintenance script imports as. That user is used only by this
script, so first-revision authorship precisely identifies importer-created pages. Pages
created by someone else and merely overwritten by the import (for example `Main_Page`,
created by the installer) are never deleted.

This managed set is derived from the wiki itself, which is why there is no repo-side
tombstone or manifest list: nothing to keep in sync or forget to update, and renames are
handled automatically — the old title is absent from the current run and gets deleted, the
new title is created.

## Current set and deletion

The current run records every title it imports (across the main, `Schema:`, `Layout:`,
`Module:` and `Mapping:` namespaces), reusing the action's existing title derivation.
Attempted imports count as current even when the save fails, so a transient save error
never cascades into deleting the page. After the import pass, pages in the managed set but
not the current set are deleted through MediaWiki's `DeletePage` machinery, performed as
the same system user with a clear reason. Normal deletion hooks run, so the graph
projection (Neo4j / SPARQL) stays in sync.

There is no opt-in flag: this is dev/demo tooling with reseed semantics and the managed-set
identification is precise. One intended consequence: on a wiki without SPARQL stores
configured, `DemoData/SparqlPage/` files are not imported, so SPARQL demo pages left by an
earlier SPARQL-enabled run are pruned there — which is correct, since `{{#sparql_raw}}`
would render as literal wikitext on such a wiki.

## Structure

Following the extension's hexagonal layering, `ImportPagesAction` gains two collaborator
ports — `ImportedPageTitlesLookup` (find previously imported page titles) and `PageDeleter`
(delete a page) — with MediaWiki implementations in `src/Persistence/MediaWiki/`. The
managed-set implementation narrows candidates to the importer's actor via the `revision`
table, then confirms each with `RevisionLookup::getFirstRevision()` rather than trusting
`rev_parent_id`. `ImportPresenter` gains deletion-progress methods wired to the maintenance
output; the maintenance script wires everything.

Covered by an orchestration test (delete what is removed, keep what is current, do not
delete on a save failure, delete nothing when unchanged, report deletion failures) and
integration tests for the managed-set lookup (first-revision discrimination, deleted and
never-authored pages) and the page deleter.

> <sub>AI-authored — Claude Code, `Opus 4.8 (max)`; detailed spec from @JeroenDeDauw, executed end-to-end without human redirection; diff not yet human-reviewed; tests written and run locally (full suite green: 1861 passing), phpcs + phpstan green, live-verified in the dev stack (file removal reseeds the page and purges its graph node, siblings survive); CI green.</sub>
