### PR TITLE
Follow-ups to #1080: batch subject removal, self-loop deletion, test hardening

### DIFF
--- a/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStore.php
+++ b/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStore.php
@@ -70,17 +70,18 @@ readonly class Neo4jProjectionStore implements GraphDatabasePlugin {
 
 	/**
 	 * Removes the subjects that are attached to the page in the graph but are no longer present on the
-	 * page. This reuses deleteSubject so that a removed subject still referenced by other subjects is
+	 * page. This reuses removeSubjects so that a removed subject still referenced by other subjects is
 	 * kept as a stub instead of being deleted, keeping the incoming relations valid.
 	 */
 	private function removeAbsentSubjects( TransactionInterface $transaction, Page $page ): void {
 		$presentSubjectIds = $page->getSubjects()->getAllSubjects()->getIdsAsTextArray();
 
-		foreach ( $this->getSubjectIdsByPageId( $transaction, $page->getId() ) as $attachedSubjectId ) {
-			if ( !in_array( $attachedSubjectId, $presentSubjectIds, true ) ) {
-				$this->deleteSubject( $transaction, new SubjectId( $attachedSubjectId ) );
-			}
-		}
+		$absentSubjectIds = array_values( array_filter(
+			$this->getSubjectIdsByPageId( $transaction, $page->getId() ),
+			fn( string $subjectId ) => !in_array( $subjectId, $presentSubjectIds, true )
+		) );
+
+		$this->removeSubjects( $transaction, $absentSubjectIds );
 	}
 
 	private function detachSubjectsFromPage( TransactionInterface $transaction, PageId $pageId ): void {
@@ -153,9 +154,7 @@ readonly class Neo4jProjectionStore implements GraphDatabasePlugin {
 
 	public function deletePage( PageId $pageId ): void {
 		$this->client->writeTransaction( function ( TransactionInterface $transaction ) use ( $pageId ): void {
-			foreach ( $this->getSubjectIdsByPageId( $transaction, $pageId ) as $subjectId ) {
-				$this->deleteSubject( $transaction, new SubjectId( $subjectId ) );
-			}
+			$this->removeSubjects( $transaction, $this->getSubjectIdsByPageId( $transaction, $pageId ) );
 
 			$this->deletePageNode( $transaction, $pageId );
 		} );
@@ -178,7 +177,7 @@ readonly class Neo4jProjectionStore implements GraphDatabasePlugin {
 		 */
 		$results = $transaction->run(
 			'MATCH (page:Page {id: $pageId, wiki_id: $wikiId})-[:HasSubject]->(subject:Subject)
-				RETURN subject.id AS id, subject AS properties, labels(subject) AS labels',
+				RETURN subject.id AS id',
 			[ 'pageId' => $pageId->id, 'wikiId' => $this->wikiId ]
 		);
 
@@ -188,17 +187,68 @@ readonly class Neo4jProjectionStore implements GraphDatabasePlugin {
 		);
 	}
 
-	private function deleteSubject( TransactionInterface $transaction, SubjectId $subjectId ): void {
-		if ( $this->subjectHasIncomingRelations( $transaction, $subjectId ) ) {
-			$this->reduceSubjectToStub( $transaction, $subjectId );
+	/**
+	 * Removes the given subjects from the graph. A subject still referenced by an incoming relation from
+	 * another subject is reduced to a stub so that reference stays valid; the rest are deleted outright.
+	 *
+	 * The referenced/unreferenced split is computed with a single query and the unreferenced subjects are
+	 * deleted with a single query, rather than one round trip per subject.
+	 *
+	 * @param string[] $subjectIds
+	 */
+	private function removeSubjects( TransactionInterface $transaction, array $subjectIds ): void {
+		if ( $subjectIds === [] ) {
+			return;
 		}
-		else {
-			$transaction->run(
-				'MATCH (subject {id: $subjectId})
-				DETACH DELETE subject',
-				[ 'subjectId' => $subjectId->text ]
-			);
+
+		$referencedSubjectIds = $this->subjectIdsWithIncomingRelations( $transaction, $subjectIds );
+
+		$this->deleteSubjects( $transaction, array_values( array_diff( $subjectIds, $referencedSubjectIds ) ) );
+
+		foreach ( $referencedSubjectIds as $subjectId ) {
+			$this->reduceSubjectToStub( $transaction, new SubjectId( $subjectId ) );
 		}
+	}
+
+	/**
+	 * Returns the subset of the given subject ids that still have an incoming relation from a *different*
+	 * subject. HasSubject relations do not count, and neither does a self-loop: a subject whose only
+	 * incoming relation is its own outgoing self-reference has no external referrer, so it is deleted
+	 * rather than kept as an unreachable stub.
+	 *
+	 * @param string[] $subjectIds
+	 * @return string[]
+	 */
+	private function subjectIdsWithIncomingRelations( TransactionInterface $transaction, array $subjectIds ): array {
+		/**
+		 * @var SummarizedResult $result
+		 */
+		$result = $transaction->run(
+			'UNWIND $subjectIds AS subjectId
+				MATCH (subject {id: subjectId})<-[incomingRelation]-(other)
+				WHERE NOT incomingRelation:HasSubject AND other <> subject
+				RETURN DISTINCT subject.id AS id',
+			[ 'subjectIds' => $subjectIds ]
+		);
+
+		return array_map(
+			fn( $record ) => $record->get( 'id' ),
+			$result->toArray()
+		);
+	}
+
+	/**
+	 * @param string[] $subjectIds
+	 */
+	private function deleteSubjects( TransactionInterface $transaction, array $subjectIds ): void {
+		if ( $subjectIds === [] ) {
+			return;
+		}
+
+		$transaction->run(
+			'MATCH (subject) WHERE subject.id IN $subjectIds DETACH DELETE subject',
+			[ 'subjectIds' => $subjectIds ]
+		);
 	}
 
 	/**
@@ -213,6 +263,7 @@ readonly class Neo4jProjectionStore implements GraphDatabasePlugin {
 				OPTIONAL MATCH ()-[hasSubject:HasSubject]->(subject)
 				OPTIONAL MATCH (subject)-[outgoingRelation]->()
 				DELETE hasSubject, outgoingRelation
+				WITH DISTINCT subject
 				SET subject = {id: $subjectId, wiki_id: $wikiId}
 				SET subject:Subject',
 			[ 'subjectId' => $subjectId->text, 'wikiId' => $this->wikiId ]
@@ -227,15 +278,6 @@ readonly class Neo4jProjectionStore implements GraphDatabasePlugin {
 			$subjectId->text,
 			array_diff( Neo4jNodeLabels::read( $transaction, $subjectId->text ), [ 'Subject' ] )
 		);
-	}
-
-	private function subjectHasIncomingRelations( TransactionInterface $transaction, SubjectId $subjectId ): bool {
-		return $transaction->run(
-			'MATCH (subject {id: $subjectId})<-[incomingRelation]-()
-			WHERE NOT incomingRelation:HasSubject
-			RETURN incomingRelation',
-			[ 'subjectId' => $subjectId->text ]
-		)->isEmpty() === false;
 	}
 
 }

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStoreTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStoreTest.php
@@ -305,7 +305,7 @@ class Neo4jProjectionStoreTest extends NeoWikiIntegrationTestCase {
 
 		$store->savePage( TestPage::build( id: 1 ) );
 
-		$this->assertRelationExists( self::GUID_2, 'LocatedIn', self::GUID_1 );
+		$this->assertRelationExists( self::GUID_2, 'LocatedIn', self::GUID_1, 'rTestNQS1111rr1' );
 	}
 
 	public function testSavingPageWithoutAReferencedSubjectReducesItToAStub(): void {
@@ -361,7 +361,7 @@ class Neo4jProjectionStoreTest extends NeoWikiIntegrationTestCase {
 		$store->deletePage( new PageId( 1 ) );
 
 		$this->assertSubjectIsStub( self::GUID_1 );
-		$this->assertRelationExists( self::GUID_2, 'LocatedIn', self::GUID_1 );
+		$this->assertRelationExists( self::GUID_2, 'LocatedIn', self::GUID_1, 'rTestNQS1111rr1' );
 	}
 
 	public function testSavingASubjectUpgradesItsStubInPlace(): void {
@@ -390,7 +390,7 @@ class Neo4jProjectionStoreTest extends NeoWikiIntegrationTestCase {
 
 		$this->assertSame( [ 'Subject', TestSubject::DEFAULT_SCHEMA_ID ], $labels );
 		$this->assertSame( 'Real subject', $row['name'] );
-		$this->assertRelationExists( self::GUID_2, 'LocatedIn', self::GUID_1 );
+		$this->assertRelationExists( self::GUID_2, 'LocatedIn', self::GUID_1, 'rTestNQS1111rr1' );
 	}
 
 	public function testReducingReferencedSubjectToStubKeepsIncomingRelationsButStripsOutgoingRelationsAndProperties(): void {
@@ -435,8 +435,55 @@ class Neo4jProjectionStoreTest extends NeoWikiIntegrationTestCase {
 
 		$this->assertSubjectIsStub( self::GUID_1 );
 		$this->assertOutgoingRelationCount( self::GUID_1, 0 );
-		$this->assertRelationExists( self::GUID_2, 'LocatedIn', self::GUID_1 );
-		$this->assertRelationExists( self::GUID_5, 'LocatedIn', self::GUID_1 );
+		$this->assertRelationExists( self::GUID_2, 'LocatedIn', self::GUID_1, 'rTestNQS1111rCA' );
+		$this->assertRelationExists( self::GUID_5, 'LocatedIn', self::GUID_1, 'rTestNQS1111rDA' );
+	}
+
+	public function testFlippingASubjectBetweenMainAndChildLeavesASingleHasSubjectEdge(): void {
+		$store = $this->newProjectionStore();
+
+		$store->savePage( TestPage::build(
+			id: 42,
+			mainSubject: TestSubject::build( id: self::GUID_1 ),
+			childSubjects: new SubjectMap(
+				TestSubject::build( id: self::GUID_2 ),
+			)
+		) );
+
+		// Swap the roles: GUID_2 becomes the main subject and GUID_1 becomes a child.
+		// The HasSubject relation carries the isMain flag, so re-saving must not leave a
+		// second, stale HasSubject edge behind for either subject.
+		$store->savePage( TestPage::build(
+			id: 42,
+			mainSubject: TestSubject::build( id: self::GUID_2 ),
+			childSubjects: new SubjectMap(
+				TestSubject::build( id: self::GUID_1 ),
+			)
+		) );
+
+		$this->assertPageHasSubjects(
+			[
+				[ 'id' => self::GUID_1, 'hs' => [ 'isMain' => false ] ],
+				[ 'id' => self::GUID_2, 'hs' => [ 'isMain' => true ] ],
+			],
+			42
+		);
+	}
+
+	public function testRemovingASelfReferencingSubjectDeletesItRatherThanStubbingIt(): void {
+		$store = $this->newProjectionStoreWithLocationRelation();
+
+		// GUID_1 holds a relation to itself and nothing else references it.
+		$store->savePage( TestPage::build(
+			id: 1,
+			mainSubject: $this->buildSubjectWithLocationRelation( self::GUID_1, self::GUID_1, 'rTestNQS1111rr1' ),
+		) );
+
+		// Removing it from its page must delete it: a self-loop is not an external reference,
+		// so keeping it as a stub would leave an unreachable orphan node.
+		$store->savePage( TestPage::build( id: 1 ) );
+
+		$this->assertSubjectDoesNotExist( self::GUID_1 );
 	}
 
 	private function newProjectionStoreWithLocationRelation( string $wikiId = self::WIKI_ID ): GraphDatabasePlugin {
@@ -481,9 +528,14 @@ class Neo4jProjectionStoreTest extends NeoWikiIntegrationTestCase {
 		);
 	}
 
-	private function assertRelationExists( string $fromSubjectId, string $relationType, string $toSubjectId ): void {
+	private function assertRelationExists(
+		string $fromSubjectId,
+		string $relationType,
+		string $toSubjectId,
+		?string $expectedRelationId = null
+	): void {
 		$result = $this->readGraph(
-			'MATCH ({id: $from})-[relation:' . $relationType . ']->({id: $to}) RETURN relation',
+			'MATCH ({id: $from})-[relation:' . $relationType . ']->({id: $to}) RETURN relation.id AS id',
 			[ 'from' => $fromSubjectId, 'to' => $toSubjectId ]
 		);
 
@@ -491,6 +543,16 @@ class Neo4jProjectionStoreTest extends NeoWikiIntegrationTestCase {
 			$result->isEmpty(),
 			"Relation {$fromSubjectId}-[{$relationType}]->{$toSubjectId} should exist"
 		);
+
+		// Readers reconcile relations by their id, so a relation that survives by endpoints and type
+		// but loses its id is broken. Assert the id is preserved when the caller pins it down.
+		if ( $expectedRelationId !== null ) {
+			$this->assertSame(
+				$expectedRelationId,
+				$result->first()->toRecursiveArray()['id'],
+				"Relation {$fromSubjectId}-[{$relationType}]->{$toSubjectId} should keep its id"
+			);
+		}
 	}
 
 	private function subjectHasProperty( string $subjectId, string $property ): bool {


### PR DESCRIPTION
Addresses the review findings on #1080. Targets the PR branch (`fix/544-referenced-subject-stubs`), not master, so it can be folded into that PR before it merges.

## What each commit does

**Batch subject removal** — `src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStore.php`
- `removeAbsentSubjects` and `deletePage` now route through one `removeSubjects()`, which classifies referenced-vs-unreferenced subjects in a single query and deletes the unreferenced ones in a single query, replacing the per-subject round-trip loop. Both call sites stay unified on the same stub/delete logic (the point of the fix in #1080), so this does not re-introduce a `savePage`/`deletePage` split.
- The classification excludes self-loops (`other <> subject`), so a subject whose only incoming relation is its own self-reference is deleted rather than left as an unreachable orphan stub.
- `reduceSubjectToStub` gets `WITH DISTINCT subject` so the property/label reset runs once, not once per outgoing relation (the two `OPTIONAL MATCH`es form a cartesian product).
- `getSubjectIdsByPageId` stops returning the node properties and label list that both callers discarded.

**Test hardening** — `tests/…/Neo4jProjectionStoreTest.php`
- `testFlippingASubjectBetweenMainAndChildLeavesASingleHasSubjectEdge` locks `detachSubjectsFromPage`, which had no coverage. Because `HasSubject` is MERGEd with its `isMain` property, flipping a persisting subject's role would leave a duplicate edge without that method. Teeth-verified: the test goes red when the `detachSubjectsFromPage` call is removed.
- `testRemovingASelfReferencingSubjectDeletesItRatherThanStubbingIt` — verified red on the pre-fix code (a self-loop subject was kept as a stub), green after.
- `assertRelationExists` optionally asserts the preserved relation's `id`, so a regression that keeps an incoming relation by endpoints and type but drops its `id` is caught. Pinned at the four preservation call sites.

## Behavioural note for the reviewer

Batching the classification changes one acknowledged-limitation edge: removing **two mutually-referencing subjects in one save** now leaves *both* as orphan stubs (deterministic) instead of one stub + one deleted (order-dependent). Both outcomes are within the acknowledged, harmless, self-healing orphan-stub limitation from #1080; the proper cascade-sweep fix is deferred and tracked in #1112. Flagging it because it is a minor semantic shift.

## Validation

Run locally against the dev stack (`@group Database`):
- `Neo4jProjectionStore` 34 ✓, `Neo4jSubjectRelationUpdater` 8 ✓
- Projection consumers: `ReplaceSubjectApi` ✓, `Neo4jPageIdentifiersLookup` ✓, `Neo4jSubjectLabelLookup` ✓, `MediaWikiPageDeleter` ✓
- `make cs` (phpcs 579 files + phpstan) ✓
- Live smoke on the dev wiki: `deletePage` on a referenced subject reduced it to a correct stub with its incoming relations preserved; a full graph rebuild restored the projection to baseline.

Draft because the full suite was not run locally; CI is the gate for the remainder.

> <sub>AI-authored — Claude Code, `Opus 4.8 (1M context)`, as follow-ups to a code review of #1080. Each production change validated against the touched + consumer `@group Database` tests locally, plus a live smoke on the dev wiki; not yet human-reviewed.</sub>