### PR TITLE
Pin cursor-pagination behaviors left untested in #1131

### DIFF
--- a/resources/ext.neowiki/tests/VueTestHelpers.ts
+++ b/resources/ext.neowiki/tests/VueTestHelpers.ts
@@ -1,6 +1,6 @@
-import { mount, VueWrapper } from '@vue/test-utils';
+import { mount, VueWrapper, DOMWrapper } from '@vue/test-utils';
 import { Component, DefineComponent } from 'vue';
-import { vi } from 'vitest';
+import { expect, vi } from 'vitest';
 import { ValidationMessages, ValidationStatusType } from '@wikimedia/codex';
 import { NeoWikiTestServices } from './NeoWikiTestServices.ts';
 
@@ -13,6 +13,18 @@ export function createI18nMock(): ReturnType<typeof vi.fn> {
 	return vi.fn().mockImplementation( ( key ) => ( {
 		text: () => key,
 	} ) );
+}
+
+/**
+ * Locates the CdxTable pager's "Next page" button, asserting it exists so a selector that matches
+ * nothing fails loudly here. A missed find() returns an empty DOMWrapper whose
+ * attributes( 'disabled' ) is undefined, which would silently satisfy a toBeUndefined()
+ * enabled-state assertion against a button that is not in the DOM.
+ */
+export function findNextPageButton( wrapper: VueWrapper ): DOMWrapper<Element> {
+	const button = wrapper.find( '.cdx-table-pager button[aria-label="Next page"]' );
+	expect( button.exists() ).toBe( true );
+	return button;
 }
 
 export function createTestWrapper<TComponent extends DefineComponent<any, any, any>>(

--- a/resources/ext.neowiki/tests/components/LayoutsPage/LayoutsPage.spec.ts
+++ b/resources/ext.neowiki/tests/components/LayoutsPage/LayoutsPage.spec.ts
@@ -1,0 +1,120 @@
+import { mount, VueWrapper, flushPromises } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+import LayoutsPage from '@/components/LayoutsPage/LayoutsPage.vue';
+import { createI18nMock, setupMwMock } from '../../VueTestHelpers.ts';
+
+interface LayoutSummary {
+	name: string;
+	schema: string;
+	type: string;
+	description: string;
+	ruleCount: number;
+}
+
+const canCreateLayoutsRef = ref( false );
+const canEditLayoutRef = ref( false );
+const checkCreatePermissionMock = vi.fn();
+const checkEditPermissionMock = vi.fn();
+
+let layoutsResponse: { layouts: LayoutSummary[]; nextCursor: string | null } = { layouts: [], nextCursor: null };
+
+vi.mock( '@/composables/useLayoutPermissions.ts', () => ( {
+	useLayoutPermissions: () => ( {
+		canCreateLayouts: canCreateLayoutsRef,
+		canEditLayout: canEditLayoutRef,
+		checkCreatePermission: checkCreatePermissionMock,
+		checkEditPermission: checkEditPermissionMock,
+	} ),
+} ) );
+
+vi.mock( '@/stores/LayoutStore.ts', () => ( {
+	useLayoutStore: () => ( {
+		fetchLayout: vi.fn(),
+		getLayout: vi.fn(),
+		saveLayout: vi.fn(),
+	} ),
+} ) );
+
+vi.mock( '@/NeoWikiExtension.ts', () => ( {
+	NeoWikiExtension: {
+		getInstance: () => ( {
+			getMediaWiki: () => ( {
+				util: { wikiScript: () => '/rest.php' },
+			} ),
+			newHttpClient: () => ( {
+				get: vi.fn().mockResolvedValue( {
+					ok: true,
+					json: () => Promise.resolve( layoutsResponse ),
+				} ),
+			} ),
+		} ),
+	},
+} ) );
+
+function fullPage(): LayoutSummary[] {
+	return Array.from( { length: 10 }, ( _value, index ) => ( {
+		name: `Layout${ index }`,
+		schema: 'Person',
+		type: 'infobox',
+		description: '',
+		ruleCount: 0,
+	} ) );
+}
+
+function mountComponent( summaries: LayoutSummary[] = [], nextCursor: string | null = null ): VueWrapper {
+	layoutsResponse = {
+		layouts: summaries,
+		nextCursor: nextCursor,
+	};
+	setupMwMock( { functions: [ 'msg', 'util', 'message', 'notify' ] } );
+
+	return mount( LayoutsPage, {
+		global: {
+			mocks: { $i18n: createI18nMock() },
+			stubs: {
+				LayoutCreatorDialog: true,
+				LayoutEditorDialog: true,
+				EditSummary: true,
+				I18nSlot: true,
+				CdxIcon: true,
+			},
+		},
+	} );
+}
+
+describe( 'LayoutsPage', () => {
+	beforeEach( () => {
+		canCreateLayoutsRef.value = false;
+		canEditLayoutRef.value = false;
+		checkCreatePermissionMock.mockClear();
+		checkEditPermissionMock.mockClear();
+		layoutsResponse = { layouts: [], nextCursor: null };
+	} );
+
+	it( 'disables next when a full page ends the listing', async () => {
+		// A listing that ends exactly on a page boundary returns a full page with a null cursor.
+		// CdxTable's indeterminate mode would keep next enabled (its heuristic is a short page), so
+		// the component must switch the table to a known total.
+		const wrapper = mountComponent( fullPage(), null );
+		await flushPromises();
+
+		const nextButton = wrapper.find( '.cdx-table-pager button[aria-label="Next page"]' );
+
+		expect( nextButton.attributes( 'disabled' ) ).toBeDefined();
+		expect( wrapper.text() ).toContain( 'of 10' );
+	} );
+
+	it( 'keeps next enabled while the listing continues', async () => {
+		// A full page with a non-null cursor means more rows follow. The component must leave
+		// totalRows undefined so CdxTable stays in its indeterminate mode (next enabled, "of many"
+		// label); a known total here would wrongly disable next and hide the remaining pages.
+		const wrapper = mountComponent( fullPage(), 'next-page-cursor' );
+		await flushPromises();
+
+		const nextButton = wrapper.find( '.cdx-table-pager button[aria-label="Next page"]' );
+
+		expect( nextButton.attributes( 'disabled' ) ).toBeUndefined();
+		expect( wrapper.text() ).toContain( 'of many' );
+	} );
+} );

--- a/resources/ext.neowiki/tests/components/LayoutsPage/LayoutsPage.spec.ts
+++ b/resources/ext.neowiki/tests/components/LayoutsPage/LayoutsPage.spec.ts
@@ -2,7 +2,7 @@ import { mount, VueWrapper, flushPromises } from '@vue/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ref } from 'vue';
 import LayoutsPage from '@/components/LayoutsPage/LayoutsPage.vue';
-import { createI18nMock, setupMwMock } from '../../VueTestHelpers.ts';
+import { createI18nMock, findNextPageButton, setupMwMock } from '../../VueTestHelpers.ts';
 
 interface LayoutSummary {
 	name: string;
@@ -99,7 +99,7 @@ describe( 'LayoutsPage', () => {
 		const wrapper = mountComponent( fullPage(), null );
 		await flushPromises();
 
-		const nextButton = wrapper.find( '.cdx-table-pager button[aria-label="Next page"]' );
+		const nextButton = findNextPageButton( wrapper );
 
 		expect( nextButton.attributes( 'disabled' ) ).toBeDefined();
 		expect( wrapper.text() ).toContain( 'of 10' );
@@ -112,7 +112,7 @@ describe( 'LayoutsPage', () => {
 		const wrapper = mountComponent( fullPage(), 'next-page-cursor' );
 		await flushPromises();
 
-		const nextButton = wrapper.find( '.cdx-table-pager button[aria-label="Next page"]' );
+		const nextButton = findNextPageButton( wrapper );
 
 		expect( nextButton.attributes( 'disabled' ) ).toBeUndefined();
 		expect( wrapper.text() ).toContain( 'of many' );

--- a/resources/ext.neowiki/tests/components/MappingsPage/MappingsPage.spec.ts
+++ b/resources/ext.neowiki/tests/components/MappingsPage/MappingsPage.spec.ts
@@ -68,10 +68,10 @@ function findDeleteButtons( wrapper: VueWrapper ): VueWrapper[] {
 		.filter( ( btn ) => btn.attributes( 'aria-label' ) === 'neowiki-mapping-delete' );
 }
 
-function mountComponent( summaries: MappingSummary[] = [] ): VueWrapper {
+function mountComponent( summaries: MappingSummary[] = [], nextCursor: string | null = null ): VueWrapper {
 	mappingsResponse = {
 		mappings: summaries,
-		nextCursor: null,
+		nextCursor: nextCursor,
 	};
 	setupMwMock( {
 		functions: [ 'msg', 'util', 'message', 'notify' ],
@@ -155,6 +155,25 @@ describe( 'MappingsPage', () => {
 		await flushPromises();
 
 		expect( wrapper.text() ).toContain( 'neowiki-mappings-empty' );
+	} );
+
+	it( 'keeps next enabled while the listing continues', async () => {
+		// A full page (the default size) with a non-null cursor means more rows follow. The
+		// component must leave totalRows undefined so CdxTable stays in its indeterminate mode
+		// (next enabled, "of many" label); a known total here would wrongly disable next and hide
+		// the remaining pages.
+		const wrapper = mountComponent(
+			Array.from( { length: 10 }, ( _value, index ) => (
+				{ name: `Mapping${ index }`, schemas: [] }
+			) ),
+			'next-page-cursor',
+		);
+		await flushPromises();
+
+		const nextButton = wrapper.find( '.cdx-table-pager button[aria-label="Next page"]' );
+
+		expect( nextButton.attributes( 'disabled' ) ).toBeUndefined();
+		expect( wrapper.text() ).toContain( 'of many' );
 	} );
 
 	it( 'shows the create button when the user may create mappings', async () => {

--- a/resources/ext.neowiki/tests/components/MappingsPage/MappingsPage.spec.ts
+++ b/resources/ext.neowiki/tests/components/MappingsPage/MappingsPage.spec.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ref } from 'vue';
 import MappingsPage from '@/components/MappingsPage/MappingsPage.vue';
 import MappingCreatorDialog from '@/components/MappingsPage/MappingCreatorDialog.vue';
-import { createI18nMock, setupMwMock } from '../../VueTestHelpers.ts';
+import { createI18nMock, findNextPageButton, setupMwMock } from '../../VueTestHelpers.ts';
 import { CdxButton, CdxDialog } from '@wikimedia/codex';
 
 interface MappingSummary {
@@ -170,7 +170,7 @@ describe( 'MappingsPage', () => {
 		);
 		await flushPromises();
 
-		const nextButton = wrapper.find( '.cdx-table-pager button[aria-label="Next page"]' );
+		const nextButton = findNextPageButton( wrapper );
 
 		expect( nextButton.attributes( 'disabled' ) ).toBeUndefined();
 		expect( wrapper.text() ).toContain( 'of many' );

--- a/resources/ext.neowiki/tests/components/MappingsPage/MappingsPage.spec.ts
+++ b/resources/ext.neowiki/tests/components/MappingsPage/MappingsPage.spec.ts
@@ -157,6 +157,23 @@ describe( 'MappingsPage', () => {
 		expect( wrapper.text() ).toContain( 'neowiki-mappings-empty' );
 	} );
 
+	it( 'disables next when a full page ends the listing', async () => {
+		// A listing that ends exactly on a page boundary returns a full page with a null cursor.
+		// CdxTable's indeterminate mode would keep next enabled (its heuristic is a short page), so
+		// the component must switch the table to a known total.
+		const wrapper = mountComponent(
+			Array.from( { length: 10 }, ( _value, index ) => (
+				{ name: `Mapping${ index }`, schemas: [] }
+			) ),
+		);
+		await flushPromises();
+
+		const nextButton = findNextPageButton( wrapper );
+
+		expect( nextButton.attributes( 'disabled' ) ).toBeDefined();
+		expect( wrapper.text() ).toContain( 'of 10' );
+	} );
+
 	it( 'keeps next enabled while the listing continues', async () => {
 		// A full page (the default size) with a non-null cursor means more rows follow. The
 		// component must leave totalRows undefined so CdxTable stays in its indeterminate mode

--- a/resources/ext.neowiki/tests/components/SchemasPage/SchemasPage.spec.ts
+++ b/resources/ext.neowiki/tests/components/SchemasPage/SchemasPage.spec.ts
@@ -79,10 +79,10 @@ function findDeleteButtons( wrapper: VueWrapper ): VueWrapper[] {
 		.filter( ( btn ) => btn.attributes( 'aria-label' ) === 'neowiki-schema-delete' );
 }
 
-function mountComponent( summaries: unknown[] = [] ): VueWrapper {
+function mountComponent( summaries: unknown[] = [], nextCursor: string | null = null ): VueWrapper {
 	schemasResponse = {
 		schemas: summaries,
-		nextCursor: null,
+		nextCursor: nextCursor,
 	};
 	setupMwMock( { functions: [ 'msg', 'util', 'message', 'notify' ] } );
 
@@ -160,6 +160,21 @@ describe( 'SchemasPage', () => {
 
 		expect( nextButton.attributes( 'disabled' ) ).toBeDefined();
 		expect( wrapper.text() ).toContain( 'of 10' );
+	} );
+
+	it( 'keeps next enabled while the listing continues', async () => {
+		// A full page with a non-null cursor means more rows follow. The component must leave
+		// totalRows undefined so CdxTable stays in its indeterminate mode (next enabled, "of many"
+		// label); a known total here would wrongly disable next and hide the remaining pages.
+		const wrapper = mountComponent( Array.from( { length: 10 }, ( _value, index ) => (
+			{ name: `Schema${ index }`, description: '', propertyCount: 1 }
+		) ), 'next-page-cursor' );
+		await flushPromises();
+
+		const nextButton = wrapper.find( '.cdx-table-pager button[aria-label="Next page"]' );
+
+		expect( nextButton.attributes( 'disabled' ) ).toBeUndefined();
+		expect( wrapper.text() ).toContain( 'of many' );
 	} );
 
 	it( 'shows empty value indicator for schemas without a description', async () => {

--- a/resources/ext.neowiki/tests/components/SchemasPage/SchemasPage.spec.ts
+++ b/resources/ext.neowiki/tests/components/SchemasPage/SchemasPage.spec.ts
@@ -4,7 +4,7 @@ import { ref } from 'vue';
 import SchemasPage from '@/components/SchemasPage/SchemasPage.vue';
 import SchemaCreatorDialog from '@/components/SchemasPage/SchemaCreatorDialog.vue';
 import SchemaEditorDialog from '@/components/SchemaEditor/SchemaEditorDialog.vue';
-import { createI18nMock, setupMwMock } from '../../VueTestHelpers.ts';
+import { createI18nMock, findNextPageButton, setupMwMock } from '../../VueTestHelpers.ts';
 import { CdxButton, CdxDialog } from '@wikimedia/codex';
 import { Schema } from '@/domain/Schema.ts';
 import { PropertyDefinitionList } from '@/domain/PropertyDefinitionList.ts';
@@ -156,7 +156,7 @@ describe( 'SchemasPage', () => {
 		) ) );
 		await flushPromises();
 
-		const nextButton = wrapper.find( '.cdx-table-pager button[aria-label="Next page"]' );
+		const nextButton = findNextPageButton( wrapper );
 
 		expect( nextButton.attributes( 'disabled' ) ).toBeDefined();
 		expect( wrapper.text() ).toContain( 'of 10' );
@@ -171,7 +171,7 @@ describe( 'SchemasPage', () => {
 		) ), 'next-page-cursor' );
 		await flushPromises();
 
-		const nextButton = wrapper.find( '.cdx-table-pager button[aria-label="Next page"]' );
+		const nextButton = findNextPageButton( wrapper );
 
 		expect( nextButton.attributes( 'disabled' ) ).toBeUndefined();
 		expect( wrapper.text() ).toContain( 'of many' );

--- a/src/EntryPoints/REST/CursorPaginationTrait.php
+++ b/src/EntryPoints/REST/CursorPaginationTrait.php
@@ -59,8 +59,9 @@ trait CursorPaginationTrait {
 
 	/**
 	 * Fills a page with up to $limit summaries and derives the follow-up cursor. The cursor is the
-	 * page ID of the last consumed name, so names a load skips (readable but malformed) are not
-	 * re-consumed by the next page. nextCursor is null exactly when the listing is exhausted.
+	 * page ID of the last served item: a name skipped mid-page (readable but malformed) sorts below
+	 * it and is not revisited, while a malformed name after it is scanned and skipped afresh by the
+	 * next page. nextCursor is null exactly when the listing is exhausted.
 	 *
 	 * @param iterable<int, mixed> $readableNames
 	 * @param callable(mixed): ?array $loadSummary null when the name does not resolve to a listable item

--- a/src/Persistence/MediaWiki/DatabaseLayoutNameLookup.php
+++ b/src/Persistence/MediaWiki/DatabaseLayoutNameLookup.php
@@ -13,7 +13,7 @@ use Wikimedia\Rdbms\IDatabase;
 
 class DatabaseLayoutNameLookup implements LayoutNameLookup {
 
-	private const READABLE_NAMES_BATCH_SIZE = 100;
+	public const int READABLE_NAMES_BATCH_SIZE = 100;
 
 	public function __construct(
 		private readonly IDatabase $db,

--- a/src/Persistence/MediaWiki/DatabaseMappingNameLookup.php
+++ b/src/Persistence/MediaWiki/DatabaseMappingNameLookup.php
@@ -14,7 +14,7 @@ use Wikimedia\Rdbms\IDatabase;
 
 class DatabaseMappingNameLookup implements MappingNameLookup {
 
-	private const READABLE_NAMES_BATCH_SIZE = 100;
+	public const int READABLE_NAMES_BATCH_SIZE = 100;
 
 	public function __construct(
 		private readonly IDatabase $db,

--- a/src/Persistence/MediaWiki/DatabaseSchemaNameLookup.php
+++ b/src/Persistence/MediaWiki/DatabaseSchemaNameLookup.php
@@ -16,7 +16,7 @@ use Wikimedia\Rdbms\IResultWrapper;
 
 class DatabaseSchemaNameLookup implements SchemaNameLookup {
 
-	private const READABLE_NAMES_BATCH_SIZE = 100;
+	public const int READABLE_NAMES_BATCH_SIZE = 100;
 
 	public function __construct(
 		private readonly IDatabase $db,

--- a/tests/phpunit/EntryPoints/REST/GetMappingSummariesApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/GetMappingSummariesApiTest.php
@@ -154,4 +154,67 @@ JSON
 		$this->assertNull( $data['nextCursor'] );
 	}
 
+	public function testUnloadableMappingDoesNotConsumePageSpace(): void {
+		// A readable Mapping whose stored JSON cannot be parsed into a Mapping (here it is missing the
+		// required "schemas" key) is skipped by the summary loader, and a readable Mapping after it
+		// fills the freed slot, so the page still returns a full $limit items and reports no more to
+		// come. Such a page is reachable in production through XML import, which bypasses
+		// MappingContentHandler::validateSave (#1022).
+		$this->createMappingsWithUnloadableMiddle();
+
+		$page = $this->requestMappings( [ 'limit' => '2' ] );
+
+		$this->assertSame( [ 'Alpha', 'Gamma' ], array_column( $page['mappings'], 'name' ) );
+		$this->assertNull( $page['nextCursor'] );
+	}
+
+	public function testWalkingPastAnUnloadableMappingNeverYieldsAnEmptyPage(): void {
+		// Walked one item at a time, the unloadable Mapping is skipped inside the page that reaches it
+		// rather than served as an empty page with a follow-up cursor: it never appears, and no page in
+		// the walk comes back empty while items still remain.
+		$this->createMappingsWithUnloadableMiddle();
+
+		$firstPage = $this->requestMappings( [ 'limit' => '1' ] );
+
+		$this->assertSame( [ 'Alpha' ], array_column( $firstPage['mappings'], 'name' ) );
+		$this->assertIsString( $firstPage['nextCursor'] );
+
+		$secondPage = $this->requestMappings( [ 'limit' => '1', 'cursor' => $firstPage['nextCursor'] ] );
+
+		$this->assertSame( [ 'Gamma' ], array_column( $secondPage['mappings'], 'name' ) );
+		$this->assertNull( $secondPage['nextCursor'] );
+	}
+
+	/**
+	 * @return array{mappings: list<array{name: string, schemas: list<string>}>, nextCursor: ?string}
+	 */
+	private function requestMappings( array $queryParams ): array {
+		return json_decode(
+			$this->executeHandler(
+				new GetMappingSummariesApi(),
+				new RequestData( [ 'method' => 'GET', 'queryParams' => $queryParams ] )
+			)->getBody()->getContents(),
+			true
+		);
+	}
+
+	/**
+	 * Creates three Mappings in page-ID order — Alpha, an unloadable Beta, then Gamma — so a page
+	 * request has to skip a readable-but-unparseable Mapping sitting between two good ones. Beta's dump
+	 * is derived from Alpha (a real list member) so no extra page pollutes the listing, and its content
+	 * is broken by dropping the required "schemas" key. It goes in through XML import because
+	 * MappingContentHandler::validateSave would reject such content on the edit path (#1022).
+	 */
+	private function createMappingsWithUnloadableMiddle(): void {
+		$this->markPageTableAsUsed();
+		$this->createMapping( 'Alpha', '{"version":1,"schemas":{}}' );
+
+		$xml = $this->exportPageToXml( 'Mapping:Alpha' );
+		$xml = str_replace( 'Mapping:Alpha', 'Mapping:Beta', $xml );
+		$xml = str_replace( '"schemas"', '"schemaX"', $xml );
+		$this->importXml( $xml );
+
+		$this->createMapping( 'Gamma', '{"version":1,"schemas":{}}' );
+	}
+
 }

--- a/tests/phpunit/EntryPoints/REST/GetMappingSummariesApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/GetMappingSummariesApiTest.php
@@ -9,6 +9,7 @@ use MediaWiki\Rest\HttpException;
 use MediaWiki\Rest\RequestData;
 use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\GetMappingSummariesApi;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
 
 /**
@@ -206,15 +207,33 @@ JSON
 	 * MappingContentHandler::validateSave would reject such content on the edit path (#1022).
 	 */
 	private function createMappingsWithUnloadableMiddle(): void {
-		$this->markPageTableAsUsed();
-		$this->createMapping( 'Alpha', '{"version":1,"schemas":{}}' );
+		$alpha = $this->createMapping( 'Alpha', '{"version":1,"schemas":{}}' )->getPageId();
 
 		$xml = $this->exportPageToXml( 'Mapping:Alpha' );
 		$xml = str_replace( 'Mapping:Alpha', 'Mapping:Beta', $xml );
 		$xml = str_replace( '"schemas"', '"schemaX"', $xml );
+		// Guard the fixture's own premise: the title substitution must have produced a Beta dump and the
+		// content substitution must have removed the required key. If either misses (e.g. an export-format
+		// change), the import would recreate a loadable Alpha instead of an unloadable Beta.
+		$this->assertStringContainsString( 'Mapping:Beta', $xml );
+		$this->assertStringNotContainsString( '"schemas"', $xml );
 		$this->importXml( $xml );
 
-		$this->createMapping( 'Gamma', '{"version":1,"schemas":{}}' );
+		$gamma = $this->createMapping( 'Gamma', '{"version":1,"schemas":{}}' )->getPageId();
+
+		// The import must have created a distinct Beta page sitting between Alpha and Gamma in page-ID
+		// order. Without this, a silently no-op import (Beta absent) leaves only Alpha and Gamma, whose
+		// listing is byte-identical to the asserted result — so both tests would pass while the skip
+		// branch they exist to pin never runs.
+		$beta = (int)$this->getDb()->newSelectQueryBuilder()
+			->select( 'page_id' )
+			->from( 'page' )
+			->where( [ 'page_namespace' => NeoWikiExtension::NS_MAPPING, 'page_title' => 'Beta' ] )
+			->caller( __METHOD__ )
+			->fetchField();
+
+		$this->assertGreaterThan( $alpha, $beta, 'the imported unloadable Beta page must exist' );
+		$this->assertGreaterThan( $beta, $gamma );
 	}
 
 }

--- a/tests/phpunit/EntryPoints/REST/GetMappingSummariesApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/GetMappingSummariesApiTest.php
@@ -213,10 +213,13 @@ JSON
 		$xml = str_replace( 'Mapping:Alpha', 'Mapping:Beta', $xml );
 		$xml = str_replace( '"schemas"', '"schemaX"', $xml );
 		// Guard the fixture's own premise: the title substitution must have produced a Beta dump and the
-		// content substitution must have removed the required key. If either misses (e.g. an export-format
-		// change), the import would recreate a loadable Alpha instead of an unloadable Beta.
+		// content substitution must have replaced the required key with its schemaX token. If either
+		// misses (e.g. an export-format change), the import would recreate a loadable Alpha instead of an
+		// unloadable Beta. Both guards assert a replacement TARGET, so each fails when its str_replace
+		// matched nothing — asserting the removed "schemas" token is absent would instead be tautological,
+		// since str_replace makes that true unconditionally.
 		$this->assertStringContainsString( 'Mapping:Beta', $xml );
-		$this->assertStringNotContainsString( '"schemas"', $xml );
+		$this->assertStringContainsString( '"schemaX"', $xml );
 		$this->importXml( $xml );
 
 		$gamma = $this->createMapping( 'Gamma', '{"version":1,"schemas":{}}' )->getPageId();

--- a/tests/phpunit/NeoWikiIntegrationTestCase.php
+++ b/tests/phpunit/NeoWikiIntegrationTestCase.php
@@ -149,6 +149,53 @@ class NeoWikiIntegrationTestCase extends MediaWikiIntegrationTestCase {
 	}
 
 	/**
+	 * Bulk-inserts bare page rows — no revisions or content — straight into the page table with a
+	 * single multi-row insert. The keyset name-lookup generators read only page_id and page_title and
+	 * authorize by Title, so bare rows are enough to drive them past their batch size far more cheaply
+	 * than creating that many real pages. Titles are $titlePrefix followed by a zero-padded counter
+	 * (Foo001, Foo002, …). Returns each created title mapped to its assigned page ID, in page-ID order.
+	 *
+	 * @return array<string, int>
+	 */
+	protected function createBarePages( int $namespace, string $titlePrefix, int $count ): array {
+		$titles = [];
+		$rows = [];
+
+		for ( $i = 1; $i <= $count; $i++ ) {
+			$title = sprintf( '%s%03d', $titlePrefix, $i );
+			$titles[] = $title;
+			$rows[] = [
+				'page_namespace' => $namespace,
+				'page_title' => $title,
+				'page_random' => 0.5,
+				'page_touched' => $this->getDb()->timestamp(),
+				'page_latest' => 0,
+				'page_len' => 0,
+				'page_is_redirect' => 0,
+				'page_is_new' => 0,
+			];
+		}
+
+		$this->getDb()->insert( 'page', $rows, __METHOD__ );
+
+		$pageIds = [];
+
+		$result = $this->getDb()->newSelectQueryBuilder()
+			->select( [ 'page_id', 'page_title' ] )
+			->from( 'page' )
+			->where( [ 'page_namespace' => $namespace, 'page_title' => $titles ] )
+			->orderBy( 'page_id ASC' )
+			->caller( __METHOD__ )
+			->fetchResultSet();
+
+		foreach ( $result as $row ) {
+			$pageIds[$row->page_title] = (int)$row->page_id;
+		}
+
+		return $pageIds;
+	}
+
+	/**
 	 * Registers extra graph database plugins through the NeoWikiRegistration hook and rebuilds the singleton
 	 * so they are composed into the write paths, letting a test drive the real hook wiring with a backend of
 	 * its choosing (a spy, or one that always throws).

--- a/tests/phpunit/NeoWikiIntegrationTestCase.php
+++ b/tests/phpunit/NeoWikiIntegrationTestCase.php
@@ -176,7 +176,11 @@ class NeoWikiIntegrationTestCase extends MediaWikiIntegrationTestCase {
 			];
 		}
 
-		$this->getDb()->insert( 'page', $rows, __METHOD__ );
+		$this->getDb()->newInsertQueryBuilder()
+			->insertInto( 'page' )
+			->rows( $rows )
+			->caller( __METHOD__ )
+			->execute();
 
 		$pageIds = [];
 

--- a/tests/phpunit/Persistence/MediaWiki/DatabaseLayoutNameLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/DatabaseLayoutNameLookupTest.php
@@ -8,6 +8,7 @@ use MediaWiki\Page\PageIdentity;
 use MediaWiki\Permissions\Authority;
 use MediaWiki\Title\TitleValue;
 use ProfessionalWiki\NeoWiki\Infrastructure\AuthorityBasedPageReadAuthorizer;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\DatabaseLayoutNameLookup;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiMockAuthorityTrait;
@@ -94,6 +95,19 @@ class DatabaseLayoutNameLookupTest extends NeoWikiIntegrationTestCase {
 				)
 			)
 		);
+	}
+
+	public function testGetReadableLayoutNamesDrainsPastTheBatchSize(): void {
+		// The generator pages the namespace in 100-row keyset batches. With more rows than one batch,
+		// it must keep querying past the first batch: every Layout is yielded, the lowest page ID
+		// first and the highest last. A single truncated batch would drop the tail.
+		$bulk = $this->createBarePages( NeoWikiExtension::NS_LAYOUT, 'BulkLayout', 120 );
+
+		$drained = iterator_to_array( $this->getLookup()->getReadableLayoutNames() );
+
+		$this->assertCount( count( $this->pageIds ) + count( $bulk ), $drained );
+		$this->assertSame( $this->pageIds['LayoutNameLookupTest1'], array_key_first( $drained ) );
+		$this->assertSame( max( $bulk ), array_key_last( $drained ) );
 	}
 
 }

--- a/tests/phpunit/Persistence/MediaWiki/DatabaseLayoutNameLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/DatabaseLayoutNameLookupTest.php
@@ -97,17 +97,44 @@ class DatabaseLayoutNameLookupTest extends NeoWikiIntegrationTestCase {
 		);
 	}
 
-	public function testGetReadableLayoutNamesDrainsPastTheBatchSize(): void {
-		// The generator pages the namespace in 100-row keyset batches. With more rows than one batch,
-		// it must keep querying past the first batch: every Layout is yielded, the lowest page ID
-		// first and the highest last. A single truncated batch would drop the tail.
-		$bulk = $this->createBarePages( NeoWikiExtension::NS_LAYOUT, 'BulkLayout', 120 );
+	public function testGetReadableLayoutNamesDrainsEveryBatchInPageIdOrder(): void {
+		// The generator pages the namespace in fixed-size keyset batches. With more rows than one batch,
+		// it must keep querying past the first batch and yield every Layout exactly once, in strictly
+		// ascending page-ID order — a single truncated batch would drop the tail.
+		$bulk = $this->createBarePages(
+			NeoWikiExtension::NS_LAYOUT,
+			'BulkLayout',
+			DatabaseLayoutNameLookup::READABLE_NAMES_BATCH_SIZE + 20
+		);
 
-		$drained = iterator_to_array( $this->getLookup()->getReadableLayoutNames() );
+		$this->assertSame(
+			$this->expectedByPageId( $bulk ),
+			array_map(
+				static fn ( TitleValue $title ): string => $title->getText(),
+				iterator_to_array( $this->getLookup()->getReadableLayoutNames() )
+			)
+		);
+	}
 
-		$this->assertCount( count( $this->pageIds ) + count( $bulk ), $drained );
-		$this->assertSame( $this->pageIds['LayoutNameLookupTest1'], array_key_first( $drained ) );
-		$this->assertSame( max( $bulk ), array_key_last( $drained ) );
+	/**
+	 * The setUp Layouts then the bulk rows, each page ID mapped to its title, in page-ID order —
+	 * the exact [pageId => name] map getReadableLayoutNames should yield when everything is readable.
+	 *
+	 * @param array<string, int> $bulk
+	 * @return array<int, string>
+	 */
+	private function expectedByPageId( array $bulk ): array {
+		$expected = [];
+
+		foreach ( $this->pageIds as $name => $id ) {
+			$expected[$id] = $name;
+		}
+
+		foreach ( $bulk as $title => $id ) {
+			$expected[$id] = $title;
+		}
+
+		return $expected;
 	}
 
 }

--- a/tests/phpunit/Persistence/MediaWiki/DatabaseMappingNameLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/DatabaseMappingNameLookupTest.php
@@ -8,6 +8,7 @@ use MediaWiki\Page\PageIdentity;
 use MediaWiki\Permissions\Authority;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\MappingName;
 use ProfessionalWiki\NeoWiki\Infrastructure\AuthorityBasedPageReadAuthorizer;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\DatabaseMappingNameLookup;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiMockAuthorityTrait;
@@ -111,6 +112,19 @@ class DatabaseMappingNameLookupTest extends NeoWikiIntegrationTestCase {
 				)
 			)
 		);
+	}
+
+	public function testGetReadableMappingNamesDrainsPastTheBatchSize(): void {
+		// The generator pages the namespace in 100-row keyset batches. With more rows than one batch,
+		// it must keep querying past the first batch: every Mapping is yielded, the lowest page ID
+		// first and the highest last. A single truncated batch would drop the tail.
+		$bulk = $this->createBarePages( NeoWikiExtension::NS_MAPPING, 'BulkMapping', 120 );
+
+		$drained = iterator_to_array( $this->getLookup()->getReadableMappingNames() );
+
+		$this->assertCount( count( $this->pageIds ) + count( $bulk ), $drained );
+		$this->assertSame( $this->pageIds['MappingLookupTest1'], array_key_first( $drained ) );
+		$this->assertSame( max( $bulk ), array_key_last( $drained ) );
 	}
 
 }

--- a/tests/phpunit/Persistence/MediaWiki/DatabaseMappingNameLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/DatabaseMappingNameLookupTest.php
@@ -114,17 +114,44 @@ class DatabaseMappingNameLookupTest extends NeoWikiIntegrationTestCase {
 		);
 	}
 
-	public function testGetReadableMappingNamesDrainsPastTheBatchSize(): void {
-		// The generator pages the namespace in 100-row keyset batches. With more rows than one batch,
-		// it must keep querying past the first batch: every Mapping is yielded, the lowest page ID
-		// first and the highest last. A single truncated batch would drop the tail.
-		$bulk = $this->createBarePages( NeoWikiExtension::NS_MAPPING, 'BulkMapping', 120 );
+	public function testGetReadableMappingNamesDrainsEveryBatchInPageIdOrder(): void {
+		// The generator pages the namespace in fixed-size keyset batches. With more rows than one batch,
+		// it must keep querying past the first batch and yield every Mapping exactly once, in strictly
+		// ascending page-ID order — a single truncated batch would drop the tail.
+		$bulk = $this->createBarePages(
+			NeoWikiExtension::NS_MAPPING,
+			'BulkMapping',
+			DatabaseMappingNameLookup::READABLE_NAMES_BATCH_SIZE + 20
+		);
 
-		$drained = iterator_to_array( $this->getLookup()->getReadableMappingNames() );
+		$this->assertSame(
+			$this->expectedByPageId( $bulk ),
+			array_map(
+				static fn ( MappingName $name ): string => $name->getText(),
+				iterator_to_array( $this->getLookup()->getReadableMappingNames() )
+			)
+		);
+	}
 
-		$this->assertCount( count( $this->pageIds ) + count( $bulk ), $drained );
-		$this->assertSame( $this->pageIds['MappingLookupTest1'], array_key_first( $drained ) );
-		$this->assertSame( max( $bulk ), array_key_last( $drained ) );
+	/**
+	 * The setUp Mappings then the bulk rows, each page ID mapped to its title, in page-ID order —
+	 * the exact [pageId => name] map getReadableMappingNames should yield when everything is readable.
+	 *
+	 * @param array<string, int> $bulk
+	 * @return array<int, string>
+	 */
+	private function expectedByPageId( array $bulk ): array {
+		$expected = [];
+
+		foreach ( $this->pageIds as $name => $id ) {
+			$expected[$id] = $name;
+		}
+
+		foreach ( $bulk as $title => $id ) {
+			$expected[$id] = $title;
+		}
+
+		return $expected;
 	}
 
 }

--- a/tests/phpunit/Persistence/MediaWiki/DatabaseSchemaNameLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/DatabaseSchemaNameLookupTest.php
@@ -233,9 +233,9 @@ class DatabaseSchemaNameLookupTest extends NeoWikiIntegrationTestCase {
 
 	public function testGetReadableSchemaNamesContinuesPastAnUnreadableRowAtABatchBoundary(): void {
 		// The Schema whose page ID sits exactly on the first batch boundary (row 100, batch size 100)
-		// is denied. The generator advances its keyset anchor past every scanned row, readable or not,
-		// so the next batch still seeks beyond the denied row and returns rows 101+. The denied row is
-		// the only one absent; every later row still arrives.
+		// is denied. The drain's continue decision must count fetched rows, not yielded ones: batch
+		// one comes back full yet yields only 99, and the next batch must still be fetched, so rows
+		// 101+ arrive and the denied row is the only one absent.
 		$bulk = $this->createBarePages( NeoWikiExtension::NS_SCHEMA, 'BulkSchema', 120 );
 
 		$expected = $this->expectedByPageId( $bulk );

--- a/tests/phpunit/Persistence/MediaWiki/DatabaseSchemaNameLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/DatabaseSchemaNameLookupTest.php
@@ -216,4 +216,67 @@ class DatabaseSchemaNameLookupTest extends NeoWikiIntegrationTestCase {
 		$this->assertSame( [ 'SchemaNameLookupTest22' ], $names );
 	}
 
+	public function testGetReadableSchemaNamesDrainsEveryBatchInPageIdOrder(): void {
+		// The generator pages the namespace in 100-row keyset batches. With more rows than one batch,
+		// it must keep querying past the first batch and yield every Schema exactly once, in strictly
+		// ascending page-ID order — a single truncated batch would drop the tail.
+		$bulk = $this->createBarePages( NeoWikiExtension::NS_SCHEMA, 'BulkSchema', 120 );
+
+		$this->assertSame(
+			$this->expectedByPageId( $bulk ),
+			array_map(
+				static fn ( TitleValue $title ): string => $title->getText(),
+				iterator_to_array( $this->getLookup()->getReadableSchemaNames() )
+			)
+		);
+	}
+
+	public function testGetReadableSchemaNamesContinuesPastAnUnreadableRowAtABatchBoundary(): void {
+		// The Schema whose page ID sits exactly on the first batch boundary (row 100, batch size 100)
+		// is denied. The generator advances its keyset anchor past every scanned row, readable or not,
+		// so the next batch still seeks beyond the denied row and returns rows 101+. The denied row is
+		// the only one absent; every later row still arrives.
+		$bulk = $this->createBarePages( NeoWikiExtension::NS_SCHEMA, 'BulkSchema', 120 );
+
+		$expected = $this->expectedByPageId( $bulk );
+		// 100 = DatabaseSchemaNameLookup::READABLE_NAMES_BATCH_SIZE (private); the 100th row is the last of batch one.
+		$boundaryPageId = array_keys( $expected )[99];
+		$boundaryTitle = $expected[$boundaryPageId];
+		unset( $expected[$boundaryPageId] );
+
+		$denyBoundary = static fn ( string $permission, ?PageIdentity $page = null ): bool =>
+			$page === null || $page->getDBkey() !== $boundaryTitle;
+
+		$this->assertSame(
+			$expected,
+			array_map(
+				static fn ( TitleValue $title ): string => $title->getText(),
+				iterator_to_array(
+					$this->getLookup( $this->mockRegisteredAuthority( $denyBoundary ) )->getReadableSchemaNames()
+				)
+			)
+		);
+	}
+
+	/**
+	 * The 4 setUp Schemas then the bulk rows, each page ID mapped to its title, in page-ID order —
+	 * the exact [pageId => name] map getReadableSchemaNames should yield when everything is readable.
+	 *
+	 * @param array<string, int> $bulk
+	 * @return array<int, string>
+	 */
+	private function expectedByPageId( array $bulk ): array {
+		$expected = [];
+
+		foreach ( $this->pageIds as $name => $id ) {
+			$expected[$id] = $name;
+		}
+
+		foreach ( $bulk as $title => $id ) {
+			$expected[$id] = $title;
+		}
+
+		return $expected;
+	}
+
 }

--- a/tests/phpunit/Persistence/MediaWiki/DatabaseSchemaNameLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/DatabaseSchemaNameLookupTest.php
@@ -217,10 +217,14 @@ class DatabaseSchemaNameLookupTest extends NeoWikiIntegrationTestCase {
 	}
 
 	public function testGetReadableSchemaNamesDrainsEveryBatchInPageIdOrder(): void {
-		// The generator pages the namespace in 100-row keyset batches. With more rows than one batch,
+		// The generator pages the namespace in fixed-size keyset batches. With more rows than one batch,
 		// it must keep querying past the first batch and yield every Schema exactly once, in strictly
 		// ascending page-ID order — a single truncated batch would drop the tail.
-		$bulk = $this->createBarePages( NeoWikiExtension::NS_SCHEMA, 'BulkSchema', 120 );
+		$bulk = $this->createBarePages(
+			NeoWikiExtension::NS_SCHEMA,
+			'BulkSchema',
+			DatabaseSchemaNameLookup::READABLE_NAMES_BATCH_SIZE + 20
+		);
 
 		$this->assertSame(
 			$this->expectedByPageId( $bulk ),
@@ -232,15 +236,19 @@ class DatabaseSchemaNameLookupTest extends NeoWikiIntegrationTestCase {
 	}
 
 	public function testGetReadableSchemaNamesContinuesPastAnUnreadableRowAtABatchBoundary(): void {
-		// The Schema whose page ID sits exactly on the first batch boundary (row 100, batch size 100)
-		// is denied. The drain's continue decision must count fetched rows, not yielded ones: batch
-		// one comes back full yet yields only 99, and the next batch must still be fetched, so rows
-		// 101+ arrive and the denied row is the only one absent.
-		$bulk = $this->createBarePages( NeoWikiExtension::NS_SCHEMA, 'BulkSchema', 120 );
+		// The Schema whose page ID sits exactly on the first batch boundary (the last row of the first
+		// full batch) is denied. The drain's continue decision must count fetched rows, not yielded ones:
+		// batch one comes back full yet yields one short, and the next batch must still be fetched, so the
+		// rows past the boundary arrive and the denied row is the only one absent.
+		$bulk = $this->createBarePages(
+			NeoWikiExtension::NS_SCHEMA,
+			'BulkSchema',
+			DatabaseSchemaNameLookup::READABLE_NAMES_BATCH_SIZE + 20
+		);
 
 		$expected = $this->expectedByPageId( $bulk );
-		// 100 = DatabaseSchemaNameLookup::READABLE_NAMES_BATCH_SIZE (private); the 100th row is the last of batch one.
-		$boundaryPageId = array_keys( $expected )[99];
+		// The last row of the first batch sits at index READABLE_NAMES_BATCH_SIZE - 1.
+		$boundaryPageId = array_keys( $expected )[DatabaseSchemaNameLookup::READABLE_NAMES_BATCH_SIZE - 1];
 		$boundaryTitle = $expected[$boundaryPageId];
 		unset( $expected[$boundaryPageId] );
 
@@ -259,7 +267,7 @@ class DatabaseSchemaNameLookupTest extends NeoWikiIntegrationTestCase {
 	}
 
 	/**
-	 * The 4 setUp Schemas then the bulk rows, each page ID mapped to its title, in page-ID order —
+	 * The setUp Schemas then the bulk rows, each page ID mapped to its title, in page-ID order —
 	 * the exact [pageId => name] map getReadableSchemaNames should yield when everything is readable.
 	 *
 	 * @param array<string, int> $bulk


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1131 — review-fix tests for the three coverage gaps found in its AI review, plus one doc-block correction. No production logic changes.

- **Indeterminate pager half of the determinate flip.** Each list page keeps CdxTable's `totalRows` undefined while a response carries a non-null cursor; only the null-cursor flip was tested. An "unconditional flip" mutation survived the whole vitest suite while disabling Next on every full page mid-listing. Adds the indeterminate test to all three pages, including a first `LayoutsPage` spec (which also pins its determinate flip).
- **`buildPage` back-fill over unloadable rows.** A readable-but-unparseable page (reachable through XML import, which bypasses `validateSave` — the #1022 flow) must not consume page space or surface in the walk. The branch had zero executions; a mutation counting skips against the limit survived the suite. Pinned on the Mapping endpoint with an imported Mapping missing its `schemas` key.
- **Keyset batch-boundary drain.** The 100-row batch loop in the three name lookups never iterated in any test; `while(false)` (truncate every listing at 100 rows) survived. Adds >100-row drains via a shared bare-page insert helper; the Schema case also denies the row sitting exactly on the batch boundary.
- **Trait doc correction.** `buildPage`'s cursor is the last *served* item's page ID, so a trailing skipped row is re-scanned by the next page; the old sentence claimed skips are never re-consumed.

Every test was sabotage-checked: the target mutation applied → test fails on the pinned behavior → mutation reverted → green. Full local `make phpunit` (1976 tests), `make cs`, vitest (1107 tests, single-worker) and `make ts-lint` pass.

Merge note: master has since gained its own `LayoutsPage.spec.ts` (delete-dialog tests, `totalRows`-shaped mocks). When #1131 takes a master merge, resolve the add/add by folding this PR's two pager tests into master's scaffolding and converting its mocks to the `nextCursor` shape.

> <sub>AI-authored — Claude Code, `Fable 5 (max)`; produced by the /pr-review run on #1131 for @JeroenDeDauw, no revisions; diff not yet human-reviewed; sabotage-checked TDD (every test seen failing against its target mutation first), full PHPUnit/vitest/phpcs/phpstan/ts-lint green locally, CI pending.</sub>

<details><summary>Production notes</summary>

Review orchestration and finding verification by `Fable 5 (max)`; test implementation by an `Opus 4.8 (max)` subagent against a fully specified brief. Findings confirmed by independent refute-first verifier agents before any test was written.

</details>