### PR TITLE
Serve the Data tab at /wiki/PageName/subjects in the demo image

### DIFF
--- a/Docker/SettingsTemplate.php
+++ b/Docker/SettingsTemplate.php
@@ -44,6 +44,9 @@ $wgScriptPath = '/w';
 $wgArticlePath = "/wiki/$1";
 $wgUsePathInfo = true;
 
+## Pretty URLs for the NeoWiki Data tab: /wiki/PageName/subjects
+$wgActionPaths['subjects'] = "/wiki/$1/subjects";
+
 ## The protocol and server name to use in fully-qualified URLs
 $wgServer = getenv( 'MW_SERVER' );
 

--- a/docs/operations/installation.md
+++ b/docs/operations/installation.md
@@ -158,6 +158,18 @@ php maintenance/run.php NeoWiki:RebuildGraphDatabases
 
 If all four steps work, your install is complete.
 
+### Optional: Pretty URLs for the Data tab
+
+The Data tab is the `subjects` action. Add an action path to serve it at `/wiki/PageName/subjects` instead of the
+`index.php?action=subjects` form:
+
+```php
+$wgActionPaths['subjects'] = "/wiki/$1/subjects";
+```
+
+Use the same pattern as your wiki's article path. The Docker stack ships this by default. A page whose title ends
+in `/subjects` is then shadowed — reachable only through `index.php?title=`.
+
 ## Key settings
 
 These are the settings you are most likely to change. For the full list with descriptions and defaults, see the

--- a/docs/operations/installation.md
+++ b/docs/operations/installation.md
@@ -160,7 +160,7 @@ If all four steps work, your install is complete.
 
 ### Optional: Pretty URLs for the Data tab
 
-The Data tab is the `subjects` action. Add an action path to serve it at `/wiki/PageName/subjects` instead of the
+Serve the Data tab (the `subjects` action) at `/wiki/PageName/subjects` instead of the
 `index.php?action=subjects` form:
 
 ```php

--- a/docs/operations/installation.md
+++ b/docs/operations/installation.md
@@ -160,15 +160,11 @@ If all four steps work, your install is complete.
 
 ### Optional: Pretty URLs for the Data tab
 
-Serve the Data tab (the `subjects` action) at `/wiki/PageName/subjects` instead of the
-`index.php?action=subjects` form:
+Serve the Data tab at `/wiki/PageName/subjects` instead of `index.php?action=subjects` with:
 
 ```php
 $wgActionPaths['subjects'] = "/wiki/$1/subjects";
 ```
-
-Use the same pattern as your wiki's article path. The Docker stack ships this by default. A page whose title ends
-in `/subjects` is then shadowed — reachable only through `index.php?title=`.
 
 ## Key settings
 


### PR DESCRIPTION
Serve NeoWiki's Data tab (the `subjects` action) at `/wiki/PageName/subjects` rather than
`/w/index.php?title=PageName&action=subjects`, so a shared deep link to a Subject reads like
`https://host/wiki/Rijksmuseum/subjects#sEpfwJLAtndCccC`.

`Docker/SettingsTemplate.php` — baked into the demo image as `LocalSettings.php`, and used by the dev
stack — gains one action path:

```php
$wgActionPaths['subjects'] = "/wiki/$1/subjects";
```

No extension code is needed. NeoWiki builds every `action=subjects` URL through
`Title::getLocalURL`/`getCanonicalURL` — the Data-tab link, the page-tools link, and (when
`$wgNeoWikiDereferenceSubjectsToDataTab` is enabled) the concept-URI dereference redirect — which
MediaWiki already routes through `$wgActionPaths`; incoming requests reuse the same `PathRouter` that
serves the `/wiki/$1` article path, so slashed titles still resolve. Old `?action=subjects` URLs keep
working.

Accepted trade-off: a page whose title ends in `/subjects` is shadowed — its pretty URL and internal
links route to the parent title's Data tab; the page stays reachable via `index.php?title=`. Fine for
the demo image default.

`docs/operations/installation.md` documents the setting for manual installers (the Docker stack ships it
by default).

Verified live on a seeded demo wiki (config + docs only, no extension code, so no new tests): the
Data-tab link now emits `/wiki/Rijksmuseum/subjects`; that URL serves the Data tab while
`/wiki/Rijksmuseum` still serves the page; the old `?action=subjects` URL still works; a slashed title
(`Foo/Bar`) routes correctly both ways; and `/wiki/Rijksmuseum/subjects#<subjectId>` expands and
highlights the target Subject row.

> <sub>AI-authored — Claude Code, `Opus 4.8 (max)`; detailed spec from @JeroenDeDauw, executed by an Opus subagent with no mid-task human steering; self-reviewed in-session (not yet human-reviewed); `make cs` green, `ResolveSubjectIriApiTest` passing, URL routing and fragment deep-link verified live on the dev stack, CI green.</sub>
