### PR TITLE
Require an explicit pick in the schema selector

### DIFF
--- a/resources/ext.neowiki/src/components/common/SchemaPicker.vue
+++ b/resources/ext.neowiki/src/components/common/SchemaPicker.vue
@@ -1,8 +1,10 @@
 <template>
 	<div class="ext-neowiki-schema-picker">
-		<CdxCombobox
-			ref="comboboxRef"
-			v-model:selected="selectedSchema"
+		<CdxLookup
+			v-if="schemasLoaded"
+			ref="lookupRef"
+			v-model:selected="pickedSchema"
+			v-model:input-value="inputText"
 			:menu-items="menuItems"
 			:placeholder="$i18n( 'neowiki-schema-picker-placeholder' ).text()"
 			@input="filterSchemas"
@@ -13,10 +15,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue';
-import { CdxCombobox } from '@wikimedia/codex';
+import { computed, nextTick, ref, watch } from 'vue';
+import { CdxLookup } from '@wikimedia/codex';
 import type { MenuItemData } from '@wikimedia/codex';
-import { normalizeSchemaName, useSchemaStore } from '@/stores/SchemaStore.ts';
+import { useSchemaStore } from '@/stores/SchemaStore.ts';
 import type { SchemaSummary } from '@/application/SchemaLookup.ts';
 
 const props = defineProps<{
@@ -29,10 +31,12 @@ const emit = defineEmits<{
 }>();
 
 const schemaStore = useSchemaStore();
-const selectedSchema = ref<string>( props.selected ?? '' );
+const pickedSchema = ref<string | null>( props.selected ?? null );
+const inputText = ref<string | number>( props.selected ?? '' );
 const summaries = ref<SchemaSummary[]>( [] );
+const schemasLoaded = ref( false );
 const query = ref<string>( '' );
-const comboboxRef = ref<InstanceType<typeof CdxCombobox> | null>( null );
+const lookupRef = ref<InstanceType<typeof CdxLookup> | null>( null );
 
 const menuItems = computed<MenuItemData[]>( () => {
 	const matches = query.value === '' ?
@@ -45,53 +49,64 @@ const menuItems = computed<MenuItemData[]>( () => {
 	} ) );
 } );
 
-onMounted( async () => {
+// CdxLookup decides whether focus opens the menu from the menu items it was created
+// with, so the field is only rendered once the schemas are in. A picker whose schemas
+// failed to load still renders, so the field is never missing.
+async function loadSchemas(): Promise<void> {
 	try {
 		summaries.value = await schemaStore.getAllSchemaSummaries();
 	} catch ( error ) {
 		console.error( 'Failed to load schemas for the picker:', error );
 	}
-} );
+	schemasLoaded.value = true;
+}
+
+const schemasReady = loadSchemas();
 
 watch( () => props.selected, ( value ) => {
-	selectedSchema.value = value ?? '';
+	pickedSchema.value = selectableSchema( value ?? null );
+	inputText.value = value ?? '';
 } );
 
-function findSchema( name: string ): SchemaSummary | undefined {
-	const normalized = normalizeSchemaName( name );
-	return summaries.value.find( ( summary ) => summary.name === normalized );
+// CdxLookup takes the field's text for a selection from the matching menu entry and
+// empties the field when there is none, so it is only handed a schema it lists. The
+// field keeps showing the committed name either way.
+function selectableSchema( schemaName: string | null ): string | null {
+	return summaries.value.some( ( summary ) => summary.name === schemaName ) ? schemaName : null;
 }
 
-function filterSchemas( event: Event ): void {
-	query.value = ( event.target as HTMLInputElement ).value.trim().toLowerCase();
+function filterSchemas( value: string ): void {
+	query.value = value.trim().toLowerCase();
 }
 
-// CdxCombobox's `selected` tracks the typed text, not only menu picks, so only
-// commit it when it resolves to an exact existing schema. The name is matched the
-// way a save would normalise it (case-insensitive first letter, collapsed
-// whitespace), and the schema's canonical name is emitted rather than the raw input.
-// Resetting the filter on commit restores the full menu, so reopening the picker
-// without leaving the field browses every schema again rather than the stale filter.
-function onSelect( value: string ): void {
-	const schema = findSchema( value );
-	if ( schema && schema.name !== props.selected ) {
-		emit( 'select', schema.name );
-		query.value = '';
+// CdxLookup reports a selection only for a menu entry the user picks, and null while
+// they type, so a schema name typed out in full is not picked by itself. Resetting the
+// filter restores the full menu, so reopening the picker without leaving the field
+// browses every schema again rather than the last filter.
+function onSelect( schemaName: string | null ): void {
+	if ( schemaName === null ) {
+		return;
 	}
+
+	inputText.value = schemaName;
+	query.value = '';
+	emit( 'select', schemaName );
 }
 
-// On blur, snap `selected` back to the committed schema (empty for a target schema
-// that has not been set yet) so unconfirmed typing reverts and the field only ever
-// shows an existing schema. Clearing the query restores the full menu so the
-// committed label renders.
+// On blur, drop typing that was never picked: the field returns to the committed schema
+// (empty when none is set) and the menu to the full list.
 function reconcileOnBlur(): void {
-	selectedSchema.value = props.selected ?? '';
+	pickedSchema.value = selectableSchema( props.selected ?? null );
+	inputText.value = props.selected ?? '';
 	query.value = '';
 	emit( 'blur' );
 }
 
-function focus(): void {
-	const input = ( comboboxRef.value?.$el as HTMLElement )?.querySelector( 'input' );
+// Waits for the schemas so that focus lands on a field whose menu can open right away.
+async function focus(): Promise<void> {
+	await schemasReady;
+	await nextTick();
+	const input = ( lookupRef.value?.$el as HTMLElement )?.querySelector( 'input' );
 	input?.focus();
 }
 
@@ -99,7 +114,7 @@ defineExpose( { focus } );
 </script>
 
 <style lang="less">
-.ext-neowiki-schema-picker .cdx-combobox {
+.ext-neowiki-schema-picker .cdx-lookup {
 	width: 100%;
 }
 </style>

--- a/resources/ext.neowiki/src/components/common/SchemaPicker.vue
+++ b/resources/ext.neowiki/src/components/common/SchemaPicker.vue
@@ -3,13 +3,13 @@
 		<CdxLookup
 			v-if="schemasLoaded"
 			ref="lookupRef"
-			v-model:selected="pickedSchema"
+			v-model:selected="selectedSchema"
 			v-model:input-value="inputText"
 			:menu-items="menuItems"
 			:placeholder="$i18n( 'neowiki-schema-picker-placeholder' ).text()"
 			@input="filterSchemas"
 			@update:selected="onSelect"
-			@blur="reconcileOnBlur"
+			@blur="revertUncommittedTyping"
 		/>
 	</div>
 </template>
@@ -31,7 +31,7 @@ const emit = defineEmits<{
 }>();
 
 const schemaStore = useSchemaStore();
-const pickedSchema = ref<string | null>( props.selected ?? null );
+const selectedSchema = ref<string | null>( props.selected ?? null );
 const inputText = ref<string | number>( props.selected ?? '' );
 const summaries = ref<SchemaSummary[]>( [] );
 const schemasLoaded = ref( false );
@@ -50,8 +50,9 @@ const menuItems = computed<MenuItemData[]>( () => {
 } );
 
 // CdxLookup decides whether focus opens the menu from the menu items it was created
-// with, so the field is only rendered once the schemas are in. A picker whose schemas
-// failed to load still renders, so the field is never missing.
+// with, so the field is only rendered once the schemas have arrived. Loading them is
+// also marked done when the request fails, so a failure leaves a usable field rather
+// than none at all.
 async function loadSchemas(): Promise<void> {
 	try {
 		summaries.value = await schemaStore.getAllSchemaSummaries();
@@ -63,9 +64,12 @@ async function loadSchemas(): Promise<void> {
 
 const schemasReady = loadSchemas();
 
+// The filter is reset alongside the field: CdxLookup resolves a selection against the
+// menu as it currently stands, and would empty the field for a schema the filter hides.
 watch( () => props.selected, ( value ) => {
-	pickedSchema.value = selectableSchema( value ?? null );
+	selectedSchema.value = selectableSchema( value ?? null );
 	inputText.value = value ?? '';
+	query.value = '';
 } );
 
 // CdxLookup takes the field's text for a selection from the matching menu entry and
@@ -80,9 +84,12 @@ function filterSchemas( value: string ): void {
 }
 
 // CdxLookup reports a selection only for a menu entry the user picks, and null while
-// they type, so a schema name typed out in full is not picked by itself. Resetting the
-// filter restores the full menu, so reopening the picker without leaving the field
-// browses every schema again rather than the last filter.
+// they type, so a schema name typed out in full is not picked by itself.
+//
+// Setting the field text is load-bearing: left to do it itself, CdxLookup announces the
+// name as typed input, which would re-apply the filter cleared on the next line.
+// Restoring the full menu means reopening the picker without leaving the field browses
+// every schema again rather than the last filter.
 function onSelect( schemaName: string | null ): void {
 	if ( schemaName === null ) {
 		return;
@@ -90,13 +97,14 @@ function onSelect( schemaName: string | null ): void {
 
 	inputText.value = schemaName;
 	query.value = '';
-	emit( 'select', schemaName );
+
+	if ( schemaName !== props.selected ) {
+		emit( 'select', schemaName );
+	}
 }
 
-// On blur, drop typing that was never picked: the field returns to the committed schema
-// (empty when none is set) and the menu to the full list.
-function reconcileOnBlur(): void {
-	pickedSchema.value = selectableSchema( props.selected ?? null );
+function revertUncommittedTyping(): void {
+	selectedSchema.value = selectableSchema( props.selected ?? null );
 	inputText.value = props.selected ?? '';
 	query.value = '';
 	emit( 'blur' );

--- a/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
@@ -39,8 +39,8 @@ vi.mock( '@/composables/useSchemaPermissions.ts' );
 const SchemaPickerStub = {
 	template: '<div class="schema-lookup-stub"></div>',
 	emits: [ 'select' ],
-	methods: {
-		focus: vi.fn(),
+	setup() {
+		return { focus: vi.fn() };
 	},
 };
 
@@ -401,6 +401,30 @@ describe( 'SubjectCreatorDialog', () => {
 			expect.any( String ),
 			expect.objectContaining( { type: 'error' } ),
 		);
+	} );
+
+	describe( 'Existing schema flow', () => {
+		it( 'focuses SchemaPicker when the dialog opens', async () => {
+			const wrapper = mountComponent();
+
+			subjectStore.subjectCreatorOpen = true;
+			await flushPromises();
+
+			const pickerVm = wrapper.findComponent( SchemaPicker ).vm as any;
+			expect( pickerVm.focus ).toHaveBeenCalled();
+		} );
+
+		it( 'focuses SchemaPicker when switching back to "Use existing"', async () => {
+			const wrapper = mountComponent();
+			await switchToNewSchema( wrapper );
+
+			wrapper.findComponent( { name: 'CdxToggleButtonGroup' } )
+				.vm.$emit( 'update:modelValue', 'existing' );
+			await flushPromises();
+
+			const pickerVm = wrapper.findComponent( SchemaPicker ).vm as any;
+			expect( pickerVm.focus ).toHaveBeenCalled();
+		} );
 	} );
 
 	describe( 'Create new schema flow', () => {

--- a/resources/ext.neowiki/tests/components/common/SchemaPicker.spec.ts
+++ b/resources/ext.neowiki/tests/components/common/SchemaPicker.spec.ts
@@ -49,9 +49,12 @@ describe( 'SchemaPicker', () => {
 		return wrapper;
 	}
 
+	// Focused, because CdxMenu only opens on focus: assertions about what the list shows
+	// would otherwise pass against a list the user cannot see.
 	async function mountLoadedPicker( props: Record<string, unknown> = {} ): Promise<VueWrapper> {
 		const wrapper = mountPicker( props );
 		await flushPromises();
+		await focusField( wrapper );
 		return wrapper;
 	}
 
@@ -72,7 +75,7 @@ describe( 'SchemaPicker', () => {
 	}
 
 	function chosenSchema( wrapper: VueWrapper ): string | null {
-		const chosen = wrapper.find( '.cdx-menu-item--selected .cdx-menu-item__text__label' );
+		const chosen = wrapper.find( '[role="option"][aria-selected="true"] .cdx-menu-item__text__label' );
 		return chosen.exists() ? chosen.text() : null;
 	}
 
@@ -87,7 +90,7 @@ describe( 'SchemaPicker', () => {
 	}
 
 	async function clickSchema( wrapper: VueWrapper, name: string ): Promise<void> {
-		const item = wrapper.findAll( '.cdx-menu-item' )
+		const item = wrapper.findAll( '[role="option"]' )
 			.find( ( candidate ) => candidate.text().includes( name ) );
 		expect( item, `no menu entry for ${ name }` ).toBeDefined();
 		await item!.trigger( 'click' );
@@ -111,6 +114,14 @@ describe( 'SchemaPicker', () => {
 			const wrapper = await mountLoadedPicker();
 
 			await type( wrapper, 'off' );
+
+			expect( listedSchemas( wrapper ) ).toEqual( [ 'Office' ] );
+		} );
+
+		it( 'ignores whitespace around the typed text when filtering', async () => {
+			const wrapper = await mountLoadedPicker();
+
+			await type( wrapper, '  off  ' );
 
 			expect( listedSchemas( wrapper ) ).toEqual( [ 'Office' ] );
 		} );
@@ -163,6 +174,15 @@ describe( 'SchemaPicker', () => {
 			expect( wrapper.emitted( 'select' ) ).toBeFalsy();
 		} );
 
+		it( 'does not pick a schema whose name is typed out in full and confirmed with enter', async () => {
+			const wrapper = await mountLoadedPicker();
+
+			await type( wrapper, 'Office' );
+			await pressKey( wrapper, 'Enter' );
+
+			expect( wrapper.emitted( 'select' ) ).toBeFalsy();
+		} );
+
 		it( 'picks the schema whose menu entry is clicked', async () => {
 			const wrapper = await mountLoadedPicker();
 
@@ -174,11 +194,11 @@ describe( 'SchemaPicker', () => {
 		it( 'picks the schema highlighted with the arrow keys and confirmed with enter', async () => {
 			const wrapper = await mountLoadedPicker();
 
-			await focusField( wrapper );
+			await pressKey( wrapper, 'ArrowDown' );
 			await pressKey( wrapper, 'ArrowDown' );
 			await pressKey( wrapper, 'Enter' );
 
-			expect( wrapper.emitted( 'select' ) ).toEqual( [ [ 'Product' ] ] );
+			expect( wrapper.emitted( 'select' ) ).toEqual( [ [ 'Office' ] ] );
 		} );
 
 		it( 'picks the clicked schema when its name was already typed out in full', async () => {
@@ -193,12 +213,19 @@ describe( 'SchemaPicker', () => {
 		it( 'picks the confirmed schema when its name was already typed out in full', async () => {
 			const wrapper = await mountLoadedPicker();
 
-			await focusField( wrapper );
 			await type( wrapper, 'Office' );
 			await pressKey( wrapper, 'ArrowDown' );
 			await pressKey( wrapper, 'Enter' );
 
 			expect( wrapper.emitted( 'select' ) ).toEqual( [ [ 'Office' ] ] );
+		} );
+
+		it( 'reports nothing when the picked schema is already the committed one', async () => {
+			const wrapper = await mountLoadedPicker( { selected: 'Office' } );
+
+			await clickSchema( wrapper, 'Office' );
+
+			expect( wrapper.emitted( 'select' ) ).toBeFalsy();
 		} );
 
 		it( 'shows the picked schema in the field', async () => {
@@ -296,8 +323,7 @@ describe( 'SchemaPicker', () => {
 
 	describe( 'focusing', () => {
 		// The schemas are delivered only after focus() has been called, as they are over the
-		// network: focusing before they arrive is what used to leave the list closed until
-		// the user left the field and came back.
+		// network: the field must end up focused with its list open regardless.
 		it( 'lists every schema straight away when focused, without waiting for a second focus', async () => {
 			let deliverSchemas: ( summaries: typeof SUMMARIES ) => void = () => undefined;
 			schemaStore.getAllSchemaSummaries = vi.fn().mockReturnValue(
@@ -314,7 +340,7 @@ describe( 'SchemaPicker', () => {
 			await nextTick();
 
 			expect( document.activeElement ).toBe( field( wrapper ).element );
-			expect( wrapper.find( '.cdx-menu' ).isVisible() ).toBe( true );
+			expect( field( wrapper ).attributes( 'aria-expanded' ) ).toBe( 'true' );
 			expect( listedSchemas( wrapper ) ).toEqual( [ 'Product', 'Office', 'City' ] );
 		} );
 	} );

--- a/resources/ext.neowiki/tests/components/common/SchemaPicker.spec.ts
+++ b/resources/ext.neowiki/tests/components/common/SchemaPicker.spec.ts
@@ -71,6 +71,11 @@ describe( 'SchemaPicker', () => {
 		return wrapper.findAll( '.cdx-menu-item__text__description' ).map( ( d ) => d.text() );
 	}
 
+	function chosenSchema( wrapper: VueWrapper ): string | null {
+		const chosen = wrapper.find( '.cdx-menu-item--selected .cdx-menu-item__text__label' );
+		return chosen.exists() ? chosen.text() : null;
+	}
+
 	async function type( wrapper: VueWrapper, text: string ): Promise<void> {
 		await field( wrapper ).setValue( text );
 		await flushPromises();
@@ -254,6 +259,14 @@ describe( 'SchemaPicker', () => {
 			expect( fieldText( wrapper ) ).toBe( 'City' );
 		} );
 
+		it( 'marks a newly committed schema as the chosen one in the list', async () => {
+			const wrapper = await mountLoadedPicker();
+
+			await wrapper.setProps( { selected: 'City' } );
+
+			expect( chosenSchema( wrapper ) ).toBe( 'City' );
+		} );
+
 		it( 'shows a committed schema that is missing from the list', async () => {
 			const wrapper = await mountLoadedPicker();
 
@@ -282,10 +295,22 @@ describe( 'SchemaPicker', () => {
 	} );
 
 	describe( 'focusing', () => {
+		// The schemas are delivered only after focus() has been called, as they are over the
+		// network: focusing before they arrive is what used to leave the list closed until
+		// the user left the field and came back.
 		it( 'lists every schema straight away when focused, without waiting for a second focus', async () => {
+			let deliverSchemas: ( summaries: typeof SUMMARIES ) => void = () => undefined;
+			schemaStore.getAllSchemaSummaries = vi.fn().mockReturnValue(
+				new Promise( ( resolve ) => {
+					deliverSchemas = resolve;
+				} ),
+			);
 			const wrapper = mountPicker();
 
-			await ( wrapper.vm as unknown as { focus: () => Promise<void> } ).focus();
+			const focusing = ( wrapper.vm as unknown as { focus: () => Promise<void> } ).focus();
+			await nextTick();
+			deliverSchemas( SUMMARIES );
+			await focusing;
 			await nextTick();
 
 			expect( document.activeElement ).toBe( field( wrapper ).element );

--- a/resources/ext.neowiki/tests/components/common/SchemaPicker.spec.ts
+++ b/resources/ext.neowiki/tests/components/common/SchemaPicker.spec.ts
@@ -1,5 +1,5 @@
-import { mount, VueWrapper, flushPromises } from '@vue/test-utils';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DOMWrapper, mount, VueWrapper, flushPromises } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { nextTick } from 'vue';
 import SchemaPicker from '@/components/common/SchemaPicker.vue';
 import { createPinia, setActivePinia } from 'pinia';
@@ -8,46 +8,19 @@ import { createI18nMock } from '../../VueTestHelpers.ts';
 
 const $i18n = createI18nMock();
 
-const CdxComboboxStub = {
-	props: [ 'selected', 'menuItems' ],
-	emits: [ 'update:selected', 'input', 'blur' ],
-	template: '<div class="cdx-combobox-stub"></div>',
-};
-
 const SUMMARIES = [
 	{ name: 'Product', description: 'A product', propertyCount: 2 },
 	{ name: 'Office', description: 'A physical location', propertyCount: 4 },
 	{ name: 'City', description: '', propertyCount: 3 },
 ];
 
+// The picker is mounted with the real Codex component: which of a keystroke, a click
+// or a keyboard confirmation counts as picking a schema is decided by Codex, so a
+// stubbed field would only assert this component's own wiring back to itself.
 describe( 'SchemaPicker', () => {
 	let pinia: ReturnType<typeof createPinia>;
-	let schemaStore: any;
-
-	const mountComponent = ( props: Record<string, unknown> = {} ): VueWrapper => (
-		mount( SchemaPicker, {
-			props,
-			global: {
-				mocks: {
-					$i18n,
-				},
-				plugins: [ pinia ],
-				stubs: {
-					CdxCombobox: CdxComboboxStub,
-				},
-			},
-		} )
-	);
-
-	async function mountLoaded( props: Record<string, unknown> = {} ): Promise<VueWrapper> {
-		const wrapper = mountComponent( props );
-		await flushPromises();
-		return wrapper;
-	}
-
-	function typeText( combobox: VueWrapper, value: string ): void {
-		combobox.vm.$emit( 'input', { target: { value } } );
-	}
+	let schemaStore: ReturnType<typeof useSchemaStore>;
+	const wrappers: VueWrapper[] = [];
 
 	beforeEach( () => {
 		pinia = createPinia();
@@ -57,193 +30,267 @@ describe( 'SchemaPicker', () => {
 		schemaStore.getAllSchemaSummaries = vi.fn().mockResolvedValue( SUMMARIES );
 	} );
 
+	afterEach( () => {
+		wrappers.splice( 0 ).forEach( ( wrapper ) => wrapper.unmount() );
+	} );
+
+	// Attached to the document so focus lands on the field: jsdom ignores focus() on a
+	// detached element, which would silently skip the menu-opening behaviour.
+	function mountPicker( props: Record<string, unknown> = {} ): VueWrapper {
+		const wrapper = mount( SchemaPicker, {
+			props,
+			attachTo: document.body,
+			global: {
+				mocks: { $i18n },
+				plugins: [ pinia ],
+			},
+		} );
+		wrappers.push( wrapper );
+		return wrapper;
+	}
+
+	async function mountLoadedPicker( props: Record<string, unknown> = {} ): Promise<VueWrapper> {
+		const wrapper = mountPicker( props );
+		await flushPromises();
+		return wrapper;
+	}
+
+	function field( wrapper: VueWrapper ): DOMWrapper<HTMLInputElement> {
+		return wrapper.find( 'input' );
+	}
+
+	function fieldText( wrapper: VueWrapper ): string {
+		return field( wrapper ).element.value;
+	}
+
+	function listedSchemas( wrapper: VueWrapper ): string[] {
+		return wrapper.findAll( '.cdx-menu-item__text__label' ).map( ( label ) => label.text() );
+	}
+
+	function listedDescriptions( wrapper: VueWrapper ): string[] {
+		return wrapper.findAll( '.cdx-menu-item__text__description' ).map( ( d ) => d.text() );
+	}
+
+	async function type( wrapper: VueWrapper, text: string ): Promise<void> {
+		await field( wrapper ).setValue( text );
+		await flushPromises();
+	}
+
+	async function focusField( wrapper: VueWrapper ): Promise<void> {
+		await field( wrapper ).trigger( 'focus' );
+		await nextTick();
+	}
+
+	async function clickSchema( wrapper: VueWrapper, name: string ): Promise<void> {
+		const item = wrapper.findAll( '.cdx-menu-item' )
+			.find( ( candidate ) => candidate.text().includes( name ) );
+		expect( item, `no menu entry for ${ name }` ).toBeDefined();
+		await item!.trigger( 'click' );
+		await flushPromises();
+	}
+
+	async function pressKey( wrapper: VueWrapper, key: string ): Promise<void> {
+		await field( wrapper ).trigger( 'keydown', { key } );
+		await flushPromises();
+	}
+
 	describe( 'browsing and filtering', () => {
-		it( 'populates the menu with all schemas and their descriptions on mount', async () => {
-			const wrapper = await mountLoaded();
-			const combobox = wrapper.findComponent( CdxComboboxStub );
+		it( 'lists every schema with its description', async () => {
+			const wrapper = await mountLoadedPicker();
 
-			expect( combobox.props( 'menuItems' ) ).toEqual( [
-				{ label: 'Product', value: 'Product', description: 'A product' },
-				{ label: 'Office', value: 'Office', description: 'A physical location' },
-				{ label: 'City', value: 'City', description: undefined },
-			] );
+			expect( listedSchemas( wrapper ) ).toEqual( [ 'Product', 'Office', 'City' ] );
+			expect( listedDescriptions( wrapper ) ).toEqual( [ 'A product', 'A physical location' ] );
 		} );
 
-		it( 'filters the menu to schemas matching the typed text', async () => {
-			const wrapper = await mountLoaded();
-			const combobox = wrapper.findComponent( CdxComboboxStub );
+		it( 'lists only the schemas matching the typed text', async () => {
+			const wrapper = await mountLoadedPicker();
 
-			typeText( combobox, 'off' );
-			await nextTick();
+			await type( wrapper, 'off' );
 
-			expect( combobox.props( 'menuItems' ) ).toEqual( [
-				{ label: 'Office', value: 'Office', description: 'A physical location' },
-			] );
+			expect( listedSchemas( wrapper ) ).toEqual( [ 'Office' ] );
 		} );
 
-		it( 'shows all schemas again when the input is cleared', async () => {
-			const wrapper = await mountLoaded();
-			const combobox = wrapper.findComponent( CdxComboboxStub );
+		it( 'lists every schema again when the field is cleared', async () => {
+			const wrapper = await mountLoadedPicker();
 
-			typeText( combobox, 'off' );
-			typeText( combobox, '' );
-			await nextTick();
+			await type( wrapper, 'off' );
+			await type( wrapper, '' );
 
-			expect( combobox.props( 'menuItems' ) ).toHaveLength( 3 );
+			expect( listedSchemas( wrapper ) ).toEqual( [ 'Product', 'Office', 'City' ] );
 		} );
 
-		it( 'restores the full menu after a selection is committed', async () => {
-			const wrapper = await mountLoaded();
-			const combobox = wrapper.findComponent( CdxComboboxStub );
+		it( 'lists every schema again after one is picked', async () => {
+			const wrapper = await mountLoadedPicker();
 
-			typeText( combobox, 'off' );
-			await nextTick();
-			expect( combobox.props( 'menuItems' ) ).toHaveLength( 1 );
+			await type( wrapper, 'off' );
+			await clickSchema( wrapper, 'Office' );
 
-			combobox.vm.$emit( 'update:selected', 'Office' );
-			await nextTick();
-
-			expect( combobox.props( 'menuItems' ) ).toHaveLength( 3 );
+			expect( listedSchemas( wrapper ) ).toEqual( [ 'Product', 'Office', 'City' ] );
 		} );
 
-		it( 'leaves the menu empty without throwing when loading schemas fails', async () => {
+		it( 'lists no schemas and reports the failure when loading them fails', async () => {
 			const consoleError = vi.spyOn( console, 'error' ).mockImplementation( () => undefined );
 			schemaStore.getAllSchemaSummaries = vi.fn().mockRejectedValue( new Error( 'load failed' ) );
 
-			const wrapper = await mountLoaded();
-			const combobox = wrapper.findComponent( CdxComboboxStub );
+			const wrapper = await mountLoadedPicker();
 
-			expect( combobox.props( 'menuItems' ) ).toEqual( [] );
+			expect( listedSchemas( wrapper ) ).toEqual( [] );
+			expect( field( wrapper ).exists() ).toBe( true );
 			expect( consoleError ).toHaveBeenCalled();
 			consoleError.mockRestore();
 		} );
 	} );
 
-	describe( 'committing a selection', () => {
-		it( 'emits the schema when an exact schema name is selected', async () => {
-			const wrapper = await mountLoaded();
-			const combobox = wrapper.findComponent( CdxComboboxStub );
+	describe( 'picking a schema', () => {
+		it( 'does not pick a schema whose name is typed out in full', async () => {
+			const wrapper = await mountLoadedPicker();
 
-			combobox.vm.$emit( 'update:selected', 'Office' );
-
-			expect( wrapper.emitted( 'select' )?.[ 0 ] ).toEqual( [ 'Office' ] );
-		} );
-
-		it( 'does not emit for a value that is not a schema name', async () => {
-			const wrapper = await mountLoaded();
-			const combobox = wrapper.findComponent( CdxComboboxStub );
-
-			combobox.vm.$emit( 'update:selected', 'Off' );
+			await type( wrapper, 'Office' );
 
 			expect( wrapper.emitted( 'select' ) ).toBeFalsy();
 		} );
 
-		it( 'commits the canonical schema name when the input has surrounding whitespace', async () => {
-			const wrapper = await mountLoaded();
-			const combobox = wrapper.findComponent( CdxComboboxStub );
+		it( 'does not pick a schema while the typed text only partially matches one', async () => {
+			const wrapper = await mountLoadedPicker();
 
-			combobox.vm.$emit( 'update:selected', 'Office ' );
-
-			expect( wrapper.emitted( 'select' )?.[ 0 ] ).toEqual( [ 'Office' ] );
-		} );
-
-		it( 'commits the canonical schema name when the input differs only in case', async () => {
-			const wrapper = await mountLoaded();
-			const combobox = wrapper.findComponent( CdxComboboxStub );
-
-			combobox.vm.$emit( 'update:selected', 'office' );
-
-			expect( wrapper.emitted( 'select' )?.[ 0 ] ).toEqual( [ 'Office' ] );
-		} );
-
-		it( 'does not re-emit when the value already equals the committed schema', async () => {
-			const wrapper = await mountLoaded( { selected: 'Office' } );
-			const combobox = wrapper.findComponent( CdxComboboxStub );
-
-			combobox.vm.$emit( 'update:selected', 'Office' );
+			await type( wrapper, 'Offic' );
 
 			expect( wrapper.emitted( 'select' ) ).toBeFalsy();
+		} );
+
+		it( 'picks the schema whose menu entry is clicked', async () => {
+			const wrapper = await mountLoadedPicker();
+
+			await clickSchema( wrapper, 'Office' );
+
+			expect( wrapper.emitted( 'select' ) ).toEqual( [ [ 'Office' ] ] );
+		} );
+
+		it( 'picks the schema highlighted with the arrow keys and confirmed with enter', async () => {
+			const wrapper = await mountLoadedPicker();
+
+			await focusField( wrapper );
+			await pressKey( wrapper, 'ArrowDown' );
+			await pressKey( wrapper, 'Enter' );
+
+			expect( wrapper.emitted( 'select' ) ).toEqual( [ [ 'Product' ] ] );
+		} );
+
+		it( 'picks the clicked schema when its name was already typed out in full', async () => {
+			const wrapper = await mountLoadedPicker();
+
+			await type( wrapper, 'Office' );
+			await clickSchema( wrapper, 'Office' );
+
+			expect( wrapper.emitted( 'select' ) ).toEqual( [ [ 'Office' ] ] );
+		} );
+
+		it( 'picks the confirmed schema when its name was already typed out in full', async () => {
+			const wrapper = await mountLoadedPicker();
+
+			await focusField( wrapper );
+			await type( wrapper, 'Office' );
+			await pressKey( wrapper, 'ArrowDown' );
+			await pressKey( wrapper, 'Enter' );
+
+			expect( wrapper.emitted( 'select' ) ).toEqual( [ [ 'Office' ] ] );
+		} );
+
+		it( 'shows the picked schema in the field', async () => {
+			const wrapper = await mountLoadedPicker();
+
+			await type( wrapper, 'off' );
+			await clickSchema( wrapper, 'Office' );
+
+			expect( fieldText( wrapper ) ).toBe( 'Office' );
 		} );
 	} );
 
-	describe( 'rejecting invalid input', () => {
-		it( 'reverts to the committed schema and restores the menu on blur', async () => {
-			const wrapper = await mountLoaded( { selected: 'Product' } );
-			const combobox = wrapper.findComponent( CdxComboboxStub );
+	describe( 'reverting uncommitted typing', () => {
+		it( 'restores the committed schema in the field on blur', async () => {
+			const wrapper = await mountLoadedPicker( { selected: 'Product' } );
 
-			combobox.vm.$emit( 'update:selected', 'xyz' );
-			combobox.vm.$emit( 'blur' );
+			await type( wrapper, 'xyz' );
+			await field( wrapper ).trigger( 'blur' );
 			await nextTick();
 
-			expect( combobox.props( 'selected' ) ).toBe( 'Product' );
-			expect( combobox.props( 'menuItems' ) ).toHaveLength( 3 );
+			expect( fieldText( wrapper ) ).toBe( 'Product' );
+			expect( listedSchemas( wrapper ) ).toEqual( [ 'Product', 'Office', 'City' ] );
 			expect( wrapper.emitted( 'select' ) ).toBeFalsy();
 		} );
 
-		it( 'leaves a not-yet-set field empty on blur', async () => {
-			const wrapper = await mountLoaded();
-			const combobox = wrapper.findComponent( CdxComboboxStub );
+		it( 'empties a field that has no committed schema on blur', async () => {
+			const wrapper = await mountLoadedPicker();
 
-			combobox.vm.$emit( 'update:selected', 'xyz' );
-			combobox.vm.$emit( 'blur' );
+			await type( wrapper, 'xyz' );
+			await field( wrapper ).trigger( 'blur' );
 			await nextTick();
 
-			expect( combobox.props( 'selected' ) ).toBe( '' );
+			expect( fieldText( wrapper ) ).toBe( '' );
 			expect( wrapper.emitted( 'select' ) ).toBeFalsy();
 		} );
 
 		it( 'emits blur so the consumer can mark the field touched', async () => {
-			const wrapper = await mountLoaded();
-			const combobox = wrapper.findComponent( CdxComboboxStub );
+			const wrapper = await mountLoadedPicker();
 
-			combobox.vm.$emit( 'blur' );
+			await field( wrapper ).trigger( 'blur' );
 
 			expect( wrapper.emitted( 'blur' ) ).toBeTruthy();
 		} );
 	} );
 
-	describe( 'reflecting the selected prop', () => {
-		it( 'shows the selected schema in the field', () => {
-			const wrapper = mountComponent( { selected: 'Product' } );
-			const combobox = wrapper.findComponent( CdxComboboxStub );
+	describe( 'reflecting the committed schema', () => {
+		it( 'shows the schema it was given', async () => {
+			const wrapper = await mountLoadedPicker( { selected: 'Product' } );
 
-			expect( combobox.props( 'selected' ) ).toBe( 'Product' );
+			expect( fieldText( wrapper ) ).toBe( 'Product' );
 		} );
 
-		it( 'updates the field when the selected prop changes', async () => {
-			const wrapper = mountComponent();
-			const combobox = wrapper.findComponent( CdxComboboxStub );
+		it( 'shows a schema committed after it was created', async () => {
+			const wrapper = await mountLoadedPicker();
 
-			await wrapper.setProps( { selected: 'NewSchema' } );
-			expect( combobox.props( 'selected' ) ).toBe( 'NewSchema' );
+			await wrapper.setProps( { selected: 'City' } );
+
+			expect( fieldText( wrapper ) ).toBe( 'City' );
+		} );
+
+		it( 'shows a committed schema that is missing from the list', async () => {
+			const wrapper = await mountLoadedPicker();
+
+			await wrapper.setProps( { selected: 'Archived' } );
+
+			expect( fieldText( wrapper ) ).toBe( 'Archived' );
+		} );
+
+		it( 'keeps showing a committed schema that is missing from the list on blur', async () => {
+			const wrapper = await mountLoadedPicker( { selected: 'Archived' } );
+
+			await type( wrapper, 'xyz' );
+			await field( wrapper ).trigger( 'blur' );
+			await flushPromises();
+
+			expect( fieldText( wrapper ) ).toBe( 'Archived' );
+		} );
+
+		it( 'empties the field when the committed schema is cleared', async () => {
+			const wrapper = await mountLoadedPicker( { selected: 'Product' } );
 
 			await wrapper.setProps( { selected: null } );
-			expect( combobox.props( 'selected' ) ).toBe( '' );
+
+			expect( fieldText( wrapper ) ).toBe( '' );
 		} );
 	} );
 
-	it( 'exposes focus method', () => {
-		const CdxComboboxInputStub = {
-			template: '<div><input /></div>',
-		};
+	describe( 'focusing', () => {
+		it( 'lists every schema straight away when focused, without waiting for a second focus', async () => {
+			const wrapper = mountPicker();
 
-		const wrapper = mount( SchemaPicker, {
-			global: {
-				mocks: {
-					$i18n,
-				},
-				plugins: [ pinia ],
-				stubs: {
-					CdxCombobox: CdxComboboxInputStub,
-				},
-			},
+			await ( wrapper.vm as unknown as { focus: () => Promise<void> } ).focus();
+			await nextTick();
+
+			expect( document.activeElement ).toBe( field( wrapper ).element );
+			expect( wrapper.find( '.cdx-menu' ).isVisible() ).toBe( true );
+			expect( listedSchemas( wrapper ) ).toEqual( [ 'Product', 'Office', 'City' ] );
 		} );
-
-		const input = wrapper.find( 'input' );
-		const focusSpy = vi.spyOn( input.element, 'focus' );
-
-		( wrapper.vm as any ).focus();
-
-		expect( focusSpy ).toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/980

Two fixes to the schema selector, used both when creating a subject from an existing
schema and when choosing a relation's target schema.

Typing a schema name out in full no longer selects it. The keystroke that completed the
name used to commit the match, which in the subject creator jumped to the next step while
the user was still typing. A schema is now selected only by clicking its entry or
confirming the highlighted one with the keyboard.

The schema list now opens as soon as the field is focused. It used to stay closed until
the user left the field and came back, because the field was focused before the schemas
had finished loading.

The field is a Codex Lookup rather than a Combobox; the Lookup reports typing and picking
separately. Its expander chevron is gone as a result, and the field appears only once the
schemas have finished loading — a Lookup opens its menu on focus only if it was created
with entries.

Considered, omitted: a placeholder control for the moment before the schemas arrive. The
wait is one microtask once the list is cached, but on a wiki with hundreds of schemas the
first open pages through them serially, so this is worth a look if that gap becomes
visible.

> <sub>AI-authored — Claude Code, `Opus 5 (max)`; detailed spec from an orchestrating Claude session on @JeroenDeDauw's instruction, which named both bugs and their causes and asked for the Lookup and Combobox routes to be weighed against the installed Codex, no redirections; diff not yet human-reviewed; regression tests written first against the real Codex component and seen failing on master, 12 mutations run against the picker and all caught, full vitest suite (1158) plus ts-lint and ts-build green locally, and every acceptance case driven in a real browser on a dev wiki (subject creator and relation target, 17 checks, no console errors). Fresh-context code, security, test, design and edge-case reviews were run and applied in the third commit; the design verdict was good-enough, with CdxLookup judged forced rather than preferred.</sub>
