### PR TITLE
Review fixes for #1123: test the hash wiring, stop the highlight diverging

### DIFF
--- a/resources/ext.neowiki/src/components/SubjectsManager/SubjectsManagerPage.vue
+++ b/resources/ext.neowiki/src/components/SubjectsManager/SubjectsManagerPage.vue
@@ -658,6 +658,11 @@ function openExport( value: string | number | null ): void {
 }
 
 function toggleExpanded( id: string ): void {
+	// The arrival highlight is a one-time "you landed here" cue from a deep link. The first manual
+	// expand/collapse is the user taking over, so dismiss it: otherwise it would linger on the
+	// originally linked row while the address-bar fragment (rewritten below) moves to a different one,
+	// leaving the visible highlight and a copied URL disagreeing. Mirrors focusedId, likewise transient.
+	highlightedId.value = null;
 	const next = new Set( expandedIds.value );
 	if ( next.has( id ) ) {
 		next.delete( id );
@@ -870,6 +875,10 @@ async function executeDelete( comment: string ): Promise<void> {
 function applyHash(): void {
 	const id = subjectIdFromHash( window.location.hash.slice( 1 ) );
 	if ( id === null ) {
+		// The fragment no longer names a Subject (navigated to a foreign anchor, or cleared), so no row
+		// is the deep-link target any more: drop any stale highlight rather than leave it on a row the
+		// address bar no longer points at.
+		highlightedId.value = null;
 		return;
 	}
 	highlightedId.value = id;

--- a/resources/ext.neowiki/tests/components/SubjectsManager/SubjectsManagerPage.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectsManager/SubjectsManagerPage.spec.ts
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+import { shallowMount, VueWrapper, flushPromises } from '@vue/test-utils';
+import SubjectsManagerPage from '@/components/SubjectsManager/SubjectsManagerPage.vue';
+import { createI18nMock, setupMwMock } from '../../VueTestHelpers.ts';
+import { Subject } from '@/domain/Subject.ts';
+import { SubjectId } from '@/domain/SubjectId.ts';
+import { StatementList } from '@/domain/StatementList.ts';
+import { subjectRowDomId } from '@/presentation/subjectRowAnchor.ts';
+
+// Two subject-id-shaped ids (s + 14 base58 chars), so the deep-link fragment parser accepts them.
+const ID_A = 's1aaaaaaaaaaaa1';
+const ID_B = 's1bbbbbbbbbbbb1';
+const PAGE_ID = 42;
+
+function subject( id: string ): Subject {
+	return new Subject( new SubjectId( id ), 'Label ' + id, 'Person', new StatementList( [] ) );
+}
+
+const loadPageSubjectsMock = vi.fn().mockResolvedValue( undefined );
+let storeSubjects: Subject[] = [];
+let mainSubjectId: SubjectId | null = null;
+
+vi.mock( '@/stores/SubjectStore.ts', () => ( {
+	useSubjectStore: () => ( {
+		loadPageSubjects: loadPageSubjectsMock,
+		getSubject: ( id: SubjectId ) => storeSubjects.find( ( s ) => s.getId().text === id.text ),
+		openSubjectCreator: vi.fn(),
+		get pageSubjects() {
+			return {
+				getSubjects: () => storeSubjects,
+				getMainSubjectId: () => mainSubjectId,
+			};
+		},
+	} ),
+} ) );
+
+vi.mock( '@/stores/SchemaStore.ts', () => ( {
+	useSchemaStore: () => ( {
+		fetchSchema: vi.fn(),
+		saveSchema: vi.fn(),
+		getSchema: vi.fn(),
+	} ),
+} ) );
+
+vi.mock( '@/composables/useSubjectPermissions.ts', () => ( {
+	useSubjectPermissions: () => ( {
+		canCreateMainSubject: ref( false ),
+		canCreateChildSubject: ref( false ),
+		canEditSubject: ref( false ),
+		canDeleteSubject: ref( false ),
+		checkPermissions: vi.fn().mockResolvedValue( undefined ),
+	} ),
+} ) );
+
+// The drag wiring boots SortableJS against real DOM, which is irrelevant here and awkward in jsdom.
+vi.mock( '@/composables/useSubjectDrag.ts', () => ( {
+	useSubjectDrag: vi.fn(),
+} ) );
+
+const HIGHLIGHT_CLASS = 'ext-neowiki-subjects-manager__row--highlighted';
+
+function rowFor( wrapper: VueWrapper, id: string ): VueWrapper {
+	return wrapper.find( '#' + subjectRowDomId( id ) ) as unknown as VueWrapper;
+}
+
+async function mountPage(): Promise<VueWrapper> {
+	setupMwMock( {
+		functions: [ 'config', 'msg', 'message', 'notify', 'util' ],
+		config: {
+			wgNeoWikiManageSubjectsPageId: PAGE_ID,
+			wgNeoWikiRdfProjections: [],
+			wgNeoWikiSubjectIriBase: '',
+		},
+	} );
+
+	const wrapper = shallowMount( SubjectsManagerPage, {
+		attachTo: document.body,
+		global: {
+			mocks: { $i18n: createI18nMock() },
+			stubs: { CdxIcon: true },
+		},
+	} );
+
+	// onMounted awaits checkPermissions + loadSubjects; then applyHash schedules the scroll on nextTick.
+	await flushPromises();
+	await flushPromises();
+
+	return wrapper;
+}
+
+describe( 'SubjectsManagerPage deep-link / hash wiring', () => {
+
+	beforeEach( () => {
+		storeSubjects = [ subject( ID_A ), subject( ID_B ) ];
+		mainSubjectId = null;
+		loadPageSubjectsMock.mockClear();
+		window.location.hash = '';
+		// jsdom implements neither of these; the component calls both while landing on a row.
+		Element.prototype.scrollIntoView = vi.fn();
+		window.matchMedia = vi.fn().mockReturnValue( { matches: false } ) as unknown as typeof window.matchMedia;
+	} );
+
+	afterEach( () => {
+		document.body.innerHTML = '';
+		window.location.hash = '';
+		vi.restoreAllMocks();
+	} );
+
+	it( 'expands, highlights, and scrolls to the row named by a subject-id fragment', async () => {
+		window.location.hash = '#' + ID_A;
+
+		const wrapper = await mountPage();
+
+		const row = rowFor( wrapper, ID_A );
+		expect( row.exists() ).toBe( true );
+		expect( row.classes() ).toContain( HIGHLIGHT_CLASS );
+		expect( ( row.find( 'details' ).element as HTMLDetailsElement ).open ).toBe( true );
+		// The scrolled element is the target row itself. Asserting the context rather than a call count
+		// keeps this independent of how many hashchange events jsdom synthesizes for the programmatic
+		// location.hash assignment above (a real page load sets the hash once, with no hashchange).
+		const scroll = vi.mocked( Element.prototype.scrollIntoView );
+		expect( scroll ).toHaveBeenCalled();
+		expect( scroll.mock.contexts ).toContain( row.element );
+
+		// The other row is untouched.
+		expect( rowFor( wrapper, ID_B ).classes() ).not.toContain( HIGHLIGHT_CLASS );
+	} );
+
+	it( 'leaves every row untouched for a fragment that is not a subject id', async () => {
+		window.location.hash = '#section-heading';
+
+		const wrapper = await mountPage();
+
+		expect( rowFor( wrapper, ID_A ).classes() ).not.toContain( HIGHLIGHT_CLASS );
+		expect( rowFor( wrapper, ID_B ).classes() ).not.toContain( HIGHLIGHT_CLASS );
+		expect( Element.prototype.scrollIntoView ).not.toHaveBeenCalled();
+	} );
+
+	it( 'writes the bare subject id to the address bar via replaceState when a row is expanded', async () => {
+		const replaceState = vi.spyOn( window.history, 'replaceState' );
+
+		const wrapper = await mountPage();
+		await rowFor( wrapper, ID_A ).find( 'summary' ).trigger( 'click' );
+
+		expect( replaceState ).toHaveBeenCalledWith( null, '', '#' + ID_A );
+		expect( ( rowFor( wrapper, ID_A ).find( 'details' ).element as HTMLDetailsElement ).open ).toBe( true );
+		// replaceState fires no hashchange, so applyHash never re-runs and never highlights the row.
+		expect( rowFor( wrapper, ID_A ).classes() ).not.toContain( HIGHLIGHT_CLASS );
+	} );
+
+	it( 'dismisses the arrival highlight on the first manual expand of a different row', async () => {
+		window.location.hash = '#' + ID_A;
+
+		const wrapper = await mountPage();
+		expect( rowFor( wrapper, ID_A ).classes() ).toContain( HIGHLIGHT_CLASS );
+
+		await rowFor( wrapper, ID_B ).find( 'summary' ).trigger( 'click' );
+
+		// The highlight no longer clings to A while the fragment (now #ID_B) has moved on.
+		expect( rowFor( wrapper, ID_A ).classes() ).not.toContain( HIGHLIGHT_CLASS );
+		expect( rowFor( wrapper, ID_B ).classes() ).not.toContain( HIGHLIGHT_CLASS );
+	} );
+
+	it( 'stops responding to hashchange after unmount', async () => {
+		const removeListener = vi.spyOn( window, 'removeEventListener' );
+
+		const wrapper = await mountPage();
+		wrapper.unmount();
+
+		expect( removeListener ).toHaveBeenCalledWith( 'hashchange', expect.any( Function ) );
+	} );
+
+} );


### PR DESCRIPTION
Draft, targeting **#1123** (`feature/subject-row-deep-links`) so it can be merged straight into that branch. Addresses two review findings on #1123.

### 1. Behavioral test for the deep-link / hash wiring (was untested)

#1123 covered the pure fragment helpers (`subjectRowAnchor`) but not the component wiring that consumes them: `applyHash()`'s expand + highlight + scroll, the `hashchange` listener lifecycle, and `toggleExpanded`'s `replaceState`. That's the most defect-prone code in the PR and the kind that regresses silently (e.g. a later edit swapping `replaceState` for a `location.hash =` would re-enter `applyHash` and pollute history, with nothing red).

Adds `SubjectsManagerPage.spec.ts` (shallow-mount, so the native `<details>`/`<li>`/`<summary>` rows stay real while the heavy children are stubbed) asserting:
- a subject-id fragment expands, highlights, and scrolls the matching row;
- a non-subject fragment is a no-op;
- expanding a row writes the bare id via `replaceState` and does **not** re-highlight (no hashchange);
- the arrival highlight is dismissed on the first manual interaction;
- the `hashchange` listener is removed on unmount.

### 2. Stop the arrival highlight diverging from the fragment

`applyHash()` set `highlightedId` on a deep-link arrival and nothing ever cleared it. Expanding a *different* row rewrote the address-bar fragment via `replaceState` but left the highlight on the originally linked row, so the visible highlight and a copied URL could name different rows indefinitely (the `focusedId` cue, by contrast, auto-clears).

Now the highlight is dismissed on the first manual expand/collapse (the user taking over), and dropped when a `hashchange` lands on a non-subject fragment — so it never lingers on a row the fragment no longer points at. This is the "persistent-until-first-interaction" model (GitHub's line-highlight behaviour); the fragment-on-collapse contract from #1123 is unchanged.

A third review item — that a bad `\$wgNeoWikiSubjectDereferenceTarget` surfaces only on the HTML branch (RDF requests never validate it) — was left out on purpose: making RDF dereferences fail on the misconfig would contradict #1123's "RDF branches unchanged" design, and validating once at init is a heavier change than the nit warrants. Noted here so it's a deliberate omission.

### Verification

`make ts-build`, `make ts-lint`, and the full vitest suite (107 files / 1061 tests) pass locally. No PHP touched.

## Manual Browser Check

On a page with at least two Subjects, open its Data tab (`?action=subjects`):

1. **Deep link + scroll/highlight** — append `#<subjectId>` to the URL and load. The matching row expands, scrolls into view, and is highlighted.
2. **Highlight follows the fragment, not a stale row** — from that highlighted state, manually expand a *different* row. The address bar fragment updates to the newly opened row, and the earlier highlight clears (nothing stays highlighted that the URL no longer names).
3. **No history spam** — expand/collapse a few rows, then use the browser Back button. It leaves the Data tab in one step (the fragment writes use `replaceState`, so they add no history entries).
4. **Foreign fragment is inert** — with a highlighted row, change the fragment to something that isn't a Subject id (e.g. `#foo`). The highlight clears and no row is expanded/scrolled.

<sub>AI-authored — Claude Code, `Opus 4.8 (1M context)`; review fixes for #1123 at @alistair3149's direction (added the missing behavioral test for the hash wiring + fixed the highlight/fragment divergence; config-validation nit deliberately omitted, see above). `make ts-build` + `make ts-lint` + full vitest (107 files / 1061 tests, run serially to avoid a local OOM) green locally; no PHP touched; **not** browser-verified by the author — the human is reviewing in the dev wiki. Built on the unmerged #1123, so a rebase is needed if that branch moves.</sub>