### PR TITLE
Document the Relations model (ADR 28 + planning doc)

### DIFF
--- a/docs/adr/028-relations-model.md
+++ b/docs/adr/028-relations-model.md
@@ -33,10 +33,9 @@ Qualification and references are already modeled as typed Subjects
 ([Qualifiers and References](../qualifiers-and-references.md)): a qualified value becomes its own Subject under its own
 Schema, validated and rendered like any other data. Edge properties are a second, half-built path to the same end —
 scalar-only, with no editing UI, no Lua exposure, dropped by the ontology-mapping projection, and silently lost when a
-Subject carrying REST-written edge properties is re-saved through the editor
-([#1119](https://github.com/ProfessionalWiki/NeoWiki/issues/1119)). Finishing them would mean schema definitions for
-edge properties, an editor, and Lua and mapping support — duplicating what Subjects already provide. Schema-less
-qualifier bags are the Wikibase failure mode named in the epic
+Subject carrying REST-written edge properties is re-saved through the editor. Finishing them would mean schema
+definitions for edge properties, an editor, and Lua and mapping support — duplicating what Subjects already provide.
+Schema-less qualifier bags are the Wikibase failure mode named in the epic
 ([#630](https://github.com/ProfessionalWiki/NeoWiki/issues/630)); removal is tracked in
 [#1119](https://github.com/ProfessionalWiki/NeoWiki/issues/1119).
 
@@ -105,7 +104,7 @@ keying divergence.
 
 ## Consequences
 
-- Implementation is gated on ratification (team and partner review). Trackers:
+- Implementation is gated on ratification. Trackers:
   [#1119](https://github.com/ProfessionalWiki/NeoWiki/issues/1119) (remove edge properties),
   [#991](https://github.com/ProfessionalWiki/NeoWiki/issues/991) (target-Schema list),
   [#1120](https://github.com/ProfessionalWiki/NeoWiki/issues/1120) (red links).

--- a/docs/adr/028-relations-model.md
+++ b/docs/adr/028-relations-model.md
@@ -1,0 +1,127 @@
+# Relations Model
+
+Date: 2026-07-21
+
+Status: Draft
+
+Feedback welcome; the decisions are proposed as a set, and ratification (team and partner review) gates implementation.
+
+## Context
+
+Relations — the Statement values that point one Subject at another — accumulated open design questions, collected in
+the Relations epic ([#630](https://github.com/ProfessionalWiki/NeoWiki/issues/630)).
+
+An integrity pass landed first: referenced-but-absent Subjects are kept as stub nodes rather than dropped
+([#1080](https://github.com/ProfessionalWiki/NeoWiki/pull/1080)), relation targets are validated server-side
+([#1082](https://github.com/ProfessionalWiki/NeoWiki/pull/1082)), Neo4j node-uniqueness constraints are created on
+rebuild ([#1083](https://github.com/ProfessionalWiki/NeoWiki/pull/1083)), and target autocomplete is scoped to the
+current wiki ([#1084](https://github.com/ProfessionalWiki/NeoWiki/pull/1084)). With integrity in place, this ADR settles
+the model questions as one coherent set.
+
+Two earlier decisions left threads this one closes. [ADR 7](007-multiple-subjects-per-page.md) allowed multiple
+Subjects per page but left an automatic relation between the Main and Child Subjects open.
+[ADR 10](010-add-guids-to-relations.md) gave Relations stable IDs and named edge properties as roadmap.
+
+## Decision
+
+### Qualify with typed Subjects, not edge properties
+
+A Relation is `{id, target}`. The `properties` map on Relations (`RelationProperties`) is removed — from the domain
+model, the JSON serializations, the Neo4j edge writes, and the native-RDF qualifier triples.
+
+Qualification and references are already modeled as typed Subjects
+([Qualifiers and References](../qualifiers-and-references.md)): a qualified value becomes its own Subject under its own
+Schema, validated and rendered like any other data. Edge properties are a second, half-built path to the same end —
+scalar-only, with no editing UI, no Lua exposure, dropped by the ontology-mapping projection, and silently lost when a
+Subject carrying REST-written edge properties is re-saved through the editor
+([#1119](https://github.com/ProfessionalWiki/NeoWiki/issues/1119)). Finishing them would mean schema definitions for
+edge properties, an editor, and Lua and mapping support — duplicating what Subjects already provide. Schema-less
+qualifier bags are the Wikibase failure mode named in the epic
+([#630](https://github.com/ProfessionalWiki/NeoWiki/issues/630)); removal is tracked in
+[#1119](https://github.com/ProfessionalWiki/NeoWiki/issues/1119).
+
+### Keep per-relation IDs
+
+Per-relation IDs stay, and multiple Relations of the same type to the same target remain legal — the ID, not the
+(type, target) pair, distinguishes them. It gives each edge a stable identity across edits and anchors the native-RDF
+reification node and the synthesized-node IRIs the ontology mapping mints. Global relation-ID uniqueness is not
+graph-enforceable over an open set of edge types ([#351](https://github.com/ProfessionalWiki/NeoWiki/issues/351)). This
+reaffirms [ADR 10](010-add-guids-to-relations.md) minus the edge-property roadmap that the previous decision drops.
+
+### Constrain targets to one or more Schemas
+
+A relation property's target constraint is a list of Schemas: the single `targetSchema` widens to a list
+([#991](https://github.com/ProfessionalWiki/NeoWiki/issues/991)), and a target Subject must use one of them. This
+covers the concrete polymorphic cases — an artwork creator that may be a person, collective, or studio; a place that
+may be a city, province, or country — with no schema-inheritance machinery.
+
+Not taken: subclass-based target constraints, where a relation targets a supertype and accepts its subtypes. That needs
+a schema-inheritance system NeoWiki does not have and nothing else calls for; an explicit list covers the raised cases
+directly. Fully-unconstrained targets ("any Subject") stay out until a concrete need arrives.
+
+### Missing targets are red links
+
+A Relation may point at a Subject that does not exist yet. Forward references are wiki-native — a red link to an
+unwritten page — and creating interlinked Subjects in a batch depends on them: client-supplied and pre-minted IDs
+([#1100](https://github.com/ProfessionalWiki/NeoWiki/issues/1100),
+[#1101](https://github.com/ProfessionalWiki/NeoWiki/pull/1101)) let a Subject be created referencing a target ID before
+that target is written.
+
+Server-side, [`relation-target-not-found`](../api/validation-codes.md#relation-target-not-found) is a non-blocking
+warning and [`relation-target-schema-mismatch`](../api/validation-codes.md#relation-target-schema-mismatch) a blocking
+error (both in [#1082](https://github.com/ProfessionalWiki/NeoWiki/pull/1082)); an absent target still exists in the
+graph as a stub node ([#1080](https://github.com/ProfessionalWiki/NeoWiki/pull/1080)). The UI direction is red-link
+rendering with a create affordance ([#1120](https://github.com/ProfessionalWiki/NeoWiki/issues/1120)), not error
+styling.
+
+### Same-page relationships are schema-defined
+
+No Relation is created automatically between Subjects that share a page. A Child Subject relates to the page's Main
+Subject only through an explicit relation property in its Schema. An unstated co-location link would carry no defined
+meaning, and the same relationship expressed across pages would then diverge from the same-page shortcut (positions in
+[#959](https://github.com/ProfessionalWiki/NeoWiki/issues/959)).
+
+The Main Subject designation stays: it anchors the automatic display and the page-topic semantics, and the
+page/document-type pattern builds on it ([#959](https://github.com/ProfessionalWiki/NeoWiki/issues/959)). Pre-filling a
+Child Subject's relation to the Main Subject during creation is editing convenience layered on this rule, not a model
+relation. This resolves the open question in [ADR 7](007-multiple-subjects-per-page.md).
+
+### Name a relation once, on the property
+
+**Least settled — needs team review before ratification; no other decision depends on it.**
+
+Drop the separate relation-type name (the `relation` attribute on a relation property) and key both the graph edge type
+and the native-RDF predicate on the property name. Today a relation property carries two names: the property name and a
+relation-type name used as the Neo4j edge label. One name removes a concept users must define and a divergence: the
+native RDF projection keys predicates on the relation-type name while ontology mappings key on the property name. It
+also halves the rename footgun: renaming either name silently re-types existing edges on the next graph rebuild
+([ADR 17](017-names-as-identifiers.md) territory).
+
+Cost: Cypher edge types then read as property names ("Birth place") rather than verb phrases ("Born in"). Demo data and
+docs migrate — trivial pre-production.
+
+Not taken (status quo): keep both names for better-reading graph queries, at the cost of the extra concept and the
+keying divergence.
+
+## Consequences
+
+- Implementation is gated on ratification (team and partner review). Trackers:
+  [#1119](https://github.com/ProfessionalWiki/NeoWiki/issues/1119) (remove edge properties),
+  [#991](https://github.com/ProfessionalWiki/NeoWiki/issues/991) (target-Schema list),
+  [#1120](https://github.com/ProfessionalWiki/NeoWiki/issues/1120) (red links).
+- What gets simpler: no schema-for-edge-properties design, no separate qualifier editor, and the RDF reification
+  question narrows to relation identity alone (see [planning/Relations.md](../planning/Relations.md)).
+- Breaking data-format changes are acceptable: NeoWiki is not in production.
+- Out of scope, mapped in [planning/Relations.md](../planning/Relations.md): nested-vs-flat authoring of intermediate
+  structures, unconstrained targets, cardinality beyond single/multiple, no-value/some-value markers
+  ([#937](https://github.com/ProfessionalWiki/NeoWiki/issues/937)), and inverse-display configuration
+  ([#904](https://github.com/ProfessionalWiki/NeoWiki/issues/904)).
+
+## Related
+
+- [planning/Relations.md](../planning/Relations.md) — the remaining Relations work, open questions, and forward map.
+- [Qualifiers and References](../qualifiers-and-references.md), [Graph Model](../api/graph-model.md),
+  [Subject Format](../api/subject-format.md), [Validation Codes](../api/validation-codes.md).
+- [ADR 7](007-multiple-subjects-per-page.md), [ADR 10](010-add-guids-to-relations.md),
+  [ADR 17](017-names-as-identifiers.md), [ADR 26](026-validation-severity-levels.md).
+- [#630](https://github.com/ProfessionalWiki/NeoWiki/issues/630) — the Relations epic.

--- a/docs/adr/028-relations-model.md
+++ b/docs/adr/028-relations-model.md
@@ -2,7 +2,7 @@
 
 Date: 2026-07-21
 
-Status: Draft
+Status: Draft; not fully reviewed by Jeroen yet
 
 Feedback welcome; the decisions are proposed as a set, and ratification (team and partner review) gates implementation.
 

--- a/docs/planning/Relations.md
+++ b/docs/planning/Relations.md
@@ -1,0 +1,143 @@
+# Relations
+
+Written 2026-07-21 by Jeroen De Dauw with help from Claude Opus 4.8.
+
+Status: Proposal for team and ECHOLOT-partner review. We are after disagreement and additions: if an open question
+below is framed wrong, or work is missing, say so.
+
+Discussion: _to be opened; a maintainer will create the GitHub Discussion thread and link it here._
+
+This is a proposal-stage map of the remaining work on NeoWiki Relations. The model itself — what a Relation is and the
+rules governing it — is proposed in [ADR 28: Relations Model](../adr/028-relations-model.md); this doc carries the
+landed groundwork, the open questions, and the forward map. For the concepts
+(Subject, Statement, Relation, Schema) see the [glossary](../glossary.md); for modeling qualifiers and references, see
+[Qualifiers and References](../qualifiers-and-references.md).
+
+## Where Relations stand
+
+A Relation is the value of a `relation`-typed Statement: `{id, target}`, where `target` is another Subject's id and
+`id` gives the edge a stable identity ([subject format](../api/subject-format.md#relation-relation),
+[graph model](../api/graph-model.md#typed-relations)). At the Schema level a relation Property Definition carries
+`relation` (the graph edge-type name), `targetSchema` (the Schema the target must use), and `multiple` (whether more
+than one target is allowed). A per-relation edge-`properties` bag also exists today; model decision 1 below removes it.
+
+An integrity pass landed ahead of the model decisions: referenced-but-absent Subjects are kept as stub nodes rather
+than dropped ([#1080](https://github.com/ProfessionalWiki/NeoWiki/pull/1080)); relation targets are validated
+server-side — a `relation-target-not-found` warning, a `relation-target-schema-mismatch` error, and `single-value-only`
+([#1082](https://github.com/ProfessionalWiki/NeoWiki/pull/1082)); Neo4j uniqueness constraints are created on rebuild
+([#1083](https://github.com/ProfessionalWiki/NeoWiki/pull/1083)); target autocomplete is scoped to the current wiki
+([#1084](https://github.com/ProfessionalWiki/NeoWiki/pull/1084)); and the `expand=relations` REST response shape is
+documented ([#1085](https://github.com/ProfessionalWiki/NeoWiki/pull/1085)). Batch ID minting also landed — pre-minted
+and client-supplied Subject IDs on create ([#1101](https://github.com/ProfessionalWiki/NeoWiki/pull/1101)) — so
+interlinked imports can wire relations before their targets exist.
+
+## Model decisions
+
+[ADR 28](../adr/028-relations-model.md) settles six questions; rationale lives there.
+
+1. **Qualify with typed Subjects, not edge properties** — the edge-`properties` bag is removed
+   ([#1119](https://github.com/ProfessionalWiki/NeoWiki/issues/1119)).
+2. **Keep per-relation IDs** — multiple same-type edges to one target stay legal and individually addressable
+   ([#351](https://github.com/ProfessionalWiki/NeoWiki/issues/351)).
+3. **Constrain targets to one or more Schemas** — `targetSchema` widens to a list
+   ([#991](https://github.com/ProfessionalWiki/NeoWiki/issues/991)).
+4. **Missing targets are red links** — legitimate forward references; a warning, not an error
+   ([#1120](https://github.com/ProfessionalWiki/NeoWiki/issues/1120)).
+5. **Same-page relationships are schema-defined** — no automatic Main/Child relation
+   ([#959](https://github.com/ProfessionalWiki/NeoWiki/issues/959)).
+6. **Name a relation once, on the property** — proposed, least settled and the item most open to feedback: key edges
+   and predicates on the property name, dropping the separate relation-type name (the status-quo case for keeping both
+   names is recorded in the epic, [#630](https://github.com/ProfessionalWiki/NeoWiki/issues/630)).
+
+## Open questions
+
+### Nested vs flat authoring of intermediate structures
+
+CIDOC-CRM-style intermediate nodes — a birth event; a dimension with unit, upper and lower bound, source — can be
+expressed today as Child Subjects or a separately linked Subject. The open question is how they are *authored*:
+
+- **Route A — flat schemas, mapping synthesizes.** Schemas stay flat; the ontology mapping assembles the intermediate
+  node at RDF-projection time. Cost: the mapping must coordinate several flat fields into one shared node.
+- **Route B — Child Subjects as the native representation.** The nesting is real Subjects, with inline editing UX that
+  projects the structure down into a form. Cost: editor complexity and lazy-loading performance.
+
+Public positions lean toward Route B ([discussion #996](https://github.com/ProfessionalWiki/NeoWiki/discussions/996),
+[#999](https://github.com/ProfessionalWiki/NeoWiki/discussions/999)). The decision follows the neutral-person → EDM
+end-to-end projection exercise ([Person to EDM](../examples/person-to-edm.md)) rather than preceding it.
+
+### Relations in RDF
+
+The native projection reifies a Relation: a direct triple plus a `neo:Relation` node preserving the relation's identity
+([RDF export](../rdf/rdf-export.md),
+[Qualifiers and References](../qualifiers-and-references.md#in-the-graph-and-in-rdf)). With edge properties removed
+(model decision 1), the reification node's only remaining job is stable relation identity. Open: whether reification
+meets the LOD community's expectations, and whether to plan an RDF-star migration
+([#999](https://github.com/ProfessionalWiki/NeoWiki/discussions/999)).
+
+### Inverse display configuration
+
+Default-off is decided — relations are stored one-directionally, and the inverse is a display concern. Open: the
+configuration granularity (wiki, schema, or view) and the inverse labels, which cannot be derived from the forward name
+([#904](https://github.com/ProfessionalWiki/NeoWiki/issues/904)).
+
+### Autocomplete value sourcing
+
+With Property Definitions local to their Schema, where relation-target autocomplete draws candidates beyond
+target-Schema filtering is open ([#1122](https://github.com/ProfessionalWiki/NeoWiki/issues/1122)).
+
+### Parked
+
+Unconstrained ("any Subject") targets; cardinality beyond single/multiple; no-value / some-value markers
+([#937](https://github.com/ProfessionalWiki/NeoWiki/issues/937)).
+
+## Forward work
+
+### Editing
+
+- In-flow creation and editing of relation targets, and where in-flow-created Subjects live
+  ([#971](https://github.com/ProfessionalWiki/NeoWiki/issues/971)).
+- Red-link create affordance for missing targets ([#1120](https://github.com/ProfessionalWiki/NeoWiki/issues/1120)).
+- Main-Subject prefill as editing sugar (model decision 5).
+
+### Display
+
+- Incoming / inverse relations ([#904](https://github.com/ProfessionalWiki/NeoWiki/issues/904)).
+- A built-in incoming-relations section — the smallest non-Lua path to reach related and Child Subjects.
+- Relation hover card ([#377](https://github.com/ProfessionalWiki/NeoWiki/issues/377)).
+- Target links in the Schema view ([#519](https://github.com/ProfessionalWiki/NeoWiki/issues/519)).
+- Where-used over incoming relations ([#1039](https://github.com/ProfessionalWiki/NeoWiki/issues/1039)).
+
+### APIs and import
+
+- Statement-level write API ([#591](https://github.com/ProfessionalWiki/NeoWiki/issues/591)).
+
+### Query rendering
+
+- Relation columns in `{{#cypher}}` result tables ([#809](https://github.com/ProfessionalWiki/NeoWiki/issues/809);
+  prior analysis [LegacyNeoWiki #625](https://github.com/ProfessionalWiki/LegacyNeoWiki/issues/625)).
+
+### Cross-Source targets
+
+- v1 restricts relation targets to resolvable Sources
+  ([#1043](https://github.com/ProfessionalWiki/NeoWiki/pull/1043)); opening cross-Source relations — remote display,
+  graceful degradation — follows the [Subject Sources](SubjectSources.md) track
+  ([#993](https://github.com/ProfessionalWiki/NeoWiki/issues/993), [ADR 23](../adr/023-subject-sources.md)).
+
+## Track coordination
+
+Relations intersect three tracks in flight. [Subject Sources](SubjectSources.md)
+([ADR 23](../adr/023-subject-sources.md)) makes `(source, localId)` the reference form a relation target resolves
+through. [Ontology mapping](OntologyMapping.md) and the QLever projection synthesize intermediate nodes from relations
+in their structural tier — the nested-vs-flat question above.
+[Validation severity levels](../adr/026-validation-severity-levels.md) (ADR 26) govern the error and warning tiers of
+the new relation codes.
+
+## Related
+
+- ADRs: [028 relations model](../adr/028-relations-model.md) (the decisions),
+  [007 multiple subjects per page](../adr/007-multiple-subjects-per-page.md),
+  [010 relation IDs](../adr/010-add-guids-to-relations.md), [023 subject sources](../adr/023-subject-sources.md),
+  [026 validation severity](../adr/026-validation-severity-levels.md).
+- Reference: [Qualifiers and References](../qualifiers-and-references.md), [Graph Model](../api/graph-model.md),
+  [Subject Format](../api/subject-format.md), [Validation Codes](../api/validation-codes.md).
+- Epic: [#630](https://github.com/ProfessionalWiki/NeoWiki/issues/630).


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/NeoWiki/issues/630

Add a Draft ADR and a planning doc for NeoWiki Relations, following the integrity pass that
landed in #1080, #1082, #1083, and #1084.

docs/adr/028-relations-model.md (Draft) settles six model questions as a coherent set: qualify
with typed Subjects and remove relation edge properties; keep per-relation IDs; constrain a
relation's target to one or more Schemas; treat missing targets as red links; make same-page
relationships schema-defined (resolving ADR 7's open question); and — flagged least-settled,
pending team review — name a relation once, on the property. Each decision carries its
rationale, rejected alternative, and tracker. Implementation is gated on ratification (#1119
remove edge properties, #991 target-schema list, #1120 red links).

docs/planning/Relations.md maps the remaining work: current state, a one-line summary of the
six decisions, the open questions (nested-vs-flat authoring, RDF reification, inverse display,
autocomplete sourcing, parked items), a grouped forward-work map, and coordination with the
Subject Sources, ontology-mapping, and validation-severity tracks.

A maintainer needs to open the GitHub Discussion thread for the planning doc and fill in its
`Discussion:` link (the doc marks it pending, matching the sibling planning docs); Discussions
cannot be created with the available token.

Considered, omitted:
- A separate "Alternatives Considered" section — each decision states its rejected alternative
  inline, to keep the ADR terse.
- Batch ID minting as forward work — it already landed (#1101), so decision 4 references it as
  an existing capability rather than listing it as remaining work.
- Autocomplete-sourcing (#1122) appears once, as an open question, not repeated in the
  forward-work map.
- A concrete Discussion URL — pending the maintainer action noted above.

> <sub>AI-authored — Claude Code, `Opus 4.8 (max)`; detailed spec from @JeroenDeDauw, one mid-course correction; not yet human-reviewed; relative doc links verified to resolve, markdown line-length/budget and a blind fresh-context editorial-judge pass done, docs-only change with CI pending.</sub>
