### PR TITLE
Docs text pass: every user-facing page to the writing.md standard

### DIFF
--- a/docs/api/graph-model.md
+++ b/docs/api/graph-model.md
@@ -4,34 +4,28 @@ order: 6
 ---
 # Graph Model
 
-NeoWiki stores a query-optimized projection of its data in a Neo4j graph database ([ADR 3](../adr/003-neo4j-as-graph-database.md)).
-The source of truth for all data remains in MediaWiki revision slots ([ADR 4](../adr/004-use-dedicated-slot.md));
-the graph is a secondary store that enables efficient querying and relationship traversal.
+NeoWiki projects its data into a Neo4j graph for querying ([ADR 3](../adr/003-neo4j-as-graph-database.md)). The graph
+is a secondary store; the source of truth is the MediaWiki revision slots it is built from
+([ADR 4](../adr/004-use-dedicated-slot.md)).
 
 For definitions of domain terms like Subject, Statement, and Schema, see the [Glossary](../glossary.md).
 
 ## Overview
 
-The graph consists of two node types and two relationship categories:
+Two node types and two relationship categories:
 
 ```
 (:Page)-[:HasSubject {isMain}]->(:Subject:SchemaName)
 (:Subject)-[:RelationType {id, ...}]->(:Subject)
 ```
 
-Page nodes represent MediaWiki pages and carry page-level metadata. Subject nodes represent structured data entities.
-`HasSubject` relationships connect pages to their Subjects. Typed relationships connect Subjects to other Subjects
-via Relations.
-
 ## Page Nodes
 
-Every page that contains structured data has a corresponding `:Page` node. These nodes make page metadata available
-for graph queries.
+Every page that contains structured data has a `:Page` node.
 
-Page identity is scoped per wiki. A shared graph can hold pages from multiple wikis (e.g. a wiki farm), and MediaWiki
-page ids are only unique within a single wiki. Each page node therefore carries a `wiki_id` and is identified by the
-`(wiki_id, id)` pair ([ADR 22](../adr/022-multi-wiki-node-identity.md)). In a single-wiki install there is one
-`wiki_id` value and behaviour is unchanged.
+A shared graph can hold pages from multiple wikis (a wiki farm), and MediaWiki page ids are unique only within a wiki,
+so a page is identified by the `(wiki_id, id)` pair, not `id` alone ([ADR 22](../adr/022-multi-wiki-node-identity.md)).
+A single-wiki install has just one `wiki_id`.
 
 | Property | Neo4j Type | Description |
 |----------|------------|-------------|
@@ -44,18 +38,14 @@ page ids are only unique within a single wiki. Each page node therefore carries 
 | `lastEditor` | string | Username of the last editor |
 | `categories` | string[] | MediaWiki categories the page belongs to |
 
-`creationTime` and `lastUpdated` are stored as Neo4j datetime values (ISO 8601), converted from MediaWiki's
-`YmdHis` timestamp format.
-
-`namespaceId` holds MediaWiki's canonical namespace ID. Built-in namespaces (e.g. `0` main, `12` Help, `14`
-Category) have the same ID on every wiki, so filtering by `namespaceId` behaves consistently across a graph
-shared by multiple wikis. Custom namespaces defined via `$wgExtraNamespaces` get per-wiki IDs that may differ in
-meaning between wikis, so pair `namespaceId` with `wiki_id` to filter those unambiguously.
+Built-in namespaces have the same ID on every wiki, so `namespaceId` filters consistently across a shared graph.
+Custom namespaces (`$wgExtraNamespaces`) get per-wiki IDs whose meaning can differ between wikis; pair `namespaceId`
+with `wiki_id` to filter those unambiguously.
 
 ## Subject Nodes
 
-Each Subject stored on a page gets a `:Subject` node. Subject nodes carry two labels: `Subject` and the name of
-their Schema (e.g., `:Subject:Person`, `:Subject:Company`). The Schema label changes if a Subject's type changes.
+Each Subject stored on a page gets a `:Subject` node. Subject nodes carry two labels: `Subject` and the name of their
+Schema (e.g. `:Subject:Person`, `:Subject:Company`). The Schema label changes if a Subject's type changes.
 
 ### Fixed properties
 
@@ -66,17 +56,31 @@ their Schema (e.g., `:Subject:Person`, `:Subject:Company`). The Schema label cha
 | `wiki_id` | string | [MediaWiki Wiki ID](https://www.mediawiki.org/wiki/Manual:Wiki_ID) of the wiki that owns the Subject |
 
 Unlike page ids, Subject ids are globally unique nanoids ([ADR 14](../adr/014-improved-id-format.md)), so a Subject's
-identity is its `id` alone. The `wiki_id` is carried only for per-wiki query filtering in a shared graph; Subject-id
-namespacing is deferred ([ADR 22](../adr/022-multi-wiki-node-identity.md)).
+identity is its `id` alone. The `wiki_id` is carried only for per-wiki query filtering in a shared graph.
 
 ### Dynamic properties
 
-Each Statement on a Subject becomes a node property, keyed by Property Name. The value is converted to a
-Neo4j-compatible format by the corresponding PropertyType implementation. For example, a Statement with
-Property Name "Founded at" and a number value of `2019` results in a node property `Founded at: 2019`.
+Each non-relation Statement becomes a node property keyed by its Property Name. A `number` Statement with Property
+Name "Founded at" and value `2019` becomes the node property `Founded at: 2019`. A key that is not a valid Cypher
+identifier must be backtick-escaped when read (`` s.`Founded at` ``).
 
-Relation-type Statements are not stored as node properties. They are stored as relationships between Subject
-nodes (see below).
+The PropertyType determines the value's Neo4j type:
+
+| PropertyType | Neo4j value |
+|--------------|-------------|
+| `text`, `url`, `select` | list of strings |
+| `number` | integer or float |
+| `boolean` | boolean |
+| `date` | list of dates |
+| `dateTime` | list of datetimes |
+| `relation` | stored as a [relationship](#typed-relations), not a node property |
+
+A Property Name that collides with a fixed property (`id`, `name`, `wiki_id`) does not override it: the fixed value
+wins and the Statement's value is not projected.
+
+Values a PropertyType cannot represent are dropped from the projection: a property whose type has no registered
+PropertyType produces no node property, and non-ISO 8601 `date`/`dateTime` parts are omitted from the stored value.
+The revision slot stays authoritative.
 
 ## Relationships
 
@@ -93,8 +97,8 @@ A page can have at most one Main Subject and any number of Child Subjects
 
 ### Typed Relations
 
-Subject-to-Subject relationships represent Relations. The relationship type in Neo4j is the Relation Type defined
-in the Property Definition (e.g., `Has author`, `Has product`). Names that are not valid Cypher identifiers are
+Subject-to-Subject relationships represent Relations. The relationship type in Neo4j is the Relation Type defined in
+the Property Definition (e.g. `Has author`, `Has product`). Names that are not valid Cypher identifiers are
 backtick-escaped.
 
 | Property | Neo4j Type | Description |
@@ -103,20 +107,18 @@ backtick-escaped.
 | *(additional)* | scalar | Any properties from the Relation's property map |
 
 When a Subject is deleted but still has incoming relations from other Subjects, its outgoing relationships and
-`HasSubject` relationship are removed, but the node itself is kept so that the incoming references remain valid.
+`HasSubject` relationship are removed, but the node itself is kept so incoming references stay valid. Such a retained
+node keeps its Schema labels and dynamic properties; the absence of an incoming `HasSubject` relationship distinguishes
+it from a live Subject.
 
 ## Constraints
 
-Two node uniqueness constraints are defined for the graph: the `(wiki_id, id)` pair is unique on `:Page` nodes
-([ADR 22](../adr/022-multi-wiki-node-identity.md)), and `Subject.id` is unique. They are created by running the
-`RebuildGraphDatabases.php` maintenance script, and creation is idempotent (`CREATE CONSTRAINT ... IF NOT EXISTS`),
-so re-running it is safe. The incremental projection that runs on each page edit does not create them, so an
-existing graph gains them only after the rebuild has been run.
+Two node uniqueness constraints apply: `(wiki_id, id)` on `:Page` nodes
+([ADR 22](../adr/022-multi-wiki-node-identity.md)) and `id` on `:Subject` nodes. A graph that has never been rebuilt
+with `RebuildGraphDatabases.php` lacks them: the incremental per-edit projection does not create them.
 
-Relation (edge) `id` values are not constrained at the graph level: Neo4j relationship uniqueness constraints
-are per relationship type, and Relations use an open, user-defined set of relationship types, so no single
-constraint can enforce global Relation-`id` uniqueness (see
-[#351](https://github.com/ProfessionalWiki/NeoWiki/issues/351)).
+Relation (edge) `id` values carry no uniqueness constraint
+([#351](https://github.com/ProfessionalWiki/NeoWiki/issues/351)).
 
 ## Related Documentation
 

--- a/docs/api/query-api.md
+++ b/docs/api/query-api.md
@@ -5,30 +5,30 @@ order: 5
 # Query API
 
 `POST /neowiki/v0/query/cypher` runs a read-only Cypher query against the configured Neo4j backend and returns
-results as a structured JSON envelope. The endpoint exists only when a Neo4j graph backend is configured; on a
-wiki without one the route is absent and does not appear in the OpenAPI spec.
+results as a structured JSON envelope. The route exists only when a Neo4j backend is configured; on a wiki without
+one it is absent and does not appear in the OpenAPI spec.
 
 ## Stability
 
-Pre-1.0. The endpoint, request shape, response envelope, and error contract may change without notice until 1.0.
-Do not treat `/neowiki/v0/query/cypher` as stable for third-party integrations yet.
+Pre-1.0. The endpoint, request shape, response envelope, and error contract may change without notice before 1.0;
+not yet stable for third-party integrations.
 
 ## Discovery flow
 
-Before writing a query, a client or LLM should learn the data model. The recommended sequence:
+To write a query you need the graph's labels, properties, and relationships. Learn them from:
 
-1. **`GET /neowiki/v0/schemas`** — Returns a list of available Schema names (e.g. `Person`, `Company`, `Document`).
-2. **`GET /neowiki/v0/schema/{name}`** — Returns the full Property Definitions for one Schema: property names,
-   types, and constraints. This tells you which node properties exist on `:Subject:SchemaName` nodes and what
-   values they hold.
-3. *(Optional)* **`GET /neowiki/v0/subject/{id}`** — Fetch a live Subject to see the actual data shape, including
-   any Statements that differ from the Schema defaults.
-4. **Read the [Graph Model](graph-model.md)** — Describes the Neo4j label and relationship structure in full.
-   Essential for writing Cypher beyond simple `MATCH (s:Subject)` patterns: Page nodes, `HasSubject`
-   relationships, typed Subject-to-Subject relationships, and available node properties.
-5. **`POST /neowiki/v0/query/cypher`** — Run the query.
+1. **`GET /neowiki/v0/schemas`** — the available Schema names (e.g. `Person`, `Company`, `Document`).
+2. **`GET /neowiki/v0/schema/{name}`** — one Schema's Property Definitions: the names, types, and constraints of the
+   properties carried by its `:Subject:SchemaName` nodes.
+3. **`GET /neowiki/v0/subject/{id}`** — a live Subject, to see the actual stored data shape (optional).
+4. **[Graph Model](graph-model.md)** — the full Neo4j label, relationship, and node-property structure; required
+   for anything beyond simple `MATCH (s:Subject)` patterns.
 
 ## Endpoint contract
+
+The POST is read-only and needs no CSRF/edit token. Access is governed solely by the `neowiki-query` right; a caller
+with that right on a wiki where it is not granted to anonymous users authenticates with normal MediaWiki session
+credentials.
 
 ### Request
 
@@ -49,6 +49,9 @@ Content-Type: application/json
 | `cypher` | string | Yes | A read-only Cypher query. Single statement. Queries with write keywords cause a `writeQueryRejected` error. |
 | `parameters` | object | No | Parameter name → value map. Reference as `$name` in the query. Defaults to `{}`. |
 
+Property names containing spaces must be backtick-escaped in Cypher, e.g. `` s.`Birth year` ``. Pass values via
+`parameters` rather than concatenating them into the query string — parameters reach the driver injection-safe.
+
 ### Successful response (200)
 
 ```json
@@ -66,10 +69,10 @@ Content-Type: application/json
 
 | Field | Type | Description |
 |---|---|---|
-| `columns` | array of string | RETURN aliases in declaration order. Separate from `rows` because JSON object key order is not guaranteed. |
+| `columns` | array of string | RETURN aliases in declaration order. Row object key order is not guaranteed; use this for column order. |
 | `rows` | array of object | Each row keyed by RETURN alias. |
-| `truncated` | boolean | `true` when the result was cut at `maxRows`. Narrow the query or use the `expensive` tier for more rows. |
-| `resultCount` | integer | Number of rows returned (always ≤ `maxRows`). |
+| `truncated` | boolean | `true` when the result was cut at `maxRows`; narrow the query or add `LIMIT`. |
+| `resultCount` | integer | Number of rows in `rows`. |
 | `durationMs` | integer | Server-measured query execution time in milliseconds, excluding network round-trip. |
 
 #### Cell normalization
@@ -83,13 +86,10 @@ Scalar Cypher values (strings, integers, floats, booleans, `null`) pass through 
 | UnboundRelationship | `{ "id": ..., "type": "...", "properties": {...} }` (no start/end node ids; appears in undirected pattern matches) |
 | Path | `{ "nodes": [...], "relationships": [...] }` |
 | `date` | ISO 8601 date string, e.g. `"2023-10-01"` |
-| `datetime` / zoned `time` | ISO 8601 string with offset, e.g. `"2023-09-13T14:22:23+00:00"` / `"14:22:23+02:00"` |
+| `datetime` / zoned `time` | ISO 8601 string with a whole-minute offset, e.g. `"2023-09-13T14:22:23+00:00"` / `"14:22:23+02:00"` |
 | `localdatetime` / `localtime` | ISO 8601 string without offset, e.g. `"2023-09-13T14:22:23"` / `"09:30:00"` |
 | `duration` | `{ "months": ..., "days": ..., "seconds": ..., "nanoseconds": ... }` |
 | `point` | `{ "x": ..., "y": ..., "crs": "...", "srid": ... }` (plus `"z"` for 3D points) |
-
-Temporal values render as ISO 8601 strings (timezone offsets to whole-minute precision). `duration` and
-spatial `point` values render as component objects.
 
 ### Error response
 
@@ -109,96 +109,12 @@ spatial `point` values render as component objects.
 | `queryTimeout` | 408 | Query execution exceeded `timeoutSeconds` for the caller's tier. |
 | `rateLimitExceeded` | 429 | Request frequency exceeded the `neowiki-query` rate limit. |
 | `permissionDenied` | 403 | Caller lacks the `neowiki-query` right. |
-| `backendUnavailable` | 503 | No graph backend is reachable (graceful degradation, see [ADR 19](../adr/019-graph-database-architecture.md)). |
+| `backendUnavailable` | 503 | No graph backend is reachable. |
 | `internalError` | 500 | Anything else. |
 
-`errorType` strings are stable across releases. Clients and LLMs should branch on `errorType`, not on `message`
-text. The REST `message` is always English and may change between releases; it is intended for logging and
-debugging, not display. User-facing localization applies only to the wikitext surfaces — the `{{#cypher_raw}}`
-parser function and `nw.query()` in Lua — which render translated messages derived from the same `errorType`
-classification.
-
-## Example walkthrough
-
-This example follows the full discovery flow for a wiki that has a `Person` schema, then queries for all people
-born after the year 2000.
-
-### Step 1 — List available schemas
-
-```bash
-curl http://localhost:8484/rest.php/neowiki/v0/schemas
-```
-
-Response (abbreviated):
-
-```json
-[
-    { "name": "Company" },
-    { "name": "Document" },
-    { "name": "Person" }
-]
-```
-
-### Step 2 — Fetch the Person schema
-
-```bash
-curl http://localhost:8484/rest.php/neowiki/v0/schema/Person
-```
-
-Response (abbreviated):
-
-```json
-{
-    "name": "Person",
-    "description": "A human being.",
-    "properties": [
-        { "name": "Birth year", "type": "number", "required": false },
-        { "name": "Nationality", "type": "select", "required": false },
-        { "name": "Employer",   "type": "relation", "required": false }
-    ]
-}
-```
-
-From this you know: the Neo4j node for a Person has a `Birth year` numeric property, a `Nationality` string
-property, and outgoing `Employer` relationships to other Subject nodes.
-
-### Step 3 — (Optional) Sample a subject
-
-```bash
-curl http://localhost:8484/rest.php/neowiki/v0/subject/s1abc5def6ghi78
-```
-
-### Step 4 — Run the query
-
-Using the property name discovered in Step 2 (`Birth year`). Property names with spaces must be backtick-escaped
-in Cypher.
-
-```bash
-curl -X POST http://localhost:8484/rest.php/neowiki/v0/query/cypher \
-     -H 'Content-Type: application/json' \
-     -d '{
-       "cypher": "MATCH (s:Subject:Person) WHERE s.`Birth year` > $minYear RETURN s.name, s.`Birth year` AS year",
-       "parameters": { "minYear": 2000 }
-     }'
-```
-
-Response:
-
-```json
-{
-    "columns":     ["name", "year"],
-    "rows":        [
-        { "name": "Alice Fontaine", "year": 2001 },
-        { "name": "Ben Markov",     "year": 2003 }
-    ],
-    "truncated":   false,
-    "resultCount": 2,
-    "durationMs":  11
-}
-```
-
-Always prefer parameterized queries (`$name` syntax) over string concatenation. Parameters are passed safely to
-the database driver and protect against injection.
+`errorType` strings are stable across releases; branch on them, not on `message`. The `message` is English, may change
+between releases, and is meant for logging, not display. Localized messages are rendered only by the wikitext surfaces
+— `{{#cypher_raw}}` and `nw.query()` — from the same `errorType` classification.
 
 ## Limits and tiers
 
@@ -209,24 +125,7 @@ Two resource tiers control per-query timeout and row cap:
 | `default` | Any user with `neowiki-query` | 30 s | 5,000 rows |
 | `expensive` | Any user with the core `apihighlimits` right | 300 s | 50,000 rows |
 
-`apihighlimits` is a MediaWiki core right granted by default to `bot` and `sysop` groups. It exists precisely for
-"heavier API queries" and is reused rather than introducing a NeoWiki-specific right.
-
-When `truncated` is `true`, the result was cut at `maxRows`. Narrow the query with `WHERE` clauses, add `LIMIT`
-to the Cypher, or use an account with `apihighlimits` for a higher cap.
-
-### Overriding limits
-
-```php
-// LocalSettings.php
-$wgNeoWikiQueryLimits = [
-    'default'   => [ 'timeoutSeconds' => 15,   'maxRows' => 1000  ],
-    'expensive' => [ 'timeoutSeconds' => 120,  'maxRows' => 20000 ],
-];
-```
-
-Both keys must be present. The values above are examples; tune for your deployment's hardware and expected query
-patterns.
+The tier is selected automatically from the caller's rights; it cannot be requested per call.
 
 ### Rate limits
 
@@ -240,18 +139,6 @@ Defaults shipped by NeoWiki:
 | Bot | 1000 requests / 60 s |
 | Sysop / Bureaucrat | Unlimited (via core `noratelimit` right) |
 
-Other accounts can be exempted from rate limits by granting them the core `noratelimit` right.
-
-Override for your site:
-
-```php
-// LocalSettings.php — example: tighten anonymous access, raise for logged-in users
-$wgRateLimits['neowiki-query'] = [
-    'anon' => [ 5, 60 ],
-    'user' => [ 120, 60 ],
-];
-```
-
 ## Permissions
 
 | Right | Default groups | Purpose |
@@ -259,48 +146,15 @@ $wgRateLimits['neowiki-query'] = [
 | `neowiki-query` | `*` (everyone, including anonymous visitors) | Required to call the query endpoint. |
 | `apihighlimits` | `bot`, `sysop` (core defaults) | Grants the `expensive` resource tier. |
 
-To restrict the endpoint on a closed wiki:
-
-```php
-// LocalSettings.php
-$wgGroupPermissions['*']['neowiki-query'] = false;
-$wgGroupPermissions['user']['neowiki-query'] = true;  // logged-in users only
-```
-
-Or remove it from all groups and grant it selectively:
-
-```php
-$wgGroupPermissions['*']['neowiki-query'] = false;
-$wgGroupPermissions['researcher']['neowiki-query'] = true;
-```
-
-## Deployment notes
-
-NeoWiki enforces a transaction timeout in-process via `Neo4jQueryLimits::$timeoutSeconds`. This is the primary
-protection against long-running queries. For defense-in-depth, configure Neo4j itself with matching server-side
-limits so that a bug or misconfiguration in the application layer does not leave the database exposed:
-
-```ini
-# neo4j.conf
-db.transaction.timeout=60s
-db.memory.transaction.max=512m
-```
-
-The `db.transaction.timeout` value should be slightly above the `expensive` tier timeout (300 s by default) so
-that legitimate long queries are not killed server-side before the application timeout fires, but runaway queries
-that bypass the application layer are still bounded. A value such as `360s` gives a 60-second grace margin.
-`db.memory.transaction.max` caps per-transaction heap to prevent a single query from exhausting server memory.
-
-These settings apply to all connections to the Neo4j instance, not only NeoWiki traffic. Adjust to your
-deployment's needs.
-
 ## SPARQL query endpoint
 
 `POST /neowiki/v0/query/sparql` runs a read-only SPARQL query against the first configured
-[SPARQL store](../operations/installation.md#optional-sparql-graph-stores) and returns the results. Like the Cypher
-endpoint, it exists only when a store is configured; on a wiki without one the route is absent and does not appear in
-the OpenAPI spec. Multi-store query addressing is a later addition — for now the endpoint always targets the first
-configured store.
+[SPARQL store](../operations/installation.md#optional-sparql-graph-stores) and returns its results. Like the Cypher
+endpoint, it exists only when a store is configured; otherwise the route is absent and does not appear in the OpenAPI
+spec.
+
+For the RDF vocabulary (predicates, graph shape) to query, see [RDF Export](../rdf/rdf-export.md) and
+[Ontology Mapping](../rdf/ontology-mapping.md).
 
 ### Request
 
@@ -319,8 +173,7 @@ Content-Type: application/json
 |---|---|---|---|
 | `query` | string | Yes | A read-only SPARQL 1.1 `SELECT` or `ASK` query. |
 
-`CONSTRUCT` and `DESCRIBE` are not supported yet: they return an RDF graph rather than the
-`application/sparql-results+json` document this endpoint negotiates.
+`CONSTRUCT` and `DESCRIBE` are not supported.
 
 ### Successful response (200)
 
@@ -348,17 +201,12 @@ Same shape as the Cypher endpoint (`{ "errorType", "message" }`); branch on `err
 | `rateLimitExceeded` | 429 | Request frequency exceeded the `neowiki-query` rate limit. |
 | `permissionDenied` | 403 | Caller lacks the `neowiki-query` right. |
 
-### Differences from the Cypher endpoint
+### Limits
 
-- **Read-only by protocol, not by a validator.** The query is sent as a SPARQL 1.1 *query* operation
-  (`Content-Type: application/sparql-query`), and the SPARQL query grammar contains no update forms, so no read-only
-  validator is needed. The endpoint only ever posts to the store's `queryUrl`, never to `updateUrl`.
-- **The result document is returned unmodified, with no envelope**, so there is no `columns` / `rows` / `resultCount`
-  reshaping and no cell normalization — the store's JSON already carries typed RDF terms.
-- **Limits: the per-tier timeout is applied** (as the HTTP client timeout), reusing the same `$wgNeoWikiQueryLimits`
-  tiers and `neowiki-query` right and rate limits as the Cypher endpoint. The `maxRows` cap is **not** applied:
-  truncating `results.bindings` would alter the W3C document, and signaling the truncation would require inventing a
-  field, so neither is done. Bound result size with `LIMIT` in the query.
+Reuses the Cypher endpoint's `$wgNeoWikiQueryLimits` tiers, `neowiki-query` right, and rate limits. The per-tier
+timeout applies (as the HTTP client timeout); the `maxRows` cap does not, so bound result size with `LIMIT` in the
+query. There is no distinct timeout `errorType`: a timed-out query surfaces as `sparqlStoreUnavailable` (503), the
+same as an unreachable store.
 
 ## Related
 

--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -3,31 +3,23 @@ title: REST API
 order: 1
 ---
 
-<!-- DOC INTENT — read before editing.
-Audience: developers deciding if NeoWiki's API fits, and developers doing a specific task with it.
-Job: let them scan what the API can do and find the right endpoint fast.
-Keep out: how the API/spec is built, CI/test mechanics, generator internals — those live in code and tests.
-Order: group by resource; keep a resource's operations together; lead with the common reads; cross-link, don't restate.
-Voice: terse — every sentence earns its place; link to the format docs instead of repeating them.
--->
-
 # REST API
 
-NeoWiki's REST API lives under `/rest.php/neowiki/v0/*` and uses JSON.
+NeoWiki's REST API lives under `/rest.php/neowiki/v0/*`. Requests and responses are JSON; the RDF export endpoints
+return TriG or Turtle instead.
 
-By default, reads are public and writes require a logged-in user with edit rights and a CSRF token. Additional
-permissions might be required depending on the wiki configuration.
+By default, reads are public and writes require a logged-in user with `edit` rights and a CSRF token; wiki
+configuration may require more.
 
-You can find all endpoints in [the OpenAPI 3.0 description](#full-specification) exposed via the REST API itself.
-Demo wiki example: [neowiki.dev/w/rest.php/specs/v0/module/-](https://neowiki.dev/w/rest.php/specs/v0/module/-)
+Every endpoint is also published as a complete [OpenAPI 3.0 description](#full-specification).
 
 ## Permissions
 
-The Subject, Schema, Layout, Mapping and RDF read endpoints enforce the caller's per-page `read` permission: read
-whitelists and permission extensions apply. (MediaWiki's `read` action ignores page protection and
-`$wgNamespaceProtection`, so neither restricts these endpoints.) When you may not read a page, they respond as if
-the data were absent — a `null` value, an empty list, or a `404` — rather than with a `403`. Treat a not-found
-response as "not available": it may mean the data does not exist, or that you may not read it.
+The Subject, page-subjects, Schema, Layout, RDF export, and entity-dereference read endpoints enforce the caller's
+per-page `read` permission; page protection and `$wgNamespaceProtection` do not restrict them, because MediaWiki's
+`read` action ignores both. When you may not read a page they respond as if the data were absent — a `null` value, an
+empty list, or a `404` — never a `403`. `GET /subject-labels` is the exception: it filters only by wiki and Schema, not
+by per-page `read`.
 
 Subject write endpoints require per-page `edit` permission and answer `403` on denial.
 
@@ -52,10 +44,10 @@ Read, change, and validate Subjects. New Subjects are created on a page — see
 | `GET /neowiki/v0/entity/{subjectId}` | Dereference a Subject's concept URI. `303` to the Subject's RDF (`Accept: application/trig` or `text/turtle`) or to the hosting page (otherwise). See [Dereferencing subject IRIs](../rdf/rdf-export.md#dereferencing-subject-iris). |
 | `PUT /neowiki/v0/subject/{subjectId}` | Replace a Subject's label and statements. |
 | `DELETE /neowiki/v0/subject/{subjectId}` | Delete a Subject. |
-| `POST /neowiki/v0/subject/validate` | Check whether a new Subject is valid, without saving it. |
-| `POST /neowiki/v0/subject/{subjectId}/validate` | Check whether a change to a Subject is valid, without saving it. |
+| `POST /neowiki/v0/subject/validate` | Check whether a new Subject is valid, without saving it. Returns `{violations: [...]}` — see [Validation codes](validation-codes.md). |
+| `POST /neowiki/v0/subject/{subjectId}/validate` | Check whether a change to a Subject is valid, without saving it. Returns `{violations: [...]}` — see [Validation codes](validation-codes.md). |
 | `POST /neowiki/v0/subject-ids` | Mint a batch of unused Subject IDs to assign on create, e.g. to wire relations across an interlinked import. Body `count` (1–1000). |
-| `GET /neowiki/v0/subject-labels` | Find Subjects of a Schema by label; returns `id`/`label` pairs. |
+| `GET /neowiki/v0/subject-labels` | Find Subjects of a Schema by label; returns `id`/`label` pairs. Query: `schema` (required), `search` (label prefix), `limit`. |
 
 ### Pages and Subjects
 
@@ -101,17 +93,16 @@ A Layout defines how a Subject is displayed.
 
 ## The `expand` parameter
 
-The Subject read and page-subjects read endpoints take an optional multi-valued `expand` query parameter (e.g.
-`?expand=page|relations`) that embeds related data so a client can render without follow-up requests. On the
-Subject read, `page` adds the page fields described in [Subject format](subject-format.md#reading-subjects) to
-each returned Subject. On the page-subjects read, `schemas` adds a top-level `schemas` map from Schema name to the
-[Schema format](schema-format.md) body of every Schema the returned Subjects use. Both endpoints accept
-`relations`, which shapes the response differently on each endpoint. Per-Subject objects follow
-[Subject format](subject-format.md) — page fields are trimmed from the examples below.
+The Subject read and page-subjects read endpoints take an optional multi-valued `expand` query parameter (pipe-separated,
+e.g. `?expand=schemas|relations`) that embeds related data in the response. On the Subject read, `page` adds the page fields
+described in [Subject format](subject-format.md#reading-subjects) to each returned Subject. On the page-subjects read,
+`schemas` adds a top-level `schemas` map from Schema name to the [Schema format](schema-format.md) body of every Schema
+the returned Subjects use. Both endpoints accept `relations`, which shapes the response differently on each endpoint.
+Per-Subject objects follow [Subject format](subject-format.md) — page fields are trimmed from the examples below.
 
-`expand=relations` resolves every relation-type Statement value (each holds a `target` Subject ID) to the full
-target Subject; match a relation value's `target` against the resolved Subjects to look one up. A `target` that
-does not resolve to an existing Subject is silently omitted — the relation value itself is unchanged.
+`expand=relations` resolves every relation-type Statement value (each holds a `target` Subject ID) to the full target
+Subject; match a relation value's `target` against the resolved Subjects to look one up. A `target` that does not
+resolve to a Subject you can read is silently omitted — the relation value itself is unchanged.
 
 On the **Subject read**, the targets are merged into the same `subjects` map as the requested Subject, which
 `requestedId` identifies:
@@ -161,17 +152,8 @@ A target already among the page's own Subjects (a relation to another Subject on
 
 ## Full specification
 
-Every endpoint also publishes a complete OpenAPI 3.0 description: parameters, request bodies, and
-responses.
-
-Browse it live on the demo wiki:
-[neowiki.dev/w/rest.php/specs/v0/module/-](https://neowiki.dev/w/rest.php/specs/v0/module/-).
-Paste that JSON into [editor.swagger.io](https://editor.swagger.io) or any OpenAPI viewer.
-
-To expose it on your own wiki, register the spec routes in `LocalSettings.php`:
-
-```php
-$wgRestAPIAdditionalRouteFiles[] = 'includes/Rest/specs.v0.json';
-```
-
-Then fetch `/rest.php/specs/v0/module/-` on your wiki.
+The OpenAPI 3.0 description carries every endpoint's parameters, request bodies, and responses. Browse it live on the
+demo wiki: [neowiki.dev/w/rest.php/specs/v0/module/-](https://neowiki.dev/w/rest.php/specs/v0/module/-). Paste that JSON
+into [editor.swagger.io](https://editor.swagger.io) or any OpenAPI viewer. On your own wiki, register the spec routes
+first — `$wgRestAPIAdditionalRouteFiles[] = 'includes/Rest/specs.v0.json';` in `LocalSettings.php` — then fetch
+`/rest.php/specs/v0/module/-`.

--- a/docs/api/schema-format.md
+++ b/docs/api/schema-format.md
@@ -4,13 +4,12 @@ order: 2
 ---
 # Schema JSON Format
 
-This document describes the JSON format used to store Schema data on pages in the Schema namespace (7474) and
-returned by the REST API.
-
-For definitions of terms like Schema and Property Definition, see the [Glossary](../glossary.md).
-
-A JSON Schema for validation is available at
-[`src/Persistence/MediaWiki/schemaContentSchema.json`](../../src/Persistence/MediaWiki/schemaContentSchema.json).
+Schemas are stored as the JSON content of pages in the Schema namespace (7474), and returned by the
+[Schema REST endpoints](rest-api.md#schemas). For terms like Schema and Property Definition, see the
+[Glossary](../glossary.md). A machine-readable JSON Schema for this format is at
+[`schemaContentSchema.json`](../../src/Persistence/MediaWiki/schemaContentSchema.json); it checks structure only.
+Per-type value constraints (`options`, ranges, string formats, `uniqueItems`) are enforced server-side and reported as
+[validation codes](validation-codes.md).
 
 ## Top-Level Structure
 
@@ -31,15 +30,13 @@ A JSON Schema for validation is available at
 
 ## Property Definition
 
-Each property definition in `propertyDefinitions` has common fields and type-specific fields.
+Every property definition carries the common fields below plus the type-specific fields for its `type`.
 
 ### Common Fields
 
-All property types share these fields:
-
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `type` | string | Yes | - | The property type. See Property Types below. |
+| `type` | string | Yes | - | The property type. See [Property Types](#property-types). |
 | `description` | string | No | `""` | Human-readable description of the property |
 | `required` | boolean | No | `false` | Whether a value is required for this property |
 | `default` | varies | No | `null` | Default value when none is provided |
@@ -50,26 +47,19 @@ All property types share these fields:
 
 Plain text values.
 
-```json
-{
-  "type": "text"
-}
-```
-
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `multiple` | boolean | `false` | Allow multiple values |
-| `uniqueItems` | boolean | `false` | Require unique values (only meaningful when `multiple` is true) |
-
-Example with options:
+| `uniqueItems` | boolean | `false` | Reject duplicate values (only with `multiple`) |
+| `minLength` | number | `null` | Minimum trimmed length of each value |
+| `maxLength` | number | `null` | Maximum trimmed length of each value |
 
 ```json
 {
   "type": "text",
   "multiple": true,
   "uniqueItems": true,
-  "required": true,
-  "description": "Tags for this item"
+  "maxLength": 50
 }
 ```
 
@@ -77,50 +67,33 @@ Example with options:
 
 URL values.
 
-```json
-{
-  "type": "url"
-}
-```
-
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `multiple` | boolean | `false` | Allow multiple values |
-| `uniqueItems` | boolean | `false` | Require unique values |
+| `uniqueItems` | boolean | `false` | Reject duplicate values (only with `multiple`) |
 
 ### Number (`number`)
 
 Numeric values (integer or float).
 
-```json
-{
-  "type": "number"
-}
-```
-
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `precision` | number | `null` | Number of decimal places for display |
-| `minimum` | number | `null` | Minimum allowed value |
-| `maximum` | number | `null` | Maximum allowed value |
-
-Example with constraints:
+| `minimum` | number | `null` | Minimum allowed value (inclusive) |
+| `maximum` | number | `null` | Maximum allowed value (inclusive) |
 
 ```json
 {
   "type": "number",
   "minimum": 0,
   "maximum": 100,
-  "precision": 2,
-  "description": "Percentage value"
+  "precision": 2
 }
 ```
 
 ### Select (`select`)
 
-A fixed set of allowed options that users pick from. Each option has a stable ID;
-stored statement values reference the ID, so renaming an option's label does not break
-existing data.
+A fixed set of options the user picks from.
 
 ```json
 {
@@ -135,130 +108,76 @@ existing data.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `options` | `SelectOption[]` | `[]` | The allowed values to choose from. |
-| `multiple` | boolean | `false` | Allow selecting multiple options. |
+| `options` | `SelectOption[]` | `[]` | The allowed options to choose from |
+| `multiple` | boolean | `false` | Allow selecting more than one |
 
 Each `SelectOption`:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `id` | string | Yes | Stable identifier. Unique within the property. Statements store this. |
-| `label` | string | Yes | Human-readable display text. Unique (case-insensitive, trimmed) within the property. |
+| `id` | string | Yes | Stable identifier, unique within the property. Statements store this. |
+| `label` | string | Yes | Display text, unique (case-insensitive, trimmed) within the property. |
 
-Stored statement values for a select property are option IDs (not labels). Display and
-API reads resolve IDs to labels via the current Schema.
-
-On write (create/replace statement), the API accepts either an option `id` or a `label`
-(case-insensitive, whitespace-trimmed). A `{ "id": ..., "label": ... }` object is also
-accepted when consistent; mismatched `id`/`label` is rejected.
-
-Example with multi-select:
-
-```json
-{
-  "type": "select",
-  "options": [
-    { "id": "opt_red",    "label": "Red" },
-    { "id": "opt_green",  "label": "Green" },
-    { "id": "opt_blue",   "label": "Blue" },
-    { "id": "opt_yellow", "label": "Yellow" }
-  ],
-  "multiple": true,
-  "required": true,
-  "description": "Color tags"
-}
-```
+On write, a Statement value may be an option `id`, a `label` (case-insensitive, trimmed), or a `{ "id", "label" }`
+object; a mismatched `id`/`label` is rejected. Reads and display resolve stored `id`s back to labels via the current
+Schema.
 
 ### Relation (`relation`)
 
 References to other Subjects.
 
-```json
-{
-  "type": "relation",
-  "relation": "Has author",
-  "targetSchema": "Person"
-}
-```
-
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `relation` | string | Yes | - | The relation type name (used in Neo4j as relationship type) |
-| `targetSchema` | string | Yes | - | Name of the schema that target subjects must follow |
+| `relation` | string | Yes | - | The relation type name |
+| `targetSchema` | string | Yes | - | Name of the Schema that target Subjects must follow |
 | `multiple` | boolean | No | `false` | Allow multiple relations |
-
-Example:
 
 ```json
 {
   "type": "relation",
   "relation": "Has product",
   "targetSchema": "Product",
-  "multiple": true,
-  "description": "Products made by this company"
+  "multiple": true
 }
 ```
 
 ### Boolean (`boolean`)
 
-A true/false value, edited via a toggle switch and displayed as "Yes" or "No".
-
-```json
-{
-  "type": "boolean"
-}
-```
-
-This type has no type-specific fields beyond the [common fields](#common-fields).
-The `default` may be `true`, `false`, or `null` (no default).
-
-Example:
+A true/false value. No type-specific fields; `default` may be `true`, `false`, or `null` (no default).
 
 ```json
 {
   "type": "boolean",
-  "default": false,
-  "description": "Whether the company is publicly traded"
+  "default": false
 }
 ```
 
-## Reserved Property Types
+### Date (`date`)
 
-The following types are defined in the JSON schema but not yet implemented:
+A calendar date, stored as a strict ISO 8601 `YYYY-MM-DD` string (no time or timezone; see
+[`invalid-date`](validation-codes.md#invalid-date)). `minimum`, `maximum`, and any `default` use the same format.
 
-- `email` - Email addresses
-- `phoneNumber` - Phone numbers
-- `date` - Date values
-- `time` - Time values
-- `dateTime` - Combined date and time
-- `duration` - Time durations
-- `currency` - Monetary values
-- `progress` - Progress indicators
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `minimum` | string | `null` | Earliest allowed date |
+| `maximum` | string | `null` | Latest allowed date |
+
+### DateTime (`dateTime`)
+
+A date and time, stored as a strict ISO 8601 / `xsd:dateTime` string with an explicit timezone offset or `Z`
+(e.g. `2025-06-15T14:30:00Z`; see [`invalid-datetime`](validation-codes.md#invalid-datetime)). `minimum`, `maximum`,
+and any `default` use the same format.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `minimum` | string | `null` | Earliest allowed datetime |
+| `maximum` | string | `null` | Latest allowed datetime |
 
 ## REST API
 
-### Reading Schemas
-
-`GET /rest.php/neowiki/v0/schema/{schemaName}`
-
-Returns the schema wrapped in a response object:
-
-```json
-{
-  "schema": {
-    "description": "...",
-    "propertyDefinitions": { ... }
-  }
-}
-```
-
-Returns `{"schema": null}` if the schema is not found.
-
-### Searching Schema Names
-
-`GET /rest.php/neowiki/v0/schema-names/{search}`
-
-Returns a list of schema names matching the search term.
+`GET /neowiki/v0/schema/{schemaName}` wraps this format as `{ "schema": ... }`, or `{ "schema": null }` when the Schema
+does not exist or you may not [read](rest-api.md#permissions) it. There is no write endpoint; create or edit a Schema by
+editing its page in the Schema namespace.
 
 ## Complete Example
 
@@ -309,7 +228,4 @@ A "Company" schema with various property types:
 
 ## Related Documentation
 
-- [ADR 006: Schemas](../adr/006-schemas.md)
-- [ADR 009: Move Away from JSON Schema](../adr/009-move-away-from-json-schema.md)
-- [ADR 017: Names as Identifiers](../adr/017-names-as-identifiers.md)
-- [Subject Format](subject-format.md) - Format for Subject data that follows schemas
+- [Subject Format](subject-format.md) — format for the Subject data that follows Schemas.

--- a/docs/api/subject-format.md
+++ b/docs/api/subject-format.md
@@ -4,24 +4,21 @@ order: 3
 ---
 # Subject JSON Format
 
-This document describes the JSON format used to store Subject data in MediaWiki revision slots and returned by
-the REST API (GET endpoints). The same format is used for write operations (POST/PUT) with minor differences
-noted below.
+Subject data is [stored as JSON](../adr/002-store-data-as-json.md). The REST API returns and accepts the same object
+shapes; its read envelope and write differences are under [REST API](#rest-api).
 
-For definitions of terms like Subject, Statement, and Value, see the [Glossary](../glossary.md).
+For Subject, Statement, and Value, see the [Glossary](../glossary.md).
 
-## Overview
+## Top-level structure
 
-Subject data is stored as JSON in a dedicated MediaWiki revision slot. Each page can contain multiple Subjects:
-one optional "main subject" and zero or more "child subjects".
-
-## Top-Level Structure
+A page holds one optional main Subject and zero or more child Subjects
+([ADR 007](../adr/007-multiple-subjects-per-page.md)), all in one `subjects` map with `mainSubject` pointing at
+the main one.
 
 ```json
 {
   "mainSubject": "<subject-id>",
   "subjects": {
-    "<subject-id>": { ... },
     "<subject-id>": { ... }
   }
 }
@@ -29,19 +26,16 @@ one optional "main subject" and zero or more "child subjects".
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `mainSubject` | string | No | ID of the main subject on this page. If omitted, the page has no main subject. |
-| `subjects` | object | No | Map of subject IDs to subject objects. If omitted, the page has no subjects. |
+| `mainSubject` | string | No | ID of the page's main Subject. Omitted or `null` when the page has none. |
+| `subjects` | object | No | Map of Subject ID to [Subject object](#subject-object). Omitted or empty when the page has no Subjects. |
 
-## Subject Object
-
-Each subject in the `subjects` map has the following structure:
+## Subject object
 
 ```json
 {
   "label": "Professional Wiki GmbH",
   "schema": "Company",
   "statements": {
-    "<property-name>": { ... },
     "<property-name>": { ... }
   }
 }
@@ -49,68 +43,13 @@ Each subject in the `subjects` map has the following structure:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `label` | string | Yes | Human-readable label for the subject |
-| `schema` | string | Yes | Name of the Schema this subject follows (page name in the Schema namespace) |
-| `statements` | object | No | Map of property names to statement objects. If omitted, the subject has no statements. |
+| `label` | string | Yes | Human-readable label for the Subject. |
+| `schema` | string | Yes | Name of the Schema the Subject follows (a page in the Schema namespace). |
+| `statements` | object | No | Map of property name to [Statement object](#statement-object). Omitted when the Subject has none. |
 
-## Statement Object
+A property mapped to `null` instead of a Statement object is skipped when the JSON is read.
 
-Each statement represents a property value and includes the "writer's schema" - the property type at the time
-the value was written. This allows the system to handle schema changes gracefully.
-
-```json
-{
-  "type": "<property-type>",
-  "value": <value>
-}
-```
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `type` | string | Yes | The property type when this value was written (writer's schema). See Value Formats below. |
-| `value` | varies | Yes | The actual value. Format depends on `type`. |
-
-## Value Formats by Type
-
-### Text (`text`)
-
-Array of strings.
-
-```json
-{
-  "type": "text",
-  "value": ["Germany"]
-}
-```
-
-```json
-{
-  "type": "text",
-  "value": ["First value", "Second value"]
-}
-```
-
-### URL (`url`)
-
-Array of strings (URLs).
-
-```json
-{
-  "type": "url",
-  "value": ["https://professional.wiki"]
-}
-```
-
-```json
-{
-  "type": "url",
-  "value": ["https://professional.wiki", "https://wikibase.consulting"]
-}
-```
-
-### Number (`number`)
-
-Single numeric value (integer or float).
+## Statement object
 
 ```json
 {
@@ -119,36 +58,52 @@ Single numeric value (integer or float).
 }
 ```
 
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | string | Yes | The property's type when the value was written — the writer's schema ([ADR 011](../adr/011-include-writers-schema.md)). |
+| `value` | varies | Yes | The value, shaped by `type`. See [Value formats](#value-formats). |
+
+## Value formats
+
+`type` holds the property type name, which fixes the `value` shape:
+
+| `type` | `value` |
+|--------|---------|
+| `text`, `url`, `select`, `date`, `dateTime` | Array of strings, one per value part. |
+| `number` | A single number (integer or float). |
+| `boolean` | A single boolean. |
+| `relation` | Array of [relation objects](#relations). |
+
+A multi-part `text` value:
+
 ```json
-{
-  "type": "number",
-  "value": 3.14159
-}
+{ "type": "text", "value": [ "First value", "Second value" ] }
 ```
 
-### Relation (`relation`)
+Every registered PropertyType uses one of these four `value` shapes. A `type` whose PropertyType is not
+registered — its extension disabled — keeps the raw value that was stored
+([`unregistered-type`](validation-codes.md#unregistered-type)).
 
-Array of Relation objects, each pointing to another subject.
+### Relations
+
+Each `relation` value is an array of objects pointing at other Subjects:
 
 ```json
 {
   "type": "relation",
   "value": [
-    {
-      "id": "r1demo5rrrrrrr1",
-      "target": "s1demo4sssssss1"
-    }
+    { "id": "r1demo5rrrrrrr1", "target": "s1demo4sssssss1" }
   ]
 }
 ```
 
 | Field | Type | Required | Description |
-|-------|------|-------------|-------------|
-| `id` | string | Yes | Unique identifier for this relation |
-| `target` | string | Yes | Subject ID of the target subject |
-| `properties` | object | No | Key-value pairs of relation properties. Only included when non-empty. |
+|-------|------|----------|-------------|
+| `id` | string | Yes | ID of this relation. |
+| `target` | string | Yes | ID of the target Subject. |
+| `properties` | object | No | Key-value relation properties. Present only when non-empty. |
 
-Relation properties example:
+With relation properties:
 
 ```json
 {
@@ -161,68 +116,42 @@ Relation properties example:
 }
 ```
 
-## Empty and Null Values
+## IDs
 
-- If `mainSubject` is omitted or `null`, the page has no main subject
-- If `subjects` is omitted, it defaults to an empty object (no subjects)
-- If `statements` is omitted, the subject has no statements
-- Individual statements set to `null` are skipped during deserialization
-
-## ID Formats
-
-### Subject IDs
-
-Subject IDs are 15-character nanoid-style identifiers that are lexicographically sortable by creation time.
-They start with `s`.
-
-Example: `s1demo5sssssss1`
-
-### Relation IDs
-
-Relation IDs follow the same format as subject IDs but start with `r`.
-
-Example: `r1demo5rrrrrrr1`
-
-See [ADR 014](../adr/014-improved-id-format.md) for details on the ID format.
+Subject and Relation IDs are 15-character nanoid-style strings, lexicographically sortable by creation time.
+Subject IDs start with `s` (`s1demo5sssssss1`), Relation IDs with `r` (`r1demo5rrrrrrr1`). See
+[ADR 014](../adr/014-improved-id-format.md).
 
 ## REST API
 
 ### Reading Subjects
 
-`GET /rest.php/neowiki/v0/subject/{subjectId}`
+`GET /rest.php/neowiki/v0/subject/{subjectId}` returns a top-level `requestedId` and a `subjects` map; each
+Subject gains an `id` field. Statements use the storage `type` key.
 
-Returns the same statement format as storage, with additional fields:
-- `requestedId`: The ID that was requested
-- Each subject includes an `id` field. Passing `?expand=page` adds the page fields `pageId`,
-  `pageTitle`, and `pageNamespaceId`. `pageTitle` is the full page title including the namespace prefix
-  (e.g. `Help:Installation`); `pageNamespaceId` is the page's canonical MediaWiki namespace ID (e.g. `0`
-  for the main namespace, `12` for Help), which is stable regardless of the wiki's content language.
-- Passing `?expand=relations` also embeds the Subjects targeted by this Subject's relation values; see
-  [REST API](rest-api.md#the-expand-parameter) for the response shape.
+- `?expand=page` adds `pageId`, `pageTitle`, and `pageNamespaceId` to each Subject. `pageTitle` is the full page
+  title with namespace prefix (e.g. `Help:Installation`); `pageNamespaceId` is the canonical MediaWiki namespace
+  ID (e.g. `0` for the main namespace, `12` for Help).
+- `?expand=relations` embeds the Subjects this one's relations target; see
+  [REST API](rest-api.md#the-expand-parameter) for the shape.
+- `?revisionId=` returns the Subject as of that MediaWiki revision; an unknown or unreadable revision returns `404`.
 
 ### Creating Subjects
 
-`POST /rest.php/neowiki/v0/page/{pageId}/mainSubject`
-`POST /rest.php/neowiki/v0/page/{pageId}/childSubjects`
+`POST /rest.php/neowiki/v0/page/{pageId}/mainSubject` and `.../childSubjects` create a Subject on a page. The body
+takes `label`, `schema`, and `statements` (all required), plus an optional `comment` edit summary. Statements use the
+`propertyType` write shape [below](#writing-subjects), not the storage `type` key.
 
-Create a Subject on a page from a [Subject object](#subject-object) (`label`, `schema`, `statements`),
-with an optional `comment` edit summary.
-
-The Subject ID is normally minted server-side. To set it yourself — for example to wire relations across
-a batch before the target Subjects exist — pass an optional `id`:
+The server mints the Subject ID unless you pass one:
 
 | Field | Required | Notes |
-|---|---|---|
-| `id` | No | Subject ID to assign. Must be well-formed (`400` otherwise) and unused (`409` otherwise). Omit to have the server mint one. Pre-mint a batch of IDs with `POST /neowiki/v0/subject-ids`. |
-
-After creation the ID is immutable; the replace endpoint below ignores it.
+|-------|----------|-------|
+| `id` | No | Subject ID to assign. Well-formed (`400` otherwise) and unused (`409` otherwise). Pre-mint a batch with `POST /rest.php/neowiki/v0/subject-ids` to wire relations before their targets exist. |
 
 ### Writing Subjects
 
-`PUT /rest.php/neowiki/v0/subject/{subjectId}`
-
-Full replace of the Subject's writable state (label and statements). The request body uses
-`propertyType` instead of `type` for statements:
+`PUT /rest.php/neowiki/v0/subject/{subjectId}` replaces the Subject's label and statements. Statements use
+`propertyType` in place of `type`:
 
 ```json
 {
@@ -238,19 +167,20 @@ Full replace of the Subject's writable state (label and statements). The request
 ```
 
 | Field | Required | Notes |
-|---|---|---|
+|-------|----------|-------|
 | `label` | Yes | Non-empty after `trim`. |
-| `statements` | Yes | Map of property name to Statement. Property names not in the map are deleted from the Subject. Pass `{}` to clear all statements. |
-| `comment` | No | Optional edit summary. |
+| `statements` | Yes | Map of property name to Statement; omitted names are deleted. Pass `{}` to clear all. |
+| `comment` | No | Edit summary. |
 
-The Subject's `id`, `schema`, `pageId`, `pageTitle`, and `pageNamespaceId` are immutable after creation
-and are not part of the request body. If sent, they are ignored.
+A statement entry without `propertyType`, or whose value is empty for its type, is dropped without error. For
+schema/value validation outcomes see [Validation Codes](validation-codes.md).
 
-Relation IDs can be omitted for new relations (a fresh ID is generated server-side).
+A relation may omit `id`; the server generates one. The Subject's `id`, `schema`, and page fields are immutable
+and ignored if sent.
 
-## Complete Example
+## Complete example
 
-A page about Berlin with multiple subjects (main subject + child subjects for population data):
+A page about Berlin with a main Subject and a child Subject for population data:
 
 ```json
 {
@@ -287,11 +217,3 @@ A page about Berlin with multiple subjects (main subject + child subjects for po
   }
 }
 ```
-
-## Related Documentation
-
-- [ADR 002: Store Data as JSON](../adr/002-store-data-as-json.md)
-- [ADR 004: Use Dedicated Slot](../adr/004-use-dedicated-slot.md)
-- [ADR 007: Multiple Subjects Per Page](../adr/007-multiple-subjects-per-page.md)
-- [ADR 011: Include Writer's Schema](../adr/011-include-writers-schema.md)
-- [ADR 014: Improved ID Format](../adr/014-improved-id-format.md)

--- a/docs/authoring/lua-api.md
+++ b/docs/authoring/lua-api.md
@@ -40,13 +40,17 @@ value. Use [`nw.getAll()`](#nwgetallpropertyname-options) when you need every va
 | `propertyName` | string | Required. The name of the property. |
 | `options` | table | Optional. `{ page = '...' }` or `{ subject = '...' }`. If both are passed, `subject` takes precedence. |
 
+The current-page (no options) and `{ page = '...' }` forms read the page's **Main Subject**; a property
+that lives only on a Child Subject is not found. Use `{ subject = '...' }` to address a specific Subject
+(including a Child) by ID.
+
 #### Returns
 
 The first value of the property, type-converted for Lua:
 
 | Property type | Returned type |
 |---------------|---------------|
-| `text`, `url`, `select` | string |
+| `text`, `url`, `select`, `date`, `dateTime` | string |
 | `number` | number |
 | `boolean` | boolean |
 | `relation` | string (target Subject's label, falls back to target ID if lookup fails) |
@@ -66,16 +70,15 @@ nw.getValue('City', { subject = 's1abc5def6ghi78' })   --> "Berlin"
 
 ### `nw.getAll(propertyName, options)`
 
-Returns every value for a property as a 1-indexed Lua table. Use this when a property is
-multi-valued and you need all values. Even single-valued properties are wrapped in a 1-element
-table.
+Returns every value for a property as a 1-indexed Lua table. Even single-valued properties are
+wrapped in a 1-element table.
 
 Same parameters and resolution rules as [`nw.getValue()`](#nwgetvaluepropertyname-options).
 
 #### Returns
 
-A 1-indexed Lua table of values, type-converted as in `getValue`. For relations, each entry is
-the target Subject's label.
+A 1-indexed Lua table of values, in the order they are stored on the Subject, type-converted as in
+`getValue`. For relations, each entry is the target Subject's label.
 
 Returns `nil` under the same conditions as `getValue`.
 
@@ -166,10 +169,9 @@ end
 
 ### `nw.query(cypher, params)`
 
-Runs a read-only Cypher query against the graph database and returns each row as a Lua table. Use
-this when a single property lookup is not enough — for example, to join multiple Subjects, filter
-or sort in the query, or build a custom table. It is available only when a Neo4j graph backend is
-configured; on a wiki without one, `mw.neowiki.query` is nil.
+Runs a read-only Cypher query against the graph database and returns each row as a Lua table. It
+is available only when a Neo4j graph backend is configured; on a wiki without one,
+`mw.neowiki.query` is nil.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
@@ -196,9 +198,6 @@ Scalar values come back as strings, numbers, booleans, or `nil`. Nested Cypher l
 | `duration` | `{ months, days, seconds, nanoseconds }` |
 | `point` | `{ x, y, crs, srid }` (plus `z` for 3D points) |
 
-Temporal values come back as ISO 8601 strings (timezone offsets to whole-minute precision). `duration`
-and spatial `point` values come back as component tables.
-
 #### Errors
 
 Always throws on failure; wrap in `pcall` if you need graceful degradation.
@@ -209,8 +208,7 @@ Always throws on failure; wrap in `pcall` if you need graceful degradation.
 
 #### Expensive
 
-Every call counts as an expensive parser function. Keep an eye on your page's expensive function
-limit if a template calls `nw.query` in a loop.
+Every call counts as an expensive parser function.
 
 #### Examples
 
@@ -241,7 +239,7 @@ without one, `mw.neowiki.sparqlQuery` is nil.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `sparql` | string | Required. A SPARQL `SELECT` or `ASK` query. Read-only by protocol. `CONSTRUCT` / `DESCRIBE` are not supported yet (they return an RDF graph, not a results document). |
+| `sparql` | string | Required. A SPARQL `SELECT` or `ASK` query. Read-only by protocol. `CONSTRUCT` and `DESCRIBE` are not supported. |
 
 #### Returns
 
@@ -259,8 +257,7 @@ Always throws on failure; wrap in `pcall` if you need graceful degradation.
 
 #### Expensive
 
-Every call counts as an expensive parser function. Keep an eye on your page's expensive function
-limit if a template calls `nw.sparqlQuery` in a loop.
+Every call counts as an expensive parser function.
 
 #### Examples
 
@@ -276,9 +273,7 @@ end
 
 ### `nw.getSchema(name)`
 
-Returns a Schema as a Lua table so your module can inspect it at runtime. Use it to build generic
-infoboxes, render a property list for any Schema, or check what properties a Subject should have —
-without hardcoding property names.
+Returns a Schema as a Lua table so a module can inspect it at runtime.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
@@ -287,8 +282,7 @@ without hardcoding property names.
 #### Returns
 
 A Schema table, or `nil` if no Schema with that name exists. An empty or whitespace-only `name`
-and the reserved names `page` and `subject` also return `nil`, so bad input never errors — always
-guard with `if schema then`.
+and the reserved names `page` and `subject` also return `nil`. Guard with `if schema then`.
 
 Top-level fields:
 
@@ -298,30 +292,33 @@ Top-level fields:
 | `description` | string | The Schema description. Omitted when empty. |
 | `properties` | table | 1-indexed list of properties, in Schema-defined order. |
 
-Every property entry has `name`, `type`, and `required`. Further fields depend on `type`:
+Every property entry has `name`, `type`, and `required`, plus `description` and `default` when
+those are set. Beyond that core, the fields depend on `type`:
 
 | Property type | Always present | Present only when set |
 |---------------|----------------|------------------------|
-| `text` | `multiple`, `uniqueItems` | `description`, `default` |
-| `url`  | `multiple`, `uniqueItems` | `description`, `default` |
-| `number` | — | `description`, `default`, `precision`, `minimum`, `maximum` |
-| `select` | `multiple`, `options` (1-indexed list of `{ id, label }` entries) | `description`, `default` |
-| `relation` | `multiple`, `relation`, `targetSchema` | `description`, `default` |
+| `text` | `multiple`, `uniqueItems` | `minLength`, `maxLength` |
+| `url` | `multiple`, `uniqueItems` | — |
+| `number` | — | `precision`, `minimum`, `maximum` |
+| `date`, `dateTime` | — | `minimum`, `maximum` |
+| `select` | `multiple`, `options` (1-indexed list of `{ id, label }` entries) | — |
+| `relation` | `multiple`, `relation`, `targetSchema` | — |
+| `boolean` | — | — |
 
 Optional fields are **omitted entirely** when unset, so check with `if prop.description then …`.
-Boolean flags in the "always present" column (such as `required`, `multiple`, `uniqueItems`) are
-emitted even when `false` — read them directly. `if prop.required then` would silently skip
-`false` as well as missing.
+`required` is always present, and `multiple`/`uniqueItems` are present for the types the table
+marks under **Always present**; where present, these boolean flags are emitted even when `false`,
+so read them directly rather than testing truthiness. For a type where the table does not list
+`multiple`/`uniqueItems`, they are absent (`nil`), not `false`.
 
 #### Errors
 
-Raises a Lua error only when `name` is missing or not a string. Every other case — unknown Schema,
-empty string, reserved name — returns `nil`.
+Raises a Lua error only when `name` is missing or not a string. Wrap a computed or possibly-`nil`
+name in `pcall`.
 
 #### Expensive
 
-Every call counts as an expensive parser function against the page's limit. Call `nw.getSchema`
-once per page and reuse the result rather than re-fetching inside a loop.
+Every call counts as an expensive parser function.
 
 #### Examples
 
@@ -335,8 +332,7 @@ end
 ```
 
 ```lua
--- Render a property overview for the current page's Main Subject — works
--- for any Schema, because nothing is hardcoded.
+-- Render a property overview for the current page's Main Subject.
 local subject = nw.getMainSubject()
 local schema = subject and nw.getSchema( subject.schema )
 
@@ -397,8 +393,10 @@ Notes:
 
 ## Performance
 
-Calls that look up another page or a specific Subject ID count as expensive parser functions
-(against the page's expensive function limit). Calls that read from the current page do not.
+Each of these counts as an expensive parser function (against the page's expensive function limit):
+`nw.query`, `nw.sparqlQuery`, `nw.getSchema`, and `nw.getSubject` on every call; `nw.getValue`,
+`nw.getAll`, `nw.getMainSubject`, and `nw.getChildSubjects` only when passed a `page`/`subject`
+option or page name. Reads of the current page do not count.
 
 ## Related Documentation
 

--- a/docs/authoring/parser-functions.md
+++ b/docs/authoring/parser-functions.md
@@ -4,7 +4,7 @@ order: 1
 ---
 # Parser Functions
 
-NeoWiki provides three parser functions for use in wikitext.
+NeoWiki provides these parser functions for use in wikitext.
 
 | If you want to... | Use |
 |-------------------|-----|
@@ -44,8 +44,8 @@ and how.
 
 ### Notes
 
-- Returns an empty string if the resolved Subject does not exist.
-- The View Type (e.g. `infobox`) is determined by the Layout. Only `infobox` is implemented today.
+- Renders nothing when the Subject does not exist, or when no Subject is given and the page has no
+  Main Subject.
 - Rendering happens client-side, so the Subject view appears once the page's JavaScript has loaded.
 
 ### Examples
@@ -63,8 +63,7 @@ Subject both positionally and as `subject=` produce a visible parser error.
 
 ## `{{#neowiki_value}}`
 
-Returns the value of a single property from a Subject, formatted as a string. Designed for inline
-use in wikitext and for other extensions that need to read NeoWiki metadata via parser functions.
+Returns the value of a single property from a Subject, formatted as a string.
 
 ### Syntax
 
@@ -88,7 +87,7 @@ use in wikitext and for other extensions that need to read NeoWiki metadata via 
 
 | Type | Output |
 |------|--------|
-| `text`, `url`, `select` | The string value. Multiple values joined with `separator`. |
+| `text`, `url`, `select`, `date`, `dateTime` | The string value. Multiple values joined with `separator`. |
 | `number` | The number, e.g. `42` or `19.99`. |
 | `boolean` | `true` or `false`. |
 | `relation` | The target Subject's label. Multiple targets joined with `separator`. Falls back to the target Subject ID if the label cannot be looked up. |
@@ -99,8 +98,7 @@ as "empty".
 ### Output is plain text
 
 The output is HTML-escaped and not interpreted as wikitext. Links, templates, and HTML inside
-property values render as literal characters. Useful when you want exactly what the user typed;
-not useful when you want to emit links or styled markup.
+property values render as literal characters.
 
 When you pass the result to another parser function as an argument, that function also receives
 HTML-encoded text — a value of `Engineers & Designers` arrives as `Engineers &amp; Designers`.
@@ -128,14 +126,13 @@ Passing a value to another extension's parser function:
 
 ## `{{#cypher_raw}}`
 
-Executes a read-only Cypher query and returns the raw results as JSON in a code block. Mainly
-useful for development and debugging. It is available only when a Neo4j graph backend is configured;
-on a wiki without one, `{{#cypher_raw: …}}` is not registered and renders as ordinary wikitext.
+Executes a read-only Cypher query and returns the raw results as JSON in a code block, for
+development and debugging. Available only when a Neo4j graph backend is configured; on a wiki
+without one, `{{#cypher_raw: …}}` is not registered and renders as ordinary wikitext. The
+[Graph Model](../api/graph-model.md) describes the node and relationship structure to query.
 
-For end-user dashboards, formatted query result rendering is planned (see
-[#809](https://github.com/ProfessionalWiki/NeoWiki/issues/809)). A Lua
-[`nw.query()`](lua-api.md#nwquerycypher-params) function is already available for building
-custom result formatting in templates.
+For formatted result rendering, build it in a template with Lua
+[`nw.query()`](lua-api.md#nwquerycypher-params).
 
 ### Syntax
 
@@ -147,6 +144,9 @@ custom result formatting in templates.
 
 - Only read queries are allowed. Anything that creates, modifies, or deletes data is rejected,
   including `CALL` (even for read-only procedures).
+- Results are capped at the `maxRows` limit from `$wgNeoWikiQueryLimits` (higher for users with
+  `apihighlimits`); rows beyond it are dropped silently. Queries also stop at that tier's
+  `timeoutSeconds`.
 - Errors (rejected queries, syntax errors, the database being unavailable, etc.) render as a
   styled error message in place of the result.
 - Output is HTML-escaped, so query results containing `<`, `>`, `&`, etc. display safely.
@@ -164,12 +164,12 @@ custom result formatting in templates.
 ## `{{#sparql_raw}}`
 
 Executes a read-only SPARQL query against the first configured [SPARQL store](../operations/installation.md#optional-sparql-graph-stores)
-and returns the raw results as JSON in a code block. The SPARQL counterpart of `{{#cypher_raw}}`, mainly
-useful for development and debugging. It is available only when a SPARQL store is configured; on a wiki
-without one, `{{#sparql_raw: …}}` is not registered and renders as ordinary wikitext.
+and returns the raw results as JSON in a code block. The SPARQL counterpart of `{{#cypher_raw}}`, for
+development and debugging. Available only when a SPARQL store is configured; on a wiki without one,
+`{{#sparql_raw: …}}` is not registered and renders as ordinary wikitext.
 
-The output is the W3C [`application/sparql-results+json`](https://www.w3.org/TR/sparql11-results-json/)
-document, unmodified — the standard `head` / `results` structure (or `boolean` for an `ASK` query).
+The JSON is the W3C [`application/sparql-results+json`](https://www.w3.org/TR/sparql11-results-json/)
+document — the standard `head` / `results` structure (or `boolean` for an `ASK` query).
 
 ### Syntax
 
@@ -179,9 +179,9 @@ document, unmodified — the standard `head` / `results` structure (or `boolean`
 
 ### Notes
 
-- Read-only by protocol, not by a keyword filter: the query is sent as a SPARQL 1.1 *query* operation
-  (`SELECT` / `ASK` / `CONSTRUCT` / `DESCRIBE`), and the SPARQL query grammar contains no update forms, so
-  no read-only validator is needed (unlike Cypher, where one language expresses both reads and writes).
+- Read-only: the query cannot modify the store.
+- No row cap is applied — the full results document is returned. Queries stop at the
+  `timeoutSeconds` from `$wgNeoWikiQueryLimits` (higher for users with `apihighlimits`).
 - Errors (a query the store rejects, the store being unavailable, etc.) render as a styled error message
   in place of the result.
 - Output is HTML-escaped, so results containing `<`, `>`, `&`, etc. display safely.
@@ -193,12 +193,3 @@ document, unmodified — the standard `head` / `results` structure (or `boolean`
 ```
 {{#sparql_raw: SELECT ?label WHERE { ?s <http://www.w3.org/2000/01/rdf-schema#label> ?label } LIMIT 10}}
 ```
-
-## Related Documentation
-
-- [Lua API](lua-api.md) — Programmatic access to the same data via `mw.neowiki`
-- [Glossary](../glossary.md) — Definitions of Subject, Schema, Layout, View, etc.
-- [Schema Format](../api/schema-format.md) — How Schemas and properties are defined
-- [Subject Format](../api/subject-format.md) — How Subject data is stored
-- [Graph Model](../api/graph-model.md) — Neo4j node and relationship structure (relevant for
-  `{{#cypher_raw}}` queries)

--- a/docs/examples/person-to-edm.md
+++ b/docs/examples/person-to-edm.md
@@ -4,62 +4,56 @@ order: 1
 ---
 # Worked example: projecting a Person to EDM
 
-This is an end-to-end walkthrough of the [Ontology Mapping](../rdf/ontology-mapping.md) v1
-projection: a NeoWiki-native `Person` Schema, an EDM Mapping, and a demo page, projected into
-[Europeana Data Model](https://pro.europeana.eu/page/edm-documentation) (EDM) RDF and compared with the
-native projection.
+End-to-end walkthrough of the [Ontology Mapping](../rdf/ontology-mapping.md) v1 projection: a NeoWiki-native `Person`
+Schema, an EDM Mapping, and a demo page projected into
+[Europeana Data Model](https://pro.europeana.eu/page/edm-documentation) (EDM) RDF, shown against the native projection.
 
-It implements the EDM column of the shared "Neutral Person to Many Standards" toy model (takin, ECHOLOT
-WP2/WP3) — the first end-to-end proof of the mapping mechanism proposed in
-[planning/OntologyMapping.md](../planning/OntologyMapping.md). Everything here ships as
-[demo data](../../DemoData/), so a fresh wiki with the demo data imported reproduces it — up to
-instance-specific page IDs and base URI (and, in the page metadata, timestamps and last editor).
+It projects the EDM column of a small "person to many standards" toy model. Everything here ships as
+[demo data](../../DemoData/), so a wiki with the demo data imported (`php maintenance/run.php NeoWiki:ImportDemoData`)
+reproduces it — up to instance-specific page IDs and base URI (and, in the page metadata, timestamps and last editor).
 
-> **Scope: the near-1:1 tier only.** EDM is flat and property-centric, so the mapping is term
-> substitution. The toy model's CIDOC-CRM column is event-based (birth becomes an `E67_Birth` node
-> between the person and the date/place) and needs the intermediate-node **synthesis** that v1
-> deliberately does not do — see [Known next tier](#known-next-tier-cidoc-crm) below.
+> **Scope: the near-1:1 tier only.** Event-based ontologies like CIDOC-CRM need the intermediate-node synthesis that v1
+> does not do — see [Known next tier: CIDOC-CRM](#known-next-tier-cidoc-crm).
 
 ## The toy model
 
 | Neutral Person field | Example value | EDM target |
 |---|---|---|
-| Name | "Pablo Picasso" | `foaf:name` — **see the finding below**; v1 emits the name only as `rdfs:label` |
+| Name | "Pablo Picasso" | `foaf:name` *(not in v1 — see [Findings](#findings))* |
 | Gender | "Male" | `rdaGr2:gender` literal |
-| Birth Date | 1881-10-25 | `rdaGr2:dateOfBirth` (`xsd:date`) |
-| Birth Location | Málaga (Getty TGN 7007942) | `rdaGr2:placeOfBirth` → an `edm:Place` |
+| Birth date | 1881-10-25 | `rdaGr2:dateOfBirth` (`xsd:date`) |
+| Birth place | Málaga | `rdaGr2:placeOfBirth` → an `edm:Place` |
 | Description | biography text | `skos:note` literal |
-| Source | "A Life of Picasso I…" (ISBN) | **n/a in EDM** — deliberately unmapped |
+| Source | "A Life of Picasso I…" (ISBN) | **n/a in EDM** — unmapped |
 
 Prefixes: `edm: http://www.europeana.eu/schemas/edm/`, `rdaGr2: http://rdvocab.info/ElementsGr2/`,
 `skos: http://www.w3.org/2004/02/skos/core#`.
 
 ## 1. The Schemas
 
-The demo `Person` Schema ([`DemoData/Schema/Person.json`](../../DemoData/Schema/Person.json)) carries the
-flat toy-model fields. It is deliberately **not** a parallel schema: the existing rich, event-based Bach
-family data (birth as its own `Birth` Subject) keeps working; the flat `Birth date` / `Birth place`
-fields are the form the near-1:1 EDM projection consumes.
+The demo `Person` Schema ([`DemoData/Schema/Person.json`](../../DemoData/Schema/Person.json)) carries the flat toy-model
+fields. Abbreviated (property descriptions and the multi-valued `Also known as` field omitted):
 
 ```json
 {
-    "Gender":      { "type": "text" },
-    "Birth date":  { "type": "date" },
-    "Birth place": { "type": "relation", "relation": "Born in", "targetSchema": "City" },
-    "Source":      { "type": "text" },
-    "Description": { "type": "text" }
+    "propertyDefinitions": {
+        "Gender":      { "type": "text" },
+        "Birth date":  { "type": "date" },
+        "Birth place": { "type": "relation", "relation": "Born in", "targetSchema": "City" },
+        "Source":      { "type": "text" },
+        "Description": { "type": "text" }
+    }
 }
 ```
 
-Birth Location is a **relation** to a `City` Subject. The demo `City` Schema
-([`DemoData/Schema/City.json`](../../DemoData/Schema/City.json)) is used unchanged.
+The demo `City` Schema ([`DemoData/Schema/City.json`](../../DemoData/Schema/City.json)) is used unchanged.
 
 ## 2. The Mapping
 
-One Mapping page, **[`Mapping:EDM`](../../DemoData/Mapping/EDM.json)**, targets EDM and holds an entry
-for every mapped Schema. The page title (`EDM`) is the projection name. Abbreviated to the two entries
-this walkthrough uses (the shipped file also maps `Artwork` and `Artist`, and declares the extra
-`dc`/`dcterms`/`foaf`/`xsd` prefixes those need):
+One Mapping page, **[`Mapping:EDM`](../../DemoData/Mapping/EDM.json)**, holds an entry per mapped Schema; its title
+(`EDM`) is the projection name (see [Ontology Mapping](../rdf/ontology-mapping.md) for the format). Abbreviated to the
+two entries this walkthrough uses — the shipped file also maps `Artwork` and `Artist` and declares the
+`dc`/`dcterms`/`foaf`/`xsd` prefixes those need:
 
 ```json
 {
@@ -87,23 +81,17 @@ this walkthrough uses (the shipped file also maps `Artwork` and `Artist`, and de
 }
 ```
 
-`prefixes` are page-level, shared by every entry. The **City** entry maps **only the class**
-(`edm:Place`), with no property mappings. For the birthplace use case, all EDM needs from Málaga is
-a labelled `edm:Place` that `rdaGr2:placeOfBirth` can point at. The City's
-`Country`/`Population`/`Website` have no near-1:1 EDM `Place` predicate in the flat tier (place
-geography would use `wgs84_pos`, outside the toy model), so they are deliberately unmapped — see the
-[findings](#findings).
+`prefixes` are page-level. The `City` entry maps **only the class** (`edm:Place`).
 
 ## 3. The demo page
 
-[`Pablo_Picasso`](../../DemoData/Subject/Pablo_Picasso.json) is a `Person` main Subject with every
-toy-model value, its `Birth place` relation pointing at [`Málaga`](../../DemoData/Subject/Málaga.json)
-(a `City`).
+[`Pablo_Picasso`](../../DemoData/Subject/Pablo_Picasso.json) is a `Person` main Subject carrying every toy-model value,
+its `Birth place` relation pointing at [`Málaga`](../../DemoData/Subject/Málaga.json) (a `City`).
 
 ## 4. Running the projection
 
-Per page, via the [RDF export endpoint](../rdf/rdf-export.md#endpoint) (the `projection` query
-parameter selects the vocabulary):
+Per page, via the [RDF export endpoint](../rdf/rdf-export.md#endpoint) — the `projection` query parameter selects the
+vocabulary:
 
 ```sh
 # native (default):
@@ -120,8 +108,9 @@ php maintenance/run.php NeoWiki:DumpRdf --projection=EDM > dump-edm.trig
 
 ## 5. Native vs EDM output
 
-Real output from the demo wiki (Turtle; shared prefix header trimmed). **Native** projection of
-`Pablo_Picasso` — NeoWiki's own vocabulary, lossless, with page metadata and the two-layer relation:
+Real output from the demo wiki (Turtle; shared prefix header trimmed — the `neo*` CURIEs are the
+[IRI scheme](../rdf/rdf-export.md#iri-scheme)). The **native** projection of `Pablo_Picasso` —
+NeoWiki's own vocabulary, lossless, with page metadata and the two-layer relation:
 
 ```turtle
 <.../page/115> a neo:Page;
@@ -144,8 +133,7 @@ neo-rel:r2picasso2city2 a neo:Relation;
     neo:relationType neo-prop:Born_in.
 ```
 
-**EDM** projection of the same page — target vocabulary only, no page metadata, no relation
-reification:
+The **EDM** projection of the same page — target vocabulary only, no page metadata, no relation reification:
 
 ```turtle
 neo-subj:s2picasso2aaaa2 a edm:Agent;
@@ -156,7 +144,7 @@ neo-subj:s2picasso2aaaa2 a edm:Agent;
     rdaGr2:placeOfBirth neo-subj:s2birthcity2aa2.
 ```
 
-**EDM** projection of `Málaga` (its own page) — typed `edm:Place`:
+The **EDM** projection of `Málaga` (its own page) — a typed `edm:Place`:
 
 ```turtle
 neo-subj:s2birthcity2aa2 a edm:Place;
@@ -165,26 +153,22 @@ neo-subj:s2birthcity2aa2 a edm:Place;
 
 What changed, native → EDM:
 
-- The Subject IRI is **unchanged** (`neo-subj:s2picasso2aaaa2`): the entity stays the wiki's own; only
-  the *vocabulary* is EDM. Sibling projections mint identical IRIs.
-- `rdf:type` `neo-schema:Person` → `edm:Agent`; `Málaga` → `edm:Place`.
-- `rdfs:label` is kept verbatim (a standard term EDM also uses).
-- Each mapped property's predicate is substituted: `neo-prop:Gender` → `rdaGr2:gender`, `Birth_date` →
-  `rdaGr2:dateOfBirth`, `Description` → `skos:note` (now carrying `@en`).
-- The **datatype is preserved** by the value mapper, not the Mapping: `"1881-10-25"^^xsd:date` is
-  identical in both projections.
-- The birth-place **relation** becomes a direct triple `rdaGr2:placeOfBirth neo-subj:s2birthcity2aa2`.
-  Note the predicate is keyed on the **property name** `Birth place`, whereas the native predicate
-  (`neo-prop:Born_in`) uses the **relation-type name** `Born in`.
-- **Absent in EDM:** page metadata (`neo:Page`, `neo:hasSubject`), the `neo:Relation` reification node,
-  the `Source` property (unmapped), and any native-only property. Conformant EDM is the point.
+- The Subject IRI is unchanged (`neo-subj:s2picasso2aaaa2`): the entity stays the wiki's own, only the vocabulary is
+  EDM.
+- `rdf:type` and each mapped predicate are substituted; `rdfs:label` is a shared term, kept verbatim.
+- The datatype comes from the value mapper, not the Mapping: `"1881-10-25"^^xsd:date` is identical in both. A Mapping
+  property may override it with `datatype`.
+- The birth-place relation becomes one direct triple. Its EDM predicate keys on the **property name** `Birth place`
+  (`rdaGr2:placeOfBirth`); the native predicate keys on the **relation-type name** `Born in` (`neo-prop:Born_in`).
+- Absent from EDM: page metadata, the `neo:Relation` reification node, and unmapped properties (`Source`, and any
+  native-only property).
 
 ### Per-page vs bulk: the relation target's type
 
-In the **per-page** EDM export of `Pablo_Picasso`, `neo-subj:s2birthcity2aa2` (Málaga) appears as the
-object of `rdaGr2:placeOfBirth` but is **untyped** — its `a edm:Place` triple lives in Málaga's own
-page graph. The **bulk** `DumpRdf --projection=EDM` contains both named graphs, so across the dataset
-Málaga is a typed `edm:Place`:
+In the **per-page** EDM export of `Pablo_Picasso`, `neo-subj:s2birthcity2aa2` (Málaga) is the object of
+`rdaGr2:placeOfBirth` but appears as a **bare IRI** — no `a edm:Place` type, no `rdfs:label`: those triples live in
+Málaga's own page graph. The **bulk** `DumpRdf --projection=EDM` holds both named graphs, so across the dataset Málaga
+is a typed, labelled `edm:Place`:
 
 ```trig
 <.../graph/EDM/page/115> { neo-subj:s2picasso2aaaa2 a edm:Agent; … rdaGr2:placeOfBirth neo-subj:s2birthcity2aa2 }
@@ -192,59 +176,29 @@ Málaga is a typed `edm:Place`:
 ```
 
 The native projection of the same pages lands in sibling `.../graph/native/page/{id}` graphs, so both projections can
-share one triple store.
-
-(The dump also projects the other demo `Person`/`City` Subjects — Bach persons as `edm:Agent`, the
-other cities as `edm:Place` — since the Mapping applies to every Subject of its Schema.)
+share one triple store. A consumer that needs a relation target's type or label must load the target's graph.
 
 ## Findings
 
-The point of this exercise is to surface gaps honestly. From doing it:
-
-1. **The name is only `rdfs:label`; `foaf:name` cannot be emitted (v1 format gap).** A NeoWiki Subject's
-   name is its built-in **label**, not a property. The projector always emits it as `rdfs:label`, and
-   v1 has **no facility to map the label to an additional predicate**, so the toy model's
-   `Name → foaf:name` cannot be produced. Adding a redundant "Name" property purely to force `foaf:name`
-   out would duplicate the label and misrepresent the model, so we did not. This is a real limitation of
-   the v1 format: it needs a way to say "also emit the label as `<predicate>`" (and, more generally, to
-   map the label per target). Recorded for the mapping-formalism discussion
-   ([#996](https://github.com/ProfessionalWiki/NeoWiki/discussions/996)).
-2. **A `select` value would project its option id, not its label.** `Gender` is a controlled
-   vocabulary, so a `select` property is the natural model. But a select value is stored as the option
-   **id**, and the v1 value mapper emits that id as the literal — so `rdaGr2:gender` would carry an
-   opaque `o1…` id, not `"Male"`. We used a **text** property to get a meaningful literal. A
-   select→label (or select→`skos:Concept` IRI) projection is future work.
-3. **EDM's flat `Place` vocabulary is thin.** The City entry maps only the class. Country/Population/Website
-   have no obvious near-1:1 EDM `Place` predicate without stretching semantics; coordinates would need a
-   geo vocabulary (`wgs84_pos`) beyond the toy model. Class-only is the honest v1 result and is exactly
-   what the birthplace reference needs.
-4. **Relation predicates key on the property name, literal predicates likewise.** The mapping's
-   `properties` keys are **property names** (`Birth place`), while the native projection's relation
-   predicate uses the **relation-type name** (`Born in`). Authors of a Mapping must use property names,
-   not relation-type names — worth stating in the format reference if it trips people up.
-5. **Untyped relation targets in a per-page export are expected.** As above; only the bulk dump (or a
-   store holding all graphs) types the target. Consumers that need the target's type must load its graph.
-
-None of these blocked the exercise; the near-1:1 EDM projection works end to end. (1) is the one that is
-a genuine v1 **format** gap rather than a deliberate boundary.
+1. **The name projects only as `rdfs:label`; `foaf:name` is unreachable in v1.** A Subject's name is its built-in label,
+   not a property; the projector always emits it as `rdfs:label`, and v1 has no facility to also map the label to
+   another predicate. The toy model's `Name → foaf:name` therefore cannot be produced. Tracked at
+   [#996](https://github.com/ProfessionalWiki/NeoWiki/discussions/996).
+2. **A `select` value projects its stored option id, not its label.** The v1 value mapper emits the stored id, so a
+   `select` `Gender` would carry an opaque `o1…` id instead of `"Male"`. The demo uses a `text` property to get a
+   meaningful literal; a select→label (or select→`skos:Concept` IRI) projection is later work.
 
 ## Querying via SPARQL
 
-v1 ships the projection and the export surfaces (endpoint + dump). It does **not** yet load the RDF into
-a triple store — the pluggable SPARQL store that would let you run EDM SPARQL against this data is
-[#586](https://github.com/ProfessionalWiki/NeoWiki/issues/586), which consumes the
-`newRdfProjection(name)` seam this work exposes. Until then, feed the `DumpRdf --projection=EDM` output
-into any SPARQL engine (e.g. a local QLever) to query the EDM projection. Once #586 lands, a store can be
-configured to hold the `EDM` projection directly and be queried in EDM terms.
+Configure a SPARQL store for the `EDM` projection and each save is projected into it, queryable through the SPARQL
+read surface — see [Ontology Mapping](../rdf/ontology-mapping.md) and [RDF Export](../rdf/rdf-export.md). For an ad-hoc
+load, feed the `DumpRdf --projection=EDM` output into any SPARQL engine (e.g. a local QLever).
 
 ## Known next tier: CIDOC-CRM
 
-The toy model's CIDOC-CRM column is **out of scope for v1**. CIDOC-CRM mediates birth through an event:
-a person's birth date and place hang off a synthesized `E67_Birth` node
-(`E21_Person → P98i_was_born → E67_Birth → P4_has_time-span / P7_took_place_at`). That node has no
-counterpart in NeoWiki's flat data; the mapping must **mint** it, coordinating several flat fields onto
-one shared node. Expressing that path expansion and node synthesis is the hard tier
-([OntologyMapping.md](../planning/OntologyMapping.md) Q2), and the open mapping-formalism question
-([OntologyMapping.md Q1](../planning/OntologyMapping.md#open-questions),
-[#995](https://github.com/ProfessionalWiki/NeoWiki/issues/995)) is precisely about choosing a formalism
-that can. EDM proves the mechanism end to end; CIDOC-CRM is the next tier it must grow into.
+The toy model's CIDOC-CRM column is out of scope for v1. CIDOC-CRM mediates birth through a synthesized `E67_Birth`
+event node with no counterpart in NeoWiki's flat data, which v1's term substitution cannot mint. Choosing a formalism
+that can is the open mapping-formalism question ([OntologyMapping.md Q1](../planning/OntologyMapping.md#open-questions),
+[#995](https://github.com/ProfessionalWiki/NeoWiki/issues/995)).
+</content>
+</invoke>

--- a/docs/extending/extending.md
+++ b/docs/extending/extending.md
@@ -5,8 +5,7 @@ order: 1
 # Extending NeoWiki
 
 NeoWiki exposes extension points so other MediaWiki extensions can add custom Property Types, contribute
-page metadata to the graph, and reuse NeoWiki's UI. This page is the reference for those extension points and
-the APIs extensions build on.
+page metadata to the graph, and reuse NeoWiki's UI.
 
 NeoWiki concepts referenced here — Subject, Schema, Property Type, Page Property — are defined in the
 [Glossary](../glossary.md).
@@ -50,6 +49,9 @@ public static function onNeoWikiRegistration( NeoWikiRegistrar $registrar ): voi
 
 Full example: [`src/RedHerbHooks.php`](https://github.com/ProfessionalWiki/NeoWiki/blob/master/tests/RedHerb/src/RedHerbHooks.php).
 
+Registering a Property Type or View Type under a name already in use — a built-in's or another extension's —
+replaces the earlier registration; the last registration wins, on both the backend and the frontend.
+
 ## Backend extension points (PHP)
 
 ### Property Types
@@ -64,7 +66,7 @@ Example: [`src/ColorType.php`](https://github.com/ProfessionalWiki/NeoWiki/blob/
 [`src/ColorProperty.php`](https://github.com/ProfessionalWiki/NeoWiki/blob/master/tests/RedHerb/src/ColorProperty.php)
 (`extends PropertyDefinition`).
 
-If your Property Type stores a value that isn't already a Neo4j scalar, also register a builder that converts it,
+To project your Property Type's values into Neo4j, register a builder that converts the Value to Neo4j scalars,
 keyed by the Property Type name:
 
 ```php
@@ -73,32 +75,11 @@ $registrar->addNeo4jValueBuilder( ColorType::NAME, static fn ( $value ) => $valu
 
 #### Contributing RDF value mappers
 
-For the [RDF export](../rdf/rdf-export.md), register a mapper that turns your Property Type's value into RDF
-literals, keyed by the Property Type name. It returns a list of `Literal`s (one per value part):
-
-```php
-$registrar->addRdfValueMapper(
-	ColorType::NAME,
-	static function ( NeoValue $value ): array {
-		// Your mapper is called for whatever a Statement holds, so guard the value shape.
-		$scalars = $value->toScalars();
-
-		if ( !is_array( $scalars ) ) {
-			return [];
-		}
-
-		$literals = [];
-
-		foreach ( $scalars as $part ) {
-			if ( is_scalar( $part ) ) {
-				$literals[] = RdfLiteralFactory::typed( (string)$part, 'string' );
-			}
-		}
-
-		return $literals;
-	}
-);
-```
+For the [RDF export](../rdf/rdf-export.md), register a mapper keyed by the Property Type name with
+`NeoWikiRegistrar::addRdfValueMapper()`. It receives the Statement's `NeoValue` and returns a `Literal` list, one
+per value part. Guard the value shape, since the mapper is called for whatever a Statement holds. RedHerb's
+[`RedHerbHooks.php`](https://github.com/ProfessionalWiki/NeoWiki/blob/master/tests/RedHerb/src/RedHerbHooks.php)
+registers a guarded mapper for its color type.
 
 Without a mapper, a Property Type's Statements are omitted from the RDF export, just as they are from the
 Neo4j projection.
@@ -119,8 +100,10 @@ class StaticPagePropertyProvider implements PagePropertyProvider {
 }
 ```
 
-Register with `NeoWikiRegistrar::addPagePropertyProvider()`. The context exposes the page id, title,
-creation and modification times, categories, and last editor. Example:
+Register with `NeoWikiRegistrar::addPagePropertyProvider()`. Keys are merged across all providers into one
+key/value map, with the last-registered provider winning on a key collision, so namespace your keys (e.g. with an
+extension prefix). The context exposes the page id, title and namespace, creation and modification times,
+categories, and last editor. Example:
 [`src/StaticPagePropertyProvider.php`](https://github.com/ProfessionalWiki/NeoWiki/blob/master/tests/RedHerb/src/StaticPagePropertyProvider.php).
 
 ### Refreshing a page's data without an edit
@@ -170,12 +153,13 @@ class MyGraphDatabasePlugin implements GraphDatabasePlugin {
 Register with `NeoWikiRegistrar::addGraphDatabasePlugin()`. Example:
 [`src/RedHerbGraphDatabasePlugin.php`](https://github.com/ProfessionalWiki/NeoWiki/blob/master/tests/RedHerb/src/RedHerbGraphDatabasePlugin.php).
 
-`savePage` hands you the page with all of its Subjects and runs for every revision, so subject edits, undeletions
-and page moves all reach you as a save. `deletePage` gets only the page id.
+`savePage` hands you the page with all of its Subjects and the Page Properties contributed by every
+`PagePropertyProvider`, and runs for every revision, so subject edits, undeletions and page moves all reach you as a
+save. `deletePage` gets only the page id.
 
 `initialize` runs once at the start of a `RebuildGraphDatabases` run, before any page is projected — create the
-store-level structures a fresh store needs there (this is how NeoWiki's own Neo4j backend creates its uniqueness
-constraints). Make it idempotent, since every rebuild calls it; it never runs on an individual edit.
+store-level structures a fresh store needs there. Make it idempotent, since every rebuild calls it; it never runs
+on an individual edit.
 
 **Signal failure by throwing.** On an edit, delete or undelete, NeoWiki logs the failure and lets the user's
 operation commit, so a backend being down never blocks the wiki or starves the other backends — your projection is
@@ -222,10 +206,10 @@ The `User` in `forUser()` only sizes the limits: how heavy a single query may be
 query at all or how often. When running user-supplied queries, check the `neowiki-query` right and rate
 limit yourself, as the [Query API](../api/query-api.md) endpoint does.
 
-Two sharp edges: the write check is keyword-based and also rejects `CALL` and `SHOW`, even for read-only
-procedures (see the [parser function notes](../authoring/parser-functions.md)). And the row cap truncates
-the result only after the query has run in full, so bound expensive queries with `LIMIT` in the Cypher
-itself.
+Two sharp edges: the write check is a keyword check plus `EXPLAIN`, and the keyword check also rejects `CALL` and
+`SHOW`, even for read-only procedures (see the [parser function notes](../authoring/parser-functions.md)). And the
+row cap truncates the result only after the query has run in full, so bound expensive queries with `LIMIT` in the
+Cypher itself.
 
 Example: [`src/Specials/SpecialRedHerbContentPageCount.php`](https://github.com/ProfessionalWiki/NeoWiki/blob/master/tests/RedHerb/src/Specials/SpecialRedHerbContentPageCount.php).
 
@@ -369,9 +353,8 @@ and [`resources/subjectFinder/`](https://github.com/ProfessionalWiki/NeoWiki/tre
 
 ### Authoring in TypeScript
 
-Plain JavaScript is the simplest path and needs no build step. You can instead write your extension in TypeScript and
-get types for NeoWiki's API. This is configuration on your side; NeoWiki ships nothing extra for it. See
-[ADR 24](../adr/024-frontend-extension-mechanism.md) for the reasoning.
+You can write your extension in TypeScript and get types for NeoWiki's API. This is configuration on your side;
+NeoWiki ships nothing extra for it. See [ADR 24](../adr/024-frontend-extension-mechanism.md) for the reasoning.
 
 Point your `tsconfig.json` `paths` at NeoWiki's barrel source, which sits next to your extension in `extensions/`:
 
@@ -459,8 +442,6 @@ client, but compare what the documented query interfaces
   `LIMIT` in the Cypher either way.
 - **Result handling.** The query interfaces return normalized rows and columns; the raw client returns
   Laudis driver types that you convert yourself.
-- **Churn exposure.** The query interfaces are documented contracts (alpha, like everything on this page);
-  the client accessors are internal wiring that can change or disappear in any release.
 
 Writing to the graph directly deserves particular caution: the graph is a projection of wiki content that
 NeoWiki rewrites at will. Saving a page that carries the Subject slot re-projects that page's nodes, and

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -14,8 +14,8 @@ MediaWiki concept. Also known as "Wiki page".
 Pages have
 
 * A **title**: shown in the URL and H1, can be changed by "moving" the page.
-* An **id**: persistent numeric auto-increment ID, sometimes useful for programmatic interaction, like via the API.
-* **Content**: wikitext, editable both via source and visual editors
+* An **id**: persistent numeric ID.
+* **Content**: wikitext
 * **Subjects**: list of Subjects, can be empty ([ADR 7](adr/007-multiple-subjects-per-page.md))
 * **Main Subject**: optional identifier of a Subject in the page's Subjects list. Indicates which Subject represents the same entity as the page itself. All other Subjects stored on a page are called **Child Subjects**.
 
@@ -36,8 +36,8 @@ Corresponds to one row in an infobox.
 
 Statements have
 
-- A `propertyName`. Refers to the Property Definition with the same name.
-- A `propertyType`. This is the type of the referenced property at the time the Statement was last changed. This is called "the writer's schema". ("Property Type" was formerly "Value Format")
+- A `propertyName`. Refers to the Property Definition with the same name in the Subject's Schema.
+- A `propertyType`: the type the referenced property had when the Statement was last changed — "the writer's schema".
 - A `value` of type Value
 
 Example: Property Name "age" with Value `42` and Property Type `number`.
@@ -46,22 +46,24 @@ NeoWiki Statements are not equivalent to Wikibase Statements. The latter have a 
 
 ### Value
 
-Values have a type, for instance, "url". This is called the **Value Type**. NeoWiki has a predefined list of these Value Types.
+Values have a type, for instance, `string`. This is called the **Value Type**. NeoWiki has a predefined list of
+these Value Types; each Property Type stores its values as one of them — a `url` property's value is a StringValue.
 
-Values can have multiple **parts**. For instance, a "url" value could be `["https://pro.wiki", "https://professional.wiki"]`.
+String and Relation Values can hold multiple **parts**. For instance, a `url` property's value could be
+`["https://pro.wiki", "https://professional.wiki"]`.
 
 Value Types:
 
-- StringValue, identified with `string`. A non-empty collection of strings
-- NumberValue, identified with `number`
-- BooleanValue, identified with `boolean`
-- RelationValue, identified with `relation`. A non-empty collection of Relation
+- StringValue, identified with `string`. A collection of strings
+- NumberValue, identified with `number`. A single number
+- BooleanValue, identified with `boolean`. A single boolean
+- RelationValue, identified with `relation`. A collection of Relations
 
 Each Relation has
 
 - An `id`: persistent identifier. Relation IDs start with `r` and are always 15 characters long
 - A `target`: Subject ID of the referenced Subject
-- `properties`: Possibly empty collection of property-value pairs. TODO: rename like we did with statements
+- `properties`: possibly empty collection of property-value pairs
 
 
 
@@ -73,11 +75,10 @@ Schemas have a name, description, and a list of Property Definitions
 
 ### Property Definition
 
-They always have a Property Name and a Property Type. Depending on the Type, they might have additional information.
-Property Types can be defined by extensions.
+A Property Definition has:
 
 - A **name**. Example: "Website".
-- A **type**. Example: "url". (formerly "format")
+- A **type**: a Property Type. Example: "url".
 - Boolean **required**
 - Optional **description** string
 - Optional **default**, which is a Value
@@ -86,13 +87,18 @@ Property Types can be defined by extensions.
 - **Display Attributes**: presentation configuration specific to the Property Type. Example: `"precision": 2`,
   `"color": "blue"`. These serve as defaults that can be overridden per-Layout via Display Rules.
 
+### Property Type
+
+The kind of data a Property Definition holds, and how it is edited and displayed. Examples: "text", "url",
+"number", "relation". Extensions can define additional Property Types ([Extending NeoWiki](extending/extending.md)).
+Each Property Type stores its values as one of the Value Types.
+
 
 
 ## View
 
 A View is an on-page rendering of a Subject. Views are placed on wiki pages via the `{{#view}}` parser function or
-automatically for a page's Main Subject. Each View renders a Subject using a **View Type** (e.g., infobox, card,
-table).
+automatically for a page's Main Subject. Each View renders a Subject using a View Type.
 
 A View can optionally reference a Layout to customize which properties are shown and how. Without a Layout, all
 properties are shown in Schema-defined order.
@@ -114,24 +120,16 @@ You create a finances Layout for that company Schema that shows only Revenue, Pr
 Layouts have:
 
 - A **Schema** reference
-- A **View Type**, such as "infobox", "factbox", or "table"
+- A **View Type**
 - **Display Rules**: an ordered list that specifies which properties to show and how (see below)
 - **Settings**: Layout-level configuration specific to the View Type (e.g., `borderColor` for infobox)
 - Optional **description**
 
-When a Subject is displayed without a specified Layout, all properties are shown in Schema-defined order (fallback
-behavior). There is no stored "Default Layout" entity.
-
 ### Display Rule
 
-A Display Rule is an entry in a Layout's ordered allowlist. Each Display Rule references a property by name and
-optionally overrides Display Attributes for that property. Unlisted properties are hidden.
-
-Display Rules have:
-
-- A **property** reference (the property name from the Schema's Property Definitions)
-- Optional **Display Attributes** overrides (e.g., `precision`, `color`). These override the defaults from the
-  Property Definition. Unspecified Display Attributes are inherited from the Property Definition.
+A Display Rule is an entry in a Layout's ordered allowlist: it references a property by name and optionally
+overrides its Display Attributes; unspecified ones are inherited from the Property Definition. Unlisted
+properties are hidden.
 
 
 
@@ -141,11 +139,4 @@ A key-value pair stored on the Page node in the graph database. Page Properties 
 itself, as opposed to Subject Statements, which are structured data about the entities described on the page.
 
 Built-in Page Properties include `name`, `namespaceId`, `creationTime`, `lastUpdated`, `categories`, and `lastEditor`.
-Extensions can contribute additional Page Properties.
-
-Page Properties are written when the page is edited and during a full graph rebuild. When extension-contributed
-data changes outside an edit, an extension can refresh them on demand without creating a revision (see
-[Extending NeoWiki](extending/extending.md)).
-
-When using Neo4j, Page Properties are available on every Page node and are queryable via Cypher
-(e.g., `MATCH (page:Page) WHERE page.lastUpdated > datetime("2024-01-01")`).
+Extensions can contribute additional Page Properties (see [Extending NeoWiki](extending/extending.md)).

--- a/docs/operations/installation.md
+++ b/docs/operations/installation.md
@@ -8,10 +8,10 @@ order: 1
 NeoWiki is pre-release software. It is not production ready, and breaking changes can land at any time without a
 migration path. Treat any install as an evaluation or pilot and run it on disposable data.
 
-There are two ways to install NeoWiki, both covered below. The Docker stack is self-contained and the fastest way to a
-working wiki, so use it for evaluation. The manual install adds NeoWiki to a MediaWiki you already run.
+The Docker stack is self-contained and the fastest way to a working wiki, so use it for evaluation. The manual
+install adds NeoWiki to a MediaWiki you already run.
 
-To install the development environment, see the [README on GitHub](https://github.com/ProfessionalWiki/NeoWiki/blob/master/README.md) instead.
+To set up the development environment instead, see the [README on GitHub](https://github.com/ProfessionalWiki/NeoWiki/blob/master/README.md).
 
 ## Method A: Docker
 
@@ -37,16 +37,15 @@ For an empty wiki without the sample data, run `make up && make install-db && ma
 
 Open `http://localhost:8484` and log in as `AdminName` with the password `AdminPassword`.
 
-You now have a complete evaluation instance with the development UI enabled and demo data loaded.
-
 ### Optional: share the demo with others
 
 By default, the stack runs on localhost. To let others reach it, host it on a server. Edit `Docker/.env` and change
 every value marked `# Change for production`, which covers the passwords and `MW_SERVER`. Then start the stack with the
-`server` profile, which adds automatic HTTPS through Caddy:
+`server` profile, which adds automatic HTTPS through Caddy. Run it from the repository root so the follow-up `make`
+commands target the same stack:
 
 ```sh
-docker compose --profile server up -d
+docker compose -p neowiki-neowiki --env-file Docker/.env -f Docker/docker-compose.yml --profile server up -d
 ```
 
 Then run `make install-db`, `make load-neo4j-users` and `make import-demo-data` against it. This is still an
@@ -63,16 +62,20 @@ Use this to add NeoWiki to a MediaWiki you already run. You provide the surround
 | MediaWiki 1.43.0 or later | |
 | PHP 8.3 with `ext-json`   | |
 | Composer                  | Installs NeoWiki's runtime dependencies. No `vendor/` is shipped. |
-| Neo4j 5.x over Bolt       | The graph backend. A reachable instance is required. |
+| Neo4j 5.x over Bolt       | The graph backend. Required to use NeoWiki's structured-data features; the wiki boots without it. |
 | Node.js 24 or later       | Needed only to build the frontend bundle in step 2. |
 
 These extensions are recommended. NeoWiki runs without them, but you lose the matching functionality:
 
 - **Scribunto** adds the Lua API and its `nw.*` functions.
-- **CodeEditor** adds JSON syntax highlighting when you edit Schema and Layout pages.
+- **CodeEditor** adds JSON syntax highlighting when you edit Schema, Layout, and Mapping pages.
 - **ParserFunctions** is commonly used alongside NeoWiki's parser functions.
 
-The steps below assume the extension is checked out at `extensions/NeoWiki/` under your MediaWiki root.
+Check the extension out at `extensions/NeoWiki/` under your MediaWiki root:
+
+```sh
+git clone https://github.com/ProfessionalWiki/NeoWiki.git extensions/NeoWiki
+```
 
 ### 1. Install Composer dependencies
 
@@ -91,8 +94,7 @@ composer update
 
 ### 2. Build the frontend bundle
 
-The compiled frontend is git-ignored, so a fresh clone ships no UI until you build it. The build is standalone and
-needs Node.js 24 or later:
+A fresh checkout ships no compiled frontend, so there is no UI until you build it:
 
 ```sh
 cd extensions/NeoWiki/resources/ext.neowiki
@@ -108,8 +110,7 @@ Add the following to your `LocalSettings.php`:
 ```php
 wfLoadExtension( 'NeoWiki' );
 
-// Required for NeoWiki's features. Without them the wiki still loads and ordinary pages work,
-// but NeoWiki's features are disabled. For a simple setup, point both URLs at the same Neo4j user.
+// Point both at your Neo4j instance; for a simple setup, use the same user for both.
 $wgNeoWikiNeo4jInternalWriteUrl = 'bolt://neo4j:SECRET@neo4j-host:7687';
 $wgNeoWikiNeo4jInternalReadUrl  = 'bolt://neo4j:SECRET@neo4j-host:7687';
 
@@ -119,9 +120,8 @@ wfLoadExtension( 'CodeEditor' );
 wfLoadExtension( 'ParserFunctions' );
 ```
 
-Both URLs are required for NeoWiki's structured-data features. Without them the wiki still loads and ordinary
-pages render, but NeoWiki's features are disabled and the query surfaces (`{{#cypher_raw}}`, `nw.query`,
-`POST /neowiki/v0/query/cypher`) are absent. The format is `bolt://user:password@host:7687`.
+Without both Neo4j URLs set, the wiki still loads and ordinary pages render, but NeoWiki's structured-data features
+and the query surfaces (`{{#cypher_raw}}`, `nw.query`, `POST /neowiki/v0/query/cypher`) stay disabled.
 
 ### 4. Run the updater
 
@@ -131,7 +131,9 @@ Run this from the MediaWiki root:
 php maintenance/run.php update --quick
 ```
 
-If your wiki already has subject pages, build the Neo4j projection from MediaWiki:
+Build the Neo4j projection from MediaWiki whenever it is out of sync with the revision slots — after the initial
+install if the wiki already has subject pages, and after Subjects arrive by a path other than a normal edit (such as
+an import):
 
 ```sh
 php maintenance/run.php NeoWiki:RebuildGraphDatabases
@@ -163,15 +165,12 @@ These are the settings you are most likely to change. For the full list with des
 
 | Setting | Purpose | Default | Required |
 |---|---|---|---|
-| `$wgNeoWikiNeo4jInternalWriteUrl` | Bolt URL for writing the graph projection | _none_ | For features¹ |
-| `$wgNeoWikiNeo4jInternalReadUrl` | Bolt URL for read and query traffic | _none_ | For features¹ |
+| `$wgNeoWikiNeo4jInternalWriteUrl` | Bolt URL for writing the graph projection | _none_ | For features |
+| `$wgNeoWikiNeo4jInternalReadUrl` | Bolt URL for read and query traffic | _none_ | For features |
 | `$wgNeoWikiEnableDevelopmentUI` | Enables development-only UIs | `false` | No |
 | `$wgNeoWikiEnforceValidation` | Rejects writes that introduce new constraint violations | `false` | No |
 | `$wgNeoWikiAutoRenderMainSubject` | Automatically renders a page's Main Subject as an infobox | `true` | No |
 | `$wgNeoWikiSparqlStores` | SPARQL 1.1 graph stores to keep in sync and query, e.g. QLever | `[]` | No |
-
-¹ Required for NeoWiki's structured-data features. The wiki still loads without them; NeoWiki's features are
-simply disabled until both are set.
 
 ## Optional: SPARQL graph stores
 
@@ -180,8 +179,7 @@ works with QLever and any other SPARQL 1.1 store. Each configured store receives
 becomes a named graph, replaced on each edit and dropped on deletion.
 
 A SPARQL store does not yet replace Neo4j: NeoWiki's interactive features (the Subject editing UIs, views, and value
-accessors) still require a configured Neo4j backend. Running NeoWiki without Neo4j is tracked in
-[#1040](https://github.com/ProfessionalWiki/NeoWiki/issues/1040).
+accessors) still require a configured Neo4j backend.
 
 Configure the stores with `$wgNeoWikiSparqlStores`, a list of objects:
 
@@ -203,21 +201,19 @@ $wgNeoWikiSparqlStores = [
 ];
 ```
 
-A store entry whose `updateUrl` is missing or empty is skipped with a warning rather than failing the wiki. Leaving
-`$wgNeoWikiSparqlStores` empty (the default) configures no SPARQL stores.
+A store entry whose `updateUrl` is missing or empty is skipped with a warning rather than failing the wiki.
 
 ### Querying a SPARQL store
 
 When at least one store is configured, three read-only query surfaces become available and target the **first**
-configured store (multi-store query addressing is a later addition):
+configured store:
 
 - The [`{{#sparql_raw}}`](../authoring/parser-functions.md#sparql_raw) parser function.
 - The [`nw.sparqlQuery()`](../authoring/lua-api.md#nwsparqlquerysparql) Lua function.
 - The [`POST /neowiki/v0/query/sparql`](../api/query-api.md#sparql-query-endpoint) REST endpoint.
 
-Each is read-only *by protocol*: the query is sent as a SPARQL 1.1 *query* operation, whose grammar has no update
-forms, so no read-only validator is needed (unlike the Cypher surfaces). They never post to `updateUrl` — only to
-`queryUrl` — and return the W3C `application/sparql-results+json` document unmodified.
+Each is read-only: the query is sent as a SPARQL 1.1 *query* operation, posted only to `queryUrl` and never
+`updateUrl`.
 
 The bundled development stack ships a working QLever example wired up this way — see
 [`Docker/README.md`](../../Docker/README.md#qlever-sparql-store-dev) for the service, its `--persist-updates`
@@ -253,8 +249,6 @@ Restricting the store is worth combining with restricting who may query it. The 
 NeoWiki is pre-release, so this is not needed for an evaluation. It applies later, when NeoWiki is production-ready.
 
 ### Separate read and write Neo4j users
-
-This applies only to wikis that use Neo4j as the graph backend.
 
 Give read and query traffic its own Neo4j user that cannot modify the graph. Create a read-only user:
 

--- a/docs/operations/maintenance.md
+++ b/docs/operations/maintenance.md
@@ -5,8 +5,7 @@ order: 2
 
 # Maintaining NeoWiki
 
-This covers the upkeep an evaluation NeoWiki instance needs: rebuilding the graph and the current limitations to be
-aware of. For first-time setup, see [installation](installation.md).
+Upkeep tasks for an evaluation NeoWiki instance. For first-time setup, see [installation](installation.md).
 
 ## Rebuilding the graph
 
@@ -31,40 +30,31 @@ Two things to plan around:
 
 ## Upgrades
 
-NeoWiki adds no database tables of its own, so an upgrade is a code swap plus MediaWiki's standard updater. Update the
-NeoWiki code, then run the updater from the MediaWiki root:
+Update the NeoWiki code, then run MediaWiki's standard updater from the root:
 
 ```sh
 php maintenance/run.php update --quick
 ```
 
-If the new version changes how data is stored in the graph, [rebuild the projection](#rebuilding-the-graph) afterwards
-so it matches.
+If the new version changes how data is stored in the graph, [rebuild the projection](#rebuilding-the-graph) afterwards.
 
-NeoWiki is pre-release, so a new version can change the schema or data format with no migration path. Your evaluation
-data may not survive an upgrade, so be ready to rebuild it from scratch.
+NeoWiki is pre-release, so a new version can change the canonical revision-slot format with no migration path. Your
+evaluation data may not survive an upgrade, so be ready to recreate it from scratch — a projection rebuild does not
+recover data the new version can no longer read.
 
 ## What happens during a Neo4j outage
 
-The graph is a regenerable copy, so NeoWiki never fails an edit because it could not write to it. Ordinary wiki
-editing survives an outage; structured data does not.
-
 - **Editing pages works.** Edits, deletions and undeletions all commit. NeoWiki logs the projection failure on the
-  `NeoWiki` channel and stays out of the way.
-- **Editing and displaying Subjects fails**, along with queries and anything else that reads the graph. Subjects are
-  resolved to their page through an index that lives only in Neo4j.
+  `NeoWiki` channel.
+- **Editing and displaying Subjects fails**, along with queries and anything else that reads the graph.
 
-Once Neo4j is back, [rebuild the graph](#rebuilding-the-graph). It re-saves the pages that still exist and removes the
-ones MediaWiki no longer has, repairing both a failed save and a failed delete, and it names any page it could not
-reconcile.
+Once Neo4j is back, [rebuild the graph](#rebuilding-the-graph): it repairs both a failed save and a failed delete. It
+names any page it could not reconcile; re-run it once you have cleared the cause.
 
 Route the `NeoWiki` log channel somewhere you read. On a default MediaWiki install it goes nowhere, which leaves the
 rebuild's output as your only sign that anything went wrong.
 
-## Current limitations
+## Backups
 
-One known limitation while NeoWiki is pre-release:
-
-- **NeoWiki requires a configured graph backend.** The subject-to-page index lives only in Neo4j, so a wiki with no
-  backend configured cannot create, edit or display Subjects. Tracked in
-  [#895](https://github.com/ProfessionalWiki/NeoWiki/issues/895).
+Back up the MediaWiki database as usual; it holds the canonical data. Neo4j needs no backup — it is a regenerable copy
+you can [rebuild](#rebuilding-the-graph) from the revision slots.

--- a/docs/qualifiers-and-references.md
+++ b/docs/qualifiers-and-references.md
@@ -5,39 +5,23 @@ order: 2
 ---
 # Qualifiers and References
 
-NeoWiki Statements have no qualifiers, references, or rank the way Wikibase Statements do. NeoWiki uses a different
-approach, which still allows you to express qualified and referenced data, and comes with notable benefits like
-unlimited depth and Schemas (validation, UIs).
+NeoWiki Statements have no qualifiers, references, or rank, unlike Wikibase Statements. A Statement is flat: one
+property and its Value, with no inner structure. You express qualified and referenced data by reifying it — the value
+that needs context becomes its own Subject with its own Schema, linked from the main Subject by a Relation. A page can
+hold any number of Subjects ([ADR 7](adr/007-multiple-subjects-per-page.md)), so this adds Subjects, not a page per
+value.
 
-This page explains how NeoWiki models the same needs, and why it follows the
-[Property Graph model](https://en.wikipedia.org/wiki/Property_graph).
+NeoWiki is a [Property Graph](https://en.wikipedia.org/wiki/Property_graph): Subjects are nodes with typed properties
+and Relations are edges that also carry properties.
 
 For the underlying concepts (Subject, Statement, Relation, Schema), see the [Glossary](glossary.md).
 
-## The short version
-
-NeoWiki's Statements are flat: one property and its Value. They have no inner structure.
-
-You model what would be a qualified Statement in Wikibase as a NeoWiki Subject.
-
-Example: In Wikibase, you might have an Item about Berlin, with Statements about its population, qualified by year of
-measurement. In NeoWiki you instead have one Subject for Berlin, and then an additional Subject per population figure.
-The Berlin Subject links to these population Subjects via Relations.
-
-Because your population Subjects have their own Schema, your users get a form-like experience when adding a new
-population: the right properties are shown, and the validation rules you specified are applied. In Wikibase terms, you
-get *schemas for your qualifiers*.
-
-NeoWiki allows storing an arbitrary number of Subjects on a single page, so there is no explosion of Subject pages,
-which a Wikibase user might otherwise expect.
-
 ## Qualifying a value: model it as its own Subject
 
-When a value needs context, promote it into a dedicated Subject and link it from the main Subject with a Relation. This
-is the same move as a Semantic MediaWiki subobject or an Item-valued Statement in Wikidata, but the intermediate node
+Promoting a value into its own Subject is the same move as a Semantic MediaWiki subobject, except the intermediate node
 has a Schema.
 
-Take a museum's yearly attendance. You define an `Attendance` Schema and link one Attendance Subject per year:
+Take a museum's yearly attendance. Define an `Attendance` Schema and link one Attendance Subject per year:
 
 ```text
 Museum Schema
@@ -49,38 +33,39 @@ Attendance Schema
   Source:   url
 ```
 
-Each Attendance Subject (`{ Year: 2024, Visitors: 2500000, Source: "https://…" }`) carries what Wikibase would express
-as the qualifier (`Year`) and the reference (`Source`) on a single population-style Statement. Here they are real,
-typed properties governed by the `Attendance` Schema, so they validate and render like any other data. There is no
-depth limit: a linked Subject can link to further Subjects.
+Each Attendance Subject (`{ Year: 2024, Visitors: 2500000, Source: "https://…" }`) holds what Wikibase would put as a
+qualifier (`Year`) and a reference (`Source`) on one population Statement. Here they are typed properties governed by
+the `Attendance` Schema, so they validate and render like any other data. A linked Subject can link to further
+Subjects, with no depth limit.
 
-The [Subject Format](api/subject-format.md#complete-example) reference shows this exact pattern in JSON: a city whose
-population Subjects carry a `Date` and a `References` property. The Attendance Subjects can live on their own pages or
-as [Child Subjects](glossary.md#page) on the museum's page.
+The Attendance Subjects can live on their own pages or as [Child Subjects](glossary.md#page) on the museum's page. The
+[Subject Format](api/subject-format.md#complete-example) shows the same pattern in JSON.
 
 ## Qualifying a relationship: relation properties
 
-When the thing being qualified is a link between two Subjects, the Relation itself carries the qualifier. A "Has CEO"
-relationship can hold `role` and `since`:
+When what needs qualifying is the link between two Subjects, the Relation carries the qualifier. A `Has CEO` Relation
+to a Person holds `role` and `since` as its own properties:
 
 ```text
 Company Schema
-  Has CEO: relation → Person (with properties: role, since)
+  Has CEO: relation → Person
 ```
 
-This is the closest direct analogue of a Wikibase qualifier. Each Relation also has a stable ID
-([ADR 10](adr/010-add-guids-to-relations.md)), so — unlike a Statement — an individual relationship is
-addressable.
+Relation properties are free-form key/values on the Relation; unlike a linked Subject's properties they are not declared
+in a Schema and not validated.
+
+This is the closest analogue of a Wikibase qualifier. Each Relation has a stable ID
+([ADR 10](adr/010-add-guids-to-relations.md)), so an individual relationship is addressable where a Statement is not.
 
 ## References
 
-A reference is provenance, so it is modelled as a normal property: add a `Source` (or similar) property to the Schema
-of the linked Subject, or put one on the Relation. The `Source` in the Attendance example above is exactly this.
+A reference is provenance, modelled as an ordinary property: add a `Source` (or similar) property to the linked
+Subject's Schema, or put one on the Relation.
 
 ## Rank
 
-NeoWiki has no rank. What rank encodes is ordinary data, modelled with the standard mechanisms as the data modeller
-sees fit — typically a date property for current vs. historical values, or a status property for deprecated ones.
+NeoWiki has no rank. What rank encodes is ordinary data: model it explicitly — typically a date property for current
+vs. historical values, or a status property for deprecated ones.
 
 ## Mapping from Wikibase
 
@@ -92,52 +77,21 @@ sees fit — typically a date property for current vs. historical values, or a s
 | Reference | An ordinary property (e.g. `Source`) on the linked Subject or Relation |
 | Rank | No equivalent; model explicitly (dated Subjects, status properties) |
 | Statement ID | Statements have none; Subjects and Relations both have stable IDs |
-| `novalue` / `somevalue` | Not currently modelled (open: [#937](https://github.com/ProfessionalWiki/NeoWiki/issues/937)) |
+| `novalue` / `somevalue` | No equivalent |
 
-## Why this approach
+## In RDF
 
-NeoWiki follows the Property Graph model: Subjects are nodes with typed properties, and Relations are edges that can
-carry properties of their own, so qualifying a relationship needs no extra machinery.
-
-- **Simplicity.** A Statement stays a property/value pair and a Schema stays two-dimensional — easy to reason about,
-  edit, and render.
-- **Schemas for everything.** Qualifiers and references live on Subjects and Relations that have Schemas, so they are
-  typed and validated instead of being free-form key/value bags.
-- **One mechanism.** There is a single way to add structure — link a Subject — usable at any depth, rather than a
-  separate qualifier, reference, and rank mechanism bolted onto each Statement.
-- **Clean projection.** Linked Subjects are graph nodes and Relations are graph edges, so the graph and RDF
-  projections fall out naturally (below).
-
-The trade-off is more Subjects to create. This downside is partially mitigated by NeoWiki's support for multiple
-Subjects per page.
-
-## In the graph and in RDF
-
-In Neo4j, a Relation is an edge and a linked Subject is another node; see the
-[Graph Model](api/graph-model.md).
-
-In RDF, the projection uses Wikibase-style reification: a direct triple for simple queries, plus a Relation node that
-preserves the Relation's ID and its properties. A linked Subject is simply its own resource with its own triples, so a
-"qualified value" round-trips without loss. See [RDF Export](rdf/rdf-export.md) for the native projection, and
+A qualified value round-trips without loss: a linked Subject is its own resource, and a Relation keeps its ID and its
+properties ([Graph Model](api/graph-model.md)). See [RDF Export](rdf/rdf-export.md) for the native projection and
 [Ontology Mapping](rdf/ontology-mapping.md) for projecting into standard ontologies such as EDM.
 
-## Related metadata and display
+## Presentation
 
-Two things Wikibase veterans sometimes group with qualifiers are handled separately in NeoWiki:
-
-- **Per-Statement metadata.** Each Statement does record the property's type at write time — the "writer's schema"
-  ([ADR 11](adr/011-include-writers-schema.md)) — so historical Statements stay interpretable after a Schema
-  changes.
-- **Presentation.** How a property renders is configured by Display Attributes and [Layouts](glossary.md#layout), not
-  by fields on the Statement.
+How a property renders is set by Display Attributes and [Layouts](glossary.md#layout), not by fields on the Statement.
 
 ## Further reading
 
 - [Glossary](glossary.md) — Subject, Statement, Relation, Schema, Layout
-- [ADR 7: Multiple Subjects Per Page](adr/007-multiple-subjects-per-page.md)
-- [ADR 10: Add GUIDs to Relations](adr/010-add-guids-to-relations.md)
 - [Subject Format](api/subject-format.md) and [Graph Model](api/graph-model.md)
 - [Worked example: Person to EDM](examples/person-to-edm.md) — ontology mapping end to end; its CIDOC-CRM tier
   revisits intermediate-node modelling at the RDF level
-- Open design: [#630 (Relations design)](https://github.com/ProfessionalWiki/NeoWiki/issues/630),
-  [#959 (Main/Child Subject semantics)](https://github.com/ProfessionalWiki/NeoWiki/issues/959)

--- a/docs/rdf/ontology-mapping.md
+++ b/docs/rdf/ontology-mapping.md
@@ -4,45 +4,34 @@ order: 2
 ---
 # Ontology Mapping
 
-NeoWiki stores data in its own native Schemas and projects it to RDF.
+Alongside the built-in [native projection](rdf-export.md), which needs no mapping, you can project to an
+established ontology such as EDM by defining an **ontology mapping**.
 
-Users can project to established ontologies like EDM and Dublin Core by defining **ontology mappings**.
+The native projection and each ontology mapping are sibling projections of the same source data. Several can
+run at once: an export request selects one by name, and a SPARQL store can be configured for any of them.
 
-NeoWiki also comes with a [**native projection**](rdf-export.md), based on the native Schemas, available
-without having to define an ontology mapping first.
+The design and its open questions live in [planning/OntologyMapping.md](../planning/OntologyMapping.md); this
+page is the as-built reference for the shipped v1. The
+[Person-to-EDM worked example](../examples/person-to-edm.md) walks through a Person Schema projected to EDM,
+with native and mapped output side by side and the current gaps.
 
-The native projection and each ontology mapping are sibling projections of the same source data. Multiple
-can be supported at the same time, letting API users choose their RDF format, and giving wiki admins the
-option to realize multiple projections in separate SPARQL stores.
-
-The design and its open questions are in
-[planning/OntologyMapping.md](../planning/OntologyMapping.md); this page is the as-built reference for
-the shipped v1. See the
-[Person-to-EDM worked example](../examples/person-to-edm.md) for a complete walkthrough: a Person Schema projected to EDM, the native
-and mapped output side by side, and the current gaps.
-
-> **v1 is deliberately minimal and the stored format is provisional.** v1 covers only the *near-1:1
-> tier* — term substitution: a target class for the Subject and one target predicate per mapped
-> property. It does **not** synthesize the intermediate event nodes that CIDOC-CRM-style ontologies
-> need. The mapping-formalism question is still open
-> ([OntologyMapping.md Q1](../planning/OntologyMapping.md#open-questions), [#995](https://github.com/ProfessionalWiki/NeoWiki/issues/995)),
-> so the `"version": 1` format may change. It is versioned so a later tier can supersede it.
+> **v1 scope.** It covers only *near-1:1* term substitution — a target class per Subject and one target
+> predicate per mapped property — and does **not** synthesize the intermediate event nodes that
+> CIDOC-CRM-style ontologies need. The stored `"version": 1` format may change; see the
+> [open questions](../planning/OntologyMapping.md#open-questions).
 
 ## Ontology Mappings are wiki pages
 
-A Mapping is a page in the **`Mapping:` namespace** with content model `NeoWikiMapping` (JSON), edited
-like a Schema or Layout page and gated by the `neowiki-mapping-edit` right. There is **one Mapping page
-per target ontology**, and the page title is the target's name — the projection name you pass to the
-export surfaces below ([ADR 17](../adr/017-names-as-identifiers.md)-style, just like Schema pages). The
-page `Mapping:EDM`, for example, defines the `EDM` projection.
+A Mapping is a page in the **`Mapping:` namespace** with content model `NeoWikiMapping` (JSON), gated by the
+`neowiki-mapping-edit` right. There is **one Mapping page per target ontology**, and the page title is the
+projection name you pass to the export surfaces: the page `Mapping:EDM` defines the `EDM` projection.
 
-A single page holds an entry for **every mapped Schema**. You map a Schema to an ontology by adding an
-entry to that ontology's page, not by creating a page. A Schema still maps to several ontologies — one
-entry on each ontology's page — and the Schema is never changed to fit an ontology.
+A single page holds an entry for **every mapped Schema** — map a Schema to an ontology by adding an entry to
+that ontology's page, not by creating a page. A Schema maps to several ontologies through one entry on each
+ontology's page.
 
-Uniqueness is **by construction**: a page cannot list the same Schema twice (they are JSON object keys),
-and page titles are unique, so no save-time duplicate check is needed. The name **`native`** is reserved
-for the built-in [native projection](rdf-export.md), so a `Mapping:Native` page is rejected on save.
+The name **`native`** is reserved for the built-in [native projection](rdf-export.md), so a `Mapping:Native`
+page is rejected on save.
 
 ## Format (version 1)
 
@@ -97,74 +86,52 @@ Each **property** entry:
 ### CURIEs, IRIs, and safety
 
 A `class`, `predicate`, or `datatype` is either a **CURIE** `prefix:local` whose prefix is declared in
-`prefixes`, or an **absolute IRI** containing `://`. A CURIE with an undeclared prefix is rejected (it
-is a typo, not a bare IRI). Non-authority IRI schemes (`urn:`, `mailto:`, …) are out of scope for v1.
+`prefixes`, or an **absolute IRI** containing `://`. A CURIE with an undeclared prefix is rejected;
+non-authority schemes (`urn:`, `mailto:`, …) are out of scope for v1.
 
-Terms are expanded to exact ontology IRIs and are **never percent-encoded** — a Mapping must reproduce
-the ontology's terms verbatim. A term (or a declared prefix namespace) that would expand to an IRI
-containing an IRIREF-illegal character (`< > " { } | ^ \` backtick, space, control characters) is
-**rejected at save time**. The `lang` tag is constrained the same way — it must be BCP-47-shaped, so it
-cannot smuggle a datatype or a stray `"` into the serialized literal.
+Terms are reproduced verbatim, never percent-encoded. A term or a declared prefix namespace that would expand
+to an IRI containing an IRIREF-illegal character (`< > " { } | ^ \` backtick, space, control characters) is
+**rejected at save time**, as is a `lang` tag that is not BCP-47-shaped and a property entry that sets both
+`lang` and `datatype`.
 
-Both checks are re-applied at **projection time**, so a Mapping stored before validation existed (or
-loaded via `importDump`) still cannot corrupt the output: a class, predicate, datatype, or prefix that
-does not re-expand safely is dropped, and an invalid language tag falls back to a plain literal — each
-with a logged warning. A bad stored Mapping degrades the projection rather than aborting the export.
+The same checks re-run at **projection time**: a class, predicate, datatype, or prefix that does not re-expand
+safely is dropped, an invalid language tag falls back to a plain literal, and each is logged. The projection
+degrades rather than aborting the export.
 
 ## What gets emitted
 
 For each Subject on a page whose Schema has an entry on the requested projection's Mapping page:
 
 - `rdf:type <subject.class>`.
-- `rdfs:label "<label>"` — always, so every projected entity is labelled.
-- One triple per mapped property **value** (multi-valued properties repeat the predicate). Unmapped
-  properties are **absent** — conformant output is the point.
-- A **relation** value becomes a direct triple to the target Subject's IRI. No `neo:Relation`
-  reification node and no relation qualifiers are projected (native-vocabulary constructs with no v1
-  mapping).
+- `rdfs:label "<label>"` — the Subject's label, always.
+- One triple per mapped property **value**; multi-valued properties repeat the predicate. Unmapped properties
+  are absent.
+- A **relation** value becomes a direct triple to the target Subject's IRI. No `neo:Relation` reification node
+  and no relation qualifiers are projected.
 
-Deliberate v1 boundaries:
+v1 boundaries:
 
-- **Subject IRIs stay native** (`neo-subj:` under the wiki's RDF base URI): the entity is the wiki's
-  own; only the *vocabulary* comes from the target ontology. Cross-linking to external entities
-  (`owl:sameAs`, reconciliation) is later work.
-- A **Subject whose Schema has no entry** on the Mapping page is absent entirely. Its IRI can still
-  appear as the target of a relation from a mapped Subject — untyped — exactly as a missing Schema
-  behaves in the native projection.
+- **Subject IRIs stay native** (`neo-subj:`): only the vocabulary comes from the target ontology. Cross-linking
+  to external entities (`owl:sameAs`, reconciliation) is later work.
+- A **Subject whose Schema has no entry** on the Mapping page is absent, but its IRI can still appear as a
+  bare IRI — no type, no label — as the target of a relation from a mapped Subject.
 - **No page-metadata triples** are emitted (no page node, `neo:hasSubject`, etc.).
-- Quads are placed in the **per-page named graph for this target** (`$base/graph/{target}/page/{id}`), like the
-  native projection, so the same per-page sync infrastructure works for an ontology store — and because the graph
-  is qualified by the target, sibling projections of a page can share one store.
+- Quads go in the per-page named graph for this target (`$base/graph/{target}/page/{id}`), where `{target}` is
+  the projection name.
 
 ## Selecting a projection
 
-The RDF export surfaces take an optional `projection`:
-
-`GET /rest.php/neowiki/v0/page/{pageId}/rdf?projection=EDM`
-
-- `projection` is `native` (the default, unchanged behaviour) or the name of a Mapping page (its title).
-- An unknown projection returns **`400`** listing the known projections.
-
-```sh
-# Native (default):
-curl 'https://wiki.example/rest.php/neowiki/v0/page/42/rdf'
-# EDM ontology projection:
-curl 'https://wiki.example/rest.php/neowiki/v0/page/42/rdf?projection=EDM&format=turtle'
-```
-
-The bulk dump takes the same option:
-
-```sh
-php maintenance/run.php NeoWiki:DumpRdf --projection=EDM > dump.trig
-```
+The RDF export surfaces — the per-page and per-Subject endpoints and the `DumpRdf` bulk dump — take a
+`projection` parameter whose value is a projection name — a Mapping page title without the `Mapping:`
+prefix (`EDM`), or `native` for the built-in projection. See
+[RDF Export](rdf-export.md#endpoint) for the contract.
 
 ## Authoring a Mapping
 
-1. Create a page in the `Mapping:` namespace named after the target ontology — the title is the
-   projection name, e.g. `Mapping:EDM`. If a page for that ontology already exists, edit it instead.
+1. Create a page in the `Mapping:` namespace named after the target ontology (`Mapping:EDM`), or edit the
+   existing one.
 2. Declare the page-level `prefixes` you will use.
-3. Add an entry under `schemas` for each Schema you want to project: give the Subject a `subject.class`
-   and map the properties you want to publish. Only listed properties are projected.
-4. Save. Structural errors and unresolvable/unsafe terms are reported on save; the reserved page name
-   `native` is rejected.
-5. Export a page of a mapped Schema with `?projection=<page title>` to see the result.
+3. Add an entry under `schemas` for each Schema to project: give the Subject a `subject.class` and map the
+   properties to publish.
+4. Save. Structural errors and unresolvable or unsafe terms are reported on save.
+5. Export a page of a mapped Schema with `?projection=EDM` (the page title without the `Mapping:` prefix).

--- a/docs/rdf/rdf-export.md
+++ b/docs/rdf/rdf-export.md
@@ -4,16 +4,14 @@ order: 1
 ---
 # RDF Export
 
-NeoWiki projects its data to RDF in its own vocabulary — the **native projection**. Each wiki page
-becomes a named graph containing its page metadata, its Subjects (one RDF resource each), their
-Statements, and their Relations. The projection is lossless and self-sufficient.
+NeoWiki projects its data to RDF in its own vocabulary — the **native projection**. Each wiki page becomes a named
+graph holding its page metadata and its Subjects (one RDF resource each) with their Statements and Relations.
 
-The model is specified in [NativeRdfProjection.md](../planning/NativeRdfProjection.md); this page is
-the as-built reference for the export surface (config, IRI scheme, endpoint, script). The SPARQL
-store and live sync, ontology mappings, and RDF import are separate, later concerns.
+The model is specified in [NativeRdfProjection.md](../planning/NativeRdfProjection.md); this page is the as-built
+reference for the export surface.
 
-For an end-to-end example that exports a page as RDF and compares the native and ontology-mapped
-output, see the [Person-to-EDM worked example](../examples/person-to-edm.md).
+For an end-to-end example comparing the native and ontology-mapped output, see the
+[Person-to-EDM worked example](../examples/person-to-edm.md).
 
 ## Configuration
 
@@ -21,14 +19,10 @@ output, see the [Person-to-EDM worked example](../examples/person-to-edm.md).
 |---|---|---|
 | `$wgNeoWikiRdfBaseUri` | the wiki's canonical URL (`$wgCanonicalServer`) | Base URI under which all NeoWiki IRIs are minted. |
 
-The base URI is wiki-level on purpose: sibling projections (native and, later, ontology-mapped)
-describe the same entities, so their Subject IRIs must be identical across stores. Set it explicitly
-to align with an institutional URI policy.
-
 ## IRI scheme
 
-All NeoWiki IRIs live under `$base` (`$wgNeoWikiRdfBaseUri`). Standard vocabulary (`rdf:`, `rdfs:`,
-`xsd:`, `dcterms:`) is used for standard concepts.
+All NeoWiki IRIs live under `$base` (`$wgNeoWikiRdfBaseUri`). Standard vocabulary (`rdf:`, `rdfs:`, `xsd:`,
+`dcterms:`) is used for standard concepts.
 
 | Prefix | Namespace | Used for |
 |---|---|---|
@@ -38,36 +32,33 @@ All NeoWiki IRIs live under `$base` (`$wgNeoWikiRdfBaseUri`). Standard vocabular
 | `neo-schema:` | `$base/schema/` | Schema classes (`neo-schema:Person`) |
 | `neo-rel:` | `$base/relation/` | Relation node IRIs (`neo-rel:r1demo8aaaaaaD6`) |
 | `neo-page:` | `$base/page/` | Page resource IRIs (`neo-page:42`) — the subject of the page-metadata triples |
-| `neo-graph:` | `$base/graph/{projection}/page/` | Named-graph IRIs, qualified by projection (`$base/graph/native/page/42`) |
 
-The `{projection}` segment of the named-graph IRI is `native` or a Mapping page name (e.g. `EDM`), encoded like the
-Property and Schema names below, so sibling projections of a page write disjoint graphs and can share one triple
-store — see [Ontology Mapping](ontology-mapping.md). The page *resource* IRI (`neo-page:42`) stays
-projection-independent and keeps appearing inside the triples.
+Each page's named-graph IRI is `$base/graph/{projection}/page/{id}`. The `{projection}` segment is `native` or a
+Mapping page name (e.g. `EDM`), encoded like the names below — see [Ontology Mapping](ontology-mapping.md). The page
+*resource* IRI (`neo-page:42`)
+stays projection-independent and appears inside the triples.
 
-Property and Schema names form the local part of their IRI: spaces become underscores
-(e.g. `Has author` → `neo-prop:Has_author`), and any character that is illegal in an IRI (`%`, the
-specials `< > " { } | ^ \`, backtick, and control characters) is percent-encoded so an authored name
-can never break out of its IRI or forge extra triples. Non-ASCII Unicode is kept raw, so multilingual
-names stay readable. **Caveat:** the space→underscore step collides when a name already contains an
-underscore (`Has author` and `Has_author` share the `neo-prop:Has_author` predicate IRI). The native
-projection accepts this. (The base URI is trusted admin config and is not encoded.)
+Property, Schema, and Relation-type names, and Relation-property keys, form the local part of their IRI: spaces become
+underscores (`Has author` → `neo-prop:Has_author`), and characters illegal in an IRI (`%`, `< > " { } | ^ \`, backtick,
+control characters) are percent-encoded. Non-ASCII Unicode is kept raw. **Caveat:** the space→underscore step collides
+when a name already contains an underscore — `Has author` and `Has_author` share the `neo-prop:Has_author` IRI, which
+the native projection accepts. The base URI is trusted admin config and is not encoded.
 
-Value types map to `xsd` datatypes: `text`/`select` → `xsd:string`, `url` → `xsd:anyURI`, `number` →
-`xsd:decimal` (or `xsd:integer` when fractionless), `boolean` → `xsd:boolean`, `date` → `xsd:date`,
-`date-time` → `xsd:dateTime`. Extensions map their own property types via
-[`addRdfValueMapper`](../extending/extending.md#contributing-rdf-value-mappers).
+Value types map to `xsd` datatypes: `text`/`select` → `xsd:string`, `url` → `xsd:anyURI`, `number` → `xsd:decimal`
+(or `xsd:integer` when fractionless), `boolean` → `xsd:boolean`, `date` → `xsd:date`, `dateTime` → `xsd:dateTime`.
+Extensions map their own property types via
+[`addRdfValueMapper`](../extending/extending.md#contributing-rdf-value-mappers). A Statement whose property type has no
+registered mapper — including an unregistered type — is omitted from the projection.
 
-A Subject whose Schema is unavailable (for example, its Schema page was deleted) is omitted from the
-projection entirely — the same graceful degradation as the Neo4j projection — so the two stores always
-describe the same set of entities. A warning is logged for each omitted Subject.
+A Subject whose Schema cannot be loaded (for example, its Schema page was deleted) is omitted from the projection; a
+warning is logged for each.
 
 ## Endpoint
 
-RDF is served per page or per Subject. Both take the same `projection` and `format` query parameters.
-The `projection` selects the vocabulary: `native` (the default, described here) or the name of a
-Mapping page — see [Ontology Mapping](ontology-mapping.md); an unknown projection returns `400`. The
-`format` picks the serialization, falling back to the `Accept` header, then to TriG:
+RDF is served per page or per Subject. Both take the same `projection` and `format` query parameters. `projection`
+selects the vocabulary: `native` (the default, described here) or the name of a Mapping page — see
+[Ontology Mapping](ontology-mapping.md); an unknown projection returns `400`. `format` picks the serialization,
+falling back to the `Accept` header, then to TriG; a value other than `trig` or `turtle` returns `400`:
 
 | `format` | `Accept` | Content-Type | Named graph |
 |---|---|---|---|
@@ -78,8 +69,8 @@ Mapping page — see [Ontology Mapping](ontology-mapping.md); an unknown project
 
 `GET /rest.php/neowiki/v0/page/{pageId}/rdf`
 
-Returns the page's projection: its page metadata and every Subject on it, in the page's named graph.
-Returns `404` when the page does not exist or has no NeoWiki Subject data.
+Returns the page's projection: its page metadata and every Subject on it, in the page's named graph. Returns `404`
+when the page does not exist, carries no NeoWiki Subject data, or is not readable by the caller.
 
 ```sh
 curl 'https://wiki.example/rest.php/neowiki/v0/page/42/rdf?format=turtle'
@@ -89,14 +80,13 @@ curl 'https://wiki.example/rest.php/neowiki/v0/page/42/rdf?format=turtle'
 
 `GET /rest.php/neowiki/v0/subject/{subjectId}/rdf`
 
-Returns one Subject's projection: exactly the triples the page export emits for that Subject — its
-outbound description, including the native relation reification — with none of the page-metadata
-triples, in the hosting page's named graph. Inbound relations pointing at the Subject from elsewhere
-are not included.
+Returns one Subject's projection: exactly the triples the page export emits for that Subject — its outbound
+description, including the native relation reification — with none of the page-metadata triples, in the hosting page's
+named graph. Inbound relations pointing at the Subject from elsewhere are not included.
 
-Returns `404` when the Subject does not exist or is on a page the caller may not read — the two are
-indistinguishable. A malformed Subject ID returns `400`. A readable Subject whose Schema has no mapping
-for the requested ontology target projects to an empty graph — a `200`, not a `404`.
+Returns `404` when the Subject does not exist or is on a page the caller may not read — the two are indistinguishable.
+A malformed Subject ID returns `400`. A readable Subject whose Schema has no mapping for the requested ontology target
+projects to an empty graph — a `200`, not a `404`.
 
 ```sh
 curl 'https://wiki.example/rest.php/neowiki/v0/subject/s1demo8aaaaaab5/rdf?projection=EDM'
@@ -113,8 +103,8 @@ content-negotiates it and answers `303 See Other` with an absolute `Location`:
 | `text/turtle` | the Subject's Turtle RDF (`.../subject/{id}/rdf?format=turtle`) |
 | `text/html`, `*/*`, absent, anything else | the Subject's hosting page |
 
-TriG wins when both RDF types are acceptable; the RDF redirects use the native projection. A Subject that
-is absent or on a page the caller may not read returns one indistinguishable `404`; a malformed id `400`.
+TriG wins when both RDF types are acceptable; the RDF redirects use the native projection. A Subject that is absent or
+on a page the caller may not read returns one indistinguishable `404`; a malformed id `400`.
 
 The negotiator is always reachable at the REST path, which needs no server configuration:
 
@@ -122,31 +112,29 @@ The negotiator is always reachable at the REST path, which needs no server confi
 curl -H 'Accept: text/turtle' 'https://wiki.example/rest.php/neowiki/v0/entity/s1demo8aaaaaab5'
 ```
 
-To make the bare `neo-subj:` IRI itself dereference, route `/entity/{id}` to that REST path. MediaWiki's
-REST router matches on the request path, so an internal self-proxy (not a plain rewrite, which would leave
-the path unchanged) presents it without a client-visible redirect. The dev image ships this, on Apache with
-`mod_proxy` and `mod_proxy_http`:
+To make the bare `neo-subj:` IRI dereference, route `/entity/{id}` to that REST path with an internal proxy — a plain
+rewrite leaves the path unchanged, so MediaWiki's REST router never matches it. The dev image ships this on Apache
+(`mod_proxy` + `mod_proxy_http`); its `/w/` is the dev image's `$wgScriptPath`, which a different install replaces with
+its own `rest.php` path:
 
 ```apache
 RewriteRule ^/?entity/(.+)$ http://127.0.0.1/w/rest.php/neowiki/v0/entity/$1 [P,L]
 ```
 
-This applies when `$wgNeoWikiRdfBaseUri` is the wiki's own host (the default); an external or institutional
-base URI is the operator's own routing concern.
+This applies when `$wgNeoWikiRdfBaseUri` is the wiki's own host (the default); an external or institutional base URI is
+the operator's own routing concern.
 
 ### Finding these exports
 
-These exports are surfaced in the UI: the Data tab (`?action=subjects`) links to each Subject's JSON and
-per-projection Turtle/TriG, and to the same for the whole page. Pages that carry NeoWiki data also
-advertise the page export through `<link rel="alternate">` autodiscovery tags (Turtle and TriG, native
-projection) in the HTML head, so Linked Data tooling can locate the data without reading this reference.
+These exports are surfaced in the UI. The Data tab (`?action=subjects`) links to each Subject's JSON and per-projection
+Turtle/TriG, and the same for the whole page. Pages that carry NeoWiki data also emit `<link rel="alternate">`
+autodiscovery tags (Turtle and TriG, native projection) in the HTML head.
 
 ## Bulk dump
 
-`maintenance/DumpRdf.php` streams the projection of **every** subject page to stdout as TriG, one named
-graph per page. Progress goes to stderr so stdout stays a clean RDF document. It defaults to the native
-projection; `--projection=<name>` selects an ontology projection by its Mapping page name (see
-[Ontology Mapping](ontology-mapping.md)).
+`maintenance/DumpRdf.php` streams the projection of **every** subject page to stdout as TriG, one named graph per page.
+Progress goes to stderr. It defaults to the native projection; `--projection=<name>`
+selects an ontology projection by its Mapping page name (see [Ontology Mapping](ontology-mapping.md)).
 
 ```sh
 php maintenance/run.php NeoWiki:DumpRdf > dump.trig


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1106 and applies [docs/writing.md](https://github.com/ProfessionalWiki/NeoWiki/blob/master/docs/writing.md) across every user-facing docs page: 15 files, 590 insertions, 1112 deletions, one commit per file so any single page can be reverted alone.

Each page went through a three-stage pipeline: a rewrite agent bound to the page's genre row and required to verify every behavioral claim against source before keeping or tightening it; a fresh-context judge seeing only the artifact and the standard; and a conservative apply step that re-verified the judge's factual findings before touching the file. A review pass followed and restored three over-cuts: the `$wgNamespaceProtection` caveat and the OpenAPI spec-registration snippet in rest-api.md, and the parameter-injection note in query-api.md.

The pass removed false claims, not just noise. Notable corrections:

- schema-format.md listed `date`/`dateTime` as reserved/not implemented; both are registered, working types. Their fields are now documented, as are text's previously undocumented `minLength`/`maxLength`.
- person-to-edm.md's Person Schema snippet lacked the required `propertyDefinitions` wrapper, so it could not be pasted as-is.
- installation.md's "share the demo" docker compose command was not runnable as written.
- parser-functions.md counted "three parser functions" while documenting four, and misdescribed `{{#view}}`'s behavior for a nonexistent Subject ID.
- qualifiers-and-references.md described relation-carried qualifiers as Schema-typed and validated; relation properties are free-form.
- rest-api.md named a nonexistent "Mapping" read endpoint in the permissions list; `GET /subject-labels` is now documented as the exception that does not enforce per-page `read`, and `expand=relations` as also dropping targets on unreadable pages.
- rdf-export.md claimed the projection is "lossless and self-sufficient" (it drops unrepresentable values and Subjects with unavailable Schemas) and listed a `neo-graph:` prefix that is deliberately not emitted; the value-type list said `date-time` where the type name is `dateTime`.
- graph-model.md said each Statement becomes a node property (relation Statements become relationships) and stated the uniqueness constraints unconditionally (a never-rebuilt graph lacks them). The PropertyType-to-Neo4j type mapping, the backtick-escaping rule for property keys, fixed-property collision behavior, and how to recognize a deleted-but-retained Subject node are now documented.
- lua-api.md's return and getSchema tables were missing their date/dateTime/boolean rows; glossary.md called `url` a Value Type (it is a Property Type storing a StringValue) and carried a published `TODO`.

<details><summary>Per-file ledger: considered-omitted cuts, skipped judge findings, unverified claims</summary>

**glossary.md** (151→135) — omitted: dedicated Validation entry (validation-codes.md is the home); "no stored Default Layout entity" clarification; inline Cypher example. Unverified: none.

**api/graph-model.md** (128→119) — omitted: overview restating the diagram; ISO-conversion note; constraint-idempotency mechanism; duplicate namespace examples. Skipped: exact stored date serialization (below wire register). Unverified: "Founded at: 2019" rendering (code-consistent, not run live).

**api/query-api.md** (375→267) — omitted: the ~80-line curl walkthrough (restated the contracts); temporal-rendering paragraph (folded into the table); apihighlimits rationale; `$wgNeoWikiQueryLimits` override PHP example (key remains documented); SPARQL "differences from Cypher" bullets. Unverified: duration/point JSON shapes fall through to the Laudis driver.

**api/rest-api.md** (177→~173) — omitted: DOC-INTENT editorial comment (superseded by writing.md); "render without follow-up" narration. Skipped: write auth/CSRF mechanics (standard MediaWiki); pagination signaling (deferred to OpenAPI). Unverified: demo-wiki spec URL liveness.

**api/schema-format.md** (316→234) — omitted: reserved-types roadmap list (email/phone/…: absent from code, no wire contract); boolean frontend-display note; endpoint re-listing (rest-api.md owns it); trivial one-line examples. Unverified: `precision` is display-only (not enforced in PHP); select id→label display resolution not inspected.

**api/subject-format.md** (297→215) — omitted: Overview section (folded); per-type value examples the new shape table covers; facts homed in validation-codes/graph-model/rest-api. Unverified: none.

**authoring/lua-api.md** (409→405) — omitted: "use this when" preambles; conversion-table restatement. Skipped: exact accepted Lua parameter types for nw.query (could not cheaply verify; no unverified contract asserted). Unverified: integer-comparison toInteger advice kept as defensive guidance.

**authoring/parser-functions.md** (205→194) — omitted: Related-Documentation footer; header-restating notes; unregistered-type edge case. Skipped: propertyName case-sensitivity (unverified match semantics); relation "label" definition (glossary's job). Unverified: client-side rendering behaviors (frontend half inferred).

**examples/person-to-edm.md** (250→215) — omitted: origin/meta framing of the toy model; standalone "findings" section (each folded into its home section); forward-looking seam notes. Unverified: instance-specific literals (page ids, timestamps — flagged in-doc); external CIDOC-CRM path is illustrative.

**extending/extending.md** (472→451) — omitted: 21-line RDF value-mapper listing identical to the linked RedHerbHooks.php (contract kept in prose). Skipped: one judge finding whose premise was false in code (the adjacent real inaccuracy was fixed instead). Unverified: four pre-existing behavioral claims not traced (SVG icon type, rebuild delete loop, failure paths, no-mapper omission).

**operations/installation.md** (274→267) — omitted: heading-restating intro; reassurance sentences; SPARQL "no validator needed" mechanism. Skipped: third-party Neo4j provisioning steps (explicitly delegated). Unverified: "Neo4j 5.x" minimum is pinned nowhere in-repo (left as stated).

**operations/maintenance.md** (70→63) — omitted: stale intro enumeration; outage/rebuild duplication; "lives only in Neo4j, so" mechanism. Skipped: a wipe-the-data-volume command (deployment-specific); naming a changelog source (none verified to exist).

**qualifiers-and-references.md** (143→100) — omitted: "The short version" duplicate walkthrough; "Why this approach" advocacy section (two content-bearing points moved to the intro); dev-state issue links; RDF reification mechanism (round-trip contract kept). Skipped: a novalue/somevalue modeling recipe (would be speculative). Unverified: RDF round-trip losslessness for the qualified-value pattern.

**rdf/ontology-mapping.md** (171→137) — omitted: projection-selection curl/DumpRdf duplication (rdf-export.md owns it); rationale clauses; raw issue link. Skipped: two judge findings whose premises were wrong (named graphs share a store); reserved-prefix trap (could not prove, would risk asserting falsehood).

**rdf/rdf-export.md** (160→149) — omitted: IRI-encoding security justification; autodiscovery rationale; "later concerns" intro. Skipped: authentication (MediaWiki-level, not this page's home); full emitted-predicate enumeration (NativeRdfProjection.md's home). Unverified: illustrative example IRIs.

</details>

> <sub>AI-authored — Claude Code; rewrite/judge/apply fleet of 42 `Opus 4.8 (max)` agents over a deterministic Workflow pipeline, spec, review pass, restorations and glossary by `Fable 5 (max)`, directed by @JeroenDeDauw; not yet human-reviewed; every behavioral claim source-verified by the rewriters, judge findings re-verified before application, spot re-verification in review (three restorations), CI pending at submission.</sub>
