### PR TITLE
Text pass and navigation aids for the RDF and ontology mappings demo page

### DIFF
--- a/DemoData/Page/RDF_and_ontology_mappings.wikitext
+++ b/DemoData/Page/RDF_and_ontology_mappings.wikitext
@@ -15,14 +15,17 @@ Each Mapping page targets one ontology, named by the page title, and holds an en
 
 Follow these in order; each link downloads the projection so you can read it.
 
+You don't need these links to reach an export: on any subject page, the Data tab offers per-projection downloads (Turtle or TriG) and a copy-IRI control, and the sidebar has a View RDF link.
+
 # '''Pablo Picasso''', [{{SERVER}}{{SCRIPTPATH}}/rest.php/neowiki/v0/page/{{PAGEID:Pablo Picasso}}/rdf native] vs [{{SERVER}}{{SCRIPTPATH}}/rest.php/neowiki/v0/page/{{PAGEID:Pablo Picasso}}/rdf?projection=EDM EDM]: the native file has everything, including the two-layer "Born in" relation and the page metadata; the EDM file is an <code>edm:Agent</code> carrying only the mapped vocabulary, with the unmapped <code>Source</code> absent.
 # '''Málaga''', [{{SERVER}}{{SCRIPTPATH}}/rest.php/neowiki/v0/page/{{PAGEID:Málaga}}/rdf?projection=EDM EDM]: an <code>edm:Place</code> with the very same entity IRI that Picasso's <code>rdaGr2:placeOfBirth</code> points at, because sibling projections share entity IRIs.
 # '''The Milkmaid''', [{{SERVER}}{{SCRIPTPATH}}/rest.php/neowiki/v0/page/{{PAGEID:The Milkmaid}}/rdf?projection=EDM EDM]: an <code>edm:ProvidedCHO</code> whose <code>dc:creator</code> is the IRI of [{{SERVER}}{{SCRIPTPATH}}/rest.php/neowiki/v0/page/{{PAGEID:Johannes Vermeer}}/rdf?projection=EDM Vermeer] (an <code>edm:Agent</code>) and whose <code>edm:currentLocation</code> is the Rijksmuseum.
-# '''Johann Sebastian Bach''', [{{SERVER}}{{SCRIPTPATH}}/rest.php/neowiki/v0/page/{{PAGEID:Johann Sebastian Bach}}/rdf?projection=EDM EDM]: Bach's birth is modelled as its own Birth Subject instead of flat fields, so his <code>edm:Agent</code> projects sparse. Same Person Schema as Picasso, a different modelling style.
+# '''Johann Sebastian Bach''', [{{SERVER}}{{SCRIPTPATH}}/rest.php/neowiki/v0/page/{{PAGEID:Johann Sebastian Bach}}/rdf?projection=EDM EDM]: Bach's birth is modelled as its own [[Birth of Johann Sebastian Bach|Birth Subject]] instead of flat fields, so his <code>edm:Agent</code> projects sparse. Same Person Schema as Picasso, a different modelling style.
 # '''ACME Inc''', [{{SERVER}}{{SCRIPTPATH}}/rest.php/neowiki/v0/page/{{PAGEID:ACME Inc}}/rdf?projection=EDM EDM]: its Company Schema has no EDM Mapping, so the EDM projection comes back empty. An unmapped Schema is simply left out, so the projection stays conformant.
 
 == Learn more ==
 
+* [[Special:Mappings]]: every ontology Mapping on this wiki
 * [https://github.com/ProfessionalWiki/NeoWiki/blob/master/docs/rdf/rdf-export.md RDF export reference]
 * [https://github.com/ProfessionalWiki/NeoWiki/blob/master/docs/rdf/ontology-mapping.md Ontology mapping reference]
 * [https://github.com/ProfessionalWiki/NeoWiki/blob/master/docs/examples/person-to-edm.md Person-to-EDM worked example]

--- a/DemoData/Page/RDF_and_ontology_mappings.wikitext
+++ b/DemoData/Page/RDF_and_ontology_mappings.wikitext
@@ -3,23 +3,23 @@ Every NeoWiki page's Subjects are available as '''RDF'''. The same data is offer
 * A '''native projection''' in NeoWiki's own vocabulary. Lossless, always available, no setup.
 * '''Ontology projections''' that re-express the data in an established vocabulary such as the [https://pro.europeana.eu/page/edm-documentation Europeana Data Model] (EDM). Each one is defined by a '''Mapping''' page.
 
-Each export is produced on demand from the page's current data and downloads as a Turtle or TriG file. A projection can also be kept in a SPARQL store and queried live — see [[SPARQL queries]] on wikis that have a store configured, such as the NeoWiki development stack.
+Each export is produced on demand from the page's current data and downloads as a Turtle or TriG file. A projection can also be kept in a SPARQL store and queried live. See [[SPARQL queries]] on wikis that have a store configured, such as the NeoWiki development stack.
 
 == The Mapping page ==
 
 Each Mapping page targets one ontology, named by the page title, and holds an entry for every mapped Schema. [[Special:Mappings]] lists them all; this wiki ships one:
 
-* [[Mapping:EDM]] — the Person, City, Artwork and Artist Schemas, all mapped to EDM
+* [[Mapping:EDM]]: the Person, City, Artwork and Artist Schemas, all mapped to EDM
 
 == Explore the projections ==
 
 Follow these in order; each link downloads the projection so you can read it.
 
 # '''Pablo Picasso''', [{{SERVER}}{{SCRIPTPATH}}/rest.php/neowiki/v0/page/{{PAGEID:Pablo Picasso}}/rdf native] vs [{{SERVER}}{{SCRIPTPATH}}/rest.php/neowiki/v0/page/{{PAGEID:Pablo Picasso}}/rdf?projection=EDM EDM]: the native file has everything, including the two-layer "Born in" relation and the page metadata; the EDM file is an <code>edm:Agent</code> carrying only the mapped vocabulary, with the unmapped <code>Source</code> absent.
-# '''Málaga''', [{{SERVER}}{{SCRIPTPATH}}/rest.php/neowiki/v0/page/{{PAGEID:Málaga}}/rdf?projection=EDM EDM]: an <code>edm:Place</code> — and the very same entity IRI that Picasso's <code>rdaGr2:placeOfBirth</code> points at, because sibling projections share entity IRIs.
+# '''Málaga''', [{{SERVER}}{{SCRIPTPATH}}/rest.php/neowiki/v0/page/{{PAGEID:Málaga}}/rdf?projection=EDM EDM]: an <code>edm:Place</code> with the very same entity IRI that Picasso's <code>rdaGr2:placeOfBirth</code> points at, because sibling projections share entity IRIs.
 # '''The Milkmaid''', [{{SERVER}}{{SCRIPTPATH}}/rest.php/neowiki/v0/page/{{PAGEID:The Milkmaid}}/rdf?projection=EDM EDM]: an <code>edm:ProvidedCHO</code> whose <code>dc:creator</code> is the IRI of [{{SERVER}}{{SCRIPTPATH}}/rest.php/neowiki/v0/page/{{PAGEID:Johannes Vermeer}}/rdf?projection=EDM Vermeer] (an <code>edm:Agent</code>) and whose <code>edm:currentLocation</code> is the Rijksmuseum.
-# '''Johann Sebastian Bach''', [{{SERVER}}{{SCRIPTPATH}}/rest.php/neowiki/v0/page/{{PAGEID:Johann Sebastian Bach}}/rdf?projection=EDM EDM]: Bach's birth is modelled as its own Birth Subject instead of flat fields, so his <code>edm:Agent</code> projects sparse — the same Person Schema as Picasso, a different modelling style.
-# '''ACME Inc''', [{{SERVER}}{{SCRIPTPATH}}/rest.php/neowiki/v0/page/{{PAGEID:ACME Inc}}/rdf?projection=EDM EDM]: its Company Schema has no EDM Mapping, so the EDM projection comes back empty — a Schema without a Mapping is simply absent, which is how conformant output stays conformant.
+# '''Johann Sebastian Bach''', [{{SERVER}}{{SCRIPTPATH}}/rest.php/neowiki/v0/page/{{PAGEID:Johann Sebastian Bach}}/rdf?projection=EDM EDM]: Bach's birth is modelled as its own Birth Subject instead of flat fields, so his <code>edm:Agent</code> projects sparse. Same Person Schema as Picasso, a different modelling style.
+# '''ACME Inc''', [{{SERVER}}{{SCRIPTPATH}}/rest.php/neowiki/v0/page/{{PAGEID:ACME Inc}}/rdf?projection=EDM EDM]: its Company Schema has no EDM Mapping, so the EDM projection comes back empty. An unmapped Schema is simply left out, so the projection stays conformant.
 
 == Learn more ==
 


### PR DESCRIPTION
Meaning-preserving style pass on the RDF/ontology-mapping demo tour page (`DemoData/Page/RDF_and_ontology_mappings.wikitext`): removed all em-dashes and flattened AI-tell phrasing, with structure, links, and register unchanged.

Three content enhancements (each verified against master and the fixtures):

* Bach's birth now links to its native subject page (`[[Birth of Johann Sebastian Bach]]`) so a reader can see the event structure rather than only the sparse EDM export.
* **Learn more** lists `[[Special:Mappings]]`, the on-wiki index of the wiki's ontology Mappings (special page present on master: `SpecialMappings`, `neowiki-special-mappings`).
* A discoverability line notes that every subject page reaches its exports through the **Data** tab (per-projection Turtle/TriG downloads and a copy-IRI control) and the sidebar **View RDF** link, so the tour's direct links are a shortcut rather than the only route.

Considered, omitted:

* Parallel native-page wikilinks on the other tour items (Vermeer, The Milkmaid, Málaga), left out to keep only the requested Bach link.
* `[[Special:Mappings]]` is now referenced twice — once inline in **The Mapping page** ("lists them all"), once in **Learn more**. Both kept (contextual vs. navigational); a maintainer may prefer to drop one.

> <sub>AI-authored — Claude Code, `Opus 4.8 (max)`; text pass and three specified enhancements requested by @JeroenDeDauw via session; diff not yet human-reviewed; links and UI-surface names verified against master and the live demo wiki.</sub>
