### PR TITLE
Fall back to page (with a warning) for an unrecognized dereference target

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -198,7 +198,7 @@
 			"value": null
 		},
 		"NeoWikiSubjectDereferenceTarget": {
-			"description": "Where a browser dereferencing a Subject's concept URI (Accept: text/html) is sent: 'page' (default) for the Subject's hosting page, or 'data-tab' for that page's Data tab (?action=subjects) opened on the Subject's row (expanded, scrolled to, highlighted). Any other value is a configuration error.",
+			"description": "Where a browser dereferencing a Subject's concept URI (Accept: text/html) is sent: 'page' (default) for the Subject's hosting page, or 'data-tab' for that page's Data tab (?action=subjects) opened on the Subject's row (expanded, scrolled to, highlighted). Any other value falls back to 'page' and logs a warning.",
 			"value": "page"
 		},
 		"NeoWikiSparqlStores": {

--- a/src/EntryPoints/REST/ResolveSubjectIriApi.php
+++ b/src/EntryPoints/REST/ResolveSubjectIriApi.php
@@ -4,7 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\EntryPoints\REST;
 
-use MediaWiki\Config\ConfigException;
+use MediaWiki\Logger\LoggerFactory;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Rest\Response;
 use MediaWiki\Rest\SimpleHandler;
@@ -112,14 +112,20 @@ class ResolveSubjectIriApi extends SimpleHandler {
 	private function dataTabDereference(): bool {
 		$value = MediaWikiServices::getInstance()->getMainConfig()->get( 'NeoWikiSubjectDereferenceTarget' );
 
-		// An unrecognized value is surfaced as a configuration error rather than silently treated as 'page'.
-		return match ( $value ) {
-			'data-tab' => true,
-			'page' => false,
-			default => throw new ConfigException(
-				'Unrecognized $wgNeoWikiSubjectDereferenceTarget value: ' . var_export( $value, true )
-			),
-		};
+		if ( $value === 'data-tab' ) {
+			return true;
+		}
+
+		if ( $value !== 'page' ) {
+			// A config typo must not take down the wiki: fall back to the 'page' default — a correct
+			// response for the visitor dereferencing the concept URI — and log so the admin who set the
+			// value notices it (alongside the unexpected landing page).
+			LoggerFactory::getInstance( 'NeoWiki' )->warning(
+				'Unrecognized $wgNeoWikiSubjectDereferenceTarget value ' . var_export( $value, true ) . '; falling back to "page".'
+			);
+		}
+
+		return false;
 	}
 
 	private function noDataResponse( string $subjectId ): Response {

--- a/tests/phpunit/EntryPoints/REST/ResolveSubjectIriApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ResolveSubjectIriApiTest.php
@@ -4,7 +4,6 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\REST;
 
-use MediaWiki\Config\ConfigException;
 use MediaWiki\Permissions\Authority;
 use MediaWiki\Rest\RequestData;
 use MediaWiki\Rest\Response;
@@ -16,6 +15,7 @@ use ProfessionalWiki\NeoWiki\EntryPoints\REST\ResolveSubjectIriApi;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiMockAuthorityTrait;
+use WMDE\PsrLogTestDoubles\LegacyLoggerSpy;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\EntryPoints\REST\ResolveSubjectIriApi
@@ -139,12 +139,19 @@ class ResolveSubjectIriApiTest extends NeoWikiIntegrationTestCase {
 		$this->assertSubjectRdfLocation( $response, 'trig' );
 	}
 
-	public function testUnrecognizedDereferenceTargetIsAConfigError(): void {
+	public function testUnrecognizedDereferenceTargetFallsBackToThePlainHostingPageAndLogsAWarning(): void {
 		$this->overrideConfigValue( 'NeoWikiSubjectDereferenceTarget', 'sidebar' );
+		$logger = new LegacyLoggerSpy();
+		$this->setLogger( 'NeoWiki', $logger );
 
-		$this->expectException( ConfigException::class );
+		$response = $this->deref( headers: [ 'Accept' => 'text/html' ] );
 
-		$this->deref( headers: [ 'Accept' => 'text/html' ] );
+		$this->assertSame( 303, $response->getStatusCode() );
+		$this->assertHostingPageLocation( $response );
+		$this->assertStringContainsString(
+			'Unrecognized $wgNeoWikiSubjectDereferenceTarget value',
+			implode( "\n", $logger->getLogCalls()->getMessages() )
+		);
 	}
 
 	public function testReturns404ForAnUnknownSubject(): void {


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1123

An unrecognized `$wgNeoWikiSubjectDereferenceTarget` now **falls back to `page` and logs a warning** instead of throwing a `ConfigException`.

The only people who hit a bad value unknowingly are external visitors dereferencing concept URIs — the audience least able to report a 500 — so graceful fallback serves them a correct default response. It matches the repo's config-typo convention (a config typo must not take down the wiki) and degrades safely across upgrades. The admin who set the value still notices: the wrong landing page, plus the logged warning (which names the bad value).

The dereference endpoint's HTML branch is the only reader; the RDF branches are unaffected.

**Verification.** Full `make phpunit` (1951) + `make cs` (phpcs 590 / phpstan) green; the handler test asserts the 303-to-page fallback and the logged warning (via a `LegacyLoggerSpy` on the `NeoWiki` channel). Live smoke in the dev wiki: a junk `sidebar` value → `303` to the plain page, with the container log line `Unrecognized $wgNeoWikiSubjectDereferenceTarget value 'sidebar'; falling back to "page".`

> <sub>AI-authored — Claude Code, `Opus 4.8 (max)`; approved micro-change from @JeroenDeDauw's review of #1123, no revisions during execution; diff not yet human-reviewed; full PHPUnit + phpcs/phpstan green locally, live-smoke-verified (fallback + warning line); CI green.</sub>

