### PR TITLE
Replace the enum dereference target with a boolean setting

### DIFF
--- a/docs/rdf/rdf-export.md
+++ b/docs/rdf/rdf-export.md
@@ -18,7 +18,7 @@ For an end-to-end example comparing the native and ontology-mapped output, see t
 | Setting | Default | Purpose |
 |---|---|---|
 | `$wgNeoWikiRdfBaseUri` | the wiki's canonical URL (`$wgCanonicalServer`) | Base URI under which all NeoWiki IRIs are minted. |
-| `$wgNeoWikiSubjectDereferenceTarget` | `page` | Where a browser dereferencing a Subject IRI lands: the hosting `page`, or its `data-tab` row. |
+| `$wgNeoWikiDereferenceSubjectsToDataTab` | `false` | Whether a browser dereferencing a Subject IRI lands on the hosting page's Data tab row instead of the plain page. |
 
 ## IRI scheme
 
@@ -108,7 +108,7 @@ TriG wins when both RDF types are acceptable; the RDF redirects use the native p
 on a page the caller may not read returns one indistinguishable `404`; a malformed id `400`.
 
 The HTML target is the Subject's hosting page by default, or that page's Data tab (`?action=subjects`) opened on the
-Subject's row (`#{subjectId}`) when `$wgNeoWikiSubjectDereferenceTarget` is `data-tab`.
+Subject's row (`#{subjectId}`) when `$wgNeoWikiDereferenceSubjectsToDataTab` is enabled.
 
 The negotiator is always reachable at the REST path, which needs no server configuration:
 

--- a/extension.json
+++ b/extension.json
@@ -197,9 +197,9 @@
 			"description": "Base URI under which the RDF export mints all NeoWiki IRIs (entity, property, schema, page, etc.). When null, defaults to the wiki's canonical URL ($wgCanonicalServer). Wiki-level on purpose, so sibling projections describe the same entities with identical IRIs.",
 			"value": null
 		},
-		"NeoWikiSubjectDereferenceTarget": {
-			"description": "Where a browser dereferencing a Subject's concept URI (Accept: text/html) is sent: 'page' (default) for the Subject's hosting page, or 'data-tab' for that page's Data tab (?action=subjects) opened on the Subject's row (expanded, scrolled to, highlighted). Any other value is a configuration error.",
-			"value": "page"
+		"NeoWikiDereferenceSubjectsToDataTab": {
+			"description": "Whether a browser dereferencing a Subject's concept URI (Accept: text/html) is sent to the hosting page's Data tab (?action=subjects) opened on the Subject's row (expanded, scrolled to, highlighted). When false (default), it is sent to the plain hosting page.",
+			"value": false
 		},
 		"NeoWikiSparqlStores": {
 			"description": "SPARQL 1.1 graph stores to keep in sync with page changes and to query, in addition to any Neo4j backend. A list of objects, each with: 'updateUrl' (required, the store's SPARQL 1.1 Update endpoint, e.g. a QLever instance); 'queryUrl' (optional, the store's SPARQL 1.1 Query endpoint the read surfaces use; defaults to 'updateUrl', which is correct for QLever where the two are the same); 'accessToken' (optional, sent as an HTTP Bearer token on both update and query requests, e.g. for a QLever access token or a read-protected endpoint); and 'projection' (optional, the RDF vocabulary written to the store: 'native' by default, or any configured Mapping target). The query surfaces (the {{#sparql_raw}} parser function, nw.sparqlQuery() in Lua, and POST /neowiki/v0/query/sparql) target the first configured store. Works with QLever and any SPARQL 1.1 store. Empty by default.",

--- a/src/EntryPoints/REST/ResolveSubjectIriApi.php
+++ b/src/EntryPoints/REST/ResolveSubjectIriApi.php
@@ -4,7 +4,6 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\EntryPoints\REST;
 
-use MediaWiki\Config\ConfigException;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Rest\Response;
 use MediaWiki\Rest\SimpleHandler;
@@ -24,7 +23,7 @@ use Wikimedia\ParamValidator\ParamValidator;
  *   - else `Accept` includes `text/turtle` → the Subject's Turtle RDF export (TriG wins a tie, matching
  *     {@see RdfFormatNegotiation}).
  *   - else (a browser's `text/html`, `*&#47;*`, an absent or unrecognized `Accept`) → the hosting page, or
- *     its Data tab row when `$wgNeoWikiSubjectDereferenceTarget` is `data-tab`.
+ *     its Data tab row when `$wgNeoWikiDereferenceSubjectsToDataTab` is enabled.
  *
  * The RDF branches target the native projection: selecting an ontology target or a specific
  * serialization stays on the per-Subject RDF endpoint, keeping this concept-URI surface Accept-only.
@@ -110,16 +109,7 @@ class ResolveSubjectIriApi extends SimpleHandler {
 	}
 
 	private function dataTabDereference(): bool {
-		$value = MediaWikiServices::getInstance()->getMainConfig()->get( 'NeoWikiSubjectDereferenceTarget' );
-
-		// An unrecognized value is surfaced as a configuration error rather than silently treated as 'page'.
-		return match ( $value ) {
-			'data-tab' => true,
-			'page' => false,
-			default => throw new ConfigException(
-				'Unrecognized $wgNeoWikiSubjectDereferenceTarget value: ' . var_export( $value, true )
-			),
-		};
+		return MediaWikiServices::getInstance()->getMainConfig()->get( 'NeoWikiDereferenceSubjectsToDataTab' ) === true;
 	}
 
 	private function noDataResponse( string $subjectId ): Response {

--- a/tests/phpunit/EntryPoints/REST/ResolveSubjectIriApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ResolveSubjectIriApiTest.php
@@ -4,7 +4,6 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\REST;
 
-use MediaWiki\Config\ConfigException;
 use MediaWiki\Permissions\Authority;
 use MediaWiki\Rest\RequestData;
 use MediaWiki\Rest\Response;
@@ -34,10 +33,10 @@ class ResolveSubjectIriApiTest extends NeoWikiIntegrationTestCase {
 	public function setUp(): void {
 		$this->setUpNeo4j();
 
-		// Pin the default dereference target so the Accept-negotiation tests are independent of any
-		// ambient $wgNeoWikiSubjectDereferenceTarget (e.g. a dev LocalSettings override). Tests that
-		// exercise a specific target override this.
-		$this->overrideConfigValue( 'NeoWikiSubjectDereferenceTarget', 'page' );
+		// Pin the default so the Accept-negotiation tests are independent of any ambient
+		// $wgNeoWikiDereferenceSubjectsToDataTab (e.g. a dev LocalSettings override). The Data-tab tests
+		// override this.
+		$this->overrideConfigValue( 'NeoWikiDereferenceSubjectsToDataTab', false );
 
 		$this->createSchema( self::SCHEMA );
 
@@ -109,7 +108,7 @@ class ResolveSubjectIriApiTest extends NeoWikiIntegrationTestCase {
 	}
 
 	public function testDataTabDereferenceTargetRedirectsToTheSubjectsRow(): void {
-		$this->overrideConfigValue( 'NeoWikiSubjectDereferenceTarget', 'data-tab' );
+		$this->overrideConfigValue( 'NeoWikiDereferenceSubjectsToDataTab', true );
 
 		$response = $this->deref( headers: [ 'Accept' => 'text/html' ] );
 
@@ -131,20 +130,12 @@ class ResolveSubjectIriApiTest extends NeoWikiIntegrationTestCase {
 	}
 
 	public function testDataTabTargetLeavesTheRdfBranchesUnchanged(): void {
-		$this->overrideConfigValue( 'NeoWikiSubjectDereferenceTarget', 'data-tab' );
+		$this->overrideConfigValue( 'NeoWikiDereferenceSubjectsToDataTab', true );
 
 		$response = $this->deref( headers: [ 'Accept' => 'application/trig' ] );
 
 		$this->assertSame( 303, $response->getStatusCode() );
 		$this->assertSubjectRdfLocation( $response, 'trig' );
-	}
-
-	public function testUnrecognizedDereferenceTargetIsAConfigError(): void {
-		$this->overrideConfigValue( 'NeoWikiSubjectDereferenceTarget', 'sidebar' );
-
-		$this->expectException( ConfigException::class );
-
-		$this->deref( headers: [ 'Accept' => 'text/html' ] );
 	}
 
 	public function testReturns404ForAnUnknownSubject(): void {


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1123

Replaces the string `$wgNeoWikiSubjectDereferenceTarget` (`page` | `data-tab`) with the boolean `$wgNeoWikiDereferenceSubjectsToDataTab` (default `false` = the hosting page). The name parallels `$wgNeoWikiAutoRenderMainSubject`.

The enum only ever had two values and manufactured an unrecognized-value failure class that `ResolveSubjectIriApi` handled with a `ConfigException`, and that the now-closed https://github.com/ProfessionalWiki/NeoWiki/pull/1138 set out to soften into a fallback+warning. A boolean cannot be unrecognized, so the whole failure class — the `match`, the `ConfigException`, and its test — is deleted rather than handled. No third target is imminent; if one ever appears, boolean -> enum is a config rename at that point, accepted deliberately.

NeoWiki is not in production, so this is a clean rename with no back-compat shim.

`ResolveSubjectIriApi` now reads the setting as a strict `=== true` boolean, mirroring `shouldAutoRenderMainSubject()`. Swept the old setting from `extension.json`, `docs/rdf/rdf-export.md`, and the handler docblock; the Data-tab redirect (`?action=subjects#{subjectId}`) is unchanged.

> <sub>AI-authored — Claude Code, `Opus 4.8 (max)`; part of a two-change follow-up steered by @JeroenDeDauw's review of #1139; diff not yet human-reviewed; full PHPUnit (1950) + phpcs + phpstan green, live-smoked on a dev wiki (boolean true → Data-tab 303, false → hosting page); CI green.</sub>

