### PR TITLE
Correct ADR 004's claim that Subject JSON is only accessible via NeoWiki interfaces

### DIFF
--- a/docs/adr/004-use-dedicated-slot.md
+++ b/docs/adr/004-use-dedicated-slot.md
@@ -16,5 +16,7 @@ wikitext pages as usual and then add the JSON to a dedicated revision slot.
 ## Consequences
 
 * Improved usability compared to Wikibase by having the data on the same page as the wikitext.
-* The structured data JSON is only accessible via our own interfaces. This improves security and control but also means
-  that we need to create our own web APIs and interfaces.
+* The JSON is reachable through MediaWiki's generic revision surfaces — `action=raw`, `prop=revisions`,
+  `Special:Export` and diffs — each gated on the page's `read` permission. The slot is not an access-control boundary:
+  MediaWiki has no way to restrict read access to a single slot separately from the page.
+* Editing the JSON, and reading it as structured data, require our own web APIs and interfaces.


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/1166

ADR 004 listed as a consequence that the structured data JSON "is only accessible via our own
interfaces", and that this "improves security and control". MediaWiki's generic revision surfaces
reach the slot without touching a NeoWiki interface: `action=raw&slot=neo` serves the raw JSON as
`text/plain`, `prop=revisions&rvslots=neo` returns it, `Special:Export` emits it as an MCR
`<content>` element, and diffs render it.

Each of those is gated on the page's `read` permission, so the behaviour is safe. The rationale was
not: the slot is not an access-control boundary, and MediaWiki has no per-slot read primitive at all
— `SlotRoleHandler` never sees an `Authority`, revision audience checks are RevDel-only and
role-agnostic, and there is no config setting or hook for it.

The decision itself is unaffected, so the status line is unchanged.

Considered, omitted: the specific core classes and line numbers, which belong in the investigation
record rather than a decision record; a note that import and rollback can write non-main slots,
which concerns write paths rather than this bullet's claim.

> <sub>AI-authored — Claude Code, `Fable 5 (max)`; follow-up to the #350 investigation, approved by @JeroenDeDauw as a one-line go-ahead, no revisions; not yet human-reviewed; the corrected claims were checked against MediaWiki 1.43.6 source and reproduced on a 1.43.8 dev wiki, docs-only change with no tests referencing ADR files.</sub>
