### PR TITLE
Set proper filename with pageid for RDF-Export

### DIFF
--- a/docs/rdf/rdf-export.md
+++ b/docs/rdf/rdf-export.md
@@ -66,6 +66,9 @@ falling back to the `Accept` header, then to TriG; a value other than `trig` or 
 | `trig` (default) | `application/trig` | `application/trig; charset=utf-8` | yes |
 | `turtle` | `text/turtle` | `text/turtle; charset=utf-8` | no (same triples, no graph wrapper) |
 
+Responses carry `Content-Disposition: inline` with a filename of the page or Subject ID plus the format's
+extension (`42.trig`, `42.ttl`).
+
 ### Page
 
 `GET /rest.php/neowiki/v0/page/{pageId}/rdf`

--- a/src/EntryPoints/REST/ExportPageRdfApi.php
+++ b/src/EntryPoints/REST/ExportPageRdfApi.php
@@ -61,7 +61,10 @@ class ExportPageRdfApi extends SimpleHandler {
 			return $this->noDataResponse( $pageId );
 		}
 
-		return $this->rdfResponse( $document, $format );
+		#return $this->rdfResponse( $document, $format );
+		$response = $this->rdfResponse( $document, $format );
+		$response->setHeader( 'Content-Disposition', 'attachment; filename="' . $pageId . '.rdf"' );
+		return $response;
 	}
 
 	private function noDataResponse( int $pageId ): Response {

--- a/src/EntryPoints/REST/ExportPageRdfApi.php
+++ b/src/EntryPoints/REST/ExportPageRdfApi.php
@@ -61,10 +61,7 @@ class ExportPageRdfApi extends SimpleHandler {
 			return $this->noDataResponse( $pageId );
 		}
 
-		#return $this->rdfResponse( $document, $format );
-		$response = $this->rdfResponse( $document, $format );
-		$response->setHeader( 'Content-Disposition', 'attachment; filename="' . $pageId . '.rdf"' );
-		return $response;
+		return $this->rdfResponse( $document, $format, (string)$pageId );
 	}
 
 	private function noDataResponse( int $pageId ): Response {

--- a/src/EntryPoints/REST/ExportSubjectRdfApi.php
+++ b/src/EntryPoints/REST/ExportSubjectRdfApi.php
@@ -67,7 +67,7 @@ class ExportSubjectRdfApi extends SimpleHandler {
 			return $this->noDataResponse( $subjectId );
 		}
 
-		return $this->rdfResponse( $document, $format );
+		return $this->rdfResponse( $document, $format, $subjectId );
 	}
 
 	private function noDataResponse( string $subjectId ): Response {

--- a/src/EntryPoints/REST/RdfFormatNegotiation.php
+++ b/src/EntryPoints/REST/RdfFormatNegotiation.php
@@ -12,7 +12,11 @@ use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfFormat;
  * Shared RDF serialization negotiation for the RDF export handlers ({@see ExportPageRdfApi},
  * {@see ExportSubjectRdfApi}): the `format` query parameter wins, then the `Accept` header, then TriG.
  * TriG keeps the named graph; Turtle emits the same triples without it. Kept in one place so the two
- * endpoints stay byte-for-byte consistent in what they accept and the Content-Type they return.
+ * endpoints stay byte-for-byte consistent in what they accept and in the Content-Type and download
+ * filename they return. The filename stem callers pass (a page ID or validated Subject ID) must be
+ * header-safe without escaping. The disposition is `inline` rather than `attachment` so Turtle stays
+ * viewable in the browser — the sidebar "View RDF" link depends on that — while TriG, which browsers
+ * do not render, downloads under the stem plus the format's own extension.
  *
  * Used only by {@see \MediaWiki\Rest\SimpleHandler} subclasses, whose request/response accessors it
  * calls.
@@ -24,6 +28,9 @@ trait RdfFormatNegotiation {
 
 	private const string CONTENT_TYPE_TRIG = 'application/trig; charset=utf-8';
 	private const string CONTENT_TYPE_TURTLE = 'text/turtle; charset=utf-8';
+
+	private const string FILE_EXTENSION_TRIG = 'trig';
+	private const string FILE_EXTENSION_TURTLE = 'ttl';
 
 	private function resolveFormat(): RdfFormat {
 		$requested = $this->getValidatedParams()['format'] ?? null;
@@ -50,15 +57,23 @@ trait RdfFormatNegotiation {
 		return RdfFormat::TriG;
 	}
 
-	private function rdfResponse( string $document, RdfFormat $format ): Response {
+	private function rdfResponse( string $document, RdfFormat $format, string $filenameStem ): Response {
 		$response = $this->getResponseFactory()->create();
 		$response->setHeader(
 			'Content-Type',
 			$format === RdfFormat::Turtle ? self::CONTENT_TYPE_TURTLE : self::CONTENT_TYPE_TRIG
 		);
+		$response->setHeader(
+			'Content-Disposition',
+			'inline; filename="' . $filenameStem . '.' . $this->fileExtension( $format ) . '"'
+		);
 		$response->setBody( new StringStream( $document ) );
 
 		return $response;
+	}
+
+	private function fileExtension( RdfFormat $format ): string {
+		return $format === RdfFormat::Turtle ? self::FILE_EXTENSION_TURTLE : self::FILE_EXTENSION_TRIG;
 	}
 
 }

--- a/tests/phpunit/EntryPoints/REST/ExportPageRdfApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ExportPageRdfApiTest.php
@@ -20,6 +20,7 @@ use ProfessionalWiki\NeoWiki\Tests\NeoWikiMockAuthorityTrait;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\EntryPoints\REST\ExportPageRdfApi
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\REST\RdfFormatNegotiation
  * @group Database
  */
 class ExportPageRdfApiTest extends NeoWikiIntegrationTestCase {
@@ -122,6 +123,33 @@ JSON
 		$this->assertSame( 'application/trig; charset=utf-8', $response->getHeaderLine( 'Content-Type' ) );
 	}
 
+	public function testTriGExportNamesTheDownloadAfterThePageId(): void {
+		$response = $this->export();
+
+		$this->assertSame( 200, $response->getStatusCode() );
+		$this->assertSame(
+			'inline; filename="' . $this->pageId . '.trig"',
+			$response->getHeaderLine( 'Content-Disposition' )
+		);
+	}
+
+	public function testTurtleExportNamesTheDownloadWithTheTtlExtension(): void {
+		$response = $this->export( query: [ 'format' => 'turtle' ] );
+
+		$this->assertSame( 200, $response->getStatusCode() );
+		$this->assertSame(
+			'inline; filename="' . $this->pageId . '.ttl"',
+			$response->getHeaderLine( 'Content-Disposition' )
+		);
+	}
+
+	public function testErrorResponseCarriesNoDownloadFilename(): void {
+		$response = $this->export( pageId: 999999 );
+
+		$this->assertSame( 404, $response->getStatusCode() );
+		$this->assertSame( '', $response->getHeaderLine( 'Content-Disposition' ) );
+	}
+
 	public function testReturns404ForMissingPage(): void {
 		$response = $this->export( pageId: 999999 );
 
@@ -153,6 +181,10 @@ JSON
 		$this->assertSame(
 			$absentResponse->getHeaderLine( 'Content-Type' ),
 			$deniedResponse->getHeaderLine( 'Content-Type' )
+		);
+		$this->assertSame(
+			$absentResponse->getHeaderLine( 'Content-Disposition' ),
+			$deniedResponse->getHeaderLine( 'Content-Disposition' )
 		);
 	}
 

--- a/tests/phpunit/EntryPoints/REST/ExportSubjectRdfApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ExportSubjectRdfApiTest.php
@@ -137,6 +137,26 @@ JSON
 		$this->assertSame( 'application/trig; charset=utf-8', $response->getHeaderLine( 'Content-Type' ) );
 	}
 
+	public function testTriGExportNamesTheDownloadAfterTheSubjectId(): void {
+		$response = $this->export();
+
+		$this->assertSame( 200, $response->getStatusCode() );
+		$this->assertSame(
+			'inline; filename="' . self::BERLIN_ID . '.trig"',
+			$response->getHeaderLine( 'Content-Disposition' )
+		);
+	}
+
+	public function testTurtleExportNamesTheDownloadWithTheTtlExtension(): void {
+		$response = $this->export( query: [ 'format' => 'turtle' ] );
+
+		$this->assertSame( 200, $response->getStatusCode() );
+		$this->assertSame(
+			'inline; filename="' . self::BERLIN_ID . '.ttl"',
+			$response->getHeaderLine( 'Content-Disposition' )
+		);
+	}
+
 	public function testReturns404ForAnUnknownSubject(): void {
 		$response = $this->export( subjectId: self::ABSENT_ID );
 


### PR DESCRIPTION
Add Content-Disposition header for proper RDF filename download

Currently, RDF exports from `/rest.php/neowiki/v0/page/{id}/rdf` are
downloaded by browsers as a generic file named "rdf".

This PR adds a `Content-Disposition: attachment; filename="{pageId}.rdf"`
header so files download with proper names like `36.rdf`, `42.rdf`, etc.