### PR TITLE
Give the demo wiki a main menu tailored to its content

### DIFF
--- a/DemoData/AGENTS.md
+++ b/DemoData/AGENTS.md
@@ -14,12 +14,16 @@ partners, knowledge managers, MediaWiki ecosystem evaluators, and live-demo audi
 | `Page/<Name>.wikitext` | Free-form wiki pages (hubs, references) | Main namespace, `<Name>` |
 | `SparqlPage/<Name>.wikitext` | Pages demoing the SPARQL surfaces. Imported only when `$wgNeoWikiSparqlStores` is non-empty (elsewhere `{{#sparql_raw}}` is unregistered and would render literally). | Main namespace, `<Name>` |
 | `Module/<Name>.lua` | Scribunto modules | `Module:<Name>` |
+| `MediaWiki/<Name>.wikitext` | Interface pages, such as `Sidebar` (the main menu) | `MediaWiki:<Name>` |
 
 `ImportDemoData.php` reseeds the demo set: it creates and updates pages from these directories, and
 deletes pages a previous import created whose source file is now gone. So renaming or removing a
 file and re-importing is enough — no `make reinstall-db` needed. Only pages the import itself created
 are pruned; a page someone else created — like `Main_Page`, which the installer creates and the
 import merely overwrites — is never deleted, even if its source file is removed.
+
+`MediaWiki/Sidebar.wikitext` links to `SPARQL queries`. Drop that line when seeding a wiki without a
+SPARQL store, or the main menu shows a red link.
 
 ## Filename and ID conventions
 

--- a/DemoData/MediaWiki/Sidebar.wikitext
+++ b/DemoData/MediaWiki/Sidebar.wikitext
@@ -1,0 +1,15 @@
+* Demo tour
+** Main Page|Main page
+** Museum collection|Museum collection
+** ACME Inc|ACME Inc
+** Research catalog|Research catalog
+** People and life events|People and life events
+* Features
+** Special:Schemas|Schemas
+** Subject views|Subject views
+** RDF and ontology mappings|RDF and ontology mappings
+** SPARQL queries|SPARQL queries
+** Developers|Developers hub
+* About NeoWiki
+** https://neowiki.ai|NeoWiki website
+** https://github.com/ProfessionalWiki/NeoWiki/issues|Issue tracker

--- a/DemoData/MediaWiki/Sidebar.wikitext
+++ b/DemoData/MediaWiki/Sidebar.wikitext
@@ -5,6 +5,7 @@
 ** Research catalog|Research catalog
 ** People and life events|People and life events
 * Features
+** {{fullurl:Rijksmuseum|action=subjects}}|Subjects on a page
 ** Special:Schemas|Schemas
 ** Subject views|Subject views
 ** RDF and ontology mappings|RDF and ontology mappings

--- a/maintenance/ImportDemoData.php
+++ b/maintenance/ImportDemoData.php
@@ -76,6 +76,12 @@ class ImportDemoData extends Maintenance {
 				],
 				new SimpleFileFetcher()
 			),
+			mediaWikiContentSource: new PageContentSource(
+				[
+					NeoWikiExtension::getInstance()->getNeoWikiRootDirectory() . '/DemoData/MediaWiki',
+				],
+				new SimpleFileFetcher()
+			),
 			layoutContentSource: new LayoutContentSource(
 				NeoWikiExtension::getInstance()->getNeoWikiRootDirectory() . '/DemoData/Layout',
 				new SimpleFileFetcher()

--- a/src/Application/Actions/ImportPages/ImportPagesAction.php
+++ b/src/Application/Actions/ImportPages/ImportPagesAction.php
@@ -37,6 +37,7 @@ class ImportPagesAction {
 		private readonly SubjectPageSource $subjectPageSource,
 		private readonly PageContentSource $pageContentSource,
 		private readonly PageContentSource $moduleContentSource,
+		private readonly PageContentSource $mediaWikiContentSource,
 		private readonly LayoutContentSource $layoutContentSource,
 		private readonly MappingContentSource $mappingContentSource,
 	) {
@@ -96,6 +97,15 @@ class ImportPagesAction {
 				'Module:' . self::stripFileExtension( $moduleName ),
 				[
 					'main' => $this->fileNameAndSourceToContent( $moduleName, $moduleContent ),
+				]
+			);
+		}
+
+		foreach ( $this->mediaWikiContentSource->getPageContentStrings() as $fileName => $sourceText ) {
+			$this->createPage(
+				'MediaWiki:' . self::stripFileExtension( $fileName ),
+				[
+					'main' => $this->fileNameAndSourceToContent( $fileName, $sourceText ),
 				]
 			);
 		}

--- a/tests/phpunit/Application/Actions/ImportPagesActionTest.php
+++ b/tests/phpunit/Application/Actions/ImportPagesActionTest.php
@@ -29,6 +29,7 @@ class ImportPagesActionTest extends \MediaWikiIntegrationTestCase {
 	private SubjectPageSource $subjectPageSource;
 	private PageContentSource $pageContentSource;
 	private PageContentSource $moduleContentSource;
+	private PageContentSource $mediaWikiContentSource;
 	private LayoutContentSource $layoutContentSource;
 	private MappingContentSource $mappingContentSource;
 	private ImportPagesAction $importPagesAction;
@@ -39,6 +40,7 @@ class ImportPagesActionTest extends \MediaWikiIntegrationTestCase {
 		$this->subjectPageSource = $this->createMock( SubjectPageSource::class );
 		$this->pageContentSource = $this->createMock( PageContentSource::class );
 		$this->moduleContentSource = $this->createMock( PageContentSource::class );
+		$this->mediaWikiContentSource = $this->createMock( PageContentSource::class );
 		$this->layoutContentSource = $this->createMock( LayoutContentSource::class );
 		$this->mappingContentSource = $this->createMock( MappingContentSource::class );
 
@@ -54,6 +56,7 @@ class ImportPagesActionTest extends \MediaWikiIntegrationTestCase {
 			$this->subjectPageSource,
 			$this->pageContentSource,
 			$this->moduleContentSource,
+			$this->mediaWikiContentSource,
 			$this->layoutContentSource,
 			$this->mappingContentSource,
 		);

--- a/tests/phpunit/Application/Actions/ImportPagesDeletionTest.php
+++ b/tests/phpunit/Application/Actions/ImportPagesDeletionTest.php
@@ -4,8 +4,6 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Tests\Application\Actions;
 
-use MediaWiki\CommentStore\CommentStoreComment;
-use MediaWiki\Page\PageIdentity;
 use MediaWiki\Page\ProperPageIdentity;
 use MediaWiki\Page\WikiPageFactory;
 use MediaWiki\Permissions\Authority;
@@ -18,13 +16,12 @@ use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\MappingContentSourc
 use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\PageContentSource;
 use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\SchemaContentSource;
 use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\SubjectPageSource;
-use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Persistence\ImportedPageTitlesLookup;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\PageContentSaver;
-use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\PageContentSavingStatus;
 use ProfessionalWiki\NeoWiki\Persistence\PageDeleter;
 use ProfessionalWiki\NeoWiki\Persistence\PageDeletionStatus;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\ImportPresenterSpy;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\PageContentSaverStub;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\PageDeleterSpy;
 
 /**
@@ -128,6 +125,7 @@ class ImportPagesDeletionTest extends MediaWikiIntegrationTestCase {
 			subjectPageSource: $this->createMock( SubjectPageSource::class ),
 			pageContentSource: $pageContentSource,
 			moduleContentSource: $this->createMock( PageContentSource::class ),
+			mediaWikiContentSource: $this->createMock( PageContentSource::class ),
 			layoutContentSource: $this->createMock( LayoutContentSource::class ),
 			mappingContentSource: $this->createMock( MappingContentSource::class ),
 		) )->import();
@@ -151,37 +149,12 @@ class ImportPagesDeletionTest extends MediaWikiIntegrationTestCase {
 		};
 	}
 
-	/**
-	 * A saver that persists nothing and simply reports the outcome the test asked for, so the action's
-	 * deletion decision can be exercised without touching the database.
-	 */
 	private function newPageContentSaver( string ...$failingKeys ): PageContentSaver {
-		return new class(
+		return new PageContentSaverStub(
 			$this->createMock( WikiPageFactory::class ),
 			$this->createMock( Authority::class ),
 			$failingKeys
-		) extends PageContentSaver {
-
-			/**
-			 * @param string[] $failingKeys
-			 */
-			public function __construct(
-				WikiPageFactory $wikiPageFactory,
-				Authority $performer,
-				private readonly array $failingKeys
-			) {
-				parent::__construct( $wikiPageFactory, $performer );
-			}
-
-			public function saveContent( PageIdentity|PageId $page, array $contentBySlot, CommentStoreComment $comment ): PageContentSavingStatus {
-				if ( $page instanceof PageIdentity && in_array( $page->getDBkey(), $this->failingKeys, true ) ) {
-					return new PageContentSavingStatus( PageContentSavingStatus::ERROR, 'forced failure' );
-				}
-
-				return new PageContentSavingStatus( PageContentSavingStatus::REVISION_CREATED );
-			}
-
-		};
+		);
 	}
 
 	private function newPageDeleterSpy(): PageDeleterSpy {

--- a/tests/phpunit/Application/Actions/ImportPagesNamespaceTest.php
+++ b/tests/phpunit/Application/Actions/ImportPagesNamespaceTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Application\Actions;
+
+use MediaWiki\Page\WikiPageFactory;
+use MediaWiki\Permissions\Authority;
+use MediaWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\ImportPagesAction;
+use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\LayoutContentSource;
+use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\MappingContentSource;
+use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\PageContentSource;
+use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\SchemaContentSource;
+use ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\SubjectPageSource;
+use ProfessionalWiki\NeoWiki\Persistence\ImportedPageTitlesLookup;
+use ProfessionalWiki\NeoWiki\Persistence\PageDeleter;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\ImportPresenterSpy;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\PageContentSaverStub;
+
+/**
+ * Covers which namespace each demo data source directory imports into. The saver is a stub, so the
+ * titles the action derives from the file names can be checked without touching the database.
+ *
+ * @covers \ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\ImportPagesAction
+ */
+class ImportPagesNamespaceTest extends MediaWikiIntegrationTestCase {
+
+	public function testPageFilesImportIntoTheMainNamespace(): void {
+		$presenter = $this->runImport( pageFiles: [ 'Museum collection.wikitext' => 'hubs' ] );
+
+		$this->assertSame( [ 'Museum collection' ], $presenter->created );
+	}
+
+	public function testModuleFilesImportIntoTheModuleNamespace(): void {
+		$presenter = $this->runImport( moduleFiles: [ 'SubjectRow.lua' => 'return {}' ] );
+
+		$this->assertSame( [ 'Module:SubjectRow' ], $presenter->created );
+	}
+
+	public function testMediaWikiFilesImportIntoTheMediaWikiNamespace(): void {
+		$presenter = $this->runImport( mediaWikiFiles: [ 'Sidebar.wikitext' => '* Demo tour' ] );
+
+		$this->assertSame( [ 'MediaWiki:Sidebar' ], $presenter->created );
+	}
+
+	/**
+	 * @param array<string, string> $pageFiles Source files (name => content) per source directory.
+	 * @param array<string, string> $moduleFiles
+	 * @param array<string, string> $mediaWikiFiles
+	 */
+	private function runImport(
+		array $pageFiles = [],
+		array $moduleFiles = [],
+		array $mediaWikiFiles = [],
+	): ImportPresenterSpy {
+		$presenter = new ImportPresenterSpy();
+
+		( new ImportPagesAction(
+			presenter: $presenter,
+			pageContentSaver: new PageContentSaverStub(
+				$this->createMock( WikiPageFactory::class ),
+				$this->createMock( Authority::class )
+			),
+			importedPageTitlesLookup: $this->createMock( ImportedPageTitlesLookup::class ),
+			pageDeleter: $this->createMock( PageDeleter::class ),
+			schemaContentSource: $this->createMock( SchemaContentSource::class ),
+			subjectPageSource: $this->createMock( SubjectPageSource::class ),
+			pageContentSource: $this->newPageContentSource( $pageFiles ),
+			moduleContentSource: $this->newPageContentSource( $moduleFiles ),
+			mediaWikiContentSource: $this->newPageContentSource( $mediaWikiFiles ),
+			layoutContentSource: $this->createMock( LayoutContentSource::class ),
+			mappingContentSource: $this->createMock( MappingContentSource::class ),
+		) )->import();
+
+		return $presenter;
+	}
+
+	/**
+	 * @param array<string, string> $files
+	 */
+	private function newPageContentSource( array $files ): PageContentSource {
+		$source = $this->createMock( PageContentSource::class );
+		$source->method( 'getPageContentStrings' )->willReturn( $files );
+
+		return $source;
+	}
+
+}

--- a/tests/phpunit/TestDoubles/PageContentSaverStub.php
+++ b/tests/phpunit/TestDoubles/PageContentSaverStub.php
@@ -1,0 +1,40 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\TestDoubles;
+
+use MediaWiki\CommentStore\CommentStoreComment;
+use MediaWiki\Page\PageIdentity;
+use MediaWiki\Page\WikiPageFactory;
+use MediaWiki\Permissions\Authority;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\PageContentSaver;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\PageContentSavingStatus;
+
+/**
+ * A saver that persists nothing and reports the outcome the test asked for, so the import action can
+ * be exercised without touching the database.
+ */
+class PageContentSaverStub extends PageContentSaver {
+
+	/**
+	 * @param string[] $failingKeys DB keys whose save is rejected.
+	 */
+	public function __construct(
+		WikiPageFactory $wikiPageFactory,
+		Authority $performer,
+		private readonly array $failingKeys = []
+	) {
+		parent::__construct( $wikiPageFactory, $performer );
+	}
+
+	public function saveContent( PageIdentity|PageId $page, array $contentBySlot, CommentStoreComment $comment ): PageContentSavingStatus {
+		if ( $page instanceof PageIdentity && in_array( $page->getDBkey(), $this->failingKeys, true ) ) {
+			return new PageContentSavingStatus( PageContentSavingStatus::ERROR, 'forced failure' );
+		}
+
+		return new PageContentSavingStatus( PageContentSavingStatus::REVISION_CREATED );
+	}
+
+}


### PR DESCRIPTION
The demo wiki ships MediaWiki's stock sidebar — Main page, Recent changes, Random page, MediaWiki help — so a visitor who lands on a subject page rather than the Main Page has no route to the datasets or the feature demos, and a quarter of the menu points off-site.

Add `MediaWiki:Sidebar` to the demo data: the four dataset hubs in the order the Main Page presents them, then the feature demos, then the two exits an evaluator wants. Labels match the Main Page's names for the same pages, so both surfaces teach one vocabulary. Features runs data → model → display → export → query → build, opening on the Rijksmuseum Data tab, which the Main Page was the only route to. Sidebar lines containing a pipe run through `MessageCache::transform`, so the `{{fullurl:}}` that reaches an action view resolves against whichever wiki serves the demo data.

The demo data had no route into the MediaWiki namespace, so `DemoData/MediaWiki/` joins `Module/` as a directory whose files import under a namespace prefix.

Considered, omitted: Recent changes and Random page — anonymous visitors cannot edit a sandbox that resets periodically, and the corpus holds enough thin reference subjects that random landings undersell it. Special:Layouts and Special:Mappings — both are one hop away via the Main Page and the Developers hub, where Special:Schemas alone is not. Validation Demo — its payoff is an editing flow anonymous visitors cannot run.

Note that Vector 2022 keeps the main menu behind the hamburger for anonymous visitors, so on neowiki.dev this menu is one click away until https://github.com/ProfessionalWiki/DockerWiki/pull/970 grows a matching line for `main-menu-pinned`.

> <sub>AI-authored — Claude Code, `Opus 5 (max)`; open-ended ask from @JeroenDeDauw ("optimize the main menu for the DemoData", then a pointer that the Data tab is a set piece), menu content designed by a `Fable 5 (max)` subagent and reviewed by a fresh-context text-review subagent, whose out-of-scope prose edits I reverted; diff not yet human-reviewed; full PHPUnit suite and `make cs` green locally, CI green, and every link checked against a worktree wiki — all 13 resolve, none red.</sub>