### PR TITLE
Close the page-existence oracle on Subject write endpoints

### DIFF
--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -21,7 +21,9 @@ per-page `read` permission; page protection and `$wgNamespaceProtection` do not 
 empty list, or a `404` — never a `403`. `GET /subject-labels` is the exception: it filters only by wiki and Schema, not
 by per-page `read`.
 
-Subject write endpoints require per-page `edit` permission and answer `403` on denial.
+Subject write endpoints require per-page `edit` permission. On the create, main-subject, and ordering
+endpoints, which are keyed by page id, a page you may not read and a page id that does not exist answer an
+identical `404`; a page you may read but not edit answers `403`.
 
 The Cypher query endpoint is gated only by the `neowiki-query` right, with no per-page filtering (see
 [Query API](query-api.md)).

--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -21,9 +21,9 @@ per-page `read` permission; page protection and `$wgNamespaceProtection` do not 
 empty list, or a `404` — never a `403`. `GET /subject-labels` is the exception: it filters only by wiki and Schema, not
 by per-page `read`.
 
-Subject write endpoints require per-page `edit` permission. On the create, main-subject, and ordering
-endpoints, which are keyed by page id, a page you may not read and a page id that does not exist answer an
-identical `404`; a page you may read but not edit answers `403`.
+Subject write endpoints require per-page `edit` permission and answer `403` on denial. On the write endpoints keyed
+by page id ([Pages and Subjects](#pages-and-subjects)), a page you may not read answers the same `404` as a page id
+that does not exist.
 
 The Cypher query endpoint is gated only by the `neowiki-query` right, with no per-page filtering (see
 [Query API](query-api.md)).

--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -21,8 +21,8 @@ per-page `read` permission; page protection and `$wgNamespaceProtection` do not 
 empty list, or a `404` — never a `403`. `GET /subject-labels` is the exception: it filters only by wiki and Schema, not
 by per-page `read`.
 
-Subject write endpoints require per-page `edit` permission and answer `403` on denial. On the write endpoints keyed
-by page id ([Pages and Subjects](#pages-and-subjects)), a page you may not read answers the same `404` as a page id
+Subject write endpoints require per-page `edit` permission and answer `403` on denial. The write endpoints keyed by
+page id ([Pages and Subjects](#pages-and-subjects)) answer the same `404` for a page you may not read as for a page id
 that does not exist.
 
 The Cypher query endpoint is gated only by the `neowiki-query` right, with no per-page filtering (see

--- a/src/Application/Actions/CreateSubject/CreateSubjectAction.php
+++ b/src/Application/Actions/CreateSubject/CreateSubjectAction.php
@@ -6,6 +6,7 @@ namespace ProfessionalWiki\NeoWiki\Application\Actions\CreateSubject;
 
 use InvalidArgumentException;
 use ProfessionalWiki\NeoWiki\Application\PageIdentifiersLookup;
+use ProfessionalWiki\NeoWiki\Application\PageReadAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
 use ProfessionalWiki\NeoWiki\Application\SelectStatementResolver;
 use ProfessionalWiki\NeoWiki\Application\StatementListBuilder;
@@ -27,6 +28,7 @@ readonly class CreateSubjectAction {
 		private CreateSubjectPresenter $presenter,
 		private SubjectRepository $subjectRepository,
 		private IdGenerator $idGenerator,
+		private PageReadAuthorizer $readAuthorizer,
 		private SubjectWriteAuthorizer $writeAuthorizer,
 		private StatementListBuilder $statementListBuilder,
 		private SchemaLookup $schemaLookup,
@@ -43,6 +45,15 @@ readonly class CreateSubjectAction {
 		}
 
 		$pageId = new PageId( $request->pageId );
+
+		// Gate on read before write, and before touching any page state: a page the caller may not
+		// read, and a page that does not exist, both answer the same not-found shape, so restricted
+		// pages cannot be told apart from absent ones by sweeping page ids. Only a page the caller
+		// can read (its existence already public) proceeds to the write check and its 403.
+		if ( !$this->readAuthorizer->authorizeReadByPageId( $pageId ) ) {
+			$this->presenter->presentPageNotFound();
+			return;
+		}
 
 		if ( !$this->writeAuthorizer->authorize( $pageId ) ) {
 			throw new RuntimeException( 'You do not have the necessary permissions to create this subject' );

--- a/src/Application/Actions/CreateSubject/CreateSubjectAction.php
+++ b/src/Application/Actions/CreateSubject/CreateSubjectAction.php
@@ -20,6 +20,7 @@ use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
 use ProfessionalWiki\NeoWiki\Infrastructure\IdGenerator;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\PageContentSavingStatus;
 use RuntimeException;
 
 readonly class CreateSubjectAction {
@@ -86,7 +87,15 @@ readonly class CreateSubjectAction {
 			return;
 		}
 
-		$this->subjectRepository->savePageSubjects( $pageSubjects, $pageId, $request->comment );
+		$status = $this->subjectRepository->savePageSubjects( $pageSubjects, $pageId, $request->comment );
+
+		// The read gate above already turns an unresolvable page away; this catches the page going
+		// away between that check and the save, so a dropped write is never reported as created.
+		if ( $status->status === PageContentSavingStatus::ERROR ) {
+			$this->presenter->presentPageNotFound();
+			return;
+		}
+
 		$this->presenter->presentCreated( $subject->id->text, $violations );
 	}
 

--- a/src/Application/Actions/CreateSubject/CreateSubjectPresenter.php
+++ b/src/Application/Actions/CreateSubject/CreateSubjectPresenter.php
@@ -14,6 +14,13 @@ interface CreateSubjectPresenter {
 	public function presentSubjectAlreadyExists(): void;
 
 	/**
+	 * Called when the target page cannot be resolved: it does not exist, or the caller may not read
+	 * it. Both take this one shape so a caller cannot tell a hidden page apart from an absent one by
+	 * sweeping page ids (see PageReadAuthorizer).
+	 */
+	public function presentPageNotFound(): void;
+
+	/**
 	 * Called when validation enforcement rejects a Subject the request would
 	 * have created.
 	 *

--- a/src/Application/Actions/SetMainSubject/SetMainSubjectAction.php
+++ b/src/Application/Actions/SetMainSubject/SetMainSubjectAction.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Application\Actions\SetMainSubject;
 
+use ProfessionalWiki\NeoWiki\Application\PageReadAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\SubjectWriteAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\SubjectRepository;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
@@ -16,12 +17,21 @@ readonly class SetMainSubjectAction {
 	public function __construct(
 		private SetMainSubjectPresenter $presenter,
 		private SubjectRepository $subjectRepository,
+		private PageReadAuthorizer $readAuthorizer,
 		private SubjectWriteAuthorizer $writeAuthorizer,
 	) {
 	}
 
 	public function setMainSubject( SetMainSubjectRequest $request ): void {
 		$pageId = new PageId( $request->pageId );
+
+		// Gate on read before write, and before any no-op short-circuit below: a page the caller may
+		// not read, and a page that does not exist, both answer the same not-found shape, so a hidden
+		// page cannot be told apart from an absent one by sweeping page ids.
+		if ( !$this->readAuthorizer->authorizeReadByPageId( $pageId ) ) {
+			$this->presenter->presentPageNotFound();
+			return;
+		}
 
 		if ( !$this->writeAuthorizer->authorize( $pageId ) ) {
 			throw new \RuntimeException( 'You do not have the necessary permissions to change the main subject' );

--- a/src/Application/Actions/SetMainSubject/SetMainSubjectAction.php
+++ b/src/Application/Actions/SetMainSubject/SetMainSubjectAction.php
@@ -11,6 +11,7 @@ use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\PageContentSavingStatus;
 
 readonly class SetMainSubjectAction {
 
@@ -57,8 +58,7 @@ readonly class SetMainSubjectAction {
 		$pageSubjects->removeSubject( $previousMain->id );
 		$pageSubjects->createChildSubject( $previousMain );
 
-		$this->subjectRepository->savePageSubjects( $pageSubjects, $pageId, $comment );
-		$this->presenter->presentMainSubjectChanged();
+		$this->saveAndPresentChanged( $pageSubjects, $pageId, $comment );
 	}
 
 	private function promoteToMain(
@@ -87,7 +87,19 @@ readonly class SetMainSubjectAction {
 			$pageSubjects->createChildSubject( $previousMain );
 		}
 
-		$this->subjectRepository->savePageSubjects( $pageSubjects, $pageId, $comment );
+		$this->saveAndPresentChanged( $pageSubjects, $pageId, $comment );
+	}
+
+	private function saveAndPresentChanged( PageSubjects $pageSubjects, PageId $pageId, ?string $comment ): void {
+		$status = $this->subjectRepository->savePageSubjects( $pageSubjects, $pageId, $comment );
+
+		// The read gate at the top already turns an unresolvable page away; this catches the page
+		// going away between that check and the save, so a dropped write is never reported as changed.
+		if ( $status->status === PageContentSavingStatus::ERROR ) {
+			$this->presenter->presentPageNotFound();
+			return;
+		}
+
 		$this->presenter->presentMainSubjectChanged();
 	}
 

--- a/src/Application/Actions/SetMainSubject/SetMainSubjectPresenter.php
+++ b/src/Application/Actions/SetMainSubject/SetMainSubjectPresenter.php
@@ -12,4 +12,11 @@ interface SetMainSubjectPresenter {
 
 	public function presentSubjectNotFound(): void;
 
+	/**
+	 * Called when the target page cannot be resolved: it does not exist, or the caller may not read
+	 * it. Both take this one shape so a caller cannot tell a hidden page apart from an absent one by
+	 * sweeping page ids (see PageReadAuthorizer).
+	 */
+	public function presentPageNotFound(): void;
+
 }

--- a/src/Application/Actions/SetSubjectsOrdering/SetSubjectsOrderingAction.php
+++ b/src/Application/Actions/SetSubjectsOrdering/SetSubjectsOrderingAction.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Application\Actions\SetSubjectsOrdering;
 
 use InvalidArgumentException;
+use ProfessionalWiki\NeoWiki\Application\PageReadAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\SubjectWriteAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\SubjectRepository;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
@@ -17,12 +18,21 @@ readonly class SetSubjectsOrderingAction {
 	public function __construct(
 		private SetSubjectsOrderingPresenter $presenter,
 		private SubjectRepository $subjectRepository,
+		private PageReadAuthorizer $readAuthorizer,
 		private SubjectWriteAuthorizer $writeAuthorizer,
 	) {
 	}
 
 	public function setOrdering( SetSubjectsOrderingRequest $request ): void {
 		$pageId = new PageId( $request->pageId );
+
+		// Gate on read before write, and before any no-op short-circuit below: a page the caller may
+		// not read, and a page that does not exist, both answer the same not-found shape, so a hidden
+		// page cannot be told apart from an absent one by sweeping page ids.
+		if ( !$this->readAuthorizer->authorizeReadByPageId( $pageId ) ) {
+			$this->presenter->presentPageNotFound();
+			return;
+		}
 
 		if ( !$this->writeAuthorizer->authorize( $pageId ) ) {
 			throw new RuntimeException( 'You do not have the necessary permissions to change the subject ordering' );

--- a/src/Application/Actions/SetSubjectsOrdering/SetSubjectsOrderingAction.php
+++ b/src/Application/Actions/SetSubjectsOrdering/SetSubjectsOrderingAction.php
@@ -11,6 +11,7 @@ use ProfessionalWiki\NeoWiki\Application\SubjectRepository;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\PageContentSavingStatus;
 use RuntimeException;
 
 readonly class SetSubjectsOrderingAction {
@@ -55,7 +56,15 @@ readonly class SetSubjectsOrderingAction {
 			return;
 		}
 
-		$this->subjectRepository->savePageSubjects( $pageSubjects, $pageId, $request->comment );
+		$status = $this->subjectRepository->savePageSubjects( $pageSubjects, $pageId, $request->comment );
+
+		// The read gate above already turns an unresolvable page away; this catches the page going
+		// away between that check and the save, so a dropped write is never reported as changed.
+		if ( $status->status === PageContentSavingStatus::ERROR ) {
+			$this->presenter->presentPageNotFound();
+			return;
+		}
+
 		$this->presenter->presentOrderingChanged();
 	}
 

--- a/src/Application/Actions/SetSubjectsOrdering/SetSubjectsOrderingPresenter.php
+++ b/src/Application/Actions/SetSubjectsOrdering/SetSubjectsOrderingPresenter.php
@@ -12,4 +12,11 @@ interface SetSubjectsOrderingPresenter {
 
 	public function presentInvalidOrdering( string $reason ): void;
 
+	/**
+	 * Called when the target page cannot be resolved: it does not exist, or the caller may not read
+	 * it. Both take this one shape so a caller cannot tell a hidden page apart from an absent one by
+	 * sweeping page ids (see PageReadAuthorizer).
+	 */
+	public function presentPageNotFound(): void;
+
 }

--- a/src/Application/SubjectRepository.php
+++ b/src/Application/SubjectRepository.php
@@ -8,6 +8,7 @@ use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\PageContentSavingStatus;
 
 interface SubjectRepository extends SubjectLookup {
 
@@ -29,8 +30,12 @@ interface SubjectRepository extends SubjectLookup {
 	public function getSubjectsByPageId( PageId $pageId ): PageSubjects;
 
 	/**
+	 * Returns the outcome of the save. A PageContentSavingStatus::ERROR means the write did not land
+	 * - most notably when the target page no longer resolves - so callers can avoid reporting success
+	 * for a write that was silently dropped.
+	 *
 	 * TODO: document exceptions
 	 */
-	public function savePageSubjects( PageSubjects $pageSubjects, PageId $pageId, ?string $comment = null ): void;
+	public function savePageSubjects( PageSubjects $pageSubjects, PageId $pageId, ?string $comment = null ): PageContentSavingStatus;
 
 }

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -822,6 +822,7 @@ class NeoWikiExtension {
 			presenter: $presenter,
 			subjectRepository: $this->getSubjectRepository(),
 			idGenerator: $this->getIdGenerator(),
+			readAuthorizer: $this->newPageReadAuthorizer( $authority ),
 			writeAuthorizer: $this->newSubjectWriteAuthorizer( $authority ),
 			statementListBuilder: $this->getStatementListBuilder(),
 			schemaLookup: $this->getSchemaLookup(),
@@ -891,6 +892,7 @@ class NeoWikiExtension {
 		return new SetMainSubjectAction(
 			presenter: $presenter,
 			subjectRepository: $this->getSubjectRepository(),
+			readAuthorizer: $this->newPageReadAuthorizer( $authority ),
 			writeAuthorizer: $this->newSubjectWriteAuthorizer( $authority ),
 		);
 	}
@@ -899,6 +901,7 @@ class NeoWikiExtension {
 		return new SetSubjectsOrderingAction(
 			presenter: $presenter,
 			subjectRepository: $this->getSubjectRepository(),
+			readAuthorizer: $this->newPageReadAuthorizer( $authority ),
 			writeAuthorizer: $this->newSubjectWriteAuthorizer( $authority ),
 		);
 	}

--- a/src/Persistence/MediaWiki/Subject/MediaWikiSubjectRepository.php
+++ b/src/Persistence/MediaWiki/Subject/MediaWikiSubjectRepository.php
@@ -15,6 +15,7 @@ use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\EntryPoints\Content\SubjectContent;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\PageContentSaver;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\PageContentSavingStatus;
 
 class MediaWikiSubjectRepository implements SubjectRepository {
 
@@ -89,16 +90,14 @@ class MediaWikiSubjectRepository implements SubjectRepository {
 		$content->setPageSubjects( $contentData );
 	}
 
-	private function saveContent( SubjectContent $content, PageId $pageId, ?string $comment = null ): void {
-		$this->pageContentSaver->saveContent(
+	private function saveContent( SubjectContent $content, PageId $pageId, ?string $comment = null ): PageContentSavingStatus {
+		return $this->pageContentSaver->saveContent(
 			$pageId,
 			[
 				self::SLOT_NAME => $content,
 			],
 			CommentStoreComment::newUnsavedComment( $comment ?? 'Update NeoWiki subject' )
 		);
-
-		// TODO: expose failure information
 	}
 
 	public function deleteSubject( SubjectId $id, ?string $comment ): void {
@@ -129,11 +128,11 @@ class MediaWikiSubjectRepository implements SubjectRepository {
 		return $this->getContentByPageId( $pageId )?->getPageSubjects() ?? PageSubjects::newEmpty();
 	}
 
-	public function savePageSubjects( PageSubjects $pageSubjects, PageId $pageId, ?string $comment = null ): void {
+	public function savePageSubjects( PageSubjects $pageSubjects, PageId $pageId, ?string $comment = null ): PageContentSavingStatus {
 		$content = $this->getContentByPageId( $pageId ) ?? SubjectContent::newEmpty();
 
 		$content->setPageSubjects( $pageSubjects );
 
-		$this->saveContent( $content, $pageId, $comment );
+		return $this->saveContent( $content, $pageId, $comment );
 	}
 }

--- a/src/Presentation/RestCreateSubjectPresenter.php
+++ b/src/Presentation/RestCreateSubjectPresenter.php
@@ -40,6 +40,14 @@ class RestCreateSubjectPresenter implements CreateSubjectPresenter {
 		$this->statusCode = 409;
 	}
 
+	public function presentPageNotFound(): void {
+		$this->apiResponse = [
+			'status' => 'error',
+			'message' => 'Page not found',
+		];
+		$this->statusCode = 404;
+	}
+
 	/**
 	 * @param Violation[] $violations
 	 */

--- a/src/Presentation/RestSetMainSubjectPresenter.php
+++ b/src/Presentation/RestSetMainSubjectPresenter.php
@@ -34,4 +34,9 @@ class RestSetMainSubjectPresenter implements SetMainSubjectPresenter {
 		$this->statusCode = 404;
 	}
 
+	public function presentPageNotFound(): void {
+		$this->apiResponse = [ 'status' => 'error', 'message' => 'Page not found' ];
+		$this->statusCode = 404;
+	}
+
 }

--- a/src/Presentation/RestSetSubjectsOrderingPresenter.php
+++ b/src/Presentation/RestSetSubjectsOrderingPresenter.php
@@ -34,4 +34,9 @@ class RestSetSubjectsOrderingPresenter implements SetSubjectsOrderingPresenter {
 		$this->statusCode = 400;
 	}
 
+	public function presentPageNotFound(): void {
+		$this->apiResponse = [ 'status' => 'error', 'message' => 'Page not found' ];
+		$this->statusCode = 404;
+	}
+
 }

--- a/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
@@ -29,6 +29,7 @@ use ProfessionalWiki\NeoWiki\Domain\Value\RelationValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeRegistry;
 use ProfessionalWiki\NeoWiki\Infrastructure\IdGenerator;
+use ProfessionalWiki\NeoWiki\Application\PageReadAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\SubjectWriteAuthorizer;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestRelation;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestStatement;
@@ -38,6 +39,7 @@ use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectLookup;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectRepository;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpySubjectWriteAuthorizer;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubIdGenerator;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubPageReadAuthorizer;
 use RuntimeException;
 
 /**
@@ -52,6 +54,7 @@ class CreateSubjectActionTest extends TestCase {
 	private InMemorySubjectRepository $subjectRepository;
 	private IdGenerator $idGenerator;
 	private CreateSubjectPresenterSpy $presenterSpy;
+	private PageReadAuthorizer $readAuthorizer;
 	private SubjectWriteAuthorizer $authorizer;
 	private InMemorySchemaLookup $schemaLookup;
 	private InMemoryPageIdentifiersLookup $pageIdentifiersLookup;
@@ -60,6 +63,7 @@ class CreateSubjectActionTest extends TestCase {
 		$this->subjectRepository = new InMemorySubjectRepository();
 		$this->idGenerator = new StubIdGenerator( self::STUB_ID );
 		$this->presenterSpy = new CreateSubjectPresenterSpy();
+		$this->readAuthorizer = new StubPageReadAuthorizer( allowed: true );
 		$this->authorizer = new SpySubjectWriteAuthorizer( allowed: true );
 		$this->schemaLookup = new InMemorySchemaLookup();
 		$this->pageIdentifiersLookup = new InMemoryPageIdentifiersLookup();
@@ -71,6 +75,7 @@ class CreateSubjectActionTest extends TestCase {
 			$this->presenterSpy,
 			$this->subjectRepository,
 			$this->idGenerator,
+			$this->readAuthorizer,
 			$this->authorizer,
 			new StatementListBuilder(
 				$registry,
@@ -177,6 +182,43 @@ class CreateSubjectActionTest extends TestCase {
 				statements: []
 			)
 		);
+	}
+
+	public function testReportsPageNotFoundWhenUserMayNotReadPage(): void {
+		$this->readAuthorizer = new StubPageReadAuthorizer( allowed: false );
+
+		$this->newCreateSubjectAction()->createSubject(
+			new CreateSubjectRequest(
+				pageId: 1,
+				isMainSubject: true,
+				label: 'Some Label',
+				schemaName: 'some-schema-id',
+				statements: []
+			)
+		);
+
+		$this->assertSame( 'presentPageNotFound', $this->presenterSpy->result );
+		// A denied read never reaches the write: no Subject is created.
+		$this->assertNull( $this->subjectRepository->getSubject( new SubjectId( 's' . self::STUB_ID ) ) );
+	}
+
+	public function testReadDenialTakesPrecedenceOverWriteDenial(): void {
+		// A page the caller can neither read nor edit answers not-found, never the write 403, so a
+		// hidden page is indistinguishable from an absent one.
+		$this->readAuthorizer = new StubPageReadAuthorizer( allowed: false );
+		$this->authorizer = new SpySubjectWriteAuthorizer( allowed: false );
+
+		$this->newCreateSubjectAction()->createSubject(
+			new CreateSubjectRequest(
+				pageId: 1,
+				isMainSubject: true,
+				label: 'Some Label',
+				schemaName: 'some-schema-id',
+				statements: []
+			)
+		);
+
+		$this->assertSame( 'presentPageNotFound', $this->presenterSpy->result );
 	}
 
 	public function testCommentIsPassedToRepository(): void {

--- a/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
@@ -221,6 +221,25 @@ class CreateSubjectActionTest extends TestCase {
 		$this->assertSame( 'presentPageNotFound', $this->presenterSpy->result );
 	}
 
+	public function testReportsPageNotFoundWhenTheSaveFails(): void {
+		// The page passed the read and write checks but is gone by the time the save runs: the
+		// dropped write must be reported as not-found, never as created.
+		$this->subjectRepository->failNextSave = true;
+
+		$this->newCreateSubjectAction()->createSubject(
+			new CreateSubjectRequest(
+				pageId: 1,
+				isMainSubject: true,
+				label: 'Some Label',
+				schemaName: 'some-schema-id',
+				statements: []
+			)
+		);
+
+		$this->assertSame( 'presentPageNotFound', $this->presenterSpy->result );
+		$this->assertNull( $this->subjectRepository->getSubject( new SubjectId( 's' . self::STUB_ID ) ) );
+	}
+
 	public function testCommentIsPassedToRepository(): void {
 		$this->subjectRepository->savePageSubjects( PageSubjects::newEmpty(), new PageId( 1 ) );
 

--- a/tests/phpunit/Application/Actions/CreateSubjectPresenterSpy.php
+++ b/tests/phpunit/Application/Actions/CreateSubjectPresenterSpy.php
@@ -25,6 +25,10 @@ class CreateSubjectPresenterSpy implements CreateSubjectPresenter {
 		$this->result = 'presentSubjectAlreadyExists';
 	}
 
+	public function presentPageNotFound(): void {
+		$this->result = 'presentPageNotFound';
+	}
+
 	public function presentValidationFailed( array $violations ): void {
 		$this->validationFailed = true;
 		$this->violations = $violations;

--- a/tests/phpunit/Application/Actions/SetMainSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/SetMainSubjectActionTest.php
@@ -159,6 +159,21 @@ class SetMainSubjectActionTest extends TestCase {
 		$this->assertTrue( $presenter->pageNotFound );
 	}
 
+	public function testReportsPageNotFoundWhenTheSaveFails(): void {
+		// The page passed the read and write checks but is gone by the time the save runs: the
+		// dropped write must be reported as not-found, never as changed.
+		$repository = $this->newRepositoryWithMainAndChild();
+		$repository->failNextSave = true;
+
+		$presenter = $this->newSpyPresenter();
+		$this->newAction( $presenter, $repository )->setMainSubject(
+			new SetMainSubjectRequest( pageId: self::PAGE_ID, subjectId: self::CHILD_ID )
+		);
+
+		$this->assertTrue( $presenter->pageNotFound );
+		$this->assertFalse( $presenter->changed );
+	}
+
 	private function newRepositoryWithMainAndChild(): InMemorySubjectRepository {
 		$repository = new InMemorySubjectRepository();
 		$repository->savePageSubjects(

--- a/tests/phpunit/Application/Actions/SetMainSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/SetMainSubjectActionTest.php
@@ -14,6 +14,7 @@ use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectMap;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectRepository;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpySubjectWriteAuthorizer;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubPageReadAuthorizer;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\Application\Actions\SetMainSubject\SetMainSubjectAction
@@ -107,10 +108,11 @@ class SetMainSubjectActionTest extends TestCase {
 		$this->assertSame( self::MAIN_ID, $saved->getMainSubject()->id->text );
 	}
 
-	public function testThrowsWhenUserMayNotEditSubject(): void {
+	public function testThrowsWhenUserMayReadButNotEditPage(): void {
 		$action = new SetMainSubjectAction(
 			presenter: $this->newSpyPresenter(),
 			subjectRepository: new InMemorySubjectRepository(),
+			readAuthorizer: new StubPageReadAuthorizer( allowed: true ),
 			writeAuthorizer: new SpySubjectWriteAuthorizer( allowed: false ),
 		);
 
@@ -118,6 +120,43 @@ class SetMainSubjectActionTest extends TestCase {
 		$this->expectExceptionMessage( 'You do not have the necessary permissions to change the main subject' );
 
 		$action->setMainSubject( new SetMainSubjectRequest( pageId: self::PAGE_ID, subjectId: self::CHILD_ID ) );
+	}
+
+	public function testReportsPageNotFoundWhenUserMayNotReadPage(): void {
+		$repository = $this->newRepositoryWithMainAndChild();
+		$before = $repository->getSubjectsByPageId( new PageId( self::PAGE_ID ) );
+
+		$presenter = $this->newSpyPresenter();
+
+		( new SetMainSubjectAction(
+			presenter: $presenter,
+			subjectRepository: $repository,
+			readAuthorizer: new StubPageReadAuthorizer( allowed: false ),
+			writeAuthorizer: new SpySubjectWriteAuthorizer( allowed: true ),
+		) )->setMainSubject(
+			new SetMainSubjectRequest( pageId: self::PAGE_ID, subjectId: self::CHILD_ID )
+		);
+
+		$this->assertTrue( $presenter->pageNotFound );
+		// The page is left untouched: a denied read never reaches the write.
+		$this->assertEquals( $before, $repository->getSubjectsByPageId( new PageId( self::PAGE_ID ) ) );
+	}
+
+	public function testReadDenialTakesPrecedenceOverWriteDenial(): void {
+		// A page the caller can neither read nor edit answers not-found, never the write 403, so a
+		// hidden page is indistinguishable from an absent one.
+		$presenter = $this->newSpyPresenter();
+
+		( new SetMainSubjectAction(
+			presenter: $presenter,
+			subjectRepository: $this->newRepositoryWithMainAndChild(),
+			readAuthorizer: new StubPageReadAuthorizer( allowed: false ),
+			writeAuthorizer: new SpySubjectWriteAuthorizer( allowed: false ),
+		) )->setMainSubject(
+			new SetMainSubjectRequest( pageId: self::PAGE_ID, subjectId: self::CHILD_ID )
+		);
+
+		$this->assertTrue( $presenter->pageNotFound );
 	}
 
 	private function newRepositoryWithMainAndChild(): InMemorySubjectRepository {
@@ -136,6 +175,7 @@ class SetMainSubjectActionTest extends TestCase {
 		return new SetMainSubjectAction(
 			presenter: $presenter,
 			subjectRepository: $repository,
+			readAuthorizer: new StubPageReadAuthorizer( allowed: true ),
 			writeAuthorizer: new SpySubjectWriteAuthorizer( allowed: true ),
 		);
 	}
@@ -146,6 +186,7 @@ class SetMainSubjectActionTest extends TestCase {
 			public bool $changed = false;
 			public bool $noChange = false;
 			public bool $notFound = false;
+			public bool $pageNotFound = false;
 
 			public function presentMainSubjectChanged(): void {
 				$this->changed = true;
@@ -157,6 +198,10 @@ class SetMainSubjectActionTest extends TestCase {
 
 			public function presentSubjectNotFound(): void {
 				$this->notFound = true;
+			}
+
+			public function presentPageNotFound(): void {
+				$this->pageNotFound = true;
 			}
 
 		};

--- a/tests/phpunit/Application/Actions/SetSubjectsOrderingActionTest.php
+++ b/tests/phpunit/Application/Actions/SetSubjectsOrderingActionTest.php
@@ -250,6 +250,25 @@ class SetSubjectsOrderingActionTest extends TestCase {
 		$this->assertTrue( $presenter->pageNotFound );
 	}
 
+	public function testReportsPageNotFoundWhenTheSaveFails(): void {
+		// The page passed the read and write checks but is gone by the time the save runs: the
+		// dropped write must be reported as not-found, never as changed.
+		$repository = $this->newRepositoryWithMainAndThreeChildren();
+		$repository->failNextSave = true;
+
+		$presenter = $this->newSpyPresenter();
+		$this->newAction( $presenter, $repository )->setOrdering(
+			new SetSubjectsOrderingRequest(
+				pageId: self::PAGE_ID,
+				mainSubjectId: self::MAIN_ID,
+				childSubjectIds: [ self::THIRD_ID, self::FIRST_ID, self::SECOND_ID ],
+			)
+		);
+
+		$this->assertTrue( $presenter->pageNotFound );
+		$this->assertFalse( $presenter->changed );
+	}
+
 	private function newRepositoryWithMainAndThreeChildren(): InMemorySubjectRepository {
 		$repository = new InMemorySubjectRepository();
 		$repository->savePageSubjects(

--- a/tests/phpunit/Application/Actions/SetSubjectsOrderingActionTest.php
+++ b/tests/phpunit/Application/Actions/SetSubjectsOrderingActionTest.php
@@ -14,6 +14,7 @@ use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectMap;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectRepository;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpySubjectWriteAuthorizer;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubPageReadAuthorizer;
 use RuntimeException;
 
 /**
@@ -185,10 +186,11 @@ class SetSubjectsOrderingActionTest extends TestCase {
 		$this->assertTrue( $saved->getChildSubjects()->isEmpty() );
 	}
 
-	public function testThrowsWhenUserMayNotEditSubject(): void {
+	public function testThrowsWhenUserMayReadButNotEditPage(): void {
 		$action = new SetSubjectsOrderingAction(
 			presenter: $this->newSpyPresenter(),
 			subjectRepository: new InMemorySubjectRepository(),
+			readAuthorizer: new StubPageReadAuthorizer( allowed: true ),
 			writeAuthorizer: new SpySubjectWriteAuthorizer( allowed: false ),
 		);
 
@@ -202,6 +204,50 @@ class SetSubjectsOrderingActionTest extends TestCase {
 				childSubjectIds: [],
 			)
 		);
+	}
+
+	public function testReportsPageNotFoundWhenUserMayNotReadPage(): void {
+		$repository = $this->newRepositoryWithMainAndThreeChildren();
+		$before = $repository->getSubjectsByPageId( new PageId( self::PAGE_ID ) );
+		$presenter = $this->newSpyPresenter();
+
+		( new SetSubjectsOrderingAction(
+			presenter: $presenter,
+			subjectRepository: $repository,
+			readAuthorizer: new StubPageReadAuthorizer( allowed: false ),
+			writeAuthorizer: new SpySubjectWriteAuthorizer( allowed: true ),
+		) )->setOrdering(
+			new SetSubjectsOrderingRequest(
+				pageId: self::PAGE_ID,
+				mainSubjectId: self::MAIN_ID,
+				childSubjectIds: [ self::THIRD_ID, self::FIRST_ID, self::SECOND_ID ],
+			)
+		);
+
+		$this->assertTrue( $presenter->pageNotFound );
+		// A denied read never reaches the write: the ordering is left untouched.
+		$this->assertEquals( $before, $repository->getSubjectsByPageId( new PageId( self::PAGE_ID ) ) );
+	}
+
+	public function testReadDenialTakesPrecedenceOverWriteDenial(): void {
+		// A page the caller can neither read nor edit answers not-found, never the write 403, so a
+		// hidden page is indistinguishable from an absent one.
+		$presenter = $this->newSpyPresenter();
+
+		( new SetSubjectsOrderingAction(
+			presenter: $presenter,
+			subjectRepository: $this->newRepositoryWithMainAndThreeChildren(),
+			readAuthorizer: new StubPageReadAuthorizer( allowed: false ),
+			writeAuthorizer: new SpySubjectWriteAuthorizer( allowed: false ),
+		) )->setOrdering(
+			new SetSubjectsOrderingRequest(
+				pageId: self::PAGE_ID,
+				mainSubjectId: self::MAIN_ID,
+				childSubjectIds: [ self::THIRD_ID, self::FIRST_ID, self::SECOND_ID ],
+			)
+		);
+
+		$this->assertTrue( $presenter->pageNotFound );
 	}
 
 	private function newRepositoryWithMainAndThreeChildren(): InMemorySubjectRepository {
@@ -224,6 +270,7 @@ class SetSubjectsOrderingActionTest extends TestCase {
 		return new SetSubjectsOrderingAction(
 			presenter: $presenter,
 			subjectRepository: $repository,
+			readAuthorizer: new StubPageReadAuthorizer( allowed: true ),
 			writeAuthorizer: new SpySubjectWriteAuthorizer( allowed: true ),
 		);
 	}
@@ -234,6 +281,7 @@ class SetSubjectsOrderingActionTest extends TestCase {
 			public bool $changed = false;
 			public bool $noChange = false;
 			public bool $invalid = false;
+			public bool $pageNotFound = false;
 			public ?string $invalidReason = null;
 
 			public function presentOrderingChanged(): void {
@@ -247,6 +295,10 @@ class SetSubjectsOrderingActionTest extends TestCase {
 			public function presentInvalidOrdering( string $reason ): void {
 				$this->invalid = true;
 				$this->invalidReason = $reason;
+			}
+
+			public function presentPageNotFound(): void {
+				$this->pageNotFound = true;
 			}
 
 		};

--- a/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
@@ -5,12 +5,11 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\REST;
 
 use MediaWiki\MediaWikiServices;
-use MediaWiki\Page\PageIdentity;
 use MediaWiki\Rest\HttpException;
 use MediaWiki\Rest\RequestData;
 use MediaWiki\Rest\Response;
 use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
-use MediaWiki\Tests\Unit\Permissions\MockAuthorityTrait;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiMockAuthorityTrait;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
@@ -31,7 +30,10 @@ use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
  */
 class CreateSubjectApiTest extends NeoWikiIntegrationTestCase {
 	use HandlerTestTrait;
-	use MockAuthorityTrait;
+	use NeoWikiMockAuthorityTrait;
+
+	// A page id far above anything a fresh test database mints, so it resolves to no page.
+	private const int NONEXISTENT_PAGE_ID = 999999;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -119,13 +121,14 @@ class CreateSubjectApiTest extends NeoWikiIntegrationTestCase {
 		return MediaWikiServices::getInstance()->getWikiPageFactory()->newFromTitle( $title )->getId();
 	}
 
-	public function testPermissionDenied(): void {
+	public function testReadableButNotEditablePageReturns403(): void {
 		$this->createSchema( 'Employee' );
 
+		// The caller can read the page - so its existence is already public - but cannot edit it.
 		$response = $this->executeHandler(
 			$this->newCreateSubjectApi(),
 			$this->createValidRequestData(),
-			authority: $this->mockAnonAuthorityWithPermissions( [] )
+			authority: $this->authorityWithGlobalEditButNoPageEdit()
 		);
 
 		$responseData = json_decode( $response->getBody()->getContents(), true );
@@ -136,23 +139,35 @@ class CreateSubjectApiTest extends NeoWikiIntegrationTestCase {
 		$this->assertArrayNotHasKey( 'violations', $responseData );
 	}
 
-	public function testDeniedOnProtectedPageDespiteGlobalEditRight(): void {
+	public function testUnreadablePageIsIndistinguishableFromNonexistentPage(): void {
 		$this->createSchema( 'Employee' );
 
-		$response = $this->executeHandler(
+		// A real page the caller may not read: a write to it must not reveal that it exists.
+		$unreadable = $this->executeHandler(
 			$this->newCreateSubjectApi(),
 			$this->createValidRequestData(),
-			authority: $this->mockRegisteredAuthority(
-				// Holds the wiki-global 'edit' right, but cannot edit this specific (e.g. protected) page.
-				static fn ( string $permission, ?PageIdentity $page = null ): bool =>
-					$permission === 'edit' && $page === null
-			)
+			authority: $this->authorityWithGlobalReadButNoPageRead()
 		);
 
-		$responseData = json_decode( $response->getBody()->getContents(), true );
+		// A page id that resolves to no page at all.
+		$nonexistent = $this->executeHandler(
+			$this->newCreateSubjectApi(),
+			new RequestData( [
+				'method' => 'POST',
+				'pathParams' => [ 'pageId' => self::NONEXISTENT_PAGE_ID ],
+				'bodyContents' => json_encode( $this->validBody() ),
+				'headers' => [ 'Content-Type' => 'application/json' ],
+			] ),
+			authority: $this->authorityWithGlobalReadButNoPageRead()
+		);
 
-		$this->assertSame( 403, $response->getStatusCode() );
-		$this->assertSame( 'You do not have the necessary permissions to create this subject', $responseData['message'] );
+		$this->assertSame( 404, $unreadable->getStatusCode() );
+		$this->assertSame( 404, $nonexistent->getStatusCode() );
+		// Byte-identical: a caller sweeping page ids cannot tell a hidden page from an absent one.
+		$this->assertSame(
+			$nonexistent->getBody()->getContents(),
+			$unreadable->getBody()->getContents()
+		);
 	}
 
 	public function testResponseIncludesViolationsWhenRequiredPropertyMissing(): void {

--- a/tests/phpunit/EntryPoints/REST/SetMainSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/SetMainSubjectApiTest.php
@@ -7,7 +7,7 @@ namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\REST;
 use MediaWiki\Rest\HttpException;
 use MediaWiki\Rest\RequestData;
 use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
-use MediaWiki\Tests\Unit\Permissions\MockAuthorityTrait;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiMockAuthorityTrait;
 use MediaWiki\Revision\RevisionRecord;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
@@ -27,7 +27,10 @@ use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
  */
 class SetMainSubjectApiTest extends NeoWikiIntegrationTestCase {
 	use HandlerTestTrait;
-	use MockAuthorityTrait;
+	use NeoWikiMockAuthorityTrait;
+
+	// A page id far above anything a fresh test database mints, so it resolves to no page.
+	private const int NONEXISTENT_PAGE_ID = 999999;
 
 	public function setUp(): void {
 		$this->setUpNeo4j();
@@ -113,16 +116,43 @@ class SetMainSubjectApiTest extends NeoWikiIntegrationTestCase {
 		);
 	}
 
-	public function testPermissionDenied(): void {
+	public function testReadableButNotEditablePageReturns403(): void {
 		$pageId = $this->createPageWithMainAndChild()->getPage()->getId();
 
+		// The caller can read the page - so its existence is already public - but cannot edit it.
 		$response = $this->executeHandler(
 			$this->newApi(),
 			$this->newRequest( $pageId, [ 'subjectId' => 'sTestSMS1111ch1' ] ),
-			authority: $this->mockAnonAuthorityWithPermissions( [] )
+			authority: $this->authorityWithGlobalEditButNoPageEdit()
 		);
 
 		$this->assertSame( 403, $response->getStatusCode() );
+	}
+
+	public function testUnreadablePageIsIndistinguishableFromNonexistentPage(): void {
+		$pageId = $this->createPageWithMainAndChild()->getPage()->getId();
+
+		// A real page the caller may not read: a write to it must not reveal that it exists.
+		$unreadable = $this->executeHandler(
+			$this->newApi(),
+			$this->newRequest( $pageId, [ 'subjectId' => 'sTestSMS1111ch1' ] ),
+			authority: $this->authorityWithGlobalReadButNoPageRead()
+		);
+
+		// A page id that resolves to no page at all.
+		$nonexistent = $this->executeHandler(
+			$this->newApi(),
+			$this->newRequest( self::NONEXISTENT_PAGE_ID, [ 'subjectId' => 'sTestSMS1111ch1' ] ),
+			authority: $this->authorityWithGlobalReadButNoPageRead()
+		);
+
+		$this->assertSame( 404, $unreadable->getStatusCode() );
+		$this->assertSame( 404, $nonexistent->getStatusCode() );
+		// Byte-identical: a caller sweeping page ids cannot tell a hidden page from an absent one.
+		$this->assertSame(
+			$nonexistent->getBody()->getContents(),
+			$unreadable->getBody()->getContents()
+		);
 	}
 
 	private function newApi(): SetMainSubjectApi {

--- a/tests/phpunit/EntryPoints/REST/SetSubjectsOrderingApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/SetSubjectsOrderingApiTest.php
@@ -8,7 +8,7 @@ use MediaWiki\MediaWikiServices;
 use MediaWiki\Rest\RequestData;
 use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
-use MediaWiki\Tests\Unit\Permissions\MockAuthorityTrait;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiMockAuthorityTrait;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
@@ -29,7 +29,10 @@ use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
  */
 class SetSubjectsOrderingApiTest extends NeoWikiIntegrationTestCase {
 	use HandlerTestTrait;
-	use MockAuthorityTrait;
+	use NeoWikiMockAuthorityTrait;
+
+	// A page id far above anything a fresh test database mints, so it resolves to no page.
+	private const int NONEXISTENT_PAGE_ID = 999999;
 
 	private const string SCHEMA = 'SetSubjectsOrderingApiTestSchema';
 	private const string MAIN = 'sTestSso1111maa';
@@ -191,19 +194,51 @@ class SetSubjectsOrderingApiTest extends NeoWikiIntegrationTestCase {
 		);
 	}
 
-	public function testPermissionDenied(): void {
+	public function testReadableButNotEditablePageReturns403(): void {
 		$pageId = $this->createPageWithMainAndChildren()->getPage()->getId();
 
+		// The caller can read the page - so its existence is already public - but cannot edit it.
 		$response = $this->executeHandler(
 			$this->newApi(),
 			$this->newRequest( $pageId, [
 				'mainSubjectId' => self::MAIN,
-				'childSubjectIds' => [ self::CHILD_1, self::CHILD_2, self::CHILD_3 ],
+				'childSubjectIds' => [ self::CHILD_3, self::CHILD_1, self::CHILD_2 ],
 			] ),
-			authority: $this->mockAnonAuthorityWithPermissions( [] )
+			authority: $this->authorityWithGlobalEditButNoPageEdit()
 		);
 
 		$this->assertSame( 403, $response->getStatusCode() );
+	}
+
+	public function testUnreadablePageIsIndistinguishableFromNonexistentPage(): void {
+		$pageId = $this->createPageWithMainAndChildren()->getPage()->getId();
+
+		$body = [
+			'mainSubjectId' => self::MAIN,
+			'childSubjectIds' => [ self::CHILD_3, self::CHILD_1, self::CHILD_2 ],
+		];
+
+		// A real page the caller may not read: a write to it must not reveal that it exists.
+		$unreadable = $this->executeHandler(
+			$this->newApi(),
+			$this->newRequest( $pageId, $body ),
+			authority: $this->authorityWithGlobalReadButNoPageRead()
+		);
+
+		// A page id that resolves to no page at all.
+		$nonexistent = $this->executeHandler(
+			$this->newApi(),
+			$this->newRequest( self::NONEXISTENT_PAGE_ID, $body ),
+			authority: $this->authorityWithGlobalReadButNoPageRead()
+		);
+
+		$this->assertSame( 404, $unreadable->getStatusCode() );
+		$this->assertSame( 404, $nonexistent->getStatusCode() );
+		// Byte-identical: a caller sweeping page ids cannot tell a hidden page from an absent one.
+		$this->assertSame(
+			$nonexistent->getBody()->getContents(),
+			$unreadable->getBody()->getContents()
+		);
 	}
 
 	private function newApi(): SetSubjectsOrderingApi {

--- a/tests/phpunit/NeoWikiMockAuthorityTrait.php
+++ b/tests/phpunit/NeoWikiMockAuthorityTrait.php
@@ -28,4 +28,17 @@ trait NeoWikiMockAuthorityTrait {
 		return $this->mockRegisteredAuthority( $canReadGloballyButNotPerPage );
 	}
 
+	/**
+	 * Can read every page and holds the wiki-global 'edit' right, but cannot edit any specific page
+	 * (as under page protection or an ACL extension that grants read but denies edit). Such a page
+	 * is readable, so its existence is already public: a write to it is answered with 403, not the
+	 * not-found shape reserved for pages the caller cannot read.
+	 */
+	private function authorityWithGlobalEditButNoPageEdit(): Authority {
+		$canReadAnyPageAndEditGloballyButNotPerPage = static fn ( string $permission, ?PageIdentity $page = null ): bool =>
+			$permission === 'read' || ( $permission === 'edit' && $page === null );
+
+		return $this->mockRegisteredAuthority( $canReadAnyPageAndEditGloballyButNotPerPage );
+	}
+
 }

--- a/tests/phpunit/TestDoubles/InMemorySubjectRepository.php
+++ b/tests/phpunit/TestDoubles/InMemorySubjectRepository.php
@@ -9,6 +9,7 @@ use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\PageContentSavingStatus;
 
 class InMemorySubjectRepository implements SubjectRepository {
 
@@ -28,6 +29,12 @@ class InMemorySubjectRepository implements SubjectRepository {
 	public array $comments = [];
 
 	public int $updateSubjectCallCount = 0;
+
+	/**
+	 * When true, savePageSubjects reports a save failure without storing anything, standing in for a
+	 * page that has gone away underneath the write (the branch PageContentSaver returns ERROR for).
+	 */
+	public bool $failNextSave = false;
 
 	public function getSubject( SubjectId $subjectId ): ?Subject {
 		return $this->subjects[$subjectId->text] ?? null;
@@ -52,13 +59,19 @@ class InMemorySubjectRepository implements SubjectRepository {
 		return PageSubjects::newEmpty();
 	}
 
-	public function savePageSubjects( PageSubjects $pageSubjects, PageId $pageId, ?string $comment = null ): void {
+	public function savePageSubjects( PageSubjects $pageSubjects, PageId $pageId, ?string $comment = null ): PageContentSavingStatus {
+		if ( $this->failNextSave ) {
+			return new PageContentSavingStatus( PageContentSavingStatus::ERROR, 'Page not found' );
+		}
+
 		$this->subjectsByPage[$pageId->id] = $pageSubjects;
 		$this->comments[$pageId->id] = $comment;
 
 		foreach ( $pageSubjects->getAllSubjects()->asArray() as $subject ) {
 			$this->subjects[$subject->getId()->text] = $subject;
 		}
+
+		return new PageContentSavingStatus( PageContentSavingStatus::REVISION_CREATED );
 	}
 
 }


### PR DESCRIPTION
Fixes #1061

The four page-id-keyed Subject **write** endpoints — `CreateSubject` (main and child), `SetMainSubject`, `SetSubjectsOrdering`, all keyed by a dense integer MediaWiki page id — were a page-existence oracle. A caller holding the wiki-global `edit` right (an ordinary editor) got a `403` for a page they could not edit but a `201`/`200` no-op for a nonexistent page id, so sweeping page ids distinguished "restricted page exists here" from "no page here". This is the write-side mirror of the read-side oracle #1058 (#1046) closed, and its `POST` final commit noted these writes were "not yet enumeration-hardened".

## The fix

Each of the four endpoints now gates on `PageReadAuthorizer::authorizeReadByPageId()` — the same binding per-page `read` check #1058 built — **before** the write authorization and **before** any no-op short-circuit. That authorizer already returns false for both a nonexistent page and a page the caller may not read.

| page state (caller holds global `edit`) | before | after |
|---|---|---|
| exists, caller can edit | `201` / `200` | `201` / `200` (unchanged) |
| exists, caller can **read** but not edit | `403` | `403` (unchanged — existence already public via GET) |
| exists, caller may **not read** (ACL / `$wgWhitelistRead`) | `403` | **`404`** |
| nonexistent page id | `201` / `200` no-op | **`404`** |

A page you cannot read and a page that does not exist now return a **byte-identical** `404` (`{"status":"error","message":"Page not found"}`), so page ids can no longer be swept to reveal restricted pages. A readable-but-not-editable page still returns `403`, because its existence is already public through the read endpoints. The gate runs before the `SetMainSubject`/`SetSubjectsOrdering` no-op paths, which previously answered `200 unchanged` for a nonexistent page.

## Backstop: surface swallowed save failures

`SubjectRepository::savePageSubjects` returned `void` and `MediaWikiSubjectRepository` dropped the `PageContentSaver` status on the floor (the `// TODO: expose failure information`), so a save that failed — most notably a page that no longer resolves — was reported to the caller as a successful create/change. `savePageSubjects` now returns the `PageContentSavingStatus`, and the three actions turn an `ERROR` into the same `404`. With the read gate in front this is a belt-and-suspenders for the page being deleted between the gate and the save; on its own it stops the write path from claiming success for a write that never landed. `updateSubject`/`deleteSubject` keep their `void` contract.

## Scope

In: the four page-id-keyed writes. Out, deliberately: `PUT`/`DELETE /subject/{id}` (Replace/Delete) are subject-id-keyed, and `Special:NeoJson` is title-keyed — page existence by title is already public, so neither is the dense-integer-id oracle this fixes.

## Considered, omitted

The backstop maps *any* post-gate `PageContentSavingStatus::ERROR` to the same `404`, discarding `errorMessage` — so a rare non-page-gone save failure (an `EditFilterMergedContent` abort, an edit conflict) on an existing editable page would also read as "Page not found". This is a strict improvement over the prior behaviour (a fabricated `201`/`200` that claimed a write which never landed), maps uniformly regardless of page existence (no oracle), and is narrowly reachable on these slot-write paths. Distinguishing failure kinds needs a typed reason out of `PageContentSaver`, which is beyond this issue.

## Verification

`make cs` (phpcs + phpstan) clean. The gate is pinned by action-unit tests proven load-bearing by mutation (neutralising the gate creates the Subject and returns the wrong `403`), and by API integration tests asserting **byte-identity** between the unreadable-page and nonexistent-page `404`s on all three endpoints, plus a readable-but-not-editable `403` (mock grants `read`, denies page `edit`). The backstop is pinned by an action test that fails the save (`InMemorySubjectRepository::failNextSave`) and asserts not-found, not created/changed.

Verified live on the dev wiki (per-page `read` denied on page 30 via a `getUserPermissionsErrors` hook):

| request | result |
|---|---|
| `POST /page/30/mainSubject` (read-restricted) | `404` `{"status":"error","message":"Page not found"}` |
| `POST /page/999999/mainSubject` (nonexistent) | **byte-identical** `404` |
| `POST /page/30/childSubjects`, `PUT /page/30/mainSubject`, `PUT /page/30/subjectsOrdering` | `404` |
| `POST /page/39/childSubjects` as an anon (readable, not editable) | `403` |
| `POST /page/39/childSubjects` as an editor | `201 created` |

> `CreateSubjectApiTest` runs its full ~24-case suite past the dev-stack's Neo4j-connection budget and times out locally; the four gate/backstop cases and the happy path were verified with targeted filters (CI runs the full suite).

## Manual check

A sitewide read lockdown cannot exercise these gates — MediaWiki's REST framework rejects all routes on the wiki-global `read` right first. Use a targeted per-page denial. Append to `Docker/LocalSettings.local.php` (edit in place with `cat >>`, replacing it breaks the bind mount):

```php
$wgHooks['getUserPermissionsErrors'][] = static function ( $title, $user, $action, &$result ) {
    if ( $action === 'read' && $title->getDBkey() === 'ACME_Amsterdam_HQ' ) {
        $result = 'badaccess-group0';
        return false;
    }
    return true;
};
```

As a logged-in ordinary editor (demo data: page 30 = ACME Amsterdam HQ), with a CSRF token:

- `POST <wiki>/w/rest.php/neowiki/v0/page/30/mainSubject` (a valid Subject body) → `404` `{"status":"error","message":"Page not found"}`
- `POST .../page/999999/mainSubject` (nonexistent id) → **identical** `404`
- `POST .../page/30/childSubjects`, `PUT .../page/30/mainSubject`, `PUT .../page/30/subjectsOrdering` → same `404`
- Any page you can read but not edit → `403`; any page you can edit → `201`/`200`.

Remove the hook → full behaviour returns.

> Directed by @alistair3149; the denial shape (read-gate → 404 mirroring #1058, vs a uniform 403 or the issue's literal 404-for-nonexistent-only) was chosen explicitly in review.
> <sub>Written by Claude Code, `Opus 4.8 (1M context)`</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
