### PR TITLE
Add per-Constraint validation severity levels (ADR 26, backend)

### DIFF
--- a/docs/adr/026-validation-severity-levels.md
+++ b/docs/adr/026-validation-severity-levels.md
@@ -87,6 +87,9 @@ carve-out:
 | `invalid-url` / `invalid-date` / `invalid-datetime` | the value cannot be interpreted as its type | `error` | type integrity, comparable to a parse error in a linter, which is fatal regardless of rule configuration |
 | `single-value-only` | multiple values on a single-value property | `error` | `multiple` declares the value's shape, like `type` itself, so it is a shape condition rather than a Constraint |
 | `schema-not-found` | the Subject's Schema page is missing | `warning` | severity configuration lives in the Schema and there is none to read from; a warning keeps the Subject editable |
+| `unregistered-type` | the Statement's Property Type is not registered (extension disabled) | `warning` | degraded wiki state, not a bad edit; keeps the Subject editable, like `schema-not-found` |
+| `relation-target-not-found` | a relation value points to a Subject that does not exist | `warning` | red-link philosophy: the target may be minted later (e.g. during import) |
+| `relation-target-schema-mismatch` | a resolvable relation target's own Schema is not the declared `targetSchema` | `error` | a resolvable target with the wrong shape is a genuine integrity error |
 
 The fixed `error` for uninterpretable values (`invalid-url`, `invalid-date`, `invalid-datetime`) is the most
 debatable of these classifications: messy cultural-heritage imports contain exactly such values. It stays workable

--- a/docs/api/schema-format.md
+++ b/docs/api/schema-format.md
@@ -38,8 +38,37 @@ Every property definition carries the common fields below plus the type-specific
 |-------|------|----------|---------|-------------|
 | `type` | string | Yes | - | The property type. See [Property Types](#property-types). |
 | `description` | string | No | `""` | Human-readable description of the property |
-| `required` | boolean | No | `false` | Whether a value is required for this property |
+| `required` | boolean or object | No | `false` | Whether a value is required. Accepts a [severity](#constraint-severity). |
 | `default` | varies | No | `null` | Default value when none is provided |
+
+## Constraint severity
+
+Every Constraint carries a severity of `error` or `warning`, which decides whether violating it can
+block a write. Write a Constraint either as the bare value, which keeps the default `warning`, or as
+an object carrying the severity:
+
+```json
+{
+  "type": "number",
+  "required": { "severity": "error" },
+  "minimum": 0,
+  "maximum": { "value": 100, "severity": "error" }
+}
+```
+
+Boolean Constraints (`required`, `uniqueItems`) take no `value` in the object form — writing the
+object at all implies `true`. Every other Constraint carries its value under `value`, including
+`options`, whose `value` is the options array.
+
+The Constraints that accept a severity are `required`, `minimum`, `maximum`, `minLength`,
+`maxLength`, `uniqueItems`, and `options`. Severity is a Constraint concept, so it does not apply to
+Display Attributes such as `precision`, where it is discarded, nor to the shape-declaring fields
+`type`, `multiple`, `relation`, and `targetSchema`, where it is rejected when the Schema is saved.
+
+Canonical output emits the bare form whenever the severity is the default, so a Schema that sets no
+severities round-trips unchanged. Which violation each Constraint produces, and the fixed severities
+of the codes no Constraint backs, are covered in
+[Validation codes](validation-codes.md#severity-blocking-and-enforcement).
 
 ## Property Types
 

--- a/docs/api/validation-codes.md
+++ b/docs/api/validation-codes.md
@@ -29,6 +29,7 @@ Each violation in the response has this shape:
   "propertyName": "Website",
   "code": "invalid-url",
   "args": [],
+  "severity": "error",
   "valuePartIndex": 0
 }
 ```
@@ -36,20 +37,30 @@ Each violation in the response has this shape:
 - `propertyName` is the property name as a string, or `null` for Subject-level violations.
 - `code` is one of the stable strings documented below.
 - `args` is always present; `[]` when there is nothing to interpolate.
+- `severity` is always present and is either `error` or `warning`. See
+  [Severity, blocking, and enforcement](#severity-blocking-and-enforcement).
 - `valuePartIndex` is the zero-based index of the offending part of a multi-part value. Only the
   codes that document it set it; the key is omitted from the JSON otherwise.
 
-## Blocking and enforcement
+## Severity, blocking, and enforcement
 
-Three codes are non-blocking warnings: [`unregistered-type`](#unregistered-type),
-[`schema-not-found`](#schema-not-found), and [`relation-target-not-found`](#relation-target-not-found).
-They are marked "Non-blocking" below and never cause a write to be rejected. Every other code blocks.
+Severity decides whether a write can be rejected: warnings never block, errors can. Each code in the
+reference below documents its own severity.
+
+Where a violation is backed by a Constraint the schema author writes — `required`, `minimum`,
+`maximum`, `minLength`, `maxLength`, `uniqueItems`, `options` — that author sets its severity in the
+Schema, per Constraint, and the default is `warning`. See
+[Constraint severity](schema-format.md#constraint-severity) for the JSON. Because the default is
+`warning`, an unannotated Schema blocks nothing at all: invalid Subjects are a normal, supported
+state, and blocking is what an author opts into. Every other code reports a system condition rather
+than a user-correctable Constraint, so its severity is fixed.
 
 Blocking matters only when an admin enables enforcement (`$wgNeoWikiEnforceValidation`; off by
-default, so every write persists). Under enforcement, a write that introduces *new* blocking
+default, so every write persists). Under enforcement, a write that introduces *new* `error`
 violations is rejected with `422 Unprocessable Entity` and an `{ status, message, violations }` body,
 where `violations` carries the full proposed list, not just the newly-introduced ones. Violations
-already present on the stored Subject never block, so an already-invalid Subject stays editable. See
+already present on the stored Subject never block, so an already-invalid Subject stays editable, and
+raising a Constraint's severity does not make an existing violation count as newly introduced. See
 [ADR 21](../adr/021-add-backend-validation.md) and
 [ADR 26](../adr/026-validation-severity-levels.md).
 
@@ -62,13 +73,13 @@ Statement for the property, and when a Statement is present but its value is emp
 only whitespace (`text`, `date`, `dateTime`), no parts (`url`, `select`), no targets (`relation`),
 or no value at all (`number`, `boolean`).
 
-`args`: `[]`.
+`args`: `[]`. `severity`: set by the `required` Constraint (default `warning`).
 
 ### `label-required`
 
 The Subject's label is empty or whitespace-only. Subject-level: `propertyName` is `null`.
 
-`args`: `[]`.
+`args`: `[]`. `severity`: `error` (fixed).
 
 ### `type-mismatch`
 
@@ -77,7 +88,7 @@ Schema currently declares for the property — for example, a Statement written 
 a `url`, after the Schema changed the property to `number`. When this fires, it is the only
 violation reported for that property: per-type checks and `required` are suppressed.
 
-`args`: `[writerType, currentType]`.
+`args`: `[writerType, currentType]`. `severity`: `error` (fixed).
 
 ### `invalid-url`
 
@@ -86,20 +97,21 @@ On `url` properties. A non-empty value does not match the allowed URL pattern. T
 port, path, query, and fragment. It rejects other schemes (`ftp://`, `file://`), spaces, and
 disallowed characters.
 
-`args`: `[]`. `valuePartIndex`: the offending part.
+`args`: `[]`. `valuePartIndex`: the offending part. `severity`: `error` (fixed).
 
 ### `unique`
 
 On `text` and `url` properties with `uniqueItems` enabled: the value contains duplicate parts.
 
-`args`: `[]`.
+`args`: `[]`. `severity`: set by the `uniqueItems` Constraint (default `warning`).
 
 ### `min-length` / `max-length`
 
 On `text` properties. A part's trimmed length is below `minLength` or above `maxLength`. Empty
 parts are not length-checked.
 
-`args`: `[minLength]` / `[maxLength]`. `valuePartIndex`: the offending part.
+`args`: `[minLength]` / `[maxLength]`. `valuePartIndex`: the offending part. `severity`: set by the
+`minLength` / `maxLength` Constraint (default `warning`).
 
 ### `min-value` / `max-value`
 
@@ -107,20 +119,22 @@ On `number`, `date`, and `dateTime` properties. The value is below the property'
 `minimum` or above its inclusive `maximum`.
 
 `args`: `[minimum]` / `[maximum]` — a number for `number` properties, the declared ISO 8601 string
-for `date` and `dateTime`.
+for `date` and `dateTime`. `severity`: set by the `minimum` / `maximum` Constraint (default
+`warning`).
 
 ### `invalid-option`
 
 On `select` properties. A part is not in the property's `options` allow-list.
 
-`args`: `[offendingPart]`. `valuePartIndex`: the offending part.
+`args`: `[offendingPart]`. `valuePartIndex`: the offending part. `severity`: set by the `options`
+Constraint (default `warning`).
 
 ### `single-value-only`
 
 On single-valued (`multiple: false`) `select` and `relation` properties: more than one part
 (`select`) or relation target (`relation`) was supplied.
 
-`args`: `[]`.
+`args`: `[]`. `severity`: `error` (fixed).
 
 ### `invalid-datetime`
 
@@ -128,27 +142,27 @@ On `dateTime` properties. The value is not a strict ISO 8601 / `xsd:dateTime` st
 explicit timezone offset or `Z`. Includes calendar-overflow cases like `2025-02-30T00:00:00Z`,
 partial dates (`2025`, `2025-06`, `2025-06-15`), and missing offsets.
 
-`args`: `[]`.
+`args`: `[]`. `severity`: `error` (fixed).
 
 ### `invalid-date`
 
 On `date` properties. The value is not a strict ISO 8601 calendar date (`YYYY-MM-DD`). Time or
 timezone components and calendar overflows like `2025-02-30` are rejected.
 
-`args`: `[]`.
+`args`: `[]`. `severity`: `error` (fixed).
 
 ### `unregistered-type`
 
-Non-blocking. The property's type has no registered PropertyType — typically the extension providing
-the type is disabled. The value cannot be interpreted, so it is preserved verbatim and no other
-checks run for the property. A required property of an unregistered type reports this code instead
-of `required`, so the Subject stays saveable.
+The property's type has no registered PropertyType — typically the extension providing the type is
+disabled. The value cannot be interpreted, so it is preserved verbatim and no other checks run for
+the property. A required property of an unregistered type reports this code instead of `required`,
+so the Subject stays saveable.
 
-`args`: `[propertyType]`.
+`args`: `[propertyType]`. `severity`: `warning` (fixed).
 
 ### `schema-not-found`
 
-Non-blocking. The Subject's Schema cannot be loaded — usually deleted or renamed since the Subject
+The Subject's Schema cannot be loaded — usually deleted or renamed since the Subject
 was created, or the Subject was created or imported referencing a Schema that does not (yet) exist.
 The write proceeds and reports the violation; creating or renaming the Schema page resolves it.
 Subject-level: `propertyName` is `null`.
@@ -157,7 +171,7 @@ Returned by the update dry-run and both write endpoints. The create dry-run
 (`POST /subject/validate`) instead returns `404`, because there the Schema is the addressed
 resource.
 
-`args`: `[schemaName]`.
+`args`: `[schemaName]`. `severity`: `warning` (fixed).
 
 ### `relation-target-schema-mismatch`
 
@@ -165,15 +179,16 @@ On `relation` properties. The relation targets a Subject that exists but whose o
 property's declared `targetSchema`. A target that cannot be resolved is reported as
 [`relation-target-not-found`](#relation-target-not-found) instead.
 
-`args`: `[expectedSchema, actualSchema]`. `valuePartIndex`: the offending target.
+`args`: `[expectedSchema, actualSchema]`. `valuePartIndex`: the offending target. `severity`: `error`
+(fixed).
 
 ### `relation-target-not-found`
 
-Non-blocking. On `relation` properties. The relation targets a Subject ID that does not resolve to
-any existing Subject. Deliberately a warning: pointing at a not-yet-created Subject is wiki-native
-red-link behavior, and an import may legitimately mint the target later.
+On `relation` properties. The relation targets a Subject ID that does not resolve to any existing
+Subject. Deliberately a warning: pointing at a not-yet-created Subject is wiki-native red-link
+behavior, and an import may legitimately mint the target later.
 
-`args`: `[targetId]`. `valuePartIndex`: the offending target.
+`args`: `[targetId]`. `valuePartIndex`: the offending target. `severity`: `warning` (fixed).
 
 ## Out-of-schema Statements
 
@@ -194,7 +209,12 @@ violation code:
    convention as the codes above.
 4. If the violation points at a specific part of a multi-part Value, set `valuePartIndex` to
    that part's zero-based index.
-5. Document your new code in your extension's documentation.
+5. Set the severity. A `Violation` defaults to `warning`, which never blocks a write. If your code
+   is backed by a Constraint the schema author writes, take the configured value with
+   `$definition->severityOf( 'yourConstraintKey' )` so authors can make it blocking; if it reports a
+   fixed system condition, pass `Severity::Error` or `Severity::Warning` explicitly. Severity applies
+   to Constraints only — a severity written on one of your Display Attributes is discarded.
+6. Document your new code in your extension's documentation.
 
 RedHerb's `ColorType` (`tests/RedHerb/src/ColorType.php`) is a worked example, including its own
 `invalid-color` code.

--- a/docs/api/validation-codes.md
+++ b/docs/api/validation-codes.md
@@ -14,7 +14,8 @@ Violations are returned by:
   body against an existing Subject's Schema.
 - `POST /neowiki/v0/subject` and `PUT /neowiki/v0/subject/{subjectId}` — the write endpoints include
   the resulting `violations` array in their `201`/`200` success body. Whether a write with violations
-  is rejected is covered under [Blocking and enforcement](#blocking-and-enforcement).
+  is rejected is covered under
+  [Severity, blocking, and enforcement](#severity-blocking-and-enforcement).
 
 The `/validate` endpoints return `200 OK` with a `{violations: [...]}` body whenever the request is
 well-formed; violations in the body do not change the HTTP status. `400` is reserved for malformed

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -82,8 +82,9 @@ A Property Definition has:
 - Boolean **required**
 - Optional **description** string
 - Optional **default**, which is a Value
-- **Constraints**: validation and data rules specific to the Property Type. Example: `"minimum": 42`. Not overridable
-  in Layouts.
+- **Constraints**: validation and data rules specific to the Property Type. Example: `"minimum": 42`. Each carries a
+  severity of `error` or `warning` (default `warning`) that decides whether violating it can block a write — see
+  [Constraint severity](api/schema-format.md#constraint-severity). Not overridable in Layouts.
 - **Display Attributes**: presentation configuration specific to the Property Type. Example: `"precision": 2`,
   `"color": "blue"`. These serve as defaults that can be overridden per-Layout via Display Rules.
 

--- a/docs/operations/installation.md
+++ b/docs/operations/installation.md
@@ -168,7 +168,7 @@ These are the settings you are most likely to change. For the full list with des
 | `$wgNeoWikiNeo4jInternalWriteUrl` | Bolt URL for writing the graph projection | _none_ | For features |
 | `$wgNeoWikiNeo4jInternalReadUrl` | Bolt URL for read and query traffic | _none_ | For features |
 | `$wgNeoWikiEnableDevelopmentUI` | Enables development-only UIs | `false` | No |
-| `$wgNeoWikiEnforceValidation` | Rejects writes that introduce new constraint violations | `false` | No |
+| `$wgNeoWikiEnforceValidation` | Rejects writes that introduce new `error`-severity violations | `false` | No |
 | `$wgNeoWikiAutoRenderMainSubject` | Automatically renders a page's Main Subject as an infobox | `true` | No |
 | `$wgNeoWikiSparqlStores` | SPARQL 1.1 graph stores to keep in sync and query, e.g. QLever | `[]` | No |
 

--- a/extension.json
+++ b/extension.json
@@ -167,7 +167,7 @@
 			"value": false
 		},
 		"NeoWikiEnforceValidation": {
-			"description": "Whether write endpoints reject edits that introduce new constraint violations. When false, violations are surfaced in responses but writes always persist.",
+			"description": "Whether write endpoints reject edits that introduce new error-severity violations. Warnings never block. When false, violations are surfaced in responses but writes always persist.",
 			"value": false
 		},
 		"NeoWikiAutoRenderMainSubject": {

--- a/src/Application/Queries/ValidateSubjectUpdate/ValidateSubjectUpdateQuery.php
+++ b/src/Application/Queries/ValidateSubjectUpdate/ValidateSubjectUpdateQuery.php
@@ -14,6 +14,7 @@ use ProfessionalWiki\NeoWiki\Application\SubjectRepository;
 use ProfessionalWiki\NeoWiki\Application\Validation\SubjectValidator;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
 
 readonly class ValidateSubjectUpdateQuery {
@@ -66,6 +67,7 @@ readonly class ValidateSubjectUpdateQuery {
 					propertyName: null,
 					code: 'schema-not-found',
 					args: [ $subject->getSchemaName()->getText() ],
+					severity: Severity::Warning,
 				),
 			];
 		}

--- a/src/Application/Validation/ProposedSubjectValidator.php
+++ b/src/Application/Validation/ProposedSubjectValidator.php
@@ -6,6 +6,7 @@ namespace ProfessionalWiki\NeoWiki\Application\Validation;
 
 use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
 
 /**
@@ -41,6 +42,7 @@ readonly class ProposedSubjectValidator {
 					propertyName: null,
 					code: 'schema-not-found',
 					args: [ $subject->getSchemaName()->getText() ],
+					severity: Severity::Warning,
 				),
 			];
 		}

--- a/src/Application/Validation/SubjectValidator.php
+++ b/src/Application/Validation/SubjectValidator.php
@@ -15,6 +15,7 @@ use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Statement;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
 use ProfessionalWiki\NeoWiki\Domain\Value\RelationValue;
 
@@ -33,7 +34,7 @@ readonly class SubjectValidator {
 		$violations = [];
 
 		if ( trim( $label->text ) === '' ) {
-			$violations[] = new Violation( propertyName: null, code: 'label-required' );
+			$violations[] = new Violation( propertyName: null, code: 'label-required', severity: Severity::Error );
 		}
 
 		foreach ( $statements->asArray() as $statement ) {
@@ -63,6 +64,7 @@ readonly class SubjectValidator {
 				propertyName: $propertyName,
 				code: 'type-mismatch',
 				args: [ $statement->getPropertyType(), $definition->getPropertyType() ],
+				severity: Severity::Error,
 			) ];
 		}
 
@@ -148,6 +150,7 @@ readonly class SubjectValidator {
 				code: 'relation-target-not-found',
 				args: [ $relation->targetId->text ],
 				valuePartIndex: $valuePartIndex,
+				severity: Severity::Warning,
 			);
 		}
 
@@ -157,6 +160,7 @@ readonly class SubjectValidator {
 				code: 'relation-target-schema-mismatch',
 				args: [ $targetSchema->getText(), $target->getSchemaName()->getText() ],
 				valuePartIndex: $valuePartIndex,
+				severity: Severity::Error,
 			);
 		}
 
@@ -187,7 +191,7 @@ readonly class SubjectValidator {
 			// extension returns. Report the degraded type instead.
 			$violations[] = $this->propertyTypeLookup->getType( $definition->getPropertyType() ) === null
 				? $this->newUnregisteredTypeViolation( $propertyName, $definition->getPropertyType() )
-				: new Violation( propertyName: $propertyName, code: 'required' );
+				: new Violation( propertyName: $propertyName, code: 'required', severity: $definition->severityOf( 'required' ) );
 		}
 
 		return $violations;
@@ -198,6 +202,7 @@ readonly class SubjectValidator {
 			propertyName: $propertyName,
 			code: 'unregistered-type',
 			args: [ $propertyType ],
+			severity: Severity::Warning,
 		);
 	}
 

--- a/src/Domain/PropertyType/Types/BooleanType.php
+++ b/src/Domain/PropertyType/Types/BooleanType.php
@@ -42,7 +42,7 @@ class BooleanType implements PropertyType {
 		}
 
 		if ( !$value instanceof BooleanValue && $definition->isRequired() ) {
-			return [ new Violation( propertyName: null, code: 'required' ) ];
+			return [ new Violation( propertyName: null, code: 'required', severity: $definition->severityOf( 'required' ) ) ];
 		}
 
 		return [];

--- a/src/Domain/PropertyType/Types/DateTimeType.php
+++ b/src/Domain/PropertyType/Types/DateTimeType.php
@@ -9,6 +9,7 @@ use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyType;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\DateTimeProperty;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinition;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
 use ProfessionalWiki\NeoWiki\Domain\Value\NeoValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
@@ -46,23 +47,23 @@ class DateTimeType implements PropertyType {
 
 		if ( $rawValue === null ) {
 			return $definition->isRequired()
-				? [ new Violation( propertyName: null, code: 'required' ) ]
+				? [ new Violation( propertyName: null, code: 'required', severity: $definition->severityOf( 'required' ) ) ]
 				: [];
 		}
 
 		$parsed = DateTimeProperty::parseStrictDateTime( $rawValue );
 
 		if ( $parsed === null ) {
-			return [ new Violation( propertyName: null, code: 'invalid-datetime' ) ];
+			return [ new Violation( propertyName: null, code: 'invalid-datetime', severity: Severity::Error ) ];
 		}
 
 		return array_values( array_filter( [
-			$this->checkMinimum( $parsed, $definition->getMinimum() ),
-			$this->checkMaximum( $parsed, $definition->getMaximum() ),
+			$this->checkMinimum( $parsed, $definition->getMinimum(), $definition->severityOf( 'minimum' ) ),
+			$this->checkMaximum( $parsed, $definition->getMaximum(), $definition->severityOf( 'maximum' ) ),
 		] ) );
 	}
 
-	private function checkMinimum( DateTimeImmutable $parsed, ?string $minString ): ?Violation {
+	private function checkMinimum( DateTimeImmutable $parsed, ?string $minString, Severity $severity ): ?Violation {
 		if ( $minString === null ) {
 			return null;
 		}
@@ -70,10 +71,10 @@ class DateTimeType implements PropertyType {
 		if ( $min === null || $parsed >= $min ) {
 			return null;
 		}
-		return new Violation( propertyName: null, code: 'min-value', args: [ $minString ] );
+		return new Violation( propertyName: null, code: 'min-value', args: [ $minString ], severity: $severity );
 	}
 
-	private function checkMaximum( DateTimeImmutable $parsed, ?string $maxString ): ?Violation {
+	private function checkMaximum( DateTimeImmutable $parsed, ?string $maxString, Severity $severity ): ?Violation {
 		if ( $maxString === null ) {
 			return null;
 		}
@@ -81,7 +82,7 @@ class DateTimeType implements PropertyType {
 		if ( $max === null || $parsed <= $max ) {
 			return null;
 		}
-		return new Violation( propertyName: null, code: 'max-value', args: [ $maxString ] );
+		return new Violation( propertyName: null, code: 'max-value', args: [ $maxString ], severity: $severity );
 	}
 
 	private function extractFirstString( NeoValue $value ): ?string {

--- a/src/Domain/PropertyType/Types/DateType.php
+++ b/src/Domain/PropertyType/Types/DateType.php
@@ -9,6 +9,7 @@ use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyType;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\DateProperty;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinition;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
 use ProfessionalWiki\NeoWiki\Domain\Value\NeoValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
@@ -46,23 +47,23 @@ class DateType implements PropertyType {
 
 		if ( $rawValue === null ) {
 			return $definition->isRequired()
-				? [ new Violation( propertyName: null, code: 'required' ) ]
+				? [ new Violation( propertyName: null, code: 'required', severity: $definition->severityOf( 'required' ) ) ]
 				: [];
 		}
 
 		$parsed = DateProperty::parseStrictDate( $rawValue );
 
 		if ( $parsed === null ) {
-			return [ new Violation( propertyName: null, code: 'invalid-date' ) ];
+			return [ new Violation( propertyName: null, code: 'invalid-date', severity: Severity::Error ) ];
 		}
 
 		return array_values( array_filter( [
-			$this->checkMinimum( $parsed, $definition->getMinimum() ),
-			$this->checkMaximum( $parsed, $definition->getMaximum() ),
+			$this->checkMinimum( $parsed, $definition->getMinimum(), $definition->severityOf( 'minimum' ) ),
+			$this->checkMaximum( $parsed, $definition->getMaximum(), $definition->severityOf( 'maximum' ) ),
 		] ) );
 	}
 
-	private function checkMinimum( DateTimeImmutable $parsed, ?string $minString ): ?Violation {
+	private function checkMinimum( DateTimeImmutable $parsed, ?string $minString, Severity $severity ): ?Violation {
 		if ( $minString === null ) {
 			return null;
 		}
@@ -70,10 +71,10 @@ class DateType implements PropertyType {
 		if ( $min === null || $parsed >= $min ) {
 			return null;
 		}
-		return new Violation( propertyName: null, code: 'min-value', args: [ $minString ] );
+		return new Violation( propertyName: null, code: 'min-value', args: [ $minString ], severity: $severity );
 	}
 
-	private function checkMaximum( DateTimeImmutable $parsed, ?string $maxString ): ?Violation {
+	private function checkMaximum( DateTimeImmutable $parsed, ?string $maxString, Severity $severity ): ?Violation {
 		if ( $maxString === null ) {
 			return null;
 		}
@@ -81,7 +82,7 @@ class DateType implements PropertyType {
 		if ( $max === null || $parsed <= $max ) {
 			return null;
 		}
-		return new Violation( propertyName: null, code: 'max-value', args: [ $maxString ] );
+		return new Violation( propertyName: null, code: 'max-value', args: [ $maxString ], severity: $severity );
 	}
 
 	private function extractFirstString( NeoValue $value ): ?string {

--- a/src/Domain/PropertyType/Types/NumberType.php
+++ b/src/Domain/PropertyType/Types/NumberType.php
@@ -43,7 +43,7 @@ class NumberType implements PropertyType {
 
 		if ( !$value instanceof NumberValue ) {
 			if ( $definition->isRequired() ) {
-				return [ new Violation( propertyName: null, code: 'required' ) ];
+				return [ new Violation( propertyName: null, code: 'required', severity: $definition->severityOf( 'required' ) ) ];
 			}
 			return [];
 		}
@@ -55,6 +55,7 @@ class NumberType implements PropertyType {
 				propertyName: null,
 				code: 'min-value',
 				args: [ $definition->getMinimum() ],
+				severity: $definition->severityOf( 'minimum' ),
 			);
 		}
 
@@ -63,6 +64,7 @@ class NumberType implements PropertyType {
 				propertyName: null,
 				code: 'max-value',
 				args: [ $definition->getMaximum() ],
+				severity: $definition->severityOf( 'maximum' ),
 			);
 		}
 

--- a/src/Domain/PropertyType/Types/RelationType.php
+++ b/src/Domain/PropertyType/Types/RelationType.php
@@ -8,6 +8,7 @@ use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyType;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\RelationProperty;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinition;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
 use ProfessionalWiki\NeoWiki\Domain\Value\NeoValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\RelationValue;
@@ -44,13 +45,13 @@ class RelationType implements PropertyType {
 		$relations = $value instanceof RelationValue ? $value->relations : [];
 
 		if ( $definition->isRequired() && $relations === [] ) {
-			return [ new Violation( propertyName: null, code: 'required' ) ];
+			return [ new Violation( propertyName: null, code: 'required', severity: $definition->severityOf( 'required' ) ) ];
 		}
 
 		$violations = [];
 
 		if ( !$definition->allowsMultipleValues() && count( $relations ) > 1 ) {
-			$violations[] = new Violation( propertyName: null, code: 'single-value-only' );
+			$violations[] = new Violation( propertyName: null, code: 'single-value-only', severity: Severity::Error );
 		}
 
 		return $violations;

--- a/src/Domain/PropertyType/Types/SelectType.php
+++ b/src/Domain/PropertyType/Types/SelectType.php
@@ -8,6 +8,7 @@ use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyType;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\SelectProperty;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinition;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
 use ProfessionalWiki\NeoWiki\Domain\Value\NeoValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
@@ -44,7 +45,7 @@ class SelectType implements PropertyType {
 		$parts = $value instanceof StringValue ? $value->strings : [];
 
 		if ( $definition->isRequired() && $parts === [] ) {
-			return [ new Violation( propertyName: null, code: 'required' ) ];
+			return [ new Violation( propertyName: null, code: 'required', severity: $definition->severityOf( 'required' ) ) ];
 		}
 
 		$validIds = [];
@@ -61,12 +62,13 @@ class SelectType implements PropertyType {
 					code: 'invalid-option',
 					args: [ $part ],
 					valuePartIndex: $index,
+					severity: $definition->severityOf( 'options' ),
 				);
 			}
 		}
 
 		if ( !$definition->allowsMultipleValues() && count( $parts ) > 1 ) {
-			$violations[] = new Violation( propertyName: null, code: 'single-value-only' );
+			$violations[] = new Violation( propertyName: null, code: 'single-value-only', severity: Severity::Error );
 		}
 
 		return $violations;

--- a/src/Domain/PropertyType/Types/TextType.php
+++ b/src/Domain/PropertyType/Types/TextType.php
@@ -56,7 +56,7 @@ class TextType implements PropertyType {
 		}
 
 		if ( $definition->isRequired() && !$hasContent ) {
-			$violations[] = new Violation( propertyName: null, code: 'required' );
+			$violations[] = new Violation( propertyName: null, code: 'required', severity: $definition->severityOf( 'required' ) );
 		}
 
 		$violations = array_merge( $violations, $this->validateLengths( $value, $definition ) );
@@ -64,7 +64,7 @@ class TextType implements PropertyType {
 		if ( $definition->enforcesUniqueValues()
 			&& count( array_unique( $value->strings ) ) !== count( $value->strings )
 		) {
-			$violations[] = new Violation( propertyName: null, code: 'unique' );
+			$violations[] = new Violation( propertyName: null, code: 'unique', severity: $definition->severityOf( 'uniqueItems' ) );
 		}
 
 		return $violations;
@@ -93,6 +93,7 @@ class TextType implements PropertyType {
 					code: 'min-length',
 					args: [ $definition->getMinLength() ],
 					valuePartIndex: $index,
+					severity: $definition->severityOf( 'minLength' ),
 				);
 			}
 
@@ -102,6 +103,7 @@ class TextType implements PropertyType {
 					code: 'max-length',
 					args: [ $definition->getMaxLength() ],
 					valuePartIndex: $index,
+					severity: $definition->severityOf( 'maxLength' ),
 				);
 			}
 		}

--- a/src/Domain/PropertyType/Types/UrlType.php
+++ b/src/Domain/PropertyType/Types/UrlType.php
@@ -8,6 +8,7 @@ use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyType;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\UrlProperty;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinition;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
 use ProfessionalWiki\NeoWiki\Domain\Value\NeoValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
@@ -56,7 +57,7 @@ class UrlType implements PropertyType {
 		}
 
 		if ( $definition->isRequired() && !$hasContent ) {
-			return [ new Violation( propertyName: null, code: 'required' ) ];
+			return [ new Violation( propertyName: null, code: 'required', severity: $definition->severityOf( 'required' ) ) ];
 		}
 
 		$violations = [];
@@ -68,6 +69,7 @@ class UrlType implements PropertyType {
 					propertyName: null,
 					code: 'invalid-url',
 					valuePartIndex: $index,
+					severity: Severity::Error,
 				);
 			}
 		}
@@ -75,7 +77,7 @@ class UrlType implements PropertyType {
 		if ( $definition->enforcesUniqueValues()
 			&& count( array_unique( $value->strings ) ) !== count( $value->strings )
 		) {
-			$violations[] = new Violation( propertyName: null, code: 'unique' );
+			$violations[] = new Violation( propertyName: null, code: 'unique', severity: $definition->severityOf( 'uniqueItems' ) );
 		}
 
 		return $violations;

--- a/src/Domain/Schema/PropertyCore.php
+++ b/src/Domain/Schema/PropertyCore.php
@@ -4,15 +4,22 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Domain\Schema;
 
+use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
+
 readonly class PropertyCore {
 
 	/**
 	 * A null default means there is no default.
+	 *
+	 * @param array<string, Severity> $constraintSeverities Per-Constraint severity, keyed by
+	 *   the Constraint's JSON key (e.g. 'maximum', 'required'). Populated generically at the
+	 *   JSON boundary; read via PropertyDefinition::severityOf(). See ADR 26.
 	 */
 	public function __construct(
 		public string $description,
 		public bool $required,
 		public mixed $default,
+		public array $constraintSeverities = [],
 	) {
 	}
 

--- a/src/Domain/Schema/PropertyCore.php
+++ b/src/Domain/Schema/PropertyCore.php
@@ -12,8 +12,7 @@ readonly class PropertyCore {
 	 * A null default means there is no default.
 	 *
 	 * @param array<string, Severity> $constraintSeverities Per-Constraint severity, keyed by
-	 *   the Constraint's JSON key (e.g. 'maximum', 'required'). Populated generically at the
-	 *   JSON boundary; read via PropertyDefinition::severityOf(). See ADR 26.
+	 *   the Constraint's JSON key (e.g. 'maximum', 'required'). See ADR 26.
 	 */
 	public function __construct(
 		public string $description,

--- a/src/Domain/Schema/PropertyDefinition.php
+++ b/src/Domain/Schema/PropertyDefinition.php
@@ -7,6 +7,8 @@ namespace ProfessionalWiki\NeoWiki\Domain\Schema;
 use InvalidArgumentException;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeLookup;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\UnregisteredTypeProperty;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
+use ProfessionalWiki\NeoWiki\Domain\Validation\SeverityNormalizer;
 use Throwable;
 
 abstract class PropertyDefinition {
@@ -26,6 +28,10 @@ abstract class PropertyDefinition {
 		return $this->core->required;
 	}
 
+	public function severityOf( string $constraint ): Severity {
+		return $this->core->constraintSeverities[$constraint] ?? Severity::Warning;
+	}
+
 	public function getDefault(): mixed {
 		return $this->core->default;
 	}
@@ -39,7 +45,10 @@ abstract class PropertyDefinition {
 	}
 
 	public function toJson(): array {
-		return array_merge( $this->coreToJson(), $this->nonCoreToJson() );
+		return SeverityNormalizer::apply(
+			array_merge( $this->coreToJson(), $this->nonCoreToJson() ),
+			$this->core->constraintSeverities
+		);
 	}
 
 	/**
@@ -74,23 +83,43 @@ abstract class PropertyDefinition {
 			throw new InvalidArgumentException( 'Property definition needs a non-empty type: ' . json_encode( $json ) );
 		}
 
+		[ $values, $severities ] = SeverityNormalizer::extract( $json );
+
+		/** @var string $description */
+		$description = $values['description'] ?? '';
+		/** @var bool $required */
+		$required = $values['required'] ?? false;
+
 		$propertyType = $propertyTypeLookup->getType( $json['type'] );
 
+		// Severity is a Constraint concept. Display Attributes are explicitly not Constraints
+		// (they are overridable per Layout), so a severity on one is meaningless. Drop it:
+		// left in the map it would make toJson re-emit the attribute as an object and break
+		// every consumer that reads it as a scalar.
+		if ( $propertyType !== null ) {
+			foreach ( $propertyType->getDisplayAttributeNames() as $displayAttribute ) {
+				unset( $severities[$displayAttribute] );
+			}
+		}
+
 		$propertyCore = new PropertyCore(
-			description: $json['description'] ?? '',
-			required: $json['required'] ?? false,
-			default: $json['default'] ?? null
+			description: $description,
+			required: $required,
+			default: $values['default'] ?? null,
+			constraintSeverities: $severities,
 		);
 
-		// The extension owning the type is disabled or failed to load. Preserve the
-		// definition instead of dropping it, so the rest of the Schema keeps working
-		// and the property survives a re-save.
+		// The extension owning the type is disabled or failed to load. Preserve the property
+		// (incl. its object-form constraint severities) so the Schema still serves it and a
+		// re-save does not drop it; it never validates, so the severity map is inert here.
+		// It is built from the normalized $values (not raw $json) so toJson re-wraps every
+		// annotated key through the same apply() path as registered types.
 		if ( $propertyType === null ) {
-			return UnregisteredTypeProperty::fromPartialJson( $propertyCore, $json );
+			return UnregisteredTypeProperty::fromPartialJson( $propertyCore, $values );
 		}
 
 		try {
-			return $propertyType->buildPropertyDefinitionFromJson( $propertyCore, $json );
+			return $propertyType->buildPropertyDefinitionFromJson( $propertyCore, $values );
 		} catch ( Throwable $e ) {
 			throw new InvalidArgumentException( 'Invalid property definition: ' . json_encode( $json ), 0, $e );
 		}

--- a/src/Domain/Validation/Severity.php
+++ b/src/Domain/Validation/Severity.php
@@ -1,0 +1,10 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\Validation;
+
+enum Severity: string {
+	case Error = 'error';
+	case Warning = 'warning';
+}

--- a/src/Domain/Validation/SeverityNormalizer.php
+++ b/src/Domain/Validation/SeverityNormalizer.php
@@ -1,0 +1,80 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\Validation;
+
+use InvalidArgumentException;
+
+/**
+ * Parses and serializes the two Schema-JSON forms a Constraint can take (ADR 26):
+ * a bare scalar/array (default `warning` severity) or an object `{ value, severity }`
+ * (booleans drop `value` and imply `true`; `options` carries the array in `value`).
+ *
+ * A value is treated as object-form iff it is an array carrying a `severity` key. This is
+ * intentionally permissive: being type-agnostic is what lets a custom Property Type's own
+ * Constraint keys round-trip without any core change.
+ *
+ * A severity on a key no Violation reads never affects enforcement, but it is not wholly
+ * inert: apply() would re-emit that key in object form. Two guards keep that from
+ * corrupting non-Constraints — PropertyDefinition::fromJson drops severities on declared
+ * Display Attributes, and `schemaContentSchema.json` rejects them on the shape-declaring
+ * keys (`multiple`, `relation`, `targetSchema`) at authoring time.
+ */
+final class SeverityNormalizer {
+
+	/** Core keys handled outside the Constraint model; never severity-bearing. */
+	private const RESERVED = [ 'type', 'description', 'default' ];
+
+	/**
+	 * @param array<string, mixed> $property
+	 * @return array{0: array<string, mixed>, 1: array<string, Severity>} bare values, name->severity
+	 */
+	public static function extract( array $property ): array {
+		$values = $property;
+		$severities = [];
+
+		foreach ( $property as $key => $raw ) {
+			if ( in_array( $key, self::RESERVED, true ) ) {
+				continue;
+			}
+
+			if ( is_array( $raw ) && array_key_exists( 'severity', $raw ) ) {
+				$severity = is_string( $raw['severity'] ) ? Severity::tryFrom( $raw['severity'] ) : null;
+
+				if ( $severity === null ) {
+					throw new InvalidArgumentException( 'Invalid severity: ' . json_encode( $raw['severity'] ) );
+				}
+
+				// array_key_exists, not ??: an explicit "value": null must stay null (the
+				// boolean object form is the one that legitimately omits the key).
+				$values[$key] = array_key_exists( 'value', $raw ) ? $raw['value'] : true;
+				$severities[$key] = $severity;
+			}
+		}
+
+		return [ $values, $severities ];
+	}
+
+	/**
+	 * Canonical output: re-wrap only `error`-annotated (present) keys; `warning` is the
+	 * default and emits as shorthand, so unannotated Schemas round-trip byte-for-byte.
+	 *
+	 * @param array<string, mixed> $json
+	 * @param array<string, Severity> $severities
+	 * @return array<string, mixed>
+	 */
+	public static function apply( array $json, array $severities ): array {
+		foreach ( $severities as $key => $severity ) {
+			if ( $severity === Severity::Warning || !array_key_exists( $key, $json ) ) {
+				continue;
+			}
+
+			$json[$key] = is_bool( $json[$key] )
+				? [ 'severity' => $severity->value ]
+				: [ 'value' => $json[$key], 'severity' => $severity->value ];
+		}
+
+		return $json;
+	}
+}

--- a/src/Domain/Validation/SeverityNormalizer.php
+++ b/src/Domain/Validation/SeverityNormalizer.php
@@ -70,7 +70,11 @@ final class SeverityNormalizer {
 				continue;
 			}
 
-			$json[$key] = is_bool( $json[$key] )
+			// Only `true` may drop the value key: extract() reads the value-less form as true,
+			// so emitting it for `false` would flip a Constraint the author disabled. Core
+			// booleans are always true here (booleanConstraint forbids a value key), but a
+			// custom Property Type's own boolean key is not constrained that way.
+			$json[$key] = $json[$key] === true
 				? [ 'severity' => $severity->value ]
 				: [ 'value' => $json[$key], 'severity' => $severity->value ];
 		}

--- a/src/Domain/Validation/Violation.php
+++ b/src/Domain/Validation/Violation.php
@@ -8,18 +8,12 @@ use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyName;
 
 readonly class Violation {
 
-	/**
-	 * System conditions rather than user-correctable Constraints: the wiki, not the edit,
-	 * is in a degraded state. They are reported but never reject a write. These are the
-	 * `warning` tier that ADR 26 will make configurable per Constraint.
-	 */
-	private const NON_BLOCKING_CODES = [ 'schema-not-found', 'unregistered-type', 'relation-target-not-found' ];
-
 	public function __construct(
 		public ?PropertyName $propertyName,
 		public string $code,
 		public array $args = [],
 		public ?int $valuePartIndex = null,
+		public Severity $severity = Severity::Warning,
 	) {
 	}
 
@@ -29,14 +23,15 @@ readonly class Violation {
 			code: $this->code,
 			args: $this->args,
 			valuePartIndex: $this->valuePartIndex,
+			severity: $this->severity,
 		);
 	}
 
 	/**
-	 * Whether this Violation should block writes under enforcement.
+	 * Whether this Violation should block writes under enforcement (ADR 26).
 	 */
 	public function isBlocking(): bool {
-		return !in_array( $this->code, self::NON_BLOCKING_CODES, true );
+		return $this->severity === Severity::Error;
 	}
 
 }

--- a/src/Persistence/MediaWiki/schemaContentSchema.json
+++ b/src/Persistence/MediaWiki/schemaContentSchema.json
@@ -1,6 +1,29 @@
 {
 	"$schema": "https://json-schema.org/draft/2020-12/schema#",
 	"type": "object",
+	"$defs": {
+		"severity": {
+			"enum": [ "error", "warning" ]
+		},
+		"booleanConstraint": {
+			"oneOf": [
+				{ "type": "boolean" },
+				{
+					"type": "object",
+					"required": [ "severity" ],
+					"additionalProperties": false,
+					"properties": { "severity": { "$ref": "#/$defs/severity" } }
+				}
+			]
+		},
+		"scalarConstraint": {
+			"if": { "type": "object" },
+			"then": {
+				"required": [ "value", "severity" ],
+				"properties": { "severity": { "$ref": "#/$defs/severity" } }
+			}
+		}
+	},
 	"properties": {
 		"description": {
 			"type": "string"
@@ -22,15 +45,16 @@
 							"type": "string",
 							"minLength": 1
 						},
-						"required": {
-							"type": "boolean"
-						},
+						"required": { "$ref": "#/$defs/booleanConstraint" },
 						"multiple": {
 							"type": "boolean"
 						},
-						"uniqueItems": {
-							"type": "boolean"
-						}
+						"uniqueItems": { "$ref": "#/$defs/booleanConstraint" },
+						"minimum": { "$ref": "#/$defs/scalarConstraint" },
+						"maximum": { "$ref": "#/$defs/scalarConstraint" },
+						"minLength": { "$ref": "#/$defs/scalarConstraint" },
+						"maxLength": { "$ref": "#/$defs/scalarConstraint" },
+						"options": { "$ref": "#/$defs/scalarConstraint" }
 					},
 					"allOf": [
 						{

--- a/src/Persistence/MediaWiki/schemaContentSchema.json
+++ b/src/Persistence/MediaWiki/schemaContentSchema.json
@@ -20,6 +20,19 @@
 			"if": { "type": "object" },
 			"then": {
 				"required": [ "value", "severity" ],
+				"additionalProperties": false,
+				"properties": {
+					"value": true,
+					"severity": { "$ref": "#/$defs/severity" }
+				}
+			}
+		},
+		"customConstraint": {
+			"if": {
+				"type": "object",
+				"required": [ "severity" ]
+			},
+			"then": {
 				"properties": { "severity": { "$ref": "#/$defs/severity" } }
 			}
 		}
@@ -33,7 +46,7 @@
 			"patternProperties": {
 				"^.*$": {
 					"type": "object",
-					"additionalProperties": true,
+					"additionalProperties": { "$ref": "#/$defs/customConstraint" },
 					"required": [
 						"type"
 					],
@@ -45,6 +58,7 @@
 							"type": "string",
 							"minLength": 1
 						},
+						"default": true,
 						"required": { "$ref": "#/$defs/booleanConstraint" },
 						"multiple": {
 							"type": "boolean"

--- a/src/Presentation/ViolationSerializer.php
+++ b/src/Presentation/ViolationSerializer.php
@@ -16,6 +16,7 @@ final class ViolationSerializer {
 			'propertyName' => $violation->propertyName?->__toString(),
 			'code' => $violation->code,
 			'args' => $violation->args,
+			'severity' => $violation->severity->value,
 		];
 
 		if ( $violation->valuePartIndex !== null ) {

--- a/tests/RedHerb/extension.json
+++ b/tests/RedHerb/extension.json
@@ -159,8 +159,8 @@
 				"redherb-card-edit-subject",
 				"redherb-card-edit-schema",
 				"redherb-card-edit-layout",
-				"neowiki-field-invalid-hex",
-				"neowiki-field-not-in-palette",
+				"neowiki-field-invalid-color",
+				"neowiki-field-invalid-option",
 				"neowiki-field-required"
 			]
 		}

--- a/tests/RedHerb/i18n/en.json
+++ b/tests/RedHerb/i18n/en.json
@@ -35,6 +35,5 @@
 	"redherb-card-edit-subject": "Edit subject",
 	"redherb-card-edit-schema": "Edit schema",
 	"redherb-card-edit-layout": "Edit layout",
-	"neowiki-field-invalid-hex": "Please enter a 6-digit hex color like #ff5733.",
-	"neowiki-field-not-in-palette": "This color is not in the allowed palette."
+	"neowiki-field-invalid-color": "\"$1\" is not a valid color. Enter a 6-digit hex color like #ff5733."
 }

--- a/tests/RedHerb/i18n/qqq.json
+++ b/tests/RedHerb/i18n/qqq.json
@@ -35,6 +35,5 @@
 	"redherb-card-edit-subject": "Label of the button on the RedHerb card View Type that opens the subject editor dialog.",
 	"redherb-card-edit-schema": "Label of the link on the RedHerb card View Type that opens the Subject's Schema page for editing.",
 	"redherb-card-edit-layout": "Label of the link on the RedHerb card View Type that opens the Layout page for editing.",
-	"neowiki-field-invalid-hex": "Validation error shown when a Color input value is not a valid 6-digit hex code.",
-	"neowiki-field-not-in-palette": "Validation error shown when a Color input value is not one of the property's allowed palette entries."
+	"neowiki-field-invalid-color": "Validation error shown when a Color input value is not a valid 6-digit hex code. Corresponds to ColorType's <code>invalid-color</code> violation code. $1 is the offending value."
 }

--- a/tests/RedHerb/src/ColorType.php
+++ b/tests/RedHerb/src/ColorType.php
@@ -7,6 +7,7 @@ namespace ProfessionalWiki\RedHerb;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyType;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinition;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
 use ProfessionalWiki\NeoWiki\Domain\Value\NeoValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
@@ -47,7 +48,7 @@ class ColorType implements PropertyType {
 		}
 
 		if ( $definition->isRequired() && $value->strings === [] ) {
-			return [ new Violation( propertyName: null, code: 'required' ) ];
+			return [ new Violation( propertyName: null, code: 'required', severity: $definition->severityOf( 'required' ) ) ];
 		}
 
 		$allowed = $definition->getAllowedColors();
@@ -62,6 +63,7 @@ class ColorType implements PropertyType {
 					code: 'invalid-color',
 					args: [ $part ],
 					valuePartIndex: $index,
+					severity: Severity::Error,
 				);
 				continue;
 			}
@@ -72,6 +74,7 @@ class ColorType implements PropertyType {
 					code: 'invalid-option',
 					args: [ $part ],
 					valuePartIndex: $index,
+					severity: $definition->severityOf( 'allowedColors' ),
 				);
 			}
 		}

--- a/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
@@ -25,6 +25,7 @@ use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
 use ProfessionalWiki\NeoWiki\Domain\Value\RelationValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeRegistry;
@@ -482,7 +483,7 @@ class CreateSubjectActionTest extends TestCase {
 			description: '',
 			properties: new PropertyDefinitions( [
 				'Name' => new SelectProperty(
-					core: new PropertyCore( description: '', required: true, default: null ),
+					core: new PropertyCore( description: '', required: true, default: null, constraintSeverities: [ 'required' => Severity::Error ] ),
 					options: [ new SelectOption( id: 'opt_alice', label: 'Alice' ) ],
 					multiple: false,
 				),

--- a/tests/phpunit/Application/Actions/ReplaceSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/ReplaceSubjectActionTest.php
@@ -28,6 +28,7 @@ use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
 use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
 use ProfessionalWiki\NeoWiki\Application\SubjectWriteAuthorizer;
 use ProfessionalWiki\NeoWiki\Domain\Value\UnregisteredTypeValue;
@@ -342,12 +343,12 @@ class ReplaceSubjectActionTest extends TestCase {
 			description: '',
 			properties: new PropertyDefinitions( [
 				'Alpha' => new SelectProperty(
-					core: new PropertyCore( description: '', required: true, default: null ),
+					core: new PropertyCore( description: '', required: true, default: null, constraintSeverities: [ 'required' => Severity::Error ] ),
 					options: [ new SelectOption( id: 'opt_a', label: 'A' ) ],
 					multiple: false,
 				),
 				'Beta' => new SelectProperty(
-					core: new PropertyCore( description: '', required: true, default: null ),
+					core: new PropertyCore( description: '', required: true, default: null, constraintSeverities: [ 'required' => Severity::Error ] ),
 					options: [ new SelectOption( id: 'opt_b', label: 'B' ) ],
 					multiple: false,
 				),

--- a/tests/phpunit/Application/Validation/SubjectValidatorTest.php
+++ b/tests/phpunit/Application/Validation/SubjectValidatorTest.php
@@ -407,7 +407,7 @@ class SubjectValidatorTest extends TestCase {
 
 		$this->assertCount( 2, $violations );
 		$this->assertSame( 'required', $violations[0]->code );
-		$this->assertTrue( $violations[0]->isBlocking() );
+		$this->assertFalse( $violations[0]->isBlocking() );
 		$this->assertSame( 'unregistered-type', $violations[1]->code );
 	}
 

--- a/tests/phpunit/Application/Validation/SubjectValidatorTest.php
+++ b/tests/phpunit/Application/Validation/SubjectValidatorTest.php
@@ -19,6 +19,7 @@ use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Statement;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
 use ProfessionalWiki\NeoWiki\Domain\Value\NumberValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\RelationValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\UnregisteredTypeValue;
@@ -79,6 +80,7 @@ class SubjectValidatorTest extends TestCase {
 		$this->assertCount( 1, $violations );
 		$this->assertSame( 'label-required', $violations[0]->code );
 		$this->assertNull( $violations[0]->propertyName );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
 	}
 
 	public function testWhitespaceOnlyLabelReturnsLabelRequired(): void {
@@ -248,6 +250,7 @@ class SubjectValidatorTest extends TestCase {
 		$this->assertSame( 'type-mismatch', $violations[0]->code );
 		$this->assertEquals( new PropertyName( 'Age' ), $violations[0]->propertyName );
 		$this->assertSame( [ 'text', 'number' ], $violations[0]->args );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
 	}
 
 	public function testTypeMismatchSkipsPerTypeValidation(): void {

--- a/tests/phpunit/Domain/PropertyType/Types/DateTimeTypeValidateTest.php
+++ b/tests/phpunit/Domain/PropertyType/Types/DateTimeTypeValidateTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\Types\DateTimeType;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\DateTimeProperty;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
 use ProfessionalWiki\NeoWiki\Domain\Value\NumberValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
 
@@ -75,6 +76,7 @@ class DateTimeTypeValidateTest extends TestCase {
 		$this->assertCount( 1, $violations );
 		$this->assertSame( 'invalid-datetime', $violations[0]->code );
 		$this->assertNull( $violations[0]->propertyName );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
 	}
 
 	public function testYearOnlyReturnsInvalidDatetime(): void {

--- a/tests/phpunit/Domain/PropertyType/Types/DateTimeTypeValidateTest.php
+++ b/tests/phpunit/Domain/PropertyType/Types/DateTimeTypeValidateTest.php
@@ -5,9 +5,11 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Tests\Domain\PropertyType\Types;
 
 use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeRegistry;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\Types\DateTimeType;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\DateTimeProperty;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinition;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
 use ProfessionalWiki\NeoWiki\Domain\Value\NumberValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
@@ -175,6 +177,7 @@ class DateTimeTypeValidateTest extends TestCase {
 		$this->assertSame( 'min-value', $violations[0]->code );
 		$this->assertSame( [ '2025-01-01T00:00:00Z' ], $violations[0]->args );
 		$this->assertNull( $violations[0]->propertyName );
+		$this->assertSame( Severity::Warning, $violations[0]->severity );
 	}
 
 	public function testAfterMaximumReturnsMaxValue(): void {
@@ -187,6 +190,44 @@ class DateTimeTypeValidateTest extends TestCase {
 		$this->assertSame( 'max-value', $violations[0]->code );
 		$this->assertSame( [ '2025-12-31T23:59:59Z' ], $violations[0]->args );
 		$this->assertNull( $violations[0]->propertyName );
+		$this->assertSame( Severity::Warning, $violations[0]->severity );
+	}
+
+	/**
+	 * Unlike NumberType, the bound severities reach checkMinimum()/checkMaximum() as arguments
+	 * rather than being read at the raise site. Each test therefore leaves the other bound
+	 * unannotated, so swapping the two arguments hands the violation the sibling's warning.
+	 */
+	public function testMinValueViolationUsesErrorWhenMinimumAnnotated(): void {
+		$definition = PropertyDefinition::fromJson(
+			[
+				'type' => 'dateTime',
+				'minimum' => [ 'value' => '2025-01-01T00:00:00Z', 'severity' => 'error' ],
+				'maximum' => '2025-12-31T23:59:59Z',
+			],
+			PropertyTypeRegistry::withCoreTypes(),
+		);
+
+		$violations = $this->type->validate( new StringValue( '2024-12-31T23:59:59Z' ), $definition );
+
+		$this->assertSame( 'min-value', $violations[0]->code );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
+	}
+
+	public function testMaxValueViolationUsesErrorWhenMaximumAnnotated(): void {
+		$definition = PropertyDefinition::fromJson(
+			[
+				'type' => 'dateTime',
+				'minimum' => '2025-01-01T00:00:00Z',
+				'maximum' => [ 'value' => '2025-12-31T23:59:59Z', 'severity' => 'error' ],
+			],
+			PropertyTypeRegistry::withCoreTypes(),
+		);
+
+		$violations = $this->type->validate( new StringValue( '2026-01-01T00:00:00Z' ), $definition );
+
+		$this->assertSame( 'max-value', $violations[0]->code );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
 	}
 
 	public function testEqualToBoundsReturnsNoViolations(): void {

--- a/tests/phpunit/Domain/PropertyType/Types/DateTypeValidateTest.php
+++ b/tests/phpunit/Domain/PropertyType/Types/DateTypeValidateTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\Types\DateType;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\DateProperty;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
 use ProfessionalWiki\NeoWiki\Domain\Value\NumberValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
 
@@ -61,6 +62,7 @@ class DateTypeValidateTest extends TestCase {
 		);
 
 		$this->assertSame( 'invalid-date', $violations[0]->code );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
 	}
 
 	public function testYearOnlyReturnsInvalidDate(): void {

--- a/tests/phpunit/Domain/PropertyType/Types/DateTypeValidateTest.php
+++ b/tests/phpunit/Domain/PropertyType/Types/DateTypeValidateTest.php
@@ -5,9 +5,11 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Tests\Domain\PropertyType\Types;
 
 use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeRegistry;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\Types\DateType;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\DateProperty;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinition;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
 use ProfessionalWiki\NeoWiki\Domain\Value\NumberValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
@@ -125,6 +127,7 @@ class DateTypeValidateTest extends TestCase {
 
 		$this->assertSame( 'min-value', $violations[0]->code );
 		$this->assertSame( [ '2025-01-01' ], $violations[0]->args );
+		$this->assertSame( Severity::Warning, $violations[0]->severity );
 	}
 
 	public function testAfterMaximumReturnsMaxValue(): void {
@@ -135,6 +138,44 @@ class DateTypeValidateTest extends TestCase {
 
 		$this->assertSame( 'max-value', $violations[0]->code );
 		$this->assertSame( [ '2025-12-31' ], $violations[0]->args );
+		$this->assertSame( Severity::Warning, $violations[0]->severity );
+	}
+
+	/**
+	 * Unlike NumberType, the bound severities reach checkMinimum()/checkMaximum() as arguments
+	 * rather than being read at the raise site. Each test therefore leaves the other bound
+	 * unannotated, so swapping the two arguments hands the violation the sibling's warning.
+	 */
+	public function testMinValueViolationUsesErrorWhenMinimumAnnotated(): void {
+		$definition = PropertyDefinition::fromJson(
+			[
+				'type' => 'date',
+				'minimum' => [ 'value' => '2025-01-01', 'severity' => 'error' ],
+				'maximum' => '2025-12-31',
+			],
+			PropertyTypeRegistry::withCoreTypes(),
+		);
+
+		$violations = $this->type->validate( new StringValue( '2024-12-31' ), $definition );
+
+		$this->assertSame( 'min-value', $violations[0]->code );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
+	}
+
+	public function testMaxValueViolationUsesErrorWhenMaximumAnnotated(): void {
+		$definition = PropertyDefinition::fromJson(
+			[
+				'type' => 'date',
+				'minimum' => '2025-01-01',
+				'maximum' => [ 'value' => '2025-12-31', 'severity' => 'error' ],
+			],
+			PropertyTypeRegistry::withCoreTypes(),
+		);
+
+		$violations = $this->type->validate( new StringValue( '2026-01-01' ), $definition );
+
+		$this->assertSame( 'max-value', $violations[0]->code );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
 	}
 
 	public function testEqualToBoundsReturnsNoViolations(): void {

--- a/tests/phpunit/Domain/PropertyType/Types/NumberTypeValidateTest.php
+++ b/tests/phpunit/Domain/PropertyType/Types/NumberTypeValidateTest.php
@@ -5,9 +5,12 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Tests\Domain\PropertyType\Types;
 
 use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeRegistry;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\Types\NumberType;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\NumberProperty;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinition;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
 use ProfessionalWiki\NeoWiki\Domain\Value\NumberValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
 
@@ -91,6 +94,27 @@ class NumberTypeValidateTest extends TestCase {
 		);
 
 		$this->assertSame( [], $violations );
+	}
+
+	public function testMaxValueViolationDefaultsToWarningSeverity(): void {
+		$violations = $this->type->validate(
+			new NumberValue( 101 ),
+			$this->newProperty( required: false, maximum: 100 ),
+		);
+
+		$this->assertSame( Severity::Warning, $violations[0]->severity );
+	}
+
+	public function testMaxValueViolationUsesErrorWhenMaximumAnnotated(): void {
+		$definition = PropertyDefinition::fromJson(
+			[ 'type' => 'number', 'maximum' => [ 'value' => 100, 'severity' => 'error' ] ],
+			PropertyTypeRegistry::withCoreTypes(),
+		);
+
+		$violations = $this->type->validate( new NumberValue( 101 ), $definition );
+
+		$this->assertSame( 'max-value', $violations[0]->code );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
 	}
 
 	private function newProperty(

--- a/tests/phpunit/Domain/PropertyType/Types/NumberTypeValidateTest.php
+++ b/tests/phpunit/Domain/PropertyType/Types/NumberTypeValidateTest.php
@@ -117,6 +117,18 @@ class NumberTypeValidateTest extends TestCase {
 		$this->assertSame( Severity::Error, $violations[0]->severity );
 	}
 
+	public function testMinValueViolationUsesErrorWhenMinimumAnnotated(): void {
+		$definition = PropertyDefinition::fromJson(
+			[ 'type' => 'number', 'minimum' => [ 'value' => 0, 'severity' => 'error' ] ],
+			PropertyTypeRegistry::withCoreTypes(),
+		);
+
+		$violations = $this->type->validate( new NumberValue( -1 ), $definition );
+
+		$this->assertSame( 'min-value', $violations[0]->code );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
+	}
+
 	private function newProperty(
 		bool $required,
 		float|int|null $minimum = null,

--- a/tests/phpunit/Domain/PropertyType/Types/SelectTypeValidateTest.php
+++ b/tests/phpunit/Domain/PropertyType/Types/SelectTypeValidateTest.php
@@ -5,9 +5,12 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Tests\Domain\PropertyType\Types;
 
 use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeRegistry;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\Types\SelectType;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\SelectProperty;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinition;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
 use ProfessionalWiki\NeoWiki\Domain\Value\NumberValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
 
@@ -95,6 +98,29 @@ class SelectTypeValidateTest extends TestCase {
 		$this->assertNull( $violations[1]->propertyName );
 	}
 
+	public function testInvalidOptionUsesErrorWhenOptionsAnnotated(): void {
+		$definition = PropertyDefinition::fromJson(
+			[
+				'type' => 'select',
+				'multiple' => true,
+				'options' => [
+					'value' => [
+						[ 'id' => 'opt_a', 'label' => 'A' ],
+						[ 'id' => 'opt_b', 'label' => 'B' ],
+					],
+					'severity' => 'error',
+				],
+			],
+			PropertyTypeRegistry::withCoreTypes(),
+		);
+
+		$violations = $this->type->validate( new StringValue( 'opt_a', 'opt_c', 'opt_b' ), $definition );
+
+		$this->assertCount( 1, $violations );
+		$this->assertSame( 'invalid-option', $violations[0]->code );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
+	}
+
 	public function testSingleValueOnlyWhenMultipleIsFalseAndMoreThanOnePart(): void {
 		$violations = $this->type->validate(
 			new StringValue( 'red', 'green' ),
@@ -107,6 +133,7 @@ class SelectTypeValidateTest extends TestCase {
 		$singleViolation = array_values( array_filter( $violations, static fn( $v ) => $v->code === 'single-value-only' ) )[0];
 		$this->assertNull( $singleViolation->valuePartIndex );
 		$this->assertNull( $singleViolation->propertyName );
+		$this->assertSame( Severity::Error, $singleViolation->severity );
 	}
 
 	public function testMultipleTrueAndManyValidPartsReturnsNoViolations(): void {

--- a/tests/phpunit/Domain/PropertyType/Types/TextTypeValidateTest.php
+++ b/tests/phpunit/Domain/PropertyType/Types/TextTypeValidateTest.php
@@ -5,9 +5,12 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Tests\Domain\PropertyType\Types;
 
 use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeRegistry;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\Types\TextType;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\TextProperty;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinition;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
 use ProfessionalWiki\NeoWiki\Domain\Value\NumberValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
 
@@ -73,6 +76,18 @@ class TextTypeValidateTest extends TestCase {
 		$this->assertNull( $violations[0]->valuePartIndex );
 	}
 
+	public function testUniqueViolationUsesErrorWhenUniqueItemsAnnotated(): void {
+		$definition = PropertyDefinition::fromJson(
+			[ 'type' => 'text', 'multiple' => true, 'uniqueItems' => [ 'severity' => 'error' ] ],
+			PropertyTypeRegistry::withCoreTypes(),
+		);
+
+		$violations = $this->type->validate( new StringValue( 'foo', 'bar', 'foo' ), $definition );
+
+		$this->assertSame( 'unique', $violations[0]->code );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
+	}
+
 	public function testUniqueItemsWithAllDistinctReturnsNoViolation(): void {
 		$violations = $this->type->validate(
 			new StringValue( 'foo', 'bar', 'baz' ),
@@ -114,6 +129,18 @@ class TextTypeValidateTest extends TestCase {
 		$this->assertSame( 1, $violations[0]->valuePartIndex );
 	}
 
+	public function testMinLengthViolationUsesErrorWhenMinLengthAnnotated(): void {
+		$definition = PropertyDefinition::fromJson(
+			[ 'type' => 'text', 'multiple' => true, 'minLength' => [ 'value' => 3, 'severity' => 'error' ] ],
+			PropertyTypeRegistry::withCoreTypes(),
+		);
+
+		$violations = $this->type->validate( new StringValue( 'abc', 'ab' ), $definition );
+
+		$this->assertSame( 'min-length', $violations[0]->code );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
+	}
+
 	public function testPartLongerThanMaxLengthProducesMaxLengthViolation(): void {
 		$violations = $this->type->validate(
 			new StringValue( 'ok', 'toolong' ),
@@ -124,6 +151,18 @@ class TextTypeValidateTest extends TestCase {
 		$this->assertSame( 'max-length', $violations[0]->code );
 		$this->assertSame( [ 4 ], $violations[0]->args );
 		$this->assertSame( 1, $violations[0]->valuePartIndex );
+	}
+
+	public function testMaxLengthViolationUsesErrorWhenMaxLengthAnnotated(): void {
+		$definition = PropertyDefinition::fromJson(
+			[ 'type' => 'text', 'multiple' => true, 'maxLength' => [ 'value' => 4, 'severity' => 'error' ] ],
+			PropertyTypeRegistry::withCoreTypes(),
+		);
+
+		$violations = $this->type->validate( new StringValue( 'ok', 'toolong' ), $definition );
+
+		$this->assertSame( 'max-length', $violations[0]->code );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
 	}
 
 	public function testTrimmedLengthBelowMinimumProducesViolation(): void {

--- a/tests/phpunit/Domain/PropertyType/Types/UrlTypeValidateTest.php
+++ b/tests/phpunit/Domain/PropertyType/Types/UrlTypeValidateTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\Types\UrlType;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\UrlProperty;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
 use ProfessionalWiki\NeoWiki\Domain\Value\NumberValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
 
@@ -70,6 +71,7 @@ class UrlTypeValidateTest extends TestCase {
 		$this->assertCount( 1, $violations );
 		$this->assertSame( 'invalid-url', $violations[0]->code );
 		$this->assertSame( 0, $violations[0]->valuePartIndex );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
 	}
 
 	public function testEachInvalidPartReturnsIndexedViolation(): void {

--- a/tests/phpunit/Domain/Schema/Property/NumberPropertyTest.php
+++ b/tests/phpunit/Domain/Schema/Property/NumberPropertyTest.php
@@ -103,4 +103,89 @@ JSON
 		);
 	}
 
+	public function testMaximumWithErrorSeverityRoundTrips(): void {
+		$this->assertSerializationDoesNotChange(
+			<<<JSON
+{
+	"type": "number",
+	"description": "",
+	"required": false,
+	"default": null,
+	"precision": null,
+	"minimum": null,
+	"maximum": { "value": 100, "severity": "error" }
+}
+JSON
+		);
+	}
+
+	public function testRequiredWithErrorSeverityRoundTrips(): void {
+		$this->assertSerializationDoesNotChange(
+			<<<JSON
+{
+	"type": "number",
+	"description": "",
+	"required": { "severity": "error" },
+	"default": null,
+	"precision": null,
+	"minimum": null,
+	"maximum": null
+}
+JSON
+		);
+	}
+
+	public function testExplicitWarningSeverityCanonicalizesToShorthand(): void {
+		$this->assertJsonStringEqualsJsonString(
+			<<<JSON
+{
+	"type": "number",
+	"description": "",
+	"required": false,
+	"default": null,
+	"precision": null,
+	"minimum": null,
+	"maximum": 100
+}
+JSON,
+			$this->deserializeAndReserialize(
+				<<<JSON
+{
+	"type": "number",
+	"maximum": { "value": 100, "severity": "warning" }
+}
+JSON
+			)
+		);
+	}
+
+	/**
+	 * precision is a Display Attribute, not a Constraint, so a severity on it is meaningless.
+	 * It must be dropped rather than re-emitted, which would turn precision into an object
+	 * and break every consumer that reads it as a scalar.
+	 */
+	public function testSeverityOnDisplayAttributeIsDroppedRatherThanReserialized(): void {
+		$this->assertJsonStringEqualsJsonString(
+			<<<JSON
+{
+	"type": "number",
+	"description": "",
+	"required": false,
+	"default": null,
+	"precision": 2,
+	"minimum": null,
+	"maximum": null
+}
+JSON,
+			$this->deserializeAndReserialize(
+				<<<JSON
+{
+	"type": "number",
+	"precision": { "value": 2, "severity": "error" }
+}
+JSON
+			)
+		);
+	}
+
 }

--- a/tests/phpunit/Domain/Schema/Property/SelectPropertyTest.php
+++ b/tests/phpunit/Domain/Schema/Property/SelectPropertyTest.php
@@ -52,6 +52,27 @@ JSON
 		);
 	}
 
+	public function testObjectFormOptionsSeverityIsStable(): void {
+		$this->assertSerializationDoesNotChange(
+			<<<JSON
+{
+	"type": "select",
+	"description": "Document status",
+	"required": false,
+	"default": null,
+	"options": {
+		"value": [
+			{ "id": "opt1", "label": "Draft" },
+			{ "id": "opt2", "label": "Review" }
+		],
+		"severity": "error"
+	},
+	"multiple": false
+}
+JSON
+		);
+	}
+
 	public function testExceptionOnLegacyStringOption(): void {
 		$this->expectException( InvalidArgumentException::class );
 		$this->fromJson(

--- a/tests/phpunit/Domain/Schema/Property/UnregisteredTypePropertyTest.php
+++ b/tests/phpunit/Domain/Schema/Property/UnregisteredTypePropertyTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Domain\Schema\Property;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Domain\Schema\Property\UnregisteredTypeProperty
+ */
+class UnregisteredTypePropertyTest extends PropertyTestCase {
+
+	/**
+	 * The type "color" is not among the core types, so it deserializes to an
+	 * UnregisteredTypeProperty. Its object-form constraint severities must survive a
+	 * round-trip (regression: the core `required` severity was previously dropped).
+	 */
+	public function testObjectFormRequiredSeverityRoundTripsForUnregisteredType(): void {
+		$this->assertSerializationDoesNotChange(
+			<<<JSON
+{
+	"type": "color",
+	"description": "",
+	"required": { "severity": "error" },
+	"default": null,
+	"allowedColors": [ "#ff0000" ]
+}
+JSON
+		);
+	}
+
+	public function testUnannotatedUnregisteredTypeRoundTripsUnchanged(): void {
+		$this->assertSerializationDoesNotChange(
+			<<<JSON
+{
+	"type": "color",
+	"description": "",
+	"required": false,
+	"default": null,
+	"allowedColors": [ "#ff0000" ]
+}
+JSON
+		);
+	}
+
+}

--- a/tests/phpunit/Domain/Schema/Property/UnregisteredTypePropertyTest.php
+++ b/tests/phpunit/Domain/Schema/Property/UnregisteredTypePropertyTest.php
@@ -47,6 +47,24 @@ JSON
 		);
 	}
 
+	/**
+	 * A custom boolean Constraint set to false must keep its explicit `value` key: the
+	 * value-less object form implies true, so dropping it would flip the Constraint on.
+	 */
+	public function testObjectFormFalseCustomConstraintRoundTripsForUnregisteredType(): void {
+		$this->assertSerializationDoesNotChange(
+			<<<JSON
+{
+	"type": "color",
+	"description": "",
+	"required": false,
+	"default": null,
+	"caseSensitive": { "value": false, "severity": "error" }
+}
+JSON
+		);
+	}
+
 	public function testUnannotatedUnregisteredTypeRoundTripsUnchanged(): void {
 		$this->assertSerializationDoesNotChange(
 			<<<JSON

--- a/tests/phpunit/Domain/Schema/Property/UnregisteredTypePropertyTest.php
+++ b/tests/phpunit/Domain/Schema/Property/UnregisteredTypePropertyTest.php
@@ -28,6 +28,25 @@ JSON
 		);
 	}
 
+	/**
+	 * The severity on a type-specific key the core knows nothing about must survive too:
+	 * the property is rebuilt from the normalized values, so re-serializing re-wraps the
+	 * key once rather than wrapping the already-wrapped object again.
+	 */
+	public function testObjectFormCustomConstraintSeverityRoundTripsForUnregisteredType(): void {
+		$this->assertSerializationDoesNotChange(
+			<<<JSON
+{
+	"type": "color",
+	"description": "",
+	"required": false,
+	"default": null,
+	"allowedColors": { "value": [ "#ff0000" ], "severity": "error" }
+}
+JSON
+		);
+	}
+
 	public function testUnannotatedUnregisteredTypeRoundTripsUnchanged(): void {
 		$this->assertSerializationDoesNotChange(
 			<<<JSON

--- a/tests/phpunit/Domain/Validation/SeverityNormalizerTest.php
+++ b/tests/phpunit/Domain/Validation/SeverityNormalizerTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Domain\Validation;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
+use ProfessionalWiki\NeoWiki\Domain\Validation\SeverityNormalizer;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Domain\Validation\SeverityNormalizer
+ */
+class SeverityNormalizerTest extends TestCase {
+
+	public function testShorthandScalarPassesThroughWithNoSeverity(): void {
+		[ $values, $severities ] = SeverityNormalizer::extract( [ 'maximum' => 100 ] );
+
+		$this->assertSame( [ 'maximum' => 100 ], $values );
+		$this->assertSame( [], $severities );
+	}
+
+	public function testObjectFormScalarIsUnwrapped(): void {
+		[ $values, $severities ] = SeverityNormalizer::extract(
+			[ 'maximum' => [ 'value' => 100, 'severity' => 'error' ] ]
+		);
+
+		$this->assertSame( [ 'maximum' => 100 ], $values );
+		$this->assertSame( [ 'maximum' => Severity::Error ], $severities );
+	}
+
+	public function testObjectFormBooleanImpliesTrue(): void {
+		[ $values, $severities ] = SeverityNormalizer::extract(
+			[ 'required' => [ 'severity' => 'error' ] ]
+		);
+
+		$this->assertSame( [ 'required' => true ], $values );
+		$this->assertSame( [ 'required' => Severity::Error ], $severities );
+	}
+
+	public function testReservedKeysAreNeverNormalized(): void {
+		$raw = [ 'type' => 'number', 'description' => 'x', 'default' => 5 ];
+
+		[ $values, $severities ] = SeverityNormalizer::extract( $raw );
+
+		$this->assertSame( $raw, $values );
+		$this->assertSame( [], $severities );
+	}
+
+	public function testUnknownSeverityThrows(): void {
+		$this->expectException( InvalidArgumentException::class );
+		SeverityNormalizer::extract( [ 'maximum' => [ 'value' => 1, 'severity' => 'bogus' ] ] );
+	}
+
+	public function testApplyWrapsErrorScalarAndSkipsWarning(): void {
+		$json = [ 'minimum' => 0, 'maximum' => 100 ];
+		$severities = [ 'minimum' => Severity::Warning, 'maximum' => Severity::Error ];
+
+		$this->assertSame(
+			[ 'minimum' => 0, 'maximum' => [ 'value' => 100, 'severity' => 'error' ] ],
+			SeverityNormalizer::apply( $json, $severities )
+		);
+	}
+
+	public function testApplyWrapsErrorBooleanWithoutValue(): void {
+		$this->assertSame(
+			[ 'required' => [ 'severity' => 'error' ] ],
+			SeverityNormalizer::apply( [ 'required' => true ], [ 'required' => Severity::Error ] )
+		);
+	}
+
+	public function testExplicitNullValueIsPreservedRatherThanCoalescedToTrue(): void {
+		[ $values, ] = SeverityNormalizer::extract(
+			[ 'maximum' => [ 'value' => null, 'severity' => 'error' ] ]
+		);
+
+		$this->assertNull( $values['maximum'] );
+	}
+
+	public function testExtractApplyRoundTripsErrorAnnotations(): void {
+		$original = [ 'options' => [ 'value' => [ 'a', 'b' ], 'severity' => 'error' ] ];
+
+		[ $values, $severities ] = SeverityNormalizer::extract( $original );
+
+		$this->assertSame( $original, SeverityNormalizer::apply( $values, $severities ) );
+	}
+}

--- a/tests/phpunit/Domain/Validation/SeverityNormalizerTest.php
+++ b/tests/phpunit/Domain/Validation/SeverityNormalizerTest.php
@@ -86,4 +86,26 @@ class SeverityNormalizerTest extends TestCase {
 
 		$this->assertSame( $original, SeverityNormalizer::apply( $values, $severities ) );
 	}
+
+	/**
+	 * The value-less object form implies true, so emitting it for a `false` value would read
+	 * back as `true` and silently enable a Constraint the author disabled. Core booleans are
+	 * always true when annotated — the content schema forbids a `value` key on them — but a
+	 * custom Property Type's own boolean key carries no such guard.
+	 */
+	public function testApplyKeepsFalseBooleanValueRatherThanImplyingTrue(): void {
+		$this->assertSame(
+			[ 'caseSensitive' => [ 'value' => false, 'severity' => 'error' ] ],
+			SeverityNormalizer::apply( [ 'caseSensitive' => false ], [ 'caseSensitive' => Severity::Error ] )
+		);
+	}
+
+	public function testFalseBooleanCustomKeyRoundTrips(): void {
+		$original = [ 'caseSensitive' => [ 'value' => false, 'severity' => 'error' ] ];
+
+		[ $values, $severities ] = SeverityNormalizer::extract( $original );
+
+		$this->assertFalse( $values['caseSensitive'] );
+		$this->assertSame( $original, SeverityNormalizer::apply( $values, $severities ) );
+	}
 }

--- a/tests/phpunit/Domain/Validation/SeverityNormalizerTest.php
+++ b/tests/phpunit/Domain/Validation/SeverityNormalizerTest.php
@@ -39,8 +39,9 @@ class SeverityNormalizerTest extends TestCase {
 		$this->assertSame( [ 'required' => Severity::Error ], $severities );
 	}
 
-	public function testReservedKeysAreNeverNormalized(): void {
-		$raw = [ 'type' => 'number', 'description' => 'x', 'default' => 5 ];
+	public function testReservedKeyCarryingSeverityIsNotNormalized(): void {
+		// 'high' is not a severity: normalizing this key would throw rather than pass it through.
+		$raw = [ 'type' => 'number', 'description' => 'x', 'default' => [ 'severity' => 'high' ] ];
 
 		[ $values, $severities ] = SeverityNormalizer::extract( $raw );
 

--- a/tests/phpunit/Domain/Validation/ViolationDiffTest.php
+++ b/tests/phpunit/Domain/Validation/ViolationDiffTest.php
@@ -6,6 +6,7 @@ namespace ProfessionalWiki\NeoWiki\Tests\Domain\Validation;
 
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyName;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
 use ProfessionalWiki\NeoWiki\Domain\Validation\ViolationDiff;
 
@@ -122,6 +123,13 @@ class ViolationDiffTest extends TestCase {
 		);
 
 		$this->assertSame( [ $indexNull ], $result );
+	}
+
+	public function testSameViolationWithDifferentSeverityIsNotNew(): void {
+		$asWarning = new Violation( new PropertyName( 'Age' ), 'max-value', args: [ 100 ], severity: Severity::Warning );
+		$asError = new Violation( new PropertyName( 'Age' ), 'max-value', args: [ 100 ], severity: Severity::Error );
+
+		$this->assertSame( [], ViolationDiff::newViolations( proposed: [ $asError ], prior: [ $asWarning ] ) );
 	}
 
 	private function required( string $property ): Violation {

--- a/tests/phpunit/Domain/Validation/ViolationTest.php
+++ b/tests/phpunit/Domain/Validation/ViolationTest.php
@@ -6,6 +6,7 @@ namespace ProfessionalWiki\NeoWiki\Tests\Domain\Validation;
 
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyName;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
 
 /**
@@ -66,24 +67,28 @@ class ViolationTest extends TestCase {
 		$this->assertSame( 1, $named->valuePartIndex );
 	}
 
-	public function testSchemaNotFoundIsNotBlocking(): void {
-		$violation = new Violation( propertyName: null, code: 'schema-not-found', args: [ 'Person' ] );
+	public function testErrorSeverityIsBlocking(): void {
+		$violation = new Violation( propertyName: null, code: 'required', severity: Severity::Error );
+
+		$this->assertTrue( $violation->isBlocking() );
+	}
+
+	public function testWarningSeverityIsNotBlocking(): void {
+		$violation = new Violation( propertyName: null, code: 'required', severity: Severity::Warning );
 
 		$this->assertFalse( $violation->isBlocking() );
 	}
 
-	public function testUnregisteredTypeIsNotBlocking(): void {
-		$violation = new Violation( propertyName: new PropertyName( 'Swatch' ), code: 'unregistered-type', args: [ 'color' ] );
+	public function testDefaultSeverityIsWarning(): void {
+		$violation = new Violation( propertyName: null, code: 'required' );
 
-		$this->assertFalse( $violation->isBlocking() );
+		$this->assertSame( Severity::Warning, $violation->severity );
 	}
 
-	public function testOtherCodesAreBlocking(): void {
-		$required = new Violation( propertyName: new PropertyName( 'Status' ), code: 'required' );
-		$invalid = new Violation( propertyName: new PropertyName( 'Website' ), code: 'invalid-url' );
+	public function testWithPropertyNamePreservesSeverity(): void {
+		$original = new Violation( propertyName: null, code: 'max-value', severity: Severity::Error );
 
-		$this->assertTrue( $required->isBlocking() );
-		$this->assertTrue( $invalid->isBlocking() );
+		$this->assertSame( Severity::Error, $original->withPropertyName( new PropertyName( 'Age' ) )->severity );
 	}
 
 }

--- a/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
@@ -267,7 +267,7 @@ class CreateSubjectApiTest extends NeoWikiIntegrationTestCase {
 
 		$this->createSchema(
 			'EnforcementSchema',
-			'{"title":"EnforcementSchema","propertyDefinitions":{"Required":{"type":"text","required":true}}}'
+			'{"title":"EnforcementSchema","propertyDefinitions":{"Required":{"type":"text","required":{"severity":"error"}}}}'
 		);
 
 		$body = $this->validBody();

--- a/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
@@ -286,6 +286,32 @@ class CreateSubjectApiTest extends NeoWikiIntegrationTestCase {
 		$this->assertSame( 'Validation failed', $responseData['message'] );
 		$this->assertSame( 'Required', $responseData['violations'][0]['propertyName'] );
 		$this->assertSame( 'required', $responseData['violations'][0]['code'] );
+		$this->assertSame( 'error', $responseData['violations'][0]['severity'] );
+	}
+
+	public function testEnforcementAllowsUnannotatedConstraintViolation(): void {
+		$this->setMwGlobals( 'wgNeoWikiEnforceValidation', true );
+
+		$this->createSchema(
+			'UnannotatedSchema',
+			'{"title":"UnannotatedSchema","propertyDefinitions":{"Required":{"type":"text","required":true}}}'
+		);
+
+		$body = $this->validBody();
+		$body['schema'] = 'UnannotatedSchema';
+		$body['statements'] = [];
+
+		$response = $this->executeHandler(
+			$this->newCreateSubjectApi(),
+			$this->createRequestData( $body )
+		);
+
+		$responseData = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertSame( 201, $response->getStatusCode() );
+		$this->assertSame( 'created', $responseData['status'] );
+		$this->assertSame( 'required', $responseData['violations'][0]['code'] );
+		$this->assertSame( 'warning', $responseData['violations'][0]['severity'] );
 	}
 
 	public function testCreatesChildSubjectWithSuppliedId(): void {

--- a/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
@@ -306,7 +306,7 @@ class ReplaceSubjectApiTest extends NeoWikiIntegrationTestCase {
 
 		$this->createSchema(
 			'EnforcementSchema',
-			'{"title":"EnforcementSchema","propertyDefinitions":{"Required":{"type":"text","required":true}}}'
+			'{"title":"EnforcementSchema","propertyDefinitions":{"Required":{"type":"text","required":{"severity":"error"}}}}'
 		);
 		$this->createPageWithSubjects(
 			'ReplaceSubjectApiEnforcementTest',

--- a/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
@@ -341,6 +341,7 @@ class ReplaceSubjectApiTest extends NeoWikiIntegrationTestCase {
 		$this->assertNotEmpty( $responseData['violations'] );
 		$this->assertSame( 'Required', $responseData['violations'][0]['propertyName'] );
 		$this->assertSame( 'required', $responseData['violations'][0]['code'] );
+		$this->assertSame( 'error', $responseData['violations'][0]['severity'] );
 	}
 
 	private function createPages(): void {

--- a/tests/phpunit/Persistence/MediaWiki/SchemaContentValidatorTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/SchemaContentValidatorTest.php
@@ -209,6 +209,68 @@ JSON
 		);
 	}
 
+	public function testRequiredWithSeverityObjectFormPassesValidation(): void {
+		$validator = SchemaContentValidator::newInstance();
+
+		$valid = $validator->validate(
+			$this->schemaWithProperty( '{ "type": "text", "required": { "severity": "error" } }' )
+		);
+
+		if ( !$valid ) {
+			$this->assertSame( [], $validator->getErrors() );
+		}
+
+		$this->assertTrue( $valid );
+	}
+
+	public function testScalarConstraintWithValidSeverityObjectFormPassesValidation(): void {
+		$validator = SchemaContentValidator::newInstance();
+
+		$valid = $validator->validate(
+			$this->schemaWithProperty( '{ "type": "number", "maximum": { "value": 100, "severity": "error" } }' )
+		);
+
+		if ( !$valid ) {
+			$this->assertSame( [], $validator->getErrors() );
+		}
+
+		$this->assertTrue( $valid );
+	}
+
+	public function testScalarConstraintWithInvalidSeverityStringFailsValidation(): void {
+		$validator = SchemaContentValidator::newInstance();
+
+		$this->assertFalse(
+			$validator->validate(
+				$this->schemaWithProperty( '{ "type": "number", "maximum": { "value": 100, "severity": "eror" } }' )
+			)
+		);
+	}
+
+	public function testScalarConstraintObjectFormMissingValueFailsValidation(): void {
+		$validator = SchemaContentValidator::newInstance();
+
+		$this->assertFalse(
+			$validator->validate(
+				$this->schemaWithProperty( '{ "type": "number", "maximum": { "severity": "error" } }' )
+			)
+		);
+	}
+
+	/**
+	 * The boolean object form implies true and carries no value key. Permitting a stray
+	 * one would let "value": false round-trip back as true, silently flipping the Constraint.
+	 */
+	public function testBooleanConstraintObjectFormWithValueKeyFailsValidation(): void {
+		$validator = SchemaContentValidator::newInstance();
+
+		$this->assertFalse(
+			$validator->validate(
+				$this->schemaWithProperty( '{ "type": "text", "required": { "value": false, "severity": "error" } }' )
+			)
+		);
+	}
+
 	/**
 	 * Wraps the property under test between two valid siblings so a regression that only
 	 * inspects the first or last property definition is caught.

--- a/tests/phpunit/Persistence/MediaWiki/SchemaContentValidatorTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/SchemaContentValidatorTest.php
@@ -237,6 +237,37 @@ JSON
 		$this->assertTrue( $valid );
 	}
 
+	public function testOptionsWithSeverityObjectFormPassesValidation(): void {
+		$validator = SchemaContentValidator::newInstance();
+
+		$valid = $validator->validate(
+			$this->schemaWithProperty(
+				'{ "type": "select", "multiple": false, "options": { "value": [ { "id": "opt_a", "label": "A" } ], "severity": "error" } }'
+			)
+		);
+
+		if ( !$valid ) {
+			$this->assertSame( [], $validator->getErrors() );
+		}
+
+		$this->assertTrue( $valid );
+	}
+
+	/**
+	 * `multiple` declares the value's shape rather than a Constraint, so the object form is
+	 * rejected at authoring time: the normalizer is deliberately key-agnostic and would
+	 * otherwise unwrap it into a severity nothing reads.
+	 */
+	public function testShapeKeyWithSeverityObjectFormFailsValidation(): void {
+		$validator = SchemaContentValidator::newInstance();
+
+		$this->assertFalse(
+			$validator->validate(
+				$this->schemaWithProperty( '{ "type": "text", "multiple": { "severity": "error" } }' )
+			)
+		);
+	}
+
 	public function testScalarConstraintWithInvalidSeverityStringFailsValidation(): void {
 		$validator = SchemaContentValidator::newInstance();
 

--- a/tests/phpunit/Persistence/MediaWiki/SchemaContentValidatorTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/SchemaContentValidatorTest.php
@@ -289,6 +289,34 @@ JSON
 	}
 
 	/**
+	 * The positive `options` case above cannot fail on its own: the property definition schema
+	 * sets `additionalProperties: true`, so dropping the `options` $ref would still accept the
+	 * object form. These two pin that the $ref is actually wired up — without it a typo'd
+	 * severity saves cleanly and then throws on every subsequent read of the Schema page.
+	 */
+	public function testOptionsObjectFormWithInvalidSeverityFailsValidation(): void {
+		$validator = SchemaContentValidator::newInstance();
+
+		$this->assertFalse(
+			$validator->validate(
+				$this->schemaWithProperty(
+					'{ "type": "select", "multiple": false, "options": { "value": [ { "id": "opt_a", "label": "A" } ], "severity": "eror" } }'
+				)
+			)
+		);
+	}
+
+	public function testOptionsObjectFormMissingValueFailsValidation(): void {
+		$validator = SchemaContentValidator::newInstance();
+
+		$this->assertFalse(
+			$validator->validate(
+				$this->schemaWithProperty( '{ "type": "select", "multiple": false, "options": { "severity": "error" } }' )
+			)
+		);
+	}
+
+	/**
 	 * The boolean object form implies true and carries no value key. Permitting a stray
 	 * one would let "value": false round-trip back as true, silently flipping the Constraint.
 	 */

--- a/tests/phpunit/Persistence/MediaWiki/SchemaContentValidatorTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/SchemaContentValidatorTest.php
@@ -289,10 +289,10 @@ JSON
 	}
 
 	/**
-	 * The positive `options` case above cannot fail on its own: the property definition schema
-	 * sets `additionalProperties: true`, so dropping the `options` $ref would still accept the
-	 * object form. These two pin that the $ref is actually wired up — without it a typo'd
-	 * severity saves cleanly and then throws on every subsequent read of the Schema page.
+	 * The positive `options` case above cannot fail on its own: a key left declared but
+	 * unconstrained still accepts the object form, and being declared also puts it outside the
+	 * additionalProperties guard. These two pin that the $ref is actually wired up — without it
+	 * a typo'd severity saves cleanly and then throws on every subsequent read of the Schema page.
 	 */
 	public function testOptionsObjectFormWithInvalidSeverityFailsValidation(): void {
 		$validator = SchemaContentValidator::newInstance();
@@ -326,6 +326,76 @@ JSON
 		$this->assertFalse(
 			$validator->validate(
 				$this->schemaWithProperty( '{ "type": "text", "required": { "value": false, "severity": "error" } }' )
+			)
+		);
+	}
+
+	/**
+	 * A custom Property Type's own Constraint keys are not declared here, so only the
+	 * additionalProperties guard checks their severity. Without it the typo saves cleanly and
+	 * SeverityNormalizer::extract then throws on every read, which SchemaPersistenceDeserializer
+	 * swallows — silently removing the property from the Schema with no error and no log.
+	 */
+	public function testCustomKeyObjectFormWithInvalidSeverityFailsValidation(): void {
+		$validator = SchemaContentValidator::newInstance();
+
+		$this->assertFalse(
+			$validator->validate(
+				$this->schemaWithProperty(
+					'{ "type": "color", "allowedColors": { "value": [ "#ff0000" ], "severity": "eror" } }'
+				)
+			)
+		);
+	}
+
+	public function testCustomKeyObjectFormWithValidSeverityPassesValidation(): void {
+		$validator = SchemaContentValidator::newInstance();
+
+		$valid = $validator->validate(
+			$this->schemaWithProperty(
+				'{ "type": "color", "allowedColors": { "value": [ "#ff0000" ], "severity": "error" } }'
+			)
+		);
+
+		if ( !$valid ) {
+			$this->assertSame( [], $validator->getErrors() );
+		}
+
+		$this->assertTrue( $valid );
+	}
+
+	/**
+	 * `default` is reserved: SeverityNormalizer never treats it as a Constraint, so a default
+	 * value that happens to be an object carrying a `severity` key is data, not an annotation,
+	 * and the guard on unlisted keys must not reject it.
+	 */
+	public function testReservedDefaultKeyCarryingArbitrarySeverityPassesValidation(): void {
+		$validator = SchemaContentValidator::newInstance();
+
+		$valid = $validator->validate(
+			$this->schemaWithProperty( '{ "type": "color", "default": { "severity": "high" } }' )
+		);
+
+		if ( !$valid ) {
+			$this->assertSame( [], $validator->getErrors() );
+		}
+
+		$this->assertTrue( $valid );
+	}
+
+	/**
+	 * extract() reads only `value` and `severity`, so a stray sibling is silently discarded.
+	 * booleanConstraint already closes its object; scalarConstraint must too, or a typo'd
+	 * `sevrity` looks accepted while the Constraint keeps the default warning.
+	 */
+	public function testScalarConstraintObjectFormWithUnknownKeyFailsValidation(): void {
+		$validator = SchemaContentValidator::newInstance();
+
+		$this->assertFalse(
+			$validator->validate(
+				$this->schemaWithProperty(
+					'{ "type": "number", "maximum": { "value": 100, "severity": "error", "sevrity": "warning" } }'
+				)
 			)
 		);
 	}

--- a/tests/phpunit/Presentation/RestCreateSubjectPresenterTest.php
+++ b/tests/phpunit/Presentation/RestCreateSubjectPresenterTest.php
@@ -27,7 +27,7 @@ class RestCreateSubjectPresenterTest extends TestCase {
 				'status' => 'created',
 				'subjectId' => 's1demo1aaaaaaa1',
 				'violations' => [
-					[ 'propertyName' => 'Status', 'code' => 'required', 'args' => [] ],
+					[ 'propertyName' => 'Status', 'code' => 'required', 'args' => [], 'severity' => 'warning' ],
 				],
 			],
 			$presenter->getJsonArray()
@@ -68,7 +68,7 @@ class RestCreateSubjectPresenterTest extends TestCase {
 				'status' => 'error',
 				'message' => 'Validation failed',
 				'violations' => [
-					[ 'propertyName' => 'Required', 'code' => 'required', 'args' => [] ],
+					[ 'propertyName' => 'Required', 'code' => 'required', 'args' => [], 'severity' => 'warning' ],
 				],
 			],
 			$presenter->getJsonArray()

--- a/tests/phpunit/Presentation/RestReplaceSubjectPresenterTest.php
+++ b/tests/phpunit/Presentation/RestReplaceSubjectPresenterTest.php
@@ -28,8 +28,8 @@ class RestReplaceSubjectPresenterTest extends TestCase {
 				'status' => 'updated',
 				'subjectId' => 's1demo1aaaaaaa1',
 				'violations' => [
-					[ 'propertyName' => 'Status', 'code' => 'required', 'args' => [] ],
-					[ 'propertyName' => null, 'code' => 'schema-not-found', 'args' => [ 'Person' ] ],
+					[ 'propertyName' => 'Status', 'code' => 'required', 'args' => [], 'severity' => 'warning' ],
+					[ 'propertyName' => null, 'code' => 'schema-not-found', 'args' => [ 'Person' ], 'severity' => 'warning' ],
 				],
 			],
 			$presenter->getJsonArray()
@@ -58,7 +58,7 @@ class RestReplaceSubjectPresenterTest extends TestCase {
 				'status' => 'error',
 				'message' => 'Validation failed',
 				'violations' => [
-					[ 'propertyName' => 'Status', 'code' => 'required', 'args' => [] ],
+					[ 'propertyName' => 'Status', 'code' => 'required', 'args' => [], 'severity' => 'warning' ],
 				],
 			],
 			$presenter->getJsonArray()

--- a/tests/phpunit/Presentation/ViolationSerializerTest.php
+++ b/tests/phpunit/Presentation/ViolationSerializerTest.php
@@ -29,6 +29,7 @@ class ViolationSerializerTest extends TestCase {
 				'propertyName' => 'Website',
 				'code' => 'invalid-url',
 				'args' => [ 'bad' ],
+				'severity' => 'warning',
 				'valuePartIndex' => 2,
 			],
 			$serialized

--- a/tests/phpunit/Presentation/ViolationSerializerTest.php
+++ b/tests/phpunit/Presentation/ViolationSerializerTest.php
@@ -6,6 +6,7 @@ namespace ProfessionalWiki\NeoWiki\Tests\Presentation;
 
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyName;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
 use ProfessionalWiki\NeoWiki\Presentation\ViolationSerializer;
 
@@ -21,6 +22,7 @@ class ViolationSerializerTest extends TestCase {
 				code: 'invalid-url',
 				args: [ 'bad' ],
 				valuePartIndex: 2,
+				severity: Severity::Error,
 			)
 		);
 
@@ -29,7 +31,7 @@ class ViolationSerializerTest extends TestCase {
 				'propertyName' => 'Website',
 				'code' => 'invalid-url',
 				'args' => [ 'bad' ],
-				'severity' => 'warning',
+				'severity' => 'error',
 				'valuePartIndex' => 2,
 			],
 			$serialized

--- a/tests/phpunit/RedHerb/ColorTypeValidateTest.php
+++ b/tests/phpunit/RedHerb/ColorTypeValidateTest.php
@@ -5,7 +5,10 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Tests\RedHerb;
 
 use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeRegistry;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinition;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
 use ProfessionalWiki\NeoWiki\Domain\Value\NumberValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
 use ProfessionalWiki\RedHerb\ColorProperty;
@@ -33,6 +36,28 @@ class ColorTypeValidateTest extends TestCase {
 		$this->assertNull( $violations[0]->valuePartIndex );
 	}
 
+	public function testRequiredViolationDefaultsToWarningSeverity(): void {
+		$violations = $this->type->validate(
+			new StringValue(),
+			$this->newProperty( required: true ),
+		);
+
+		$this->assertSame( Severity::Warning, $violations[0]->severity );
+	}
+
+	public function testRequiredViolationUsesErrorWhenRequiredAnnotated(): void {
+		$violations = $this->type->validate(
+			new StringValue(),
+			$this->newProperty(
+				required: true,
+				constraintSeverities: [ 'required' => Severity::Error ],
+			),
+		);
+
+		$this->assertSame( 'required', $violations[0]->code );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
+	}
+
 	public function testValidHexReturnsNoViolations(): void {
 		$violations = $this->type->validate(
 			new StringValue( '#aabbcc' ),
@@ -52,6 +77,16 @@ class ColorTypeValidateTest extends TestCase {
 		$this->assertSame( 'invalid-color', $violations[0]->code );
 		$this->assertSame( [ '#xxx' ], $violations[0]->args );
 		$this->assertSame( 0, $violations[0]->valuePartIndex );
+	}
+
+	public function testInvalidColorViolationIsError(): void {
+		$violations = $this->type->validate(
+			new StringValue( 'notacolor' ),
+			$this->newProperty( required: false ),
+		);
+
+		$this->assertSame( 'invalid-color', $violations[0]->code );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
 	}
 
 	public function testMultipleInvalidHexProducesIndexedViolations(): void {
@@ -88,12 +123,57 @@ class ColorTypeValidateTest extends TestCase {
 		$this->assertSame( 1, $violations[0]->valuePartIndex );
 	}
 
+	public function testInvalidOptionViolationUsesErrorWhenAllowedColorsAnnotated(): void {
+		$violations = $this->type->validate(
+			new StringValue( '#aabbcc', '#112233', '#ddeeff' ),
+			$this->newProperty(
+				required: false,
+				allowedColors: [ '#aabbcc', '#ddeeff' ],
+				constraintSeverities: [ 'allowedColors' => Severity::Error ],
+			),
+		);
+
+		$this->assertCount( 1, $violations );
+		$this->assertSame( 'invalid-option', $violations[0]->code );
+		$this->assertSame( 1, $violations[0]->valuePartIndex );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
+	}
+
+	public function testSeverityOfCustomConstraintComesFromSchemaJson(): void {
+		$registry = new PropertyTypeRegistry();
+		$registry->registerType( new ColorType() );
+
+		$definition = PropertyDefinition::fromJson(
+			[
+				'type' => 'color',
+				'required' => true,
+				'allowedColors' => [ 'value' => [ '#ff0000' ], 'severity' => 'error' ],
+			],
+			$registry,
+		);
+
+		$violations = $this->type->validate( new StringValue( '#00ff00' ), $definition );
+
+		$this->assertSame( 'invalid-option', $violations[0]->code );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
+	}
+
 	/**
 	 * @param list<string> $allowedColors
+	 * @param array<string, Severity> $constraintSeverities
 	 */
-	private function newProperty( bool $required, array $allowedColors = [] ): ColorProperty {
+	private function newProperty(
+		bool $required,
+		array $allowedColors = [],
+		array $constraintSeverities = [],
+	): ColorProperty {
 		return ColorProperty::fromPartialJson(
-			new PropertyCore( description: '', required: $required, default: null ),
+			new PropertyCore(
+				description: '',
+				required: $required,
+				default: null,
+				constraintSeverities: $constraintSeverities,
+			),
 			[ 'allowedColors' => $allowedColors ],
 		);
 	}


### PR DESCRIPTION
Implements the backend half of [ADR 26](https://github.com/ProfessionalWiki/NeoWiki/blob/master/docs/adr/026-validation-severity-levels.md): every Constraint carries a severity (`error` / `warning`), and enforcement blocks only when a write introduces a **new** `error` violation.

## What changes

A Constraint is now written either as the bare scalar shorthand (severity defaults to `warning`) or as an object carrying the severity:

```json
{
  "type": "number",
  "required": { "severity": "error" },
  "minimum": 0,
  "maximum": { "value": 100, "severity": "error" }
}
```

* `Violation` carries a `severity`, stamped where it is raised — Constraint-backed codes take the severity their Constraint configures, system conditions take the fixed severity from the ADR.
* `isBlocking()` now means `severity === error`, replacing the hardcoded non-blocking code list.
* Every serialized violation gains an always-present `severity` field, in the dry-run 200 bodies and the enforcement 422 alike.
* Severity is deliberately **not** part of `ViolationDiff` identity, so changing a Constraint's severity never makes a pre-existing violation count as newly introduced.

### Behaviour change worth noting

`required` (and the other authorable Constraints) now default to `warning`, so with `$wgNeoWikiEnforceValidation` on, an **unannotated** Schema blocks nothing beyond the fixed-`error` system conditions. That is the ADR's intent — invalid Subjects are a normal, supported state, and blocking is what a schema author opts into. The enforcement fixtures in the test suite were annotated `error` to keep testing the blocking path.

## Design note

Severity is stored in a name-keyed map on `PropertyCore`, populated by a generic `SeverityNormalizer` at the JSON boundary and read via `PropertyDefinition::severityOf()`. The concrete `*Property` classes are untouched.

The alternative — a `minimumSeverity` sibling field per Constraint on each Property class — was rejected because Property Types are an extensibility surface: this way an existing custom type (e.g. RedHerb's `ColorType`) keeps working with **zero** changes and opts into severity with a single `severityOf()` call, and the name-keyed map generalises to the ADR's deferred "constraints as data" direction. The accepted cost is that severity is not visible as a typed field on `NumberProperty`; the code↔constraint link stays local at each `validate()` site.

Severities annotated on declared Display Attributes are dropped (they are not Constraints, and re-emitting them would change the attribute's serialized shape), and the content schema rejects a malformed severity at save.

## ADR amendment

ADR 26's fixed-severity table omitted three codes the validator already produces. They are documented at the severity that preserves their existing behaviour: `unregistered-type` → `warning`, `relation-target-not-found` → `warning`, `relation-target-schema-mismatch` → `error`.

## Docs

`docs/` publishes to neowiki.ai, so the user-facing contracts this PR changes are updated alongside it: the always-present `severity` field and a per-code severity in [Validation codes](docs/api/validation-codes.md) (whose "three codes are non-blocking, every other code blocks" rule this PR replaces), the scalar-or-object Constraint form in [Schema format](docs/api/schema-format.md), the Constraint entry in the [Glossary](docs/glossary.md), and the corrected `$wgNeoWikiEnforceValidation` description in both the installation docs and `extension.json`.

## Scope

Backend only. The follow-ups the ADR anticipates in its Cons are tracked separately:

* #1148 — the frontend must parse the dual Constraint form and style `warning` vs `error`. Until it lands, a Schema saved with object-form Constraints is mis-read by the schema editor.
* #1149 — the per-Constraint severity control in the Schema editor. Until then, `error` severity is authored by hand-editing Schema JSON.

## Verification

`make phpunit` (targeted suites) and `make cs` green locally: SeverityNormalizer 9, Property 369, Presentation 62, Violation 131, Type 205, Validation 88, SchemaContentValidator 21, CreateSubjectApi 17, ReplaceSubjectApi 14; phpcs 593/593 and phpstan clean.

Smoke-tested live against a dev wiki over the REST API — object-form Schemas save, a typo'd severity is rejected at save, Constraints round-trip (`error` keeps the object form, unannotated stays shorthand, a Display Attribute stays a bare scalar), and `POST /subject/validate` returns:

```json
[{"propertyName":"Score","code":"max-value","args":[100],"severity":"error"},
 {"propertyName":"Code","code":"required","args":[],"severity":"error"},
 {"propertyName":"Note","code":"required","args":[],"severity":"warning"}]
```

## Manual Browser Check

N/A — backend only. There is no UI surface in this PR; the warning-vs-error styling and the severity authoring control arrive in #1148 and #1149 respectively. The behaviour above was verified over the REST API instead.

<sub>AI-authored — Claude Code, `Opus 4.8 (1M context)`; implemented from the pre-existing ADR 26, with the domain-representation fork (generic normalization vs per-Constraint fields) explored and decided by @alistair3149; reviewed by a three-lens agent panel (design soundness / elegance / correctness) and its findings applied; full targeted PHPUnit suites and phpcs/phpstan green locally, live-verified via the REST API; CI not yet run.</sub>
