### PR TITLE
Fix on-wiki config page view framing on diffs and stray </div>

### DIFF
--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -483,23 +483,41 @@ class NeoWikiHooks {
 			return;
 		}
 
-		$action = MediaWikiServices::getInstance()->getActionFactory()->getActionName( $out->getContext() );
+		$context = $out->getContext();
+		$action = MediaWikiServices::getInstance()->getActionFactory()->getActionName( $context );
 
-		if ( $action !== 'view' ) {
+		// A diff request also resolves to the 'view' action, but renders a comparison the framing
+		// would discard, so only a plain page view is reduced to the JSON table and framed.
+		if ( $action !== 'view' || $context->getRequest()->getCheck( 'diff' ) ) {
 			return;
 		}
 
-		$builder = NeoWikiExtension::getInstance()->newConfigDocumentationBuilder( $out->getContext() );
-		$trimmed = self::trimToJsonTable( $out->getHTML() );
+		$builder = NeoWikiExtension::getInstance()->newConfigDocumentationBuilder( $context );
+		$table = self::extractJsonTable( $out->getHTML() );
 
 		$out->clearHTML();
-		$out->addHTML( $builder->buildPointer() . $trimmed . $builder->buildReference() );
+		$out->addHTML( $builder->buildPointer() . $table . $builder->buildReference() );
 	}
 
-	private static function trimToJsonTable( string $html ): string {
-		$position = strpos( $html, '<table class="mw-json"' );
+	/**
+	 * Extracts just the core JSON table element. Core wraps it in a <div class="noresize">, so taking
+	 * the balanced <table>...</table> rather than everything to the end of the body avoids re-emitting
+	 * that wrapper's orphaned closing tag.
+	 */
+	private static function extractJsonTable( string $html ): string {
+		$start = strpos( $html, '<table class="mw-json"' );
 
-		return $position === false ? $html : substr( $html, $position );
+		if ( $start === false ) {
+			return $html;
+		}
+
+		$end = strpos( $html, '</table>', $start );
+
+		if ( $end === false ) {
+			return substr( $html, $start );
+		}
+
+		return substr( $html, $start, $end - $start + strlen( '</table>' ) );
 	}
 
 }

--- a/tests/phpunit/EntryPoints/ConfigPageFramingHooksTest.php
+++ b/tests/phpunit/EntryPoints/ConfigPageFramingHooksTest.php
@@ -20,7 +20,12 @@ use ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiHooks;
 class ConfigPageFramingHooksTest extends MediaWikiIntegrationTestCase {
 
 	private const string SEED_HTML =
-		'<div id="intro">Default intro</div><table class="mw-json"><tr><td>data</td></tr></table>';
+		'<div id="intro">Default intro</div>'
+		. '<div class="noresize"><table class="mw-json"><tbody><tr><td>data</td></tr></tbody></table></div>';
+
+	private const string DIFF_HTML =
+		'<table class="diff"><tr><td class="diff-marker">+</td></tr></table>'
+		. '<div class="noresize"><table class="mw-json"><tbody><tr><td>data</td></tr></tbody></table></div>';
 
 	private function configTitle(): Title {
 		return Title::makeTitle( NS_MEDIAWIKI, 'NeoWiki' );
@@ -66,11 +71,15 @@ class ConfigPageFramingHooksTest extends MediaWikiIntegrationTestCase {
 	}
 
 	private function renderView( Title $title, string $action ): string {
+		return $this->renderViewWithRequest( $title, [ 'action' => $action ], self::SEED_HTML );
+	}
+
+	private function renderViewWithRequest( Title $title, array $requestParams, string $seedHtml ): string {
 		$context = $this->englishContext( $title );
-		$context->setRequest( new FauxRequest( [ 'action' => $action ] ) );
+		$context->setRequest( new FauxRequest( $requestParams ) );
 
 		$out = $context->getOutput();
-		$out->addHTML( self::SEED_HTML );
+		$out->addHTML( $seedHtml );
 
 		NeoWikiHooks::onConfigPageBeforePageDisplay( $out, $context->getSkin() );
 
@@ -84,6 +93,27 @@ class ConfigPageFramingHooksTest extends MediaWikiIntegrationTestCase {
 		$this->assertStringContainsString( '<table class="mw-json"', $html );
 		$this->assertStringContainsString( 'neowiki.ai', $html );
 		$this->assertStringContainsString( '$wgNeoWikiDereferenceSubjectsToDataTab', $html );
+	}
+
+	public function testFramedConfigViewEmitsBalancedDivs(): void {
+		$html = $this->renderView( $this->configTitle(), 'view' );
+
+		$this->assertSame(
+			substr_count( $html, '<div' ),
+			substr_count( $html, '</div>' ),
+			'The framed config view must not leak the closing tag of the core JSON table wrapper.'
+		);
+	}
+
+	public function testConfigPageDiffIsNotFramed(): void {
+		$html = $this->renderViewWithRequest(
+			$this->configTitle(),
+			[ 'action' => 'view', 'diff' => '2' ],
+			self::DIFF_HTML
+		);
+
+		$this->assertStringContainsString( 'diff-marker', $html );
+		$this->assertStringNotContainsString( '$wgNeoWikiDereferenceSubjectsToDataTab', $html );
 	}
 
 	public function testConfigPageIsUntouchedForNonViewActions(): void {


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1139

`onConfigPageBeforePageDisplay` reduced the config page to its JSON table on every `view` action. A diff request (`?diff=`) also resolves to the `view` action, so the comparison table was discarded and replaced by the framed current revision; guard against it so diffs of `MediaWiki:NeoWiki` render normally.

The trim also took everything from the mw-json table to the end of the body. Core wraps that table in `<div class="noresize">`, so the slice re-emitted the wrapper's orphaned closing `</div>`, leaving the framed view with unbalanced HTML (the reference block escaped `#mw-content-text`). Extract the balanced `<table>...</table>` element instead.

### Scope: minimal guard vs. content-layer framing

Guarding on the `diff` request keeps this a surgical fix. The more robust option is to stop reframing in `BeforePageDisplay` at all: that hook sees the fully-assembled page (diffs and other sub-modes included), so it has to blacklist everything that is not a plain view. Framing at the content-render layer instead, e.g. an `onArticleRevisionViewCustom`-style hook that never fires for diffs and returns balanced HTML rather than slicing core's output, would remove both defects by construction and drop the action guard entirely. WikibaseRDF already frames its config page that way. That reshapes the framing mechanism, so it is out of scope here; noted as the direction if the shared pattern is consolidated.

## Same defect in the sibling extensions sharing this pattern

This view-framing was ported from Maps' `MediaWiki:Maps` page, and the same two defects exist unchanged wherever the pattern was copied:

- Maps — `src/MapsHooks.php`
- WikibaseExport — `src/EntryPoints/MediaWikiHooks.php`
- WikibaseFacetedSearch — `src/EntryPoints/WikibaseFacetedSearchHooks.php`

Each trims with `substr( $html, strpos( $html, '<table class="mw-json">' ) )` reachable on the `view` action, so a diff of the config page is discarded and every view emits an unbalanced `</div>`. The two Wikibase ones additionally guard with `if ( !$jsonTablePosition )`, which skips trimming if the table is ever at offset 0. They warrant the same fix; out of scope for this PR.

> <sub>AI-authored — Claude Code, `Opus 4.8 (1M context)`; found and fixed during an AI review of #1139 for @malberts, no revisions; diff not yet human-reviewed; TDD regression tests (both seen failing on the unpatched code first), the config PHPUnit group, phpcs and phpstan all pass locally, and both fixes were verified live in a browser on a dev wiki. The sibling-extension defect was confirmed by reading each extension's source (Maps additionally reproduced live).</sub>
