### PR TITLE
Point the demo wiki's documentation links at the docs site

### DIFF
--- a/DemoData/Page/Developers.wikitext
+++ b/DemoData/Page/Developers.wikitext
@@ -89,7 +89,7 @@ Oldest museums in this demo:
 
 {{#invoke:LuaExample|oldestMuseums}}
 
-For the full library reference, see the [https://github.com/ProfessionalWiki/NeoWiki/blob/master/docs/authoring/lua-api.md Lua API documentation].
+For the full library reference, see the [https://neowiki.ai/docs/authoring/lua-api Lua API documentation].
 
 == Reactive UI ==
 

--- a/DemoData/Page/Main_Page.wikitext
+++ b/DemoData/Page/Main_Page.wikitext
@@ -44,7 +44,7 @@ card1_title=Museum collection
 
 * [[Developers|Developers hub]]: Cypher, parser functions, the mw.neowiki Lua library, and the REST API, each with source shown alongside the rendered result.
 * [https://github.com/ProfessionalWiki/NeoWiki Source on GitHub]
-* [https://github.com/ProfessionalWiki/NeoWiki/tree/master/docs Technical documentation]
+* [https://neowiki.ai/docs/ Technical documentation]
 * [https://github.com/ProfessionalWiki/NeoWiki/issues Issue tracker]
 
 == About this wiki ==


### PR DESCRIPTION
Two links on the demo wiki sent visitors to raw Markdown in the repository instead of the published documentation:

- The Developers hub's Lua API reference, pointing at `docs/authoring/lua-api.md`.
- "Technical documentation" on the main page, which landed on a GitHub directory listing of `docs/`.

Both now point at neowiki.ai, matching what the RDF and EDM demo pages already do.

The demo data's other GitHub links stay: the repository root, the issue tracker, a discussion thread, and
`SettingsTemplate.php`. None has a counterpart on the docs site.

The `SPARQL queries` page has three more of these, fixed in #1172.

Verified both replacements return 200 and render as expected on a dev wiki.

> <sub>AI-authored — Claude Code, `Opus 5 (max)`; one-line ask from @JeroenDeDauw to find demo-data links that should point at the docs site, following #1172; diff not yet human-reviewed; every GitHub link in `DemoData/` reviewed, the two replacements fetched, and both pages rendered on a dev wiki.</sub>