### PR TITLE
Mark ADR 19 as Accepted

### DIFF
--- a/docs/adr/019-graph-database-architecture.md
+++ b/docs/adr/019-graph-database-architecture.md
@@ -2,7 +2,7 @@
 
 Date: 2026-02-13
 
-Status: Draft
+Status: Accepted (2026-07-23)
 
 ## Context
 


### PR DESCRIPTION
ADR 19's graph-database plugin architecture is implemented (Neo4j and SPARQL plugins, per-backend query surfaces), but its status still said Draft. Mark it Accepted.

> <sub>AI-authored — Claude Code, `Fable 5 (max)`; in-session ask from @JeroenDeDauw after reviewing why the ADR was still Draft, no revisions; diff not yet human-reviewed; one-line status flip — verified the plugin system the ADR records is on master and this was the only remaining Draft ADR; CI green.</sub>