### PR TITLE
Point RDF demo page docs links at neowiki.ai

### DIFF
--- a/DemoData/Page/RDF_and_ontology_mappings.wikitext
+++ b/DemoData/Page/RDF_and_ontology_mappings.wikitext
@@ -26,7 +26,7 @@ You don't need these links to reach an export: on any subject page, the Data tab
 == Learn more ==
 
 * [[Special:Mappings]]: every ontology Mapping on this wiki
-* [https://github.com/ProfessionalWiki/NeoWiki/blob/master/docs/rdf/rdf-export.md RDF export reference]
-* [https://github.com/ProfessionalWiki/NeoWiki/blob/master/docs/rdf/ontology-mapping.md Ontology mapping reference]
-* [https://github.com/ProfessionalWiki/NeoWiki/blob/master/docs/examples/person-to-edm.md Person-to-EDM worked example]
+* [https://neowiki.ai/docs/rdf/rdf-export RDF export reference]
+* [https://neowiki.ai/docs/rdf/ontology-mapping Ontology mapping reference]
+* [https://neowiki.ai/docs/examples/person-to-edm Person-to-EDM worked example]
 * Tell us what you need from RDF and ontology mapping: [https://github.com/ProfessionalWiki/NeoWiki/discussions/996 join the discussion].


### PR DESCRIPTION
The three "Learn more" documentation links pointed at raw Markdown on GitHub; they now point at the rendered pages on neowiki.ai. The GitHub Discussions link is unchanged, having no docs-site equivalent.

> <sub>AI-authored — Claude Code, `Opus 5 (1M context, max)`; one-line ask from @JeroenDeDauw, no mid-task steering; diff not yet human-reviewed; all three target URLs confirmed to return rendered pages (a bogus sibling path 404s, so these are not soft-404s), and the edited wikitext parsed on a worktree wiki to check the resulting external links.</sub>
