### PR TITLE
Document per-genre readers and register for docs/

### DIFF
--- a/docs/writing.md
+++ b/docs/writing.md
@@ -1,0 +1,29 @@
+# Writing these docs
+
+Before writing or editing a page, fix three things: the named reader, the decision they make with the text, and a
+length budget. A sentence earns its place only if it changes what that reader predicts or does; otherwise cut it.
+
+- Reference pages state contracts; they never derive, justify, or narrate mechanism.
+- Each fact has one home; every other page links to it instead of restating it.
+- The text carries no history of its own making: nothing addressed to a reviewer, a diff, or a past design discussion.
+- When unsure whether something belongs, leave it out and list it under "considered, omitted" in the PR description.
+- Improving an existing page never lengthens it by default.
+
+## Genres
+
+Every page sits in one genre. Write to that genre's reader and register, and keep out what the last column names.
+
+| Where | Reader, and the decision they make | Register, and what to keep out |
+| --- | --- | --- |
+| `glossary.md`, `qualifiers-and-references.md` | New users and evaluators forming the mental model | Intended design; no dev-state caveats, no mechanism |
+| `api/` | API consumers deciding what a request or response means and what to do next | Wire-format vocabulary; no PHP class names |
+| `authoring/`, `rdf/`, `examples/` | Admins and integrators looking up exact behavior | Contracts, signatures, examples; no narration |
+| `operations/` | Sysadmins keeping an instance healthy | Tasks and remedies; system model only where needed to act |
+| `extending/` | Extension developers, whose interface is our internal identifiers | Point at working RedHerb code over prose |
+| `adr/` | Maintainers recording a decision | A dated record: context, decision, consequences; not retro-edited apart from status links |
+| `planning/` | Collaborators exploring an open question | A work-in-progress register, marked as such; not published to the site |
+
+## Never write
+
+- The justification register: "note that", "importantly", "this ensures", "in order to", or restating the ask.
+- Prose that restates what an adjacent table, signature, or example already shows.

--- a/docs/writing.md
+++ b/docs/writing.md
@@ -7,11 +7,11 @@ length budget. A sentence earns its place only if it changes what that reader pr
 - Each fact has one home; every other page links to it instead of restating it.
 - The text carries no history of its own making: nothing addressed to a reviewer, a diff, or a past design discussion.
 - When unsure whether something belongs, leave it out and list it under "considered, omitted" in the PR description.
-- Improving an existing page never lengthens it by default.
+- Improving an existing page does not lengthen it by default.
 
 ## Genres
 
-Every page sits in one genre. Write to that genre's reader and register, and keep out what the last column names.
+Every page sits in one genre. Write to that genre's reader and register.
 
 | Where | Reader, and the decision they make | Register, and what to keep out |
 | --- | --- | --- |


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1106

#1106 rewrote `docs/api/validation-codes.md` to its reader's altitude and cut everything that derived, justified,
or narrated mechanism rather than stating the contract. This adds `docs/writing.md`, which codifies that standard
so the next page holds to it by default.

The page states, in under 45 lines: a rule block (fix the reader, their decision, and a length budget before
writing; state contracts, don't narrate mechanism; one home per fact; no history of the text's own production;
improving a page doesn't lengthen it), a genre table assigning each `docs/` area its reader and register, and a
short list of banned phrasings.

Placement: `docs/writing.md` at the docs root, no frontmatter. The site nav is curated, not built from every file
(`planning/` is excluded per `docs/README.md`), and published leaves carry the `title`/`order` frontmatter this
page omits, so it stays out of the product navigation. The docs-deploy workflow only triggers the site build; the
nav lives in the website project.

Genre mapping: there is no `concepts/` or `reference/` directory, so those genres map to the docs-root concept
pages and to `authoring/` + `rdf/` + `examples/`. Every existing `docs/` subdirectory is covered by one row.

Considered, omitted: a standalone row for `examples/` (folded into the reference genre); `title`/`order`
frontmatter (would list it in the nav); a cross-link from `docs/README.md` (this change adds one file only); a
fuller description of the deploy pipeline (out of the page's genre). No repo-root `CLAUDE.md`/`AGENTS.md` exists,
so no AI-context pointer was added.

> <sub>AI-authored — Claude Code, `Opus 4.8 (max)`; executed from a fixed skeleton and genre assignments specified by a Fable 5 session directed by @JeroenDeDauw; not yet human-reviewed; placement verified against the docs-site build config, links checked, docs-only change.</sub>
