### PR TITLE
Stop the Neo4j instances holding their full heap while idle

### DIFF
--- a/Docker/docker-compose.dev.yml
+++ b/Docker/docker-compose.dev.yml
@@ -38,9 +38,16 @@ services:
 
   neo:
     environment:
-      - NEO4J_server_memory_heap_initial__size=512m
+      # Low initial heap with the ceiling left where it was: the JVM grows into it
+      # under load but does not hold it while the stack sits idle, which is most of
+      # the time. AlwaysPreTouch (a Neo4j default) would defeat that by committing
+      # and touching the whole heap at startup.
+      - NEO4J_server_memory_heap_initial__size=128m
       - NEO4J_server_memory_heap_max__size=512m
-      - NEO4J_server_memory_pagecache_size=256m
+      # Off-heap and pre-allocated, so it costs its full size from startup. A dev
+      # graph is a few hundred nodes; raise this if you work with a large one.
+      - NEO4J_server_memory_pagecache_size=64m
+      - NEO4J_server_jvm_additional=-XX:-AlwaysPreTouch
     mem_limit: 1536m
 
   db:
@@ -63,10 +70,12 @@ services:
       - NEO4J_AUTH=neo4j/password
       - NEO4J_server_bolt_listen__address=:7689
       - NEO4J_server_http_listen__address=:7475
-      # Smaller than neo: only holds the PHPUnit graph fixtures.
-      - NEO4J_server_memory_heap_initial__size=384m
+      # Smaller than neo: only holds the PHPUnit graph fixtures. Same low-floor /
+      # unchanged-ceiling shape as neo above.
+      - NEO4J_server_memory_heap_initial__size=128m
       - NEO4J_server_memory_heap_max__size=384m
-      - NEO4J_server_memory_pagecache_size=128m
+      - NEO4J_server_memory_pagecache_size=64m
+      - NEO4J_server_jvm_additional=-XX:-AlwaysPreTouch
     mem_limit: 1g
     healthcheck:
       test: "wget http://localhost:7475/browser -O - | grep 'Neo4j Browser'"


### PR DESCRIPTION
Both Neo4j services pinned initial heap equal to max heap, and Neo4j's default JVM args include `-XX:+AlwaysPreTouch`, which commits and touches every heap page at startup. A dev instance holding a few hundred nodes therefore paid for its entire heap from the moment it booted.

Lower the initial heap and leave each ceiling where it was, so the JVM grows under load without holding the memory while the stack sits idle, and turn `AlwaysPreTouch` off so untouched pages are never committed. Page cache is off-heap and pre-allocated, so it is also sized for a dev graph rather than a production one.

| | `neo` before | `neo` after | `test_neo` before | `test_neo` after |
|---|---:|---:|---:|---:|
| heap initial | 512m | **128m** | 384m | **128m** |
| heap max | 512m | 512m | 384m | 384m |
| page cache | 256m | **64m** | 128m | **64m** |
| AlwaysPreTouch | on (default) | **off** | on (default) | **off** |

`mem_limit` is unchanged on both, so the bounded worst case is the same.

## Measured

Four containers started simultaneously under identical host conditions, RSS+swap of the Neo4j process:

| config | before | after | delta |
|---|---:|---:|---:|
| `neo` | 868M | 508M | **−360M** |
| `test_neo` | 725M | 503M | **−222M** |

**−582 MB per dev stack.**

Isolating the two knobs on a single container (heap 512m fixed, page cache 256m):

| | java RSS |
|---|---:|
| as on master | 982M |
| `-XX:-AlwaysPreTouch` only | 889M |
| heap 128m→512m + page cache 64m + no pretouch | 617M |

Disabling the HTTP connector was also tried and made no difference, so the healthchecks are untouched.

Full-stack before/after totals are omitted deliberately: other dev stacks came and went on the measurement host partway through, which pushed every service into swap and made stack totals unusable. The paired per-service numbers above are contention-free; the in-stack readings agreed with them (−363M and −218M) before the host filled up.

## Verified

- Full PHPUnit suite passes against the resized `test_neo`: 2087 tests, 4988 assertions, 4 skipped, in 21.8 s (master config: 24.1 s, so no slowdown).
- `RebuildGraphDatabases` rebuilds all 77 demo pages in 5.3 s.
- After that rebuild `neo` sits at 718M of its unchanged 1536m limit, with `oom_kill 0` — the heap has room to grow into its ceiling and never approaches the container cap.
- Subject pages render and `GET /neowiki/v0/page/{id}/subjects` returns graph-backed data.
- Confirmed the flag actually reaches both JVMs: `-XX:+AlwaysPreTouch -XX:-AlwaysPreTouch -Xms131072k -Xmx524288k`. The image's own flag stays, and the later `-XX:-` wins, which is how JVM boolean flags resolve.

## Note

Page cache at 64m suits a dev graph of a few hundred nodes. Anyone working with a large local graph should raise it; the comment in the compose file says so.

Part of a set of three independent dev-stack memory reductions; the others cover the test-only backends and the node sidecar.

> <sub>AI-authored — Claude Code, `Opus 5 (max)`; measurement task specified by @JeroenDeDauw after an analysis of dev-stack memory use, no revisions; diff not yet human-reviewed; full PHPUnit suite, a graph rebuild, and REST/page rendering checked locally, and the A/B measured on simultaneously-started containers after host contention spoiled the first in-stack attempt.</sub>