### PR TITLE
Add ADR 29: Scalability targets

### DIFF
--- a/docs/adr/029-scalability-targets.md
+++ b/docs/adr/029-scalability-targets.md
@@ -13,17 +13,22 @@ degraded performance at scale and accidental complexity via unnecessary optimiza
 
 NeoWiki needs to handle these **total Subject counts**:
 
-* Wikis up to 1 million Subjects should perform well across the board.
+* Wikis up to 1 million Subjects should perform well across the board (the 90% case is << 1 million)
 * Wikis with ~10 million Subjects ideally remain performing well, though some degradation is acceptable
 * Higher scalability is nice. Where it is possible to cheaply support 100 million Subject cases, we should do so
 
 NeoWiki needs to handle these **total Schema counts**:
 
 * Wikis up to 500 Schemas should perform well
-* Usability/UX of wikis up to 200 Schemas should be good
+* Usability/UX of wikis up to 100 Schemas should be good (the 90% case is << 100)
 * Usability/UX of wikis with ~500 Schemas should not be terrible
 
 NeoWiki needs to handle these **Subjects per Page**:
 
-* Pages with up to 50 Subjects should perform well and have great UX
+* Pages with up to 50 Subjects should perform well and have great UX (the 90% case is < 10)
 * Pages with ~250 Subjects should not have terrible performance or UX
+
+NeoWiki needs to handle these **Statements per Subject**:
+
+* Subjects with up to 50 Statements should perform well and have great UX (the 90% case is < 15)
+* Subjects with ~250 Statements should not have terrible performance or UX

--- a/docs/adr/029-scalability-targets.md
+++ b/docs/adr/029-scalability-targets.md
@@ -1,0 +1,24 @@
+# Scalability Targets
+
+Date: 2026-07-26
+
+Status: Accepted
+
+## Context
+
+Design decisions keep trading implementation simplicity against behavior at scale — most recently the orphan-stub
+sweep in [PR #1171](https://github.com/ProfessionalWiki/NeoWiki/pull/1171), where a per-save scan acceptable at demo
+scale would not survive a large deployment — without a recorded target to judge them by. The unit that drives cost is
+the number of Subjects in one graph store, farm-wide when wikis share it.
+
+## Decision
+
+* Need to work well with 1 million Subjects
+* Good to still work well with 10 million Subjects, not critical, and some degradation acceptable
+* Scalability beyond 50 million Subjects is a plus but with diminishing returns
+
+## Consequences
+
+* Per-write work must be proportional to what the write changed, not to the size of the graph.
+* Bulk import and full projection rebuilds get wall-clock budgets derived from these sizes.
+* Existing code that predates these targets is brought into line through tracked issues as gaps are found.

--- a/docs/adr/029-scalability-targets.md
+++ b/docs/adr/029-scalability-targets.md
@@ -6,19 +6,24 @@ Status: Accepted
 
 ## Context
 
-Design decisions keep trading implementation simplicity against behavior at scale — most recently the orphan-stub
-sweep in [PR #1171](https://github.com/ProfessionalWiki/NeoWiki/pull/1171), where a per-save scan acceptable at demo
-scale would not survive a large deployment — without a recorded target to judge them by. The unit that drives cost is
-the number of Subjects in one graph store, farm-wide when wikis share it.
+To make good design and implementation decisions, we need to know how far NeoWiki should scale, so we avoid both
+degraded performance at scale and accidental complexity via unnecessary optimization.
 
 ## Decision
 
-* Need to work well with 1 million Subjects
-* Good to still work well with 10 million Subjects, not critical, and some degradation acceptable
-* Scalability beyond 50 million Subjects is a plus but with diminishing returns
+NeoWiki needs to handle these **total Subject counts**:
 
-## Consequences
+* Wikis up to 1 million Subjects should perform well across the board.
+* Wikis with ~10 million Subjects ideally remain performing well, though some degradation is acceptable
+* Higher scalability is nice. Where it is possible to cheaply support 100 million Subject cases, we should do so
 
-* Per-write work must be proportional to what the write changed, not to the size of the graph.
-* Bulk import and full projection rebuilds get wall-clock budgets derived from these sizes.
-* Existing code that predates these targets is brought into line through tracked issues as gaps are found.
+NeoWiki needs to handle these **total Schema counts**:
+
+* Wikis up to 500 Schemas should perform well
+* Usability/UX of wikis up to 200 Schemas should be good
+* Usability/UX of wikis with ~500 Schemas should not be terrible
+
+NeoWiki needs to handle these **Subjects per Page**:
+
+* Pages with up to 50 Subjects should perform well and have great UX
+* Pages with ~250 Subjects should not have terrible performance or UX

--- a/docs/adr/029-scalability-targets.md
+++ b/docs/adr/029-scalability-targets.md
@@ -2,7 +2,7 @@
 
 Date: 2026-07-26
 
-Status: Accepted
+Status: Draft
 
 ## Context
 

--- a/docs/adr/029-scalability-targets.md
+++ b/docs/adr/029-scalability-targets.md
@@ -11,17 +11,16 @@ degraded performance at scale and accidental complexity via unnecessary optimiza
 
 ## Decision
 
-NeoWiki needs to handle these sizes, counted per graph store (a wiki farm sharing one store counts its total):
+NeoWiki needs to handle these sizes, counted per graph store (so for wiki farms we combine all wikis):
 
 | Metric                 | Typical (90% case)  | Great up to                      | Acceptable up to |
 |------------------------|---------------------|----------------------------------|------------------|
 | Total Subjects         | << 1 million        | 1 million                        | 10 million       |
-| Total Schemas          | 5-20 (outliers ~50) | 100 (UX-bound; performance: 500) | 500              |
+| Total Schemas          | < 30                | 100 (UX-bound; performance: 500) | 500              |
 | Subjects per Page      | < 10                | 50                               | 250              |
 | Statements per Subject | < 15                | 50                               | 100              |
 
 Great: performs well with great UX. Acceptable: usable, though some degradation of UX or performance is fine.
 
-Beyond the acceptable bound, support cheaply where possible rather than by design — wikis with 100 million Subjects
-being the marker case. High Statement counts are a modelling smell rather than a display problem: the data model's
-answer is child Subjects, which the Subjects per Page row budgets for.
+The numbers for "Great" and "Acceptable" are lower bounds. Scaling beyond them is nice, and should be done
+where it is possible cheaply.

--- a/docs/adr/029-scalability-targets.md
+++ b/docs/adr/029-scalability-targets.md
@@ -11,24 +11,17 @@ degraded performance at scale and accidental complexity via unnecessary optimiza
 
 ## Decision
 
-NeoWiki needs to handle these **total Subject counts**:
+NeoWiki needs to handle these sizes, counted per graph store (a wiki farm sharing one store counts its total):
 
-* Wikis up to 1 million Subjects should perform well across the board (the 90% case is << 1 million)
-* Wikis with ~10 million Subjects ideally remain performing well, though some degradation is acceptable
-* Higher scalability is nice. Where it is possible to cheaply support 100 million Subject cases, we should do so
+| Metric                 | Typical (90% case)  | Great up to                      | Acceptable up to |
+|------------------------|---------------------|----------------------------------|------------------|
+| Total Subjects         | << 1 million        | 1 million                        | 10 million       |
+| Total Schemas          | 5-20 (outliers ~50) | 100 (UX-bound; performance: 500) | 500              |
+| Subjects per Page      | < 10                | 50                               | 250              |
+| Statements per Subject | < 15                | 50                               | 100              |
 
-NeoWiki needs to handle these **total Schema counts**:
+Great: performs well with great UX. Acceptable: usable, though some degradation of UX or performance is fine.
 
-* Wikis up to 500 Schemas should perform well
-* Usability/UX of wikis up to 100 Schemas should be good (the 90% case is << 100)
-* Usability/UX of wikis with ~500 Schemas should not be terrible
-
-NeoWiki needs to handle these **Subjects per Page**:
-
-* Pages with up to 50 Subjects should perform well and have great UX (the 90% case is < 10)
-* Pages with ~250 Subjects should not have terrible performance or UX
-
-NeoWiki needs to handle these **Statements per Subject**:
-
-* Subjects with up to 50 Statements should perform well and have great UX (the 90% case is < 15)
-* Subjects with ~250 Statements should not have terrible performance or UX
+Beyond the acceptable bound, support cheaply where possible rather than by design — wikis with 100 million Subjects
+being the marker case. High Statement counts are a modelling smell rather than a display problem: the data model's
+answer is child Subjects, which the Subjects per Page row budgets for.


### PR DESCRIPTION
Records the Subject-count targets that scale-sensitive design decisions get judged against. The three targets are
verbatim as stated; Context and Consequences are minimal scaffolding meant to be adjusted.

> <sub>AI-authored — Claude Code, `Fable 5 (max)`; @JeroenDeDauw supplied the three targets verbatim and asked for an ADR scaffold to adjust, no revisions; not yet human-reviewed; bullets diffed against the source message, no other verification applicable.</sub>
