### PR TITLE
Add an on-wiki JSON configuration page at MediaWiki:NeoWiki

### DIFF
--- a/docs/operations/installation.md
+++ b/docs/operations/installation.md
@@ -172,6 +172,29 @@ These are the settings you are most likely to change. For the full list with des
 | `$wgNeoWikiAutoRenderMainSubject` | Automatically renders a page's Main Subject as an infobox | `true` | No |
 | `$wgNeoWikiSparqlStores` | SPARQL 1.1 graph stores to keep in sync and query, e.g. QLever | `[]` | No |
 
+## On-wiki configuration
+
+A wiki administrator without server access can set part of NeoWiki's configuration on the `MediaWiki:NeoWiki`
+page. It holds JSON and, like other site configuration, is editable only with the `editinterface` and
+`editsitejson` rights. Two settings are exposed: `dereferenceSubjectsToDataTab` (overriding
+`$wgNeoWikiDereferenceSubjectsToDataTab`) and `autoRenderMainSubject` (overriding `$wgNeoWikiAutoRenderMainSubject`).
+Editing the page shows a reference table of the exposed keys and their accepted values, and creating it
+preloads a working example.
+
+A valid value on the page takes precedence over `LocalSettings.php`, per setting. A missing page, a
+wrong-shaped value, or an unavailable database falls back to the `LocalSettings.php` value, so a
+configuration typo cannot take down the wiki. Saving the page rejects unknown keys and wrong-typed values.
+
+Every other setting stays in `LocalSettings.php` — deliberately, for secrets and infrastructure
+(`$wgNeoWikiSparqlStores`), for settings too consequential for a wiki page (`$wgNeoWikiRdfBaseUri` re-mints
+every IRI when changed), and for development toggles (`$wgNeoWikiEnableDevelopmentUI`).
+
+`autoRenderMainSubject` changes take effect as pages are re-parsed; already-cached pages keep their previous
+rendering until then, or until purged with `?action=purge`.
+
+Set `$wgNeoWikiEnableInWikiConfig` to `false` to disable the page entirely: it is then never given the JSON
+content model, validated, or read.
+
 ## Optional: SPARQL graph stores
 
 Alongside Neo4j, NeoWiki can keep one or more SPARQL 1.1 graph stores in sync with page changes. This

--- a/extension.json
+++ b/extension.json
@@ -47,11 +47,19 @@
 
 		"CodeEditorGetPageLanguage": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onCodeEditorGetPageLanguage",
 
-		"BeforePageDisplay": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onBeforePageDisplay",
+		"BeforePageDisplay": [
+			"ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onBeforePageDisplay",
+			"ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onConfigPageBeforePageDisplay"
+		],
 
 		"SpecialPage_initList": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onSpecialPageInitList",
 
 		"ContentModelCanBeUsedOn": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onContentModelCanBeUsedOn",
+
+		"ContentHandlerDefaultModelFor": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onContentHandlerDefaultModelFor",
+		"EditFilter": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onEditFilter",
+		"AlternateEdit": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onAlternateEdit",
+		"EditFormPreloadText": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onEditFormPreloadText",
 
 		"SidebarBeforeOutput": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onSidebarBeforeOutput",
 		"SkinTemplateNavigation::Universal": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onSkinTemplateNavigationUniversal",
@@ -165,6 +173,10 @@
 		"NeoWikiEnableDevelopmentUI": {
 			"description": "Whether development UIs should be enabled",
 			"value": false
+		},
+		"NeoWikiEnableInWikiConfig": {
+			"description": "Whether NeoWiki settings may also be set on the MediaWiki:NeoWiki JSON configuration page, which requires the editinterface and editsitejson rights to edit. When false, that page is never given the JSON content model, validated, or read, so only LocalSettings.php applies. The page exposes NeoWikiDereferenceSubjectsToDataTab and NeoWikiAutoRenderMainSubject; its values take precedence over LocalSettings.php.",
+			"value": true
 		},
 		"NeoWikiEnforceValidation": {
 			"description": "Whether write endpoints reject edits that introduce new constraint violations. When false, violations are surfaced in responses but writes always persist.",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -341,5 +341,15 @@
 	"neowiki-managesubjects-export-choose-format": "Choose a format",
 	"neowiki-managesubjects-export-choose-projection": "Choose a projection",
 	"neowiki-managesubjects-export-native": "Native",
-	"action-subjects": "manage subjects on this page"
+	"action-subjects": "manage subjects on this page",
+	"neowiki-config-invalid": "The NeoWiki configuration was not saved because it is invalid:",
+	"neowiki-config-error-not-object": "The configuration must be a JSON object.",
+	"neowiki-config-error-unknown-key": "Unknown configuration setting \"$1\".",
+	"neowiki-config-error-invalid-boolean": "\"$1\" must be true or false.",
+	"neowiki-config-type-boolean": "<code>true</code> or <code>false</code>",
+	"neowiki-config-docs-heading": "Configuration reference",
+	"neowiki-config-docs-pointer": "This page configures NeoWiki as JSON. See the [[#$1|configuration reference]] below and the [$2 configuration documentation].",
+	"neowiki-config-docs-column-key": "Setting",
+	"neowiki-config-docs-column-value": "Accepted value",
+	"neowiki-config-docs-column-setting": "LocalSettings.php setting"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -272,5 +272,15 @@
 	"neowiki-managesubjects-export-choose-format": "Announced to screen-reader users when the data export menu returns to its list of export formats (JSON, Turtle, TriG).",
 	"neowiki-managesubjects-export-choose-projection": "Announced to screen-reader users when the data export menu shows its list of projections after a format is chosen. A projection is the ontology/vocabulary the data is exported as, e.g. EDM or CIDOC-CRM.",
 	"neowiki-managesubjects-export-native": "Display name of the native (NeoWiki-vocabulary) RDF projection, shown in the projection list of the data export menu.",
-	"action-subjects": "Description of the Subject management action used by MediaWiki when generating action descriptions."
+	"action-subjects": "Description of the Subject management action used by MediaWiki when generating action descriptions.",
+	"neowiki-config-invalid": "Heading shown above the list of errors when an edit to the MediaWiki:NeoWiki JSON configuration page is rejected.",
+	"neowiki-config-error-not-object": "Error shown when the MediaWiki:NeoWiki configuration is not a JSON object.",
+	"neowiki-config-error-unknown-key": "Error shown when the configuration contains a setting that is not exposed on-wiki. $1 is the unknown key.",
+	"neowiki-config-error-invalid-boolean": "Error shown when a setting that must be a boolean is not. $1 is the setting key. The words \"true\" and \"false\" are literal JSON values and must not be translated.",
+	"neowiki-config-type-boolean": "Accepted-value description in the configuration reference table for a boolean setting. Contains HTML: the literal JSON values \"true\" and \"false\", each wrapped in a <code> tag, must not be translated.",
+	"neowiki-config-docs-heading": "Heading of the configuration reference shown on the MediaWiki:NeoWiki configuration page. Also the link target of {{msg-neowiki|neowiki-config-docs-pointer}}.",
+	"neowiki-config-docs-pointer": "One-line pointer shown above the configuration editor and view. $1 is the anchor of the on-page reference, $2 is the URL of the external documentation.",
+	"neowiki-config-docs-column-key": "Column header in the configuration reference table for the setting key written on the page.",
+	"neowiki-config-docs-column-value": "Column header in the configuration reference table for the value the setting accepts.",
+	"neowiki-config-docs-column-setting": "Column header in the configuration reference table for the LocalSettings.php setting that the page key overrides."
 }

--- a/src/Application/WikiConfig/ConfigExample.php
+++ b/src/Application/WikiConfig/ConfigExample.php
@@ -1,0 +1,22 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application\WikiConfig;
+
+/**
+ * The valid example preloaded into the on-wiki configuration page when it is first created, so an
+ * administrator starts from a working configuration set to the defaults rather than a blank page. A test
+ * pins that it passes {@see ConfigValidator} and covers every {@see ConfigSchema} setting, so a schema
+ * change can never leave the preload invalid or incomplete.
+ */
+class ConfigExample {
+
+	public const string JSON = <<<'JSON'
+		{
+			"dereferenceSubjectsToDataTab": false,
+			"autoRenderMainSubject": true
+		}
+		JSON;
+
+}

--- a/src/Application/WikiConfig/ConfigSchema.php
+++ b/src/Application/WikiConfig/ConfigSchema.php
@@ -1,0 +1,51 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application\WikiConfig;
+
+/**
+ * The allowlist of settings the on-wiki configuration page (MediaWiki:NeoWiki) may set. The allowlist is
+ * the security boundary: only these settings are readable from and writable on the page. Everything else
+ * stays exclusive to LocalSettings.php — infrastructure and secrets (NeoWikiSparqlStores), settings too
+ * consequential for a wiki page (NeoWikiRdfBaseUri re-mints every IRI), and dev-only toggles
+ * (NeoWikiEnableDevelopmentUI). New settings are vetted and added one by one.
+ */
+class ConfigSchema {
+
+	/**
+	 * @var ConfigSetting[]
+	 */
+	private array $settings;
+
+	public function __construct() {
+		$this->settings = [
+			new ConfigSetting(
+				pageKey: 'dereferenceSubjectsToDataTab',
+				settingName: 'NeoWikiDereferenceSubjectsToDataTab',
+			),
+			new ConfigSetting(
+				pageKey: 'autoRenderMainSubject',
+				settingName: 'NeoWikiAutoRenderMainSubject',
+			),
+		];
+	}
+
+	/**
+	 * @return ConfigSetting[]
+	 */
+	public function getSettings(): array {
+		return $this->settings;
+	}
+
+	public function getSetting( string $pageKey ): ?ConfigSetting {
+		foreach ( $this->settings as $setting ) {
+			if ( $setting->pageKey === $pageKey ) {
+				return $setting;
+			}
+		}
+
+		return null;
+	}
+
+}

--- a/src/Application/WikiConfig/ConfigSetting.php
+++ b/src/Application/WikiConfig/ConfigSetting.php
@@ -1,0 +1,45 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application\WikiConfig;
+
+/**
+ * One boolean setting exposed on the on-wiki configuration page: the page key admins write and the
+ * LocalSettings.php setting it overrides. The single definition drives save-time validation, the
+ * generated on-page reference, and the combining read, so those cannot drift apart.
+ *
+ * Both exposed settings are boolean today, so the value shape is fixed here rather than abstracted. The
+ * first genuinely differently-shaped setting reintroduces a value-type abstraction.
+ */
+readonly class ConfigSetting {
+
+	public function __construct(
+		public string $pageKey,
+		public string $settingName,
+	) {
+	}
+
+	public function isValidValue( mixed $value ): bool {
+		return is_bool( $value );
+	}
+
+	/**
+	 * The accepted-value description for the on-page reference.
+	 *
+	 * @return array A message spec: [ messageKey, ...params ].
+	 */
+	public function describe(): array {
+		return [ 'neowiki-config-type-boolean' ];
+	}
+
+	/**
+	 * The save-time error for a value of the wrong shape.
+	 *
+	 * @return array A message spec: [ messageKey, ...params ].
+	 */
+	public function invalidValueError(): array {
+		return [ 'neowiki-config-error-invalid-boolean', $this->pageKey ];
+	}
+
+}

--- a/src/Application/WikiConfig/ConfigValidator.php
+++ b/src/Application/WikiConfig/ConfigValidator.php
@@ -1,0 +1,58 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application\WikiConfig;
+
+/**
+ * Validates the JSON of the on-wiki configuration page at save time, producing precise per-field errors
+ * so an administrator catches a typo the moment they can fix it. Strict on save (unlike the tolerant
+ * read path): non-object JSON, unknown keys, and values of the wrong shape are all rejected.
+ *
+ * Errors are returned as message specs — an array whose first element is a message key and whose rest are
+ * the parameters. An empty result means the configuration is valid.
+ */
+class ConfigValidator {
+
+	public const string ERROR_NOT_OBJECT = 'neowiki-config-error-not-object';
+	public const string ERROR_UNKNOWN_KEY = 'neowiki-config-error-unknown-key';
+
+	public function __construct(
+		private ConfigSchema $schema
+	) {
+	}
+
+	/**
+	 * @return array[] A list of message specs, each [ messageKey, ...params ]. Empty when valid.
+	 */
+	public function validate( string $json ): array {
+		$data = json_decode( $json, true );
+
+		if ( $data === null ) {
+			// A JSON syntax error is rejected by the JSON content model itself, so it is left to core.
+			// Only a literal `null`, which is syntactically valid, is flagged here.
+			return trim( $json ) === 'null' ? [ [ self::ERROR_NOT_OBJECT ] ] : [];
+		}
+
+		// A JSON object decodes to an associative array (or the empty array); a scalar or a JSON list
+		// is not an object.
+		if ( !is_array( $data ) || ( $data !== [] && array_is_list( $data ) ) ) {
+			return [ [ self::ERROR_NOT_OBJECT ] ];
+		}
+
+		$errors = [];
+
+		foreach ( $data as $key => $value ) {
+			$setting = $this->schema->getSetting( (string)$key );
+
+			if ( $setting === null ) {
+				$errors[] = [ self::ERROR_UNKNOWN_KEY, (string)$key ];
+			} elseif ( !$setting->isValidValue( $value ) ) {
+				$errors[] = $setting->invalidValueError();
+			}
+		}
+
+		return $errors;
+	}
+
+}

--- a/src/Application/WikiConfig/WikiConfigLookup.php
+++ b/src/Application/WikiConfig/WikiConfigLookup.php
@@ -1,0 +1,83 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application\WikiConfig;
+
+use InvalidArgumentException;
+use MediaWiki\Config\Config;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Resolves the effective value of an exposed setting by combining the on-wiki configuration page with the
+ * PHP/LocalSettings configuration, per setting, with the wiki page winning when it sets a valid value.
+ *
+ * A missing page, an absent key, or a value of the wrong shape falls back to the PHP configuration rather
+ * than throwing: a config typo on the page must not take down the wiki (the NeoWikiConfigFactory stance).
+ * An invalid page value is logged once so the fallback is not silent; unknown page keys are tolerated for
+ * forward compatibility. The page is read at most once (memoized), and only when in-wiki config is enabled.
+ */
+class WikiConfigLookup {
+
+	private bool $pageRead = false;
+
+	/**
+	 * @var array<string, mixed>|null
+	 */
+	private ?array $pageData = null;
+
+	public function __construct(
+		private ConfigSchema $schema,
+		private WikiConfigSource $source,
+		private Config $phpConfig,
+		private bool $enabled,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	public function getEffectiveValue( string $pageKey ): mixed {
+		$setting = $this->schema->getSetting( $pageKey );
+
+		if ( $setting === null ) {
+			throw new InvalidArgumentException( "Not an on-wiki-configurable setting: $pageKey" );
+		}
+
+		$phpValue = $this->phpConfig->get( $setting->settingName );
+
+		$pageData = $this->pageData();
+
+		if ( $pageData === null || !array_key_exists( $pageKey, $pageData ) ) {
+			return $phpValue;
+		}
+
+		$pageValue = $pageData[$pageKey];
+
+		if ( $setting->isValidValue( $pageValue ) ) {
+			return $pageValue;
+		}
+
+		$this->logger->warning(
+			'Ignoring invalid value for "{key}" on the MediaWiki:NeoWiki configuration page; using the PHP configuration instead.',
+			[ 'key' => $pageKey ]
+		);
+
+		return $phpValue;
+	}
+
+	/**
+	 * @return array<string, mixed>|null
+	 */
+	private function pageData(): ?array {
+		if ( !$this->enabled ) {
+			return null;
+		}
+
+		if ( !$this->pageRead ) {
+			$this->pageRead = true;
+			$this->pageData = $this->source->readConfig();
+		}
+
+		return $this->pageData;
+	}
+
+}

--- a/src/Application/WikiConfig/WikiConfigSource.php
+++ b/src/Application/WikiConfig/WikiConfigSource.php
@@ -1,0 +1,21 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application\WikiConfig;
+
+/**
+ * A source of the raw (undecoded-into-values, unvalidated) configuration from the on-wiki configuration
+ * page. The production implementation reads MediaWiki:NeoWiki lazily and memoizes it for the request.
+ */
+interface WikiConfigSource {
+
+	/**
+	 * The decoded top-level JSON object of the configuration page, or null when the page is absent,
+	 * unreadable (e.g. the database is down), or not a JSON object.
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	public function readConfig(): ?array;
+
+}

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -483,23 +483,41 @@ class NeoWikiHooks {
 			return;
 		}
 
-		$action = MediaWikiServices::getInstance()->getActionFactory()->getActionName( $out->getContext() );
+		$context = $out->getContext();
+		$action = MediaWikiServices::getInstance()->getActionFactory()->getActionName( $context );
 
-		if ( $action !== 'view' ) {
+		// A diff request also resolves to the 'view' action, but renders a comparison the framing
+		// would discard, so only a plain page view is reduced to the JSON table and framed.
+		if ( $action !== 'view' || $context->getRequest()->getCheck( 'diff' ) ) {
 			return;
 		}
 
-		$builder = NeoWikiExtension::getInstance()->newConfigDocumentationBuilder( $out->getContext() );
-		$trimmed = self::trimToJsonTable( $out->getHTML() );
+		$builder = NeoWikiExtension::getInstance()->newConfigDocumentationBuilder( $context );
+		$table = self::extractJsonTable( $out->getHTML() );
 
 		$out->clearHTML();
-		$out->addHTML( $builder->buildPointer() . $trimmed . $builder->buildReference() );
+		$out->addHTML( $builder->buildPointer() . $table . $builder->buildReference() );
 	}
 
-	private static function trimToJsonTable( string $html ): string {
-		$position = strpos( $html, '<table class="mw-json"' );
+	/**
+	 * Extracts just the core JSON table element. Core wraps it in a <div class="noresize">, so taking
+	 * the balanced <table>...</table> rather than everything to the end of the body avoids re-emitting
+	 * that wrapper's orphaned closing tag.
+	 */
+	private static function extractJsonTable( string $html ): string {
+		$start = strpos( $html, '<table class="mw-json"' );
 
-		return $position === false ? $html : substr( $html, $position );
+		if ( $start === false ) {
+			return $html;
+		}
+
+		$end = strpos( $html, '</table>', $start );
+
+		if ( $end === false ) {
+			return substr( $html, $start );
+		}
+
+		return substr( $html, $start, $end - $start + strlen( '</table>' ) );
 	}
 
 }

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\EntryPoints;
 
+use MediaWiki\EditPage\EditPage;
 use MediaWiki\Html\Html;
 use MediaWiki\Logger\LoggerFactory;
 use MediaWiki\MainConfigNames;
@@ -17,7 +18,9 @@ use MediaWiki\Revision\SlotRoleRegistry;
 use MediaWiki\Title\ForeignTitle;
 use MediaWiki\Title\Title;
 use MediaWiki\User\UserIdentity;
+use MessageLocalizer;
 use ProfessionalWiki\NeoWiki\Application\Rdf\RdfPageProjector;
+use ProfessionalWiki\NeoWiki\Application\WikiConfig\ConfigExample;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\EntryPoints\Content\SchemaContent;
 use ProfessionalWiki\NeoWiki\EntryPoints\Content\SubjectContent;
@@ -396,6 +399,107 @@ class NeoWikiHooks {
 				]
 			)
 		);
+	}
+
+	/**
+	 * Forces the JSON content model on the on-wiki configuration page, so MediaWiki core requires the
+	 * editinterface and editsitejson rights to edit it and enforces JSON syntax on save.
+	 */
+	public static function onContentHandlerDefaultModelFor( Title $title, ?string &$model ): void {
+		if ( NeoWikiExtension::getInstance()->isConfigPage( $title ) ) {
+			$model = CONTENT_MODEL_JSON;
+		}
+	}
+
+	/**
+	 * Validates the on-wiki configuration page on save, blocking the edit with precise per-field errors
+	 * when the configuration is invalid. A JSON syntax error is left to the JSON content model itself.
+	 */
+	public static function onEditFilter( EditPage $editor, string $text, string $section, string &$error, string $summary ): void {
+		$extension = NeoWikiExtension::getInstance();
+
+		if ( !$extension->isConfigPage( $editor->getTitle() ) ) {
+			return;
+		}
+
+		$errors = $extension->getConfigValidator()->validate( $text );
+
+		if ( $errors !== [] ) {
+			$error = self::formatConfigErrors( $errors, $editor->getContext() );
+		}
+	}
+
+	/**
+	 * @param array[] $errors A list of message specs, each [ messageKey, ...params ].
+	 */
+	private static function formatConfigErrors( array $errors, MessageLocalizer $localizer ): string {
+		$items = '';
+
+		foreach ( $errors as $errorSpec ) {
+			$items .= Html::rawElement( 'li', [], $localizer->msg( ...$errorSpec )->escaped() );
+		}
+
+		return Html::errorBox(
+			$localizer->msg( 'neowiki-config-invalid' )->escaped() . Html::rawElement( 'ul', [], $items )
+		);
+	}
+
+	/**
+	 * Preloads a small valid example when the on-wiki configuration page is created, so an administrator
+	 * starts from a working configuration rather than a blank page.
+	 */
+	public static function onEditFormPreloadText( ?string &$text, Title $title ): void {
+		if ( NeoWikiExtension::getInstance()->isConfigPage( $title ) ) {
+			$text = ConfigExample::JSON;
+		}
+	}
+
+	/**
+	 * On the on-wiki configuration page, suppresses the default MediaWiki-namespace intro and frames the
+	 * JSON editor with a pointer to the documentation and the schema-generated configuration reference.
+	 */
+	public static function onAlternateEdit( EditPage $editPage ): void {
+		$extension = NeoWikiExtension::getInstance();
+
+		if ( !$extension->isConfigPage( $editPage->getTitle() ) ) {
+			return;
+		}
+
+		$editPage->suppressIntro = true;
+
+		$builder = $extension->newConfigDocumentationBuilder( $editPage->getContext() );
+		$editPage->editFormTextTop = $builder->buildPointer();
+		$editPage->editFormTextBottom = $builder->buildReference();
+	}
+
+	/**
+	 * On viewing the on-wiki configuration page, trims the rendered page to the core JSON table and frames
+	 * it with the documentation pointer and the schema-generated configuration reference.
+	 */
+	public static function onConfigPageBeforePageDisplay( OutputPage $out, Skin $skin ): void {
+		$title = $out->getTitle();
+
+		if ( $title === null || !NeoWikiExtension::getInstance()->isConfigPage( $title ) ) {
+			return;
+		}
+
+		$action = MediaWikiServices::getInstance()->getActionFactory()->getActionName( $out->getContext() );
+
+		if ( $action !== 'view' ) {
+			return;
+		}
+
+		$builder = NeoWikiExtension::getInstance()->newConfigDocumentationBuilder( $out->getContext() );
+		$trimmed = self::trimToJsonTable( $out->getHTML() );
+
+		$out->clearHTML();
+		$out->addHTML( $builder->buildPointer() . $trimmed . $builder->buildReference() );
+	}
+
+	private static function trimToJsonTable( string $html ): string {
+		$position = strpos( $html, '<table class="mw-json"' );
+
+		return $position === false ? $html : substr( $html, $position );
 	}
 
 }

--- a/src/EntryPoints/REST/ResolveSubjectIriApi.php
+++ b/src/EntryPoints/REST/ResolveSubjectIriApi.php
@@ -109,7 +109,9 @@ class ResolveSubjectIriApi extends SimpleHandler {
 	}
 
 	private function dataTabDereference(): bool {
-		return MediaWikiServices::getInstance()->getMainConfig()->get( 'NeoWikiDereferenceSubjectsToDataTab' ) === true;
+		// The effective flag combines the MediaWiki:NeoWiki page with $wgNeoWikiDereferenceSubjectsToDataTab
+		// (the page wins when it sets a valid boolean; an invalid page value has already fallen back).
+		return NeoWikiExtension::getInstance()->dereferenceSubjectsToDataTab();
 	}
 
 	private function noDataResponse( string $subjectId ): Response {

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -16,6 +16,8 @@ use MediaWiki\Permissions\Authority;
 use MediaWiki\Rest\Response;
 use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Session\CsrfTokenSet;
+use MediaWiki\Title\Title;
+use MessageLocalizer;
 use ProfessionalWiki\NeoWiki\Application\Actions\CreateSubject\CreateSubjectAction;
 use ProfessionalWiki\NeoWiki\Application\Actions\CreateSubject\CreateSubjectPresenter;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jQueryService;
@@ -29,6 +31,10 @@ use ProfessionalWiki\NeoWiki\Application\Actions\ReplaceSubject\ReplaceSubjectPr
 use ProfessionalWiki\NeoWiki\Application\StatementListBuilder;
 use ProfessionalWiki\NeoWiki\Application\Validation\ProposedSubjectValidator;
 use ProfessionalWiki\NeoWiki\Application\Validation\SubjectValidator;
+use ProfessionalWiki\NeoWiki\Application\WikiConfig\ConfigSchema;
+use ProfessionalWiki\NeoWiki\Application\WikiConfig\ConfigValidator;
+use ProfessionalWiki\NeoWiki\Application\WikiConfig\WikiConfigLookup;
+use ProfessionalWiki\NeoWiki\Application\WikiConfig\WikiConfigSource;
 use ProfessionalWiki\NeoWiki\Application\PageIdentifiersLookup;
 use ProfessionalWiki\NeoWiki\Application\PageSubjectsLookup;
 use ProfessionalWiki\NeoWiki\Application\SubjectContentRepository;
@@ -109,6 +115,7 @@ use ProfessionalWiki\NeoWiki\Infrastructure\AuthorityBasedPageReadAuthorizer;
 use ProfessionalWiki\NeoWiki\Infrastructure\AuthorityBasedSubjectAuthorizer;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\DatabaseDeletedSubjectPageIdsLookup;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\DatabaseSchemaNameLookup;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\MediaWikiWikiConfigSource;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\PageContentFetcher;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\PageContentSaver;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\SchemaPersistenceDeserializer;
@@ -139,6 +146,7 @@ use ProfessionalWiki\NeoWiki\Persistence\DeletedSubjectPageIdsLookup;
 use ProfessionalWiki\NeoWiki\Persistence\SchemaNameLookup;
 use ProfessionalWiki\NeoWiki\Persistence\LayoutNameLookup;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\DatabaseLayoutNameLookup;
+use ProfessionalWiki\NeoWiki\Presentation\ConfigDocumentationBuilder;
 use ProfessionalWiki\NeoWiki\Presentation\CsrfValidator;
 use ProfessionalWiki\NeoWiki\Presentation\FrontendModuleLoader;
 use ProfessionalWiki\NeoWiki\Presentation\RestGetSubjectPresenter;
@@ -152,6 +160,11 @@ class NeoWikiExtension {
 	public const int NS_SCHEMA = 7474;
 	public const int NS_LAYOUT = 7476;
 	public const int NS_MAPPING = 7478;
+
+	/**
+	 * The page in the MediaWiki namespace holding the on-wiki JSON configuration (MediaWiki:NeoWiki).
+	 */
+	public const string CONFIG_PAGE_TITLE = 'NeoWiki';
 
 	private PropertyTypeRegistry $propertyTypeRegistry;
 	private PagePropertyProviderRegistry $pagePropertyProviderRegistry;
@@ -167,6 +180,7 @@ class NeoWikiExtension {
 	private ?array $sparqlPlugins = null;
 	private ClientInterface $neo4jClient;
 	private ClientInterface $readOnlyNeo4jClient;
+	private ?WikiConfigSource $wikiConfigSource = null;
 	private static ?self $instance = null;
 
 	public static function getInstance(): self {
@@ -740,10 +754,73 @@ class NeoWikiExtension {
 	}
 
 	public function shouldAutoRenderMainSubject(): bool {
-		// Behavioral config read live from MainConfig (like NeoWikiEnforceValidation),
-		// so the admin's LocalSettings value applies per request and tests can override
-		// it via overrideConfigValue() without rebuilding the getInstance() singleton.
-		return MediaWikiServices::getInstance()->getMainConfig()->get( 'NeoWikiAutoRenderMainSubject' ) === true;
+		return $this->getWikiConfigLookup()->getEffectiveValue( 'autoRenderMainSubject' ) === true;
+	}
+
+	/**
+	 * Whether a browser dereferencing a Subject concept URI is sent to the hosting page's Data tab,
+	 * combining the on-wiki configuration page with $wgNeoWikiDereferenceSubjectsToDataTab (the page wins
+	 * when it sets a valid boolean).
+	 */
+	public function dereferenceSubjectsToDataTab(): bool {
+		return $this->getWikiConfigLookup()->getEffectiveValue( 'dereferenceSubjectsToDataTab' ) === true;
+	}
+
+	/**
+	 * The combining lookup for the exposed settings. Built fresh each call so the PHP fallback and the
+	 * kill switch are read live from MainConfig (overridable in tests without a singleton rebuild), while
+	 * the page read is memoized on the shared source, keeping it to at most one read per request.
+	 */
+	public function getWikiConfigLookup(): WikiConfigLookup {
+		return new WikiConfigLookup(
+			$this->getConfigSchema(),
+			$this->getWikiConfigSource(),
+			MediaWikiServices::getInstance()->getMainConfig(),
+			$this->isInWikiConfigEnabled(),
+			LoggerFactory::getInstance( 'NeoWiki' ),
+		);
+	}
+
+	private function getWikiConfigSource(): WikiConfigSource {
+		// Cached so MediaWiki:NeoWiki is read at most once per request. Never read during extension setup:
+		// this is only reached when a request resolves an exposed setting.
+		$this->wikiConfigSource ??= new MediaWikiWikiConfigSource(
+			$this->getPageContentFetcher(),
+			$this->getRequestAuthority(),
+			self::CONFIG_PAGE_TITLE,
+			LoggerFactory::getInstance( 'NeoWiki' ),
+		);
+
+		return $this->wikiConfigSource;
+	}
+
+	public function getConfigSchema(): ConfigSchema {
+		return new ConfigSchema();
+	}
+
+	public function getConfigValidator(): ConfigValidator {
+		return new ConfigValidator( $this->getConfigSchema() );
+	}
+
+	public function newConfigDocumentationBuilder( MessageLocalizer $messageLocalizer ): ConfigDocumentationBuilder {
+		return new ConfigDocumentationBuilder( $this->getConfigSchema(), $messageLocalizer );
+	}
+
+	/**
+	 * Whether the on-wiki configuration page may be read and written. Read live from MainConfig so the
+	 * kill switch applies per request and tests can toggle it without rebuilding the singleton.
+	 */
+	public function isInWikiConfigEnabled(): bool {
+		return MediaWikiServices::getInstance()->getMainConfig()->get( 'NeoWikiEnableInWikiConfig' ) === true;
+	}
+
+	/**
+	 * Whether the given title is the on-wiki configuration page and reading it is enabled.
+	 */
+	public function isConfigPage( Title $title ): bool {
+		return $this->isInWikiConfigEnabled()
+			&& $title->getNamespace() === NS_MEDIAWIKI
+			&& $title->getText() === self::CONFIG_PAGE_TITLE;
 	}
 
 	public function getPageContentFetcher(): PageContentFetcher {

--- a/src/Persistence/MediaWiki/MediaWikiWikiConfigSource.php
+++ b/src/Persistence/MediaWiki/MediaWikiWikiConfigSource.php
@@ -1,0 +1,73 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Persistence\MediaWiki;
+
+use MediaWiki\Content\JsonContent;
+use MediaWiki\Permissions\Authority;
+use Psr\Log\LoggerInterface;
+use ProfessionalWiki\NeoWiki\Application\WikiConfig\WikiConfigSource;
+use Throwable;
+
+/**
+ * Reads the raw configuration from the on-wiki configuration page in the MediaWiki namespace, memoizing
+ * it for the request so the page is read at most once.
+ *
+ * Returns the decoded JSON object, or null when the page is missing, is not JSON, or the database is
+ * unavailable (e.g. during installation) — all fail safely to null so the caller falls back to the PHP
+ * configuration. A page that exists but does not hold a JSON object is logged once, since that is a
+ * mistake an administrator would want to see rather than a plain absence.
+ */
+class MediaWikiWikiConfigSource implements WikiConfigSource {
+
+	private bool $read = false;
+
+	/**
+	 * @var array<string, mixed>|null
+	 */
+	private ?array $config = null;
+
+	public function __construct(
+		private readonly PageContentFetcher $pageContentFetcher,
+		private readonly Authority $authority,
+		private readonly string $pageTitle,
+		private readonly LoggerInterface $logger,
+	) {
+	}
+
+	public function readConfig(): ?array {
+		if ( !$this->read ) {
+			$this->read = true;
+			$this->config = $this->doReadConfig();
+		}
+
+		return $this->config;
+	}
+
+	/**
+	 * @return array<string, mixed>|null
+	 */
+	private function doReadConfig(): ?array {
+		try {
+			$content = $this->pageContentFetcher->getPageContent( $this->pageTitle, $this->authority, NS_MEDIAWIKI );
+		} catch ( Throwable ) {
+			return null;
+		}
+
+		if ( !$content instanceof JsonContent ) {
+			return null;
+		}
+
+		$decoded = json_decode( $content->getText(), true );
+
+		if ( is_array( $decoded ) && ( $decoded === [] || !array_is_list( $decoded ) ) ) {
+			return $decoded;
+		}
+
+		$this->logger->warning( 'The MediaWiki:NeoWiki configuration page is not a JSON object; ignoring it.' );
+
+		return null;
+	}
+
+}

--- a/src/Presentation/ConfigDocumentationBuilder.php
+++ b/src/Presentation/ConfigDocumentationBuilder.php
@@ -1,0 +1,95 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Presentation;
+
+use MediaWiki\Html\Html;
+use MessageLocalizer;
+use ProfessionalWiki\NeoWiki\Application\WikiConfig\ConfigSchema;
+use ProfessionalWiki\NeoWiki\Application\WikiConfig\ConfigSetting;
+
+/**
+ * Renders the on-page reference for the on-wiki configuration page from the config schema, so it can
+ * never drift from the settings actually exposed. It lists every page key, the value it accepts, and the
+ * LocalSettings.php setting it overrides. The value description comes from each setting's own describe();
+ * the per-setting semantics live in the LocalSettings.php documentation, reached via the setting name, so
+ * they are not duplicated here.
+ */
+class ConfigDocumentationBuilder {
+
+	public const string ANCHOR = 'neowiki-config-reference';
+
+	private const string DOCUMENTATION_URL = 'https://neowiki.ai/docs/operations/installation';
+
+	public function __construct(
+		private ConfigSchema $schema,
+		private MessageLocalizer $messageLocalizer,
+	) {
+	}
+
+	/**
+	 * A one-line pointer to the on-page reference and the external documentation. Rendered to HTML so it
+	 * can be placed directly into the edit form and the view output, neither of which parses wikitext.
+	 */
+	public function buildPointer(): string {
+		return Html::rawElement(
+			'div',
+			[ 'class' => 'neowiki-config-docs-pointer' ],
+			$this->messageLocalizer->msg( 'neowiki-config-docs-pointer', self::ANCHOR, self::DOCUMENTATION_URL )->parse()
+		);
+	}
+
+	public function buildReference(): string {
+		return Html::rawElement(
+			'div',
+			[ 'class' => 'neowiki-config-docs' ],
+			Html::element(
+				'h2',
+				[ 'id' => self::ANCHOR ],
+				$this->messageLocalizer->msg( 'neowiki-config-docs-heading' )->text()
+			) . $this->renderTable()
+		);
+	}
+
+	private function renderTable(): string {
+		$rows = $this->renderHeaderRow();
+
+		foreach ( $this->schema->getSettings() as $setting ) {
+			$rows .= $this->renderRow( $setting );
+		}
+
+		return Html::rawElement( 'table', [ 'class' => 'wikitable' ], $rows );
+	}
+
+	private function renderHeaderRow(): string {
+		return Html::rawElement(
+			'tr',
+			[],
+			Html::element( 'th', [], $this->messageLocalizer->msg( 'neowiki-config-docs-column-key' )->text() )
+			. Html::element( 'th', [], $this->messageLocalizer->msg( 'neowiki-config-docs-column-value' )->text() )
+			. Html::element( 'th', [], $this->messageLocalizer->msg( 'neowiki-config-docs-column-setting' )->text() )
+		);
+	}
+
+	private function renderRow( ConfigSetting $setting ): string {
+		// The key and the LocalSettings.php setting fill their whole cell, so they are plain text; only the
+		// accepted value carries inline <code> spans on the literal JSON values, emitted raw below.
+		return Html::rawElement(
+			'tr',
+			[],
+			Html::element( 'td', [], $setting->pageKey )
+			. Html::rawElement( 'td', [], $this->describeValue( $setting ) )
+			. Html::element( 'td', [], '$wg' . $setting->settingName )
+		);
+	}
+
+	/**
+	 * The accepted-value description as HTML. The boolean type message wraps the literal JSON values in
+	 * <code> spans, so it is emitted raw — it is a trusted static message with no parameters.
+	 */
+	private function describeValue( ConfigSetting $setting ): string {
+		return $this->messageLocalizer->msg( ...$setting->describe() )->text();
+	}
+
+}

--- a/tests/phpunit/Application/WikiConfig/ConfigExampleTest.php
+++ b/tests/phpunit/Application/WikiConfig/ConfigExampleTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Application\WikiConfig;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\WikiConfig\ConfigExample;
+use ProfessionalWiki\NeoWiki\Application\WikiConfig\ConfigSchema;
+use ProfessionalWiki\NeoWiki\Application\WikiConfig\ConfigValidator;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Application\WikiConfig\ConfigExample
+ */
+class ConfigExampleTest extends TestCase {
+
+	public function testExampleIsSyntacticallyValidJson(): void {
+		json_decode( ConfigExample::JSON, true );
+
+		$this->assertSame( JSON_ERROR_NONE, json_last_error() );
+	}
+
+	public function testPreloadedExamplePassesTheValidator(): void {
+		$this->assertSame(
+			[],
+			( new ConfigValidator( new ConfigSchema() ) )->validate( ConfigExample::JSON )
+		);
+	}
+
+	public function testExampleCoversEverySetting(): void {
+		$data = json_decode( ConfigExample::JSON, true );
+
+		foreach ( ( new ConfigSchema() )->getSettings() as $setting ) {
+			$this->assertArrayHasKey( $setting->pageKey, $data );
+		}
+	}
+
+}

--- a/tests/phpunit/Application/WikiConfig/ConfigSchemaTest.php
+++ b/tests/phpunit/Application/WikiConfig/ConfigSchemaTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Application\WikiConfig;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\WikiConfig\ConfigSchema;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Application\WikiConfig\ConfigSchema
+ * @covers \ProfessionalWiki\NeoWiki\Application\WikiConfig\ConfigSetting
+ */
+class ConfigSchemaTest extends TestCase {
+
+	public function testExposesTheDereferenceSetting(): void {
+		$setting = ( new ConfigSchema() )->getSetting( 'dereferenceSubjectsToDataTab' );
+
+		$this->assertNotNull( $setting );
+		$this->assertSame( 'NeoWikiDereferenceSubjectsToDataTab', $setting->settingName );
+	}
+
+	public function testExposesTheAutoRenderSetting(): void {
+		$setting = ( new ConfigSchema() )->getSetting( 'autoRenderMainSubject' );
+
+		$this->assertNotNull( $setting );
+		$this->assertSame( 'NeoWikiAutoRenderMainSubject', $setting->settingName );
+	}
+
+	public function testExposesExactlyTheTwoAllowlistedSettings(): void {
+		$keys = array_map(
+			static fn ( $setting ): string => $setting->pageKey,
+			( new ConfigSchema() )->getSettings()
+		);
+
+		$this->assertSame( [ 'dereferenceSubjectsToDataTab', 'autoRenderMainSubject' ], $keys );
+	}
+
+	public function testUnknownKeyHasNoSetting(): void {
+		$this->assertNull( ( new ConfigSchema() )->getSetting( 'NeoWikiSparqlStores' ) );
+	}
+
+	public function testSettingAcceptsOnlyRealBooleans(): void {
+		$setting = ( new ConfigSchema() )->getSetting( 'dereferenceSubjectsToDataTab' );
+
+		$this->assertTrue( $setting->isValidValue( true ) );
+		$this->assertTrue( $setting->isValidValue( false ) );
+		$this->assertFalse( $setting->isValidValue( 'true' ) );
+		$this->assertFalse( $setting->isValidValue( 1 ) );
+		$this->assertFalse( $setting->isValidValue( null ) );
+	}
+
+	public function testSettingDescribesItselfAsBoolean(): void {
+		$setting = ( new ConfigSchema() )->getSetting( 'dereferenceSubjectsToDataTab' );
+
+		$this->assertSame( [ 'neowiki-config-type-boolean' ], $setting->describe() );
+		$this->assertSame(
+			[ 'neowiki-config-error-invalid-boolean', 'dereferenceSubjectsToDataTab' ],
+			$setting->invalidValueError()
+		);
+	}
+
+}

--- a/tests/phpunit/Application/WikiConfig/ConfigValidatorTest.php
+++ b/tests/phpunit/Application/WikiConfig/ConfigValidatorTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Application\WikiConfig;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\WikiConfig\ConfigSchema;
+use ProfessionalWiki\NeoWiki\Application\WikiConfig\ConfigValidator;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Application\WikiConfig\ConfigValidator
+ */
+class ConfigValidatorTest extends TestCase {
+
+	/**
+	 * @return array[]
+	 */
+	private function validate( string $json ): array {
+		return ( new ConfigValidator( new ConfigSchema() ) )->validate( $json );
+	}
+
+	public function testEmptyObjectIsValid(): void {
+		$this->assertSame( [], $this->validate( '{}' ) );
+	}
+
+	public function testBothSettingsPopulatedIsValid(): void {
+		$this->assertSame(
+			[],
+			$this->validate( '{ "dereferenceSubjectsToDataTab": true, "autoRenderMainSubject": false }' )
+		);
+	}
+
+	public function testSyntaxErrorIsLeftToCore(): void {
+		$this->assertSame( [], $this->validate( '{ not valid json' ) );
+	}
+
+	public function testLiteralNullIsRejectedAsNotAnObject(): void {
+		$this->assertSame( [ [ ConfigValidator::ERROR_NOT_OBJECT ] ], $this->validate( 'null' ) );
+	}
+
+	public function testJsonArrayIsRejectedAsNotAnObject(): void {
+		$this->assertSame( [ [ ConfigValidator::ERROR_NOT_OBJECT ] ], $this->validate( '[ 1, 2 ]' ) );
+	}
+
+	public function testScalarJsonIsRejectedAsNotAnObject(): void {
+		$this->assertSame( [ [ ConfigValidator::ERROR_NOT_OBJECT ] ], $this->validate( '42' ) );
+	}
+
+	public function testUnknownKeyIsRejected(): void {
+		$this->assertSame(
+			[ [ ConfigValidator::ERROR_UNKNOWN_KEY, 'NeoWikiSparqlStores' ] ],
+			$this->validate( '{ "NeoWikiSparqlStores": [] }' )
+		);
+	}
+
+	public function testWrongTypeForBooleanSettingIsRejected(): void {
+		$this->assertSame(
+			[ [ 'neowiki-config-error-invalid-boolean', 'autoRenderMainSubject' ] ],
+			$this->validate( '{ "autoRenderMainSubject": "yes" }' )
+		);
+	}
+
+	public function testWrongTypeForDereferenceSettingIsRejected(): void {
+		$this->assertSame(
+			[ [ 'neowiki-config-error-invalid-boolean', 'dereferenceSubjectsToDataTab' ] ],
+			$this->validate( '{ "dereferenceSubjectsToDataTab": "yes" }' )
+		);
+	}
+
+	public function testEveryErrorIsReported(): void {
+		$this->assertEqualsCanonicalizing(
+			[
+				[ ConfigValidator::ERROR_UNKNOWN_KEY, 'nope' ],
+				[ 'neowiki-config-error-invalid-boolean', 'dereferenceSubjectsToDataTab' ],
+			],
+			$this->validate( '{ "nope": 1, "dereferenceSubjectsToDataTab": "x" }' )
+		);
+	}
+
+}

--- a/tests/phpunit/Application/WikiConfig/WikiConfigLookupTest.php
+++ b/tests/phpunit/Application/WikiConfig/WikiConfigLookupTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Application\WikiConfig;
+
+use MediaWiki\Config\HashConfig;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\Test\TestLogger;
+use ProfessionalWiki\NeoWiki\Application\WikiConfig\ConfigSchema;
+use ProfessionalWiki\NeoWiki\Application\WikiConfig\WikiConfigLookup;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubWikiConfigSource;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Application\WikiConfig\WikiConfigLookup
+ */
+class WikiConfigLookupTest extends TestCase {
+
+	private const PHP_CONFIG = [
+		'NeoWikiDereferenceSubjectsToDataTab' => false,
+		'NeoWikiAutoRenderMainSubject' => true,
+	];
+
+	private function newLookup(
+		?array $pageData,
+		bool $enabled = true,
+		?TestLogger $logger = null
+	): WikiConfigLookup {
+		return new WikiConfigLookup(
+			new ConfigSchema(),
+			new StubWikiConfigSource( $pageData ),
+			new HashConfig( self::PHP_CONFIG ),
+			$enabled,
+			$logger ?? new TestLogger()
+		);
+	}
+
+	public function testUsesThePhpValueWhenThereIsNoConfigPage(): void {
+		$this->assertFalse( $this->newLookup( null )->getEffectiveValue( 'dereferenceSubjectsToDataTab' ) );
+	}
+
+	public function testUsesThePhpValueWhenTheKeyIsAbsentFromThePage(): void {
+		$lookup = $this->newLookup( [ 'autoRenderMainSubject' => false ] );
+
+		$this->assertFalse( $lookup->getEffectiveValue( 'dereferenceSubjectsToDataTab' ) );
+	}
+
+	public function testAValidPageValueWinsOverThePhpValue(): void {
+		$lookup = $this->newLookup( [ 'dereferenceSubjectsToDataTab' => true ] );
+
+		$this->assertTrue( $lookup->getEffectiveValue( 'dereferenceSubjectsToDataTab' ) );
+	}
+
+	public function testEachSettingIsResolvedIndependently(): void {
+		$lookup = $this->newLookup( [ 'autoRenderMainSubject' => false ] );
+
+		$this->assertFalse( $lookup->getEffectiveValue( 'autoRenderMainSubject' ) );
+	}
+
+	public function testAnInvalidPageValueFallsBackToThePhpValue(): void {
+		$lookup = $this->newLookup( [ 'dereferenceSubjectsToDataTab' => 'yes' ] );
+
+		$this->assertFalse( $lookup->getEffectiveValue( 'dereferenceSubjectsToDataTab' ) );
+	}
+
+	public function testAnInvalidPageValueLogsAWarning(): void {
+		$logger = new TestLogger();
+
+		$this->newLookup( [ 'dereferenceSubjectsToDataTab' => 'yes' ], logger: $logger )
+			->getEffectiveValue( 'dereferenceSubjectsToDataTab' );
+
+		$this->assertTrue( $logger->hasWarningRecords() );
+	}
+
+	public function testUnknownPageKeysAreToleratedOnRead(): void {
+		$logger = new TestLogger();
+		$lookup = $this->newLookup(
+			[ 'dereferenceSubjectsToDataTab' => true, 'someFutureKey' => 'whatever' ],
+			logger: $logger
+		);
+
+		$this->assertTrue( $lookup->getEffectiveValue( 'dereferenceSubjectsToDataTab' ) );
+		$this->assertFalse( $logger->hasWarningRecords() );
+	}
+
+	public function testThePageIsIgnoredWhenInWikiConfigIsDisabled(): void {
+		$lookup = $this->newLookup( [ 'dereferenceSubjectsToDataTab' => true ], enabled: false );
+
+		$this->assertFalse( $lookup->getEffectiveValue( 'dereferenceSubjectsToDataTab' ) );
+	}
+
+	public function testTheConfigPageIsReadAtMostOncePerLookup(): void {
+		$source = new StubWikiConfigSource( [ 'dereferenceSubjectsToDataTab' => true ] );
+		$lookup = new WikiConfigLookup(
+			new ConfigSchema(),
+			$source,
+			new HashConfig( self::PHP_CONFIG ),
+			true,
+			new TestLogger()
+		);
+
+		$lookup->getEffectiveValue( 'dereferenceSubjectsToDataTab' );
+		$lookup->getEffectiveValue( 'autoRenderMainSubject' );
+
+		$this->assertSame( 1, $source->readCount );
+	}
+
+}

--- a/tests/phpunit/EntryPoints/ConfigPageFramingHooksTest.php
+++ b/tests/phpunit/EntryPoints/ConfigPageFramingHooksTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints;
+
+use Article;
+use MediaWiki\Context\RequestContext;
+use MediaWiki\EditPage\EditPage;
+use MediaWiki\Request\FauxRequest;
+use MediaWiki\Title\Title;
+use MediaWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiHooks;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiHooks::onAlternateEdit
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiHooks::onConfigPageBeforePageDisplay
+ * @group Database
+ */
+class ConfigPageFramingHooksTest extends MediaWikiIntegrationTestCase {
+
+	private const string SEED_HTML =
+		'<div id="intro">Default intro</div><table class="mw-json"><tr><td>data</td></tr></table>';
+
+	private function configTitle(): Title {
+		return Title::makeTitle( NS_MEDIAWIKI, 'NeoWiki' );
+	}
+
+	private function englishContext( Title $title ): RequestContext {
+		$context = new RequestContext();
+		$context->setLanguage( 'en' );
+		$context->setTitle( $title );
+
+		return $context;
+	}
+
+	private function runAlternateEdit( Title $title ): EditPage {
+		$editPage = new EditPage( Article::newFromTitle( $title, $this->englishContext( $title ) ) );
+		NeoWikiHooks::onAlternateEdit( $editPage );
+
+		return $editPage;
+	}
+
+	public function testConfigPageEditIsFramedWithTheReference(): void {
+		$editPage = $this->runAlternateEdit( $this->configTitle() );
+
+		$this->assertTrue( $editPage->suppressIntro );
+		$this->assertStringContainsString( 'neowiki.ai', $editPage->editFormTextTop );
+		$this->assertStringContainsString( '$wgNeoWikiDereferenceSubjectsToDataTab', $editPage->editFormTextBottom );
+	}
+
+	public function testOtherMediaWikiPageEditIsNotFramed(): void {
+		$editPage = $this->runAlternateEdit( Title::makeTitle( NS_MEDIAWIKI, 'NotNeoWiki' ) );
+
+		$this->assertFalse( $editPage->suppressIntro );
+		$this->assertSame( '', $editPage->editFormTextBottom );
+	}
+
+	public function testConfigPageEditIsNotFramedWhenInWikiConfigDisabled(): void {
+		$this->overrideConfigValue( 'NeoWikiEnableInWikiConfig', false );
+
+		$editPage = $this->runAlternateEdit( $this->configTitle() );
+
+		$this->assertFalse( $editPage->suppressIntro );
+		$this->assertSame( '', $editPage->editFormTextBottom );
+	}
+
+	private function renderView( Title $title, string $action ): string {
+		$context = $this->englishContext( $title );
+		$context->setRequest( new FauxRequest( [ 'action' => $action ] ) );
+
+		$out = $context->getOutput();
+		$out->addHTML( self::SEED_HTML );
+
+		NeoWikiHooks::onConfigPageBeforePageDisplay( $out, $context->getSkin() );
+
+		return $out->getHTML();
+	}
+
+	public function testConfigPageViewIsTrimmedToTheJsonTableAndFramed(): void {
+		$html = $this->renderView( $this->configTitle(), 'view' );
+
+		$this->assertStringNotContainsString( 'Default intro', $html );
+		$this->assertStringContainsString( '<table class="mw-json"', $html );
+		$this->assertStringContainsString( 'neowiki.ai', $html );
+		$this->assertStringContainsString( '$wgNeoWikiDereferenceSubjectsToDataTab', $html );
+	}
+
+	public function testConfigPageIsUntouchedForNonViewActions(): void {
+		$html = $this->renderView( $this->configTitle(), 'history' );
+
+		$this->assertStringContainsString( 'Default intro', $html );
+		$this->assertStringNotContainsString( '$wgNeoWikiDereferenceSubjectsToDataTab', $html );
+	}
+
+	public function testOtherMediaWikiPageViewIsUntouched(): void {
+		$html = $this->renderView( Title::makeTitle( NS_MEDIAWIKI, 'NotNeoWiki' ), 'view' );
+
+		$this->assertStringContainsString( 'Default intro', $html );
+		$this->assertStringNotContainsString( '$wgNeoWikiDereferenceSubjectsToDataTab', $html );
+	}
+
+	public function testConfigPageViewIsUntouchedWhenInWikiConfigDisabled(): void {
+		$this->overrideConfigValue( 'NeoWikiEnableInWikiConfig', false );
+
+		$html = $this->renderView( $this->configTitle(), 'view' );
+
+		$this->assertStringContainsString( 'Default intro', $html );
+		$this->assertStringNotContainsString( '$wgNeoWikiDereferenceSubjectsToDataTab', $html );
+	}
+
+}

--- a/tests/phpunit/EntryPoints/ConfigPageFramingHooksTest.php
+++ b/tests/phpunit/EntryPoints/ConfigPageFramingHooksTest.php
@@ -20,7 +20,12 @@ use ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiHooks;
 class ConfigPageFramingHooksTest extends MediaWikiIntegrationTestCase {
 
 	private const string SEED_HTML =
-		'<div id="intro">Default intro</div><table class="mw-json"><tr><td>data</td></tr></table>';
+		'<div id="intro">Default intro</div>'
+		. '<div class="noresize"><table class="mw-json"><tbody><tr><td>data</td></tr></tbody></table></div>';
+
+	private const string DIFF_HTML =
+		'<table class="diff"><tr><td class="diff-marker">+</td></tr></table>'
+		. '<div class="noresize"><table class="mw-json"><tbody><tr><td>data</td></tr></tbody></table></div>';
 
 	private function configTitle(): Title {
 		return Title::makeTitle( NS_MEDIAWIKI, 'NeoWiki' );
@@ -66,11 +71,15 @@ class ConfigPageFramingHooksTest extends MediaWikiIntegrationTestCase {
 	}
 
 	private function renderView( Title $title, string $action ): string {
+		return $this->renderViewWithRequest( $title, [ 'action' => $action ], self::SEED_HTML );
+	}
+
+	private function renderViewWithRequest( Title $title, array $requestParams, string $seedHtml ): string {
 		$context = $this->englishContext( $title );
-		$context->setRequest( new FauxRequest( [ 'action' => $action ] ) );
+		$context->setRequest( new FauxRequest( $requestParams ) );
 
 		$out = $context->getOutput();
-		$out->addHTML( self::SEED_HTML );
+		$out->addHTML( $seedHtml );
 
 		NeoWikiHooks::onConfigPageBeforePageDisplay( $out, $context->getSkin() );
 
@@ -84,6 +93,27 @@ class ConfigPageFramingHooksTest extends MediaWikiIntegrationTestCase {
 		$this->assertStringContainsString( '<table class="mw-json"', $html );
 		$this->assertStringContainsString( 'neowiki.ai', $html );
 		$this->assertStringContainsString( '$wgNeoWikiDereferenceSubjectsToDataTab', $html );
+	}
+
+	public function testFramedConfigViewEmitsBalancedDivs(): void {
+		$html = $this->renderView( $this->configTitle(), 'view' );
+
+		$this->assertSame(
+			substr_count( $html, '<div' ),
+			substr_count( $html, '</div>' ),
+			'The framed config view must not leak the closing tag of the core JSON table wrapper.'
+		);
+	}
+
+	public function testConfigPageDiffIsNotFramed(): void {
+		$html = $this->renderViewWithRequest(
+			$this->configTitle(),
+			[ 'action' => 'view', 'diff' => '2' ],
+			self::DIFF_HTML
+		);
+
+		$this->assertStringContainsString( 'diff-marker', $html );
+		$this->assertStringNotContainsString( '$wgNeoWikiDereferenceSubjectsToDataTab', $html );
 	}
 
 	public function testConfigPageIsUntouchedForNonViewActions(): void {

--- a/tests/phpunit/EntryPoints/ConfigPageHooksTest.php
+++ b/tests/phpunit/EntryPoints/ConfigPageHooksTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints;
+
+use Article;
+use MediaWiki\Context\RequestContext;
+use MediaWiki\EditPage\EditPage;
+use MediaWiki\Title\Title;
+use MediaWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Application\WikiConfig\ConfigExample;
+use ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiHooks;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiHooks::onContentHandlerDefaultModelFor
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiHooks::onEditFilter
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiHooks::onEditFormPreloadText
+ * @group Database
+ */
+class ConfigPageHooksTest extends MediaWikiIntegrationTestCase {
+
+	private function configTitle(): Title {
+		return Title::makeTitle( NS_MEDIAWIKI, 'NeoWiki' );
+	}
+
+	private function newEditPage( Title $title ): EditPage {
+		$context = new RequestContext();
+		$context->setLanguage( 'en' );
+		$context->setTitle( $title );
+
+		return new EditPage( Article::newFromTitle( $title, $context ) );
+	}
+
+	private function editFilterError( Title $title, string $text ): string {
+		$error = '';
+		NeoWikiHooks::onEditFilter( $this->newEditPage( $title ), $text, '', $error, '' );
+
+		return $error;
+	}
+
+	private function preloadText( Title $title ): string {
+		$text = '';
+		NeoWikiHooks::onEditFormPreloadText( $text, $title );
+
+		return $text;
+	}
+
+	public function testConfigPageGetsTheJsonContentModel(): void {
+		$model = CONTENT_MODEL_WIKITEXT;
+
+		NeoWikiHooks::onContentHandlerDefaultModelFor( $this->configTitle(), $model );
+
+		$this->assertSame( CONTENT_MODEL_JSON, $model );
+	}
+
+	public function testOtherMediaWikiPageKeepsItsContentModel(): void {
+		$model = CONTENT_MODEL_WIKITEXT;
+
+		NeoWikiHooks::onContentHandlerDefaultModelFor( Title::makeTitle( NS_MEDIAWIKI, 'NotNeoWiki' ), $model );
+
+		$this->assertSame( CONTENT_MODEL_WIKITEXT, $model );
+	}
+
+	public function testContentModelIsNotForcedWhenInWikiConfigDisabled(): void {
+		$this->overrideConfigValue( 'NeoWikiEnableInWikiConfig', false );
+
+		$model = CONTENT_MODEL_WIKITEXT;
+		NeoWikiHooks::onContentHandlerDefaultModelFor( $this->configTitle(), $model );
+
+		$this->assertSame( CONTENT_MODEL_WIKITEXT, $model );
+	}
+
+	public function testValidConfigIsAccepted(): void {
+		$this->assertSame(
+			'',
+			$this->editFilterError( $this->configTitle(), '{ "dereferenceSubjectsToDataTab": true }' )
+		);
+	}
+
+	public function testWrongTypeForDereferenceIsRejectedWithItsMessage(): void {
+		$error = $this->editFilterError( $this->configTitle(), '{ "dereferenceSubjectsToDataTab": "sidebar" }' );
+
+		$this->assertNotSame( '', $error );
+		$this->assertStringContainsString( 'dereferenceSubjectsToDataTab', $error );
+	}
+
+	public function testUnknownKeyIsRejectedWithItsMessage(): void {
+		$error = $this->editFilterError( $this->configTitle(), '{ "NeoWikiSparqlStores": [] }' );
+
+		$this->assertStringContainsString( 'NeoWikiSparqlStores', $error );
+	}
+
+	public function testWrongTypeIsRejected(): void {
+		$error = $this->editFilterError( $this->configTitle(), '{ "autoRenderMainSubject": "yes" }' );
+
+		$this->assertStringContainsString( 'autoRenderMainSubject', $error );
+	}
+
+	public function testEditsToOtherPagesAreNotValidated(): void {
+		$this->assertSame(
+			'',
+			$this->editFilterError( Title::makeTitle( NS_MAIN, 'Some page' ), 'this is not even json' )
+		);
+	}
+
+	public function testConfigPageIsNotValidatedWhenInWikiConfigDisabled(): void {
+		$this->overrideConfigValue( 'NeoWikiEnableInWikiConfig', false );
+
+		$this->assertSame(
+			'',
+			$this->editFilterError( $this->configTitle(), '{ "dereferenceSubjectsToDataTab": "sidebar" }' )
+		);
+	}
+
+	public function testConfigPageIsPreloadedWithTheExample(): void {
+		$this->assertSame( ConfigExample::JSON, $this->preloadText( $this->configTitle() ) );
+	}
+
+	public function testOtherMediaWikiPageIsNotPreloaded(): void {
+		$this->assertSame( '', $this->preloadText( Title::makeTitle( NS_MEDIAWIKI, 'NotNeoWiki' ) ) );
+	}
+
+	public function testConfigPageIsNotPreloadedWhenInWikiConfigDisabled(): void {
+		$this->overrideConfigValue( 'NeoWikiEnableInWikiConfig', false );
+
+		$this->assertSame( '', $this->preloadText( $this->configTitle() ) );
+	}
+
+	public function testPreloadToleratesTheNullTextCorePassesForAMissingPage(): void {
+		// Core's ApiQueryInfo::extractPageInfo() invokes EditFormPreloadText with $text = null for any
+		// non-existent page (action=query&prop=info&inprop=preload), so the handler must not fatal on it.
+		$text = null;
+		NeoWikiHooks::onEditFormPreloadText( $text, Title::makeTitle( NS_MAIN, 'A missing page' ) );
+
+		$this->assertNull( $text );
+	}
+
+	public function testConfigPagePreloadFillsNullText(): void {
+		$text = null;
+		NeoWikiHooks::onEditFormPreloadText( $text, $this->configTitle() );
+
+		$this->assertSame( ConfigExample::JSON, $text );
+	}
+
+}

--- a/tests/phpunit/EntryPoints/REST/InWikiConfigDereferenceTest.php
+++ b/tests/phpunit/EntryPoints/REST/InWikiConfigDereferenceTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\REST;
+
+use MediaWiki\CommentStore\CommentStoreComment;
+use MediaWiki\Content\JsonContent;
+use MediaWiki\MediaWikiServices;
+use MediaWiki\Rest\RequestData;
+use MediaWiki\Rest\Response;
+use MediaWiki\Revision\SlotRecord;
+use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
+use MediaWiki\Title\Title;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
+use ProfessionalWiki\NeoWiki\EntryPoints\REST\ResolveSubjectIriApi;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+use TestLogger;
+
+/**
+ * End-to-end proof that the on-wiki configuration page reaches a real consumer: the Subject IRI
+ * dereference reads its target through the combining lookup, so a valid page value wins over the PHP
+ * config, an invalid one falls back with a warning, and the kill switch stops the page from applying.
+ *
+ * @covers \ProfessionalWiki\NeoWiki\Application\WikiConfig\WikiConfigLookup
+ * @covers \ProfessionalWiki\NeoWiki\NeoWikiExtension::dereferenceSubjectsToDataTab
+ * @covers \ProfessionalWiki\NeoWiki\Persistence\MediaWiki\MediaWikiWikiConfigSource
+ * @group Database
+ */
+class InWikiConfigDereferenceTest extends NeoWikiIntegrationTestCase {
+	use HandlerTestTrait;
+
+	private const string SCHEMA = 'InWikiConfigDerefSchema';
+	private const string SUBJECT_ID = 'sCfgDeref111111';
+
+	private int $pageId;
+
+	public function setUp(): void {
+		$this->setUpNeo4j();
+
+		// Pin the PHP config to the default so a passing test proves the page value, not an ambient override.
+		$this->overrideConfigValue( 'NeoWikiDereferenceSubjectsToDataTab', false );
+
+		$this->createSchema( self::SCHEMA );
+
+		$this->pageId = $this->createPageWithSubjects(
+			'InWikiConfigDereference_City',
+			mainSubject: TestSubject::build(
+				id: self::SUBJECT_ID,
+				label: new SubjectLabel( 'Berlin' ),
+				schemaName: new SchemaName( self::SCHEMA ),
+			),
+		)->getPage()->getId();
+	}
+
+	protected function tearDown(): void {
+		// Drop the memoized config-page source so a later test does not inherit it.
+		NeoWikiExtension::resetInstance();
+
+		parent::tearDown();
+	}
+
+	private function saveConfigPage( string $json ): void {
+		$wikiPage = MediaWikiServices::getInstance()->getWikiPageFactory()
+			->newFromTitle( Title::makeTitle( NS_MEDIAWIKI, NeoWikiExtension::CONFIG_PAGE_TITLE ) );
+
+		$updater = $wikiPage->newPageUpdater( $this->getTestSysop()->getUser() );
+		$updater->setContent( SlotRecord::MAIN, new JsonContent( $json ) );
+		$updater->saveRevision( CommentStoreComment::newUnsavedComment( 'config' ) );
+
+		// The source memoizes the page per request, so drop the singleton to read the just-saved page.
+		NeoWikiExtension::resetInstance();
+	}
+
+	private function htmlDereferenceLocation(): string {
+		$response = $this->executeHandler(
+			new ResolveSubjectIriApi(),
+			new RequestData( [
+				'method' => 'GET',
+				'pathParams' => [ 'subjectId' => self::SUBJECT_ID ],
+				'headers' => [ 'Accept' => 'text/html' ],
+			] ),
+		);
+
+		$this->assertSame( 303, $response->getStatusCode() );
+
+		return $response->getHeaderLine( 'Location' );
+	}
+
+	private function hostingPageUrl(): string {
+		return Title::newFromID( $this->pageId )->getCanonicalURL();
+	}
+
+	public function testAValidPageSettingWinsOverThePhpConfig(): void {
+		$this->saveConfigPage( '{ "dereferenceSubjectsToDataTab": true }' );
+
+		$location = $this->htmlDereferenceLocation();
+
+		$this->assertStringContainsString( 'action=subjects', $location, 'The redirect opens the Data tab.' );
+		$this->assertStringEndsWith( '#' . self::SUBJECT_ID, $location, 'The redirect targets the Subject row.' );
+	}
+
+	public function testAnInvalidPageSettingFallsBackToThePhpConfigAndWarns(): void {
+		$logger = new TestLogger( true );
+		$this->setLogger( 'NeoWiki', $logger );
+
+		$this->saveConfigPage( '{ "dereferenceSubjectsToDataTab": "yes" }' );
+
+		$location = $this->htmlDereferenceLocation();
+
+		$this->assertSame( $this->hostingPageUrl(), $location, 'The dereference falls back to the PHP config target.' );
+		$this->assertTrue( $this->loggedAWarning( $logger ), 'The invalid page value is logged.' );
+	}
+
+	public function testThePageSettingIsIgnoredWhenInWikiConfigIsDisabled(): void {
+		$this->saveConfigPage( '{ "dereferenceSubjectsToDataTab": true }' );
+		$this->overrideConfigValue( 'NeoWikiEnableInWikiConfig', false );
+
+		$this->assertSame(
+			$this->hostingPageUrl(),
+			$this->htmlDereferenceLocation(),
+			'With the kill switch off the page is not read, so the PHP config target applies.'
+		);
+	}
+
+	private function loggedAWarning( TestLogger $logger ): bool {
+		foreach ( $logger->getBuffer() as [ $level ] ) {
+			if ( $level === 'warning' ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+}

--- a/tests/phpunit/Persistence/MediaWiki/MediaWikiWikiConfigSourceTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/MediaWikiWikiConfigSourceTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Persistence\MediaWiki;
+
+use MediaWiki\Content\Content;
+use MediaWiki\Content\JsonContent;
+use MediaWiki\Content\WikitextContent;
+use MediaWiki\Permissions\Authority;
+use MediaWikiIntegrationTestCase;
+use Psr\Log\Test\TestLogger;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\MediaWikiWikiConfigSource;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubPageContentFetcher;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Persistence\MediaWiki\MediaWikiWikiConfigSource
+ */
+class MediaWikiWikiConfigSourceTest extends MediaWikiIntegrationTestCase {
+
+	private function newSource( ?Content $content, ?TestLogger $logger = null, bool $throw = false ): MediaWikiWikiConfigSource {
+		return new MediaWikiWikiConfigSource(
+			new StubPageContentFetcher( $content, $throw ),
+			$this->createMock( Authority::class ),
+			'NeoWiki',
+			$logger ?? new TestLogger()
+		);
+	}
+
+	public function testReturnsTheDecodedObjectFromAJsonPage(): void {
+		$source = $this->newSource( new JsonContent( '{ "dereferenceSubjectsToDataTab": true }' ) );
+
+		$this->assertSame( [ 'dereferenceSubjectsToDataTab' => true ], $source->readConfig() );
+	}
+
+	public function testReturnsNullWhenThePageIsMissing(): void {
+		$this->assertNull( $this->newSource( null )->readConfig() );
+	}
+
+	public function testReturnsNullForNonJsonContent(): void {
+		$this->assertNull( $this->newSource( new WikitextContent( '{ "x": 1 }' ) )->readConfig() );
+	}
+
+	public function testReturnsNullAndWarnsWhenThePageIsNotAJsonObject(): void {
+		$logger = new TestLogger();
+
+		$this->assertNull( $this->newSource( new JsonContent( '[ 1, 2 ]' ), $logger )->readConfig() );
+		$this->assertTrue( $logger->hasWarningRecords() );
+	}
+
+	public function testReturnsNullWhenTheDatabaseIsUnavailable(): void {
+		$this->assertNull( $this->newSource( null, throw: true )->readConfig() );
+	}
+
+	public function testReadsThePageAtMostOnce(): void {
+		$fetcher = new StubPageContentFetcher( new JsonContent( '{}' ) );
+		$source = new MediaWikiWikiConfigSource( $fetcher, $this->createMock( Authority::class ), 'NeoWiki', new TestLogger() );
+
+		$source->readConfig();
+		$source->readConfig();
+
+		$this->assertSame( 1, $fetcher->fetchCount );
+	}
+
+}

--- a/tests/phpunit/Presentation/ConfigDocumentationBuilderTest.php
+++ b/tests/phpunit/Presentation/ConfigDocumentationBuilderTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Presentation;
+
+use MediaWiki\Context\RequestContext;
+use MediaWiki\Title\Title;
+use MediaWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Application\WikiConfig\ConfigSchema;
+use ProfessionalWiki\NeoWiki\Presentation\ConfigDocumentationBuilder;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Presentation\ConfigDocumentationBuilder
+ */
+class ConfigDocumentationBuilderTest extends MediaWikiIntegrationTestCase {
+
+	private function newBuilder(): ConfigDocumentationBuilder {
+		$context = new RequestContext();
+		$context->setLanguage( 'en' );
+		$context->setTitle( Title::makeTitle( NS_MEDIAWIKI, 'NeoWiki' ) );
+
+		return new ConfigDocumentationBuilder( new ConfigSchema(), $context );
+	}
+
+	public function testReferenceListsEverySettingAndTheLocalSettingsNameItOverrides(): void {
+		$html = $this->newBuilder()->buildReference();
+
+		foreach ( ( new ConfigSchema() )->getSettings() as $setting ) {
+			$this->assertStringContainsString( '>' . $setting->pageKey . '<', $html );
+			$this->assertStringContainsString( '$wg' . $setting->settingName, $html );
+		}
+	}
+
+	public function testReferenceShowsBooleanAcceptedValuesAsCodeSpans(): void {
+		$html = $this->newBuilder()->buildReference();
+
+		$this->assertStringContainsString( '<code>true</code>', $html );
+		$this->assertStringContainsString( '<code>false</code>', $html );
+	}
+
+	public function testReferenceDoesNotWrapTheSettingKeysInCode(): void {
+		// The key and LocalSettings.php columns fill their cell, so they are plain text, not code chips.
+		$this->assertStringContainsString( '<td>dereferenceSubjectsToDataTab</td>', $this->newBuilder()->buildReference() );
+	}
+
+	public function testReferenceCarriesTheAnchorThePointerLinksTo(): void {
+		$this->assertStringContainsString(
+			'id="' . ConfigDocumentationBuilder::ANCHOR . '"',
+			$this->newBuilder()->buildReference()
+		);
+	}
+
+	public function testPointerLinksToTheReferenceAndTheDocumentation(): void {
+		$html = $this->newBuilder()->buildPointer();
+
+		$this->assertStringContainsString( '#' . ConfigDocumentationBuilder::ANCHOR, $html );
+		$this->assertStringContainsString( 'neowiki.ai/docs/operations/installation', $html );
+	}
+
+}

--- a/tests/phpunit/TestDoubles/StubPageContentFetcher.php
+++ b/tests/phpunit/TestDoubles/StubPageContentFetcher.php
@@ -1,0 +1,43 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\TestDoubles;
+
+use MediaWiki\Content\Content;
+use MediaWiki\Permissions\Authority;
+use MediaWiki\Revision\SlotRecord;
+use MediaWiki\Title\Title;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\PageContentFetcher;
+use RuntimeException;
+
+/**
+ * A PageContentFetcher that returns a fixed Content, records how many times it was asked, and can
+ * simulate the database being unavailable by throwing.
+ */
+class StubPageContentFetcher extends PageContentFetcher {
+
+	public int $fetchCount = 0;
+
+	public function __construct(
+		private readonly ?Content $content,
+		private readonly bool $throw = false,
+	) {
+	}
+
+	public function getPageContent(
+		string|Title $pageTitle,
+		Authority $authority,
+		int $defaultNamespace = NS_MAIN,
+		string $slotName = SlotRecord::MAIN
+	): ?Content {
+		$this->fetchCount++;
+
+		if ( $this->throw ) {
+			throw new RuntimeException( 'Database unavailable' );
+		}
+
+		return $this->content;
+	}
+
+}

--- a/tests/phpunit/TestDoubles/StubWikiConfigSource.php
+++ b/tests/phpunit/TestDoubles/StubWikiConfigSource.php
@@ -1,0 +1,23 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\TestDoubles;
+
+use ProfessionalWiki\NeoWiki\Application\WikiConfig\WikiConfigSource;
+
+class StubWikiConfigSource implements WikiConfigSource {
+
+	public int $readCount = 0;
+
+	public function __construct(
+		private readonly ?array $configData
+	) {
+	}
+
+	public function readConfig(): ?array {
+		$this->readCount++;
+		return $this->configData;
+	}
+
+}


### PR DESCRIPTION
Add an on-wiki JSON configuration page at MediaWiki:NeoWiki

A wiki administrator without server access can set a vetted subset of NeoWiki's configuration on the
`MediaWiki:NeoWiki` page. It holds JSON and is forced to the JSON content model on exactly that title, so
MediaWiki gives it `editinterface` + `editsitejson` edit protection, JSON syntax enforcement, and the JSON
editor for free. Set `$wgNeoWikiEnableInWikiConfig` to `false` to disable it entirely: the page is then
never given the content model, validated, or read.

> Builds on the merged #1141 (the boolean `$wgNeoWikiDereferenceSubjectsToDataTab` rename); the branch is a
> single commit on current master. Both exposed settings are boolean.

## Exposed settings (the allowlist is the security boundary)

| Page key | Overrides | Accepts |
|---|---|---|
| `dereferenceSubjectsToDataTab` | `$wgNeoWikiDereferenceSubjectsToDataTab` | `true` \| `false` |
| `autoRenderMainSubject` | `$wgNeoWikiAutoRenderMainSubject` | `true` \| `false` |

Every other setting stays exclusive to `LocalSettings.php`, deliberately: `NeoWikiSparqlStores` is
infrastructure and carries secrets (secrets never go on-wiki); `NeoWikiRdfBaseUri` re-mints every IRI when
changed, too consequential for a wiki page; `NeoWikiEnableDevelopmentUI` is dev-only. Future settings are
vetted and added one at a time.

## Precedence and failure semantics

Per setting, a valid value on the page wins; otherwise the `LocalSettings.php` value (itself the
extension.json default) applies. A missing page, unparseable JSON, a value of the wrong shape, or an
unavailable database all fall back to `LocalSettings.php` rather than throwing — a config typo must not take
down the wiki (the NeoWikiConfigFactory stance). The read path is tolerant and forward-compatible: unknown
keys are ignored, and one NeoWiki-channel warning is logged when the page exists but a value (or the whole
document) is unusable. The page is read at most once per request (memoized on a request-scoped source) and
never during extension registration.

Saving is strict: an EditFilter rejects non-object JSON, unknown keys, and wrong-typed values with precise,
i18n'd, per-field errors, so a typo is caught where the admin can fix it.

One schema structure (`ConfigSchema` → `ConfigSetting`) defines each key once and drives save validation, the
generated on-page reference table, and the preloaded example, so they cannot drift. A test pins the preloaded
example against the validator.

The two existing consumers now read through the combining lookup:
`ResolveSubjectIriApi::dataTabDereference()` and `NeoWikiExtension::shouldAutoRenderMainSubject()`, each as a
strict boolean. Their existing contracts hold whichever source supplied the value.

## Documentation affordances (that title only, kill-switch-gated)

- Editing suppresses the default MediaWiki-namespace intro and frames the JSON editor with a one-line docs
  pointer and the schema-generated reference table (page key | accepted value | LocalSettings.php setting).
  The key and setting columns are plain text; the accepted value shows the literal JSON values (`true` /
  `false`) as `<code>` spans.
- Viewing shows the same pointer and reference around the core JSON table.
- Creating preloads a small valid example covering both settings.

## Parser-cache staleness

`dereferenceSubjectsToDataTab` is read at request time, so it takes effect immediately. `autoRenderMainSubject`
affects rendered page HTML, so already-cached pages keep their previous rendering until they re-parse (or a
`?action=purge`) — accepted, and stated in the docs.

## Alternatives considered and rejected

- **CommunityConfiguration** (extension): a schema-driven config framework with a generated form UI. Rejected
  as the primary mechanism: it is a dependency, and form-first where NeoWiki wants a small JSON-first page with
  no new dependency. It stays composable — PHP/LocalSettings remains authoritative underneath, so a form layer
  could sit on top later.
- **BlueSpice ConfigManager**: the distribution's own config UI. Same shape (form-first, distribution-specific).
  NeoWiki must work on plain MediaWiki, and the JSON page composes under any such layer since the values still
  resolve through the same PHP settings.

## Considered, omitted

- A ConfigType class hierarchy (Maps ships twelve): unwarranted here. Both exposed settings are boolean, so
  `ConfigSetting` fixes the value shape directly with no discriminator; the enum machinery (and its
  `ConfigValueType`) was dropped when the dereference target became boolean, and is re-added with the first
  genuinely differently-shaped setting.
- A visual/form editor: the JSON page plus the generated reference is enough; a form layer can compose on top.
- Folding the combined values onto the `NeoWikiConfig` value object: kept separate and lazy so the eager config
  VO never triggers a DB read and behavioural settings stay overridable in tests without a singleton rebuild.

Ported from the Maps extension's `MediaWiki:Maps` pattern (PRs ProfessionalWiki/Maps#925 and #928), scaled to
two settings and NeoWiki's hexagonal layering.


> <sub>AI-authored — Claude Code, `Opus 4.8 (max)`; detailed spec from @JeroenDeDauw plus a two-change review follow-up; not yet human-reviewed (an earlier AI correctness/security + design pass caught and fixed a blocking `EditFormPreloadText` null-`$text` fatal, with a regression test). Rebased to a single commit on master after #1141 merged; both settings are boolean and the enum machinery is removed. Full PHPUnit (2018) + phpcs + phpstan green; CI green; live re-verified on a dev wiki (restyled reference table, page-wins dereference to the Data tab, save rejection, kill-switch).</sub>

