### PR TITLE
Render Mapping pages with a header and per-schema sections

### DIFF
--- a/docs/rdf/ontology-mapping.md
+++ b/docs/rdf/ontology-mapping.md
@@ -67,7 +67,7 @@ Top level:
 |---|---|---|
 | `version` | yes | Format version. Must be `1`. |
 | `prefixes` | no | Prefix label → namespace IRI, shared by every entry, used to expand the CURIEs below. |
-| `schemas` | yes | Native Schema name → the entry that projects its Subjects (see below). May be empty. A Schema's existence is not checked at save time. |
+| `schemas` | yes | Native Schema name → the entry that projects its Subjects (see below). May be empty. A Schema's existence is not checked at save time; the page's read view shows a missing Schema as a red link. |
 
 Each **schema** entry (a value in `schemas`):
 

--- a/extension.json
+++ b/extension.json
@@ -678,7 +678,8 @@
 		},
 		"ext.neowiki.styles": {
 			"styles": [
-				"resources/ext.neowiki/dist/neowiki.css"
+				"resources/ext.neowiki/dist/neowiki.css",
+				"resources/styles/mapping-page.css"
 			]
 		}
 	},

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -276,6 +276,16 @@
 	"neowiki-edit-mapping": "Edit mapping",
 	"neowiki-mapping-delete": "Delete mapping",
 
+	"neowiki-mapping-page-version": "Format version $1",
+	"neowiki-mapping-page-schemas-heading": "Mapped schemas",
+	"neowiki-mapping-page-schema-column": "Schema",
+	"neowiki-mapping-page-class-column": "Target class",
+	"neowiki-mapping-page-properties-column": "Mapped properties",
+	"neowiki-mapping-page-no-schemas": "This mapping does not map any schemas yet.",
+	"neowiki-mapping-page-prefixes-heading": "Prefixes",
+	"neowiki-mapping-page-prefix-column": "Prefix",
+	"neowiki-mapping-page-namespace-column": "Namespace IRI",
+
 	"neowiki-layout-creator-title": "Create layout",
 	"neowiki-layout-creator-button": "Create",
 	"neowiki-layout-creator-name-field": "Layout name",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -174,6 +174,16 @@
 	"neowiki-edit-mapping": "Aria label for the edit button on a Mapping row in the mappings list.",
 	"neowiki-mapping-delete": "Aria label for the delete button on a Mapping row in the mappings list.",
 
+	"neowiki-mapping-page-version": "Format version shown as a subtle line at the top of the read view of a Mapping page. Parameters:\n* $1 - the mapping format version number",
+	"neowiki-mapping-page-schemas-heading": "Heading for the overview table on the read view of a Mapping page that lists the mapped Schemas, each linked to its Schema page.",
+	"neowiki-mapping-page-schema-column": "Column header for the Schema name in the mapped-schemas overview table on a Mapping page.",
+	"neowiki-mapping-page-class-column": "Column header for the target ontology class in the mapped-schemas overview table on a Mapping page.",
+	"neowiki-mapping-page-properties-column": "Column header for the number of mapped properties in the mapped-schemas overview table on a Mapping page.",
+	"neowiki-mapping-page-no-schemas": "Message shown on the read view of a Mapping page that maps no Schemas. Tone matches {{msg-mw|neowiki-mappings-empty}}.",
+	"neowiki-mapping-page-prefixes-heading": "Heading for the table on the read view of a Mapping page that lists the namespace prefixes the mapping declares.",
+	"neowiki-mapping-page-prefix-column": "Column header for the prefix in the prefixes table on a Mapping page.",
+	"neowiki-mapping-page-namespace-column": "Column header for the namespace IRI in the prefixes table on a Mapping page.",
+
 	"neowiki-layout-creator-title": "Title of the dialog for creating a new layout.",
 	"neowiki-layout-creator-button": "Label for the button that opens the layout creation dialog on [[Special:Layouts]].",
 	"neowiki-layout-creator-name-field": "Label for the layout name input field in the layout creation dialog.",

--- a/resources/styles/mapping-page.css
+++ b/resources/styles/mapping-page.css
@@ -1,0 +1,11 @@
+/* Server-rendered read view of a Mapping page (MappingPageHtmlBuilder). */
+
+.ext-neowiki-mapping-page__version {
+	color: var( --color-subtle, #54595d );
+	font-size: 0.875rem;
+	margin-bottom: 0.5em;
+}
+
+.ext-neowiki-mapping-page__empty {
+	color: var( --color-subtle, #54595d );
+}

--- a/src/EntryPoints/Content/MappingContentHandler.php
+++ b/src/EntryPoints/Content/MappingContentHandler.php
@@ -7,12 +7,18 @@ namespace ProfessionalWiki\NeoWiki\EntryPoints\Content;
 use InvalidArgumentException;
 use MediaWiki\Content\Content;
 use MediaWiki\Content\JsonContentHandler;
+use MediaWiki\Content\Renderer\ContentParseParams;
 use MediaWiki\Content\ValidationParams;
+use MediaWiki\MediaWikiServices;
+use MediaWiki\Parser\ParserOutput;
 use MediaWiki\Title\Title;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\MappingName;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\MappingContentValidator;
+use ProfessionalWiki\NeoWiki\Presentation\MappingPageHtmlBuilder;
+use ProfessionalWiki\NeoWiki\Presentation\MappingPageRendering;
 use StatusValue;
+use stdClass;
 
 class MappingContentHandler extends JsonContentHandler {
 
@@ -47,6 +53,65 @@ class MappingContentHandler extends JsonContentHandler {
 		}
 
 		return $status;
+	}
+
+	/**
+	 * Renders the Mapping as a header (mapped-schemas overview, prefixes, format version) plus one section
+	 * per schema whose body stays the default mw-json table. Falls back to the inherited JSON rendering when
+	 * the content does not parse or is not the expected v1 shape (XML import and future versions bypass save
+	 * validation), so display never fatals.
+	 */
+	protected function fillParserOutput(
+		Content $content,
+		ContentParseParams $cpoParams,
+		ParserOutput &$parserOutput
+	): void {
+		if ( $cpoParams->getGenerateHtml() && $content instanceof MappingContent ) {
+			$mapping = $content->getData()->getValue();
+
+			if ( $this->isRenderableMapping( $mapping ) ) {
+				$this->renderMapping( $content, $mapping, $parserOutput );
+				return;
+			}
+		}
+
+		parent::fillParserOutput( $content, $cpoParams, $parserOutput );
+	}
+
+	private function renderMapping( MappingContent $content, stdClass $mapping, ParserOutput $parserOutput ): void {
+		$services = MediaWikiServices::getInstance();
+
+		$builder = new MappingPageHtmlBuilder(
+			$services->getLinkRenderer(),
+			$services->getTitleFactory(),
+			static fn ( mixed $subtree ): string => $content->rootValueTable( $subtree )
+		);
+
+		$rendering = $builder->build( $mapping );
+
+		$parserOutput->setRawText( $rendering->html );
+		$this->registerLinks( $parserOutput, $rendering );
+		$parserOutput->addModuleStyles( [ 'mediawiki.content.json', 'ext.neowiki.styles' ] );
+	}
+
+	private function registerLinks( ParserOutput $parserOutput, MappingPageRendering $rendering ): void {
+		foreach ( $rendering->schemaLinks as $schemaLink ) {
+			$parserOutput->addLink( $schemaLink );
+		}
+
+		foreach ( $rendering->externalLinks as $externalLink ) {
+			$parserOutput->addExternalLink( $externalLink );
+		}
+	}
+
+	/**
+	 * @phpstan-assert-if-true stdClass $mapping
+	 */
+	private function isRenderableMapping( mixed $mapping ): bool {
+		return $mapping instanceof stdClass
+			&& ( $mapping->version ?? null ) === 1
+			&& isset( $mapping->schemas )
+			&& $mapping->schemas instanceof stdClass;
 	}
 
 	public function makeEmptyContent(): MappingContent {

--- a/src/EntryPoints/Content/MappingContentHandler.php
+++ b/src/EntryPoints/Content/MappingContentHandler.php
@@ -44,7 +44,7 @@ class MappingContentHandler extends JsonContentHandler {
 			$status->fatal( 'neowiki-mapping-name-invalid', $exception->getMessage() );
 		}
 
-		$validator = MappingContentValidator::newInstance();
+		$validator = MappingContentValidator::newInstance( MediaWikiServices::getInstance()->getTitleParser() );
 
 		if ( !$validator->validate( $content->getText() ) ) {
 			$status->fatal( 'neowiki-mapping-invalid', count( $validator->getErrors() ) );

--- a/src/EntryPoints/Content/MappingContentHandler.php
+++ b/src/EntryPoints/Content/MappingContentHandler.php
@@ -10,8 +10,10 @@ use MediaWiki\Content\JsonContentHandler;
 use MediaWiki\Content\Renderer\ContentParseParams;
 use MediaWiki\Content\ValidationParams;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Page\PageReference;
 use MediaWiki\Parser\ParserOutput;
 use MediaWiki\Title\Title;
+use MediaWiki\Title\TitleValue;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\MappingName;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\MappingContentValidator;
@@ -70,7 +72,7 @@ class MappingContentHandler extends JsonContentHandler {
 			$mapping = $content->getData()->getValue();
 
 			if ( $this->isRenderableMapping( $mapping ) ) {
-				$this->renderMapping( $content, $mapping, $parserOutput );
+				$this->renderMapping( $content, $mapping, $cpoParams->getPage(), $parserOutput );
 				return;
 			}
 		}
@@ -78,12 +80,19 @@ class MappingContentHandler extends JsonContentHandler {
 		parent::fillParserOutput( $content, $cpoParams, $parserOutput );
 	}
 
-	private function renderMapping( MappingContent $content, stdClass $mapping, ParserOutput $parserOutput ): void {
+	private function renderMapping(
+		MappingContent $content,
+		stdClass $mapping,
+		PageReference $page,
+		ParserOutput $parserOutput
+	): void {
 		$services = MediaWikiServices::getInstance();
 
 		$builder = new MappingPageHtmlBuilder(
 			$services->getLinkRenderer(),
 			$services->getTitleFactory(),
+			$services->getLinkBatchFactory(),
+			TitleValue::newFromPage( $page ),
 			static fn ( mixed $subtree ): string => $content->rootValueTable( $subtree )
 		);
 

--- a/src/Persistence/MediaWiki/MappingContentValidator.php
+++ b/src/Persistence/MediaWiki/MappingContentValidator.php
@@ -4,14 +4,19 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Persistence\MediaWiki;
 
+use InvalidArgumentException;
+use MediaWiki\Title\MalformedTitleException;
+use MediaWiki\Title\TitleParser;
 use Opis\JsonSchema\Errors\ErrorFormatter;
 use Opis\JsonSchema\Errors\ValidationError;
 use Opis\JsonSchema\Validator;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\CurieExpander;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use RuntimeException;
 
 /**
- * Validates the JSON of a Mapping page against the v1 format, in two stages:
+ * Validates the JSON of a Mapping page against the v1 format, in three stages:
  *
  *  1. Structural validation against mappingContentSchema.json (versioned, deliberately minimal).
  *  2. Semantic IRI-safety validation: every declared prefix namespace, and every class, predicate and
@@ -19,6 +24,11 @@ use RuntimeException;
  *     lesson). A term that cannot be resolved against the declared prefixes, or that would break out of
  *     its IRI, is rejected here rather than percent-encoded — a Mapping must reproduce the ontology's
  *     exact terms.
+ *  3. Schema-name validation: each key under `schemas` must be a usable Schema name written exactly as
+ *     its Schema page title. The projector matches keys against a Subject's Schema name byte for byte,
+ *     while a page lookup normalizes, so "Person_X" would resolve to the Schema page yet never project.
+ *     Requiring the canonical form keeps those two agreeing, and makes the read view's red or blue link
+ *     an honest signal of whether the Schema is there.
  */
 class MappingContentValidator {
 
@@ -27,7 +37,7 @@ class MappingContentValidator {
 	 */
 	private array $errors = [];
 
-	public static function newInstance(): self {
+	public static function newInstance( TitleParser $titleParser ): self {
 		$json = file_get_contents( __DIR__ . '/mappingContentSchema.json' );
 
 		if ( !is_string( $json ) ) {
@@ -40,11 +50,12 @@ class MappingContentValidator {
 			throw new RuntimeException( 'Failed to deserialize JSON Schema' );
 		}
 
-		return new self( $schema );
+		return new self( $schema, $titleParser );
 	}
 
 	private function __construct(
-		private object $jsonSchema
+		private object $jsonSchema,
+		private TitleParser $titleParser
 	) {
 	}
 
@@ -93,12 +104,41 @@ class MappingContentValidator {
 
 		$schemas = is_array( $data['schemas'] ?? null ) ? $data['schemas'] : [];
 		foreach ( $schemas as $schemaName => $entry ) {
+			$errors = array_merge( $errors, $this->schemaNameErrors( (string)$schemaName ) );
+
 			if ( is_array( $entry ) ) {
 				$errors = array_merge( $errors, $this->schemaErrors( (string)$schemaName, $entry, $expander ) );
 			}
 		}
 
 		return $errors;
+	}
+
+	/**
+	 * @return array<string, string>
+	 */
+	private function schemaNameErrors( string $schemaName ): array {
+		$pointer = '/schemas/' . $schemaName;
+
+		try {
+			new SchemaName( $schemaName );
+		}
+		catch ( InvalidArgumentException $exception ) {
+			return [ $pointer => 'The Schema name "' . $schemaName . '" cannot be used: ' . $exception->getMessage() . '.' ];
+		}
+
+		try {
+			$canonical = $this->titleParser->parseTitle( $schemaName, NeoWikiExtension::NS_SCHEMA )->getText();
+		}
+		catch ( MalformedTitleException ) {
+			return [ $pointer => 'The Schema name "' . $schemaName . '" is not a valid page name.' ];
+		}
+
+		if ( $canonical !== $schemaName ) {
+			return [ $pointer => 'The Schema name "' . $schemaName . '" must be written as "' . $canonical . '", exactly as its Schema page is titled.' ];
+		}
+
+		return [];
 	}
 
 	/**

--- a/src/Presentation/MappingPageHtmlBuilder.php
+++ b/src/Presentation/MappingPageHtmlBuilder.php
@@ -1,0 +1,237 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Presentation;
+
+use Closure;
+use MediaWiki\Html\Html;
+use MediaWiki\Linker\LinkRenderer;
+use MediaWiki\Linker\LinkTarget;
+use MediaWiki\Parser\Sanitizer;
+use MediaWiki\Title\TitleFactory;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+use stdClass;
+
+/**
+ * Builds the server-rendered read view of a Mapping page: a header with a mapped-schemas overview and a
+ * prefixes table, followed by one section per schema whose body stays the core mw-json table. The schema
+ * links and prefix IRIs are collected so the handler can register them in the ParserOutput link tables.
+ */
+class MappingPageHtmlBuilder {
+
+	private const string SECTION_ID_PREFIX = 'ext-neowiki-mapping-schema-';
+
+	/** @var list<LinkTarget> */
+	private array $schemaLinks = [];
+
+	/** @var list<string> */
+	private array $externalLinks = [];
+
+	/**
+	 * @param Closure(mixed): string $renderJsonTable Renders a JSON subtree as the core mw-json table.
+	 */
+	public function __construct(
+		private readonly LinkRenderer $linkRenderer,
+		private readonly TitleFactory $titleFactory,
+		private readonly Closure $renderJsonTable
+	) {
+	}
+
+	public function build( stdClass $mapping ): MappingPageRendering {
+		$this->schemaLinks = [];
+		$this->externalLinks = [];
+
+		$schemas = $mapping->schemas;
+
+		$html = Html::rawElement(
+			'div',
+			[ 'class' => 'ext-neowiki-mapping-page' ],
+			$this->versionHtml( $mapping )
+				. $this->schemasOverviewHtml( $schemas )
+				. $this->prefixesHtml( $mapping->prefixes ?? null )
+				. $this->schemaSectionsHtml( $schemas )
+		);
+
+		return new MappingPageRendering( $html, $this->schemaLinks, $this->externalLinks );
+	}
+
+	private function versionHtml( stdClass $mapping ): string {
+		return Html::element(
+			'div',
+			[ 'class' => 'ext-neowiki-mapping-page__version' ],
+			wfMessage( 'neowiki-mapping-page-version' )->numParams( $mapping->version )->text()
+		);
+	}
+
+	private function schemasOverviewHtml( stdClass $schemas ): string {
+		if ( get_object_vars( $schemas ) === [] ) {
+			return $this->emptyStateHtml();
+		}
+
+		return $this->headingHtml( 'neowiki-mapping-page-schemas-heading' )
+			. Html::rawElement(
+				'table',
+				[ 'class' => 'wikitable ext-neowiki-mapping-page__schemas' ],
+				$this->overviewHeadHtml() . Html::rawElement( 'tbody', [], $this->overviewRowsHtml( $schemas ) )
+			);
+	}
+
+	private function overviewHeadHtml(): string {
+		return Html::rawElement( 'thead', [], Html::rawElement(
+			'tr',
+			[],
+			$this->headerCellHtml( 'neowiki-mapping-page-schema-column' )
+				. $this->headerCellHtml( 'neowiki-mapping-page-class-column' )
+				. $this->headerCellHtml( 'neowiki-mapping-page-properties-column' )
+		) );
+	}
+
+	private function overviewRowsHtml( stdClass $schemas ): string {
+		$rows = '';
+
+		foreach ( get_object_vars( $schemas ) as $name => $schema ) {
+			$rows .= $this->overviewRowHtml( (string)$name, $schema );
+		}
+
+		return $rows;
+	}
+
+	private function overviewRowHtml( string $name, mixed $schema ): string {
+		return Html::rawElement(
+			'tr',
+			[],
+			Html::rawElement( 'td', [], $this->schemaLinkHtml( $name ) )
+				. Html::element( 'td', [], $this->targetClass( $schema ) )
+				. Html::element( 'td', [], (string)$this->propertyCount( $schema ) )
+		);
+	}
+
+	private function schemaLinkHtml( string $name ): string {
+		$title = $this->titleFactory->makeTitleSafe( NeoWikiExtension::NS_SCHEMA, $name );
+
+		if ( $title === null ) {
+			return Html::element( 'span', [], $name );
+		}
+
+		$this->schemaLinks[] = $title;
+
+		return $this->linkRenderer->makeLink( $title, $name );
+	}
+
+	private function targetClass( mixed $schema ): string {
+		$subject = $schema instanceof stdClass ? ( $schema->subject ?? null ) : null;
+
+		if ( $subject instanceof stdClass && isset( $subject->class ) && is_string( $subject->class ) ) {
+			return $subject->class;
+		}
+
+		return '';
+	}
+
+	private function propertyCount( mixed $schema ): int {
+		$properties = $schema instanceof stdClass ? ( $schema->properties ?? null ) : null;
+
+		return $properties instanceof stdClass ? count( get_object_vars( $properties ) ) : 0;
+	}
+
+	private function prefixesHtml( mixed $prefixes ): string {
+		if ( !$prefixes instanceof stdClass ) {
+			return '';
+		}
+
+		$rows = $this->prefixRowsHtml( $prefixes );
+
+		if ( $rows === '' ) {
+			return '';
+		}
+
+		return $this->headingHtml( 'neowiki-mapping-page-prefixes-heading' )
+			. Html::rawElement(
+				'table',
+				[ 'class' => 'wikitable ext-neowiki-mapping-page__prefixes' ],
+				$this->prefixHeadHtml() . Html::rawElement( 'tbody', [], $rows )
+			);
+	}
+
+	private function prefixHeadHtml(): string {
+		return Html::rawElement( 'thead', [], Html::rawElement(
+			'tr',
+			[],
+			$this->headerCellHtml( 'neowiki-mapping-page-prefix-column' )
+				. $this->headerCellHtml( 'neowiki-mapping-page-namespace-column' )
+		) );
+	}
+
+	private function prefixRowsHtml( stdClass $prefixes ): string {
+		$rows = '';
+
+		foreach ( get_object_vars( $prefixes ) as $prefix => $iri ) {
+			if ( is_string( $iri ) ) {
+				$rows .= $this->prefixRowHtml( (string)$prefix, $iri );
+			}
+		}
+
+		return $rows;
+	}
+
+	private function prefixRowHtml( string $prefix, string $iri ): string {
+		return Html::rawElement(
+			'tr',
+			[],
+			Html::element( 'td', [], $prefix )
+				. Html::rawElement( 'td', [], $this->iriHtml( $iri ) )
+		);
+	}
+
+	private function iriHtml( string $iri ): string {
+		if ( !$this->isLinkableUrl( $iri ) ) {
+			return Html::element( 'span', [], $iri );
+		}
+
+		$this->externalLinks[] = $iri;
+
+		return Html::element( 'a', [ 'class' => 'external', 'rel' => 'nofollow', 'href' => $iri ], $iri );
+	}
+
+	private function isLinkableUrl( string $url ): bool {
+		return preg_match( '#^(?:https?|ftps?)://#i', $url ) === 1;
+	}
+
+	private function schemaSectionsHtml( stdClass $schemas ): string {
+		$sections = '';
+
+		foreach ( get_object_vars( $schemas ) as $name => $schema ) {
+			$sections .= $this->schemaSectionHtml( (string)$name, $schema );
+		}
+
+		return $sections;
+	}
+
+	private function schemaSectionHtml( string $name, mixed $schema ): string {
+		$heading = Html::element(
+			'h2',
+			[ 'id' => Sanitizer::escapeIdForAttribute( self::SECTION_ID_PREFIX . $name ) ],
+			$name
+		);
+
+		return $heading . ( $this->renderJsonTable )( $schema );
+	}
+
+	private function emptyStateHtml(): string {
+		return Html::element(
+			'p',
+			[ 'class' => 'ext-neowiki-mapping-page__empty' ],
+			wfMessage( 'neowiki-mapping-page-no-schemas' )->text()
+		);
+	}
+
+	private function headingHtml( string $messageKey ): string {
+		return Html::element( 'h2', [], wfMessage( $messageKey )->text() );
+	}
+
+	private function headerCellHtml( string $messageKey ): string {
+		return Html::element( 'th', [], wfMessage( $messageKey )->text() );
+	}
+
+}

--- a/src/Presentation/MappingPageHtmlBuilder.php
+++ b/src/Presentation/MappingPageHtmlBuilder.php
@@ -60,7 +60,7 @@ class MappingPageHtmlBuilder {
 		return Html::element(
 			'div',
 			[ 'class' => 'ext-neowiki-mapping-page__version' ],
-			wfMessage( 'neowiki-mapping-page-version' )->numParams( $mapping->version )->text()
+			wfMessage( 'neowiki-mapping-page-version' )->numParams( $mapping->version )->inContentLanguage()->text()
 		);
 	}
 
@@ -222,16 +222,16 @@ class MappingPageHtmlBuilder {
 		return Html::element(
 			'p',
 			[ 'class' => 'ext-neowiki-mapping-page__empty' ],
-			wfMessage( 'neowiki-mapping-page-no-schemas' )->text()
+			wfMessage( 'neowiki-mapping-page-no-schemas' )->inContentLanguage()->text()
 		);
 	}
 
 	private function headingHtml( string $messageKey ): string {
-		return Html::element( 'h2', [], wfMessage( $messageKey )->text() );
+		return Html::element( 'h2', [], wfMessage( $messageKey )->inContentLanguage()->text() );
 	}
 
 	private function headerCellHtml( string $messageKey ): string {
-		return Html::element( 'th', [], wfMessage( $messageKey )->text() );
+		return Html::element( 'th', [], wfMessage( $messageKey )->inContentLanguage()->text() );
 	}
 
 }

--- a/src/Presentation/MappingPageHtmlBuilder.php
+++ b/src/Presentation/MappingPageHtmlBuilder.php
@@ -71,6 +71,10 @@ class MappingPageHtmlBuilder {
 	 * existence query. Without this, both LinkRenderer::makeLink (red or blue?) and ParserOutput::addLink
 	 * (which page id?) do their own lookup per schema, and the schemas list is unbounded user input.
 	 *
+	 * A name is only linked when it is already the canonical page title. Save validation enforces that,
+	 * but XML import does not, and linking a name the projector will never match would show a blue link
+	 * on a Schema that is not in fact mapped.
+	 *
 	 * @return array<string, Title>
 	 */
 	private function resolveSchemaTitles( stdClass $schemas ): array {
@@ -79,7 +83,7 @@ class MappingPageHtmlBuilder {
 		foreach ( get_object_vars( $schemas ) as $name => $schema ) {
 			$title = $this->titleFactory->makeTitleSafe( NeoWikiExtension::NS_SCHEMA, (string)$name );
 
-			if ( $title !== null ) {
+			if ( $title !== null && $title->getText() === (string)$name ) {
 				$titles[(string)$name] = $title;
 			}
 		}

--- a/src/Presentation/MappingPageHtmlBuilder.php
+++ b/src/Presentation/MappingPageHtmlBuilder.php
@@ -5,10 +5,12 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Presentation;
 
 use Closure;
+use MediaWiki\Cache\LinkBatchFactory;
 use MediaWiki\Html\Html;
 use MediaWiki\Linker\LinkRenderer;
 use MediaWiki\Linker\LinkTarget;
 use MediaWiki\Parser\Sanitizer;
+use MediaWiki\Title\Title;
 use MediaWiki\Title\TitleFactory;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use stdClass;
@@ -28,12 +30,18 @@ class MappingPageHtmlBuilder {
 	/** @var list<string> */
 	private array $externalLinks = [];
 
+	/** @var array<string, Title> Schema name => its Schema page, for names that form a valid title. */
+	private array $schemaTitles = [];
+
 	/**
+	 * @param LinkTarget $pageTitle The Mapping page being rendered, for title-specific external link attributes.
 	 * @param Closure(mixed): string $renderJsonTable Renders a JSON subtree as the core mw-json table.
 	 */
 	public function __construct(
 		private readonly LinkRenderer $linkRenderer,
 		private readonly TitleFactory $titleFactory,
+		private readonly LinkBatchFactory $linkBatchFactory,
+		private readonly LinkTarget $pageTitle,
 		private readonly Closure $renderJsonTable
 	) {
 	}
@@ -43,6 +51,8 @@ class MappingPageHtmlBuilder {
 		$this->externalLinks = [];
 
 		$schemas = $mapping->schemas;
+
+		$this->schemaTitles = $this->resolveSchemaTitles( $schemas );
 
 		$html = Html::rawElement(
 			'div',
@@ -54,6 +64,29 @@ class MappingPageHtmlBuilder {
 		);
 
 		return new MappingPageRendering( $html, $this->schemaLinks, $this->externalLinks );
+	}
+
+	/**
+	 * Resolves every schema name to its Schema page up front and primes the LinkCache with a single
+	 * existence query. Without this, both LinkRenderer::makeLink (red or blue?) and ParserOutput::addLink
+	 * (which page id?) do their own lookup per schema, and the schemas list is unbounded user input.
+	 *
+	 * @return array<string, Title>
+	 */
+	private function resolveSchemaTitles( stdClass $schemas ): array {
+		$titles = [];
+
+		foreach ( get_object_vars( $schemas ) as $name => $schema ) {
+			$title = $this->titleFactory->makeTitleSafe( NeoWikiExtension::NS_SCHEMA, (string)$name );
+
+			if ( $title !== null ) {
+				$titles[(string)$name] = $title;
+			}
+		}
+
+		$this->linkBatchFactory->newLinkBatch( $titles )->setCaller( __METHOD__ )->execute();
+
+		return $titles;
 	}
 
 	private function versionHtml( stdClass $mapping ): string {
@@ -108,7 +141,7 @@ class MappingPageHtmlBuilder {
 	}
 
 	private function schemaLinkHtml( string $name ): string {
-		$title = $this->titleFactory->makeTitleSafe( NeoWikiExtension::NS_SCHEMA, $name );
+		$title = $this->schemaTitles[$name] ?? null;
 
 		if ( $title === null ) {
 			return Html::element( 'span', [], $name );
@@ -191,9 +224,14 @@ class MappingPageHtmlBuilder {
 
 		$this->externalLinks[] = $iri;
 
-		return Html::element( 'a', [ 'class' => 'external', 'rel' => 'nofollow', 'href' => $iri ], $iri );
+		return $this->linkRenderer->makeExternalLink( $iri, $iri, $this->pageTitle );
 	}
 
+	/**
+	 * Namespace IRIs are arbitrary strings as far as the mapping format is concerned, and
+	 * LinkRenderer::makeExternalLink does no scheme validation, so anything that is not plainly a web
+	 * address stays unlinked rather than becoming an href.
+	 */
 	private function isLinkableUrl( string $url ): bool {
 		return preg_match( '#^(?:https?|ftps?)://#i', $url ) === 1;
 	}

--- a/src/Presentation/MappingPageRendering.php
+++ b/src/Presentation/MappingPageRendering.php
@@ -1,0 +1,22 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Presentation;
+
+use MediaWiki\Linker\LinkTarget;
+
+class MappingPageRendering {
+
+	/**
+	 * @param list<LinkTarget> $schemaLinks Schema pages the mapping references, for the ParserOutput link table.
+	 * @param list<string> $externalLinks Prefix namespace IRIs, for the ParserOutput external link table.
+	 */
+	public function __construct(
+		public readonly string $html,
+		public readonly array $schemaLinks,
+		public readonly array $externalLinks
+	) {
+	}
+
+}

--- a/tests/phpunit/EntryPoints/Content/MappingContentHandlerParserOutputTest.php
+++ b/tests/phpunit/EntryPoints/Content/MappingContentHandlerParserOutputTest.php
@@ -60,6 +60,12 @@ class MappingContentHandlerParserOutputTest extends MediaWikiIntegrationTestCase
 		);
 	}
 
+	public function testHeaderTextUsesTheContentLanguageRatherThanTheViewerLanguage(): void {
+		$this->setUserLang( 'qqx' );
+
+		$this->assertStringContainsString( 'Mapped schemas', $this->render( $this->edm() ) );
+	}
+
 	public function testMappedSchemaPagesAreRegisteredAsLinks(): void {
 		$parserOutput = $this->parserOutput( $this->edm() );
 

--- a/tests/phpunit/EntryPoints/Content/MappingContentHandlerParserOutputTest.php
+++ b/tests/phpunit/EntryPoints/Content/MappingContentHandlerParserOutputTest.php
@@ -4,29 +4,175 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\Content;
 
+use MediaWiki\CommentStore\CommentStoreComment;
 use MediaWiki\Content\Renderer\ContentParseParams;
+use MediaWiki\Linker\LinkTarget;
+use MediaWiki\Parser\ParserOutput;
+use MediaWiki\Parser\ParserOutputLinkTypes;
 use MediaWiki\Title\Title;
 use MediaWikiIntegrationTestCase;
 use ProfessionalWiki\NeoWiki\EntryPoints\Content\MappingContent;
 use ProfessionalWiki\NeoWiki\EntryPoints\Content\MappingContentHandler;
+use ProfessionalWiki\NeoWiki\EntryPoints\Content\SchemaContent;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\EntryPoints\Content\MappingContentHandler
+ * @covers \ProfessionalWiki\NeoWiki\Presentation\MappingPageHtmlBuilder
  * @group Database
  */
 class MappingContentHandlerParserOutputTest extends MediaWikiIntegrationTestCase {
 
-	private function render( string $json, string $name = 'EDM' ): string {
+	private function parserOutput( string $json, string $name = 'EDM' ): ParserOutput {
 		$handler = new MappingContentHandler( MappingContent::CONTENT_MODEL_ID );
 		$page = Title::makeTitle( NeoWikiExtension::NS_MAPPING, $name )->toPageIdentity();
 		$cpoParams = new ContentParseParams( $page, null, null, true );
 
-		return $handler->getParserOutput( new MappingContent( $json ), $cpoParams )->getRawText();
+		return $handler->getParserOutput( new MappingContent( $json ), $cpoParams );
+	}
+
+	private function render( string $json, string $name = 'EDM' ): string {
+		return $this->parserOutput( $json, $name )->getRawText();
 	}
 
 	public function testMappingJsonIsVisibleOnTheReadTab(): void {
 		$this->assertStringContainsString( 'edm:Agent', $this->render( $this->edm() ) );
+	}
+
+	public function testPerSchemaSubtreeIsRenderedAsAJsonTable(): void {
+		$html = $this->render( $this->edm() );
+
+		$this->assertStringContainsString( 'mw-json', $html );
+		$this->assertStringContainsString( 'rdaGr2:dateOfBirth', $html );
+	}
+
+	public function testEachSchemaSectionHasADeepLinkableId(): void {
+		$this->assertStringContainsString(
+			'id="ext-neowiki-mapping-schema-Person"',
+			$this->render( $this->edm() )
+		);
+	}
+
+	public function testFormatVersionIsRenderedAsASubtleLine(): void {
+		$this->assertStringContainsString(
+			'ext-neowiki-mapping-page__version',
+			$this->render( $this->edm() )
+		);
+	}
+
+	public function testMappedSchemaPagesAreRegisteredAsLinks(): void {
+		$parserOutput = $this->parserOutput( $this->edm() );
+
+		$this->assertTrue( $this->registersLocalLink( $parserOutput, NeoWikiExtension::NS_SCHEMA, 'Person' ) );
+		$this->assertTrue( $this->registersLocalLink( $parserOutput, NeoWikiExtension::NS_SCHEMA, 'City' ) );
+	}
+
+	public function testPrefixNamespaceIrisAreRegisteredAsExternalLinks(): void {
+		$externalLinks = $this->parserOutput( $this->edm() )->getExternalLinks();
+
+		$this->assertArrayHasKey( 'http://www.europeana.eu/schemas/edm/', $externalLinks );
+		$this->assertArrayHasKey( 'http://xmlns.com/foaf/0.1/', $externalLinks );
+	}
+
+	public function testPrefixesAreRenderedAsClickableExternalLinks(): void {
+		$html = $this->render( $this->edm() );
+
+		$this->assertStringContainsString( 'ext-neowiki-mapping-page__prefixes', $html );
+		$this->assertStringContainsString( 'href="http://www.europeana.eu/schemas/edm/"', $html );
+	}
+
+	public function testPrefixIriWithAnUnsafeSchemeIsNotLinkified(): void {
+		$json = (string)json_encode( [
+			'version' => 1,
+			'prefixes' => [ 'evil' => 'javascript:alert(1)' ],
+			'schemas' => [ 'Person' => [ 'subject' => [ 'class' => 'edm:Agent' ], 'properties' => (object)[] ] ],
+		] );
+
+		$parserOutput = $this->parserOutput( $json );
+
+		$this->assertStringNotContainsString( 'href="javascript:', $parserOutput->getRawText() );
+		$this->assertArrayNotHasKey( 'javascript:alert(1)', $parserOutput->getExternalLinks() );
+	}
+
+	public function testJsonContentAndNeoWikiStyleModulesAreAdded(): void {
+		$moduleStyles = $this->parserOutput( $this->edm() )->getModuleStyles();
+
+		$this->assertContains( 'mediawiki.content.json', $moduleStyles );
+		$this->assertContains( 'ext.neowiki.styles', $moduleStyles );
+	}
+
+	public function testMissingSchemaIsLinkedAsARedLink(): void {
+		$this->assertStringContainsString(
+			'redlink=1',
+			$this->render( $this->mappingWithSchema( 'Ghost' ) )
+		);
+	}
+
+	public function testExistingSchemaIsLinkedAsABlueLink(): void {
+		$this->createSchemaPage( 'Person' );
+		$this->getServiceContainer()->getLinkCache()->clear();
+
+		$parserOutput = $this->parserOutput( $this->mappingWithSchema( 'Person' ) );
+
+		$this->assertTrue( $this->registersLocalLink( $parserOutput, NeoWikiExtension::NS_SCHEMA, 'Person' ) );
+		$this->assertStringNotContainsString( 'redlink', $parserOutput->getRawText() );
+	}
+
+	public function testEmptySchemasShowAFriendlyEmptyState(): void {
+		$html = $this->render( '{ "version": 1, "prefixes": {}, "schemas": {} }' );
+
+		$this->assertStringContainsString( 'ext-neowiki-mapping-page__empty', $html );
+		$this->assertStringNotContainsString( 'mw-json', $html );
+	}
+
+	public function testNonV1ShapeFallsBackToTheDefaultJsonTable(): void {
+		$html = $this->render( '{ "version": 2, "schemas": {} }' );
+
+		$this->assertStringContainsString( 'mw-json', $html );
+		$this->assertStringNotContainsString( 'ext-neowiki-mapping-page', $html );
+	}
+
+	public function testInvalidJsonFallsBackToTheDefaultRendering(): void {
+		$this->assertStringNotContainsString(
+			'ext-neowiki-mapping-page',
+			$this->render( 'this is not valid json' )
+		);
+	}
+
+	/**
+	 * @param array<int, array{link: LinkTarget, pageid?: int}> $links
+	 */
+	private function registersLocalLink( ParserOutput $parserOutput, int $namespace, string $dbKey ): bool {
+		$matches = array_filter(
+			$parserOutput->getLinkList( ParserOutputLinkTypes::LOCAL ),
+			static fn ( array $link ): bool =>
+				$link['link']->getNamespace() === $namespace && $link['link']->getDBkey() === $dbKey
+		);
+
+		return $matches !== [];
+	}
+
+	private function createSchemaPage( string $name ): void {
+		$wikiPage = $this->getServiceContainer()->getWikiPageFactory()->newFromTitle(
+			Title::makeTitle( NeoWikiExtension::NS_SCHEMA, $name )
+		);
+
+		$updater = $wikiPage->newPageUpdater( $this->getTestSysop()->getUser() );
+		$updater->setContent( 'main', new SchemaContent( '{ "title": "' . $name . '", "propertyDefinitions": {} }' ) );
+		$updater->saveRevision( CommentStoreComment::newUnsavedComment( 'Test schema' ) );
+	}
+
+	private function mappingWithSchema( string $schemaName ): string {
+		return (string)json_encode( [
+			'version' => 1,
+			'prefixes' => [ 'edm' => 'http://www.europeana.eu/schemas/edm/' ],
+			'schemas' => [
+				$schemaName => [
+					'subject' => [ 'class' => 'edm:Agent' ],
+					'properties' => (object)[],
+				],
+			],
+		] );
 	}
 
 	private function edm(): string {
@@ -36,7 +182,8 @@ class MappingContentHandlerParserOutputTest extends MediaWikiIntegrationTestCase
 				"prefixes": {
 					"edm": "http://www.europeana.eu/schemas/edm/",
 					"rdaGr2": "http://rdvocab.info/ElementsGr2/",
-					"skos": "http://www.w3.org/2004/02/skos/core#"
+					"skos": "http://www.w3.org/2004/02/skos/core#",
+					"foaf": "http://xmlns.com/foaf/0.1/"
 				},
 				"schemas": {
 					"Person": {
@@ -49,6 +196,12 @@ class MappingContentHandlerParserOutputTest extends MediaWikiIntegrationTestCase
 							"Birth place": { "predicate": "rdaGr2:placeOfBirth" },
 							"Description": { "predicate": "skos:note", "lang": "en" }
 						}
+					},
+					"City": {
+						"subject": {
+							"class": "edm:Place"
+						},
+						"properties": {}
 					}
 				}
 			}

--- a/tests/phpunit/EntryPoints/Content/MappingContentHandlerParserOutputTest.php
+++ b/tests/phpunit/EntryPoints/Content/MappingContentHandlerParserOutputTest.php
@@ -6,7 +6,7 @@ namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\Content;
 
 use MediaWiki\CommentStore\CommentStoreComment;
 use MediaWiki\Content\Renderer\ContentParseParams;
-use MediaWiki\Linker\LinkTarget;
+use MediaWiki\MainConfigNames;
 use MediaWiki\Parser\ParserOutput;
 use MediaWiki\Parser\ParserOutputLinkTypes;
 use MediaWiki\Title\Title;
@@ -40,17 +40,40 @@ class MappingContentHandlerParserOutputTest extends MediaWikiIntegrationTestCase
 	}
 
 	public function testPerSchemaSubtreeIsRenderedAsAJsonTable(): void {
-		$html = $this->render( $this->edm() );
+		$personSection = $this->schemaSection( $this->render( $this->edm() ), 'Person' );
 
-		$this->assertStringContainsString( 'mw-json', $html );
-		$this->assertStringContainsString( 'rdaGr2:dateOfBirth', $html );
+		$this->assertStringContainsString( 'mw-json', $personSection );
+		$this->assertStringContainsString( 'rdaGr2:dateOfBirth', $personSection );
+	}
+
+	public function testSchemaSectionContainsOnlyItsOwnSubtree(): void {
+		$citySection = $this->schemaSection( $this->render( $this->edm() ), 'City' );
+
+		$this->assertStringContainsString( 'edm:Place', $citySection );
+		$this->assertStringNotContainsString( 'rdaGr2:dateOfBirth', $citySection );
 	}
 
 	public function testEachSchemaSectionHasADeepLinkableId(): void {
-		$this->assertStringContainsString(
-			'id="ext-neowiki-mapping-schema-Person"',
-			$this->render( $this->edm() )
+		$html = $this->render( $this->edm() );
+
+		$this->assertStringContainsString( 'id="ext-neowiki-mapping-schema-Person"', $html );
+		$this->assertStringContainsString( 'id="ext-neowiki-mapping-schema-City"', $html );
+	}
+
+	public function testSchemaSectionsFollowDocumentOrder(): void {
+		$html = $this->render( $this->edm() );
+
+		$this->assertLessThan(
+			strpos( $html, 'id="ext-neowiki-mapping-schema-City"' ),
+			strpos( $html, 'id="ext-neowiki-mapping-schema-Person"' )
 		);
+	}
+
+	public function testOverviewRowsShowTheTargetClassAndMappedPropertyCount(): void {
+		$html = $this->render( $this->edm() );
+
+		$this->assertStringContainsString( '>Person</a></td><td>edm:Agent</td><td>4</td>', $html );
+		$this->assertStringContainsString( '>City</a></td><td>edm:Place</td><td>0</td>', $html );
 	}
 
 	public function testFormatVersionIsRenderedAsASubtleLine(): void {
@@ -85,6 +108,15 @@ class MappingContentHandlerParserOutputTest extends MediaWikiIntegrationTestCase
 
 		$this->assertStringContainsString( 'ext-neowiki-mapping-page__prefixes', $html );
 		$this->assertStringContainsString( 'href="http://www.europeana.eu/schemas/edm/"', $html );
+	}
+
+	public function testPrefixLinksHonorTheWikiExternalLinkConfiguration(): void {
+		$this->overrideConfigValue( MainConfigNames::NoFollowLinks, false );
+
+		$html = $this->render( $this->edm() );
+
+		$this->assertStringContainsString( 'href="http://www.europeana.eu/schemas/edm/"', $html );
+		$this->assertStringNotContainsString( 'rel="nofollow"', $html );
 	}
 
 	public function testPrefixIriWithAnUnsafeSchemeIsNotLinkified(): void {
@@ -146,8 +178,18 @@ class MappingContentHandlerParserOutputTest extends MediaWikiIntegrationTestCase
 	}
 
 	/**
-	 * @param array<int, array{link: LinkTarget, pageid?: int}> $links
+	 * The rendered HTML from the section heading of $name up to the next schema section, so assertions
+	 * about a schema's own subtree cannot be satisfied by another schema's section or by the header.
 	 */
+	private function schemaSection( string $html, string $name ): string {
+		$start = strpos( $html, 'id="ext-neowiki-mapping-schema-' . $name . '"' );
+		$this->assertIsInt( $start, "No section rendered for schema $name" );
+
+		$next = strpos( $html, 'id="ext-neowiki-mapping-schema-', $start + 1 );
+
+		return $next === false ? substr( $html, $start ) : substr( $html, $start, $next - $start );
+	}
+
 	private function registersLocalLink( ParserOutput $parserOutput, int $namespace, string $dbKey ): bool {
 		$matches = array_filter(
 			$parserOutput->getLinkList( ParserOutputLinkTypes::LOCAL ),

--- a/tests/phpunit/EntryPoints/Content/MappingContentHandlerParserOutputTest.php
+++ b/tests/phpunit/EntryPoints/Content/MappingContentHandlerParserOutputTest.php
@@ -63,10 +63,13 @@ class MappingContentHandlerParserOutputTest extends MediaWikiIntegrationTestCase
 	public function testSchemaSectionsFollowDocumentOrder(): void {
 		$html = $this->render( $this->edm() );
 
-		$this->assertLessThan(
-			strpos( $html, 'id="ext-neowiki-mapping-schema-City"' ),
-			strpos( $html, 'id="ext-neowiki-mapping-schema-Person"' )
-		);
+		$person = strpos( $html, 'id="ext-neowiki-mapping-schema-Person"' );
+		$city = strpos( $html, 'id="ext-neowiki-mapping-schema-City"' );
+
+		// Guarded, because assertLessThan( int, false ) compares as bool and would pass.
+		$this->assertIsInt( $person );
+		$this->assertIsInt( $city );
+		$this->assertLessThan( $city, $person );
 	}
 
 	public function testOverviewRowsShowTheTargetClassAndMappedPropertyCount(): void {
@@ -111,8 +114,11 @@ class MappingContentHandlerParserOutputTest extends MediaWikiIntegrationTestCase
 	}
 
 	public function testPrefixLinksHonorTheWikiExternalLinkConfiguration(): void {
-		$this->overrideConfigValue( MainConfigNames::NoFollowLinks, false );
+		// Both directions, so an anchor that simply never emits rel cannot pass.
+		$this->overrideConfigValue( MainConfigNames::NoFollowLinks, true );
+		$this->assertStringContainsString( 'rel="nofollow"', $this->render( $this->edm() ) );
 
+		$this->overrideConfigValue( MainConfigNames::NoFollowLinks, false );
 		$html = $this->render( $this->edm() );
 
 		$this->assertStringContainsString( 'href="http://www.europeana.eu/schemas/edm/"', $html );
@@ -162,12 +168,15 @@ class MappingContentHandlerParserOutputTest extends MediaWikiIntegrationTestCase
 	 * claim a mapping that does not exist.
 	 */
 	public function testSchemaNameThatIsNotTheCanonicalPageTitleIsNotLinked(): void {
-		$this->createSchemaPage( 'Person' );
+		// The page the non-canonical name normalizes to, so without the guard this would be a blue link
+		// claiming a mapping the projector will never make, rather than a red one.
+		$this->createSchemaPage( 'Person x' );
 		$this->getServiceContainer()->getLinkCache()->clear();
 
 		$parserOutput = $this->parserOutput( $this->mappingWithSchema( 'Person_x' ) );
 
 		$this->assertStringContainsString( '<span>Person_x</span>', $parserOutput->getRawText() );
+		$this->assertStringNotContainsString( 'Schema:Person_x', $parserOutput->getRawText() );
 		$this->assertFalse( $this->registersLocalLink( $parserOutput, NeoWikiExtension::NS_SCHEMA, 'Person_x' ) );
 	}
 

--- a/tests/phpunit/EntryPoints/Content/MappingContentHandlerParserOutputTest.php
+++ b/tests/phpunit/EntryPoints/Content/MappingContentHandlerParserOutputTest.php
@@ -156,6 +156,21 @@ class MappingContentHandlerParserOutputTest extends MediaWikiIntegrationTestCase
 		$this->assertStringNotContainsString( 'redlink', $parserOutput->getRawText() );
 	}
 
+	/**
+	 * Save validation rejects a name that is not its Schema page's title, but XML import does not. Such a
+	 * name resolves to an existing Schema page while the projector never matches it, so linking it would
+	 * claim a mapping that does not exist.
+	 */
+	public function testSchemaNameThatIsNotTheCanonicalPageTitleIsNotLinked(): void {
+		$this->createSchemaPage( 'Person' );
+		$this->getServiceContainer()->getLinkCache()->clear();
+
+		$parserOutput = $this->parserOutput( $this->mappingWithSchema( 'Person_x' ) );
+
+		$this->assertStringContainsString( '<span>Person_x</span>', $parserOutput->getRawText() );
+		$this->assertFalse( $this->registersLocalLink( $parserOutput, NeoWikiExtension::NS_SCHEMA, 'Person_x' ) );
+	}
+
 	public function testEmptySchemasShowAFriendlyEmptyState(): void {
 		$html = $this->render( '{ "version": 1, "prefixes": {}, "schemas": {} }' );
 

--- a/tests/phpunit/Persistence/MediaWiki/MappingContentValidatorTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/MappingContentValidatorTest.php
@@ -4,23 +4,27 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Tests\Persistence\MediaWiki;
 
-use PHPUnit\Framework\TestCase;
+use MediaWikiIntegrationTestCase;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\MappingContentValidator;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestData;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\Persistence\MediaWiki\MappingContentValidator
  */
-class MappingContentValidatorTest extends TestCase {
+class MappingContentValidatorTest extends MediaWikiIntegrationTestCase {
+
+	private function newValidator(): MappingContentValidator {
+		return MappingContentValidator::newInstance( $this->getServiceContainer()->getTitleParser() );
+	}
 
 	private function assertValid( string $json ): void {
-		$validator = MappingContentValidator::newInstance();
+		$validator = $this->newValidator();
 		$this->assertTrue( $validator->validate( $json ), 'Expected valid, got: ' . implode( '; ', $validator->getErrors() ) );
 		$this->assertSame( [], $validator->getErrors() );
 	}
 
 	private function assertInvalidAt( string $json, string $expectedErrorPointer ): void {
-		$validator = MappingContentValidator::newInstance();
+		$validator = $this->newValidator();
 		$this->assertFalse( $validator->validate( $json ) );
 		$this->assertArrayHasKey( $expectedErrorPointer, $validator->getErrors() );
 	}
@@ -69,6 +73,80 @@ class MappingContentValidatorTest extends TestCase {
 			{ "version": 2, "schemas": { "Person": { "subject": { "class": "edm:X" }, "properties": {} } }, "prefixes": { "edm": "http://europeana.eu/edm/" } }
 			JSON,
 			'/version'
+		);
+	}
+
+	/**
+	 * The projector matches a Schema name byte for byte against the name a Subject carries, while a page
+	 * lookup normalizes underscores and the leading capital. A key that only resolves after normalization
+	 * would link to its Schema page yet never project, so it is rejected with the form to use.
+	 */
+	public function testRejectsASchemaNameThatIsNotTheCanonicalPageTitle(): void {
+		foreach ( [ 'Birth_place', 'birth place', ' Person' ] as $schemaName ) {
+			$this->assertInvalidAt(
+				(string)json_encode( [
+					'version' => 1,
+					'schemas' => [
+						$schemaName => [
+							'subject' => [ 'class' => 'http://example.org/ns/Person' ],
+							'properties' => (object)[],
+						],
+					],
+				] ),
+				'/schemas/' . $schemaName
+			);
+		}
+	}
+
+	public function testSaysWhichFormANonCanonicalSchemaNameShouldTake(): void {
+		$validator = $this->newValidator();
+		$validator->validate( (string)json_encode( [
+			'version' => 1,
+			'schemas' => [
+				'Birth_place' => [
+					'subject' => [ 'class' => 'http://example.org/ns/Place' ],
+					'properties' => (object)[],
+				],
+			],
+		] ) );
+
+		$this->assertStringContainsString(
+			'must be written as "Birth place"',
+			$validator->getErrors()['/schemas/Birth_place'] ?? ''
+		);
+	}
+
+	public function testRejectsASchemaNameThatIsNotAValidPageTitle(): void {
+		$this->assertInvalidAt(
+			(string)json_encode( [
+				'version' => 1,
+				'schemas' => [
+					'Bad|Name' => [
+						'subject' => [ 'class' => 'http://example.org/ns/Person' ],
+						'properties' => (object)[],
+					],
+				],
+			] ),
+			'/schemas/Bad|Name'
+		);
+	}
+
+	/**
+	 * The deserializer drops a reserved name, so accepting one here would store an entry that renders as
+	 * a mapped Schema but projects nothing.
+	 */
+	public function testRejectsAReservedSchemaName(): void {
+		$this->assertInvalidAt(
+			(string)json_encode( [
+				'version' => 1,
+				'schemas' => [
+					'Page' => [
+						'subject' => [ 'class' => 'http://example.org/ns/Person' ],
+						'properties' => (object)[],
+					],
+				],
+			] ),
+			'/schemas/Page'
 		);
 	}
 


### PR DESCRIPTION
Mapping pages (Mapping: namespace, NeoWikiMapping content model) rendered as one
undifferentiated mw-json table of the whole document. Special:Mappings already links
Mappings and Schemas; this completes navigation on the Mapping page itself and surfaces
missing schemas as red links.

MappingContentHandler now overrides fillParserOutput to server-render:

- A header: a mapped-schemas overview (each schema linked to its Schema: page via
  LinkRenderer — existing blue, missing red — with its target class and mapped-property
  count), a prefixes table (namespace IRIs as external links), and a subtle format-version
  line. Schema links are registered with addLink and prefix IRIs with addExternalLink, so
  WhatLinksHere works and the page re-renders when a Schema page is created or deleted. A
  mapping with no schemas shows a friendly empty state.
- One section per schema, in document order: a heading plus that schema's JSON subtree,
  rendered as the same mw-json table as before, under a stable deep-linkable id.

The per-schema bodies deliberately stay JSON: the v1 mapping format is provisional (the
structural mapping tier will reshape them — see docs/planning/OntologyMapping.md), so no
bespoke UI is built there yet.

Server-rendered, no JavaScript: display-only and parser-cache friendly, and ParserOutput
registration gives WhatLinksHere and cache invalidation for free. HTML
construction lives in a Presentation builder (MappingPageHtmlBuilder); the per-schema tables
reuse JsonContent::rootValueTable. When the content does not parse or is not the expected v1
shape (XML import and future format versions bypass save validation), rendering falls back to
the inherited JSON table, so it never fatals or blanks. Raw JSON editing (action=edit) is
unchanged.

Covered by parser-output tests (link registration, red/blue rendering, empty state,
fallbacks, unsafe-scheme guard). Verified in the browser against the demo wiki's Mapping:EDM (blue schema links, clickable prefix IRIs, four
per-schema tables) and via edit preview (a missing schema renders red; empty and non-v1
mappings render the empty state and the default JSON table).

Considered, omitted:

- Linkifying CURIEs/predicates in the per-schema bodies to their expanded IRIs — deferred
  until the structural mapping tier settles the format.
- A Vue-based page app — no interactivity to justify it.
- Links on property names — properties have no pages of their own.

> <sub>AI-authored — Claude Code, `Opus 4.8 (max)`; detailed spec from @JeroenDeDauw, worked autonomously; diff not yet human-reviewed; phpcs, phpstan and the full PHPUnit suite green locally, read view and edit preview browser-verified, CI green.</sub>

