### PR TITLE
Start the test-only backends on demand instead of with every dev stack

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -40,10 +40,10 @@ from inside the stack via `make bash` or `docker compose exec`.
 
 The dev stack bundles a [QLever](https://github.com/ad-freiburg/qlever) SPARQL 1.1 graph
 store as a working example of NeoWiki's SPARQL projection plugin (issue #586). It is a
-dev-only sidecar (in `docker-compose.dev.yml`, like `test_neo`); the base "try-it-out" /
-demo stack does not run it. `SettingsTemplate.php` points `$wgNeoWikiSparqlStores` at it
-(`http://qlever:7019/`) only in dev mode, so every page save and `RebuildGraphDatabases.php`
-also projects the page's RDF into QLever as named graphs.
+dev-only sidecar (in `docker-compose.dev.yml`); the base "try-it-out" / demo stack does not
+run it. `SettingsTemplate.php` points `$wgNeoWikiSparqlStores` at it (`http://qlever:7019/`)
+only in dev mode, so every page save and `RebuildGraphDatabases.php` also projects the page's
+RDF into QLever as named graphs.
 
 Two entries point at that one endpoint: the `native` projection and the `EDM` one defined
 by the demo data's `Mapping:EDM` page. Each writes its own per-page named graphs, so one
@@ -90,17 +90,14 @@ up on demand via the `test` profile; in CI it is started explicitly (see
 `.github/workflows/ci-php.yml`), because its multi-step bring-up cannot be expressed as a
 GitHub Actions service container.
 
-### The `test` profile
+## The `test` profile
 
-`test_neo` and `test_qlever` exist only for the PHP test suite, so they sit behind the `test`
-compose profile and `make dev` does not start them. The PHP test targets (`make phpunit`,
-`make perf`) bring them up and seed them on demand, which costs a one-off Neo4j startup on the
-first run after the stack comes up. To drive them by hand, enable the profile:
+`test_neo` and `test_qlever` are only for the PHP test suite, so `make dev` does not start
+them. `make phpunit` and `make perf` start and seed them on demand; the first run after the
+stack comes up waits for Neo4j to boot. `make test-backends` starts them on their own.
 
-```sh
-docker compose -p <project> -f Docker/docker-compose.yml -f Docker/docker-compose.dev.yml \
-  --profile test up -d
-```
+Run these from the host. Inside the mediawiki container there is no compose to drive, so they
+report the backends as missing instead of starting them.
 
 ## Files
 
@@ -112,8 +109,8 @@ docker compose -p <project> -f Docker/docker-compose.yml -f Docker/docker-compos
   the profile-gated `caddy` (the `server` profile, for HTTPS hosting).
 - `docker-compose.dev.yml` — dev overlay; switches `mediawiki` to the dev image,
   bind-mounts the NeoWiki source, sets `MW_MODE=dev`, and adds the dev-only sidecars
-  `qlever` (SPARQL store, see above), `node`, and `mailcatcher`, plus the test-only
-  `test_neo` and `test_qlever` behind the `test` profile.
+  `qlever` (SPARQL store, see above), `node`, and `mailcatcher`, plus `test_neo` and
+  `test_qlever` behind the `test` profile.
 - `docker-compose.tools.yml` — opt-in overlay that exposes Neo4j and QLever to the host.
 - `SettingsTemplate.php` — `LocalSettings.php` that branches on `MW_MODE`.
 - `.env.dist` — tracked defaults; auto-copied to `.env` on first `make dev`.

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -86,8 +86,21 @@ data. `phpunit.xml.dist` points the test at it via `QLEVER_TEST_URL=http://test_
 (fixed token `neowiki_test_token`); it is reached in-network only, with no host port. Unlike
 the demo store it runs **without** `--persist-updates`: it is ephemeral test scaffolding that
 each run clears (`DROP ALL`), so keeping updates in memory is enough. `make phpunit` brings it
-up as part of the dev stack; in CI it is started explicitly (see `.github/workflows/ci-php.yml`),
-because its multi-step bring-up cannot be expressed as a GitHub Actions service container.
+up on demand via the `test` profile; in CI it is started explicitly (see
+`.github/workflows/ci-php.yml`), because its multi-step bring-up cannot be expressed as a
+GitHub Actions service container.
+
+### The `test` profile
+
+`test_neo` and `test_qlever` exist only for the PHP test suite, so they sit behind the `test`
+compose profile and `make dev` does not start them. The PHP test targets (`make phpunit`,
+`make perf`) bring them up and seed them on demand, which costs a one-off Neo4j startup on the
+first run after the stack comes up. To drive them by hand, enable the profile:
+
+```sh
+docker compose -p <project> -f Docker/docker-compose.yml -f Docker/docker-compose.dev.yml \
+  --profile test up -d
+```
 
 ## Files
 
@@ -99,7 +112,8 @@ because its multi-step bring-up cannot be expressed as a GitHub Actions service 
   the profile-gated `caddy` (the `server` profile, for HTTPS hosting).
 - `docker-compose.dev.yml` — dev overlay; switches `mediawiki` to the dev image,
   bind-mounts the NeoWiki source, sets `MW_MODE=dev`, and adds the dev-only sidecars
-  `test_neo`, `qlever` (SPARQL store, see above), `node`, and `mailcatcher`.
+  `qlever` (SPARQL store, see above), `node`, and `mailcatcher`, plus the test-only
+  `test_neo` and `test_qlever` behind the `test` profile.
 - `docker-compose.tools.yml` — opt-in overlay that exposes Neo4j and QLever to the host.
 - `SettingsTemplate.php` — `LocalSettings.php` that branches on `MW_MODE`.
 - `.env.dist` — tracked defaults; auto-copied to `.env` on first `make dev`.

--- a/Docker/docker-compose.dev.yml
+++ b/Docker/docker-compose.dev.yml
@@ -50,7 +50,12 @@ services:
   # Dev-only sidecars. They live in this overlay (not the base file) so the base
   # "try-it-out" stack stays minimal and so `make down` removes them as orphans
   # regardless of the compose backend. See the Makefile `down` target.
+  # Behind the `test` profile: only the PHP test targets use it, so `make dev` does
+  # not pay for a second Neo4j JVM around the clock. `make phpunit` brings the profile
+  # up on demand (Makefile `_test-backends`).
   test_neo:
+    profiles:
+      - test
     image: neo4j:enterprise
     restart: unless-stopped
     volumes:
@@ -139,8 +144,11 @@ services:
   # Dedicated QLever store for the SPARQL query system test, isolated from the demo `qlever` service
   # above the way `test_neo` is isolated from `neo`: the system test writes and deletes Subjects, so it
   # must not mutate the demo data. It reaches this in-network as http://test_qlever:7019/ (see
-  # QLEVER_TEST_URL in phpunit.xml.dist); no host port is exposed.
+  # QLEVER_TEST_URL in phpunit.xml.dist); no host port is exposed. Behind the `test` profile for the
+  # same reason as test_neo.
   test_qlever:
+    profiles:
+      - test
     image: docker.io/adfreiburg/qlever:latest
     restart: unless-stopped
     # Same ceiling as qlever.

--- a/Docker/docker-compose.dev.yml
+++ b/Docker/docker-compose.dev.yml
@@ -50,9 +50,9 @@ services:
   # Dev-only sidecars. They live in this overlay (not the base file) so the base
   # "try-it-out" stack stays minimal and so `make down` removes them as orphans
   # regardless of the compose backend. See the Makefile `down` target.
-  # Behind the `test` profile: only the PHP test targets use it, so `make dev` does
-  # not pay for a second Neo4j JVM around the clock. `make phpunit` brings the profile
-  # up on demand (Makefile `_test-backends`).
+
+  # Only the PHP test targets use `test_neo`, so `make dev` should not pay for a second Neo4j
+  # JVM. `make phpunit` starts the profile on demand.
   test_neo:
     profiles:
       - test
@@ -79,10 +79,9 @@ services:
       timeout: 1s
       retries: 10
 
-  # SPARQL 1.1 graph store (QLever) for the SPARQL projection plugin (#586). Dev-only,
-  # like test_neo: the base "try-it-out"/demo stack does not use it — that stack runs the
-  # prebuilt image in production mode, where SettingsTemplate.php configures no SPARQL
-  # store. NeoWiki reaches this in-network as http://qlever:7019/; a host port for manual
+  # SPARQL 1.1 graph store (QLever) for the SPARQL projection plugin (#586). Dev-only: the
+  # base "try-it-out"/demo stack does not use it — that stack runs the prebuilt image in
+  # production mode, where SettingsTemplate.php configures no SPARQL store. NeoWiki reaches this in-network as http://qlever:7019/; a host port for manual
   # inspection is opt-in via docker-compose.tools.yml.
   qlever:
     image: docker.io/adfreiburg/qlever:latest
@@ -144,8 +143,8 @@ services:
   # Dedicated QLever store for the SPARQL query system test, isolated from the demo `qlever` service
   # above the way `test_neo` is isolated from `neo`: the system test writes and deletes Subjects, so it
   # must not mutate the demo data. It reaches this in-network as http://test_qlever:7019/ (see
-  # QLEVER_TEST_URL in phpunit.xml.dist); no host port is exposed. Behind the `test` profile for the
-  # same reason as test_neo.
+  # QLEVER_TEST_URL in phpunit.xml.dist); no host port is exposed. Behind the `test` profile,
+  # like `test_neo`.
   test_qlever:
     profiles:
       - test

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ PORT_RANGE_END := 8499
 DC := docker compose -p $(PROJECT_NAME) -f Docker/docker-compose.yml
 DC_DEV := $(DC) -f Docker/docker-compose.dev.yml
 DC_TOOLS := $(DC_DEV) -f Docker/docker-compose.tools.yml
+# The test-only backends (test_neo, test_qlever) sit behind the `test` profile, so
+# reaching them needs the profile enabled. See `_test-backends`.
+DC_TEST := $(DC_DEV) --profile test
 
 # Detect the engine from what `docker` actually is (its version string), not from
 # whether a `podman` binary happens to exist: a stray podman binary alongside real
@@ -157,7 +160,7 @@ logs: ## Tail logs from all services
 	$(DC_DEV) logs -f
 
 ps: ## Show service status
-	$(DC_DEV) ps
+	$(DC_TEST) ps
 
 bash: ## Shell into the mediawiki container
 	$(DC_DEV) exec mediawiki bash
@@ -213,7 +216,6 @@ _first-run-seed:
 	else \
 		$(MAKE) --no-print-directory install-db; \
 		$(MAKE) --no-print-directory load-neo4j-users; \
-		$(MAKE) --no-print-directory setup-test-neo; \
 		$(MAKE) --no-print-directory composer-install; \
 		$(MAKE) --no-print-directory import-demo-data; \
 	fi
@@ -233,7 +235,7 @@ _first-run-seed-demo:
 
 # ---- DB and Neo4j init -------------------------------------------------------
 
-.PHONY: install-db load-neo4j-users wait-for-neo4j setup-test-neo
+.PHONY: install-db load-neo4j-users wait-for-neo4j setup-test-neo _test-backends
 
 install-db:
 	$(EXEC_MW_ROOT) bash -c '/wait-for-it.sh db:3306 -t 60'
@@ -257,11 +259,35 @@ load-neo4j-users:
 	$(DC) exec -T neo bash -c \
 		"echo \"CREATE USER $(NEO4J_USERNAME_READ) SET PASSWORD '$(NEO4J_PASSWORD_READ)' CHANGE NOT REQUIRED; GRANT ROLE reader TO $(NEO4J_USERNAME_READ);\" | cypher-shell -u neo4j -p $(NEO4J_PASSWORD) -a bolt://localhost:7687"
 
+# Bring up the test-only backends and seed them. Runs before every PHP test target.
+#
+# Short-circuits when both are already running: the bring-up path costs a few seconds
+# (compose up, wait-for-it, and a cypher-shell JVM for the seed), which would otherwise
+# be added to every `make phpunit filter=X` in a tight edit/test loop. The seed itself
+# is idempotent (CREATE USER ... IF NOT EXISTS), so the guard is an optimization, not a
+# correctness requirement.
+#
+# Inside the mediawiki container there is no compose to drive, and the host-side
+# caller has already done this before exec'ing in, so it is a no-op there.
+_test-backends:
+ifeq ($(INSIDE_CONTAINER),1)
+	@:
+else
+	@if [ "$$(docker ps --filter label=com.docker.compose.project=$(PROJECT_NAME) \
+			--format '{{.Label "com.docker.compose.service"}}' \
+			| grep -cE '^(test_neo|test_qlever)$$')" = "2" ]; then \
+		exit 0; \
+	fi; \
+	$(DC_TEST) up -d; \
+	$(MAKE) --no-print-directory setup-test-neo; \
+	$(EXEC_MW_ROOT) bash -c '/wait-for-it.sh test_qlever:7019 -t 120'
+endif
+
 # Dev-only: wait for and seed the test_neo instance. Not called from prod or CI flows.
 setup-test-neo:
 	$(EXEC_MW_ROOT) bash -c '/wait-for-it.sh test_neo:7689 -t 60'
-	$(DC_DEV) exec -T test_neo bash -c \
-		"echo \"CREATE USER mediawiki_read SET PASSWORD 'mediawiki_read' CHANGE NOT REQUIRED; GRANT ROLE reader TO mediawiki_read;\" | cypher-shell -u neo4j -p password -a bolt://localhost:7689"
+	$(DC_TEST) exec -T test_neo bash -c \
+		"echo \"CREATE USER mediawiki_read IF NOT EXISTS SET PASSWORD 'mediawiki_read' CHANGE NOT REQUIRED; GRANT ROLE reader TO mediawiki_read;\" | cypher-shell -u neo4j -p password -a bolt://localhost:7689"
 
 # ---- Composer ----------------------------------------------------------------
 
@@ -292,7 +318,7 @@ test: phpunit ## Run PHP test suite
 
 cs: phpcs stan ## Run code style checks (phpcs + phpstan)
 
-phpunit: ## Run PHPUnit (use filter=X for a single test)
+phpunit: _test-backends ## Run PHPUnit (use filter=X for a single test)
 ifeq ($(INSIDE_CONTAINER),1)
 ifdef filter
 	php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist --filter $(filter) < /dev/null
@@ -307,7 +333,7 @@ else
 endif
 endif
 
-perf: ## Run performance test group
+perf: _test-backends ## Run performance test group
 ifeq ($(INSIDE_CONTAINER),1)
 	php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist --group Performance < /dev/null
 else
@@ -413,7 +439,6 @@ reset: ## Wipe DB + Neo4j volumes and reseed demo data (recreates the dev stack)
 	@$(MAKE) --no-print-directory _wait-mw
 	$(MAKE) --no-print-directory install-db
 	$(MAKE) --no-print-directory load-neo4j-users
-	$(MAKE) --no-print-directory setup-test-neo
 	$(MAKE) --no-print-directory import-demo-data
 
 import-demo-data: ## Import the NeoWiki demo subjects

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,7 @@ PORT_RANGE_END := 8499
 DC := docker compose -p $(PROJECT_NAME) -f Docker/docker-compose.yml
 DC_DEV := $(DC) -f Docker/docker-compose.dev.yml
 DC_TOOLS := $(DC_DEV) -f Docker/docker-compose.tools.yml
-# The test-only backends (test_neo, test_qlever) sit behind the `test` profile, so
-# reaching them needs the profile enabled. See `_test-backends`.
+# The `test` profile holds the test-only backends: test_neo and test_qlever.
 DC_TEST := $(DC_DEV) --profile test
 
 # Detect the engine from what `docker` actually is (its version string), not from
@@ -235,7 +234,7 @@ _first-run-seed-demo:
 
 # ---- DB and Neo4j init -------------------------------------------------------
 
-.PHONY: install-db load-neo4j-users wait-for-neo4j setup-test-neo _test-backends
+.PHONY: install-db load-neo4j-users wait-for-neo4j setup-test-neo test-backends
 
 install-db:
 	$(EXEC_MW_ROOT) bash -c '/wait-for-it.sh db:3306 -t 60'
@@ -259,19 +258,22 @@ load-neo4j-users:
 	$(DC) exec -T neo bash -c \
 		"echo \"CREATE USER $(NEO4J_USERNAME_READ) SET PASSWORD '$(NEO4J_PASSWORD_READ)' CHANGE NOT REQUIRED; GRANT ROLE reader TO $(NEO4J_USERNAME_READ);\" | cypher-shell -u neo4j -p $(NEO4J_PASSWORD) -a bolt://localhost:7687"
 
-# Bring up the test-only backends and seed them. Runs before every PHP test target.
+# Runs before every PHP test target.
 #
-# Short-circuits when both are already running: the bring-up path costs a few seconds
-# (compose up, wait-for-it, and a cypher-shell JVM for the seed), which would otherwise
-# be added to every `make phpunit filter=X` in a tight edit/test loop. The seed itself
-# is idempotent (CREATE USER ... IF NOT EXISTS), so the guard is an optimization, not a
-# correctness requirement.
+# The already-running check is a speed optimization, not a correctness requirement: the seed
+# is idempotent. Without it every `make phpunit filter=X` would pay a few seconds for the
+# compose up and the cypher-shell JVM.
 #
-# Inside the mediawiki container there is no compose to drive, and the host-side
-# caller has already done this before exec'ing in, so it is a no-op there.
-_test-backends:
+# Inside the mediawiki container there is no compose to drive, so it can only report that the
+# backends are missing.
+test-backends: ## Start and seed the test-only backends (the PHP test targets do this for you)
 ifeq ($(INSIDE_CONTAINER),1)
-	@:
+	@if ! /wait-for-it.sh test_neo:7689 -t 1 >/dev/null 2>&1 \
+		|| ! /wait-for-it.sh test_qlever:7019 -t 1 >/dev/null 2>&1; then \
+		echo "The test-only backends are not running. Start them on the host with" >&2; \
+		echo "'make test-backends', or run the PHP test targets from the host." >&2; \
+		exit 1; \
+	fi
 else
 	@if [ "$$(docker ps --filter label=com.docker.compose.project=$(PROJECT_NAME) \
 			--format '{{.Label "com.docker.compose.service"}}' \
@@ -318,7 +320,7 @@ test: phpunit ## Run PHP test suite
 
 cs: phpcs stan ## Run code style checks (phpcs + phpstan)
 
-phpunit: _test-backends ## Run PHPUnit (use filter=X for a single test)
+phpunit: test-backends ## Run PHPUnit (use filter=X for a single test)
 ifeq ($(INSIDE_CONTAINER),1)
 ifdef filter
 	php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist --filter $(filter) < /dev/null
@@ -333,7 +335,7 @@ else
 endif
 endif
 
-perf: _test-backends ## Run performance test group
+perf: test-backends ## Run performance test group
 ifeq ($(INSIDE_CONTAINER),1)
 	php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist --group Performance < /dev/null
 else

--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ make dev
 
 This builds a dev-mode image, brings up the stack (mediawiki, db, neo, qlever, node
 watcher, mailcatcher), runs first-time install and seed, and waits until the wiki is
-reachable. The test-only backends are not part of it; `make phpunit` starts those on
-demand. It prints the URL when ready (the default is `http://localhost:8484` but
+reachable. It prints the URL when ready (the default is `http://localhost:8484` but
 the actual port is auto-allocated; see [Reserved ports](Docker/README.md#reserved-host-ports)).
 
 Mailcatcher web UI is at the port `make dev` printed (default `8025`,
@@ -58,6 +57,9 @@ make logs                 # tail logs
 make reset                # wipe DB + Neo and reseed demo data
 make import-demo-data     # load the latest demo data, overriding your changes
 ```
+
+The first `make phpunit` after `make dev` starts the test-only backends, so it is slower than
+later runs.
 
 For all targets, run `make help`.
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ To work on NeoWiki (edit code, run tests, see changes live), bring up the bundle
 make dev
 ```
 
-This builds a dev-mode image, brings up the stack (mediawiki, db, neo, test_neo, node
+This builds a dev-mode image, brings up the stack (mediawiki, db, neo, qlever, node
 watcher, mailcatcher), runs first-time install and seed, and waits until the wiki is
-reachable. It prints the URL when ready (the default is `http://localhost:8484` but
+reachable. The test-only backends are not part of it; `make phpunit` starts those on
+demand. It prints the URL when ready (the default is `http://localhost:8484` but
 the actual port is auto-allocated; see [Reserved ports](Docker/README.md#reserved-host-ports)).
 
 Mailcatcher web UI is at the port `make dev` printed (default `8025`,


### PR DESCRIPTION
`test_neo` and `test_qlever` exist only for the PHP test suite, but `make dev` started them and left them running. A second Neo4j JVM is the largest cost in a dev stack that buys nothing while you are not running tests, which matters when running several worktree stacks in parallel.

Put both behind a `test` compose profile and have the PHP test targets (`make phpunit`, `make perf`) start and seed them on demand.

## Measured

One worktree stack, same seeded data, same protocol both times: `make down && make dev`, settle 180 s, then sum each container's cgroup `memory.stat` anon+kernel. Drift between two readings of the same stack was ~2%, so the delta is well clear of noise.

| service | before | after |
|---|---:|---:|
| node | 1093M | 1102M |
| neo | 1036M | 1025M |
| **test_neo** | **798M** | **—** |
| db | 100M | 100M |
| mediawiki | 51M | 51M |
| mailcatcher | 25M | 25M |
| qlever | 9M | 9M |
| **test_qlever** | **6M** | **—** |
| **total** | **3120M** | **2314M** |

**−806 MB per stack (−26%).** Row totals are 2M under the stated totals; rows are rounded per service, the totals are summed from unrounded bytes.

## Cost

Only the first PHP test run after the stack comes up pays the bring-up.

| `make phpunit filter=SubjectTest` | time |
|---|---:|
| test backends already running | 0.6 s |
| test backends not running | 11 s |

The 11 s case is new — before this change `make dev` left the backends running, so it did not arise. Warm runs are unaffected.

`test-backends` short-circuits when both containers are already running. Without that guard the bring-up path (compose up, wait-for-it, and a cypher-shell JVM for the seed) added ~3 s to *every* invocation, measured at 3.7 s for the same single-test run — the case that matters for a tight edit/test loop.

## Verified

- Full suite passes with the backends started on demand: 2087 tests, 4988 assertions, 4 skipped.
- `make cs` clean.
- `make dev` brings up 6 services instead of 8.
- `make down` still removes the profiled containers (they remain orphans to the base compose file).
- Seeding is idempotent (`CREATE USER ... IF NOT EXISTS`), so it is safe to re-run on every test invocation.
- Running the PHP test targets from inside the container reports the missing backends and exits, rather than failing 23 tests on a Neo4j connection error.

## Notes

- CI is unaffected — it runs `test_neo` as a GitHub Actions service container and `test_qlever` via a bare `docker run`, never through the dev compose overlay.
- `setup-test-neo` moved out of the first-run seed and `reset` paths into `test-backends`, since the instance it seeds may not be running at that point.
- `make ps` now enables the `test` profile, so it lists the test backends too.
- `make test-backends` is a documented target for starting them without running tests.

Part of a set of three independent dev-stack memory reductions:

- #1178 — trim the node sidecar (−290 MB)
- #1181 — Neo4j heap/pagecache and AlwaysPreTouch (−582 MB)

> <sub>AI-authored — Claude Code, `Opus 5 (max)`; measurement task specified by @JeroenDeDauw after an analysis of dev-stack memory use, then a review pass on the result; diff not yet human-reviewed; full PHPUnit suite and `make cs` run locally, teardown and warm/cold test-loop timings measured, and the in-container path checked in both states. The two most recent commits are unsigned: a stale lock in the local GPG keyring blocked signing.</sub>
