### PR TITLE
Discard schema-summary fetches that a save invalidated

### DIFF
--- a/resources/ext.neowiki/src/stores/SchemaStore.ts
+++ b/resources/ext.neowiki/src/stores/SchemaStore.ts
@@ -49,7 +49,9 @@ export const useSchemaStore = defineStore( 'schema', {
 		// schema picker can show the full list and filter client-side. The cache is
 		// cleared on saveSchema. Concurrent callers (e.g. several relation-property
 		// pickers mounting in the same render) share one in-flight request rather
-		// than each running a full pagination.
+		// than each running a full pagination. Only the current request may publish:
+		// one that saveSchema invalidated while it ran neither caches its summaries
+		// nor releases the request that replaced it.
 		async getAllSchemaSummaries(): Promise<SchemaSummary[]> {
 			if ( this.allSummaries !== null ) {
 				return this.allSummaries;
@@ -59,32 +61,39 @@ export const useSchemaStore = defineStore( 'schema', {
 				this.summariesRequest = this.fetchAllSchemaSummaries();
 			}
 
-			return this.summariesRequest;
+			const request = this.summariesRequest;
+
+			try {
+				const summaries = await request;
+
+				if ( this.summariesRequest === request ) {
+					this.allSummaries = summaries;
+				}
+
+				return summaries;
+			} finally {
+				if ( this.summariesRequest === request ) {
+					this.summariesRequest = null;
+				}
+			}
 		},
 		// Pages through the summaries endpoint (capped at 50) by following the response's
 		// cursor until it is null. The cursor, not the page length, decides whether more
 		// pages follow: a page can come back shorter than requested when a readable Schema
-		// fails to load (malformed). The in-flight request is released on completion so a
-		// later load (after the cache is cleared, or after a failure) starts fresh.
+		// fails to load (malformed).
 		async fetchAllSchemaSummaries(): Promise<SchemaSummary[]> {
 			const repository = NeoWikiExtension.getInstance().getSchemaRepository();
 			const pageSize = 50;
 			const summaries: SchemaSummary[] = [];
+			let cursor: string | null = null;
 
-			try {
-				let cursor: string | null = null;
+			do {
+				const page = await repository.getSchemaSummaries( cursor, pageSize );
+				summaries.push( ...page.schemas );
+				cursor = page.nextCursor;
+			} while ( cursor !== null );
 
-				do {
-					const page = await repository.getSchemaSummaries( cursor, pageSize );
-					summaries.push( ...page.schemas );
-					cursor = page.nextCursor;
-				} while ( cursor !== null );
-
-				this.allSummaries = summaries;
-				return summaries;
-			} finally {
-				this.summariesRequest = null;
-			}
+			return summaries;
 		},
 		// Checks existence via the schema-names search (a 200 response) rather
 		// than getOrFetchSchema, which 404s for a missing name — those 404s are

--- a/resources/ext.neowiki/src/stores/SchemaStore.ts
+++ b/resources/ext.neowiki/src/stores/SchemaStore.ts
@@ -14,6 +14,28 @@ export function normalizeSchemaName( name: string ): string {
 	return collapsed.charAt( 0 ).toUpperCase() + collapsed.slice( 1 );
 }
 
+// Pages through the summaries endpoint (capped at 50) by following the response's
+// cursor until it is null. The cursor, not the page length, decides whether more
+// pages follow: a page can come back shorter than requested when a readable Schema
+// fails to load (malformed). Deliberately not a store action: it neither reads nor
+// maintains the cache, so exposing it alongside getAllSchemaSummaries would offer
+// callers a way to page the whole endpoint while bypassing both the cache and the
+// invalidation guard.
+async function fetchAllSchemaSummaries(): Promise<SchemaSummary[]> {
+	const repository = NeoWikiExtension.getInstance().getSchemaRepository();
+	const pageSize = 50;
+	const summaries: SchemaSummary[] = [];
+	let cursor: string | null = null;
+
+	do {
+		const page = await repository.getSchemaSummaries( cursor, pageSize );
+		summaries.push( ...page.schemas );
+		cursor = page.nextCursor;
+	} while ( cursor !== null );
+
+	return summaries;
+}
+
 export const useSchemaStore = defineStore( 'schema', {
 	state: () => ( {
 		schemas: new Map<string, Schema>(),
@@ -57,7 +79,7 @@ export const useSchemaStore = defineStore( 'schema', {
 			}
 
 			if ( this.summariesRequest === null ) {
-				this.summariesRequest = this.fetchAllSchemaSummaries();
+				this.summariesRequest = fetchAllSchemaSummaries();
 			}
 
 			const request = this.summariesRequest;
@@ -75,24 +97,6 @@ export const useSchemaStore = defineStore( 'schema', {
 					this.summariesRequest = null;
 				}
 			}
-		},
-		// Pages through the summaries endpoint (capped at 50) by following the response's
-		// cursor until it is null. The cursor, not the page length, decides whether more
-		// pages follow: a page can come back shorter than requested when a readable Schema
-		// fails to load (malformed).
-		async fetchAllSchemaSummaries(): Promise<SchemaSummary[]> {
-			const repository = NeoWikiExtension.getInstance().getSchemaRepository();
-			const pageSize = 50;
-			const summaries: SchemaSummary[] = [];
-			let cursor: string | null = null;
-
-			do {
-				const page = await repository.getSchemaSummaries( cursor, pageSize );
-				summaries.push( ...page.schemas );
-				cursor = page.nextCursor;
-			} while ( cursor !== null );
-
-			return summaries;
 		},
 		// Checks existence via the schema-names search (a 200 response) rather
 		// than getOrFetchSchema, which 404s for a missing name — those 404s are

--- a/resources/ext.neowiki/src/stores/SchemaStore.ts
+++ b/resources/ext.neowiki/src/stores/SchemaStore.ts
@@ -49,9 +49,8 @@ export const useSchemaStore = defineStore( 'schema', {
 		// schema picker can show the full list and filter client-side. The cache is
 		// cleared on saveSchema. Concurrent callers (e.g. several relation-property
 		// pickers mounting in the same render) share one in-flight request rather
-		// than each running a full pagination. Only the current request may publish:
-		// one that saveSchema invalidated while it ran neither caches its summaries
-		// nor releases the request that replaced it.
+		// than each running a full pagination. Only the request the slot still holds
+		// caches its summaries and releases the slot.
 		async getAllSchemaSummaries(): Promise<SchemaSummary[]> {
 			if ( this.allSummaries !== null ) {
 				return this.allSummaries;

--- a/resources/ext.neowiki/tests/stores/SchemaStore.spec.ts
+++ b/resources/ext.neowiki/tests/stores/SchemaStore.spec.ts
@@ -36,11 +36,11 @@ describe( 'normalizeSchemaName', () => {
 
 describe( 'SchemaStore getAllSchemaSummaries', () => {
 
-	function summary( name: string ): { name: string; description: string; propertyCount: number } {
+	function summary( name: string ): SchemaSummary {
 		return { name, description: '', propertyCount: 0 };
 	}
 
-	function manySummaries( count: number, prefix: string ): ReturnType<typeof summary>[] {
+	function manySummaries( count: number, prefix: string ): SchemaSummary[] {
 		return Array.from( { length: count }, ( _value, index ) => summary( `${ prefix }${ index }` ) );
 	}
 

--- a/resources/ext.neowiki/tests/stores/SchemaStore.spec.ts
+++ b/resources/ext.neowiki/tests/stores/SchemaStore.spec.ts
@@ -4,6 +4,13 @@ import { normalizeSchemaName, useSchemaStore } from '@/stores/SchemaStore.ts';
 import { NeoWikiExtension } from '@/NeoWikiExtension.ts';
 import { Schema } from '@/domain/Schema.ts';
 import { PropertyDefinitionList } from '@/domain/PropertyDefinitionList.ts';
+import type { SchemaSummary, SchemaSummaryPage } from '@/application/SchemaLookup.ts';
+
+interface DeferredPage {
+	promise: Promise<SchemaSummaryPage>;
+	resolve: ( page: SchemaSummaryPage ) => void;
+	reject: ( error: Error ) => void;
+}
 
 describe( 'normalizeSchemaName', () => {
 	it( 'upper-cases the first character', () => {
@@ -36,6 +43,26 @@ describe( 'SchemaStore getAllSchemaSummaries', () => {
 
 	function manySummaries( count: number, prefix: string ): ReturnType<typeof summary>[] {
 		return Array.from( { length: count }, ( _value, index ) => summary( `${ prefix }${ index }` ) );
+	}
+
+	function lastPage( summaries: SchemaSummary[] ): SchemaSummaryPage {
+		return { schemas: summaries, nextCursor: null };
+	}
+
+	function schemaNamed( name: string ): Schema {
+		return new Schema( name, '', new PropertyDefinitionList( [] ) );
+	}
+
+	function deferredPage(): DeferredPage {
+		let resolve!: ( page: SchemaSummaryPage ) => void;
+		let reject!: ( error: Error ) => void;
+
+		const promise = new Promise<SchemaSummaryPage>( ( resolvePage, rejectPage ) => {
+			resolve = resolvePage;
+			reject = rejectPage;
+		} );
+
+		return { promise, resolve, reject };
 	}
 
 	function withRepository( repository: Record<string, unknown> ): void {
@@ -122,9 +149,52 @@ describe( 'SchemaStore getAllSchemaSummaries', () => {
 		const store = useSchemaStore();
 
 		await store.getAllSchemaSummaries();
-		await store.saveSchema( new Schema( 'B', '', new PropertyDefinitionList( [] ) ) );
+		await store.saveSchema( schemaNamed( 'B' ) );
 		await store.getAllSchemaSummaries();
 
+		expect( getSchemaSummaries ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'does not cache the result of a request that a save invalidated while it ran', async () => {
+		const beforeSave = [ summary( 'Alpha' ), summary( 'Beta' ) ];
+		const afterSave = [ summary( 'Alpha' ), summary( 'Beta' ), summary( 'Gamma' ) ];
+		const invalidatedPage = deferredPage();
+		const getSchemaSummaries = vi.fn()
+			.mockReturnValueOnce( invalidatedPage.promise )
+			.mockResolvedValue( lastPage( afterSave ) );
+		withRepository( { getSchemaSummaries, saveSchema: vi.fn().mockResolvedValue( undefined ) } );
+		const store = useSchemaStore();
+
+		const invalidatedRequest = store.getAllSchemaSummaries();
+		await store.saveSchema( schemaNamed( 'Gamma' ) );
+		invalidatedPage.resolve( lastPage( beforeSave ) );
+		await invalidatedRequest;
+
+		expect( await store.getAllSchemaSummaries() ).toEqual( afterSave );
+		expect( getSchemaSummaries ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'keeps the request that replaced an invalidated one when that invalidated one fails', async () => {
+		const afterSave = [ summary( 'Alpha' ), summary( 'Beta' ) ];
+		const invalidatedPage = deferredPage();
+		const currentPage = deferredPage();
+		const getSchemaSummaries = vi.fn()
+			.mockReturnValueOnce( invalidatedPage.promise )
+			.mockReturnValueOnce( currentPage.promise )
+			.mockResolvedValue( lastPage( [ summary( 'Redundant fetch' ) ] ) );
+		withRepository( { getSchemaSummaries, saveSchema: vi.fn().mockResolvedValue( undefined ) } );
+		const store = useSchemaStore();
+
+		const invalidatedRequest = store.getAllSchemaSummaries();
+		await store.saveSchema( schemaNamed( 'Beta' ) );
+		const currentRequest = store.getAllSchemaSummaries();
+		invalidatedPage.reject( new Error( 'load failed' ) );
+		await expect( invalidatedRequest ).rejects.toThrow( 'load failed' );
+		const laterRequest = store.getAllSchemaSummaries();
+		currentPage.resolve( lastPage( afterSave ) );
+
+		expect( await laterRequest ).toEqual( afterSave );
+		expect( await currentRequest ).toEqual( afterSave );
 		expect( getSchemaSummaries ).toHaveBeenCalledTimes( 2 );
 	} );
 

--- a/resources/ext.neowiki/tests/stores/SchemaStore.spec.ts
+++ b/resources/ext.neowiki/tests/stores/SchemaStore.spec.ts
@@ -217,4 +217,28 @@ describe( 'SchemaStore getAllSchemaSummaries', () => {
 		expect( getSchemaSummaries ).toHaveBeenCalledTimes( 2 );
 	} );
 
+	it( 'lets later callers share the replacement request when an invalidated one succeeds', async () => {
+		const afterSave = [ summary( 'Alpha' ), summary( 'Beta' ) ];
+		const invalidatedPage = deferred<SchemaSummaryPage>();
+		const currentPage = deferred<SchemaSummaryPage>();
+		const getSchemaSummaries = vi.fn()
+			.mockReturnValueOnce( invalidatedPage.promise )
+			.mockReturnValueOnce( currentPage.promise )
+			.mockResolvedValue( lastPage( [ summary( 'Redundant fetch' ) ] ) );
+		withRepository( { getSchemaSummaries, saveSchema: vi.fn().mockResolvedValue( undefined ) } );
+		const store = useSchemaStore();
+
+		const invalidatedRequest = store.getAllSchemaSummaries();
+		await store.saveSchema( newSchema( { title: 'Beta' } ) );
+		const currentRequest = store.getAllSchemaSummaries();
+		invalidatedPage.resolve( lastPage( [ summary( 'Stale' ) ] ) );
+		await invalidatedRequest;
+		const laterRequest = store.getAllSchemaSummaries();
+		currentPage.resolve( lastPage( afterSave ) );
+		await currentRequest;
+
+		expect( await laterRequest ).toEqual( afterSave );
+		expect( getSchemaSummaries ).toHaveBeenCalledTimes( 2 );
+	} );
+
 } );

--- a/resources/ext.neowiki/tests/stores/SchemaStore.spec.ts
+++ b/resources/ext.neowiki/tests/stores/SchemaStore.spec.ts
@@ -2,13 +2,12 @@ import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
 import { createPinia, setActivePinia } from 'pinia';
 import { normalizeSchemaName, useSchemaStore } from '@/stores/SchemaStore.ts';
 import { NeoWikiExtension } from '@/NeoWikiExtension.ts';
-import { Schema } from '@/domain/Schema.ts';
-import { PropertyDefinitionList } from '@/domain/PropertyDefinitionList.ts';
+import { newSchema } from '@/TestHelpers.ts';
 import type { SchemaSummary, SchemaSummaryPage } from '@/application/SchemaLookup.ts';
 
-interface DeferredPage {
-	promise: Promise<SchemaSummaryPage>;
-	resolve: ( page: SchemaSummaryPage ) => void;
+interface Deferred<T> {
+	promise: Promise<T>;
+	resolve: ( value: T ) => void;
 	reject: ( error: Error ) => void;
 }
 
@@ -49,17 +48,13 @@ describe( 'SchemaStore getAllSchemaSummaries', () => {
 		return { schemas: summaries, nextCursor: null };
 	}
 
-	function schemaNamed( name: string ): Schema {
-		return new Schema( name, '', new PropertyDefinitionList( [] ) );
-	}
-
-	function deferredPage(): DeferredPage {
-		let resolve!: ( page: SchemaSummaryPage ) => void;
+	function deferred<T>(): Deferred<T> {
+		let resolve!: ( value: T ) => void;
 		let reject!: ( error: Error ) => void;
 
-		const promise = new Promise<SchemaSummaryPage>( ( resolvePage, rejectPage ) => {
-			resolve = resolvePage;
-			reject = rejectPage;
+		const promise = new Promise<T>( ( resolveValue, rejectValue ) => {
+			resolve = resolveValue;
+			reject = rejectValue;
 		} );
 
 		return { promise, resolve, reject };
@@ -149,7 +144,7 @@ describe( 'SchemaStore getAllSchemaSummaries', () => {
 		const store = useSchemaStore();
 
 		await store.getAllSchemaSummaries();
-		await store.saveSchema( schemaNamed( 'B' ) );
+		await store.saveSchema( newSchema( { title: 'B' } ) );
 		await store.getAllSchemaSummaries();
 
 		expect( getSchemaSummaries ).toHaveBeenCalledTimes( 2 );
@@ -158,7 +153,7 @@ describe( 'SchemaStore getAllSchemaSummaries', () => {
 	it( 'does not cache the result of a request that a save invalidated while it ran', async () => {
 		const beforeSave = [ summary( 'Alpha' ), summary( 'Beta' ) ];
 		const afterSave = [ summary( 'Alpha' ), summary( 'Beta' ), summary( 'Gamma' ) ];
-		const invalidatedPage = deferredPage();
+		const invalidatedPage = deferred<SchemaSummaryPage>();
 		const getSchemaSummaries = vi.fn()
 			.mockReturnValueOnce( invalidatedPage.promise )
 			.mockResolvedValue( lastPage( afterSave ) );
@@ -166,18 +161,42 @@ describe( 'SchemaStore getAllSchemaSummaries', () => {
 		const store = useSchemaStore();
 
 		const invalidatedRequest = store.getAllSchemaSummaries();
-		await store.saveSchema( schemaNamed( 'Gamma' ) );
+		await store.saveSchema( newSchema( { title: 'Gamma' } ) );
 		invalidatedPage.resolve( lastPage( beforeSave ) );
 		await invalidatedRequest;
+		const reloaded = await store.getAllSchemaSummaries();
 
-		expect( await store.getAllSchemaSummaries() ).toEqual( afterSave );
+		expect( reloaded ).toEqual( afterSave );
 		expect( getSchemaSummaries ).toHaveBeenCalledTimes( 2 );
 	} );
 
-	it( 'keeps the request that replaced an invalidated one when that invalidated one fails', async () => {
+	it( 'does not cache the result of a request that started while a save was still running', async () => {
+		const beforeSave = [ summary( 'Alpha' ), summary( 'Beta' ) ];
+		const afterSave = [ summary( 'Alpha' ), summary( 'Beta' ), summary( 'Gamma' ) ];
+		const invalidatedPage = deferred<SchemaSummaryPage>();
+		const save = deferred<void>();
+		const getSchemaSummaries = vi.fn()
+			.mockReturnValueOnce( invalidatedPage.promise )
+			.mockResolvedValue( lastPage( afterSave ) );
+		withRepository( { getSchemaSummaries, saveSchema: () => save.promise } );
+		const store = useSchemaStore();
+
+		const savingSchema = store.saveSchema( newSchema( { title: 'Gamma' } ) );
+		const invalidatedRequest = store.getAllSchemaSummaries();
+		save.resolve();
+		await savingSchema;
+		invalidatedPage.resolve( lastPage( beforeSave ) );
+		await invalidatedRequest;
+		const reloaded = await store.getAllSchemaSummaries();
+
+		expect( reloaded ).toEqual( afterSave );
+		expect( getSchemaSummaries ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'lets later callers share the replacement request when an invalidated one fails', async () => {
 		const afterSave = [ summary( 'Alpha' ), summary( 'Beta' ) ];
-		const invalidatedPage = deferredPage();
-		const currentPage = deferredPage();
+		const invalidatedPage = deferred<SchemaSummaryPage>();
+		const currentPage = deferred<SchemaSummaryPage>();
 		const getSchemaSummaries = vi.fn()
 			.mockReturnValueOnce( invalidatedPage.promise )
 			.mockReturnValueOnce( currentPage.promise )
@@ -186,15 +205,15 @@ describe( 'SchemaStore getAllSchemaSummaries', () => {
 		const store = useSchemaStore();
 
 		const invalidatedRequest = store.getAllSchemaSummaries();
-		await store.saveSchema( schemaNamed( 'Beta' ) );
+		await store.saveSchema( newSchema( { title: 'Beta' } ) );
 		const currentRequest = store.getAllSchemaSummaries();
 		invalidatedPage.reject( new Error( 'load failed' ) );
 		await expect( invalidatedRequest ).rejects.toThrow( 'load failed' );
 		const laterRequest = store.getAllSchemaSummaries();
 		currentPage.resolve( lastPage( afterSave ) );
+		await currentRequest;
 
 		expect( await laterRequest ).toEqual( afterSave );
-		expect( await currentRequest ).toEqual( afterSave );
 		expect( getSchemaSummaries ).toHaveBeenCalledTimes( 2 );
 	} );
 


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/1177

Saving a schema clears the cached schema-summary list so pickers reload it. A summaries
request already in flight when the save completed then wrote its pre-save list into the
cache, leaving the just-saved schema missing from every schema picker until the next page
load. The same stale completion also released the shared request slot, dropping the
in-flight sharing of the request that had replaced it and costing later callers a redundant
fetch.

Only the current request may now publish: on completion it writes the cache and releases the
slot only while it is still the request stored there. This covers a request that starts
during the save as well as one already running, because the invalidation lands after the
repository write returns.

fetchAllSchemaSummaries is left with just the pagination; getAllSchemaSummaries owns the
cache and the shared request slot.

Considered, omitted: a picker that already holds an invalidated request keeps the pre-save
list for its mounted lifetime, since it reads the store once. Every picker currently lives in
a dialog that closes or reloads on save, so this is not reachable today; a picker rendered
inline on a page would need to re-read.

> <sub>AI-authored — Claude Code, `Opus 5 (max)`; detailed spec from @JeroenDeDauw via an orchestrated issue-fix run, resumed once after a harness restart; diff not yet human-reviewed; all three regression tests seen failing against master's code and passing after the fix, each guard verified by mutation testing, full vitest suite plus build and lint green locally, and the create-schema-then-pick happy path checked in a browser.</sub>
