### PR TITLE
Show button focus rings for keyboard users only

### DIFF
--- a/resources/ext.neowiki/src/assets/keyboard-focus.less
+++ b/resources/ext.neowiki/src/assets/keyboard-focus.less
@@ -1,0 +1,59 @@
+/**
+ * Keyboard-only focus rings for NeoWiki's Codex buttons.
+ *
+ * Codex 1.14 styles button focus on bare `:focus`, so a mouse click — which
+ * focuses the button but, per the browser heuristic, does not match
+ * `:focus-visible` — leaves the progressive focus ring painted until focus
+ * moves away. Focus indication should be shown to keyboard users only.
+ *
+ * For `:focus:not( :focus-visible )` we drop the inset ring and restore each
+ * variant's resting `border-color`, mirroring the per-variant focus selectors
+ * in Codex's own stylesheet with `:focus-visible` and a NeoWiki scope class
+ * added. That extra class plus `:focus-visible` keep every rule more specific
+ * than the Codex rule it neutralises, so ours win regardless of load order, and
+ * the scope keeps the override off MediaWiki core and other extensions' Codex
+ * buttons. The `:not( :active )` / `:not( .cdx-button--is-active )` guards match
+ * Codex's, so the pressed and toggled states are left alone; the transparent
+ * Windows-High-Contrast outline on `:enabled:focus` is likewise untouched.
+ *
+ * Scope: `.ext-neowiki-ui` marks our Vue app mount roots (added in neowiki.ts)
+ * and our dialogs (Codex teleports these out of the mount tree, so each
+ * CdxDialog carries the class); `.ext-neowiki-view` is the on-page view
+ * placeholder. Focusable Codex UI we render must sit inside one of these.
+ *
+ * Text inputs are out of scope by design: browsers match `:focus-visible` on
+ * pointer focus for text entry, so their editing ring never reaches the
+ * `:not( :focus-visible )` branch below.
+ */
+
+@import ( reference ) '@wikimedia/codex-design-tokens/theme-wikimedia-ui.less';
+
+:is( .ext-neowiki-ui, .ext-neowiki-view ) {
+	// Framed default buttons (normal weight, any action): grey resting border.
+	.cdx-button:enabled:focus:not( :focus-visible ):not( :active ):not( .cdx-button--is-active ),
+	.cdx-button.cdx-button--fake-button--enabled:focus:not( :focus-visible ):not( :active ):not( .cdx-button--is-active ) {
+		border-color: @border-color-base;
+		box-shadow: none;
+	}
+
+	// Quiet buttons (any action): transparent resting border.
+	.cdx-button:enabled.cdx-button--weight-quiet:focus:not( :focus-visible ):not( :active ):not( .cdx-button--is-active ),
+	.cdx-button.cdx-button--fake-button--enabled.cdx-button--weight-quiet:focus:not( :focus-visible ):not( :active ):not( .cdx-button--is-active ) {
+		border-color: @border-color-transparent;
+		box-shadow: none;
+	}
+
+	// Primary progressive buttons: progressive resting border.
+	.cdx-button:enabled.cdx-button--weight-primary.cdx-button--action-progressive:focus:not( :focus-visible ):not( :active ):not( .cdx-button--is-active ),
+	.cdx-button.cdx-button--fake-button--enabled.cdx-button--weight-primary.cdx-button--action-progressive:focus:not( :focus-visible ):not( :active ):not( .cdx-button--is-active ) {
+		border-color: @border-color-progressive;
+		box-shadow: none;
+	}
+
+	// Primary destructive buttons: destructive resting border.
+	.cdx-button:enabled.cdx-button--weight-primary.cdx-button--action-destructive:focus:not( :focus-visible ):not( :active ):not( .cdx-button--is-active ),
+	.cdx-button.cdx-button--fake-button--enabled.cdx-button--weight-primary.cdx-button--action-destructive:focus:not( :focus-visible ):not( :active ):not( .cdx-button--is-active ) {
+		border-color: @border-color-destructive;
+		box-shadow: none;
+	}
+}

--- a/resources/ext.neowiki/src/components/LayoutEditor/DisplayRuleList.vue
+++ b/resources/ext.neowiki/src/components/LayoutEditor/DisplayRuleList.vue
@@ -203,7 +203,10 @@ useSortable( listRef, {
 			cursor: grab;
 
 			.ext-neowiki-display-rule-list__item:hover &,
-			.ext-neowiki-display-rule-list__item:focus-within & {
+			.ext-neowiki-display-rule-list__item:has( :focus-visible ) & {
+				// :has( :focus-visible ) rather than :focus-within: keyboard tabbing must reveal the
+				// drag handle, but a mouse click also focuses the control it hits and would keep the
+				// handle pinned visible after the pointer leaves.
 				opacity: @opacity-base;
 			}
 		}

--- a/resources/ext.neowiki/src/components/LayoutEditor/LayoutEditorDialog.vue
+++ b/resources/ext.neowiki/src/components/LayoutEditor/LayoutEditorDialog.vue
@@ -3,7 +3,7 @@
 		<CdxDialog
 			:open="props.open"
 			:use-close-button="true"
-			class="ext-neowiki-layout-editor-dialog"
+			class="ext-neowiki-ui ext-neowiki-layout-editor-dialog"
 			:title="$i18n( 'neowiki-editing-layout', props.initialLayout.getName() ).text()"
 			@update:open="onDialogUpdateOpen"
 		>

--- a/resources/ext.neowiki/src/components/LayoutsPage/LayoutCreatorDialog.vue
+++ b/resources/ext.neowiki/src/components/LayoutsPage/LayoutCreatorDialog.vue
@@ -3,7 +3,7 @@
 		<CdxDialog
 			:open="props.open"
 			:use-close-button="true"
-			class="ext-neowiki-layout-creator-dialog"
+			class="ext-neowiki-ui ext-neowiki-layout-creator-dialog"
 			:title="$i18n( 'neowiki-layout-creator-title' ).text()"
 			@update:open="onDialogUpdateOpen"
 		>

--- a/resources/ext.neowiki/src/components/MappingsPage/MappingCreatorDialog.vue
+++ b/resources/ext.neowiki/src/components/MappingsPage/MappingCreatorDialog.vue
@@ -2,7 +2,7 @@
 	<CdxDialog
 		:open="props.open"
 		:use-close-button="true"
-		class="ext-neowiki-mapping-creator-dialog"
+		class="ext-neowiki-ui ext-neowiki-mapping-creator-dialog"
 		:title="$i18n( 'neowiki-mapping-creator-title' ).text()"
 		@update:open="onDialogUpdateOpen"
 	>

--- a/resources/ext.neowiki/src/components/SchemaEditor/PropertyList.vue
+++ b/resources/ext.neowiki/src/components/SchemaEditor/PropertyList.vue
@@ -302,7 +302,10 @@ useSortable( listRef, {
 
 			.ext-neowiki-property-list__item:hover &,
 			.ext-neowiki-property-list__item--selected &,
-			.ext-neowiki-property-list__item:focus-within & {
+			.ext-neowiki-property-list__item:has( :focus-visible ) & {
+				// :has( :focus-visible ) rather than :focus-within: keyboard tabbing must reveal the
+				// action controls, but a mouse click also focuses the button it hits and would keep the
+				// cluster pinned visible after the pointer leaves.
 				opacity: 1;
 				transform: translateX( 0 );
 			}

--- a/resources/ext.neowiki/src/components/SchemaEditor/SchemaEditorDialog.vue
+++ b/resources/ext.neowiki/src/components/SchemaEditor/SchemaEditorDialog.vue
@@ -3,7 +3,7 @@
 		<CdxDialog
 			:open="props.open"
 			:use-close-button="true"
-			class="ext-neowiki-schema-editor-dialog"
+			class="ext-neowiki-ui ext-neowiki-schema-editor-dialog"
 			:class="{ 'cdx-dialog--dividers': hasOverflow }"
 			:title="$i18n( 'neowiki-editing-schema', props.initialSchema.getName() ).text()"
 			@update:open="onDialogUpdateOpen"

--- a/resources/ext.neowiki/src/components/SchemasPage/SchemaCreatorDialog.vue
+++ b/resources/ext.neowiki/src/components/SchemasPage/SchemaCreatorDialog.vue
@@ -3,7 +3,7 @@
 		<CdxDialog
 			:open="props.open"
 			:use-close-button="true"
-			class="ext-neowiki-schema-creator-dialog"
+			class="ext-neowiki-ui ext-neowiki-schema-creator-dialog"
 			:class="{ 'cdx-dialog--dividers': hasOverflow }"
 			:title="$i18n( 'neowiki-schema-creator-title' ).text()"
 			@update:open="onDialogUpdateOpen"

--- a/resources/ext.neowiki/src/components/SubjectCreator/SchemaAbandonmentDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectCreator/SchemaAbandonmentDialog.vue
@@ -1,6 +1,7 @@
 <template>
 	<CdxDialog
 		:open="open"
+		class="ext-neowiki-ui"
 		:title="$i18n( 'neowiki-schema-abandonment-title' ).text()"
 		:use-close-button="true"
 		@update:open="onUpdateOpen"

--- a/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
@@ -2,7 +2,7 @@
 <template>
 	<CdxDialog
 		:open="subjectStore.subjectCreatorOpen"
-		class="ext-neowiki-subject-creator-dialog"
+		class="ext-neowiki-ui ext-neowiki-subject-creator-dialog"
 		:class="{ 'ext-neowiki-subject-creator-dialog--wide': selectedSchemaOption === 'new' && !selectedSchemaName }"
 		:title="$i18n( 'neowiki-subject-creator-title' ).text()"
 		@update:open="onDialogUpdateOpen"

--- a/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditorDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditorDialog.vue
@@ -2,7 +2,7 @@
 	<div class="ext-neowiki-subject-editor-container">
 		<CdxDialog
 			:open="open"
-			class="ext-neowiki-subject-editor-dialog"
+			class="ext-neowiki-ui ext-neowiki-subject-editor-dialog"
 			:title="$i18n( 'neowiki-subject-editor-title', props.subject.getLabel() ).text()"
 			@update:open="onDialogUpdateOpen"
 		>

--- a/resources/ext.neowiki/src/components/SubjectsManager/SubjectsManagerPage.vue
+++ b/resources/ext.neowiki/src/components/SubjectsManager/SubjectsManagerPage.vue
@@ -435,6 +435,7 @@
 
 		<CdxDialog
 			:open="deleteConfirmOpen"
+			class="ext-neowiki-ui"
 			:title="$i18n( 'neowiki-managesubjects-delete-confirm-title' ).text()"
 			:use-close-button="true"
 			@update:open="deleteConfirmOpen = $event"

--- a/resources/ext.neowiki/src/components/common/CloseConfirmationDialog.vue
+++ b/resources/ext.neowiki/src/components/common/CloseConfirmationDialog.vue
@@ -1,6 +1,7 @@
 <template>
 	<CdxDialog
 		:open="open"
+		class="ext-neowiki-ui"
 		:title="$i18n( 'neowiki-close-confirmation-title' ).text()"
 		:use-close-button="true"
 		:stacked-actions="true"

--- a/resources/ext.neowiki/src/components/common/DeletePageDialog.vue
+++ b/resources/ext.neowiki/src/components/common/DeletePageDialog.vue
@@ -1,6 +1,7 @@
 <template>
 	<CdxDialog
 		:open="props.open"
+		class="ext-neowiki-ui"
 		:title="$i18n( 'neowiki-delete-confirm-title', props.displayName ).text()"
 		:use-close-button="true"
 		@update:open="onUpdateOpen"

--- a/resources/ext.neowiki/src/neowiki.ts
+++ b/resources/ext.neowiki/src/neowiki.ts
@@ -1,5 +1,8 @@
 import { createMwApp } from 'vue';
+import type { App } from 'vue';
 import type { Pinia } from 'pinia';
+// Global, scoped focus-ring override; see the file header for the rationale.
+import '@/assets/keyboard-focus.less';
 import NeoWikiApp from '@/components/NeoWikiApp.vue';
 import { CdxTooltip } from '@wikimedia/codex';
 import { NeoWikiServices } from '@/NeoWikiServices.ts';
@@ -35,6 +38,17 @@ export function registerSubjectCreatorClickHandler( pinia: Pinia, signal?: Abort
 	}, { signal } );
 }
 
+/**
+ * Mounts a NeoWiki Vue app, tagging its root element with `ext-neowiki-ui` so
+ * the keyboard-only focus override (assets/keyboard-focus.less) applies to our
+ * Codex buttons without touching those of MediaWiki core or other extensions.
+ * Dialogs teleport out of this root and carry the class on the CdxDialog itself.
+ */
+function mountNeoWikiApp( app: App, element: Element ): void {
+	element.classList.add( 'ext-neowiki-ui' );
+	app.mount( element );
+}
+
 function fireRegistrationHook(): void {
 	const ext = NeoWikiExtension.getInstance();
 	mw.hook( 'neowiki.registration' ).fire(
@@ -66,7 +80,7 @@ function initializeNeoWikiApp(): void {
 			const pinia = ext.getPinia();
 			app.use( pinia );
 			NeoWikiServices.registerServices( app );
-			app.mount( neowikiApp );
+			mountNeoWikiApp( app, neowikiApp );
 			registerSubjectCreatorClickHandler( pinia );
 		}
 	} );
@@ -101,7 +115,7 @@ function initializeSchemaView(): void {
 			const app = createMwApp( SchemaDisplay, { schema } );
 			app.use( ext.getPinia() );
 			NeoWikiServices.registerServices( app );
-			app.mount( viewSchema );
+			mountNeoWikiApp( app, viewSchema );
 		}
 	} );
 }
@@ -116,7 +130,7 @@ function initializeSchemasPage(): void {
 			const app = createMwApp( SchemasPage );
 			app.use( ext.getPinia() );
 			NeoWikiServices.registerServices( app );
-			app.mount( schemasPage );
+			mountNeoWikiApp( app, schemasPage );
 		}
 	} );
 }
@@ -146,7 +160,7 @@ function initializeLayoutView(): void {
 			const app = createMwApp( LayoutDisplay, { layout } );
 			app.use( ext.getPinia() );
 			NeoWikiServices.registerServices( app );
-			app.mount( viewLayout );
+			mountNeoWikiApp( app, viewLayout );
 		}
 	} );
 }
@@ -161,7 +175,7 @@ function initializeLayoutsPage(): void {
 			const app = createMwApp( LayoutsPage );
 			app.use( ext.getPinia() );
 			NeoWikiServices.registerServices( app );
-			app.mount( layoutsPage );
+			mountNeoWikiApp( app, layoutsPage );
 		}
 	} );
 }
@@ -176,7 +190,7 @@ function initializeMappingsPage(): void {
 			const app = createMwApp( MappingsPage );
 			app.use( ext.getPinia() );
 			NeoWikiServices.registerServices( app );
-			app.mount( mappingsPage );
+			mountNeoWikiApp( app, mappingsPage );
 		}
 	} );
 }
@@ -192,7 +206,7 @@ function initializeSubjectsManagerPage(): void {
 			const pinia = ext.getPinia();
 			app.use( pinia );
 			NeoWikiServices.registerServices( app );
-			app.mount( subjectsManager );
+			mountNeoWikiApp( app, subjectsManager );
 			registerSubjectCreatorClickHandler( pinia );
 		}
 	} );

--- a/resources/ext.neowiki/src/styles.d.ts
+++ b/resources/ext.neowiki/src/styles.d.ts
@@ -1,0 +1,3 @@
+// Ambient declaration so TypeScript accepts side-effect style imports (e.g. the
+// global focus-ring override bundled from neowiki.ts). Vite handles the build.
+declare module '*.less';


### PR DESCRIPTION
Clicking a NeoWiki button with the mouse left the Codex focus ring on it until focus moved away — on the Data-tab row actions (copy link, edit, delete), the export buttons, the infobox edit button, and dialog actions. Codex 1.14 styles button focus on bare `:focus`, which a mouse click matches even though the browser does not treat it as `:focus-visible`.

Focus indication is now keyboard-only. For `:focus:not( :focus-visible )` a scoped override drops the inset ring and restores each button variant's resting border-color, mirroring Codex's own per-variant focus selectors. Keyboard focus (`:focus-visible`) is left intact, as are the pressed (`:active`), toggled (`--is-active`) and Windows-High-Contrast states. The two reveal-on-focus lists in the schema and layout editors move from `:focus-within` to `:has( :focus-visible )` for the same reason, extending the row-actions change in #1144.

The override applies under `.ext-neowiki-ui`, added to every Vue app mount root through a shared mount helper and to each dialog — Codex teleports dialogs out of the mount tree, so the class rides on the CdxDialog and reaches the close and footer buttons — plus the existing `.ext-neowiki-view` page placeholder. It never touches Codex buttons from MediaWiki core or other extensions. The rationale lives in the override file header (`assets/keyboard-focus.less`).

Verified in the browser across the button variants and scopes: mouse focus leaves no ring once the pointer moves away, keyboard focus still shows it, and core skin buttons are unaffected.

> <sub>AI-authored — Claude Code, `Opus 4.8 (max)`; detailed spec from @JeroenDeDauw, no mid-task steering; diff not yet human-reviewed; lint + vitest (1136 tests) + phpcs/phpstan green locally, before/after confirmed in-browser with Playwright, CI green.</sub>
