### PR TITLE
Default Subject IRI dereference to the Data tab

### DIFF
--- a/docs/rdf/rdf-export.md
+++ b/docs/rdf/rdf-export.md
@@ -107,8 +107,8 @@ content-negotiates it and answers `303 See Other` with an absolute `Location`:
 TriG wins when both RDF types are acceptable; the RDF redirects use the native projection. A Subject that is absent or
 on a page the caller may not read returns one indistinguishable `404`; a malformed id `400`.
 
-The HTML target is that page's Data tab (`?action=subjects`) opened on the Subject's row (`#{subjectId}`) by default,
-or the plain hosting page when `$wgNeoWikiDereferenceSubjectsToDataTab` is disabled.
+The default HTML target is that page's Data tab (`/Example_Page/subjects`) opened on the Subject's row.
+When `$wgNeoWikiDereferenceSubjectsToDataTab` is set to `false`, the target is the wiki page itself (`/Example_Page`).
 
 The negotiator is always reachable at the REST path, which needs no server configuration:
 
@@ -130,7 +130,7 @@ the operator's own routing concern.
 
 ### Finding these exports
 
-These exports are surfaced in the UI. The Data tab (`?action=subjects`) links to each Subject's JSON and per-projection
+These exports are surfaced in the UI. The Data tab links to each Subject's JSON and per-projection
 Turtle/TriG, and the same for the whole page. Pages that carry NeoWiki data also emit `<link rel="alternate">`
 autodiscovery tags (Turtle and TriG, native projection) in the HTML head.
 

--- a/docs/rdf/rdf-export.md
+++ b/docs/rdf/rdf-export.md
@@ -18,7 +18,7 @@ For an end-to-end example comparing the native and ontology-mapped output, see t
 | Setting | Default | Purpose |
 |---|---|---|
 | `$wgNeoWikiRdfBaseUri` | the wiki's canonical URL (`$wgCanonicalServer`) | Base URI under which all NeoWiki IRIs are minted. |
-| `$wgNeoWikiDereferenceSubjectsToDataTab` | `false` | Whether a browser dereferencing a Subject IRI lands on the hosting page's Data tab row instead of the plain page. |
+| `$wgNeoWikiDereferenceSubjectsToDataTab` | `true` | Whether a browser dereferencing a Subject IRI lands on the hosting page's Data tab row (`true`) or the plain page (`false`). |
 
 ## IRI scheme
 
@@ -107,8 +107,8 @@ content-negotiates it and answers `303 See Other` with an absolute `Location`:
 TriG wins when both RDF types are acceptable; the RDF redirects use the native projection. A Subject that is absent or
 on a page the caller may not read returns one indistinguishable `404`; a malformed id `400`.
 
-The HTML target is the Subject's hosting page by default, or that page's Data tab (`?action=subjects`) opened on the
-Subject's row (`#{subjectId}`) when `$wgNeoWikiDereferenceSubjectsToDataTab` is enabled.
+The HTML target is that page's Data tab (`?action=subjects`) opened on the Subject's row (`#{subjectId}`) by default,
+or the plain hosting page when `$wgNeoWikiDereferenceSubjectsToDataTab` is disabled.
 
 The negotiator is always reachable at the REST path, which needs no server configuration:
 

--- a/extension.json
+++ b/extension.json
@@ -210,8 +210,8 @@
 			"value": null
 		},
 		"NeoWikiDereferenceSubjectsToDataTab": {
-			"description": "Whether a browser dereferencing a Subject's concept URI (Accept: text/html) is sent to the hosting page's Data tab (?action=subjects) opened on the Subject's row (expanded, scrolled to, highlighted). When false (default), it is sent to the plain hosting page.",
-			"value": false
+			"description": "Whether a browser dereferencing a Subject's concept URI (Accept: text/html) is sent to the hosting page's Data tab (?action=subjects) opened on the Subject's row (expanded, scrolled to, highlighted). True by default; when false, it is sent to the plain hosting page.",
+			"value": true
 		},
 		"NeoWikiSparqlStores": {
 			"description": "SPARQL 1.1 graph stores to keep in sync with page changes and to query, in addition to any Neo4j backend. A list of objects, each with: 'updateUrl' (required, the store's SPARQL 1.1 Update endpoint, e.g. a QLever instance); 'queryUrl' (optional, the store's SPARQL 1.1 Query endpoint the read surfaces use; defaults to 'updateUrl', which is correct for QLever where the two are the same); 'accessToken' (optional, sent as an HTTP Bearer token on both update and query requests, e.g. for a QLever access token or a read-protected endpoint); and 'projection' (optional, the RDF vocabulary written to the store: 'native' by default, or any configured Mapping target). The query surfaces (the {{#sparql_raw}} parser function, nw.sparqlQuery() in Lua, and POST /neowiki/v0/query/sparql) target the first configured store. Works with QLever and any SPARQL 1.1 store. Empty by default.",

--- a/src/Application/WikiConfig/ConfigExample.php
+++ b/src/Application/WikiConfig/ConfigExample.php
@@ -14,7 +14,7 @@ class ConfigExample {
 
 	public const string JSON = <<<'JSON'
 		{
-			"dereferenceSubjectsToDataTab": false,
+			"dereferenceSubjectsToDataTab": true,
 			"autoRenderMainSubject": true
 		}
 		JSON;

--- a/src/EntryPoints/REST/ResolveSubjectIriApi.php
+++ b/src/EntryPoints/REST/ResolveSubjectIriApi.php
@@ -22,8 +22,8 @@ use Wikimedia\ParamValidator\ParamValidator;
  *   - `Accept` includes `application/trig` → the Subject's TriG RDF export.
  *   - else `Accept` includes `text/turtle` → the Subject's Turtle RDF export (TriG wins a tie, matching
  *     {@see RdfFormatNegotiation}).
- *   - else (a browser's `text/html`, `*&#47;*`, an absent or unrecognized `Accept`) → the hosting page, or
- *     its Data tab row when `$wgNeoWikiDereferenceSubjectsToDataTab` is enabled.
+ *   - else (a browser's `text/html`, `*&#47;*`, an absent or unrecognized `Accept`) → the hosting page's
+ *     Data tab row by default, or the plain page when `$wgNeoWikiDereferenceSubjectsToDataTab` is disabled.
  *
  * The RDF branches target the native projection: selecting an ontology target or a specific
  * serialization stays on the per-Subject RDF endpoint, keeping this concept-URI surface Accept-only.

--- a/tests/phpunit/EntryPoints/REST/InWikiConfigDereferenceTest.php
+++ b/tests/phpunit/EntryPoints/REST/InWikiConfigDereferenceTest.php
@@ -41,7 +41,8 @@ class InWikiConfigDereferenceTest extends NeoWikiIntegrationTestCase {
 	public function setUp(): void {
 		$this->setUpNeo4j();
 
-		// Pin the PHP config to the default so a passing test proves the page value, not an ambient override.
+		// Pin the PHP config to false (the win case's page value is true) so a passing test proves the page
+		// value, not an ambient override; the fallback cases then land on the plain page.
 		$this->overrideConfigValue( 'NeoWikiDereferenceSubjectsToDataTab', false );
 
 		$this->createSchema( self::SCHEMA );

--- a/tests/phpunit/EntryPoints/REST/ResolveSubjectIriApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ResolveSubjectIriApiTest.php
@@ -33,11 +33,6 @@ class ResolveSubjectIriApiTest extends NeoWikiIntegrationTestCase {
 	public function setUp(): void {
 		$this->setUpNeo4j();
 
-		// Pin the default so the Accept-negotiation tests are independent of any ambient
-		// $wgNeoWikiDereferenceSubjectsToDataTab (e.g. a dev LocalSettings override). The Data-tab tests
-		// override this.
-		$this->overrideConfigValue( 'NeoWikiDereferenceSubjectsToDataTab', false );
-
 		$this->createSchema( self::SCHEMA );
 
 		$this->pageId = $this->createPageWithSubjects(
@@ -65,6 +60,14 @@ class ResolveSubjectIriApiTest extends NeoWikiIntegrationTestCase {
 		);
 	}
 
+	/**
+	 * NeoWiki ships the Data tab as the dereference target (extension.json). The plain-hosting-page tests
+	 * opt out explicitly; the default test leaves the setting unset to exercise the shipped default.
+	 */
+	private function disableDataTabDereference(): void {
+		$this->overrideConfigValue( 'NeoWikiDereferenceSubjectsToDataTab', false );
+	}
+
 	public function testAcceptTriGRedirectsToTheSubjectTriGExport(): void {
 		$response = $this->deref( headers: [ 'Accept' => 'application/trig' ] );
 
@@ -86,30 +89,35 @@ class ResolveSubjectIriApiTest extends NeoWikiIntegrationTestCase {
 		$this->assertSubjectRdfLocation( $response, 'trig' );
 	}
 
-	public function testAcceptHtmlRedirectsToTheHostingPage(): void {
+	public function testAcceptHtmlRedirectsToThePlainHostingPageWhenDataTabDisabled(): void {
+		$this->disableDataTabDereference();
+
 		$response = $this->deref( headers: [ 'Accept' => 'text/html' ] );
 
 		$this->assertSame( 303, $response->getStatusCode() );
 		$this->assertHostingPageLocation( $response );
 	}
 
-	public function testWildcardAcceptRedirectsToTheHostingPage(): void {
+	public function testWildcardAcceptRedirectsToThePlainHostingPageWhenDataTabDisabled(): void {
+		$this->disableDataTabDereference();
+
 		$response = $this->deref( headers: [ 'Accept' => '*/*' ] );
 
 		$this->assertSame( 303, $response->getStatusCode() );
 		$this->assertHostingPageLocation( $response );
 	}
 
-	public function testAbsentAcceptRedirectsToTheHostingPage(): void {
+	public function testAbsentAcceptRedirectsToThePlainHostingPageWhenDataTabDisabled(): void {
+		$this->disableDataTabDereference();
+
 		$response = $this->deref();
 
 		$this->assertSame( 303, $response->getStatusCode() );
 		$this->assertHostingPageLocation( $response );
 	}
 
-	public function testDataTabDereferenceTargetRedirectsToTheSubjectsRow(): void {
-		$this->overrideConfigValue( 'NeoWikiDereferenceSubjectsToDataTab', true );
-
+	public function testHtmlDereferenceRedirectsToTheSubjectsDataTabRowByDefault(): void {
+		// No config override: NeoWiki ships the Data tab as the default dereference target.
 		$response = $this->deref( headers: [ 'Accept' => 'text/html' ] );
 
 		$location = $response->getHeaderLine( 'Location' );


### PR DESCRIPTION
Default `$wgNeoWikiDereferenceSubjectsToDataTab` to `true`, so a browser dereferencing a Subject's concept URI (`/entity/{id}`, served by `ResolveSubjectIriApi`) lands on the hosting page's Data tab opened on the Subject's row, rather than the plain hosting page. RDF `Accept` negotiation (TriG/Turtle) is untouched — only the `text/html` target changes.

## Why

Only data-context users ever hold a concept URI — they come from RDF exports, SPARQL results, and reconciliation payloads — so the dereference audience wants the structured record. A page renders its Main Subject in the infobox, but child Subjects may appear nowhere on the page view, making the Data-tab row the only landing that is correct for *every* Subject. It also matches the expectation Wikibase users bring: a concept URI resolves to the entity's data view. The plain page stays one click away, and wikis that prefer it keep the setting (set it `false` on the `MediaWiki:NeoWiki` page or in `LocalSettings.php`).

## Changes

- `extension.json`: value `false` → `true`; description reworded so the stated default matches.
- `src/Application/WikiConfig/ConfigExample.php`: the `MediaWiki:NeoWiki` preload example is documented as "set to the defaults", so its `dereferenceSubjectsToDataTab` flips to `true` too.
- `src/EntryPoints/REST/ResolveSubjectIriApi.php`: class doc inverts the default/opt-out framing.
- `docs/rdf/rdf-export.md`: default column and the HTML-target prose inverted.
- Tests: the plain-page cases in `ResolveSubjectIriApiTest` now disable the setting explicitly; a new default-behavior test (`testHtmlDereferenceRedirectsToTheSubjectsDataTabRowByDefault`, no override) asserts the Data-tab `Location` (subjects action + bare Subject-id fragment). `InWikiConfigDereferenceTest`'s pin comment corrected (the false pin is now the opposite of the page value, not "the default").

No behavioural change for anyone who has set the value explicitly. The on-wiki `MediaWiki:NeoWiki` override and `LocalSettings.php` continue to take precedence as before.

## Verification

Live, on the worktree dev wiki, against a real demo Subject (`s1demo1aaaaaaa1`, hosted on `ACME_Inc`):

- Default (no override), `Accept: text/html` → `303` → `.../wiki/ACME_Inc/subjects#s1demo1aaaaaaa1` (Data-tab row).
- Setting `false` via `MediaWiki:NeoWiki` (also confirming the on-wiki override still wins), `Accept: text/html` → `303` → `.../wiki/ACME_Inc` (plain page).
- `Accept: text/turtle` → `303` → `.../subject/s1demo1aaaaaaa1/rdf?format=turtle` (RDF unaffected).

Full PHPUnit suite (2020 tests), phpcs, and phpstan all green locally.

> <sub>AI-authored — Claude Code, `Opus 4.8 (max)`; detailed spec from @JeroenDeDauw, no redirection; diff not yet human-reviewed; TDD test restructure (default test seen red before the flip), full PHPUnit suite (2020 tests) + phpcs + phpstan green locally, all three dereference cases verified live on the worktree wiki; mutation-tested; CI green.</sub>
