### PR TITLE
Name a Statement's property type `propertyType` on every surface

### DIFF
--- a/DemoData/Module/NeoWikiDemo.lua
+++ b/DemoData/Module/NeoWikiDemo.lua
@@ -61,7 +61,7 @@ function p.subject( frame )
 			end
 		end
 		rows[#rows + 1] = '|-'
-		rows[#rows + 1] = '| ' .. name .. ' || ' .. stmt.type .. ' || ' .. table.concat( vals, ', ' )
+		rows[#rows + 1] = '| ' .. name .. ' || ' .. stmt.propertyType .. ' || ' .. table.concat( vals, ', ' )
 	end
 
 	rows[#rows + 1] = '|}'

--- a/DemoData/Subject/ACME_Amsterdam_HQ.json
+++ b/DemoData/Subject/ACME_Amsterdam_HQ.json
@@ -6,11 +6,11 @@
 			"schema": "Office",
 			"statements": {
 				"Description": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Global headquarters. Houses executive leadership, engineering, and the original Anvil product team." ]
 				},
 				"City": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "r1demo7aaaaaar7",
@@ -19,11 +19,11 @@
 					]
 				},
 				"Address": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Herengracht 1, 1015 BB Amsterdam" ]
 				},
 				"Opened": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 2005
 				}
 			}

--- a/DemoData/Subject/ACME_Engineering.json
+++ b/DemoData/Subject/ACME_Engineering.json
@@ -6,11 +6,11 @@
 			"schema": "Department",
 			"statements": {
 				"Description": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Builds and maintains ACME's product portfolio, from the original Anvil through TNT." ]
 				},
 				"Headcount": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 184
 				}
 			}

--- a/DemoData/Subject/ACME_Inc.json
+++ b/DemoData/Subject/ACME_Inc.json
@@ -6,29 +6,29 @@
 			"schema": "Company",
 			"statements": {
 				"Founded at": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 2005
 				},
 				"Websites": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [
 						"https://acme.example"
 					]
 				},
 				"Status": {
-					"type": "select",
+					"propertyType": "select",
 					"value": ["o1demo1aaaaaaa1"]
 				},
 				"World domination progress": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 42
 				},
 				"Is public": {
-					"type": "boolean",
+					"propertyType": "boolean",
 					"value": true
 				},
 				"Products": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "r1demo1aaaaaar1",
@@ -45,7 +45,7 @@
 					]
 				},
 				"Departments": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "r1demo7aaaaaar1",
@@ -62,7 +62,7 @@
 					]
 				},
 				"Offices": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "r1demo7aaaaaar4",
@@ -75,7 +75,7 @@
 					]
 				},
 				"Headquarters": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "r1demo7aaaaaar6",

--- a/DemoData/Subject/ACME_Operations.json
+++ b/DemoData/Subject/ACME_Operations.json
@@ -6,11 +6,11 @@
 			"schema": "Department",
 			"statements": {
 				"Description": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Runs the back-office functions: finance, people, IT, and facilities. Keeps the world-domination roadmap on schedule." ]
 				},
 				"Headcount": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 47
 				}
 			}

--- a/DemoData/Subject/ACME_Sales.json
+++ b/DemoData/Subject/ACME_Sales.json
@@ -6,11 +6,11 @@
 			"schema": "Department",
 			"statements": {
 				"Description": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Drives global revenue across the Anvil, Rocket, and TNT product lines, with field teams in Europe and North America." ]
 				},
 				"Headcount": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 96
 				}
 			}

--- a/DemoData/Subject/ACME_Vienna_Office.json
+++ b/DemoData/Subject/ACME_Vienna_Office.json
@@ -6,11 +6,11 @@
 			"schema": "Office",
 			"statements": {
 				"Description": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Central European sales and support hub. Opened to accompany the Rocket product launch." ]
 				},
 				"City": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "r1demo7aaaaaar8",
@@ -19,11 +19,11 @@
 					]
 				},
 				"Address": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Kärntner Ring 12, 1010 Vienna" ]
 				},
 				"Opened": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 2011
 				}
 			}

--- a/DemoData/Subject/A_Survey_of_Provenance_Models_in_Open_Knowledge_Graphs.json
+++ b/DemoData/Subject/A_Survey_of_Provenance_Models_in_Open_Knowledge_Graphs.json
@@ -6,19 +6,19 @@
 			"schema": "Publication",
 			"statements": {
 				"Title": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "A Survey of Provenance Models in Open Knowledge Graphs" ]
 				},
 				"Year": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 2020
 				},
 				"Venue": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "ISWC Proceedings" ]
 				},
 				"Authors": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "r1demo8aaaaaaD6",
@@ -27,7 +27,7 @@
 					]
 				},
 				"Project": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "r1demo8aaaaaaD7",
@@ -36,7 +36,7 @@
 					]
 				},
 				"URL": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://example.org/publications/provenance-survey" ]
 				}
 			}

--- a/DemoData/Subject/Acme_Anvil.json
+++ b/DemoData/Subject/Acme_Anvil.json
@@ -6,11 +6,11 @@
 			"schema": "Product",
 			"statements": {
 				"Available since": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 2006
 				},
 				"Website": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [
 						"https://acme.example/product/anvil"
 					]

--- a/DemoData/Subject/Acme_Rocket.json
+++ b/DemoData/Subject/Acme_Rocket.json
@@ -6,11 +6,11 @@
 			"schema": "Product",
 			"statements": {
 				"Available since": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 2010
 				},
 				"Website": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [
 						"https://acme.example/product/rocket"
 					]

--- a/DemoData/Subject/Acme_TNT.json
+++ b/DemoData/Subject/Acme_TNT.json
@@ -6,11 +6,11 @@
 			"schema": "Product",
 			"statements": {
 				"Available since": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 2015
 				},
 				"Website": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [
 						"https://acme.example/product/tnt"
 					]

--- a/DemoData/Subject/Aix-en-Provence.json
+++ b/DemoData/Subject/Aix-en-Provence.json
@@ -6,15 +6,15 @@
 			"schema": "City",
 			"statements": {
 				"Country": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "France" ]
 				},
 				"Population": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 149695
 				},
 				"Website": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://www.aixenprovence.fr" ]
 				}
 			}

--- a/DemoData/Subject/Alcalá_de_Henares.json
+++ b/DemoData/Subject/Alcalá_de_Henares.json
@@ -6,15 +6,15 @@
 			"schema": "City",
 			"statements": {
 				"Country": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Spain" ]
 				},
 				"Population": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 200702
 				},
 				"Website": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://www.ayto-alcaladehenares.es" ]
 				}
 			}

--- a/DemoData/Subject/Amsterdam.json
+++ b/DemoData/Subject/Amsterdam.json
@@ -6,15 +6,15 @@
 			"schema": "City",
 			"statements": {
 				"Country": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Netherlands" ]
 				},
 				"Population": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 921402
 				},
 				"Website": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://www.amsterdam.nl" ]
 				}
 			}

--- a/DemoData/Subject/Anna_Magdalena_Bach.json
+++ b/DemoData/Subject/Anna_Magdalena_Bach.json
@@ -5,8 +5,8 @@
 			"label": "Anna Magdalena Bach",
 			"schema": "Person",
 			"statements": {
-				"Description": { "type": "text", "value": [ "Second wife of Johann Sebastian Bach; mother of Johann Christian Bach." ] },
-				"Also known as": { "type": "text", "value": [ "Anna Magdalena Wilcke" ] }
+				"Description": { "propertyType": "text", "value": [ "Second wife of Johann Sebastian Bach; mother of Johann Christian Bach." ] },
+				"Also known as": { "propertyType": "text", "value": [ "Anna Magdalena Wilcke" ] }
 			}
 		}
 	}

--- a/DemoData/Subject/Antwerp.json
+++ b/DemoData/Subject/Antwerp.json
@@ -6,15 +6,15 @@
 			"schema": "City",
 			"statements": {
 				"Country": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Belgium" ]
 				},
 				"Population": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 565039
 				},
 				"Website": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://www.antwerpen.be" ]
 				}
 			}

--- a/DemoData/Subject/Aurélie_Cordier.json
+++ b/DemoData/Subject/Aurélie_Cordier.json
@@ -6,11 +6,11 @@
 			"schema": "Author",
 			"statements": {
 				"Description": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Digital humanities researcher focused on TEI encoding and bibliographic ontologies." ]
 				},
 				"Affiliation": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "r1demo8aaaaaaB3",
@@ -19,7 +19,7 @@
 					]
 				},
 				"ORCID": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://orcid.org/0000-0003-5555-6666" ]
 				}
 			}

--- a/DemoData/Subject/Bilbao.json
+++ b/DemoData/Subject/Bilbao.json
@@ -6,15 +6,15 @@
 			"schema": "City",
 			"statements": {
 				"Country": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Spain" ]
 				},
 				"Population": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 347342
 				},
 				"Website": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://www.bilbao.eus" ]
 				}
 			}

--- a/DemoData/Subject/Birth_of_Carl_Philipp_Emanuel_Bach.json
+++ b/DemoData/Subject/Birth_of_Carl_Philipp_Emanuel_Bach.json
@@ -5,11 +5,11 @@
 			"label": "Birth of Carl Philipp Emanuel Bach",
 			"schema": "Birth",
 			"statements": {
-				"Brought into life": { "type": "relation", "value": [ { "id": "r1bachaaaaaaab2", "target": "s1bachaaaaaaaa7" } ] },
-				"By mother": { "type": "relation", "value": [ { "id": "r1bachaaaaaaab3", "target": "s1bachaaaaaaaa4" } ] },
-				"From father": { "type": "relation", "value": [ { "id": "r1bachaaaaaaab4", "target": "s1bachaaaaaaaa3" } ] },
-				"Took place at": { "type": "relation", "value": [ { "id": "r1bachaaaaaaab5", "target": "s1bachaaaaaaac3" } ] },
-				"Date": { "type": "date", "value": [ "1714-03-08" ] }
+				"Brought into life": { "propertyType": "relation", "value": [ { "id": "r1bachaaaaaaab2", "target": "s1bachaaaaaaaa7" } ] },
+				"By mother": { "propertyType": "relation", "value": [ { "id": "r1bachaaaaaaab3", "target": "s1bachaaaaaaaa4" } ] },
+				"From father": { "propertyType": "relation", "value": [ { "id": "r1bachaaaaaaab4", "target": "s1bachaaaaaaaa3" } ] },
+				"Took place at": { "propertyType": "relation", "value": [ { "id": "r1bachaaaaaaab5", "target": "s1bachaaaaaaac3" } ] },
+				"Date": { "propertyType": "date", "value": [ "1714-03-08" ] }
 			}
 		}
 	}

--- a/DemoData/Subject/Birth_of_Johann_Ambrosius_Bach.json
+++ b/DemoData/Subject/Birth_of_Johann_Ambrosius_Bach.json
@@ -5,9 +5,9 @@
 			"label": "Birth of Johann Ambrosius Bach",
 			"schema": "Birth",
 			"statements": {
-				"Brought into life": { "type": "relation", "value": [ { "id": "r1bachaaaaaaaa1", "target": "s1bachaaaaaaaa1" } ] },
-				"Took place at": { "type": "relation", "value": [ { "id": "r1bachaaaaaaaa2", "target": "s1bachaaaaaaac1" } ] },
-				"Date": { "type": "date", "value": [ "1645-02-22" ] }
+				"Brought into life": { "propertyType": "relation", "value": [ { "id": "r1bachaaaaaaaa1", "target": "s1bachaaaaaaaa1" } ] },
+				"Took place at": { "propertyType": "relation", "value": [ { "id": "r1bachaaaaaaaa2", "target": "s1bachaaaaaaac1" } ] },
+				"Date": { "propertyType": "date", "value": [ "1645-02-22" ] }
 			}
 		}
 	}

--- a/DemoData/Subject/Birth_of_Johann_Christian_Bach.json
+++ b/DemoData/Subject/Birth_of_Johann_Christian_Bach.json
@@ -5,11 +5,11 @@
 			"label": "Birth of Johann Christian Bach",
 			"schema": "Birth",
 			"statements": {
-				"Brought into life": { "type": "relation", "value": [ { "id": "r1bachaaaaaaab6", "target": "s1bachaaaaaaaa8" } ] },
-				"By mother": { "type": "relation", "value": [ { "id": "r1bachaaaaaaab7", "target": "s1bachaaaaaaaa5" } ] },
-				"From father": { "type": "relation", "value": [ { "id": "r1bachaaaaaaab8", "target": "s1bachaaaaaaaa3" } ] },
-				"Took place at": { "type": "relation", "value": [ { "id": "r1bachaaaaaaab9", "target": "s1bachaaaaaaac4" } ] },
-				"Date": { "type": "date", "value": [ "1735-09-05" ] }
+				"Brought into life": { "propertyType": "relation", "value": [ { "id": "r1bachaaaaaaab6", "target": "s1bachaaaaaaaa8" } ] },
+				"By mother": { "propertyType": "relation", "value": [ { "id": "r1bachaaaaaaab7", "target": "s1bachaaaaaaaa5" } ] },
+				"From father": { "propertyType": "relation", "value": [ { "id": "r1bachaaaaaaab8", "target": "s1bachaaaaaaaa3" } ] },
+				"Took place at": { "propertyType": "relation", "value": [ { "id": "r1bachaaaaaaab9", "target": "s1bachaaaaaaac4" } ] },
+				"Date": { "propertyType": "date", "value": [ "1735-09-05" ] }
 			}
 		}
 	}

--- a/DemoData/Subject/Birth_of_Johann_Sebastian_Bach.json
+++ b/DemoData/Subject/Birth_of_Johann_Sebastian_Bach.json
@@ -5,11 +5,11 @@
 			"label": "Birth of Johann Sebastian Bach",
 			"schema": "Birth",
 			"statements": {
-				"Brought into life": { "type": "relation", "value": [ { "id": "r1bachaaaaaaaa3", "target": "s1bachaaaaaaaa3" } ] },
-				"By mother": { "type": "relation", "value": [ { "id": "r1bachaaaaaaaa4", "target": "s1bachaaaaaaaa2" } ] },
-				"From father": { "type": "relation", "value": [ { "id": "r1bachaaaaaaaa5", "target": "s1bachaaaaaaaa1" } ] },
-				"Took place at": { "type": "relation", "value": [ { "id": "r1bachaaaaaaaa6", "target": "s1bachaaaaaaac2" } ] },
-				"Date": { "type": "date", "value": [ "1685-03-21" ] }
+				"Brought into life": { "propertyType": "relation", "value": [ { "id": "r1bachaaaaaaaa3", "target": "s1bachaaaaaaaa3" } ] },
+				"By mother": { "propertyType": "relation", "value": [ { "id": "r1bachaaaaaaaa4", "target": "s1bachaaaaaaaa2" } ] },
+				"From father": { "propertyType": "relation", "value": [ { "id": "r1bachaaaaaaaa5", "target": "s1bachaaaaaaaa1" } ] },
+				"Took place at": { "propertyType": "relation", "value": [ { "id": "r1bachaaaaaaaa6", "target": "s1bachaaaaaaac2" } ] },
+				"Date": { "propertyType": "date", "value": [ "1685-03-21" ] }
 			}
 		}
 	}

--- a/DemoData/Subject/Birth_of_Wilhelm_Friedemann_Bach.json
+++ b/DemoData/Subject/Birth_of_Wilhelm_Friedemann_Bach.json
@@ -5,11 +5,11 @@
 			"label": "Birth of Wilhelm Friedemann Bach",
 			"schema": "Birth",
 			"statements": {
-				"Brought into life": { "type": "relation", "value": [ { "id": "r1bachaaaaaaaa7", "target": "s1bachaaaaaaaa6" } ] },
-				"By mother": { "type": "relation", "value": [ { "id": "r1bachaaaaaaaa8", "target": "s1bachaaaaaaaa4" } ] },
-				"From father": { "type": "relation", "value": [ { "id": "r1bachaaaaaaaa9", "target": "s1bachaaaaaaaa3" } ] },
-				"Took place at": { "type": "relation", "value": [ { "id": "r1bachaaaaaaab1", "target": "s1bachaaaaaaac3" } ] },
-				"Date": { "type": "date", "value": [ "1710-11-22" ] }
+				"Brought into life": { "propertyType": "relation", "value": [ { "id": "r1bachaaaaaaaa7", "target": "s1bachaaaaaaaa6" } ] },
+				"By mother": { "propertyType": "relation", "value": [ { "id": "r1bachaaaaaaaa8", "target": "s1bachaaaaaaaa4" } ] },
+				"From father": { "propertyType": "relation", "value": [ { "id": "r1bachaaaaaaaa9", "target": "s1bachaaaaaaaa3" } ] },
+				"Took place at": { "propertyType": "relation", "value": [ { "id": "r1bachaaaaaaab1", "target": "s1bachaaaaaaac3" } ] },
+				"Date": { "propertyType": "date", "value": [ "1710-11-22" ] }
 			}
 		}
 	}

--- a/DemoData/Subject/CSIC_Madrid.json
+++ b/DemoData/Subject/CSIC_Madrid.json
@@ -6,11 +6,11 @@
 			"schema": "Institution",
 			"statements": {
 				"Description": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Spanish National Research Council, the largest public research institution in Spain." ]
 				},
 				"City": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "r1demo8aaaaaaA4",
@@ -19,11 +19,11 @@
 					]
 				},
 				"Founded": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 1939
 				},
 				"Website": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://www.csic.es" ]
 				}
 			}

--- a/DemoData/Subject/Carl_Philipp_Emanuel_Bach.json
+++ b/DemoData/Subject/Carl_Philipp_Emanuel_Bach.json
@@ -5,8 +5,8 @@
 			"label": "Carl Philipp Emanuel Bach",
 			"schema": "Person",
 			"statements": {
-				"Description": { "type": "text", "value": [ "Composer; second surviving son of Johann Sebastian Bach." ] },
-				"Also known as": { "type": "text", "value": [ "C. P. E. Bach", "the Berlin Bach", "the Hamburg Bach" ] }
+				"Description": { "propertyType": "text", "value": [ "Composer; second surviving son of Johann Sebastian Bach." ] },
+				"Also known as": { "propertyType": "text", "value": [ "C. P. E. Bach", "the Berlin Bach", "the Hamburg Bach" ] }
 			}
 		}
 	}

--- a/DemoData/Subject/Claude_Monet.json
+++ b/DemoData/Subject/Claude_Monet.json
@@ -6,27 +6,27 @@
 			"schema": "Artist",
 			"statements": {
 				"Born": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 1840
 				},
 				"Died": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 1926
 				},
 				"Nationality": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "French" ]
 				},
 				"Movement": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Impressionism" ]
 				},
 				"Wikipedia": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://en.wikipedia.org/wiki/Claude_Monet" ]
 				},
 				"Active period": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "1858–1926" ]
 				}
 			}

--- a/DemoData/Subject/Cross-Lingual_Author_Disambiguation_at_Scale.json
+++ b/DemoData/Subject/Cross-Lingual_Author_Disambiguation_at_Scale.json
@@ -6,19 +6,19 @@
 			"schema": "Publication",
 			"statements": {
 				"Title": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Cross-Lingual Author Disambiguation at Scale" ]
 				},
 				"Year": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 2023
 				},
 				"Venue": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "ECIR Proceedings" ]
 				},
 				"Authors": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "r1demo8aaaaaaE9",
@@ -31,7 +31,7 @@
 					]
 				},
 				"Project": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "r1demo8aaaaaaF1",
@@ -40,7 +40,7 @@
 					]
 				},
 				"URL": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://example.org/publications/cross-lingual-disambiguation" ]
 				}
 			}

--- a/DemoData/Subject/Diego_Velázquez.json
+++ b/DemoData/Subject/Diego_Velázquez.json
@@ -6,27 +6,27 @@
 			"schema": "Artist",
 			"statements": {
 				"Born": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 1599
 				},
 				"Died": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 1660
 				},
 				"Nationality": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Spanish" ]
 				},
 				"Movement": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Baroque" ]
 				},
 				"Wikipedia": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://en.wikipedia.org/wiki/Diego_Vel%C3%A1zquez" ]
 				},
 				"Active period": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "1617–1660" ]
 				}
 			}

--- a/DemoData/Subject/Dutch_Golden_Age_Highlights.json
+++ b/DemoData/Subject/Dutch_Golden_Age_Highlights.json
@@ -6,15 +6,15 @@
 			"schema": "Exhibition",
 			"statements": {
 				"Start year": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 2023
 				},
 				"End year": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 2024
 				},
 				"Venue": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "rEpfwJLoXU13f3X",
@@ -23,7 +23,7 @@
 					]
 				},
 				"Featured artists": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "rEpfwJLoYRSxeGY",
@@ -32,15 +32,15 @@
 					]
 				},
 				"Website": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://www.rijksmuseum.nl/en/whats-on/exhibitions" ]
 				},
 				"Theme": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Masterworks from the Dutch Republic's golden century of art and trade" ]
 				},
 				"Visitor count": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 380000
 				}
 			}

--- a/DemoData/Subject/Eisenach.json
+++ b/DemoData/Subject/Eisenach.json
@@ -5,9 +5,9 @@
 			"label": "Eisenach",
 			"schema": "Place",
 			"statements": {
-				"Country": { "type": "text", "value": [ "Germany" ] },
-				"Coordinates": { "type": "text", "value": [ "50.9747, 10.3247" ] },
-				"Description": { "type": "text", "value": [ "Town in Thuringia, Germany; birthplace of Johann Sebastian Bach." ] }
+				"Country": { "propertyType": "text", "value": [ "Germany" ] },
+				"Coordinates": { "propertyType": "text", "value": [ "50.9747, 10.3247" ] },
+				"Description": { "propertyType": "text", "value": [ "Town in Thuringia, Germany; birthplace of Johann Sebastian Bach." ] }
 			}
 		}
 	}

--- a/DemoData/Subject/Erfurt.json
+++ b/DemoData/Subject/Erfurt.json
@@ -5,9 +5,9 @@
 			"label": "Erfurt",
 			"schema": "Place",
 			"statements": {
-				"Country": { "type": "text", "value": [ "Germany" ] },
-				"Coordinates": { "type": "text", "value": [ "50.9787, 11.0328" ] },
-				"Description": { "type": "text", "value": [ "City in Thuringia, Germany; birthplace of Johann Ambrosius Bach." ] }
+				"Country": { "propertyType": "text", "value": [ "Germany" ] },
+				"Coordinates": { "propertyType": "text", "value": [ "50.9787, 11.0328" ] },
+				"Description": { "propertyType": "text", "value": [ "City in Thuringia, Germany; birthplace of Johann Ambrosius Bach." ] }
 			}
 		}
 	}

--- a/DemoData/Subject/European_Literary_Bibliography.json
+++ b/DemoData/Subject/European_Literary_Bibliography.json
@@ -6,15 +6,15 @@
 			"schema": "Project",
 			"statements": {
 				"Description": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "An effort to harmonise MARC21 bibliographic records across European literary archives into linked open data." ]
 				},
 				"Started": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 2021
 				},
 				"Lead institution": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "r1demo8aaaaaaC1",

--- a/DemoData/Subject/Eva_Lindqvist.json
+++ b/DemoData/Subject/Eva_Lindqvist.json
@@ -6,11 +6,11 @@
 			"schema": "Author",
 			"statements": {
 				"Description": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Computational philologist working on multilingual literary corpora." ]
 				},
 				"Affiliation": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "r1demo8aaaaaaB1",
@@ -19,7 +19,7 @@
 					]
 				},
 				"ORCID": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://orcid.org/0000-0002-1111-2222" ]
 				}
 			}

--- a/DemoData/Subject/Federated_Cypher_Queries_Across_Wiki_Instances.json
+++ b/DemoData/Subject/Federated_Cypher_Queries_Across_Wiki_Instances.json
@@ -6,19 +6,19 @@
 			"schema": "Publication",
 			"statements": {
 				"Title": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Federated Cypher Queries Across Wiki Instances" ]
 				},
 				"Year": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 2025
 				},
 				"Venue": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Knowledge-Based Systems" ]
 				},
 				"Authors": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "r1demo8aaaaaaE7",
@@ -31,7 +31,7 @@
 					]
 				},
 				"URL": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://example.org/publications/federated-cypher" ]
 				}
 			}

--- a/DemoData/Subject/Gustav_Klimt.json
+++ b/DemoData/Subject/Gustav_Klimt.json
@@ -6,27 +6,27 @@
 			"schema": "Artist",
 			"statements": {
 				"Born": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 1862
 				},
 				"Died": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 1918
 				},
 				"Nationality": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Austrian" ]
 				},
 				"Movement": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Symbolism", "Art Nouveau", "Vienna Secession" ]
 				},
 				"Wikipedia": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://en.wikipedia.org/wiki/Gustav_Klimt" ]
 				},
 				"Active period": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "1880–1918" ]
 				}
 			}

--- a/DemoData/Subject/Hannah_Voss.json
+++ b/DemoData/Subject/Hannah_Voss.json
@@ -6,11 +6,11 @@
 			"schema": "Author",
 			"statements": {
 				"Description": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Knowledge graph researcher with a focus on provenance and FAIR data principles." ]
 				},
 				"Affiliation": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "r1demo8aaaaaaB5",
@@ -19,7 +19,7 @@
 					]
 				},
 				"ORCID": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://orcid.org/0000-0001-9999-0000" ]
 				}
 			}

--- a/DemoData/Subject/Heritage_Linked_Data.json
+++ b/DemoData/Subject/Heritage_Linked_Data.json
@@ -6,15 +6,15 @@
 			"schema": "Project",
 			"statements": {
 				"Description": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "A research programme connecting European cultural heritage datasets through CIDOC CRM mappings." ]
 				},
 				"Started": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 2019
 				},
 				"Lead institution": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "r1demo8aaaaaaC2",

--- a/DemoData/Subject/Impressionist_Masters.json
+++ b/DemoData/Subject/Impressionist_Masters.json
@@ -6,15 +6,15 @@
 			"schema": "Exhibition",
 			"statements": {
 				"Start year": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 2024
 				},
 				"End year": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 2025
 				},
 				"Venue": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "rEpfwJLoUY71QX2",
@@ -23,7 +23,7 @@
 					]
 				},
 				"Featured artists": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "rEpfwJLoVW2qior",
@@ -36,11 +36,11 @@
 					]
 				},
 				"Theme": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "The evolution of light and color in French Impressionism" ]
 				},
 				"Visitor count": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 450000
 				}
 			}

--- a/DemoData/Subject/Iván_Salvador.json
+++ b/DemoData/Subject/Iván_Salvador.json
@@ -6,11 +6,11 @@
 			"schema": "Author",
 			"statements": {
 				"Description": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Information scientist working on entity reconciliation across cultural heritage datasets." ]
 				},
 				"Affiliation": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "r1demo8aaaaaaB4",
@@ -19,7 +19,7 @@
 					]
 				},
 				"ORCID": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://orcid.org/0000-0002-7777-8888" ]
 				}
 			}

--- a/DemoData/Subject/Johann_Ambrosius_Bach.json
+++ b/DemoData/Subject/Johann_Ambrosius_Bach.json
@@ -5,7 +5,7 @@
 			"label": "Johann Ambrosius Bach",
 			"schema": "Person",
 			"statements": {
-				"Description": { "type": "text", "value": [ "German musician; director of the town musicians in Eisenach and father of Johann Sebastian Bach." ] }
+				"Description": { "propertyType": "text", "value": [ "German musician; director of the town musicians in Eisenach and father of Johann Sebastian Bach." ] }
 			}
 		}
 	}

--- a/DemoData/Subject/Johann_Christian_Bach.json
+++ b/DemoData/Subject/Johann_Christian_Bach.json
@@ -5,8 +5,8 @@
 			"label": "Johann Christian Bach",
 			"schema": "Person",
 			"statements": {
-				"Description": { "type": "text", "value": [ "Composer; youngest son of Johann Sebastian Bach, active in London." ] },
-				"Also known as": { "type": "text", "value": [ "J. C. Bach", "the London Bach" ] }
+				"Description": { "propertyType": "text", "value": [ "Composer; youngest son of Johann Sebastian Bach, active in London." ] },
+				"Also known as": { "propertyType": "text", "value": [ "J. C. Bach", "the London Bach" ] }
 			}
 		}
 	}

--- a/DemoData/Subject/Johann_Sebastian_Bach.json
+++ b/DemoData/Subject/Johann_Sebastian_Bach.json
@@ -5,8 +5,8 @@
 			"label": "Johann Sebastian Bach",
 			"schema": "Person",
 			"statements": {
-				"Description": { "type": "text", "value": [ "German composer and organist of the Baroque period." ] },
-				"Also known as": { "type": "text", "value": [ "J. S. Bach" ] }
+				"Description": { "propertyType": "text", "value": [ "German composer and organist of the Baroque period." ] },
+				"Also known as": { "propertyType": "text", "value": [ "J. S. Bach" ] }
 			}
 		}
 	}

--- a/DemoData/Subject/Johannes_Vermeer.json
+++ b/DemoData/Subject/Johannes_Vermeer.json
@@ -6,27 +6,27 @@
 			"schema": "Artist",
 			"statements": {
 				"Born": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 1632
 				},
 				"Died": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 1675
 				},
 				"Nationality": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Dutch" ]
 				},
 				"Movement": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Dutch Golden Age", "Baroque" ]
 				},
 				"Wikipedia": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://en.wikipedia.org/wiki/Johannes_Vermeer" ]
 				},
 				"Active period": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "1653–1675" ]
 				}
 			}

--- a/DemoData/Subject/KNAW_Amsterdam.json
+++ b/DemoData/Subject/KNAW_Amsterdam.json
@@ -6,11 +6,11 @@
 			"schema": "Institution",
 			"statements": {
 				"Description": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Royal Netherlands Academy of Arts and Sciences, hosting humanities and social science research institutes." ]
 				},
 				"City": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "r1demo8aaaaaaA2",
@@ -19,11 +19,11 @@
 					]
 				},
 				"Founded": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 1808
 				},
 				"Website": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://www.knaw.nl" ]
 				}
 			}

--- a/DemoData/Subject/Kunsthistorisches_Museum.json
+++ b/DemoData/Subject/Kunsthistorisches_Museum.json
@@ -6,15 +6,15 @@
 			"schema": "Museum",
 			"statements": {
 				"Description": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Austrian art museum housing the extensive collections of the Habsburg monarchy" ]
 				},
 				"Founded": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 1891
 				},
 				"City": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "rEpfwJLoF7AQMbe",
@@ -23,19 +23,19 @@
 					]
 				},
 				"Website": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://www.khm.at" ]
 				},
 				"Specialization": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Old Masters", "Egyptian Antiquities", "Habsburg Collections" ]
 				},
 				"Annual visitors": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 1800000
 				},
 				"Admission fee": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 21
 				}
 			}

--- a/DemoData/Subject/Las_Meninas.json
+++ b/DemoData/Subject/Las_Meninas.json
@@ -6,15 +6,15 @@
 			"schema": "Artwork",
 			"statements": {
 				"Year": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 1656
 				},
 				"Medium": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Oil on canvas" ]
 				},
 				"Creator": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "rEpfwJLoNnEbFfz",
@@ -23,7 +23,7 @@
 					]
 				},
 				"Located at": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "rEpfwJLoPk5pFTM",
@@ -32,11 +32,11 @@
 					]
 				},
 				"Image": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://upload.wikimedia.org/wikipedia/commons/3/31/Las_Meninas%2C_by_Diego_Vel%C3%A1zquez%2C_from_Prado_in_Google_Earth.jpg" ]
 				},
 				"Estimated value": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 300
 				}
 			}

--- a/DemoData/Subject/Leipzig.json
+++ b/DemoData/Subject/Leipzig.json
@@ -5,9 +5,9 @@
 			"label": "Leipzig",
 			"schema": "Place",
 			"statements": {
-				"Country": { "type": "text", "value": [ "Germany" ] },
-				"Coordinates": { "type": "text", "value": [ "51.3397, 12.3731" ] },
-				"Description": { "type": "text", "value": [ "City in Saxony, Germany, where Johann Sebastian Bach was Thomaskantor." ] }
+				"Country": { "propertyType": "text", "value": [ "Germany" ] },
+				"Coordinates": { "propertyType": "text", "value": [ "51.3397, 12.3731" ] },
+				"Description": { "propertyType": "text", "value": [ "City in Saxony, Germany, where Johann Sebastian Bach was Thomaskantor." ] }
 			}
 		}
 	}

--- a/DemoData/Subject/Lessons_from_a_Year_of_MARC_to_RDF_Migration.json
+++ b/DemoData/Subject/Lessons_from_a_Year_of_MARC_to_RDF_Migration.json
@@ -6,19 +6,19 @@
 			"schema": "Publication",
 			"statements": {
 				"Title": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Lessons from a Year of MARC to RDF Migration" ]
 				},
 				"Year": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 2024
 				},
 				"Venue": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "D-Lib Magazine" ]
 				},
 				"Authors": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "r1demo8aaaaaaE1",
@@ -27,7 +27,7 @@
 					]
 				},
 				"Project": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "r1demo8aaaaaaE2",
@@ -36,7 +36,7 @@
 					]
 				},
 				"URL": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://example.org/publications/lessons-marc-to-rdf" ]
 				}
 			}

--- a/DemoData/Subject/Linked_Bibliography_Mappings_for_European_Archives.json
+++ b/DemoData/Subject/Linked_Bibliography_Mappings_for_European_Archives.json
@@ -6,19 +6,19 @@
 			"schema": "Publication",
 			"statements": {
 				"Title": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Linked Bibliography Mappings for European Archives" ]
 				},
 				"Year": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 2021
 				},
 				"Venue": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Journal of Digital Humanities" ]
 				},
 				"Authors": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "r1demo8aaaaaaD1",
@@ -27,7 +27,7 @@
 					]
 				},
 				"Project": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "r1demo8aaaaaaD2",
@@ -36,7 +36,7 @@
 					]
 				},
 				"URL": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://example.org/publications/linked-bibliography-mappings" ]
 				}
 			}

--- a/DemoData/Subject/Madrid.json
+++ b/DemoData/Subject/Madrid.json
@@ -6,15 +6,15 @@
 			"schema": "City",
 			"statements": {
 				"Country": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Spain" ]
 				},
 				"Population": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 3332035
 				},
 				"Website": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://www.madrid.es" ]
 				}
 			}

--- a/DemoData/Subject/Marcus_Rendl.json
+++ b/DemoData/Subject/Marcus_Rendl.json
@@ -6,11 +6,11 @@
 			"schema": "Author",
 			"statements": {
 				"Description": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Historian specialising in linked open data for cultural heritage collections." ]
 				},
 				"Affiliation": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "r1demo8aaaaaaB2",
@@ -19,7 +19,7 @@
 					]
 				},
 				"ORCID": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://orcid.org/0000-0001-3333-4444" ]
 				}
 			}

--- a/DemoData/Subject/Maria_Barbara_Bach.json
+++ b/DemoData/Subject/Maria_Barbara_Bach.json
@@ -5,7 +5,7 @@
 			"label": "Maria Barbara Bach",
 			"schema": "Person",
 			"statements": {
-				"Description": { "type": "text", "value": [ "First wife of Johann Sebastian Bach; mother of Wilhelm Friedemann and Carl Philipp Emanuel Bach." ] }
+				"Description": { "propertyType": "text", "value": [ "First wife of Johann Sebastian Bach; mother of Wilhelm Friedemann and Carl Philipp Emanuel Bach." ] }
 			}
 		}
 	}

--- a/DemoData/Subject/Maria_Elisabeth_Lämmerhirt.json
+++ b/DemoData/Subject/Maria_Elisabeth_Lämmerhirt.json
@@ -5,7 +5,7 @@
 			"label": "Maria Elisabeth Lämmerhirt",
 			"schema": "Person",
 			"statements": {
-				"Description": { "type": "text", "value": [ "Mother of Johann Sebastian Bach and wife of Johann Ambrosius Bach." ] }
+				"Description": { "propertyType": "text", "value": [ "Mother of Johann Sebastian Bach and wife of Johann Ambrosius Bach." ] }
 			}
 		}
 	}

--- a/DemoData/Subject/Multilingual_NER_Toolkit.json
+++ b/DemoData/Subject/Multilingual_NER_Toolkit.json
@@ -6,15 +6,15 @@
 			"schema": "Project",
 			"statements": {
 				"Description": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Open-source named-entity recognition tooling tuned for historical European languages." ]
 				},
 				"Started": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 2022
 				},
 				"Lead institution": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "r1demo8aaaaaaC3",

--- a/DemoData/Subject/Multilingual_Named_Entity_Recognition_for_Historical_Texts.json
+++ b/DemoData/Subject/Multilingual_Named_Entity_Recognition_for_Historical_Texts.json
@@ -6,19 +6,19 @@
 			"schema": "Publication",
 			"statements": {
 				"Title": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Multilingual Named Entity Recognition for Historical Texts" ]
 				},
 				"Year": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 2023
 				},
 				"Venue": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "ACL Findings" ]
 				},
 				"Authors": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "r1demo8aaaaaaD8",
@@ -31,7 +31,7 @@
 					]
 				},
 				"Project": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "r1demo8aaaaaaDA",
@@ -40,7 +40,7 @@
 					]
 				},
 				"URL": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://example.org/publications/multilingual-ner" ]
 				}
 			}

--- a/DemoData/Subject/Museo_del_Prado.json
+++ b/DemoData/Subject/Museo_del_Prado.json
@@ -6,15 +6,15 @@
 			"schema": "Museum",
 			"statements": {
 				"Description": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Spain's main national art museum, featuring one of the finest collections of European art from the 12th to early 20th century" ]
 				},
 				"Founded": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 1819
 				},
 				"City": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "rEpfwJLoG5ZtGDZ",
@@ -23,23 +23,23 @@
 					]
 				},
 				"Website": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://www.museodelprado.es" ]
 				},
 				"Specialization": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Spanish Art", "Italian Renaissance", "Flemish Painting" ]
 				},
 				"Annual visitors": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 3200000
 				},
 				"Admission fee": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 15
 				},
 				"Links": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [
 						"https://www.instagram.com/museoprado"
 					]

--- a/DemoData/Subject/Musée_d'Orsay.json
+++ b/DemoData/Subject/Musée_d'Orsay.json
@@ -6,15 +6,15 @@
 			"schema": "Museum",
 			"statements": {
 				"Description": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "French national museum housing the world's largest collection of Impressionist and Post-Impressionist masterpieces" ]
 				},
 				"Founded": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 1986
 				},
 				"City": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "rEpfwJLoDErEFnn",
@@ -23,23 +23,23 @@
 					]
 				},
 				"Website": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://www.musee-orsay.fr" ]
 				},
 				"Specialization": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Impressionism", "Post-Impressionism", "Art Nouveau" ]
 				},
 				"Annual visitors": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 3270000
 				},
 				"Admission fee": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 16
 				},
 				"Links": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [
 						"https://www.instagram.com/museeorsay",
 						"https://twitter.com/MuseeOrsay"
@@ -52,15 +52,15 @@
 			"schema": "Attendance",
 			"statements": {
 				"Year": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 2019
 				},
 				"Visitors": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 3651616
 				},
 				"Source": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://www.musee-orsay.fr/en/articles/key-figures" ]
 				}
 			}
@@ -70,15 +70,15 @@
 			"schema": "Attendance",
 			"statements": {
 				"Year": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 2022
 				},
 				"Visitors": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 3270000
 				},
 				"Source": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://www.musee-orsay.fr/en/articles/key-figures" ]
 				}
 			}
@@ -88,15 +88,15 @@
 			"schema": "Attendance",
 			"statements": {
 				"Year": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 2023
 				},
 				"Visitors": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 3960000
 				},
 				"Source": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://www.musee-orsay.fr/en/articles/key-figures" ]
 				}
 			}

--- a/DemoData/Subject/Málaga.json
+++ b/DemoData/Subject/Málaga.json
@@ -5,9 +5,9 @@
 			"label": "Málaga",
 			"schema": "City",
 			"statements": {
-				"Country": { "type": "text", "value": [ "Spain" ] },
-				"Population": { "type": "number", "value": 578460 },
-				"Website": { "type": "url", "value": [ "https://www.malaga.eu" ] }
+				"Country": { "propertyType": "text", "value": [ "Spain" ] },
+				"Population": { "propertyType": "number", "value": 578460 },
+				"Website": { "propertyType": "url", "value": [ "https://www.malaga.eu" ] }
 			}
 		}
 	}

--- a/DemoData/Subject/OEAW_Vienna.json
+++ b/DemoData/Subject/OEAW_Vienna.json
@@ -6,11 +6,11 @@
 			"schema": "Institution",
 			"statements": {
 				"Description": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Austrian Academy of Sciences, the largest non-university research institution in Austria." ]
 				},
 				"City": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "r1demo8aaaaaaA1",
@@ -19,11 +19,11 @@
 					]
 				},
 				"Founded": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 1847
 				},
 				"Website": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://www.oeaw.ac.at" ]
 				}
 			}

--- a/DemoData/Subject/Pablo_Picasso.json
+++ b/DemoData/Subject/Pablo_Picasso.json
@@ -5,11 +5,11 @@
 			"label": "Pablo Picasso",
 			"schema": "Person",
 			"statements": {
-				"Description": { "type": "text", "value": [ "Spanish painter, sculptor, and printmaker who co-founded the Cubist movement and is regarded as one of the most influential artists of the 20th century." ] },
-				"Gender": { "type": "text", "value": [ "Male" ] },
-				"Birth date": { "type": "date", "value": [ "1881-10-25" ] },
-				"Birth place": { "type": "relation", "value": [ { "id": "r2picasso2city2", "target": "s2birthcity2aa2" } ] },
-				"Source": { "type": "text", "value": [ "A Life of Picasso I: The Prodigy: 1881-1906 by John Richardson (ISBN 978-0375711497)" ] }
+				"Description": { "propertyType": "text", "value": [ "Spanish painter, sculptor, and printmaker who co-founded the Cubist movement and is regarded as one of the most influential artists of the 20th century." ] },
+				"Gender": { "propertyType": "text", "value": [ "Male" ] },
+				"Birth date": { "propertyType": "date", "value": [ "1881-10-25" ] },
+				"Birth place": { "propertyType": "relation", "value": [ { "id": "r2picasso2city2", "target": "s2birthcity2aa2" } ] },
+				"Source": { "propertyType": "text", "value": [ "A Life of Picasso I: The Prodigy: 1881-1906 by John Richardson (ISBN 978-0375711497)" ] }
 			}
 		}
 	}

--- a/DemoData/Subject/Paris.json
+++ b/DemoData/Subject/Paris.json
@@ -6,15 +6,15 @@
 			"schema": "City",
 			"statements": {
 				"Country": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "France" ]
 				},
 				"Population": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 2102650
 				},
 				"Website": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://www.paris.fr" ]
 				}
 			}

--- a/DemoData/Subject/Reconciling_Author_Identifiers_Across_Cultural_Heritage_Datasets.json
+++ b/DemoData/Subject/Reconciling_Author_Identifiers_Across_Cultural_Heritage_Datasets.json
@@ -6,19 +6,19 @@
 			"schema": "Publication",
 			"statements": {
 				"Title": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Reconciling Author Identifiers Across Cultural Heritage Datasets" ]
 				},
 				"Year": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 2022
 				},
 				"Venue": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Semantic Web Journal" ]
 				},
 				"Authors": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "r1demo8aaaaaaD3",
@@ -31,7 +31,7 @@
 					]
 				},
 				"Project": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "r1demo8aaaaaaD5",
@@ -40,7 +40,7 @@
 					]
 				},
 				"URL": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://example.org/publications/reconciling-author-identifiers" ]
 				}
 			}

--- a/DemoData/Subject/Rijksmuseum.json
+++ b/DemoData/Subject/Rijksmuseum.json
@@ -6,15 +6,15 @@
 			"schema": "Museum",
 			"statements": {
 				"Description": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Dutch national museum dedicated to arts and history, home to masterpieces of the Dutch Golden Age" ]
 				},
 				"Founded": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 1800
 				},
 				"City": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "rEpfwJLoEB5UuQS",
@@ -23,23 +23,23 @@
 					]
 				},
 				"Website": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://www.rijksmuseum.nl" ]
 				},
 				"Specialization": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Dutch Golden Age", "Dutch History", "Asian Art" ]
 				},
 				"Annual visitors": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 2700000
 				},
 				"Admission fee": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 22.50
 				},
 				"Links": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [
 						"https://www.instagram.com/rijksmuseum",
 						"https://twitter.com/rijksmuseum"
@@ -51,45 +51,45 @@
 			"label": "Rijksmuseum 2024",
 			"schema": "Attendance",
 			"statements": {
-				"Year": { "type": "number", "value": 2024 },
-				"Visitors": { "type": "number", "value": 2500000 },
-				"Source": { "type": "url", "value": [ "https://www.rijksmuseum.nl/en/press/press-releases/the-rijksmuseum-in-2024" ] }
+				"Year": { "propertyType": "number", "value": 2024 },
+				"Visitors": { "propertyType": "number", "value": 2500000 },
+				"Source": { "propertyType": "url", "value": [ "https://www.rijksmuseum.nl/en/press/press-releases/the-rijksmuseum-in-2024" ] }
 			}
 		},
 		"sEpfwJLAtndBbbB": {
 			"label": "Rijksmuseum 2023",
 			"schema": "Attendance",
 			"statements": {
-				"Year": { "type": "number", "value": 2023 },
-				"Visitors": { "type": "number", "value": 2700000 },
-				"Source": { "type": "url", "value": [ "https://www.rijksmuseum.nl/en/press/press-releases/rijksmuseum-rounds-off-historic-year" ] }
+				"Year": { "propertyType": "number", "value": 2023 },
+				"Visitors": { "propertyType": "number", "value": 2700000 },
+				"Source": { "propertyType": "url", "value": [ "https://www.rijksmuseum.nl/en/press/press-releases/rijksmuseum-rounds-off-historic-year" ] }
 			}
 		},
 		"sEpfwJLAtndCccC": {
 			"label": "Rijksmuseum 2022",
 			"schema": "Attendance",
 			"statements": {
-				"Year": { "type": "number", "value": 2022 },
-				"Visitors": { "type": "number", "value": 1760000 },
-				"Source": { "type": "url", "value": [ "https://www.rijksmuseum.nl/nl/pers/persberichten/het-rijksmuseum-in-2022" ] }
+				"Year": { "propertyType": "number", "value": 2022 },
+				"Visitors": { "propertyType": "number", "value": 1760000 },
+				"Source": { "propertyType": "url", "value": [ "https://www.rijksmuseum.nl/nl/pers/persberichten/het-rijksmuseum-in-2022" ] }
 			}
 		},
 		"sEpfwJLAtndDddD": {
 			"label": "Rijksmuseum 2021",
 			"schema": "Attendance",
 			"statements": {
-				"Year": { "type": "number", "value": 2021 },
-				"Visitors": { "type": "number", "value": 625000 },
-				"Source": { "type": "url", "value": [ "https://www.rijksmuseum.nl/nl/pers/persberichten/het-rijksmuseum-in-2021" ] }
+				"Year": { "propertyType": "number", "value": 2021 },
+				"Visitors": { "propertyType": "number", "value": 625000 },
+				"Source": { "propertyType": "url", "value": [ "https://www.rijksmuseum.nl/nl/pers/persberichten/het-rijksmuseum-in-2021" ] }
 			}
 		},
 		"sEpfwJLAtndEeeE": {
 			"label": "Rijksmuseum 2020",
 			"schema": "Attendance",
 			"statements": {
-				"Year": { "type": "number", "value": 2020 },
-				"Visitors": { "type": "number", "value": 675000 },
-				"Source": { "type": "url", "value": [ "https://www.rijksmuseum.nl/en/press/press-releases/the-rijksmuseum-in-2020" ] }
+				"Year": { "propertyType": "number", "value": 2020 },
+				"Visitors": { "propertyType": "number", "value": 675000 },
+				"Source": { "propertyType": "url", "value": [ "https://www.rijksmuseum.nl/en/press/press-releases/the-rijksmuseum-in-2020" ] }
 			}
 		}
 	}

--- a/DemoData/Subject/Sandbox_Subject.json
+++ b/DemoData/Subject/Sandbox_Subject.json
@@ -6,23 +6,23 @@
 			"schema": "Sandbox",
 			"statements": {
 				"Description": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "A sandbox Subject for the Subject views demo. Edit any field to see every view on the page update in place." ]
 				},
 				"Status": {
-					"type": "select",
+					"propertyType": "select",
 					"value": ["o1demo9aaaaaaa1"]
 				},
 				"Founded": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 2024
 				},
 				"Website": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://sandbox.example" ]
 				},
 				"Importance": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 5
 				}
 			}

--- a/DemoData/Subject/Sorbonne_University.json
+++ b/DemoData/Subject/Sorbonne_University.json
@@ -6,11 +6,11 @@
 			"schema": "Institution",
 			"statements": {
 				"Description": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "A public research university in Paris with strong humanities and digital scholarship programmes." ]
 				},
 				"City": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "r1demo8aaaaaaA3",
@@ -19,11 +19,11 @@
 					]
 				},
 				"Founded": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 1257
 				},
 				"Website": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://www.sorbonne-universite.fr" ]
 				}
 			}

--- a/DemoData/Subject/Starry_Night_Over_the_Rhône.json
+++ b/DemoData/Subject/Starry_Night_Over_the_Rhône.json
@@ -6,15 +6,15 @@
 			"schema": "Artwork",
 			"statements": {
 				"Year": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 1888
 				},
 				"Medium": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Oil on canvas" ]
 				},
 				"Creator": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "rEpfwJLoJv75wqU",
@@ -23,7 +23,7 @@
 					]
 				},
 				"Located at": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "rEpfwJLoKte65Di",
@@ -32,11 +32,11 @@
 					]
 				},
 				"Image": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://upload.wikimedia.org/wikipedia/commons/9/94/Starry_Night_Over_the_Rhone.jpg" ]
 				},
 				"Estimated value": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 100
 				}
 			}

--- a/DemoData/Subject/Stockholm.json
+++ b/DemoData/Subject/Stockholm.json
@@ -6,15 +6,15 @@
 			"schema": "City",
 			"statements": {
 				"Country": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Sweden" ]
 				},
 				"Population": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 996264
 				},
 				"Website": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://www.stockholm.se" ]
 				}
 			}

--- a/DemoData/Subject/TEI_Encoding_Patterns_for_Multilingual_Editions.json
+++ b/DemoData/Subject/TEI_Encoding_Patterns_for_Multilingual_Editions.json
@@ -6,19 +6,19 @@
 			"schema": "Publication",
 			"statements": {
 				"Title": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "TEI Encoding Patterns for Multilingual Editions" ]
 				},
 				"Year": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 2024
 				},
 				"Venue": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Journal of the Text Encoding Initiative" ]
 				},
 				"Authors": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "r1demo8aaaaaaE3",
@@ -27,7 +27,7 @@
 					]
 				},
 				"URL": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://example.org/publications/tei-multilingual" ]
 				}
 			}

--- a/DemoData/Subject/The_Art_of_Painting.json
+++ b/DemoData/Subject/The_Art_of_Painting.json
@@ -6,15 +6,15 @@
 			"schema": "Artwork",
 			"statements": {
 				"Year": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 1666
 				},
 				"Medium": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Oil on canvas" ]
 				},
 				"Creator": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "rEpfwJLoScyfU3j",
@@ -23,7 +23,7 @@
 					]
 				},
 				"Located at": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "rEpfwJLoTZQ5HBf",
@@ -32,11 +32,11 @@
 					]
 				},
 				"Image": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://upload.wikimedia.org/wikipedia/commons/4/4a/Johannes_Vermeer_-_The_Art_of_Painting_-_Google_Art_Project.jpg" ]
 				},
 				"Estimated value": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 200
 				}
 			}

--- a/DemoData/Subject/The_Kiss.json
+++ b/DemoData/Subject/The_Kiss.json
@@ -6,15 +6,15 @@
 			"schema": "Artwork",
 			"statements": {
 				"Year": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 1908
 				},
 				"Medium": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Oil on canvas with gold leaf" ]
 				},
 				"Creator": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "rEpfwJLoQh2vtqV",
@@ -23,7 +23,7 @@
 					]
 				},
 				"Located at": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "rEpfwJLoReZ4kwu",
@@ -32,11 +32,11 @@
 					]
 				},
 				"Image": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://upload.wikimedia.org/wikipedia/commons/4/40/The_Kiss_-_Gustav_Klimt_-_Google_Cultural_Institute.jpg" ]
 				},
 				"Estimated value": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 240
 				}
 			}

--- a/DemoData/Subject/The_Milkmaid.json
+++ b/DemoData/Subject/The_Milkmaid.json
@@ -6,15 +6,15 @@
 			"schema": "Artwork",
 			"statements": {
 				"Year": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 1658
 				},
 				"Medium": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Oil on canvas" ]
 				},
 				"Creator": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "rEpfwJLoLsv7dAs",
@@ -23,7 +23,7 @@
 					]
 				},
 				"Located at": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "rEpfwJLoMpL8EVs",
@@ -32,11 +32,11 @@
 					]
 				},
 				"Image": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://upload.wikimedia.org/wikipedia/commons/2/20/Johannes_Vermeer_-_Het_melkmeisje_-_Google_Art_Project.jpg" ]
 				},
 				"Estimated value": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 150
 				}
 			}

--- a/DemoData/Subject/Validation_Clean.json
+++ b/DemoData/Subject/Validation_Clean.json
@@ -6,54 +6,54 @@
 			"schema": "Validation Demo",
 			"statements": {
 				"Title": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "All properties filled in" ]
 				},
 				"Summary": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "A valid summary that is comfortably between ten and one hundred characters long." ]
 				},
 				"Aliases": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Clean sample", "Reference subject" ]
 				},
 				"Homepage": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://example.com" ]
 				},
 				"Tags": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [
 						"https://example.com/a",
 						"https://example.com/b"
 					]
 				},
 				"Score": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 42.5
 				},
 				"Status": {
-					"type": "select",
+					"propertyType": "select",
 					"value": [ "oVgd1htUPMmGZYT" ]
 				},
 				"Topics": {
-					"type": "select",
+					"propertyType": "select",
 					"value": [ "oVgd1Fzq3xfLnxJ", "oVgd1LjchzFUcLg" ]
 				},
 				"Featured": {
-					"type": "boolean",
+					"propertyType": "boolean",
 					"value": true
 				},
 				"Release date": {
-					"type": "date",
+					"propertyType": "date",
 					"value": [ "2024-06-15" ]
 				},
 				"Last reviewed": {
-					"type": "dateTime",
+					"propertyType": "dateTime",
 					"value": [ "2024-06-15T09:30:00Z" ]
 				},
 				"Related product": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "rVgd1keRxJzQR6e",

--- a/DemoData/Subject/Vienna.json
+++ b/DemoData/Subject/Vienna.json
@@ -6,15 +6,15 @@
 			"schema": "City",
 			"statements": {
 				"Country": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Austria" ]
 				},
 				"Population": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 1982097
 				},
 				"Website": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://www.wien.gv.at" ]
 				}
 			}

--- a/DemoData/Subject/Vincent_van_Gogh.json
+++ b/DemoData/Subject/Vincent_van_Gogh.json
@@ -6,27 +6,27 @@
 			"schema": "Artist",
 			"statements": {
 				"Born": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 1853
 				},
 				"Died": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 1890
 				},
 				"Nationality": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Dutch" ]
 				},
 				"Movement": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Post-Impressionism", "Neo-Impressionism" ]
 				},
 				"Wikipedia": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://en.wikipedia.org/wiki/Vincent_van_Gogh" ]
 				},
 				"Active period": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "1881–1890" ]
 				}
 			}

--- a/DemoData/Subject/Water_Lilies.json
+++ b/DemoData/Subject/Water_Lilies.json
@@ -6,15 +6,15 @@
 			"schema": "Artwork",
 			"statements": {
 				"Year": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 1906
 				},
 				"Medium": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Oil on canvas" ]
 				},
 				"Creator": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "rEpfwJLoH2dWKCs",
@@ -23,7 +23,7 @@
 					]
 				},
 				"Located at": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "rEpfwJLoHyZeBJC",
@@ -32,11 +32,11 @@
 					]
 				},
 				"Image": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://upload.wikimedia.org/wikipedia/commons/a/aa/Claude_Monet_-_Water_Lilies_-_1906%2C_Ryerson.jpg" ]
 				},
 				"Estimated value": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 80
 				}
 			}

--- a/DemoData/Subject/Weimar.json
+++ b/DemoData/Subject/Weimar.json
@@ -5,9 +5,9 @@
 			"label": "Weimar",
 			"schema": "Place",
 			"statements": {
-				"Country": { "type": "text", "value": [ "Germany" ] },
-				"Coordinates": { "type": "text", "value": [ "50.9795, 11.3235" ] },
-				"Description": { "type": "text", "value": [ "City in Thuringia, Germany, where Johann Sebastian Bach served as court organist." ] }
+				"Country": { "propertyType": "text", "value": [ "Germany" ] },
+				"Coordinates": { "propertyType": "text", "value": [ "50.9795, 11.3235" ] },
+				"Description": { "propertyType": "text", "value": [ "City in Thuringia, Germany, where Johann Sebastian Bach served as court organist." ] }
 			}
 		}
 	}

--- a/DemoData/Subject/Wikibase_Backends_for_GLAM_Knowledge_Graphs.json
+++ b/DemoData/Subject/Wikibase_Backends_for_GLAM_Knowledge_Graphs.json
@@ -6,19 +6,19 @@
 			"schema": "Publication",
 			"statements": {
 				"Title": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Wikibase Backends for GLAM Knowledge Graphs" ]
 				},
 				"Year": {
-					"type": "number",
+					"propertyType": "number",
 					"value": 2025
 				},
 				"Venue": {
-					"type": "text",
+					"propertyType": "text",
 					"value": [ "Code4Lib Journal" ]
 				},
 				"Authors": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "r1demo8aaaaaaE4",
@@ -31,7 +31,7 @@
 					]
 				},
 				"Project": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "r1demo8aaaaaaE6",
@@ -40,7 +40,7 @@
 					]
 				},
 				"URL": {
-					"type": "url",
+					"propertyType": "url",
 					"value": [ "https://example.org/publications/wikibase-glam" ]
 				}
 			}

--- a/DemoData/Subject/Wilhelm_Friedemann_Bach.json
+++ b/DemoData/Subject/Wilhelm_Friedemann_Bach.json
@@ -5,8 +5,8 @@
 			"label": "Wilhelm Friedemann Bach",
 			"schema": "Person",
 			"statements": {
-				"Description": { "type": "text", "value": [ "Composer and organist; eldest surviving son of Johann Sebastian Bach." ] },
-				"Also known as": { "type": "text", "value": [ "the Halle Bach" ] }
+				"Description": { "propertyType": "text", "value": [ "Composer and organist; eldest surviving son of Johann Sebastian Bach." ] },
+				"Also known as": { "propertyType": "text", "value": [ "the Halle Bach" ] }
 			}
 		}
 	}

--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -144,7 +144,7 @@ On the **Subject read**, the targets are merged into the same `subjects` map as 
       "label": "Rijksmuseum",
       "schema": "Museum",
       "statements": {
-        "City": { "type": "relation", "value": [ { "id": "rEpfwJLoEB5UuQS", "target": "sEpfwJLnuwcxvuJ" } ] }
+        "City": { "propertyType": "relation", "value": [ { "id": "rEpfwJLoEB5UuQS", "target": "sEpfwJLnuwcxvuJ" } ] }
       }
     },
     "sEpfwJLnuwcxvuJ": { "id": "sEpfwJLnuwcxvuJ", "label": "Amsterdam", "schema": "City", "statements": { ... } }

--- a/docs/api/subject-format.md
+++ b/docs/api/subject-format.md
@@ -127,7 +127,7 @@ Subject IDs start with `s` (`s1demo5sssssss1`), Relation IDs with `r` (`r1demo5r
 ### Reading Subjects
 
 `GET /rest.php/neowiki/v0/subject/{subjectId}` returns a top-level `requestedId` and a `subjects` map; each
-Subject gains an `id` field. Statements use the storage `type` key.
+Subject gains an `id` field.
 
 - `?expand=page` adds `pageId`, `pageTitle`, and `pageNamespaceId` to each Subject. `pageTitle` is the full page
   title with namespace prefix (e.g. `Help:Installation`); `pageNamespaceId` is the canonical MediaWiki namespace
@@ -139,8 +139,7 @@ Subject gains an `id` field. Statements use the storage `type` key.
 ### Creating Subjects
 
 `POST /rest.php/neowiki/v0/page/{pageId}/mainSubject` and `.../childSubjects` create a Subject on a page. The body
-takes `label`, `schema`, and `statements` (all required), plus an optional `comment` edit summary. Statements use the
-`propertyType` write shape [below](#writing-subjects), not the storage `type` key.
+takes `label`, `schema`, and `statements` (all required), plus an optional `comment` edit summary.
 
 The server mints the Subject ID unless you pass one:
 
@@ -150,15 +149,14 @@ The server mints the Subject ID unless you pass one:
 
 ### Writing Subjects
 
-`PUT /rest.php/neowiki/v0/subject/{subjectId}` replaces the Subject's label and statements. Statements use
-`propertyType` in place of `type`:
+`PUT /rest.php/neowiki/v0/subject/{subjectId}` replaces the Subject's label and statements:
 
 ```json
 {
   "label": "Updated Label",
   "statements": {
     "Founded at": {
-      "propertyType": "number",
+      "type": "number",
       "value": 2019
     }
   },
@@ -172,7 +170,7 @@ The server mints the Subject ID unless you pass one:
 | `statements` | Yes | Map of property name to Statement; omitted names are deleted. Pass `{}` to clear all. |
 | `comment` | No | Edit summary. |
 
-A statement entry without `propertyType`, or whose value is empty for its type, is dropped without error. For
+A statement entry without `type`, or whose value is empty for its type, is dropped without error. For
 schema/value validation outcomes see [Validation Codes](validation-codes.md).
 
 A relation may omit `id`; the server generates one. The Subject's `id`, `schema`, and page fields are immutable

--- a/docs/api/subject-format.md
+++ b/docs/api/subject-format.md
@@ -53,22 +53,22 @@ A property mapped to `null` instead of a Statement object is skipped when the JS
 
 ```json
 {
-  "type": "number",
+  "propertyType": "number",
   "value": 2019
 }
 ```
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `type` | string | Yes | The property's type when the value was written — the writer's schema ([ADR 011](../adr/011-include-writers-schema.md)). |
-| `value` | varies | Yes | The value, shaped by `type`. See [Value formats](#value-formats). |
+| `propertyType` | string | Yes | The property's type when the value was written — the writer's schema ([ADR 011](../adr/011-include-writers-schema.md)). |
+| `value` | varies | Yes | The value, shaped by `propertyType`. See [Value formats](#value-formats). |
 
 ## Value formats
 
-`type` holds the property type name, which fixes the `value` shape:
+`propertyType` holds the property type name, which fixes the `value` shape:
 
-| `type` | `value` |
-|--------|---------|
+| `propertyType` | `value` |
+|----------------|---------|
 | `text`, `url`, `select`, `date`, `dateTime` | Array of strings, one per value part. |
 | `number` | A single number (integer or float). |
 | `boolean` | A single boolean. |
@@ -77,10 +77,10 @@ A property mapped to `null` instead of a Statement object is skipped when the JS
 A multi-part `text` value:
 
 ```json
-{ "type": "text", "value": [ "First value", "Second value" ] }
+{ "propertyType": "text", "value": [ "First value", "Second value" ] }
 ```
 
-Every registered PropertyType uses one of these four `value` shapes. A `type` whose PropertyType is not
+Every registered PropertyType uses one of these four `value` shapes. A `propertyType` whose PropertyType is not
 registered — its extension disabled — keeps the raw value that was stored
 ([`unregistered-type`](validation-codes.md#unregistered-type)).
 
@@ -90,7 +90,7 @@ Each `relation` value is an array of objects pointing at other Subjects:
 
 ```json
 {
-  "type": "relation",
+  "propertyType": "relation",
   "value": [
     { "id": "r1demo5rrrrrrr1", "target": "s1demo4sssssss1" }
   ]
@@ -156,7 +156,7 @@ The server mints the Subject ID unless you pass one:
   "label": "Updated Label",
   "statements": {
     "Founded at": {
-      "type": "number",
+      "propertyType": "number",
       "value": 2019
     }
   },
@@ -170,7 +170,7 @@ The server mints the Subject ID unless you pass one:
 | `statements` | Yes | Map of property name to Statement; omitted names are deleted. Pass `{}` to clear all. |
 | `comment` | No | Edit summary. |
 
-On every endpoint that takes `statements`, an entry without `type`, or whose value is empty for its type, is
+On every endpoint that takes `statements`, an entry without `propertyType`, or whose value is empty for its type, is
 dropped without error. For schema/value validation outcomes see [Validation Codes](validation-codes.md).
 
 A relation may omit `id`; the server generates one. The Subject's `id`, `schema`, and page fields are immutable
@@ -189,7 +189,7 @@ A page about Berlin with a main Subject and a child Subject for population data:
       "schema": "City",
       "statements": {
         "Country": {
-          "type": "text",
+          "propertyType": "text",
           "value": ["Germany"]
         }
       }
@@ -199,15 +199,15 @@ A page about Berlin with a main Subject and a child Subject for population data:
       "schema": "Population",
       "statements": {
         "Population": {
-          "type": "number",
+          "propertyType": "number",
           "value": 3677472
         },
         "Date": {
-          "type": "text",
+          "propertyType": "text",
           "value": ["2020-12-31"]
         },
         "References": {
-          "type": "url",
+          "propertyType": "url",
           "value": ["https://example.com/Pop2020"]
         }
       }

--- a/docs/api/subject-format.md
+++ b/docs/api/subject-format.md
@@ -4,8 +4,9 @@ order: 3
 ---
 # Subject JSON Format
 
-Subject data is [stored as JSON](../adr/002-store-data-as-json.md). The REST API returns and accepts the same object
-shapes; its read envelope and write differences are under [REST API](#rest-api).
+Subject data is [stored as JSON](../adr/002-store-data-as-json.md). The REST API returns and accepts these same
+shapes, so a Statement read from the API can be sent back unchanged; the fields each endpoint adds or ignores are
+under [REST API](#rest-api).
 
 For Subject, Statement, and Value, see the [Glossary](../glossary.md).
 
@@ -139,7 +140,8 @@ Subject gains an `id` field.
 ### Creating Subjects
 
 `POST /rest.php/neowiki/v0/page/{pageId}/mainSubject` and `.../childSubjects` create a Subject on a page. The body
-takes `label`, `schema`, and `statements` (all required), plus an optional `comment` edit summary.
+takes `label`, `schema`, and [`statements`](#statement-object) (all required), plus an optional `comment` edit
+summary.
 
 The server mints the Subject ID unless you pass one:
 
@@ -170,8 +172,8 @@ The server mints the Subject ID unless you pass one:
 | `statements` | Yes | Map of property name to Statement; omitted names are deleted. Pass `{}` to clear all. |
 | `comment` | No | Edit summary. |
 
-A statement entry without `type`, or whose value is empty for its type, is dropped without error. For
-schema/value validation outcomes see [Validation Codes](validation-codes.md).
+On every endpoint that takes `statements`, an entry without `type`, or whose value is empty for its type, is
+dropped without error. For schema/value validation outcomes see [Validation Codes](validation-codes.md).
 
 A relation may omit `id`; the server generates one. The Subject's `id`, `schema`, and page fields are immutable
 and ignored if sent.

--- a/docs/api/subject-format.md
+++ b/docs/api/subject-format.md
@@ -4,9 +4,8 @@ order: 3
 ---
 # Subject JSON Format
 
-Subject data is [stored as JSON](../adr/002-store-data-as-json.md). The REST API returns and accepts these same
-shapes, so a Statement read from the API can be sent back unchanged; the fields each endpoint adds or ignores are
-under [REST API](#rest-api).
+Subject data is [stored as JSON](../adr/002-store-data-as-json.md). The REST API returns and accepts the same
+shapes; the fields each endpoint adds or ignores are under [REST API](#rest-api).
 
 For Subject, Statement, and Value, see the [Glossary](../glossary.md).
 
@@ -140,8 +139,7 @@ Subject gains an `id` field.
 ### Creating Subjects
 
 `POST /rest.php/neowiki/v0/page/{pageId}/mainSubject` and `.../childSubjects` create a Subject on a page. The body
-takes `label`, `schema`, and [`statements`](#statement-object) (all required), plus an optional `comment` edit
-summary.
+takes `label`, `schema`, and [`statements`](#statement-object) (all required), plus an optional `comment` edit summary.
 
 The server mints the Subject ID unless you pass one:
 

--- a/docs/authoring/lua-api.md
+++ b/docs/authoring/lua-api.md
@@ -364,13 +364,13 @@ structure:
     label = 'ACME Inc.',
     schema = 'Company',
     statements = {
-        ['Headquarters'] = { type = 'text',     values = { [1] = 'Berlin' } },
-        ['Founded at']   = { type = 'number',   values = { [1] = 2005 } },
-        ['Status']       = { type = 'select',   values = { [1] = 'Active' } },
-        ['Websites']     = { type = 'url',      values = { [1] = 'https://acme.com', [2] = 'https://acme.org' } },
-        ['Active']       = { type = 'boolean',  values = { [1] = true } },
+        ['Headquarters'] = { propertyType = 'text',     values = { [1] = 'Berlin' } },
+        ['Founded at']   = { propertyType = 'number',   values = { [1] = 2005 } },
+        ['Status']       = { propertyType = 'select',   values = { [1] = 'Active' } },
+        ['Websites']     = { propertyType = 'url',      values = { [1] = 'https://acme.com', [2] = 'https://acme.org' } },
+        ['Active']       = { propertyType = 'boolean',  values = { [1] = true } },
         ['Products']     = {
-            type = 'relation',
+            propertyType = 'relation',
             values = {
                 [1] = { id = 'r1...', target = 's1...', label = 'Foo' },
                 [2] = { id = 'r1...', target = 's1...', label = 'Bar' },
@@ -383,9 +383,9 @@ structure:
 Notes:
 
 - `statements` is keyed by property name. `values` within each statement is 1-indexed.
-- `type` is the property type at the time the Subject was last edited. If the Schema has changed
-  since (e.g. a property was changed from `text` to `select`), older Subjects keep their original
-  type until they are re-saved.
+- `propertyType` is the property type at the time the Subject was last edited. If the Schema has
+  changed since (e.g. a property was changed from `text` to `select`), older Subjects keep their
+  original type until they are re-saved.
 - A relation's `label` falls back to the target Subject ID if the label cannot be looked up
   (e.g. a broken reference).
 - Per-relation `properties` (qualifiers) are not currently exposed via Lua. Use the REST API if

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -186,6 +186,11 @@ parameters:
 			path: src/Presentation/TwigTemplateRenderer.php
 
 		-
+			message: "#^Cannot access offset 'propertyType' on mixed\\.$#"
+			count: 2
+			path: src/Application/StatementListBuilder.php
+
+		-
 			message: "#^Cannot access offset 'value' on mixed\\.$#"
 			count: 1
 			path: src/Application/StatementListBuilder.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -186,11 +186,6 @@ parameters:
 			path: src/Presentation/TwigTemplateRenderer.php
 
 		-
-			message: "#^Cannot access offset 'propertyType' on mixed\\.$#"
-			count: 2
-			path: src/Application/StatementListBuilder.php
-
-		-
 			message: "#^Cannot access offset 'value' on mixed\\.$#"
 			count: 1
 			path: src/Application/StatementListBuilder.php

--- a/resources/ext.neowiki/src/domain/StatementList.ts
+++ b/resources/ext.neowiki/src/domain/StatementList.ts
@@ -114,7 +114,7 @@ export function statementsToJson( statements: StatementList ): Record<string, un
 
 		valuesJson[ statement.propertyName.toString() ] = {
 			value: value,
-			propertyType: statement.propertyType,
+			type: statement.propertyType,
 		};
 	}
 

--- a/resources/ext.neowiki/src/domain/StatementList.ts
+++ b/resources/ext.neowiki/src/domain/StatementList.ts
@@ -114,7 +114,7 @@ export function statementsToJson( statements: StatementList ): Record<string, un
 
 		valuesJson[ statement.propertyName.toString() ] = {
 			value: value,
-			type: statement.propertyType,
+			propertyType: statement.propertyType,
 		};
 	}
 

--- a/resources/ext.neowiki/src/persistence/StatementDeserializer.ts
+++ b/resources/ext.neowiki/src/persistence/StatementDeserializer.ts
@@ -5,7 +5,7 @@ import { Statement } from '@/domain/Statement';
 interface StatementJson {
 
 	value: unknown;
-	type: string;
+	propertyType: string;
 
 }
 
@@ -13,7 +13,7 @@ function isJsonStatement( json: unknown ): json is StatementJson {
 	return typeof json === 'object' &&
 		json !== null &&
 		'value' in json &&
-		'type' in json;
+		'propertyType' in json;
 }
 
 export class StatementDeserializer {
@@ -30,8 +30,8 @@ export class StatementDeserializer {
 
 		return new Statement(
 			new PropertyName( propertyName ),
-			json.type,
-			this.valueDeserializer.deserialize( json.value, json.type ),
+			json.propertyType,
+			this.valueDeserializer.deserialize( json.value, json.propertyType ),
 		);
 	}
 

--- a/resources/ext.neowiki/src/persistence/__tests__/SubjectDeserializer.spec.ts
+++ b/resources/ext.neowiki/src/persistence/__tests__/SubjectDeserializer.spec.ts
@@ -43,11 +43,11 @@ describe( 'SubjectDeserializer', () => {
 			statements: {
 				Property1: {
 					value: [ 'foo' ],
-					type: 'text',
+					propertyType: 'text',
 				},
 				Property2: {
 					value: 1337,
-					type: 'number',
+					propertyType: 'number',
 				},
 			},
 			pageId: 42,

--- a/resources/ext.neowiki/tests/domain/StatementList.unit.spec.ts
+++ b/resources/ext.neowiki/tests/domain/StatementList.unit.spec.ts
@@ -189,17 +189,17 @@ describe( 'statementsToJson', () => {
 		expect( json ).toEqual( {
 			value1: {
 				value: [ 'test' ],
-				propertyType: TextType.typeName,
+				type: TextType.typeName,
 			},
 			value2: {
 				value: 123,
-				propertyType: NumberType.typeName,
+				type: NumberType.typeName,
 			},
 			value4: {
 				value: [
 					{ id: 'testId', target: 's11111111111111' },
 				],
-				propertyType: RelationType.typeName,
+				type: RelationType.typeName,
 			},
 		} );
 	} );
@@ -231,7 +231,7 @@ describe( 'unregistered-type round-trip', () => {
 		expect( statementsToJson( statements ) ).toEqual( {
 			Swatch: {
 				value: { hex: '#ff5733', palette: 'warm' },
-				propertyType: 'zzz-color',
+				type: 'zzz-color',
 			},
 		} );
 	} );

--- a/resources/ext.neowiki/tests/domain/StatementList.unit.spec.ts
+++ b/resources/ext.neowiki/tests/domain/StatementList.unit.spec.ts
@@ -116,11 +116,11 @@ describe( 'StatementList', () => {
 			{
 				property1: {
 					value: 'value1',
-					type: TextType.typeName,
+					propertyType: TextType.typeName,
 				},
 				property2: {
 					value: 'value2',
-					type: TextType.typeName,
+					propertyType: TextType.typeName,
 				},
 			},
 		);
@@ -137,11 +137,11 @@ describe( 'StatementList', () => {
 			{
 				'': {
 					value: 'value1',
-					type: TextType.typeName,
+					propertyType: TextType.typeName,
 				}, // An empty string is not a valid PropertyName
 				property2: {
 					value: 'value2',
-					type: TextType.typeName,
+					propertyType: TextType.typeName,
 				},
 			},
 		) )
@@ -153,15 +153,15 @@ describe( 'StatementList', () => {
 			{
 				p1: {
 					value: 'hello',
-					type: TextType.typeName,
+					propertyType: TextType.typeName,
 				},
 				p2: {
 					value: 42,
-					type: NumberType.typeName,
+					propertyType: NumberType.typeName,
 				},
 				p3: {
 					value: [ 'foo', 'bar' ],
-					type: TextType.typeName,
+					propertyType: TextType.typeName,
 				},
 			},
 		);
@@ -189,17 +189,17 @@ describe( 'statementsToJson', () => {
 		expect( json ).toEqual( {
 			value1: {
 				value: [ 'test' ],
-				type: TextType.typeName,
+				propertyType: TextType.typeName,
 			},
 			value2: {
 				value: 123,
-				type: NumberType.typeName,
+				propertyType: NumberType.typeName,
 			},
 			value4: {
 				value: [
 					{ id: 'testId', target: 's11111111111111' },
 				],
-				type: RelationType.typeName,
+				propertyType: RelationType.typeName,
 			},
 		} );
 	} );
@@ -224,14 +224,14 @@ describe( 'unregistered-type round-trip', () => {
 		const statements = Neo.getInstance().getSubjectDeserializer().deserializeStatements( {
 			Swatch: {
 				value: { hex: '#ff5733', palette: 'warm' },
-				type: 'zzz-color',
+				propertyType: 'zzz-color',
 			},
 		} );
 
 		expect( statementsToJson( statements ) ).toEqual( {
 			Swatch: {
 				value: { hex: '#ff5733', palette: 'warm' },
-				type: 'zzz-color',
+				propertyType: 'zzz-color',
 			},
 		} );
 	} );

--- a/resources/ext.neowiki/tests/domain/Subject.unit.spec.ts
+++ b/resources/ext.neowiki/tests/domain/Subject.unit.spec.ts
@@ -56,19 +56,19 @@ describe( 'Subject', () => {
 					{
 						Property1: {
 							value: [ 'foo' ],
-							type: TextType.typeName,
+							propertyType: TextType.typeName,
 						},
 						Property2: {
 							value: [ { target: 's11111111111111' } ],
-							type: RelationType.typeName,
+							propertyType: RelationType.typeName,
 						},
 						Property3: {
 							value: [ { target: 's11111111111112' }, { target: 's11111111111113' } ],
-							type: RelationType.typeName,
+							propertyType: RelationType.typeName,
 						},
 						Property4: {
 							value: [ 'bar' ],
-							type: TextType.typeName,
+							propertyType: TextType.typeName,
 						},
 					},
 				),
@@ -89,19 +89,19 @@ describe( 'Subject', () => {
 					{
 						Property1: {
 							value: [ 'foo' ],
-							type: TextType.typeName,
+							propertyType: TextType.typeName,
 						},
 						Property2: {
 							value: [ { target: 's11111111111118' } ],
-							type: RelationType.typeName,
+							propertyType: RelationType.typeName,
 						},
 						Property3: {
 							value: [ { target: 's11111111111111' }, { target: 's11111111111119' } ],
-							type: RelationType.typeName,
+							propertyType: RelationType.typeName,
 						},
 						Property4: {
 							value: [ 'bar' ],
-							type: TextType.typeName,
+							propertyType: TextType.typeName,
 						},
 					},
 				),

--- a/resources/ext.neowiki/tests/persistence/RestSubjectRepository.neo4j.spec.ts
+++ b/resources/ext.neowiki/tests/persistence/RestSubjectRepository.neo4j.spec.ts
@@ -31,11 +31,11 @@ const subjectResponse = {
 	statements: {
 		label: {
 			value: 'John Doe',
-			type: TextType.typeName,
+			propertyType: TextType.typeName,
 		},
 		WorkUrl: {
 			value: 'https://pro.wiki',
-			type: UrlType.typeName,
+			propertyType: UrlType.typeName,
 		},
 	},
 };
@@ -130,7 +130,7 @@ describe( 'RestSubjectRepository', () => {
 					statements: {
 						Products: {
 							value: [ { target: referencedId1 }, { target: referencedId2 } ],
-							type: RelationType.typeName,
+							propertyType: RelationType.typeName,
 						},
 					},
 				},
@@ -205,7 +205,7 @@ describe( 'RestSubjectRepository', () => {
 				statements: {
 					Mystery: {
 						value: 'x',
-						type: 'unregistered-property-type',
+						propertyType: 'unregistered-property-type',
 					},
 				},
 			};

--- a/resources/ext.neowiki/tests/persistence/RestSubjectRepository.neo4j.spec.ts
+++ b/resources/ext.neowiki/tests/persistence/RestSubjectRepository.neo4j.spec.ts
@@ -219,7 +219,7 @@ describe( 'RestSubjectRepository', () => {
 				pageId: 4,
 				pageTitle: 'Broken',
 				statements: {
-					// Missing the required `type`, so the statement cannot be deserialized.
+					// Missing the required `propertyType`, so the statement cannot be deserialized.
 					Mystery: {
 						value: 'x',
 					},

--- a/resources/ext.neowiki/tests/persistence/StoreStateLoader.spec.ts
+++ b/resources/ext.neowiki/tests/persistence/StoreStateLoader.spec.ts
@@ -50,7 +50,7 @@ function newMainSubjectWithRelationsTo( ...targets: SubjectId[] ): Subject {
 		statements: Neo.getInstance().getSubjectDeserializer().deserializeStatements( {
 			Products: {
 				value: targets.map( ( target ) => ( { target: target.text } ) ),
-				type: RelationType.typeName,
+				propertyType: RelationType.typeName,
 			},
 		} ),
 	} );

--- a/src/Application/Queries/GetPageSubjects/GetPageSubjectsQuery.php
+++ b/src/Application/Queries/GetPageSubjects/GetPageSubjectsQuery.php
@@ -161,7 +161,7 @@ readonly class GetPageSubjectsQuery {
 
 		foreach ( $statements->asArray() as $statement ) {
 			$array[$statement->getPropertyName()->text] = [
-				'type' => $statement->getPropertyType(),
+				'propertyType' => $statement->getPropertyType(),
 				'value' => $statement->getValue()->toScalars()
 			];
 		}

--- a/src/Application/Queries/GetSubject/GetSubjectQuery.php
+++ b/src/Application/Queries/GetSubject/GetSubjectQuery.php
@@ -107,7 +107,7 @@ readonly class GetSubjectQuery {
 
 		foreach ( $statements->asArray() as $statement ) {
 			$array[$statement->getPropertyName()->text] = [
-				'type' => $statement->getPropertyType(),
+				'propertyType' => $statement->getPropertyType(),
 				'value' => $statement->getValue()->toScalars()
 			];
 		}

--- a/src/Application/SelectStatementResolver.php
+++ b/src/Application/SelectStatementResolver.php
@@ -54,7 +54,7 @@ readonly class SelectStatementResolver {
 				continue;
 			}
 
-			if ( ( $entry['propertyType'] ?? null ) !== SelectType::NAME ) {
+			if ( ( $entry['type'] ?? null ) !== SelectType::NAME ) {
 				continue;
 			}
 
@@ -129,7 +129,7 @@ readonly class SelectStatementResolver {
 				continue;
 			}
 
-			if ( ( $entry['propertyType'] ?? null ) !== SelectType::NAME ) {
+			if ( ( $entry['type'] ?? null ) !== SelectType::NAME ) {
 				continue;
 			}
 

--- a/src/Application/SelectStatementResolver.php
+++ b/src/Application/SelectStatementResolver.php
@@ -54,7 +54,7 @@ readonly class SelectStatementResolver {
 				continue;
 			}
 
-			if ( ( $entry['type'] ?? null ) !== SelectType::NAME ) {
+			if ( ( $entry['propertyType'] ?? null ) !== SelectType::NAME ) {
 				continue;
 			}
 
@@ -129,7 +129,7 @@ readonly class SelectStatementResolver {
 				continue;
 			}
 
-			if ( ( $entry['type'] ?? null ) !== SelectType::NAME ) {
+			if ( ( $entry['propertyType'] ?? null ) !== SelectType::NAME ) {
 				continue;
 			}
 

--- a/src/Application/StatementListBuilder.php
+++ b/src/Application/StatementListBuilder.php
@@ -36,11 +36,11 @@ readonly class StatementListBuilder {
 		$built = [];
 
 		foreach ( $statements as $propertyName => $entry ) {
-			if ( !is_array( $entry ) || !isset( $entry['type'] ) ) {
+			if ( !is_array( $entry ) || !isset( $entry['propertyType'] ) ) {
 				continue;
 			}
 
-			$propertyType = $entry['type'];
+			$propertyType = $entry['propertyType'];
 			$value = $this->deserializeValue( $propertyType, $entry['value'] );
 
 			if ( $value->isEmpty() ) {

--- a/src/Application/StatementListBuilder.php
+++ b/src/Application/StatementListBuilder.php
@@ -36,11 +36,11 @@ readonly class StatementListBuilder {
 		$built = [];
 
 		foreach ( $statements as $propertyName => $entry ) {
-			if ( !is_array( $entry ) || !isset( $entry['propertyType'] ) ) {
+			if ( !is_array( $entry ) || !isset( $entry['type'] ) ) {
 				continue;
 			}
 
-			$propertyType = $entry['propertyType'];
+			$propertyType = $entry['type'];
 			$value = $this->deserializeValue( $propertyType, $entry['value'] );
 
 			if ( $value->isEmpty() ) {

--- a/src/EntryPoints/Scribunto/SubjectDataLookup.php
+++ b/src/EntryPoints/Scribunto/SubjectDataLookup.php
@@ -247,7 +247,7 @@ class SubjectDataLookup {
 	 */
 	private function statementToTable( Statement $statement ): array {
 		return [
-			'type' => $statement->getPropertyType(),
+			'propertyType' => $statement->getPropertyType(),
 			'values' => $this->statementValuesToLuaArray( $statement ),
 		];
 	}

--- a/src/Persistence/MediaWiki/Subject/StatementDeserializer.php
+++ b/src/Persistence/MediaWiki/Subject/StatementDeserializer.php
@@ -33,10 +33,13 @@ class StatementDeserializer {
 	}
 
 	public function deserialize( string $propertyName, array $json ): Statement {
+		// Revisions written before the key was renamed hold "type", and revision content cannot be migrated.
+		$propertyType = $json['propertyType'] ?? $json['type'];
+
 		return new Statement(
 			property: new PropertyName( $propertyName ),
-			propertyType: $json['type'],
-			value: $this->deserializeValue( $json['type'], $json['value'] ),
+			propertyType: $propertyType,
+			value: $this->deserializeValue( $propertyType, $json['value'] ),
 		);
 	}
 

--- a/src/Persistence/MediaWiki/Subject/SubjectContentDataSerializer.php
+++ b/src/Persistence/MediaWiki/Subject/SubjectContentDataSerializer.php
@@ -47,7 +47,7 @@ class SubjectContentDataSerializer {
 
 	private function serializeStatement( Statement $statement ): array {
 		return [
-			'type' => $statement->getPropertyType(),
+			'propertyType' => $statement->getPropertyType(),
 			'value' => $statement->getValue()->toScalars(),
 		];
 	}

--- a/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
@@ -283,7 +283,7 @@ class CreateSubjectActionTest extends TestCase {
 				label: 'Some Label',
 				schemaName: self::SELECT_SCHEMA_NAME,
 				statements: [
-					'Status' => [ 'type' => 'select', 'value' => 'opt_draft' ],
+					'Status' => [ 'propertyType' => 'select', 'value' => 'opt_draft' ],
 				]
 			)
 		);
@@ -301,7 +301,7 @@ class CreateSubjectActionTest extends TestCase {
 				label: 'Some Label',
 				schemaName: self::SELECT_SCHEMA_NAME,
 				statements: [
-					'Status' => [ 'type' => 'select', 'value' => '  approved  ' ],
+					'Status' => [ 'propertyType' => 'select', 'value' => '  approved  ' ],
 				]
 			)
 		);
@@ -320,7 +320,7 @@ class CreateSubjectActionTest extends TestCase {
 				schemaName: self::SELECT_SCHEMA_NAME,
 				statements: [
 					'Status' => [
-						'type' => 'select',
+						'propertyType' => 'select',
 						'value' => [ 'id' => 'opt_approved', 'label' => 'Approved' ],
 					],
 				]
@@ -343,7 +343,7 @@ class CreateSubjectActionTest extends TestCase {
 				schemaName: self::SELECT_SCHEMA_NAME,
 				statements: [
 					'Status' => [
-						'type' => 'select',
+						'propertyType' => 'select',
 						'value' => [ 'id' => 'opt_draft', 'label' => 'WrongName' ],
 					],
 				]
@@ -362,7 +362,7 @@ class CreateSubjectActionTest extends TestCase {
 				schemaName: self::SELECT_SCHEMA_NAME,
 				statements: [
 					'Status' => [
-						'type' => 'select',
+						'propertyType' => 'select',
 						'value' => [
 							'opt_draft',
 							'Approved',
@@ -387,7 +387,7 @@ class CreateSubjectActionTest extends TestCase {
 				label: 'Some Label',
 				schemaName: 'UnknownSchema',
 				statements: [
-					'Status' => [ 'type' => 'select', 'value' => 'opt_draft' ],
+					'Status' => [ 'propertyType' => 'select', 'value' => 'opt_draft' ],
 				]
 			)
 		);
@@ -498,7 +498,7 @@ class CreateSubjectActionTest extends TestCase {
 				schemaName: '00000000-8888-0000-0000-000000000022',
 				statements: [
 					'Has product' => [
-						'type' => 'relation',
+						'propertyType' => 'relation',
 						'value' => [
 							[
 								// No ID
@@ -636,7 +636,7 @@ class CreateSubjectActionTest extends TestCase {
 				label: 'Bob',
 				schemaName: 'PersonSchema',
 				statements: [
-					'Name' => [ 'type' => 'select', 'value' => 'opt_alice' ],
+					'Name' => [ 'propertyType' => 'select', 'value' => 'opt_alice' ],
 				],
 			)
 		);
@@ -713,7 +713,7 @@ class CreateSubjectActionTest extends TestCase {
 				label: 'Some Label',
 				schemaName: 'some-schema',
 				statements: [
-					'animal' => [ 'type' => 'text', 'value' => 'bunny' ],
+					'animal' => [ 'propertyType' => 'text', 'value' => 'bunny' ],
 				],
 				id: self::SUPPLIED_ID,
 			)

--- a/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
@@ -283,7 +283,7 @@ class CreateSubjectActionTest extends TestCase {
 				label: 'Some Label',
 				schemaName: self::SELECT_SCHEMA_NAME,
 				statements: [
-					'Status' => [ 'propertyType' => 'select', 'value' => 'opt_draft' ],
+					'Status' => [ 'type' => 'select', 'value' => 'opt_draft' ],
 				]
 			)
 		);
@@ -301,7 +301,7 @@ class CreateSubjectActionTest extends TestCase {
 				label: 'Some Label',
 				schemaName: self::SELECT_SCHEMA_NAME,
 				statements: [
-					'Status' => [ 'propertyType' => 'select', 'value' => '  approved  ' ],
+					'Status' => [ 'type' => 'select', 'value' => '  approved  ' ],
 				]
 			)
 		);
@@ -320,7 +320,7 @@ class CreateSubjectActionTest extends TestCase {
 				schemaName: self::SELECT_SCHEMA_NAME,
 				statements: [
 					'Status' => [
-						'propertyType' => 'select',
+						'type' => 'select',
 						'value' => [ 'id' => 'opt_approved', 'label' => 'Approved' ],
 					],
 				]
@@ -343,7 +343,7 @@ class CreateSubjectActionTest extends TestCase {
 				schemaName: self::SELECT_SCHEMA_NAME,
 				statements: [
 					'Status' => [
-						'propertyType' => 'select',
+						'type' => 'select',
 						'value' => [ 'id' => 'opt_draft', 'label' => 'WrongName' ],
 					],
 				]
@@ -362,7 +362,7 @@ class CreateSubjectActionTest extends TestCase {
 				schemaName: self::SELECT_SCHEMA_NAME,
 				statements: [
 					'Status' => [
-						'propertyType' => 'select',
+						'type' => 'select',
 						'value' => [
 							'opt_draft',
 							'Approved',
@@ -387,7 +387,7 @@ class CreateSubjectActionTest extends TestCase {
 				label: 'Some Label',
 				schemaName: 'UnknownSchema',
 				statements: [
-					'Status' => [ 'propertyType' => 'select', 'value' => 'opt_draft' ],
+					'Status' => [ 'type' => 'select', 'value' => 'opt_draft' ],
 				]
 			)
 		);
@@ -498,7 +498,7 @@ class CreateSubjectActionTest extends TestCase {
 				schemaName: '00000000-8888-0000-0000-000000000022',
 				statements: [
 					'Has product' => [
-						'propertyType' => 'relation',
+						'type' => 'relation',
 						'value' => [
 							[
 								// No ID
@@ -636,7 +636,7 @@ class CreateSubjectActionTest extends TestCase {
 				label: 'Bob',
 				schemaName: 'PersonSchema',
 				statements: [
-					'Name' => [ 'propertyType' => 'select', 'value' => 'opt_alice' ],
+					'Name' => [ 'type' => 'select', 'value' => 'opt_alice' ],
 				],
 			)
 		);
@@ -713,7 +713,7 @@ class CreateSubjectActionTest extends TestCase {
 				label: 'Some Label',
 				schemaName: 'some-schema',
 				statements: [
-					'animal' => [ 'propertyType' => 'text', 'value' => 'bunny' ],
+					'animal' => [ 'type' => 'text', 'value' => 'bunny' ],
 				],
 				id: self::SUPPLIED_ID,
 			)

--- a/tests/phpunit/Application/Actions/ReplaceSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/ReplaceSubjectActionTest.php
@@ -139,7 +139,7 @@ class ReplaceSubjectActionTest extends TestCase {
 		$this->newAction()->replace(
 			new SubjectId( self::SUBJECT_ID ),
 			'Label',
-			[ 'Founded at' => [ 'type' => 'number', 'value' => 2019 ] ],
+			[ 'Founded at' => [ 'propertyType' => 'number', 'value' => 2019 ] ],
 			null
 		);
 
@@ -157,7 +157,7 @@ class ReplaceSubjectActionTest extends TestCase {
 		$action->replace(
 			new SubjectId( self::SUBJECT_ID ),
 			'Label',
-			[ 'Keep' => [ 'type' => 'text', 'value' => 'yes' ] ],
+			[ 'Keep' => [ 'propertyType' => 'text', 'value' => 'yes' ] ],
 			null
 		);
 
@@ -217,7 +217,7 @@ class ReplaceSubjectActionTest extends TestCase {
 		$this->newAction()->replace(
 			new SubjectId( self::SUBJECT_ID ),
 			'Label',
-			[ 'Status' => [ 'type' => 'select', 'value' => 'Approved' ] ],
+			[ 'Status' => [ 'propertyType' => 'select', 'value' => 'Approved' ] ],
 			null
 		);
 
@@ -234,7 +234,7 @@ class ReplaceSubjectActionTest extends TestCase {
 		$this->newAction()->replace(
 			new SubjectId( self::SUBJECT_ID ),
 			'Label',
-			[ 'Status' => [ 'type' => 'select', 'value' => 'opt_draft' ] ],
+			[ 'Status' => [ 'propertyType' => 'select', 'value' => 'opt_draft' ] ],
 			null
 		);
 
@@ -270,7 +270,7 @@ class ReplaceSubjectActionTest extends TestCase {
 		$this->newAction()->replace(
 			new SubjectId( self::SUBJECT_ID ),
 			'New Label',
-			[ 'Status' => [ 'type' => 'select', 'value' => 'Approved' ] ],
+			[ 'Status' => [ 'propertyType' => 'select', 'value' => 'Approved' ] ],
 			null
 		);
 
@@ -384,8 +384,8 @@ class ReplaceSubjectActionTest extends TestCase {
 			new SubjectId( self::SUBJECT_ID ),
 			'After',
 			[
-				'Name' => [ 'type' => 'url', 'value' => 'https://pro.wiki' ],
-				'Swatch' => [ 'type' => 'color', 'value' => [ '#ff5733' ] ],
+				'Name' => [ 'propertyType' => 'url', 'value' => 'https://pro.wiki' ],
+				'Swatch' => [ 'propertyType' => 'color', 'value' => [ '#ff5733' ] ],
 			],
 			null
 		);
@@ -411,7 +411,7 @@ class ReplaceSubjectActionTest extends TestCase {
 		$this->newAction( validationEnforced: true )->replace(
 			new SubjectId( self::SUBJECT_ID ),
 			'After',
-			[ 'Swatch' => [ 'type' => 'color', 'value' => [ '#ff5733' ] ] ],
+			[ 'Swatch' => [ 'propertyType' => 'color', 'value' => [ '#ff5733' ] ] ],
 			null
 		);
 
@@ -504,7 +504,7 @@ class ReplaceSubjectActionTest extends TestCase {
 		$this->newAction( validationEnforced: true )->replace(
 			new SubjectId( self::SUBJECT_ID ),
 			'After',
-			[ 'Alpha' => [ 'type' => 'select', 'value' => 'opt_a' ] ],
+			[ 'Alpha' => [ 'propertyType' => 'select', 'value' => 'opt_a' ] ],
 			null
 		);
 
@@ -560,7 +560,7 @@ class ReplaceSubjectActionTest extends TestCase {
 		$this->newAction( validationEnforced: true )->replace(
 			new SubjectId( self::SUBJECT_ID ),
 			'After',
-			[ 'Website' => [ 'type' => 'url', 'value' => [ 'not-a-url', 'also-not-a-url' ] ] ],
+			[ 'Website' => [ 'propertyType' => 'url', 'value' => [ 'not-a-url', 'also-not-a-url' ] ] ],
 			null
 		);
 

--- a/tests/phpunit/Application/Actions/ReplaceSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/ReplaceSubjectActionTest.php
@@ -139,7 +139,7 @@ class ReplaceSubjectActionTest extends TestCase {
 		$this->newAction()->replace(
 			new SubjectId( self::SUBJECT_ID ),
 			'Label',
-			[ 'Founded at' => [ 'propertyType' => 'number', 'value' => 2019 ] ],
+			[ 'Founded at' => [ 'type' => 'number', 'value' => 2019 ] ],
 			null
 		);
 
@@ -157,7 +157,7 @@ class ReplaceSubjectActionTest extends TestCase {
 		$action->replace(
 			new SubjectId( self::SUBJECT_ID ),
 			'Label',
-			[ 'Keep' => [ 'propertyType' => 'text', 'value' => 'yes' ] ],
+			[ 'Keep' => [ 'type' => 'text', 'value' => 'yes' ] ],
 			null
 		);
 
@@ -217,7 +217,7 @@ class ReplaceSubjectActionTest extends TestCase {
 		$this->newAction()->replace(
 			new SubjectId( self::SUBJECT_ID ),
 			'Label',
-			[ 'Status' => [ 'propertyType' => 'select', 'value' => 'Approved' ] ],
+			[ 'Status' => [ 'type' => 'select', 'value' => 'Approved' ] ],
 			null
 		);
 
@@ -234,7 +234,7 @@ class ReplaceSubjectActionTest extends TestCase {
 		$this->newAction()->replace(
 			new SubjectId( self::SUBJECT_ID ),
 			'Label',
-			[ 'Status' => [ 'propertyType' => 'select', 'value' => 'opt_draft' ] ],
+			[ 'Status' => [ 'type' => 'select', 'value' => 'opt_draft' ] ],
 			null
 		);
 
@@ -270,7 +270,7 @@ class ReplaceSubjectActionTest extends TestCase {
 		$this->newAction()->replace(
 			new SubjectId( self::SUBJECT_ID ),
 			'New Label',
-			[ 'Status' => [ 'propertyType' => 'select', 'value' => 'Approved' ] ],
+			[ 'Status' => [ 'type' => 'select', 'value' => 'Approved' ] ],
 			null
 		);
 
@@ -384,8 +384,8 @@ class ReplaceSubjectActionTest extends TestCase {
 			new SubjectId( self::SUBJECT_ID ),
 			'After',
 			[
-				'Name' => [ 'propertyType' => 'url', 'value' => 'https://pro.wiki' ],
-				'Swatch' => [ 'propertyType' => 'color', 'value' => [ '#ff5733' ] ],
+				'Name' => [ 'type' => 'url', 'value' => 'https://pro.wiki' ],
+				'Swatch' => [ 'type' => 'color', 'value' => [ '#ff5733' ] ],
 			],
 			null
 		);
@@ -411,7 +411,7 @@ class ReplaceSubjectActionTest extends TestCase {
 		$this->newAction( validationEnforced: true )->replace(
 			new SubjectId( self::SUBJECT_ID ),
 			'After',
-			[ 'Swatch' => [ 'propertyType' => 'color', 'value' => [ '#ff5733' ] ] ],
+			[ 'Swatch' => [ 'type' => 'color', 'value' => [ '#ff5733' ] ] ],
 			null
 		);
 
@@ -504,7 +504,7 @@ class ReplaceSubjectActionTest extends TestCase {
 		$this->newAction( validationEnforced: true )->replace(
 			new SubjectId( self::SUBJECT_ID ),
 			'After',
-			[ 'Alpha' => [ 'propertyType' => 'select', 'value' => 'opt_a' ] ],
+			[ 'Alpha' => [ 'type' => 'select', 'value' => 'opt_a' ] ],
 			null
 		);
 
@@ -560,7 +560,7 @@ class ReplaceSubjectActionTest extends TestCase {
 		$this->newAction( validationEnforced: true )->replace(
 			new SubjectId( self::SUBJECT_ID ),
 			'After',
-			[ 'Website' => [ 'propertyType' => 'url', 'value' => [ 'not-a-url', 'also-not-a-url' ] ] ],
+			[ 'Website' => [ 'type' => 'url', 'value' => [ 'not-a-url', 'also-not-a-url' ] ] ],
 			null
 		);
 

--- a/tests/phpunit/Application/Queries/GetPageSubjects/GetPageSubjectsQueryTest.php
+++ b/tests/phpunit/Application/Queries/GetPageSubjects/GetPageSubjectsQueryTest.php
@@ -87,7 +87,7 @@ class GetPageSubjectsQueryTest extends TestCase {
 						schemaName: 'TestSchema',
 						statements: [
 							'name' => [
-								'type' => 'text',
+								'propertyType' => 'text',
 								'value' => [ 'Berlin' ]
 							],
 						],

--- a/tests/phpunit/Application/Queries/GetSubject/GetSubjectQueryTest.php
+++ b/tests/phpunit/Application/Queries/GetSubject/GetSubjectQueryTest.php
@@ -76,15 +76,15 @@ class GetSubjectQueryTest extends TestCase {
 						schemaName: 'GetSubjectQueryTestSchema',
 						statements: [
 							'expected property 1' => [
-								'type' => 'text',
+								'propertyType' => 'text',
 								'value' => [ 'expected value 1' ]
 							],
 							'expected property 2' => [
-								'type' => 'number',
+								'propertyType' => 'number',
 								'value' => 2
 							],
 							'FriendOf' => [
-								'type' => 'relation',
+								'propertyType' => 'relation',
 								'value' => [
 									[
 										'id' => 'r11111111111129',

--- a/tests/phpunit/Application/SelectStatementResolverTest.php
+++ b/tests/phpunit/Application/SelectStatementResolverTest.php
@@ -45,7 +45,7 @@ class SelectStatementResolverTest extends TestCase {
 
 	public function testResolvesScalarIdValue(): void {
 		$patch = [
-			'Status' => [ 'propertyType' => 'select', 'value' => 'opt1' ],
+			'Status' => [ 'type' => 'select', 'value' => 'opt1' ],
 		];
 
 		$resolved = $this->newResolver()->resolve( $this->newSchemaWithSelect(), $patch );
@@ -55,7 +55,7 @@ class SelectStatementResolverTest extends TestCase {
 
 	public function testResolvesScalarLabelValue(): void {
 		$patch = [
-			'Status' => [ 'propertyType' => 'select', 'value' => 'Draft' ],
+			'Status' => [ 'type' => 'select', 'value' => 'Draft' ],
 		];
 
 		$resolved = $this->newResolver()->resolve( $this->newSchemaWithSelect(), $patch );
@@ -66,7 +66,7 @@ class SelectStatementResolverTest extends TestCase {
 	public function testResolvesIdLabelObjectValue(): void {
 		$patch = [
 			'Status' => [
-				'propertyType' => 'select',
+				'type' => 'select',
 				'value' => [ 'id' => 'opt2', 'label' => 'Approved' ],
 			],
 		];
@@ -79,7 +79,7 @@ class SelectStatementResolverTest extends TestCase {
 	public function testResolvesListOfIds(): void {
 		$patch = [
 			'Status' => [
-				'propertyType' => 'select',
+				'type' => 'select',
 				'value' => [ 'opt1', 'opt2' ],
 			],
 		];
@@ -92,7 +92,7 @@ class SelectStatementResolverTest extends TestCase {
 	public function testResolvesListOfMixedForms(): void {
 		$patch = [
 			'Status' => [
-				'propertyType' => 'select',
+				'type' => 'select',
 				'value' => [
 					'opt1',
 					'Approved',
@@ -108,7 +108,7 @@ class SelectStatementResolverTest extends TestCase {
 
 	public function testLeavesNonSelectPropertyUntouched(): void {
 		$patch = [
-			'Name' => [ 'propertyType' => 'text', 'value' => 'Some Name' ],
+			'Name' => [ 'type' => 'text', 'value' => 'Some Name' ],
 		];
 
 		$resolved = $this->newResolver()->resolve( $this->newSchemaWithSelect(), $patch );
@@ -128,7 +128,7 @@ class SelectStatementResolverTest extends TestCase {
 
 	public function testLeavesPatchUntouchedWhenSchemaDoesNotHaveProperty(): void {
 		$patch = [
-			'Unknown' => [ 'propertyType' => 'select', 'value' => 'something' ],
+			'Unknown' => [ 'type' => 'select', 'value' => 'something' ],
 		];
 
 		$resolved = $this->newResolver()->resolve( $this->newSchemaWithSelect(), $patch );
@@ -138,7 +138,7 @@ class SelectStatementResolverTest extends TestCase {
 
 	public function testResolveOrLeaveResolvesKnownLabelToId(): void {
 		$patch = [
-			'Status' => [ 'propertyType' => 'select', 'value' => [ 'Draft' ] ],
+			'Status' => [ 'type' => 'select', 'value' => [ 'Draft' ] ],
 		];
 
 		$resolved = $this->newResolver()->resolveOrLeave( $this->newSchemaWithSelect(), $patch );
@@ -148,7 +148,7 @@ class SelectStatementResolverTest extends TestCase {
 
 	public function testResolveOrLeaveLeavesUnknownValueInPlace(): void {
 		$patch = [
-			'Status' => [ 'propertyType' => 'select', 'value' => [ 'bogus-value' ] ],
+			'Status' => [ 'type' => 'select', 'value' => [ 'bogus-value' ] ],
 		];
 
 		$resolved = $this->newResolver()->resolveOrLeave( $this->newSchemaWithSelect(), $patch );
@@ -158,7 +158,7 @@ class SelectStatementResolverTest extends TestCase {
 
 	public function testResolveOrLeaveDoesNotThrowForUnknownValue(): void {
 		$patch = [
-			'Status' => [ 'propertyType' => 'select', 'value' => 'Nonexistent' ],
+			'Status' => [ 'type' => 'select', 'value' => 'Nonexistent' ],
 		];
 
 		$resolved = $this->newResolver()->resolveOrLeave( $this->newSchemaWithSelect(), $patch );
@@ -168,7 +168,7 @@ class SelectStatementResolverTest extends TestCase {
 
 	public function testThrowsOnUnknownValueForKnownSelectProperty(): void {
 		$patch = [
-			'Status' => [ 'propertyType' => 'select', 'value' => 'Nonexistent' ],
+			'Status' => [ 'type' => 'select', 'value' => 'Nonexistent' ],
 		];
 
 		$this->expectException( InvalidArgumentException::class );
@@ -178,7 +178,7 @@ class SelectStatementResolverTest extends TestCase {
 
 	public function testIncludesPropertyNameInErrorMessage(): void {
 		$patch = [
-			'Status' => [ 'propertyType' => 'select', 'value' => 'Nonexistent' ],
+			'Status' => [ 'type' => 'select', 'value' => 'Nonexistent' ],
 		];
 
 		$this->expectException( InvalidArgumentException::class );

--- a/tests/phpunit/Application/SelectStatementResolverTest.php
+++ b/tests/phpunit/Application/SelectStatementResolverTest.php
@@ -45,7 +45,7 @@ class SelectStatementResolverTest extends TestCase {
 
 	public function testResolvesScalarIdValue(): void {
 		$patch = [
-			'Status' => [ 'type' => 'select', 'value' => 'opt1' ],
+			'Status' => [ 'propertyType' => 'select', 'value' => 'opt1' ],
 		];
 
 		$resolved = $this->newResolver()->resolve( $this->newSchemaWithSelect(), $patch );
@@ -55,7 +55,7 @@ class SelectStatementResolverTest extends TestCase {
 
 	public function testResolvesScalarLabelValue(): void {
 		$patch = [
-			'Status' => [ 'type' => 'select', 'value' => 'Draft' ],
+			'Status' => [ 'propertyType' => 'select', 'value' => 'Draft' ],
 		];
 
 		$resolved = $this->newResolver()->resolve( $this->newSchemaWithSelect(), $patch );
@@ -66,7 +66,7 @@ class SelectStatementResolverTest extends TestCase {
 	public function testResolvesIdLabelObjectValue(): void {
 		$patch = [
 			'Status' => [
-				'type' => 'select',
+				'propertyType' => 'select',
 				'value' => [ 'id' => 'opt2', 'label' => 'Approved' ],
 			],
 		];
@@ -79,7 +79,7 @@ class SelectStatementResolverTest extends TestCase {
 	public function testResolvesListOfIds(): void {
 		$patch = [
 			'Status' => [
-				'type' => 'select',
+				'propertyType' => 'select',
 				'value' => [ 'opt1', 'opt2' ],
 			],
 		];
@@ -92,7 +92,7 @@ class SelectStatementResolverTest extends TestCase {
 	public function testResolvesListOfMixedForms(): void {
 		$patch = [
 			'Status' => [
-				'type' => 'select',
+				'propertyType' => 'select',
 				'value' => [
 					'opt1',
 					'Approved',
@@ -108,7 +108,7 @@ class SelectStatementResolverTest extends TestCase {
 
 	public function testLeavesNonSelectPropertyUntouched(): void {
 		$patch = [
-			'Name' => [ 'type' => 'text', 'value' => 'Some Name' ],
+			'Name' => [ 'propertyType' => 'text', 'value' => 'Some Name' ],
 		];
 
 		$resolved = $this->newResolver()->resolve( $this->newSchemaWithSelect(), $patch );
@@ -128,7 +128,7 @@ class SelectStatementResolverTest extends TestCase {
 
 	public function testLeavesPatchUntouchedWhenSchemaDoesNotHaveProperty(): void {
 		$patch = [
-			'Unknown' => [ 'type' => 'select', 'value' => 'something' ],
+			'Unknown' => [ 'propertyType' => 'select', 'value' => 'something' ],
 		];
 
 		$resolved = $this->newResolver()->resolve( $this->newSchemaWithSelect(), $patch );
@@ -138,7 +138,7 @@ class SelectStatementResolverTest extends TestCase {
 
 	public function testResolveOrLeaveResolvesKnownLabelToId(): void {
 		$patch = [
-			'Status' => [ 'type' => 'select', 'value' => [ 'Draft' ] ],
+			'Status' => [ 'propertyType' => 'select', 'value' => [ 'Draft' ] ],
 		];
 
 		$resolved = $this->newResolver()->resolveOrLeave( $this->newSchemaWithSelect(), $patch );
@@ -148,7 +148,7 @@ class SelectStatementResolverTest extends TestCase {
 
 	public function testResolveOrLeaveLeavesUnknownValueInPlace(): void {
 		$patch = [
-			'Status' => [ 'type' => 'select', 'value' => [ 'bogus-value' ] ],
+			'Status' => [ 'propertyType' => 'select', 'value' => [ 'bogus-value' ] ],
 		];
 
 		$resolved = $this->newResolver()->resolveOrLeave( $this->newSchemaWithSelect(), $patch );
@@ -158,7 +158,7 @@ class SelectStatementResolverTest extends TestCase {
 
 	public function testResolveOrLeaveDoesNotThrowForUnknownValue(): void {
 		$patch = [
-			'Status' => [ 'type' => 'select', 'value' => 'Nonexistent' ],
+			'Status' => [ 'propertyType' => 'select', 'value' => 'Nonexistent' ],
 		];
 
 		$resolved = $this->newResolver()->resolveOrLeave( $this->newSchemaWithSelect(), $patch );
@@ -168,7 +168,7 @@ class SelectStatementResolverTest extends TestCase {
 
 	public function testThrowsOnUnknownValueForKnownSelectProperty(): void {
 		$patch = [
-			'Status' => [ 'type' => 'select', 'value' => 'Nonexistent' ],
+			'Status' => [ 'propertyType' => 'select', 'value' => 'Nonexistent' ],
 		];
 
 		$this->expectException( InvalidArgumentException::class );
@@ -178,7 +178,7 @@ class SelectStatementResolverTest extends TestCase {
 
 	public function testIncludesPropertyNameInErrorMessage(): void {
 		$patch = [
-			'Status' => [ 'type' => 'select', 'value' => 'Nonexistent' ],
+			'Status' => [ 'propertyType' => 'select', 'value' => 'Nonexistent' ],
 		];
 
 		$this->expectException( InvalidArgumentException::class );

--- a/tests/phpunit/Application/StatementListBuilderTest.php
+++ b/tests/phpunit/Application/StatementListBuilderTest.php
@@ -31,7 +31,7 @@ class StatementListBuilderTest extends TestCase {
 
 	public function testSingleStatementIsBuilt(): void {
 		$list = $this->newBuilder()->build( [
-			'Founded at' => [ 'propertyType' => 'number', 'value' => 2019 ],
+			'Founded at' => [ 'type' => 'number', 'value' => 2019 ],
 		] );
 
 		$statement = $list->getStatement( new PropertyName( 'Founded at' ) );
@@ -42,8 +42,8 @@ class StatementListBuilderTest extends TestCase {
 
 	public function testMultipleStatementsAreBuilt(): void {
 		$list = $this->newBuilder()->build( [
-			'A' => [ 'propertyType' => 'text', 'value' => 'one' ],
-			'B' => [ 'propertyType' => 'number', 'value' => 2 ],
+			'A' => [ 'type' => 'text', 'value' => 'one' ],
+			'B' => [ 'type' => 'number', 'value' => 2 ],
 		] );
 
 		$this->assertNotNull( $list->getStatement( new PropertyName( 'A' ) ) );
@@ -52,7 +52,7 @@ class StatementListBuilderTest extends TestCase {
 
 	public function testUnregisteredTypePreservesRawValue(): void {
 		$list = $this->newBuilder()->build( [
-			'Swatch' => [ 'propertyType' => 'color', 'value' => [ '#ff5733' ] ],
+			'Swatch' => [ 'type' => 'color', 'value' => [ '#ff5733' ] ],
 		] );
 
 		$statement = $list->getStatement( new PropertyName( 'Swatch' ) );
@@ -64,7 +64,7 @@ class StatementListBuilderTest extends TestCase {
 
 	public function testUnregisteredTypeStatementIsNotDroppedAsEmpty(): void {
 		$list = $this->newBuilder()->build( [
-			'Swatch' => [ 'propertyType' => 'color', 'value' => [] ],
+			'Swatch' => [ 'type' => 'color', 'value' => [] ],
 		] );
 
 		$this->assertNotNull( $list->getStatement( new PropertyName( 'Swatch' ) ) );
@@ -72,7 +72,7 @@ class StatementListBuilderTest extends TestCase {
 
 	public function testNullValueIsDropped(): void {
 		$list = $this->newBuilder()->build( [
-			'Wanted' => [ 'propertyType' => 'text', 'value' => 'yes' ],
+			'Wanted' => [ 'type' => 'text', 'value' => 'yes' ],
 			'Unwanted' => null,
 		] );
 

--- a/tests/phpunit/Application/StatementListBuilderTest.php
+++ b/tests/phpunit/Application/StatementListBuilderTest.php
@@ -31,7 +31,7 @@ class StatementListBuilderTest extends TestCase {
 
 	public function testSingleStatementIsBuilt(): void {
 		$list = $this->newBuilder()->build( [
-			'Founded at' => [ 'type' => 'number', 'value' => 2019 ],
+			'Founded at' => [ 'propertyType' => 'number', 'value' => 2019 ],
 		] );
 
 		$statement = $list->getStatement( new PropertyName( 'Founded at' ) );
@@ -42,8 +42,8 @@ class StatementListBuilderTest extends TestCase {
 
 	public function testMultipleStatementsAreBuilt(): void {
 		$list = $this->newBuilder()->build( [
-			'A' => [ 'type' => 'text', 'value' => 'one' ],
-			'B' => [ 'type' => 'number', 'value' => 2 ],
+			'A' => [ 'propertyType' => 'text', 'value' => 'one' ],
+			'B' => [ 'propertyType' => 'number', 'value' => 2 ],
 		] );
 
 		$this->assertNotNull( $list->getStatement( new PropertyName( 'A' ) ) );
@@ -52,7 +52,7 @@ class StatementListBuilderTest extends TestCase {
 
 	public function testUnregisteredTypePreservesRawValue(): void {
 		$list = $this->newBuilder()->build( [
-			'Swatch' => [ 'type' => 'color', 'value' => [ '#ff5733' ] ],
+			'Swatch' => [ 'propertyType' => 'color', 'value' => [ '#ff5733' ] ],
 		] );
 
 		$statement = $list->getStatement( new PropertyName( 'Swatch' ) );
@@ -64,8 +64,8 @@ class StatementListBuilderTest extends TestCase {
 
 	public function testEmptyValueIsDropped(): void {
 		$list = $this->newBuilder()->build( [
-			'Kept' => [ 'type' => 'text', 'value' => [ 'yes' ] ],
-			'Dropped' => [ 'type' => 'text', 'value' => [] ],
+			'Kept' => [ 'propertyType' => 'text', 'value' => [ 'yes' ] ],
+			'Dropped' => [ 'propertyType' => 'text', 'value' => [] ],
 		] );
 
 		$this->assertNotNull( $list->getStatement( new PropertyName( 'Kept' ) ) );
@@ -74,7 +74,7 @@ class StatementListBuilderTest extends TestCase {
 
 	public function testUnregisteredTypeStatementIsNotDroppedAsEmpty(): void {
 		$list = $this->newBuilder()->build( [
-			'Swatch' => [ 'type' => 'color', 'value' => [] ],
+			'Swatch' => [ 'propertyType' => 'color', 'value' => [] ],
 		] );
 
 		$this->assertNotNull( $list->getStatement( new PropertyName( 'Swatch' ) ) );
@@ -82,7 +82,7 @@ class StatementListBuilderTest extends TestCase {
 
 	public function testNullValueIsDropped(): void {
 		$list = $this->newBuilder()->build( [
-			'Wanted' => [ 'type' => 'text', 'value' => 'yes' ],
+			'Wanted' => [ 'propertyType' => 'text', 'value' => 'yes' ],
 			'Unwanted' => null,
 		] );
 

--- a/tests/phpunit/Application/StatementListBuilderTest.php
+++ b/tests/phpunit/Application/StatementListBuilderTest.php
@@ -62,6 +62,16 @@ class StatementListBuilderTest extends TestCase {
 		$this->assertEquals( new UnregisteredTypeValue( 'color', [ '#ff5733' ] ), $statement->getValue() );
 	}
 
+	public function testEmptyValueIsDropped(): void {
+		$list = $this->newBuilder()->build( [
+			'Kept' => [ 'type' => 'text', 'value' => [ 'yes' ] ],
+			'Dropped' => [ 'type' => 'text', 'value' => [] ],
+		] );
+
+		$this->assertNotNull( $list->getStatement( new PropertyName( 'Kept' ) ) );
+		$this->assertNull( $list->getStatement( new PropertyName( 'Dropped' ) ) );
+	}
+
 	public function testUnregisteredTypeStatementIsNotDroppedAsEmpty(): void {
 		$list = $this->newBuilder()->build( [
 			'Swatch' => [ 'type' => 'color', 'value' => [] ],

--- a/tests/phpunit/Application/StatementListBuilderTest.php
+++ b/tests/phpunit/Application/StatementListBuilderTest.php
@@ -90,4 +90,18 @@ class StatementListBuilderTest extends TestCase {
 		$this->assertNull( $list->getStatement( new PropertyName( 'Unwanted' ) ) );
 	}
 
+	/**
+	 * The legacy `type` key is tolerated when reading stored revisions, never on API input:
+	 * accepting both here would restore the ambiguity the rename removed.
+	 */
+	public function testLegacyTypeKeyIsNotAcceptedAsPropertyType(): void {
+		$list = $this->newBuilder()->build( [
+			'Wanted' => [ 'propertyType' => 'text', 'value' => 'yes' ],
+			'Unwanted' => [ 'type' => 'text', 'value' => 'yes' ],
+		] );
+
+		$this->assertNotNull( $list->getStatement( new PropertyName( 'Wanted' ) ) );
+		$this->assertNull( $list->getStatement( new PropertyName( 'Unwanted' ) ) );
+	}
+
 }

--- a/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
@@ -103,11 +103,11 @@ class CreateSubjectApiTest extends NeoWikiIntegrationTestCase {
 			'schema' => 'Employee',
 			'statements' => [
 				'animal' => [
-					'propertyType' => 'text',
+					'type' => 'text',
 					'value' => 'bunny'
 				],
 				'fluff' => [
-					'propertyType' => 'number',
+					'type' => 'number',
 					'value' => 9001
 				],
 			]
@@ -419,7 +419,7 @@ class CreateSubjectApiTest extends NeoWikiIntegrationTestCase {
 			'id' => $idB,
 			'statements' => [
 				'Has colleague' => [
-					'propertyType' => 'relation',
+					'type' => 'relation',
 					'value' => [ [ 'target' => $idA ] ],
 				],
 			],

--- a/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
@@ -103,11 +103,11 @@ class CreateSubjectApiTest extends NeoWikiIntegrationTestCase {
 			'schema' => 'Employee',
 			'statements' => [
 				'animal' => [
-					'type' => 'text',
+					'propertyType' => 'text',
 					'value' => 'bunny'
 				],
 				'fluff' => [
-					'type' => 'number',
+					'propertyType' => 'number',
 					'value' => 9001
 				],
 			]
@@ -419,7 +419,7 @@ class CreateSubjectApiTest extends NeoWikiIntegrationTestCase {
 			'id' => $idB,
 			'statements' => [
 				'Has colleague' => [
-					'type' => 'relation',
+					'propertyType' => 'relation',
 					'value' => [ [ 'target' => $idA ] ],
 				],
 			],

--- a/tests/phpunit/EntryPoints/REST/GetPageSubjectsApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/GetPageSubjectsApiTest.php
@@ -82,7 +82,7 @@ JSON
 		$this->assertSame( 'Berlin', $body['subjects']['sTestGPS1111111']['label'] );
 		$this->assertSame( 'GetPageSubjectsApiTestSchema', $body['subjects']['sTestGPS1111111']['schema'] );
 		$this->assertSame(
-			[ 'type' => 'text', 'value' => [ '3700000' ] ],
+			[ 'propertyType' => 'text', 'value' => [ '3700000' ] ],
 			$body['subjects']['sTestGPS1111111']['statements']['population']
 		);
 		$this->assertSame( 'Population 2024', $body['subjects']['sTestGPS1111112']['label'] );

--- a/tests/phpunit/EntryPoints/REST/GetSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/GetSubjectApiTest.php
@@ -216,7 +216,7 @@ JSON,
             "pageNamespaceId": 0,
             "statements": {
                 "MyRelation": {
-                	"type": "relation",
+                	"propertyType": "relation",
                 	"value": [
 						{
 							"id": "rTestGSA1111rr1",
@@ -248,7 +248,7 @@ JSON,
             "pageNamespaceId": 0,
             "statements": {
                 "MyRelation": {
-                "type": "relation",
+                "propertyType": "relation",
 				"value": [
 						{
 							"id": "rTestGSA1111rr3",

--- a/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
@@ -92,18 +92,19 @@ class ReplaceSubjectApiTest extends NeoWikiIntegrationTestCase {
 		$this->createPages();
 
 		$sent = $this->validBody();
-		$sent['statements'] = [
-			'Founded at' => [ 'propertyType' => 'number', 'value' => 2019 ],
-			'Website' => [ 'propertyType' => 'url', 'value' => [ 'https://example.com' ] ],
-		];
+		$sent['statements'] = $this->twoStatements();
 		$this->executeHandler( $this->newReplaceSubjectApi(), $this->createRequestData( $sent ) );
 
 		$read = $this->readStatementsFromApi( 'sTestSA11111111' );
 
 		$echoed = $this->validBody();
+		$echoed['label'] = 'Echoed back';
 		$echoed['statements'] = $read;
 		$this->executeHandler( $this->newReplaceSubjectApi(), $this->createRequestData( $echoed ) );
 
+		// The label proves the echoed request was applied: without it, a rejected write leaves the
+		// Subject untouched and every statement assertion below passes for the wrong reason.
+		$this->assertSame( 'Echoed back', $this->getSubjectFromRepository( 'sTestSA11111111' )->label->text );
 		$this->assertSame( $read, $this->readStatementsFromApi( 'sTestSA11111111' ) );
 		$this->assertSame( [ 'Founded at', 'Website' ], array_keys( $read ) );
 	}
@@ -120,14 +121,18 @@ class ReplaceSubjectApiTest extends NeoWikiIntegrationTestCase {
 		return json_decode( $response->getBody()->getContents(), true )['subjects'][$subjectId]['statements'];
 	}
 
+	private function twoStatements(): array {
+		return [
+			'Founded at' => [ 'propertyType' => 'number', 'value' => 2019 ],
+			'Website' => [ 'propertyType' => 'url', 'value' => [ 'https://example.com' ] ],
+		];
+	}
+
 	public function testOmittedStatementKeyIsDeleted(): void {
 		$this->createPages();
 
 		$bodyWithTwoStatements = $this->validBody();
-		$bodyWithTwoStatements['statements'] = [
-			'Founded at' => [ 'propertyType' => 'number', 'value' => 2019 ],
-			'Website' => [ 'propertyType' => 'url', 'value' => [ 'https://example.com' ] ],
-		];
+		$bodyWithTwoStatements['statements'] = $this->twoStatements();
 		$this->executeHandler(
 			$this->newReplaceSubjectApi(),
 			$this->createRequestData( $bodyWithTwoStatements )

--- a/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
@@ -12,6 +12,7 @@ use MediaWiki\Title\Title;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
+use ProfessionalWiki\NeoWiki\EntryPoints\REST\GetSubjectApi;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\ReplaceSubjectApi;
 use ProfessionalWiki\NeoWiki\Presentation\CsrfValidator;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestStatement;
@@ -81,6 +82,42 @@ class ReplaceSubjectApiTest extends NeoWikiIntegrationTestCase {
 		$this->assertNotEmpty( $responseData['violations'] );
 		$this->assertSame( 'required', $responseData['violations'][0]['code'] );
 		$this->assertSame( 'Status', $responseData['violations'][0]['propertyName'] );
+	}
+
+	/**
+	 * The read and write endpoints must key Statements the same way, so a Subject fetched from the API
+	 * can be sent back unchanged. When they diverged, the write silently stored nothing.
+	 */
+	public function testStatementsReadFromTheApiAreAcceptedVerbatim(): void {
+		$this->createPages();
+
+		$sent = $this->validBody();
+		$sent['statements'] = [
+			'Founded at' => [ 'type' => 'number', 'value' => 2019 ],
+			'Website' => [ 'type' => 'url', 'value' => [ 'https://example.com' ] ],
+		];
+		$this->executeHandler( $this->newReplaceSubjectApi(), $this->createRequestData( $sent ) );
+
+		$read = $this->readStatementsFromApi( 'sTestSA11111111' );
+
+		$echoed = $this->validBody();
+		$echoed['statements'] = $read;
+		$this->executeHandler( $this->newReplaceSubjectApi(), $this->createRequestData( $echoed ) );
+
+		$this->assertSame( $read, $this->readStatementsFromApi( 'sTestSA11111111' ) );
+		$this->assertSame( [ 'Founded at', 'Website' ], array_keys( $read ) );
+	}
+
+	private function readStatementsFromApi( string $subjectId ): array {
+		$response = $this->executeHandler(
+			new GetSubjectApi(),
+			new RequestData( [
+				'method' => 'GET',
+				'pathParams' => [ 'subjectId' => $subjectId ],
+			] )
+		);
+
+		return json_decode( $response->getBody()->getContents(), true )['subjects'][$subjectId]['statements'];
 	}
 
 	public function testOmittedStatementKeyIsDeleted(): void {

--- a/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
@@ -93,8 +93,8 @@ class ReplaceSubjectApiTest extends NeoWikiIntegrationTestCase {
 
 		$sent = $this->validBody();
 		$sent['statements'] = [
-			'Founded at' => [ 'type' => 'number', 'value' => 2019 ],
-			'Website' => [ 'type' => 'url', 'value' => [ 'https://example.com' ] ],
+			'Founded at' => [ 'propertyType' => 'number', 'value' => 2019 ],
+			'Website' => [ 'propertyType' => 'url', 'value' => [ 'https://example.com' ] ],
 		];
 		$this->executeHandler( $this->newReplaceSubjectApi(), $this->createRequestData( $sent ) );
 
@@ -125,8 +125,8 @@ class ReplaceSubjectApiTest extends NeoWikiIntegrationTestCase {
 
 		$bodyWithTwoStatements = $this->validBody();
 		$bodyWithTwoStatements['statements'] = [
-			'Founded at' => [ 'type' => 'number', 'value' => 2019 ],
-			'Website' => [ 'type' => 'url', 'value' => [ 'https://example.com' ] ],
+			'Founded at' => [ 'propertyType' => 'number', 'value' => 2019 ],
+			'Website' => [ 'propertyType' => 'url', 'value' => [ 'https://example.com' ] ],
 		];
 		$this->executeHandler(
 			$this->newReplaceSubjectApi(),
@@ -135,7 +135,7 @@ class ReplaceSubjectApiTest extends NeoWikiIntegrationTestCase {
 
 		$bodyOmittingOne = $this->validBody();
 		$bodyOmittingOne['statements'] = [
-			'Founded at' => [ 'type' => 'number', 'value' => 2019 ],
+			'Founded at' => [ 'propertyType' => 'number', 'value' => 2019 ],
 		];
 		$this->executeHandler(
 			$this->newReplaceSubjectApi(),
@@ -422,7 +422,7 @@ class ReplaceSubjectApiTest extends NeoWikiIntegrationTestCase {
 			'label' => 'Test subject sTestSA11111111',
 			'statements' => [
 				'Founded at' => [
-					'type' => 'number',
+					'propertyType' => 'number',
 					'value' => 2019,
 				],
 			],

--- a/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
@@ -88,8 +88,8 @@ class ReplaceSubjectApiTest extends NeoWikiIntegrationTestCase {
 
 		$bodyWithTwoStatements = $this->validBody();
 		$bodyWithTwoStatements['statements'] = [
-			'Founded at' => [ 'propertyType' => 'number', 'value' => 2019 ],
-			'Website' => [ 'propertyType' => 'url', 'value' => [ 'https://example.com' ] ],
+			'Founded at' => [ 'type' => 'number', 'value' => 2019 ],
+			'Website' => [ 'type' => 'url', 'value' => [ 'https://example.com' ] ],
 		];
 		$this->executeHandler(
 			$this->newReplaceSubjectApi(),
@@ -98,7 +98,7 @@ class ReplaceSubjectApiTest extends NeoWikiIntegrationTestCase {
 
 		$bodyOmittingOne = $this->validBody();
 		$bodyOmittingOne['statements'] = [
-			'Founded at' => [ 'propertyType' => 'number', 'value' => 2019 ],
+			'Founded at' => [ 'type' => 'number', 'value' => 2019 ],
 		];
 		$this->executeHandler(
 			$this->newReplaceSubjectApi(),
@@ -385,7 +385,7 @@ class ReplaceSubjectApiTest extends NeoWikiIntegrationTestCase {
 			'label' => 'Test subject sTestSA11111111',
 			'statements' => [
 				'Founded at' => [
-					'propertyType' => 'number',
+					'type' => 'number',
 					'value' => 2019,
 				],
 			],

--- a/tests/phpunit/EntryPoints/REST/ValidateSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ValidateSubjectApiTest.php
@@ -109,7 +109,7 @@ class ValidateSubjectApiTest extends NeoWikiIntegrationTestCase {
 
 		$body = $this->validBody();
 		$body['statements'] = [
-			'Status' => [ 'propertyType' => 'select', 'value' => [ 'bogus-id' ] ],
+			'Status' => [ 'type' => 'select', 'value' => [ 'bogus-id' ] ],
 		];
 
 		$response = $this->executeHandler(
@@ -128,7 +128,7 @@ class ValidateSubjectApiTest extends NeoWikiIntegrationTestCase {
 
 		$body = $this->validBody();
 		$body['statements'] = [
-			'Status' => [ 'propertyType' => 'select', 'value' => [ 'Active' ] ],
+			'Status' => [ 'type' => 'select', 'value' => [ 'Active' ] ],
 		];
 
 		$response = $this->executeHandler(

--- a/tests/phpunit/EntryPoints/REST/ValidateSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ValidateSubjectApiTest.php
@@ -109,7 +109,7 @@ class ValidateSubjectApiTest extends NeoWikiIntegrationTestCase {
 
 		$body = $this->validBody();
 		$body['statements'] = [
-			'Status' => [ 'type' => 'select', 'value' => [ 'bogus-id' ] ],
+			'Status' => [ 'propertyType' => 'select', 'value' => [ 'bogus-id' ] ],
 		];
 
 		$response = $this->executeHandler(
@@ -128,7 +128,7 @@ class ValidateSubjectApiTest extends NeoWikiIntegrationTestCase {
 
 		$body = $this->validBody();
 		$body['statements'] = [
-			'Status' => [ 'type' => 'select', 'value' => [ 'Active' ] ],
+			'Status' => [ 'propertyType' => 'select', 'value' => [ 'Active' ] ],
 		];
 
 		$response = $this->executeHandler(

--- a/tests/phpunit/EntryPoints/REST/ValidateSubjectUpdateApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ValidateSubjectUpdateApiTest.php
@@ -73,7 +73,7 @@ class ValidateSubjectUpdateApiTest extends NeoWikiIntegrationTestCase {
 
 		$body = $this->validBody();
 		$body['statements'] = [
-			'Founded at' => [ 'propertyType' => 'number', 'value' => 2025 ],
+			'Founded at' => [ 'type' => 'number', 'value' => 2025 ],
 		];
 
 		$response = $this->executeHandler(

--- a/tests/phpunit/EntryPoints/REST/ValidateSubjectUpdateApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ValidateSubjectUpdateApiTest.php
@@ -73,7 +73,7 @@ class ValidateSubjectUpdateApiTest extends NeoWikiIntegrationTestCase {
 
 		$body = $this->validBody();
 		$body['statements'] = [
-			'Founded at' => [ 'type' => 'number', 'value' => 2025 ],
+			'Founded at' => [ 'propertyType' => 'number', 'value' => 2025 ],
 		];
 
 		$response = $this->executeHandler(

--- a/tests/phpunit/EntryPoints/Scribunto/NeoWikiLibraryTests.lua
+++ b/tests/phpunit/EntryPoints/Scribunto/NeoWikiLibraryTests.lua
@@ -59,7 +59,7 @@ end
 local function testGetMainSubjectStatements()
 	local s = nw.getMainSubject( page )
 	if not s then return 'nil' end
-	return s.statements['City'].type, s.statements['City'].values[1]
+	return s.statements['City'].propertyType, s.statements['City'].values[1]
 end
 
 local function testGetMainSubjectNonexistentPage()

--- a/tests/phpunit/EntryPoints/Scribunto/SubjectDataLookupTest.php
+++ b/tests/phpunit/EntryPoints/Scribunto/SubjectDataLookupTest.php
@@ -436,9 +436,9 @@ class SubjectDataLookupTest extends TestCase {
 		$this->assertSame( self::SUBJECT_ID, $result[0]['id'] );
 		$this->assertSame( 'Test Subject', $result[0]['label'] );
 		$this->assertSame( 'TestSchema', $result[0]['schema'] );
-		$this->assertSame( 'text', $result[0]['statements']['City']['type'] );
+		$this->assertSame( 'text', $result[0]['statements']['City']['propertyType'] );
 		$this->assertSame( [ 1 => 'Berlin' ], $result[0]['statements']['City']['values'] );
-		$this->assertSame( 'number', $result[0]['statements']['Population']['type'] );
+		$this->assertSame( 'number', $result[0]['statements']['Population']['propertyType'] );
 		$this->assertSame( [ 1 => 3645000 ], $result[0]['statements']['Population']['values'] );
 	}
 
@@ -523,7 +523,7 @@ class SubjectDataLookupTest extends TestCase {
 
 		$result = $lookup->getSubjectData( self::SUBJECT_ID );
 
-		$this->assertSame( 'relation', $result[0]['statements']['CEO']['type'] );
+		$this->assertSame( 'relation', $result[0]['statements']['CEO']['propertyType'] );
 		$this->assertSame( 'r1test5cccccccc', $result[0]['statements']['CEO']['values'][1]['id'] );
 		$this->assertSame( self::TARGET_SUBJECT_ID, $result[0]['statements']['CEO']['values'][1]['target'] );
 		$this->assertSame( 'Jane Doe', $result[0]['statements']['CEO']['values'][1]['label'] );
@@ -588,7 +588,7 @@ class SubjectDataLookupTest extends TestCase {
 
 		$result = $lookup->getMainSubjectData( $this->createTitle() );
 
-		$this->assertSame( 'boolean', $result[0]['statements']['Active']['type'] );
+		$this->assertSame( 'boolean', $result[0]['statements']['Active']['propertyType'] );
 		$this->assertSame( [ 1 => true ], $result[0]['statements']['Active']['values'] );
 	}
 

--- a/tests/phpunit/Persistence/MediaWiki/Subject/StatementDeserializerTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/Subject/StatementDeserializerTest.php
@@ -41,6 +41,23 @@ class StatementDeserializerTest extends TestCase {
 		);
 	}
 
+	public function testDeserializesRevisionUsingTheLegacyTypeKey(): void {
+		$this->assertEquals(
+			new Statement(
+				property: new PropertyName( 'MyNumber' ),
+				propertyType: 'number',
+				value: new NumberValue( 42 )
+			),
+			$this->newDeserializer()->deserialize(
+				'MyNumber',
+				[
+					'type' => 'number',
+					'value' => 42,
+				]
+			)
+		);
+	}
+
 	/**
 	 * Core types only: no extension is loaded, so "color" is an unregistered type.
 	 */
@@ -128,23 +145,6 @@ class StatementDeserializerTest extends TestCase {
 		$statement = $this->newDeserializer()->deserialize( 'Swatch', [ 'propertyType' => 'color', 'value' => $value ] );
 
 		$this->assertSame( $value, $statement->getValue()->toScalars() );
-	}
-
-	public function testDeserializesRevisionUsingTheLegacyTypeKey(): void {
-		$this->assertEquals(
-			new Statement(
-				property: new PropertyName( 'MyNumber' ),
-				propertyType: 'number',
-				value: new NumberValue( 42 )
-			),
-			$this->newDeserializer()->deserialize(
-				'MyNumber',
-				[
-					'type' => 'number',
-					'value' => 42,
-				]
-			)
-		);
 	}
 
 }

--- a/tests/phpunit/Persistence/MediaWiki/Subject/StatementDeserializerTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/Subject/StatementDeserializerTest.php
@@ -34,7 +34,7 @@ class StatementDeserializerTest extends TestCase {
 			$this->newDeserializer()->deserialize(
 				'MyNumber',
 				[
-					'type' => 'number',
+					'propertyType' => 'number',
 					'value' => 42,
 				]
 			)
@@ -58,7 +58,7 @@ class StatementDeserializerTest extends TestCase {
 			$this->newDeserializer()->deserialize(
 				'MyText',
 				[
-					'type' => 'text',
+					'propertyType' => 'text',
 					'value' => [ 'Foo', 'Bar', 'Baz' ],
 				]
 			)
@@ -86,7 +86,7 @@ class StatementDeserializerTest extends TestCase {
 			$this->newDeserializer()->deserialize(
 				'MyRelation',
 				[
-					'type' => 'relation',
+					'propertyType' => 'relation',
 					'value' => [
 						[
 							'id' => 'rTestSDT1111rr1',
@@ -115,7 +115,7 @@ class StatementDeserializerTest extends TestCase {
 			$this->newDeserializer()->deserialize(
 				'Swatch',
 				[
-					'type' => 'color',
+					'propertyType' => 'color',
 					'value' => [ '#ff5733' ],
 				]
 			)
@@ -125,9 +125,26 @@ class StatementDeserializerTest extends TestCase {
 	public function testUnregisteredTypeValueReserializesToTheOriginalJson(): void {
 		$value = [ 'nested' => [ 'a', 1, true ], 'other' => null ];
 
-		$statement = $this->newDeserializer()->deserialize( 'Swatch', [ 'type' => 'color', 'value' => $value ] );
+		$statement = $this->newDeserializer()->deserialize( 'Swatch', [ 'propertyType' => 'color', 'value' => $value ] );
 
 		$this->assertSame( $value, $statement->getValue()->toScalars() );
+	}
+
+	public function testDeserializesRevisionUsingTheLegacyTypeKey(): void {
+		$this->assertEquals(
+			new Statement(
+				property: new PropertyName( 'MyNumber' ),
+				propertyType: 'number',
+				value: new NumberValue( 42 )
+			),
+			$this->newDeserializer()->deserialize(
+				'MyNumber',
+				[
+					'type' => 'number',
+					'value' => 42,
+				]
+			)
+		);
 	}
 
 }

--- a/tests/phpunit/Persistence/MediaWiki/Subject/SubjectContentDataDeserializerTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/Subject/SubjectContentDataDeserializerTest.php
@@ -121,7 +121,7 @@ JSON
 			"schema": "Company",
 			"statements": {
 				"Products": {
-					"type": "relation",
+					"propertyType": "relation",
 					"value": [
 						{
 							"id": "rTestSCDDrrrrr1",

--- a/tests/phpunit/Persistence/MediaWiki/Subject/SubjectContentDataSerializerTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/Subject/SubjectContentDataSerializerTest.php
@@ -78,13 +78,13 @@ class SubjectContentDataSerializerTest extends TestCase {
             "schema": "Employee",
             "statements": {
                 "founded": {
-                    "type": "text",
+                    "propertyType": "text",
                     "value": [
                         "2019-01-01"
                     ]
                 },
                 "founder": {
-                    "type": "string",
+                    "propertyType": "string",
                     "value": [
                         "John Doe"
                     ]
@@ -101,7 +101,7 @@ class SubjectContentDataSerializerTest extends TestCase {
             "schema": "TestSubjectSchemaId",
             "statements": {
                 "Has skill": {
-                    "type": "relation",
+                    "propertyType": "relation",
                     "value": [
                         {
                             "id": "rTestSCDST11rr2",
@@ -114,7 +114,7 @@ class SubjectContentDataSerializerTest extends TestCase {
                     ]
                 },
                 "Likes": {
-                    "type": "relation",
+                    "propertyType": "relation",
                     "value": [
                         {
                             "id": "rTestSCDST11rr5",
@@ -201,13 +201,13 @@ class SubjectContentDataSerializerTest extends TestCase {
 			            "schema": "TestSchema",
 			            "statements": {
 			                "Swatch": {
-			                    "type": "color",
+			                    "propertyType": "color",
 			                    "value": [
 			                        "#ff5733"
 			                    ]
 			                },
 			                "Name": {
-			                    "type": "text",
+			                    "propertyType": "text",
 			                    "value": [
 			                        "John Doe"
 			                    ]


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/1168

The Subject REST endpoints disagreed with themselves: writes read a statement's property type from `propertyType`,
while the stored slot JSON and every read emitted `type`. Both shapes were documented, but a body taken from
`GET /page/{id}/subjects` could not be sent back — the statements were dropped, the response was still
`201 {"status":"created"}`, and the only symptom was a `required` violation that reads as a Schema problem.

Reads and writes now use one shape, so Subjects round-trip. That is the pattern import and migration clients are
built on, and it is what the asymmetry cost.

`propertyType` is the name on every surface. A bare `type` takes its meaning from the object holding it: inside a
Schema's Property Definition it is right, because the object *is* the property. Inside a Statement it is not — a
Statement has no type of its own, and the sibling value does, so `type` invites exactly the wrong reading. The
domain model has always used `propertyName` and `propertyType` for this reason, and the glossary already documented
the field as `propertyType`; the serializer was dropping the qualifier on the way out.

- Stored slot JSON, REST reads, REST write input, and `statementsToJson()` in the frontend all use `propertyType`.
- The Lua accessor's statement table uses `propertyType` too, so the term is not split across surfaces. Its `values`
  key is unchanged, and the shipped `Module:NeoWikiDemo` is updated with it.
- `StatementDeserializer` accepts `propertyType` and falls back to `type`. Revisions written before the rename still
  hold the old key and revision content cannot be migrated, so without this, history pages and diffs of older
  revisions would lose their statements (#952). Writes only ever emit `propertyType`.
- A Property Definition's `type` is unchanged, in JSON and in Lua alike — there the container is the property.
- DemoData Subject fixtures are regenerated onto the new key.

Compatibility, in rough order of who notices:

- **Lua modules reading `.type` off a statement break on parse.** This is the only part that breaks *wiki content*
  rather than a client, and there is no shim: Lua output is computed fresh each parse, so nothing is unmigratable.
  The stale seeded demo module reproduced it precisely — `attempt to concatenate field 'type' (a nil value)` — until
  it was updated.
- **Consumers reading statements from the REST API** see the key change, including anything built on
  `GET /subject/{id}` or `GET /page/{id}/subjects`.
- **Clients writing** with `propertyType`, the long-documented write shape, are unaffected.

There is no production data, so nothing needs migrating beyond the above.

## Tests

`ReplaceSubjectApiTest::testStatementsReadFromTheApiAreAcceptedVerbatim` feeds `GetSubjectApi`'s response straight
into `ReplaceSubjectApi` and asserts the write landed, so it fails if either end's key drifts again.
`StatementDeserializerTest` covers a legacy `type` payload, and `StatementListBuilderTest` pins that write input
rejects it. `NeoWikiLibraryTests.lua` exercises the Lua shape through Scribunto.
`StatementListBuilderTest::testEmptyValueIsDropped` closes a gap found on the way: removing the documented
empty-value drop had left every test passing.

Verified live on a dev wiki beyond CI: the REST round-trip of a verbatim `GET` body through `PUT` and `POST`
including relation and select values; create, edit and clear in the Subject editor; a genuinely pre-rename revision
imported with a `type` slot still rendering its statements; and the Lua table reporting `propertyType` with values
intact.

## Deferred

A malformed entry is still dropped rather than reported; saying so needs a validation code rather than a throw. Split
out as https://github.com/ProfessionalWiki/NeoWiki/issues/1170, which now also records the sharpest case — a client
still sending `type` on write gets `200` and silently loses every statement — plus a pre-existing sibling symptom
where a value of the wrong type for its declared type answers `500`.

Considered, omitted: renaming the "Writing Subjects" heading to "Replacing Subjects", now that it is the superset
holding the only body example.

> <sub>AI-authored — Claude Code, `Opus 5 (max)`; implemented from specs written by an orchestrating Claude session on @JeroenDeDauw's instruction, whose first naming choice he overruled mid-PR and who then extended the rename to Lua; diff not yet human-reviewed; PHPUnit, vitest, phpcs/phpstan and ts-lint/ts-build green in CI, plus the live checks listed above.</sub>

<details><summary>Production notes</summary>

The commit history renames in two directions on purpose. The first commits resolved the read/write split onto `type`,
on the argument that a Schema's Property Definition already uses that key for the same concept. Jeroen overruled it:
a bare field name is read in the scope of its container, and a Statement's container makes `type` mean the wrong
thing. The later commits rename to `propertyType` across storage, reads, writes and the frontend, add the legacy-key
read fallback that keeping storage on `type` had not required, and finally extend the rename to Lua, which the
earlier passes had missed.

</details>
