### PR TITLE
Add write-path budgets to the scalability targets ADR

### DIFF
--- a/docs/adr/029-scalability-targets.md
+++ b/docs/adr/029-scalability-targets.md
@@ -9,6 +9,9 @@ Status: Draft
 To make good design and implementation decisions, we need to know how far NeoWiki should scale, so we avoid both
 degraded performance at scale and accidental complexity via unnecessary optimization.
 
+The documented scalability failures of comparable systems are on the write path — bulk-import throughput and rebuild
+wall-clock — rather than query latency, so the write path gets explicit budgets.
+
 ## Decision
 
 NeoWiki needs to handle these sizes, counted per graph store (so for wiki farms we combine all wikis):
@@ -24,3 +27,9 @@ Great: performs well with great UX. Acceptable: usable, though some degradation 
 
 The numbers for "Great" and "Acceptable" are lower bounds. Scaling beyond them is nice, and should be done
 where it is possible cheaply.
+
+NeoWiki needs to meet these **write-path budgets**:
+
+* Bulk import should sustain at least 100 validated Subjects per second (the fastest tooling in common use by
+  comparable systems sustains 1-4 entities per second)
+* A full projection rebuild of a wiki at the 1 million Subject tier should take minutes, not hours


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1179

The documented scalability failures of comparable systems are bulk-import throughput and rebuild wall-clock rather
than query latency, so the targets gain explicit write-path budgets: a sustained validated import rate and the
full-rebuild time at the 1 million Subject tier. Numbers are anchored in the 2026-07-26 scalability landscape
research (competitive import bar 1-4 entities/s for common tooling, ~100-150/s for the best batch paths; QLever
indexes 500M triples in under a minute, so the store is not the rebuild constraint).

> <sub>AI-authored — Claude Code, `Fable 5 (max)`; follow-up requested by @JeroenDeDauw with the additions as recommended from the landscape research, no revisions; not yet human-reviewed; numbers cross-checked against the sourced research report.</sub>
