### PR TITLE
Add ADR 27: Access Control

### DIFF
--- a/docs/adr/027-access-control.md
+++ b/docs/adr/027-access-control.md
@@ -6,9 +6,9 @@ Status: Draft
 
 ## Context
 
-NeoWiki data leaves the system through several kinds of surface: REST lookup endpoints, the REST query endpoints that
-execute a caller-supplied Cypher or SPARQL query ([query-api.md](../api/query-api.md)), parse-time accessors (parser
-functions and Lua), RDF export, and projection into graph and SPARQL stores.
+NeoWiki data leaves the system through the REST API (lookups, [caller-supplied Cypher/SPARQL
+queries](../api/query-api.md), RDF export), through parse-time accessors (parser functions and Lua), and through
+projection into graph and SPARQL stores and RDF dumps.
 Earlier ADRs settled individual pieces: Neo4j is reachable only through the backend ([ADR 13](013-restrict-neo4j-access.md)),
 SPARQL stores may be exposed directly ([ADR 19](019-graph-database-architecture.md)), and graph nodes carry per-wiki
 identity ([ADR 22](022-multi-wiki-node-identity.md), which left ACL-based query filtering out of scope). This ADR

--- a/docs/adr/027-access-control.md
+++ b/docs/adr/027-access-control.md
@@ -1,0 +1,101 @@
+# Access Control
+
+Date: 2026-07-22
+
+Status: Draft
+
+## Context
+
+NeoWiki data leaves the system through several kinds of surface: REST lookup endpoints, raw Cypher and SPARQL query
+endpoints, parse-time accessors (parser functions and Lua), RDF export, and projection into graph and SPARQL stores.
+Earlier ADRs settled individual pieces: Neo4j is reachable only through the backend ([ADR 13](013-restrict-neo4j-access.md)),
+SPARQL stores may be exposed directly ([ADR 19](019-graph-database-architecture.md)), and graph nodes carry per-wiki
+identity ([ADR 22](022-multi-wiki-node-identity.md), which left ACL-based query filtering out of scope). This ADR
+records the overall access-control model those pieces belong to, and lists the decisions that are still open.
+
+Constraints the model rests on:
+
+- In MediaWiki, whether a user may read a page is a per-title decision made by permission hooks: private-wiki mode
+  and ACL extensions (page- or namespace-scoped) plug into `Authority`. The hook evaluation *is* the permission;
+  there is no static attribute that could be copied elsewhere and stay correct.
+- The stores NeoWiki projects into cannot enforce per-user reads: Neo4j's fine-grained access control is
+  Enterprise-only, and QLever has a single server-wide access token. Whatever is in a store is readable by anyone who
+  can query that store.
+- MediaWiki's parser cache is shared across users. Parse output that varies by user either leaks into the shared
+  cache or fragments it.
+- In a wiki farm (BlueSpice Galaxy), several wikis share one graph, and access is controlled per wiki.
+
+## Decision
+
+- **MediaWiki is the sole permission authority.** Every access decision runs in PHP against the caller's `Authority`;
+  no enforcement is delegated to a store.
+- **The page is the unit of access control.** Every NeoWiki entity is governed by the page that stores it (Subjects,
+  Schemas, Layouts, Mappings): reading requires the page's `read` permission, checked at full rigor
+  (`authorizeRead`, so ACL-extension hooks run); writing requires `edit`. NeoWiki defines no ACL model of its own.
+- **A denied read is indistinguishable from absent data.** Gated read surfaces answer with a `null`, an empty list, or
+  a `404` — never a `403` — and must not reveal existence through side channels such as counts
+  ([#1062](https://github.com/ProfessionalWiki/NeoWiki/issues/1062)). Write denials answer `403`, and must equally
+  not reveal whether an unreadable page exists ([#1061](https://github.com/ProfessionalWiki/NeoWiki/issues/1061)).
+  [rest-api.md](../api/rest-api.md) documents this per endpoint.
+- **Page-attributable results are filtered per row.** Read surfaces whose results are traceable to an owning page
+  resolve each row's page and drop rows the caller may not read. Because this costs one permission check per row,
+  such surfaces must bound their result sizes.
+- **Graph projections carry scoping keys, not ACL state.** `wiki_id` and `namespaceId` let query authors scope
+  queries ([ADR 22](022-multi-wiki-node-identity.md), [graph-model](../api/graph-model.md)). User groups and page
+  restrictions are never projected: the keys are revision-derived, so nothing in a store goes stale when permissions
+  change.
+- **Raw query surfaces have whole-store read semantics.** Cypher and SPARQL result rows are not attributable to pages
+  and are not trimmed. The NeoWiki-mediated REST query endpoints are gated by the wiki-level `neowiki-query` right
+  ([query-api.md](../api/query-api.md)); granting that right grants read access to everything the wiki projects into
+  the store. Exposing a store directly (which ADR 19 allows for SPARQL) is a different surface: see "Projection as
+  publication" below.
+
+## Open decisions
+
+- **Parse-time read semantics.** Today the parse path is inconsistent: Schema/Mapping lookups are gated per user but
+  their output is parser-cached user-agnostically ([#1063](https://github.com/ProfessionalWiki/NeoWiki/issues/1063));
+  subject accessors (`{{#neowiki_value}}` and the `nw` data accessors) check only revision-deletion visibility, not
+  page `read`; `{{#cypher_raw}}` and `nw.query` check nothing
+  ([#1059](https://github.com/ProfessionalWiki/NeoWiki/issues/1059)). `{{#view}}` is the leak-free pattern: a
+  placeholder rendered at parse time, data fetched per user over REST. **TODO:** decide the parse-path rule and what
+  it means for each surface.
+- **Server-side query filter injection.** Farm deployments add scoping predicates in their own query layer; core
+  offers no extension point for injecting them server-side. **TODO:** design the seam.
+- **Cross-wiki subject display.** Rendering a subject from another wiki goes through REST, not Cypher, so query-side
+  scoping does not cover it. **TODO:** decide the check and the degradation behavior when the schema or subject is
+  not accessible. Relates to [ADR 23](023-subject-sources.md).
+- **Default grant of `neowiki-query`.** The right is granted to `*` by default. **TODO:** decide whether the default
+  changes, and how deployments with restricted content are expected to configure it.
+- **Projection as publication.** Directly exposed SPARQL endpoints (ADR 19) and RDF dumps bypass per-user checks.
+  **TODO:** decide whether projection/dump content is limited to what the public reader may read.
+- **TODO:** confirm as a non-goal: per-subject ACLs independent of the owning page.
+
+## Out of scope
+
+- Authentication (single sign-on, federated identity): a MediaWiki/deployment concern.
+- Rights and licensing metadata and provenance recording (ECHOLOT T3.4): data features, not access control.
+
+## Consequences
+
+- Every new surface that exposes NeoWiki data must be classified: page-attributable (per-row gate), raw query
+  (whole-store semantics), projection/dump (semantics pending above), or parse-time (semantics pending above).
+  There is no unclassified option.
+- Restricting a page does not remove its data from stores; it changes what the backend returns.
+
+## Alternatives Considered
+
+- **Enforce inside the store** (per-user store accounts, store-level ACLs): Enterprise-only in Neo4j, unavailable in
+  QLever, and unable to express hook-based MediaWiki permissions. Rejected, consistent with ADR 13.
+- **Project ACL state into the graph for pre-query trimming** (user groups, restriction markers): re-implements an
+  open set of permission hooks as data and goes stale, because permission changes produce no revision to sync on.
+  Not pursued.
+
+## Related
+
+- [ADR 13: Restrict Neo4j Access](013-restrict-neo4j-access.md), [ADR 19: Graph Database
+  Architecture](019-graph-database-architecture.md), [ADR 22: Multi-wiki Graph Node
+  Identity](022-multi-wiki-node-identity.md), [ADR 23: Subject Sources](023-subject-sources.md)
+- [rest-api.md Permissions](../api/rest-api.md), [query-api.md Permissions](../api/query-api.md),
+  [graph-model](../api/graph-model.md)
+- Issues: [#1046](https://github.com/ProfessionalWiki/NeoWiki/issues/1046) (per-page read enforcement),
+  [#350](https://github.com/ProfessionalWiki/NeoWiki/issues/350) (slot-level access)

--- a/docs/adr/027-access-control.md
+++ b/docs/adr/027-access-control.md
@@ -6,8 +6,9 @@ Status: Draft
 
 ## Context
 
-NeoWiki data leaves the system through several kinds of surface: REST lookup endpoints, raw Cypher and SPARQL query
-endpoints, parse-time accessors (parser functions and Lua), RDF export, and projection into graph and SPARQL stores.
+NeoWiki data leaves the system through several kinds of surface: REST lookup endpoints, the REST query endpoints that
+execute a caller-supplied Cypher or SPARQL query ([query-api.md](../api/query-api.md)), parse-time accessors (parser
+functions and Lua), RDF export, and projection into graph and SPARQL stores.
 Earlier ADRs settled individual pieces: Neo4j is reachable only through the backend ([ADR 13](013-restrict-neo4j-access.md)),
 SPARQL stores may be exposed directly ([ADR 19](019-graph-database-architecture.md)), and graph nodes carry per-wiki
 identity ([ADR 22](022-multi-wiki-node-identity.md), which left ACL-based query filtering out of scope). This ADR
@@ -44,8 +45,9 @@ Constraints the model rests on:
   queries ([ADR 22](022-multi-wiki-node-identity.md), [graph-model](../api/graph-model.md)). User groups and page
   restrictions are never projected: the keys are revision-derived, so nothing in a store goes stale when permissions
   change.
-- **Raw query surfaces have whole-store read semantics.** Cypher and SPARQL result rows are not attributable to pages
-  and are not trimmed. The NeoWiki-mediated REST query endpoints are gated by the wiki-level `neowiki-query` right
+- **Raw query surfaces have whole-store read semantics.** A raw query surface executes a caller-supplied Cypher or
+  SPARQL query; its result rows are not attributable to pages and are not trimmed. The REST query endpoints are gated
+  by the wiki-level `neowiki-query` right
   ([query-api.md](../api/query-api.md)); granting that right grants read access to everything the wiki projects into
   the store. Exposing a store directly (which ADR 19 allows for SPARQL) is a different surface: see "Projection as
   publication" below.

--- a/docs/adr/027-access-control.md
+++ b/docs/adr/027-access-control.md
@@ -11,7 +11,7 @@ queries](../api/query-api.md), RDF export), through parse-time accessors (parser
 projection into graph and SPARQL stores and RDF dumps.
 Earlier ADRs settled individual pieces: Neo4j is reachable only through the backend ([ADR 13](013-restrict-neo4j-access.md)),
 SPARQL stores may be exposed directly ([ADR 19](019-graph-database-architecture.md)), and graph nodes carry per-wiki
-identity ([ADR 22](022-multi-wiki-node-identity.md), which left ACL-based query filtering out of scope). This ADR
+identity ([ADR 22](022-multi-wiki-node-identity.md)). This ADR
 records the overall access-control model those pieces belong to, and lists the decisions that are still open.
 
 Constraints the model rests on:
@@ -43,12 +43,11 @@ Constraints the model rests on:
   such surfaces must bound their result sizes.
 - **Graph projections carry scoping keys, not ACL state.** `wiki_id` and `namespaceId` let query authors scope
   queries ([ADR 22](022-multi-wiki-node-identity.md), [graph-model](../api/graph-model.md)). User groups and page
-  restrictions are never projected: the keys are revision-derived, so nothing in a store goes stale when permissions
-  change.
+  restrictions are never projected; the projected keys are revision-derived, so nothing in a store goes stale when
+  permissions change.
 - **Raw query surfaces have whole-store read semantics.** A raw query surface executes a caller-supplied Cypher or
   SPARQL query; its result rows are not attributable to pages and are not trimmed. The REST query endpoints are gated
-  by the wiki-level `neowiki-query` right
-  ([query-api.md](../api/query-api.md)); granting that right grants read access to everything the wiki projects into
+  by the wiki-level `neowiki-query` right; granting that right gives read access to everything the wiki projects into
   the store. Exposing a store directly (which ADR 19 allows for SPARQL) is a different surface: see "Projection as
   publication" below.
 
@@ -62,7 +61,7 @@ Constraints the model rests on:
   placeholder rendered at parse time, data fetched per user over REST. **TODO:** decide the parse-path rule and what
   it means for each surface.
 - **Server-side query filter injection.** Farm deployments add scoping predicates in their own query layer; core
-  offers no extension point for injecting them server-side. **TODO:** design the seam.
+  offers no extension point for injecting them server-side. **TODO:** design that extension point.
 - **Cross-wiki subject display.** Rendering a subject from another wiki goes through REST, not Cypher, so query-side
   scoping does not cover it. **TODO:** decide the check and the degradation behavior when the schema or subject is
   not accessible. Relates to [ADR 23](023-subject-sources.md).
@@ -70,7 +69,7 @@ Constraints the model rests on:
   changes, and how deployments with restricted content are expected to configure it.
 - **Projection as publication.** Directly exposed SPARQL endpoints (ADR 19) and RDF dumps bypass per-user checks.
   **TODO:** decide whether projection/dump content is limited to what the public reader may read.
-- **TODO:** confirm as a non-goal: per-subject ACLs independent of the owning page.
+- **Per-subject ACLs.** Proposed non-goal: no ACLs on a Subject independent of its owning page. **TODO:** confirm.
 
 ## Out of scope
 
@@ -80,8 +79,8 @@ Constraints the model rests on:
 ## Consequences
 
 - Every new surface that exposes NeoWiki data must be classified: page-attributable (per-row gate), raw query
-  (whole-store semantics), projection/dump (semantics pending above), or parse-time (semantics pending above).
-  There is no unclassified option.
+  (whole-store semantics), projection/dump, or parse-time (the last two pending above). There is no unclassified
+  option.
 - Restricting a page does not remove its data from stores; it changes what the backend returns.
 
 ## Alternatives Considered

--- a/docs/adr/027-access-control.md
+++ b/docs/adr/027-access-control.md
@@ -33,6 +33,9 @@ Constraints the model rests on:
 - **The page is the unit of access control.** Every NeoWiki entity is governed by the page that stores it (Subjects,
   Schemas, Layouts, Mappings): reading requires the page's `read` permission, checked at full rigor
   (`authorizeRead`, so ACL-extension hooks run); writing requires `edit`. NeoWiki defines no ACL model of its own.
+- **Per-subject ACLs are a non-goal.** There is no access control finer than the page: no recorded use case needs
+  it, deployments separate sensitive data by page or wiki, and sub-page ACLs would complicate every read surface.
+  Revisit only with a concrete use case.
 - **A denied read is indistinguishable from absent data.** Gated read surfaces answer with a `null`, an empty list, or
   a `404` — never a `403` — and must not reveal existence through side channels such as counts
   ([#1062](https://github.com/ProfessionalWiki/NeoWiki/issues/1062)). Write denials answer `403`, and must equally
@@ -53,6 +56,9 @@ Constraints the model rests on:
 - **Raw queries will support server-side filter injection.** A deployment can register scoping predicates (such as
   restricting to the current wiki) that core applies to every caller-supplied query, so scoping is enforced rather
   than left to each caller.
+- **Projection is publication.** Stores and dumps have no per-user checks, so their content must not exceed what
+  every reader with access to them may read. A publicly exposed SPARQL endpoint or a published dump may therefore
+  carry only what the public reader may read; a store gated as a whole may carry more, up to its audience.
 
 ## Open decisions
 
@@ -68,9 +74,6 @@ Constraints the model rests on:
   not accessible. Relates to [ADR 23](023-subject-sources.md).
 - **Default grant of `neowiki-query`.** The right is granted to `*` by default. **TODO:** decide whether the default
   changes, and how deployments with restricted content are expected to configure it.
-- **Projection as publication.** Directly exposed SPARQL endpoints (ADR 19) and RDF dumps bypass per-user checks.
-  **TODO:** decide whether projection/dump content is limited to what the public reader may read.
-- **Per-subject ACLs.** Proposed non-goal: no ACLs on a Subject independent of its owning page. **TODO:** confirm.
 
 ## Out of scope
 
@@ -84,6 +87,8 @@ Constraints the model rests on:
   option.
 - Restricting a page does not remove its data from stores; it changes what the backend returns.
 - The filter-injection extension point must be designed and implemented for farms like BlueSpice Galaxy.
+- Projection and dump code do not yet filter: they emit every subject. Until a public-readable-only projection
+  exists, a wiki with restricted content must not expose a store publicly or publish its dumps.
 
 ## Alternatives Considered
 

--- a/docs/adr/027-access-control.md
+++ b/docs/adr/027-access-control.md
@@ -62,13 +62,12 @@ Constraints the model rests on:
 
 ## Open decisions
 
-- **Parse-time read semantics.** Today the parse path is inconsistent: Schema/Mapping lookups are gated per user but
-  their output is parser-cached user-agnostically ([#1063](https://github.com/ProfessionalWiki/NeoWiki/issues/1063));
-  subject accessors (`{{#neowiki_value}}` and the `nw` data accessors) check only revision-deletion visibility, not
-  page `read`; `{{#cypher_raw}}` and `nw.query` check nothing
-  ([#1059](https://github.com/ProfessionalWiki/NeoWiki/issues/1059)). `{{#view}}` is the leak-free pattern: a
-  placeholder rendered at parse time, data fetched per user over REST. **TODO:** decide the parse-path rule and what
-  it means for each surface.
+- **Parse-time read semantics.** Today the parse path is inconsistent
+  ([#1059](https://github.com/ProfessionalWiki/NeoWiki/issues/1059)): Schema/Mapping lookups are gated per user but
+  their output is parser-cached user-agnostically; subject accessors (`{{#neowiki_value}}` and the `nw` data
+  accessors) check only revision-deletion visibility, not page `read`; `{{#cypher_raw}}` and `nw.query` check
+  nothing. `{{#view}}` is the leak-free pattern: a placeholder rendered at parse time, data fetched per user over
+  REST. **TODO:** decide the parse-path rule and what it means for each surface.
 - **Cross-wiki subject display.** Rendering a subject from another wiki goes through REST, not Cypher, so query-side
   scoping does not cover it. **TODO:** decide the check and the degradation behavior when the schema or subject is
   not accessible. Relates to [ADR 23](023-subject-sources.md).

--- a/docs/adr/027-access-control.md
+++ b/docs/adr/027-access-control.md
@@ -83,8 +83,7 @@ Constraints the model rests on:
   (whole-store semantics), projection/dump, or parse-time (the last two pending above). There is no unclassified
   option.
 - Restricting a page does not remove its data from stores; it changes what the backend returns.
-- The filter-injection extension point must be designed and implemented; until it exists, farm deployments scope
-  queries in their own query layer.
+- The filter-injection extension point must be designed and implemented for farms like BlueSpice Galaxy.
 
 ## Alternatives Considered
 

--- a/docs/adr/027-access-control.md
+++ b/docs/adr/027-access-control.md
@@ -51,14 +51,14 @@ Constraints the model rests on:
 - **Raw query surfaces have whole-store read semantics.** A raw query surface executes a caller-supplied Cypher or
   SPARQL query; its result rows are not attributable to pages and are not trimmed. The REST query endpoints are gated
   by the wiki-level `neowiki-query` right; granting that right gives read access to everything the wiki projects into
-  the store. Exposing a store directly (which ADR 19 allows for SPARQL) is a different surface: see "Projection as
-  publication" below.
+  the store. Exposing a store directly (which ADR 19 allows for SPARQL) is a different surface: see the projection
+  decision below.
 - **Raw queries will support server-side filter injection.** A deployment can register scoping predicates (such as
   restricting to the current wiki) that core applies to every caller-supplied query, so scoping is enforced rather
   than left to each caller.
-- **Projection is publication.** Stores and dumps have no per-user checks, so their content must not exceed what
-  every reader with access to them may read. A publicly exposed SPARQL endpoint or a published dump may therefore
-  carry only what the public reader may read; a store gated as a whole may carry more, up to its audience.
+- **Projections and dumps are generated without permission checks.** We may add such support later, enabling a
+  public projection (a public store with a public query endpoint, holding no restricted content) alongside a private
+  one that includes restricted content.
 
 ## Open decisions
 
@@ -83,12 +83,12 @@ Constraints the model rests on:
 ## Consequences
 
 - Every new surface that exposes NeoWiki data must be classified: page-attributable (per-row gate), raw query
-  (whole-store semantics), projection/dump, or parse-time (the last two pending above). There is no unclassified
-  option.
+  (whole-store semantics), projection/dump (no permission checks), or parse-time (pending above). There is no
+  unclassified option.
 - Restricting a page does not remove its data from stores; it changes what the backend returns.
 - The filter-injection extension point must be designed and implemented for farms like BlueSpice Galaxy.
-- Projection and dump code do not yet filter: they emit every subject. Until a public-readable-only projection
-  exists, a wiki with restricted content must not expose a store publicly or publish its dumps.
+- Dumps and projections contain restricted content (unless it is omitted via a non-permission mechanism such as the
+  Mappings), so they must not be exposed to readers who may not access that content.
 
 ## Alternatives Considered
 

--- a/docs/adr/027-access-control.md
+++ b/docs/adr/027-access-control.md
@@ -50,6 +50,9 @@ Constraints the model rests on:
   by the wiki-level `neowiki-query` right; granting that right gives read access to everything the wiki projects into
   the store. Exposing a store directly (which ADR 19 allows for SPARQL) is a different surface: see "Projection as
   publication" below.
+- **Raw queries will support server-side filter injection.** A deployment can register scoping predicates (such as
+  restricting to the current wiki) that core applies to every caller-supplied query, so scoping is enforced rather
+  than left to each caller.
 
 ## Open decisions
 
@@ -60,8 +63,6 @@ Constraints the model rests on:
   ([#1059](https://github.com/ProfessionalWiki/NeoWiki/issues/1059)). `{{#view}}` is the leak-free pattern: a
   placeholder rendered at parse time, data fetched per user over REST. **TODO:** decide the parse-path rule and what
   it means for each surface.
-- **Server-side query filter injection.** Farm deployments add scoping predicates in their own query layer; core
-  offers no extension point for injecting them server-side. **TODO:** design that extension point.
 - **Cross-wiki subject display.** Rendering a subject from another wiki goes through REST, not Cypher, so query-side
   scoping does not cover it. **TODO:** decide the check and the degradation behavior when the schema or subject is
   not accessible. Relates to [ADR 23](023-subject-sources.md).
@@ -82,6 +83,8 @@ Constraints the model rests on:
   (whole-store semantics), projection/dump, or parse-time (the last two pending above). There is no unclassified
   option.
 - Restricting a page does not remove its data from stores; it changes what the backend returns.
+- The filter-injection extension point must be designed and implemented; until it exists, farm deployments scope
+  queries in their own query layer.
 
 ## Alternatives Considered
 
@@ -89,7 +92,6 @@ Constraints the model rests on:
   QLever, and unable to express hook-based MediaWiki permissions. Rejected, consistent with ADR 13.
 - **Project ACL state into the graph for pre-query trimming** (user groups, restriction markers): re-implements an
   open set of permission hooks as data and goes stale, because permission changes produce no revision to sync on.
-  Not pursued.
 
 ## Related
 

--- a/docs/adr/027-access-control.md
+++ b/docs/adr/027-access-control.md
@@ -36,18 +36,18 @@ Constraints the model rests on:
 - **Per-subject ACLs are a non-goal.** There is no access control finer than the page: no recorded use case needs
   it, deployments separate sensitive data by page or wiki, and sub-page ACLs would complicate every read surface.
   Revisit only with a concrete use case.
-- **A denied read is indistinguishable from absent data.** Gated read surfaces answer with a `null`, an empty list, or
-  a `404` — never a `403` — and must not reveal existence through side channels such as counts
-  ([#1062](https://github.com/ProfessionalWiki/NeoWiki/issues/1062)). Write denials answer `403`, and must equally
-  not reveal whether an unreadable page exists ([#1061](https://github.com/ProfessionalWiki/NeoWiki/issues/1061)).
-  [rest-api.md](../api/rest-api.md) documents this per endpoint.
+- **A denied read is indistinguishable from absent data.** Read surfaces gated on the page's `read` permission answer
+  with a `null`, an empty list, or a `404` — never a `403` — and must not reveal existence through side channels such
+  as counts ([#1062](https://github.com/ProfessionalWiki/NeoWiki/issues/1062)). Write denials answer `403`, and must
+  equally not reveal whether an unreadable page exists
+  ([#1061](https://github.com/ProfessionalWiki/NeoWiki/issues/1061)). [rest-api.md](../api/rest-api.md) documents this
+  per endpoint.
 - **Page-attributable results are filtered per row.** Read surfaces whose results are traceable to an owning page
   resolve each row's page and drop rows the caller may not read. Because this costs one permission check per row,
   such surfaces must bound their result sizes.
 - **Graph projections carry scoping keys, not ACL state.** `wiki_id` and `namespaceId` let query authors scope
   queries ([ADR 22](022-multi-wiki-node-identity.md), [graph-model](../api/graph-model.md)). User groups and page
-  restrictions are never projected; the projected keys are revision-derived, so nothing in a store goes stale when
-  permissions change.
+  restrictions are never projected, so nothing in a store goes stale when permissions change.
 - **Raw query surfaces have whole-store read semantics.** A raw query surface executes a caller-supplied Cypher or
   SPARQL query; its result rows are not attributable to pages and are not trimmed. The REST query endpoints are gated
   by the wiki-level `neowiki-query` right; granting that right gives read access to everything the wiki projects into
@@ -63,11 +63,11 @@ Constraints the model rests on:
 ## Open decisions
 
 - **Parse-time read semantics.** Today the parse path is inconsistent
-  ([#1059](https://github.com/ProfessionalWiki/NeoWiki/issues/1059)): Schema/Mapping lookups are gated per user but
-  their output is parser-cached user-agnostically; subject accessors (`{{#neowiki_value}}` and the `nw` data
-  accessors) check only revision-deletion visibility, not page `read`; `{{#cypher_raw}}` and `nw.query` check
-  nothing. `{{#view}}` is the leak-free pattern: a placeholder rendered at parse time, data fetched per user over
-  REST. **TODO:** decide the parse-path rule and what it means for each surface.
+  ([#1059](https://github.com/ProfessionalWiki/NeoWiki/issues/1059)): Schema lookups are gated per user but their
+  output is parser-cached user-agnostically; subject accessors (`{{#neowiki_value}}` and the `nw` data accessors)
+  check only revision-deletion visibility, not page `read`; `{{#cypher_raw}}`, `{{#sparql_raw}}`, `nw.query` and
+  `nw.sparqlQuery` check nothing. `{{#view}}` is the leak-free pattern: a placeholder rendered at parse time, data
+  fetched per user over REST. **TODO:** decide the parse-path rule and what it means for each surface.
 - **Cross-wiki subject display.** Rendering a subject from another wiki goes through REST, not Cypher, so query-side
   scoping does not cover it. **TODO:** decide the check and the degradation behavior when the schema or subject is
   not accessible. Relates to [ADR 23](023-subject-sources.md).


### PR DESCRIPTION
Records the access-control model the recent permission work implements: MediaWiki as the sole
permission authority, the page as the unit of access control (per-subject ACLs are an explicit
non-goal), denial as absence, per-row filtering for page-attributable results, scoping keys (not
ACL state) in graph projections, whole-store read semantics for raw queries with server-side
filter injection to come, and no permission checks in projection or dump generation (their output
can contain restricted content and must not be exposed past its audience).

Still open, recorded as explicit TODOs: the parse-path rule, cross-wiki subject display, and the
default grant of `neowiki-query`.

Related: #1046, #1059, #1063.

> <sub>AI-authored — Claude Code, `Fable 5 (max)`; directed ask from @JeroenDeDauw, with several in-session review rounds steering structure and content, plus his own edits on the branch; draft read by @JeroenDeDauw, no formal review yet; claims checked against master code/docs and the issue tracker; the per-subject-ACL non-goal and the projection decision were each backed by a dedicated sweep of the requirements record for contrary demand (none found); CI green.</sub>