### PR TITLE
Drive JSON-namespace content-model lock from a single map

### DIFF
--- a/src/EntryPoints/Content/LayoutContentHandler.php
+++ b/src/EntryPoints/Content/LayoutContentHandler.php
@@ -12,7 +12,6 @@ use MediaWiki\Content\ValidationParams;
 use MediaWiki\Title\Title;
 use MediaWiki\Parser\ParserOutput;
 use ProfessionalWiki\NeoWiki\Domain\Layout\LayoutName;
-use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\LayoutContentValidator;
 use StatusValue;
 
@@ -69,7 +68,7 @@ JSON
 	}
 
 	public function canBeUsedOn( Title $title ): bool {
-		return $title->getNamespace() === NeoWikiExtension::NS_LAYOUT;
+		return NamespaceContentModels::forNamespace( $title->getNamespace() ) === LayoutContent::CONTENT_MODEL_ID;
 	}
 
 }

--- a/src/EntryPoints/Content/MappingContentHandler.php
+++ b/src/EntryPoints/Content/MappingContentHandler.php
@@ -10,7 +10,6 @@ use MediaWiki\Content\JsonContentHandler;
 use MediaWiki\Content\ValidationParams;
 use MediaWiki\Title\Title;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\MappingName;
-use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\MappingContentValidator;
 use StatusValue;
 
@@ -61,7 +60,7 @@ JSON
 	}
 
 	public function canBeUsedOn( Title $title ): bool {
-		return $title->getNamespace() === NeoWikiExtension::NS_MAPPING;
+		return NamespaceContentModels::forNamespace( $title->getNamespace() ) === MappingContent::CONTENT_MODEL_ID;
 	}
 
 }

--- a/src/EntryPoints/Content/NamespaceContentModels.php
+++ b/src/EntryPoints/Content/NamespaceContentModels.php
@@ -1,0 +1,34 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\EntryPoints\Content;
+
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+
+/**
+ * The single source of truth binding each of NeoWiki's JSON namespaces to the one content model it is
+ * locked to. Both the ContentModelCanBeUsedOn hook and the content handlers derive their lock from this
+ * map, so a namespace added here is protected everywhere at once instead of in several hand-kept lists.
+ */
+class NamespaceContentModels {
+
+	/**
+	 * @return array<int, string> Namespace id => content model id.
+	 */
+	public static function map(): array {
+		return [
+			NeoWikiExtension::NS_SCHEMA => SchemaContent::CONTENT_MODEL_ID,
+			NeoWikiExtension::NS_LAYOUT => LayoutContent::CONTENT_MODEL_ID,
+			NeoWikiExtension::NS_MAPPING => MappingContent::CONTENT_MODEL_ID,
+		];
+	}
+
+	/**
+	 * The content model the given namespace is locked to, or null when the namespace is not one of NeoWiki's.
+	 */
+	public static function forNamespace( int $namespace ): ?string {
+		return self::map()[$namespace] ?? null;
+	}
+
+}

--- a/src/EntryPoints/Content/SchemaContentHandler.php
+++ b/src/EntryPoints/Content/SchemaContentHandler.php
@@ -12,7 +12,6 @@ use MediaWiki\Content\ValidationParams;
 use MediaWiki\Title\Title;
 use MediaWiki\Parser\ParserOutput;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
-use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\SchemaContentValidator;
 use StatusValue;
 
@@ -70,7 +69,7 @@ JSON
 	}
 
 	public function canBeUsedOn( Title $title ): bool {
-		return $title->getNamespace() === NeoWikiExtension::NS_SCHEMA;
+		return NamespaceContentModels::forNamespace( $title->getNamespace() ) === SchemaContent::CONTENT_MODEL_ID;
 	}
 
 }

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -23,6 +23,7 @@ use ProfessionalWiki\NeoWiki\EntryPoints\Content\SchemaContent;
 use ProfessionalWiki\NeoWiki\EntryPoints\Content\SubjectContent;
 use ProfessionalWiki\NeoWiki\EntryPoints\Content\LayoutContent;
 use ProfessionalWiki\NeoWiki\EntryPoints\Content\MappingContent;
+use ProfessionalWiki\NeoWiki\EntryPoints\Content\NamespaceContentModels;
 use ProfessionalWiki\NeoWiki\Application\SubjectResolver;
 use ProfessionalWiki\NeoWiki\EntryPoints\Actions\SubjectsAction;
 use ProfessionalWiki\NeoWiki\EntryPoints\Scribunto\ScribuntoLuaLibrary;
@@ -260,16 +261,10 @@ class NeoWikiHooks {
 	}
 
 	public static function onContentModelCanBeUsedOn( string $modelId, Title $title, bool &$ok ): void {
-		if ( $title->getNamespace() === NeoWikiExtension::NS_SCHEMA ) {
-			$ok = $modelId === SchemaContent::CONTENT_MODEL_ID;
-		}
+		$expectedModel = NamespaceContentModels::forNamespace( $title->getNamespace() );
 
-		if ( $title->getNamespace() === NeoWikiExtension::NS_LAYOUT ) {
-			$ok = $modelId === LayoutContent::CONTENT_MODEL_ID;
-		}
-
-		if ( $title->getNamespace() === NeoWikiExtension::NS_MAPPING ) {
-			$ok = $modelId === MappingContent::CONTENT_MODEL_ID;
+		if ( $expectedModel !== null ) {
+			$ok = $modelId === $expectedModel;
 		}
 	}
 

--- a/tests/phpunit/EntryPoints/ContentModelNamespaceLockTest.php
+++ b/tests/phpunit/EntryPoints/ContentModelNamespaceLockTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints;
+
+use MediaWiki\CommentStore\CommentStoreComment;
+use MediaWiki\Content\WikitextContent;
+use MediaWiki\Revision\SlotRecord;
+use MediaWiki\Title\Title;
+use MediaWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\EntryPoints\Content\NamespaceContentModels;
+use ProfessionalWiki\NeoWiki\EntryPoints\Content\SchemaContent;
+use ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiHooks;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+
+/**
+ * NeoWiki's JSON namespaces (Schema, Layout, Mapping) are each locked to a single content model.
+ * The lock is enforced by the ContentModelCanBeUsedOn hook and by the content handlers, both driven
+ * by the same NamespaceContentModels map, so these tests iterate that map instead of hard-coding the
+ * pairs. That way a namespace added to the map is automatically exercised here too.
+ *
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiHooks::onContentModelCanBeUsedOn
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\Content\NamespaceContentModels
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\Content\SchemaContentHandler::canBeUsedOn
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\Content\LayoutContentHandler::canBeUsedOn
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\Content\MappingContentHandler::canBeUsedOn
+ * @group Database
+ */
+class ContentModelNamespaceLockTest extends MediaWikiIntegrationTestCase {
+
+	/**
+	 * The concrete namespace/model pairs are pinned here with literal model ids, not derived from the map,
+	 * so this catches a wrong or swapped binding that the map-driven tests below (which read their expected
+	 * model from the same map) cannot.
+	 */
+	public function testLocksEachJsonNamespaceToItsContentModel(): void {
+		$this->assertSame(
+			[
+				NeoWikiExtension::NS_SCHEMA => 'NeoWikiSchema',
+				NeoWikiExtension::NS_LAYOUT => 'NeoWikiLayout',
+				NeoWikiExtension::NS_MAPPING => 'NeoWikiMapping',
+			],
+			NamespaceContentModels::map()
+		);
+	}
+
+	/**
+	 * @dataProvider namespaceAndModelProvider
+	 */
+	public function testNamespaceAllowsItsOwnContentModel( int $namespace, string $model ): void {
+		$ok = false;
+
+		NeoWikiHooks::onContentModelCanBeUsedOn( $model, Title::makeTitle( $namespace, 'Example' ), $ok );
+
+		$this->assertTrue( $ok );
+	}
+
+	/**
+	 * @dataProvider neoWikiNamespaceProvider
+	 */
+	public function testNamespaceRejectsWikitext( int $namespace ): void {
+		$ok = true;
+
+		NeoWikiHooks::onContentModelCanBeUsedOn( CONTENT_MODEL_WIKITEXT, Title::makeTitle( $namespace, 'Example' ), $ok );
+
+		$this->assertFalse( $ok );
+	}
+
+	/**
+	 * A foreign NeoWiki model (e.g. NeoWikiLayout in the Schema namespace) must be rejected too, so the
+	 * lock cannot be satisfied by any NeoWiki model regardless of the namespace it belongs to.
+	 *
+	 * @dataProvider foreignNeoWikiModelProvider
+	 */
+	public function testNamespaceRejectsForeignNeoWikiContentModels( int $namespace, string $foreignModel ): void {
+		$ok = true;
+
+		NeoWikiHooks::onContentModelCanBeUsedOn( $foreignModel, Title::makeTitle( $namespace, 'Example' ), $ok );
+
+		$this->assertFalse( $ok );
+	}
+
+	public function testLeavesForeignNamespaceDecisionUnchanged(): void {
+		$title = Title::makeTitle( NS_MAIN, 'Ordinary Page' );
+
+		$allowed = true;
+		NeoWikiHooks::onContentModelCanBeUsedOn( CONTENT_MODEL_WIKITEXT, $title, $allowed );
+		$this->assertTrue( $allowed, 'An allowed decision must be left untouched outside NeoWiki namespaces.' );
+
+		$denied = false;
+		NeoWikiHooks::onContentModelCanBeUsedOn( SchemaContent::CONTENT_MODEL_ID, $title, $denied );
+		$this->assertFalse( $denied, 'A denied decision must be left untouched outside NeoWiki namespaces.' );
+	}
+
+	/**
+	 * The handler side of the lock, reached through the real content-handler factory so this also proves
+	 * each model is registered: a NeoWiki model may be used in its own namespace but nowhere else.
+	 *
+	 * @dataProvider namespaceAndModelProvider
+	 */
+	public function testNeoWikiModelIsRestrictedToItsNamespace( int $namespace, string $model ): void {
+		$handler = $this->getServiceContainer()->getContentHandlerFactory()->getContentHandler( $model );
+
+		$this->assertTrue(
+			$handler->canBeUsedOn( Title::makeTitle( $namespace, 'Example' ) ),
+			'The model must be usable in its own namespace.'
+		);
+		$this->assertFalse(
+			$handler->canBeUsedOn( Title::makeTitle( NS_MAIN, 'Example' ) ),
+			'The model must not be usable outside its namespace.'
+		);
+	}
+
+	/**
+	 * The real save path: writing a foreign content model into a NeoWiki namespace is rejected before the
+	 * revision is created. This exercises the hook through PageUpdater, proving it is wired, not just callable.
+	 *
+	 * @dataProvider neoWikiNamespaceProvider
+	 */
+	public function testSavingForeignModelInNeoWikiNamespaceIsRejected( int $namespace ): void {
+		$title = Title::makeTitle( $namespace, 'Example' );
+		$updater = $this->getServiceContainer()->getWikiPageFactory()->newFromTitle( $title )
+			->newPageUpdater( $this->getTestSysop()->getUser() );
+		$updater->setContent( SlotRecord::MAIN, new WikitextContent( 'Plain wikitext' ) );
+
+		$updater->saveRevision( CommentStoreComment::newUnsavedComment( 'test' ) );
+
+		$this->assertStatusError( 'content-not-allowed-here', $updater->getStatus() );
+	}
+
+	public static function namespaceAndModelProvider(): iterable {
+		foreach ( NamespaceContentModels::map() as $namespace => $model ) {
+			yield $model => [ $namespace, $model ];
+		}
+	}
+
+	public static function neoWikiNamespaceProvider(): iterable {
+		foreach ( NamespaceContentModels::map() as $namespace => $model ) {
+			yield $model => [ $namespace ];
+		}
+	}
+
+	public static function foreignNeoWikiModelProvider(): iterable {
+		$map = NamespaceContentModels::map();
+
+		foreach ( $map as $namespace => $ownModel ) {
+			foreach ( $map as $foreignModel ) {
+				if ( $foreignModel !== $ownModel ) {
+					yield "$ownModel namespace rejects $foreignModel" => [ $namespace, $foreignModel ];
+				}
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
NeoWiki's Schema, Layout and Mapping namespaces are each locked to a single
JSON content model. The lock was enforced in two hand-maintained places: the
ContentModelCanBeUsedOn hook, which enumerated the three namespace/model pairs
by hand, and each content handler's canBeUsedOn(). It had no test coverage, so
adding a fourth JSON namespace risked silently shipping it unprotected.

Introduce NamespaceContentModels as the single source of truth mapping each
namespace to its content model, and drive both the hook and the handlers from
it. Behaviour is unchanged: the hook and handlers now read the lock from one
place instead of several hand-kept lists, so they cannot drift out of sync.

Add data-driven tests that iterate the map and assert, for each namespace,
that the matching model is allowed and foreign models (wikitext and other
NeoWiki models) are rejected — covering the hook directly and the real save
path — plus a test pinning the concrete namespace/model pairs.

> <sub>AI-authored — Claude Code, `Opus 4.8 (max)`; detailed spec from @JeroenDeDauw, built autonomously (no interactive human steering); diff not yet human-reviewed; TDD + mutation-checked, independently AI-reviewed (one test-quality fix applied), full PHPUnit + phpcs + phpstan and CI green.</sub>