### PR TITLE
Hide Vector's "Switch to old look" link on the demo wiki

### DIFF
--- a/DemoData/AGENTS.md
+++ b/DemoData/AGENTS.md
@@ -17,6 +17,7 @@ partners, knowledge managers, MediaWiki ecosystem evaluators, and live-demo audi
 | `EdmSparqlPage/<Name>.wikitext` | Pages demoing SPARQL over the EDM ontology projection, including joins with the native one. Imported only when the queried store holds both projections. | Main namespace, `<Name>` |
 | `Module/<Name>.lua` | Scribunto modules | `Module:<Name>` |
 | `MediaWiki/<Name>.wikitext` | Interface pages, such as `Sidebar` (the main menu) | `MediaWiki:<Name>` |
+| `MediaWiki/<Name>.css` | Site CSS, per skin (`Vector-2022.css`) or for every skin (`Common.css`) | `MediaWiki:<Name>.css` |
 
 `ImportDemoData.php` reseeds the demo set: it creates and updates pages from these directories, and
 deletes pages a previous import created whose source file is now gone. So renaming or removing a

--- a/DemoData/MediaWiki/Vector-2022.css
+++ b/DemoData/MediaWiki/Vector-2022.css
@@ -1,0 +1,5 @@
+/* Vector 2022 gives every logged-in user a "Switch to old look" link and renders it between the
+   first main menu section and the rest, so it reads as the last entry of the demo tour. */
+.vector-main-menu-action-opt-out {
+	display: none;
+}

--- a/src/Application/Actions/ImportPages/ImportPagesAction.php
+++ b/src/Application/Actions/ImportPages/ImportPagesAction.php
@@ -6,6 +6,7 @@ namespace ProfessionalWiki\NeoWiki\Application\Actions\ImportPages;
 
 use MediaWiki\CommentStore\CommentStoreComment;
 use MediaWiki\Content\Content;
+use MediaWiki\Content\CssContent;
 use MediaWiki\Content\TextContent;
 use MediaWiki\Content\WikitextContent;
 use MediaWiki\Title\Title;
@@ -122,6 +123,11 @@ class ImportPagesAction {
 	private function fileNameAndSourceToContent( string $fileName, string $sourceText ): Content {
 		if ( str_ends_with( $fileName, '.wikitext' ) ) {
 			return new WikitextContent( $sourceText );
+		}
+
+		// Site CSS pages keep the extension in their title, so stripFileExtension leaves these alone.
+		if ( str_ends_with( $fileName, '.css' ) ) {
+			return new CssContent( $sourceText );
 		}
 
 		if ( str_ends_with( $fileName, '.lua' ) ) {

--- a/tests/phpunit/Application/Actions/ImportPagesNamespaceTest.php
+++ b/tests/phpunit/Application/Actions/ImportPagesNamespaceTest.php
@@ -19,12 +19,14 @@ use ProfessionalWiki\NeoWiki\Tests\TestDoubles\ImportPresenterSpy;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\PageContentSaverStub;
 
 /**
- * Covers which namespace each demo data source directory imports into. The saver is a stub, so the
- * titles the action derives from the file names can be checked without touching the database.
+ * Covers the title and content model each demo data source directory imports into. The saver is a
+ * stub, so what the action derives from the file names can be checked without touching the database.
  *
  * @covers \ProfessionalWiki\NeoWiki\Application\Actions\ImportPages\ImportPagesAction
  */
 class ImportPagesNamespaceTest extends MediaWikiIntegrationTestCase {
+
+	private PageContentSaverStub $saver;
 
 	public function testPageFilesImportIntoTheMainNamespace(): void {
 		$presenter = $this->runImport( pageFiles: [ 'Museum collection.wikitext' => 'hubs' ] );
@@ -44,6 +46,21 @@ class ImportPagesNamespaceTest extends MediaWikiIntegrationTestCase {
 		$this->assertSame( [ 'MediaWiki:Sidebar' ], $presenter->created );
 	}
 
+	public function testCssFilesKeepTheirExtensionInTheTitle(): void {
+		$presenter = $this->runImport( mediaWikiFiles: [ 'Vector-2022.css' => '.foo { display: none; }' ] );
+
+		$this->assertSame( [ 'MediaWiki:Vector-2022.css' ], $presenter->created );
+	}
+
+	public function testCssFilesImportAsSiteCss(): void {
+		$this->runImport( mediaWikiFiles: [ 'Vector-2022.css' => '.foo { display: none; }' ] );
+
+		$this->assertSame(
+			CONTENT_MODEL_CSS,
+			$this->saver->savedContent['Vector-2022.css']['main']->getModel()
+		);
+	}
+
 	/**
 	 * @param array<string, string> $pageFiles Source files (name => content) per source directory.
 	 * @param array<string, string> $moduleFiles
@@ -55,13 +72,14 @@ class ImportPagesNamespaceTest extends MediaWikiIntegrationTestCase {
 		array $mediaWikiFiles = [],
 	): ImportPresenterSpy {
 		$presenter = new ImportPresenterSpy();
+		$this->saver = new PageContentSaverStub(
+			$this->createMock( WikiPageFactory::class ),
+			$this->createMock( Authority::class )
+		);
 
 		( new ImportPagesAction(
 			presenter: $presenter,
-			pageContentSaver: new PageContentSaverStub(
-				$this->createMock( WikiPageFactory::class ),
-				$this->createMock( Authority::class )
-			),
+			pageContentSaver: $this->saver,
 			importedPageTitlesLookup: $this->createMock( ImportedPageTitlesLookup::class ),
 			pageDeleter: $this->createMock( PageDeleter::class ),
 			schemaContentSource: $this->createMock( SchemaContentSource::class ),

--- a/tests/phpunit/TestDoubles/PageContentSaverStub.php
+++ b/tests/phpunit/TestDoubles/PageContentSaverStub.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Tests\TestDoubles;
 
 use MediaWiki\CommentStore\CommentStoreComment;
+use MediaWiki\Content\Content;
 use MediaWiki\Page\PageIdentity;
 use MediaWiki\Page\WikiPageFactory;
 use MediaWiki\Permissions\Authority;
@@ -17,6 +18,11 @@ use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\PageContentSavingStatus;
  * be exercised without touching the database.
  */
 class PageContentSaverStub extends PageContentSaver {
+
+	/**
+	 * @var array<string, array<string, Content>> Content offered per slot, keyed by page DB key.
+	 */
+	public array $savedContent = [];
 
 	/**
 	 * @param string[] $failingKeys DB keys whose save is rejected.
@@ -32,6 +38,10 @@ class PageContentSaverStub extends PageContentSaver {
 	public function saveContent( PageIdentity|PageId $page, array $contentBySlot, CommentStoreComment $comment ): PageContentSavingStatus {
 		if ( $page instanceof PageIdentity && in_array( $page->getDBkey(), $this->failingKeys, true ) ) {
 			return new PageContentSavingStatus( PageContentSavingStatus::ERROR, 'forced failure' );
+		}
+
+		if ( $page instanceof PageIdentity ) {
+			$this->savedContent[$page->getDBkey()] = $contentBySlot;
 		}
 
 		return new PageContentSavingStatus( PageContentSavingStatus::REVISION_CREATED );


### PR DESCRIPTION
Vector 2022 gives every logged-in user the link and renders it between the first main menu section and the rest, so on a wiki with the demo data it reads as the last entry of the demo tour. `VectorComponentMainMenu` adds it for any registered user with no configuration in between, so hiding it is the only lever. Preferences still offers the skin choice.

`MediaWiki:Vector-2022.css` loads only for the skin whose menu carries the link, so the rule reaches exactly the wikis and users it applies to. Site CSS pages keep the extension in their title, which is why the title mapping leaves `.css` names alone.

Verified end to end on a worktree wiki: the import creates `MediaWiki:Vector-2022.css` with content model `css`, the rule is served in the `site.styles` module, and a logged-in headless browser reports `display: none` on the element.

> <sub>AI-authored — Claude Code, `Opus 5 (max)`; @JeroenDeDauw asked for the site-CSS-via-DemoData approach after rejecting a neowiki.dev-only config fix; diff not yet human-reviewed; full PHPUnit suite and `make cs` green locally, both new tests confirmed failing without the production change, and the result checked in a logged-in browser.</sub>