### PR TITLE
Remove tool-syntax lines leaked into person-to-edm.md

### DIFF
--- a/docs/examples/person-to-edm.md
+++ b/docs/examples/person-to-edm.md
@@ -200,5 +200,3 @@ The toy model's CIDOC-CRM column is out of scope for v1. CIDOC-CRM mediates birt
 event node with no counterpart in NeoWiki's flat data, which v1's term substitution cannot mint. Choosing a formalism
 that can is the open mapping-formalism question ([OntologyMapping.md Q1](../planning/OntologyMapping.md#open-questions),
 [#995](https://github.com/ProfessionalWiki/NeoWiki/issues/995)).
-</content>
-</invoke>


### PR DESCRIPTION
The docs-fleet rewrite agent's closing tool-call tags (`</content>`, `</invoke>`) ended up as the
file's last two lines in https://github.com/ProfessionalWiki/NeoWiki/pull/1113. VitePress runs
markdown through the Vue template compiler, which rejects the stray end tags, so every website build
syncing master docs now fails (first seen on NeoWiki-Website#97's CI; the deploy triggered by the
#1113 merge will have failed the same way). Two-line deletion, nothing else changed.

Verified: the full NeoWiki-Website VitePress build passes locally with DOCS_REF pointed at this
branch, and all 15 fleet files audited clean for the same token class (this was the only leak).

Merge order: this first (unbreaks every website build), then NeoWiki-Website#97 (its CI re-run goes
green), then #1118.

> <sub>AI-authored — Claude Code, `Fable 5 (max)`; root-caused from NeoWiki-Website#97's failing CI reported by @JeroenDeDauw, no redirection; not yet human-reviewed; full site build run locally against this branch (green), leakage grep across all docs clean.</sub>
