### PR TITLE
Show toggle button focus rings for keyboard users only

### DIFF
--- a/resources/ext.neowiki/src/assets/keyboard-focus.less
+++ b/resources/ext.neowiki/src/assets/keyboard-focus.less
@@ -1,5 +1,5 @@
 /**
- * Keyboard-only focus rings for NeoWiki's Codex buttons.
+ * Keyboard-only focus rings for NeoWiki's Codex buttons and toggle buttons.
  *
  * Codex 1.14 styles button focus on bare `:focus`, so a mouse click — which
  * focuses the button but, per the browser heuristic, does not match
@@ -54,6 +54,29 @@
 	.cdx-button:enabled.cdx-button--weight-primary.cdx-button--action-destructive:focus:not( :focus-visible ):not( :active ):not( .cdx-button--is-active ),
 	.cdx-button.cdx-button--fake-button--enabled.cdx-button--weight-primary.cdx-button--action-destructive:focus:not( :focus-visible ):not( :active ):not( .cdx-button--is-active ) {
 		border-color: @border-color-destructive;
+		box-shadow: none;
+	}
+
+	// Codex rings toggle buttons on bare `:focus` too (the CdxToggleButtonGroup schema picker and
+	// the CdxMenuButton row-action triggers). Same treatment: drop the inset ring and restore each
+	// variant's resting border-color. `--toggled-on` is the persistent selected state and is kept,
+	// distinct from the `--is-active` pressed state that these guards leave alone as above.
+
+	// Framed toggle, unselected: grey resting border.
+	.cdx-toggle-button--framed:enabled:focus:not( :focus-visible ):not( :active ):not( .cdx-toggle-button--is-active ):not( .cdx-toggle-button--toggled-on ) {
+		border-color: @border-color-base;
+		box-shadow: none;
+	}
+
+	// Framed toggle, selected: progressive resting border.
+	.cdx-toggle-button--framed.cdx-toggle-button--toggled-on:enabled:focus:not( :focus-visible ):not( :active ):not( .cdx-toggle-button--is-active ) {
+		border-color: @border-color-progressive--active;
+		box-shadow: none;
+	}
+
+	// Quiet toggle (menu-button trigger): transparent resting border.
+	.cdx-toggle-button--quiet:enabled:focus:not( :focus-visible ):not( :active ):not( .cdx-toggle-button--is-active ) {
+		border-color: @border-color-transparent;
 		box-shadow: none;
 	}
 }


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1154

That change made Codex button focus rings keyboard-only, but the same Codex 1.14 bare-`:focus` behaviour still lingered on toggle buttons: a mouse click on the schema-picker toggle in the Subject Creator, and on the CdxMenuButton row-action triggers in the Subjects manager, left the progressive ring painted until focus moved away.

Those toggles already sit inside the `.ext-neowiki-ui` / `.ext-neowiki-view` scope, so this extends `assets/keyboard-focus.less` with three `.cdx-toggle-button` rules under the same scope: framed unselected (grey resting border), framed selected (progressive resting border) and quiet (transparent resting border). Each drops the inset ring on `:focus:not( :focus-visible )` and leaves keyboard focus, the pressed (`:active` / `--is-active`) state and the selected state intact.

Verified in the browser: mouse focus on the framed schema-picker toggles leaves no ring once the pointer moves away, keyboard focus still shows it.

> <sub>AI-authored — Claude Code, `Opus 4.8 (max)`; follow-up requested by @malberts after the #1154 review flagged it, no mid-task steering; diff not yet human-reviewed; verified in-browser (mouse focus leaves no ring, keyboard shows it), build + eslint/stylelint + vitest green locally.</sub>
