### PR TITLE
Fix review findings on #1136's cursor-pagination tests

### DIFF
--- a/resources/ext.neowiki/tests/VueTestHelpers.ts
+++ b/resources/ext.neowiki/tests/VueTestHelpers.ts
@@ -1,6 +1,6 @@
-import { mount, VueWrapper } from '@vue/test-utils';
+import { mount, VueWrapper, DOMWrapper } from '@vue/test-utils';
 import { Component, DefineComponent } from 'vue';
-import { vi } from 'vitest';
+import { expect, vi } from 'vitest';
 import { ValidationMessages, ValidationStatusType } from '@wikimedia/codex';
 import { NeoWikiTestServices } from './NeoWikiTestServices.ts';
 
@@ -13,6 +13,18 @@ export function createI18nMock(): ReturnType<typeof vi.fn> {
 	return vi.fn().mockImplementation( ( key ) => ( {
 		text: () => key,
 	} ) );
+}
+
+/**
+ * Locates the CdxTable pager's "Next page" button, asserting it exists so a selector that matches
+ * nothing fails loudly here. A missed find() returns an empty DOMWrapper whose
+ * attributes( 'disabled' ) is undefined, which would silently satisfy a toBeUndefined()
+ * enabled-state assertion against a button that is not in the DOM.
+ */
+export function findNextPageButton( wrapper: VueWrapper ): DOMWrapper<Element> {
+	const button = wrapper.find( '.cdx-table-pager button[aria-label="Next page"]' );
+	expect( button.exists() ).toBe( true );
+	return button;
 }
 
 export function createTestWrapper<TComponent extends DefineComponent<any, any, any>>(

--- a/resources/ext.neowiki/tests/components/LayoutsPage/LayoutsPage.spec.ts
+++ b/resources/ext.neowiki/tests/components/LayoutsPage/LayoutsPage.spec.ts
@@ -2,7 +2,7 @@ import { mount, VueWrapper, flushPromises } from '@vue/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ref } from 'vue';
 import LayoutsPage from '@/components/LayoutsPage/LayoutsPage.vue';
-import { createI18nMock, setupMwMock } from '../../VueTestHelpers.ts';
+import { createI18nMock, findNextPageButton, setupMwMock } from '../../VueTestHelpers.ts';
 
 interface LayoutSummary {
 	name: string;
@@ -99,7 +99,7 @@ describe( 'LayoutsPage', () => {
 		const wrapper = mountComponent( fullPage(), null );
 		await flushPromises();
 
-		const nextButton = wrapper.find( '.cdx-table-pager button[aria-label="Next page"]' );
+		const nextButton = findNextPageButton( wrapper );
 
 		expect( nextButton.attributes( 'disabled' ) ).toBeDefined();
 		expect( wrapper.text() ).toContain( 'of 10' );
@@ -112,7 +112,7 @@ describe( 'LayoutsPage', () => {
 		const wrapper = mountComponent( fullPage(), 'next-page-cursor' );
 		await flushPromises();
 
-		const nextButton = wrapper.find( '.cdx-table-pager button[aria-label="Next page"]' );
+		const nextButton = findNextPageButton( wrapper );
 
 		expect( nextButton.attributes( 'disabled' ) ).toBeUndefined();
 		expect( wrapper.text() ).toContain( 'of many' );

--- a/resources/ext.neowiki/tests/components/MappingsPage/MappingsPage.spec.ts
+++ b/resources/ext.neowiki/tests/components/MappingsPage/MappingsPage.spec.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ref } from 'vue';
 import MappingsPage from '@/components/MappingsPage/MappingsPage.vue';
 import MappingCreatorDialog from '@/components/MappingsPage/MappingCreatorDialog.vue';
-import { createI18nMock, setupMwMock } from '../../VueTestHelpers.ts';
+import { createI18nMock, findNextPageButton, setupMwMock } from '../../VueTestHelpers.ts';
 import { CdxButton, CdxDialog } from '@wikimedia/codex';
 
 interface MappingSummary {
@@ -170,7 +170,7 @@ describe( 'MappingsPage', () => {
 		);
 		await flushPromises();
 
-		const nextButton = wrapper.find( '.cdx-table-pager button[aria-label="Next page"]' );
+		const nextButton = findNextPageButton( wrapper );
 
 		expect( nextButton.attributes( 'disabled' ) ).toBeUndefined();
 		expect( wrapper.text() ).toContain( 'of many' );

--- a/resources/ext.neowiki/tests/components/MappingsPage/MappingsPage.spec.ts
+++ b/resources/ext.neowiki/tests/components/MappingsPage/MappingsPage.spec.ts
@@ -157,6 +157,23 @@ describe( 'MappingsPage', () => {
 		expect( wrapper.text() ).toContain( 'neowiki-mappings-empty' );
 	} );
 
+	it( 'disables next when a full page ends the listing', async () => {
+		// A listing that ends exactly on a page boundary returns a full page with a null cursor.
+		// CdxTable's indeterminate mode would keep next enabled (its heuristic is a short page), so
+		// the component must switch the table to a known total.
+		const wrapper = mountComponent(
+			Array.from( { length: 10 }, ( _value, index ) => (
+				{ name: `Mapping${ index }`, schemas: [] }
+			) ),
+		);
+		await flushPromises();
+
+		const nextButton = findNextPageButton( wrapper );
+
+		expect( nextButton.attributes( 'disabled' ) ).toBeDefined();
+		expect( wrapper.text() ).toContain( 'of 10' );
+	} );
+
 	it( 'keeps next enabled while the listing continues', async () => {
 		// A full page (the default size) with a non-null cursor means more rows follow. The
 		// component must leave totalRows undefined so CdxTable stays in its indeterminate mode

--- a/resources/ext.neowiki/tests/components/SchemasPage/SchemasPage.spec.ts
+++ b/resources/ext.neowiki/tests/components/SchemasPage/SchemasPage.spec.ts
@@ -4,7 +4,7 @@ import { ref } from 'vue';
 import SchemasPage from '@/components/SchemasPage/SchemasPage.vue';
 import SchemaCreatorDialog from '@/components/SchemasPage/SchemaCreatorDialog.vue';
 import SchemaEditorDialog from '@/components/SchemaEditor/SchemaEditorDialog.vue';
-import { createI18nMock, setupMwMock } from '../../VueTestHelpers.ts';
+import { createI18nMock, findNextPageButton, setupMwMock } from '../../VueTestHelpers.ts';
 import { CdxButton, CdxDialog } from '@wikimedia/codex';
 import { Schema } from '@/domain/Schema.ts';
 import { PropertyDefinitionList } from '@/domain/PropertyDefinitionList.ts';
@@ -156,7 +156,7 @@ describe( 'SchemasPage', () => {
 		) ) );
 		await flushPromises();
 
-		const nextButton = wrapper.find( '.cdx-table-pager button[aria-label="Next page"]' );
+		const nextButton = findNextPageButton( wrapper );
 
 		expect( nextButton.attributes( 'disabled' ) ).toBeDefined();
 		expect( wrapper.text() ).toContain( 'of 10' );
@@ -171,7 +171,7 @@ describe( 'SchemasPage', () => {
 		) ), 'next-page-cursor' );
 		await flushPromises();
 
-		const nextButton = wrapper.find( '.cdx-table-pager button[aria-label="Next page"]' );
+		const nextButton = findNextPageButton( wrapper );
 
 		expect( nextButton.attributes( 'disabled' ) ).toBeUndefined();
 		expect( wrapper.text() ).toContain( 'of many' );

--- a/src/Persistence/MediaWiki/DatabaseLayoutNameLookup.php
+++ b/src/Persistence/MediaWiki/DatabaseLayoutNameLookup.php
@@ -13,7 +13,7 @@ use Wikimedia\Rdbms\IDatabase;
 
 class DatabaseLayoutNameLookup implements LayoutNameLookup {
 
-	private const READABLE_NAMES_BATCH_SIZE = 100;
+	public const int READABLE_NAMES_BATCH_SIZE = 100;
 
 	public function __construct(
 		private readonly IDatabase $db,

--- a/src/Persistence/MediaWiki/DatabaseMappingNameLookup.php
+++ b/src/Persistence/MediaWiki/DatabaseMappingNameLookup.php
@@ -14,7 +14,7 @@ use Wikimedia\Rdbms\IDatabase;
 
 class DatabaseMappingNameLookup implements MappingNameLookup {
 
-	private const READABLE_NAMES_BATCH_SIZE = 100;
+	public const int READABLE_NAMES_BATCH_SIZE = 100;
 
 	public function __construct(
 		private readonly IDatabase $db,

--- a/src/Persistence/MediaWiki/DatabaseSchemaNameLookup.php
+++ b/src/Persistence/MediaWiki/DatabaseSchemaNameLookup.php
@@ -16,7 +16,7 @@ use Wikimedia\Rdbms\IResultWrapper;
 
 class DatabaseSchemaNameLookup implements SchemaNameLookup {
 
-	private const READABLE_NAMES_BATCH_SIZE = 100;
+	public const int READABLE_NAMES_BATCH_SIZE = 100;
 
 	public function __construct(
 		private readonly IDatabase $db,

--- a/tests/phpunit/EntryPoints/REST/GetMappingSummariesApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/GetMappingSummariesApiTest.php
@@ -9,6 +9,7 @@ use MediaWiki\Rest\HttpException;
 use MediaWiki\Rest\RequestData;
 use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\GetMappingSummariesApi;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
 
 /**
@@ -206,15 +207,33 @@ JSON
 	 * MappingContentHandler::validateSave would reject such content on the edit path (#1022).
 	 */
 	private function createMappingsWithUnloadableMiddle(): void {
-		$this->markPageTableAsUsed();
-		$this->createMapping( 'Alpha', '{"version":1,"schemas":{}}' );
+		$alpha = $this->createMapping( 'Alpha', '{"version":1,"schemas":{}}' )->getPageId();
 
 		$xml = $this->exportPageToXml( 'Mapping:Alpha' );
 		$xml = str_replace( 'Mapping:Alpha', 'Mapping:Beta', $xml );
 		$xml = str_replace( '"schemas"', '"schemaX"', $xml );
+		// Guard the fixture's own premise: the title substitution must have produced a Beta dump and the
+		// content substitution must have removed the required key. If either misses (e.g. an export-format
+		// change), the import would recreate a loadable Alpha instead of an unloadable Beta.
+		$this->assertStringContainsString( 'Mapping:Beta', $xml );
+		$this->assertStringNotContainsString( '"schemas"', $xml );
 		$this->importXml( $xml );
 
-		$this->createMapping( 'Gamma', '{"version":1,"schemas":{}}' );
+		$gamma = $this->createMapping( 'Gamma', '{"version":1,"schemas":{}}' )->getPageId();
+
+		// The import must have created a distinct Beta page sitting between Alpha and Gamma in page-ID
+		// order. Without this, a silently no-op import (Beta absent) leaves only Alpha and Gamma, whose
+		// listing is byte-identical to the asserted result — so both tests would pass while the skip
+		// branch they exist to pin never runs.
+		$beta = (int)$this->getDb()->newSelectQueryBuilder()
+			->select( 'page_id' )
+			->from( 'page' )
+			->where( [ 'page_namespace' => NeoWikiExtension::NS_MAPPING, 'page_title' => 'Beta' ] )
+			->caller( __METHOD__ )
+			->fetchField();
+
+		$this->assertGreaterThan( $alpha, $beta, 'the imported unloadable Beta page must exist' );
+		$this->assertGreaterThan( $beta, $gamma );
 	}
 
 }

--- a/tests/phpunit/EntryPoints/REST/GetMappingSummariesApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/GetMappingSummariesApiTest.php
@@ -213,10 +213,13 @@ JSON
 		$xml = str_replace( 'Mapping:Alpha', 'Mapping:Beta', $xml );
 		$xml = str_replace( '"schemas"', '"schemaX"', $xml );
 		// Guard the fixture's own premise: the title substitution must have produced a Beta dump and the
-		// content substitution must have removed the required key. If either misses (e.g. an export-format
-		// change), the import would recreate a loadable Alpha instead of an unloadable Beta.
+		// content substitution must have replaced the required key with its schemaX token. If either
+		// misses (e.g. an export-format change), the import would recreate a loadable Alpha instead of an
+		// unloadable Beta. Both guards assert a replacement TARGET, so each fails when its str_replace
+		// matched nothing — asserting the removed "schemas" token is absent would instead be tautological,
+		// since str_replace makes that true unconditionally.
 		$this->assertStringContainsString( 'Mapping:Beta', $xml );
-		$this->assertStringNotContainsString( '"schemas"', $xml );
+		$this->assertStringContainsString( '"schemaX"', $xml );
 		$this->importXml( $xml );
 
 		$gamma = $this->createMapping( 'Gamma', '{"version":1,"schemas":{}}' )->getPageId();

--- a/tests/phpunit/NeoWikiIntegrationTestCase.php
+++ b/tests/phpunit/NeoWikiIntegrationTestCase.php
@@ -176,7 +176,11 @@ class NeoWikiIntegrationTestCase extends MediaWikiIntegrationTestCase {
 			];
 		}
 
-		$this->getDb()->insert( 'page', $rows, __METHOD__ );
+		$this->getDb()->newInsertQueryBuilder()
+			->insertInto( 'page' )
+			->rows( $rows )
+			->caller( __METHOD__ )
+			->execute();
 
 		$pageIds = [];
 

--- a/tests/phpunit/Persistence/MediaWiki/DatabaseLayoutNameLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/DatabaseLayoutNameLookupTest.php
@@ -97,17 +97,44 @@ class DatabaseLayoutNameLookupTest extends NeoWikiIntegrationTestCase {
 		);
 	}
 
-	public function testGetReadableLayoutNamesDrainsPastTheBatchSize(): void {
-		// The generator pages the namespace in 100-row keyset batches. With more rows than one batch,
-		// it must keep querying past the first batch: every Layout is yielded, the lowest page ID
-		// first and the highest last. A single truncated batch would drop the tail.
-		$bulk = $this->createBarePages( NeoWikiExtension::NS_LAYOUT, 'BulkLayout', 120 );
+	public function testGetReadableLayoutNamesDrainsEveryBatchInPageIdOrder(): void {
+		// The generator pages the namespace in fixed-size keyset batches. With more rows than one batch,
+		// it must keep querying past the first batch and yield every Layout exactly once, in strictly
+		// ascending page-ID order — a single truncated batch would drop the tail.
+		$bulk = $this->createBarePages(
+			NeoWikiExtension::NS_LAYOUT,
+			'BulkLayout',
+			DatabaseLayoutNameLookup::READABLE_NAMES_BATCH_SIZE + 20
+		);
 
-		$drained = iterator_to_array( $this->getLookup()->getReadableLayoutNames() );
+		$this->assertSame(
+			$this->expectedByPageId( $bulk ),
+			array_map(
+				static fn ( TitleValue $title ): string => $title->getText(),
+				iterator_to_array( $this->getLookup()->getReadableLayoutNames() )
+			)
+		);
+	}
 
-		$this->assertCount( count( $this->pageIds ) + count( $bulk ), $drained );
-		$this->assertSame( $this->pageIds['LayoutNameLookupTest1'], array_key_first( $drained ) );
-		$this->assertSame( max( $bulk ), array_key_last( $drained ) );
+	/**
+	 * The setUp Layouts then the bulk rows, each page ID mapped to its title, in page-ID order —
+	 * the exact [pageId => name] map getReadableLayoutNames should yield when everything is readable.
+	 *
+	 * @param array<string, int> $bulk
+	 * @return array<int, string>
+	 */
+	private function expectedByPageId( array $bulk ): array {
+		$expected = [];
+
+		foreach ( $this->pageIds as $name => $id ) {
+			$expected[$id] = $name;
+		}
+
+		foreach ( $bulk as $title => $id ) {
+			$expected[$id] = $title;
+		}
+
+		return $expected;
 	}
 
 }

--- a/tests/phpunit/Persistence/MediaWiki/DatabaseMappingNameLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/DatabaseMappingNameLookupTest.php
@@ -114,17 +114,44 @@ class DatabaseMappingNameLookupTest extends NeoWikiIntegrationTestCase {
 		);
 	}
 
-	public function testGetReadableMappingNamesDrainsPastTheBatchSize(): void {
-		// The generator pages the namespace in 100-row keyset batches. With more rows than one batch,
-		// it must keep querying past the first batch: every Mapping is yielded, the lowest page ID
-		// first and the highest last. A single truncated batch would drop the tail.
-		$bulk = $this->createBarePages( NeoWikiExtension::NS_MAPPING, 'BulkMapping', 120 );
+	public function testGetReadableMappingNamesDrainsEveryBatchInPageIdOrder(): void {
+		// The generator pages the namespace in fixed-size keyset batches. With more rows than one batch,
+		// it must keep querying past the first batch and yield every Mapping exactly once, in strictly
+		// ascending page-ID order — a single truncated batch would drop the tail.
+		$bulk = $this->createBarePages(
+			NeoWikiExtension::NS_MAPPING,
+			'BulkMapping',
+			DatabaseMappingNameLookup::READABLE_NAMES_BATCH_SIZE + 20
+		);
 
-		$drained = iterator_to_array( $this->getLookup()->getReadableMappingNames() );
+		$this->assertSame(
+			$this->expectedByPageId( $bulk ),
+			array_map(
+				static fn ( MappingName $name ): string => $name->getText(),
+				iterator_to_array( $this->getLookup()->getReadableMappingNames() )
+			)
+		);
+	}
 
-		$this->assertCount( count( $this->pageIds ) + count( $bulk ), $drained );
-		$this->assertSame( $this->pageIds['MappingLookupTest1'], array_key_first( $drained ) );
-		$this->assertSame( max( $bulk ), array_key_last( $drained ) );
+	/**
+	 * The setUp Mappings then the bulk rows, each page ID mapped to its title, in page-ID order —
+	 * the exact [pageId => name] map getReadableMappingNames should yield when everything is readable.
+	 *
+	 * @param array<string, int> $bulk
+	 * @return array<int, string>
+	 */
+	private function expectedByPageId( array $bulk ): array {
+		$expected = [];
+
+		foreach ( $this->pageIds as $name => $id ) {
+			$expected[$id] = $name;
+		}
+
+		foreach ( $bulk as $title => $id ) {
+			$expected[$id] = $title;
+		}
+
+		return $expected;
 	}
 
 }

--- a/tests/phpunit/Persistence/MediaWiki/DatabaseSchemaNameLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/DatabaseSchemaNameLookupTest.php
@@ -217,10 +217,14 @@ class DatabaseSchemaNameLookupTest extends NeoWikiIntegrationTestCase {
 	}
 
 	public function testGetReadableSchemaNamesDrainsEveryBatchInPageIdOrder(): void {
-		// The generator pages the namespace in 100-row keyset batches. With more rows than one batch,
+		// The generator pages the namespace in fixed-size keyset batches. With more rows than one batch,
 		// it must keep querying past the first batch and yield every Schema exactly once, in strictly
 		// ascending page-ID order — a single truncated batch would drop the tail.
-		$bulk = $this->createBarePages( NeoWikiExtension::NS_SCHEMA, 'BulkSchema', 120 );
+		$bulk = $this->createBarePages(
+			NeoWikiExtension::NS_SCHEMA,
+			'BulkSchema',
+			DatabaseSchemaNameLookup::READABLE_NAMES_BATCH_SIZE + 20
+		);
 
 		$this->assertSame(
 			$this->expectedByPageId( $bulk ),
@@ -232,15 +236,19 @@ class DatabaseSchemaNameLookupTest extends NeoWikiIntegrationTestCase {
 	}
 
 	public function testGetReadableSchemaNamesContinuesPastAnUnreadableRowAtABatchBoundary(): void {
-		// The Schema whose page ID sits exactly on the first batch boundary (row 100, batch size 100)
-		// is denied. The drain's continue decision must count fetched rows, not yielded ones: batch
-		// one comes back full yet yields only 99, and the next batch must still be fetched, so rows
-		// 101+ arrive and the denied row is the only one absent.
-		$bulk = $this->createBarePages( NeoWikiExtension::NS_SCHEMA, 'BulkSchema', 120 );
+		// The Schema whose page ID sits exactly on the first batch boundary (the last row of the first
+		// full batch) is denied. The drain's continue decision must count fetched rows, not yielded ones:
+		// batch one comes back full yet yields one short, and the next batch must still be fetched, so the
+		// rows past the boundary arrive and the denied row is the only one absent.
+		$bulk = $this->createBarePages(
+			NeoWikiExtension::NS_SCHEMA,
+			'BulkSchema',
+			DatabaseSchemaNameLookup::READABLE_NAMES_BATCH_SIZE + 20
+		);
 
 		$expected = $this->expectedByPageId( $bulk );
-		// 100 = DatabaseSchemaNameLookup::READABLE_NAMES_BATCH_SIZE (private); the 100th row is the last of batch one.
-		$boundaryPageId = array_keys( $expected )[99];
+		// The last row of the first batch sits at index READABLE_NAMES_BATCH_SIZE - 1.
+		$boundaryPageId = array_keys( $expected )[DatabaseSchemaNameLookup::READABLE_NAMES_BATCH_SIZE - 1];
 		$boundaryTitle = $expected[$boundaryPageId];
 		unset( $expected[$boundaryPageId] );
 
@@ -259,7 +267,7 @@ class DatabaseSchemaNameLookupTest extends NeoWikiIntegrationTestCase {
 	}
 
 	/**
-	 * The 4 setUp Schemas then the bulk rows, each page ID mapped to its title, in page-ID order —
+	 * The setUp Schemas then the bulk rows, each page ID mapped to its title, in page-ID order —
 	 * the exact [pageId => name] map getReadableSchemaNames should yield when everything is readable.
 	 *
 	 * @param array<string, int> $bulk


### PR DESCRIPTION
Follows up the AI review of #1136 (which pins the cursor-pagination behaviours left untested in #1131). Fixes the eight findings from that review, plus one tautological assertion caught by re-reviewing these fixes. Test-only, except widening one constant's visibility — no production behaviour change.

Based on `pr-1131-review-fixes` (#1136's head), so the diff is only these fixes; it follows #1136's merge order.

## What changed

- **Assert the unloadable-Mapping fixture created its broken page.** `createMappingsWithUnloadableMiddle` now asserts the title/content substitutions took effect and that the imported Beta page exists between Alpha and Gamma in page-ID order. A silently no-op import used to leave both tests green while never exercising the loader's skip branch. Also drops a no-op `markPageTableAsUsed()`.
- **Build bare page rows through `InsertQueryBuilder`** instead of the `@internal` `IDatabase::insert()`, matching the read in the same helper and the suite's other raw insert.
- **Harden the keyset-drain tests against the batch size.** `READABLE_NAMES_BATCH_SIZE` is now `public const int`; the bulk row count (`+ 20`) and the boundary index (`- 1`) derive from it, so a changed batch size fails the tests instead of hollowing them into single-batch no-ops. The Layout and Mapping drains gain the Schema test's full ordered-map assertion and matching name.
- **Share the pager "Next page" selector** behind `findNextPageButton()`, which asserts the button exists so a stale selector fails loudly rather than passing vacuously; the five call sites across the three list specs use it.
- **Cover the MappingsPage determinate pager flip.** It had only the indeterminate half, so a "never flip `totalRows`" mutation shipped a listing that ends on a page boundary with Next enabled forever.
- **Assert the content substitution replaced the key** (`schemaX` present) rather than that `"schemas"` is absent — the latter is a `str_replace` post-condition and could never fail.

## Verification

- `make phpcs`, `make stan` clean; targeted PHPUnit green (Schema 16, Layout 5, Mapping 6, GetMapping 8/40 assertions); `make ts-lint` clean; full vitest 1108/1108.
- Every new guard sabotage-checked, each green on revert: import disabled → fixture existence assert fails; `while(false)` → drain + boundary fail; `totalRows = undefined` → only the MappingsPage determinate test fails; a non-matching content needle → the `schemaX` guard fails.
- Live smoke test on the dev wiki: the schema-list REST endpoint walks 23 schemas across cursor pages, each yielded once in page-ID order, null cursor at exhaustion, 400 on a malformed cursor; the rendered pager flips "of many" + Next enabled → "of 23" + Next disabled on the last page.

<sub>AI-authored — Claude Code, `Opus 4.8 (1M context)`; fixed eight findings from the /code-review of #1136 plus one caught while re-reviewing the fixes, for @alistair3149; diff not yet human-reviewed; sabotage-checked TDD (each guard seen failing against its target mutation first), targeted PHPUnit + full vitest + phpcs/phpstan/ts-lint green locally and live-smoke-tested, CI pending.</sub>

<details><summary>Production notes</summary>

Findings produced by an adversarial multi-lens review workflow (independent finders + refute-first verifiers + completeness critic); these fixes were then re-reviewed by the same harness, which caught the tautological content guard. All test execution and sabotage checks were run by the coordinator.

</details>
