### PR TITLE
Don't crash rebuilding the graph on a wiki with no subjects

### DIFF
--- a/maintenance/RebuildGraphDatabases.php
+++ b/maintenance/RebuildGraphDatabases.php
@@ -8,6 +8,7 @@ use Exception;
 use LogicException;
 use Maintenance;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Storage\NameTableAccessException;
 use MediaWiki\Title\Title;
 use ProfessionalWiki\NeoWiki\Application\PageRefreshOutcome;
 use ProfessionalWiki\NeoWiki\Application\SubjectPageRebuilder;
@@ -145,7 +146,14 @@ class RebuildGraphDatabases extends Maintenance {
 	 */
 	private function getSubjectPageIds(): array {
 		$services = MediaWikiServices::getInstance();
-		$roleId = $services->getSlotRoleStore()->getId( MediaWikiSubjectRepository::SLOT_NAME );
+
+		try {
+			$roleId = $services->getSlotRoleStore()->getId( MediaWikiSubjectRepository::SLOT_NAME );
+		} catch ( NameTableAccessException ) {
+			// No page has ever stored a Subject, so the slot role was never registered. There is
+			// nothing to rebuild; report an empty run instead of crashing.
+			return [];
+		}
 
 		$rows = $this->getReplicaDB()->newSelectQueryBuilder()
 			->select( 'page_id' )

--- a/tests/phpunit/Maintenance/RebuildGraphDatabasesTest.php
+++ b/tests/phpunit/Maintenance/RebuildGraphDatabasesTest.php
@@ -37,6 +37,21 @@ class RebuildGraphDatabasesTest extends NeoWikiIntegrationTestCase {
 		NeoWikiExtension::resetInstance();
 	}
 
+	public function testRebuildSucceedsOnAWikiThatHasNeverStoredASubject(): void {
+		// A wiki with no Subjects has never registered the 'neo' slot role, so the role-id lookup
+		// throws NameTableAccessException. Forcing that state (empty table + a store without a warmed
+		// cache) proves the rebuild treats it as an empty run instead of crashing.
+		$this->truncateTable( 'slot_roles' );
+		$this->getServiceContainer()->resetServiceForTesting( 'SlotRoleStore' );
+
+		$spy = new SpyGraphDatabasePlugin();
+		$this->registerGraphDatabasePlugins( $spy );
+
+		$this->runRebuild();
+
+		$this->assertSame( [], $spy->savedPages, 'a wiki with no Subjects has nothing to project' );
+	}
+
 	public function testRebuildRemovesADeletedSubjectPageFromTheGraph(): void {
 		$this->createPageWithSubjects( 'Surviving page before', TestSubject::build() );
 		$deleted = $this->createPageWithSubjects( 'Deleted during outage', TestSubject::build() );


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/1115

`RebuildGraphDatabases` looked up the numeric id of the subject slot role before querying for subject pages. On a wiki that has never stored a Subject, that role was never registered, so `NameTableStore::getId()` threw `NameTableAccessException` and the script aborted.

Guard the lookup and treat a missing slot role as "no subject pages", mirroring the existing handling in `DumpRdf` and `DatabaseDeletedSubjectPageIdsLookup` (same guard introduced in #1029). The rebuild now completes and reports zero pages instead of failing.

> <sub>AI-authored — Claude Code, `Opus 4.8 (high)`; @malberts asked to investigate #1115 then implement referencing the existing pattern, one exchange on comment wording; diff not yet human-reviewed; regression test added (fails before the fix, passes after), full PHPUnit suite + phpcs + phpstan green locally, CI green.</sub>