### PR TITLE
Reject NeoWikiSubject as a page main content model

### DIFF
--- a/src/EntryPoints/Content/SubjectContentHandler.php
+++ b/src/EntryPoints/Content/SubjectContentHandler.php
@@ -7,6 +7,7 @@ namespace ProfessionalWiki\NeoWiki\EntryPoints\Content;
 use MediaWiki\Content\Content;
 use MediaWiki\Content\JsonContentHandler;
 use MediaWiki\Content\Renderer\ContentParseParams;
+use MediaWiki\Title\Title;
 use MediaWiki\Parser\ParserOutput;
 
 class SubjectContentHandler extends JsonContentHandler {
@@ -25,6 +26,15 @@ class SubjectContentHandler extends JsonContentHandler {
 		ParserOutput &$parserOutput
 	): void {
 		$parserOutput->setRawText( '' );
+	}
+
+	/**
+	 * Subject content is only ever valid inside the dedicated subject slot, whose fixed content model is
+	 * enforced by the slot role rather than by this method. It is never a page's main content model, so
+	 * it must not be selectable as one.
+	 */
+	public function canBeUsedOn( Title $title ): bool {
+		return false;
 	}
 
 }

--- a/tests/phpunit/EntryPoints/Content/SubjectContentHandlerCanBeUsedOnTest.php
+++ b/tests/phpunit/EntryPoints/Content/SubjectContentHandlerCanBeUsedOnTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\Content;
+
+use MediaWiki\Page\PageIdentity;
+use MediaWiki\Revision\SlotRecord;
+use MediaWiki\Title\Title;
+use MediaWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\EntryPoints\Content\SubjectContent;
+use ProfessionalWiki\NeoWiki\EntryPoints\Content\SubjectContentHandler;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\MediaWikiSubjectRepository;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\Content\SubjectContentHandler
+ * @group Database
+ */
+class SubjectContentHandlerCanBeUsedOnTest extends MediaWikiIntegrationTestCase {
+
+	private function canBeUsedOn( int $namespace ): bool {
+		return ( new SubjectContentHandler( SubjectContent::CONTENT_MODEL_ID ) )
+			->canBeUsedOn( Title::makeTitle( $namespace, 'Subject page' ) );
+	}
+
+	public function testCannotBeUsedAsMainContentModelOfContentPages(): void {
+		$this->assertFalse( $this->canBeUsedOn( NS_MAIN ) );
+		$this->assertFalse( $this->canBeUsedOn( NS_HELP ) );
+	}
+
+	public function testMainSlotRejectsTheSubjectContentModel(): void {
+		$handler = $this->getServiceContainer()->getSlotRoleRegistry()->getRoleHandler( SlotRecord::MAIN );
+
+		$this->assertFalse( $handler->isAllowedModel( SubjectContent::CONTENT_MODEL_ID, $this->page() ) );
+	}
+
+	public function testSubjectSlotStillAcceptsTheSubjectContentModel(): void {
+		$handler = $this->getServiceContainer()->getSlotRoleRegistry()->getRoleHandler( MediaWikiSubjectRepository::SLOT_NAME );
+
+		$this->assertTrue( $handler->isAllowedModel( SubjectContent::CONTENT_MODEL_ID, $this->page() ) );
+	}
+
+	private function page(): PageIdentity {
+		return Title::makeTitle( NS_MAIN, 'Subject page' )->toPageIdentity();
+	}
+
+}


### PR DESCRIPTION
`SubjectContentHandler` inherited the permissive default `canBeUsedOn()`, which
returns true for any title. Because MediaWiki grants `editcontentmodel` to
logged-in users by default, a user could set an arbitrary page's main content
model to `NeoWikiSubject`, producing an orphan page that is not projected to the
graph and renders blank.

`NeoWikiSubject` is only ever valid inside the dedicated subject slot ("neo"),
whose content model is fixed by its slot role via `defineRoleWithModel`. That
slot role compares the model directly and never consults `canBeUsedOn`, so
overriding it to return false locks the model out of every main-content-model
path (the content-model change UI, the edit API, page moves, and imports)
without affecting subject slot writes.

> <sub>AI-authored — Claude Code, `Opus 4.8 (max)`; detailed spec from @JeroenDeDauw, no revisions; diff not yet human-reviewed; TDD (tests seen failing before the fix), full PHPUnit suite (1906) and phpcs+phpstan green locally, CI green; AI-reviewed (mutation + read-only code review), no blocking findings.</sub>
