### PR TITLE
Make id-anchored Subject lookups use the :Subject(id) index

### DIFF
--- a/docs/api/graph-model.md
+++ b/docs/api/graph-model.md
@@ -130,7 +130,7 @@ When a Subject with incoming relations from other Subjects is removed, its node 
 
 Two node uniqueness constraints apply: `(wiki_id, id)` on `:Page` nodes
 ([ADR 22](../adr/022-multi-wiki-node-identity.md)) and `id` on `:Subject` nodes. Both are created by `update.php` and
-by `RebuildGraphDatabases.php`; the incremental per-edit projection does not create them.
+by `RebuildGraphDatabases.php`, not by the incremental per-edit projection.
 
 Relation (edge) `id` values carry no uniqueness constraint
 ([#351](https://github.com/ProfessionalWiki/NeoWiki/issues/351)).

--- a/docs/api/graph-model.md
+++ b/docs/api/graph-model.md
@@ -96,8 +96,8 @@ Stubs arise in two ways:
 - **Referenced but not yet created.** When a Relation targets a Subject that does not exist yet, a stub target node
   is created so the relationship can be stored.
 
-When the real Subject is later saved, its node is upgraded in place — matched by `id` alone, so the stub gains its
-properties and Schema label without creating a duplicate node.
+When the real Subject is later saved, its node is upgraded in place: the stub gains its properties and Schema label,
+and no duplicate node is created.
 
 ## Relationships
 
@@ -129,8 +129,9 @@ When a Subject with incoming relations from other Subjects is removed, its node 
 ## Constraints
 
 Two node uniqueness constraints apply: `(wiki_id, id)` on `:Page` nodes
-([ADR 22](../adr/022-multi-wiki-node-identity.md)) and `id` on `:Subject` nodes. A graph that has never been rebuilt
-with `RebuildGraphDatabases.php` lacks them: the incremental per-edit projection does not create them.
+([ADR 22](../adr/022-multi-wiki-node-identity.md)) and `id` on `:Subject` nodes. Both are created by
+`update.php` and by `RebuildGraphDatabases.php`; the incremental per-edit projection relies on their indexes but does
+not create them.
 
 Relation (edge) `id` values carry no uniqueness constraint
 ([#351](https://github.com/ProfessionalWiki/NeoWiki/issues/351)).

--- a/docs/api/graph-model.md
+++ b/docs/api/graph-model.md
@@ -129,9 +129,8 @@ When a Subject with incoming relations from other Subjects is removed, its node 
 ## Constraints
 
 Two node uniqueness constraints apply: `(wiki_id, id)` on `:Page` nodes
-([ADR 22](../adr/022-multi-wiki-node-identity.md)) and `id` on `:Subject` nodes. Both are created by
-`update.php` and by `RebuildGraphDatabases.php`; the incremental per-edit projection relies on their indexes but does
-not create them.
+([ADR 22](../adr/022-multi-wiki-node-identity.md)) and `id` on `:Subject` nodes. Both are created by `update.php` and
+by `RebuildGraphDatabases.php`; the incremental per-edit projection does not create them.
 
 Relation (edge) `id` values carry no uniqueness constraint
 ([#351](https://github.com/ProfessionalWiki/NeoWiki/issues/351)).

--- a/docs/extending/extending.md
+++ b/docs/extending/extending.md
@@ -158,9 +158,9 @@ Register with `NeoWikiRegistrar::addGraphDatabasePlugin()`. Example:
 `PagePropertyProvider`, and runs for every revision, so subject edits, undeletions and page moves all reach you as a
 save. `deletePage` gets only the page id.
 
-`initialize` runs once at the start of a `RebuildGraphDatabases` run, before any page is projected — create the
-store-level structures a fresh store needs there. Make it idempotent, since every rebuild calls it; it never runs
-on an individual edit.
+`initialize` runs on `update.php`, and once at the start of a `RebuildGraphDatabases` run before any page is
+projected — create the store-level structures a fresh store needs there. Make it idempotent, since both paths call
+it every time; it never runs on an individual edit.
 
 **Signal failure by throwing.** On an edit, delete or undelete, NeoWiki logs the failure and lets the user's
 operation commit, so a backend being down never blocks the wiki or starves the other backends — your projection is

--- a/docs/extending/extending.md
+++ b/docs/extending/extending.md
@@ -158,15 +158,16 @@ Register with `NeoWikiRegistrar::addGraphDatabasePlugin()`. Example:
 `PagePropertyProvider`, and runs for every revision, so subject edits, undeletions and page moves all reach you as a
 save. `deletePage` gets only the page id.
 
-`initialize` runs on `update.php` and at the start of a `RebuildGraphDatabases` run, before any page is projected —
+`initialize` runs on `update.php`, and at the start of a `RebuildGraphDatabases` run before any page is projected —
 create the store-level structures a fresh store needs there. Make it idempotent, since both paths call it every time;
 it never runs on an individual edit.
 
 **Signal failure by throwing.** On an edit, delete or undelete, NeoWiki logs the failure and lets the user's
 operation commit, so a backend being down never blocks the wiki or starves the other backends — your projection is
 simply out of sync until someone runs `RebuildGraphDatabases`. During that rebuild, failures propagate instead, so
-the script can report which pages did not reconcile. On `update.php` a failing `initialize` is reported and the
-update carries on, but it stops the backends registered after yours from initializing on that run.
+the script can report which pages did not reconcile — an `initialize` throw there aborts the run before any page is
+projected. On `update.php` a failing `initialize` is reported and the update carries on, though the backends
+registered after yours do not initialize on that run.
 
 Make `deletePage` idempotent: the rebuild re-issues a delete for every page MediaWiki no longer has, so it will ask
 you to remove pages that are already gone from your store.

--- a/docs/extending/extending.md
+++ b/docs/extending/extending.md
@@ -158,14 +158,15 @@ Register with `NeoWikiRegistrar::addGraphDatabasePlugin()`. Example:
 `PagePropertyProvider`, and runs for every revision, so subject edits, undeletions and page moves all reach you as a
 save. `deletePage` gets only the page id.
 
-`initialize` runs on `update.php`, and once at the start of a `RebuildGraphDatabases` run before any page is
-projected — create the store-level structures a fresh store needs there. Make it idempotent, since both paths call
-it every time; it never runs on an individual edit.
+`initialize` runs on `update.php` and at the start of a `RebuildGraphDatabases` run, before any page is projected —
+create the store-level structures a fresh store needs there. Make it idempotent, since both paths call it every time;
+it never runs on an individual edit.
 
 **Signal failure by throwing.** On an edit, delete or undelete, NeoWiki logs the failure and lets the user's
 operation commit, so a backend being down never blocks the wiki or starves the other backends — your projection is
 simply out of sync until someone runs `RebuildGraphDatabases`. During that rebuild, failures propagate instead, so
-the script can report which pages did not reconcile.
+the script can report which pages did not reconcile. On `update.php` a failing `initialize` is reported and the
+update carries on, but it stops the backends registered after yours from initializing on that run.
 
 Make `deletePage` idempotent: the rebuild re-issues a delete for every page MediaWiki no longer has, so it will ask
 you to remove pages that are already gone from your store.

--- a/extension.json
+++ b/extension.json
@@ -38,6 +38,8 @@
 	"Hooks": {
 		"MediaWikiServices": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onMediaWikiServices",
 
+		"LoadExtensionSchemaUpdates": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onLoadExtensionSchemaUpdates",
+
 		"ParserFirstCallInit": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onParserFirstCallInit",
 
 		"RevisionFromEditComplete": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onRevisionFromEditComplete",

--- a/src/Domain/GraphDatabase/FailureIsolatingGraphDatabasePlugin.php
+++ b/src/Domain/GraphDatabase/FailureIsolatingGraphDatabasePlugin.php
@@ -44,8 +44,8 @@ class FailureIsolatingGraphDatabasePlugin implements GraphDatabasePlugin {
 
 	/**
 	 * Passed straight through without isolation: this decorator wraps plugins only on the hook-facing
-	 * write path, and that path never initializes — initialize() runs solely on the propagating
-	 * rebuild path (see GraphDatabasePlugin), where a failure must surface rather than be swallowed.
+	 * write path, and that path never initializes — initialize() runs solely on the propagating update
+	 * and rebuild paths (see GraphDatabasePlugin), where a failure must surface rather than be swallowed.
 	 */
 	public function initialize(): void {
 		$this->plugin->initialize();

--- a/src/Domain/GraphDatabase/GraphDatabasePlugin.php
+++ b/src/Domain/GraphDatabase/GraphDatabasePlugin.php
@@ -19,8 +19,9 @@ use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
  * - On maintenance rebuilds (RebuildGraphDatabases), the wiring propagates failures so they are
  *   reported truthfully per page instead of being silently swallowed. An initialize() failure
  *   propagates like any other rebuild failure.
- * - On update.php, the wiring likewise propagates, but the caller reports an initialize() failure
- *   and lets the update continue: MediaWiki's own schema changes are the point of that run.
+ * - On update.php, the wiring likewise propagates, but the caller reports an initialize() failure and
+ *   lets the update continue, since aborting there would only skip the schema updates of the
+ *   extensions queued after NeoWiki.
  *
  * The hook path never initializes.
  */

--- a/src/Domain/GraphDatabase/GraphDatabasePlugin.php
+++ b/src/Domain/GraphDatabase/GraphDatabasePlugin.php
@@ -17,17 +17,21 @@ use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
  *   each plugin (via FailureIsolatingGraphDatabasePlugin), so a throw does not abort the triggering
  *   user operation and one failing backend does not starve the others.
  * - On maintenance rebuilds (RebuildGraphDatabases), the wiring propagates failures so they are
- *   reported truthfully per page instead of being silently swallowed. The rebuild is also the only
- *   path that calls initialize(), so an initialize() failure propagates like any other rebuild
- *   failure; the hook path never initializes.
+ *   reported truthfully per page instead of being silently swallowed. An initialize() failure
+ *   propagates like any other rebuild failure.
+ * - On update.php, the wiring likewise propagates, but the caller reports an initialize() failure
+ *   and lets the update continue: MediaWiki's own schema changes are the point of that run.
+ *
+ * The hook path never initializes.
  */
 interface GraphDatabasePlugin {
 
 	/**
 	 * Prepares the backing store for projections by creating the store-level structures the backend
-	 * needs — such as uniqueness constraints — where it supports them. Idempotent, so the rebuild can
-	 * run it every time. The RebuildGraphDatabases maintenance path calls this before bulk re-projection
-	 * so a rebuilt graph carries those structures; the incremental per-edit path does not.
+	 * needs — such as uniqueness constraints — where it supports them. Idempotent, so its callers can
+	 * run it every time. update.php calls this so an ordinary install or upgrade establishes those
+	 * structures, and the RebuildGraphDatabases maintenance path calls it before bulk re-projection so a
+	 * rebuilt graph carries them; the incremental per-edit path does not.
 	 */
 	public function initialize(): void;
 

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -193,9 +193,11 @@ class NeoWikiHooks {
 	 * and RebuildGraphDatabases is not part of an ordinary install or upgrade. Idempotent, so running
 	 * it on every update.php is free.
 	 *
-	 * A backend being unreachable must not block the update: MediaWiki's own schema changes are the
-	 * point of the run, and the graph is rebuildable derived state. So the failure is reported and the
-	 * update continues.
+	 * A failing backend must not block the update: MediaWiki's own schema changes are the point of the
+	 * run, and the graph is rebuildable derived state. So the failure is reported and the update
+	 * continues. The catch is wider than the hook path's (FailureIsolatingGraphDatabasePlugin re-throws
+	 * TimeoutException and DBError) because there is no triggering user operation here that a throw
+	 * would have to abort: everything reachable from initialize() belongs to the graph backends.
 	 */
 	public static function initializeGraphDatabases( DatabaseUpdater $updater ): void {
 		$updater->output( "Initializing NeoWiki graph databases...\n" );
@@ -204,11 +206,21 @@ class NeoWikiHooks {
 			NeoWikiExtension::getInstance()->getGraphDatabasePlugin()->initialize();
 		} catch ( Exception $e ) {
 			$updater->output(
-				'...failed to initialize the NeoWiki graph databases: ' . $e->getMessage() . "\n"
+				'...failed to initialize the NeoWiki graph databases: '
+				. self::withoutCredentials( $e->getMessage() ) . "\n"
 				. "...the wiki is usable, but graph queries may be slow until this succeeds. Re-run\n"
-				. "...update.php once the backend is reachable.\n"
+				. "...update.php once the cause is resolved.\n"
 			);
 		}
+	}
+
+	/**
+	 * Strips the userinfo out of any URI in a message. A backend client reports an unreachable server by
+	 * quoting the connection URI it tried, credentials included, and this message goes to the operator's
+	 * terminal and to deployment logs.
+	 */
+	private static function withoutCredentials( string $message ): string {
+		return (string)preg_replace( '#://[^/@\s\'"]*@#', '://', $message );
 	}
 
 	public static function onParserFirstCallInit( Parser $parser ): void {

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -4,8 +4,10 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\EntryPoints;
 
+use Exception;
 use MediaWiki\EditPage\EditPage;
 use MediaWiki\Html\Html;
+use MediaWiki\Installer\DatabaseUpdater;
 use MediaWiki\Logger\LoggerFactory;
 use MediaWiki\MainConfigNames;
 use MediaWiki\MediaWikiServices;
@@ -175,6 +177,38 @@ class NeoWikiHooks {
 				);
 			}
 		);
+	}
+
+	/**
+	 * @see LoadExtensionSchemaUpdatesHook
+	 */
+	public static function onLoadExtensionSchemaUpdates( DatabaseUpdater $updater ): void {
+		$updater->addExtensionUpdate( [ [ self::class, 'initializeGraphDatabases' ] ] );
+	}
+
+	/**
+	 * Creates the store-level structures the graph backends need — for Neo4j the uniqueness
+	 * constraints, whose indexes the projection's id lookups depend on. Running this from the updater
+	 * is what gets them onto a wiki built up edit by edit: the incremental projection creates nothing,
+	 * and RebuildGraphDatabases is not part of an ordinary install or upgrade. Idempotent, so running
+	 * it on every update.php is free.
+	 *
+	 * A backend being unreachable must not block the update: MediaWiki's own schema changes are the
+	 * point of the run, and the graph is rebuildable derived state. So the failure is reported and the
+	 * update continues.
+	 */
+	public static function initializeGraphDatabases( DatabaseUpdater $updater ): void {
+		$updater->output( "Initializing NeoWiki graph databases...\n" );
+
+		try {
+			NeoWikiExtension::getInstance()->getGraphDatabasePlugin()->initialize();
+		} catch ( Exception $e ) {
+			$updater->output(
+				'...failed to initialize the NeoWiki graph databases: ' . $e->getMessage() . "\n"
+				. "...the wiki is usable, but graph queries may be slow until this succeeds. Re-run\n"
+				. "...update.php once the backend is reachable.\n"
+			);
+		}
 	}
 
 	public static function onParserFirstCallInit( Parser $parser ): void {

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -187,33 +187,61 @@ class NeoWikiHooks {
 	}
 
 	/**
-	 * A failing backend is reported rather than thrown: the update must proceed to MediaWiki's own
-	 * schema changes, and the graph is rebuildable derived state. The catch is also broader than the
-	 * hook path's deliberate TimeoutException/DBError re-throws, since there is no user operation here
-	 * to abort and everything reachable from initialize() belongs to the graph backends.
+	 * A failing backend is reported rather than thrown, and the update carries on: DatabaseUpdater runs
+	 * MediaWiki's own schema changes before it fires LoadExtensionSchemaUpdates, so a throw here would
+	 * not protect those — it would skip the updates of every extension queued after NeoWiki. The graph
+	 * is rebuildable derived state, so it is not worth that.
+	 *
+	 * The catch is broader than the hook path's deliberate TimeoutException/DBError re-throws, since
+	 * there is no user operation here to abort. It deliberately covers building the plugins as well as
+	 * initializing them, so that a wiki whose NeoWiki configuration is not readable yet — as during a
+	 * fresh install — still finishes its update.
 	 */
 	public static function initializeGraphDatabases( DatabaseUpdater $updater ): void {
-		$updater->output( "Initializing NeoWiki graph databases...\n" );
+		$updater->output( 'Initializing NeoWiki graph databases...' );
 
 		try {
 			NeoWikiExtension::getInstance()->getGraphDatabasePlugin()->initialize();
 		} catch ( Exception $e ) {
-			$updater->output(
-				'...failed to initialize the NeoWiki graph databases: '
-				. self::withoutCredentials( $e->getMessage() ) . "\n"
-				. "...the wiki is usable, but graph queries may be slow until this succeeds. Re-run\n"
-				. "...update.php once the cause is resolved.\n"
-			);
+			self::reportFailedGraphDatabaseInitialization( $updater, $e );
+			return;
 		}
+
+		$updater->output( "done.\n" );
+	}
+
+	private static function reportFailedGraphDatabaseInitialization( DatabaseUpdater $updater, Exception $e ): void {
+		$reason = self::withoutCredentials( $e->getMessage() );
+
+		$updater->output(
+			"failed.\n"
+			. '...' . $reason . "\n"
+			. "...Re-run update.php once the cause is resolved. While a backend is unreachable, Subject\n"
+			. "...editing and display and every graph read fail, and the edits made meanwhile are missing\n"
+			. "...from the projection: run RebuildGraphDatabases.php to reconcile it.\n"
+		);
+
+		// Logged as well, because update.php --quiet discards everything written to the updater, which
+		// would otherwise leave a failed initialization with no trace anywhere. The redacted reason
+		// rather than the exception, so that what is kept out of the terminal stays out of the log too.
+		LoggerFactory::getInstance( 'NeoWiki' )->error(
+			'NeoWiki failed to initialize its graph databases during update.php. The wiki is updated, but '
+			. 'the store-level structures its projection relies on are missing. Underlying error: ' . $reason
+		);
 	}
 
 	/**
 	 * Strips the userinfo out of any URI in a message. A backend client reports an unreachable server by
 	 * quoting the connection URI it tried, credentials included, and this message goes to the operator's
 	 * terminal and to deployment logs.
+	 *
+	 * The run is bounded only by whitespace and matched greedily up to its last `@`, because a password
+	 * may itself contain `/`, `@` or a quote: stopping at the first of those leaves the rest of it in
+	 * the message. The cost is that a credential-free URI whose path holds an `@` loses that path, which
+	 * is the right way round for a redaction.
 	 */
 	private static function withoutCredentials( string $message ): string {
-		return (string)preg_replace( '#://[^/@\s\'"]*@#', '://', $message );
+		return (string)preg_replace( '#(?<=://)\S*@#', '', $message );
 	}
 
 	public static function onParserFirstCallInit( Parser $parser ): void {

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -187,17 +187,10 @@ class NeoWikiHooks {
 	}
 
 	/**
-	 * Creates the store-level structures the graph backends need — for Neo4j the uniqueness
-	 * constraints, whose indexes the projection's id lookups depend on. Running this from the updater
-	 * is what gets them onto a wiki built up edit by edit: the incremental projection creates nothing,
-	 * and RebuildGraphDatabases is not part of an ordinary install or upgrade. Idempotent, so running
-	 * it on every update.php is free.
-	 *
-	 * A failing backend must not block the update: MediaWiki's own schema changes are the point of the
-	 * run, and the graph is rebuildable derived state. So the failure is reported and the update
-	 * continues. The catch is wider than the hook path's (FailureIsolatingGraphDatabasePlugin re-throws
-	 * TimeoutException and DBError) because there is no triggering user operation here that a throw
-	 * would have to abort: everything reachable from initialize() belongs to the graph backends.
+	 * A failing backend is reported rather than thrown: the update must proceed to MediaWiki's own
+	 * schema changes, and the graph is rebuildable derived state. The catch is also broader than the
+	 * hook path's deliberate TimeoutException/DBError re-throws, since there is no user operation here
+	 * to abort and everything reachable from initialize() belongs to the graph backends.
 	 */
 	public static function initializeGraphDatabases( DatabaseUpdater $updater ): void {
 		$updater->output( "Initializing NeoWiki graph databases...\n" );

--- a/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jNodeLabels.php
+++ b/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jNodeLabels.php
@@ -14,8 +14,7 @@ use Laudis\Neo4j\Databags\SummarizedResult;
  * Neo4jProjectionStore (stripping a subject down to a stub). Those classes hold their transaction
  * differently, so the transaction is passed in per call rather than owned here.
  *
- * Only Subject nodes are addressed: both queries match on the :Subject label so they can use the
- * :Subject(id) uniqueness index. Passing the id of any other kind of node matches nothing.
+ * Only Subject nodes are addressed: passing the id of any other kind of node matches nothing.
  */
 class Neo4jNodeLabels {
 

--- a/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jNodeLabels.php
+++ b/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jNodeLabels.php
@@ -8,24 +8,27 @@ use Laudis\Neo4j\Contracts\TransactionInterface;
 use Laudis\Neo4j\Databags\SummarizedResult;
 
 /**
- * Reads and removes the labels of a Neo4j node identified by its id, within a given transaction.
+ * Reads and removes the labels of a Subject node identified by its id, within a given transaction.
  *
  * Shared by Neo4jSubjectUpdater (reconciling a subject's labels with its schema) and
  * Neo4jProjectionStore (stripping a subject down to a stub). Those classes hold their transaction
  * differently, so the transaction is passed in per call rather than owned here.
+ *
+ * Only Subject nodes are addressed: both queries match on the :Subject label so they can use the
+ * :Subject(id) uniqueness index. Passing the id of any other kind of node matches nothing.
  */
 class Neo4jNodeLabels {
 
 	/**
 	 * @return string[]
 	 */
-	public static function read( TransactionInterface $transaction, string $nodeId ): array {
+	public static function read( TransactionInterface $transaction, string $subjectId ): array {
 		/**
 		 * @var SummarizedResult $result
 		 */
 		$result = $transaction->run(
-			'MATCH (n {id: $id}) RETURN labels(n) AS labels',
-			[ 'id' => $nodeId ]
+			'MATCH (n:Subject {id: $id}) RETURN labels(n) AS labels',
+			[ 'id' => $subjectId ]
 		);
 
 		if ( $result->isEmpty() ) {
@@ -38,14 +41,14 @@ class Neo4jNodeLabels {
 	/**
 	 * @param string[] $labels
 	 */
-	public static function remove( TransactionInterface $transaction, string $nodeId, array $labels ): void {
+	public static function remove( TransactionInterface $transaction, string $subjectId, array $labels ): void {
 		if ( $labels === [] ) {
 			return;
 		}
 
 		$transaction->run(
-			'MATCH (n {id: $id}) REMOVE n:' . Cypher::buildLabelList( $labels ),
-			[ 'id' => $nodeId ]
+			'MATCH (n:Subject {id: $id}) REMOVE n:' . Cypher::buildLabelList( $labels ),
+			[ 'id' => $subjectId ]
 		);
 	}
 

--- a/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jPageIdentifiersLookup.php
+++ b/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jPageIdentifiersLookup.php
@@ -30,7 +30,7 @@ class Neo4jPageIdentifiersLookup implements PageIdentifiersLookup {
 				// ever linked to its own wiki's page node.
 				$result = $transaction->run(
 					'
-					MATCH (page:Page)-[:HasSubject]->(subject {id: $subjectId})
+					MATCH (page:Page)-[:HasSubject]->(subject:Subject {id: $subjectId})
 					RETURN page.id AS id, page.name AS name, page.namespaceId AS namespaceId',
 					[ 'subjectId' => $subjectId->text ]
 				);

--- a/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStore.php
+++ b/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStore.php
@@ -225,7 +225,7 @@ readonly class Neo4jProjectionStore implements GraphDatabasePlugin {
 		 */
 		$result = $transaction->run(
 			'UNWIND $subjectIds AS subjectId
-				MATCH (subject {id: subjectId})<-[incomingRelation]-(other)
+				MATCH (subject:Subject {id: subjectId})<-[incomingRelation]-(other)
 				WHERE NOT incomingRelation:HasSubject AND other <> subject
 				RETURN DISTINCT subject.id AS id',
 			[ 'subjectIds' => $subjectIds ]
@@ -246,7 +246,7 @@ readonly class Neo4jProjectionStore implements GraphDatabasePlugin {
 		}
 
 		$transaction->run(
-			'MATCH (subject) WHERE subject.id IN $subjectIds DETACH DELETE subject',
+			'MATCH (subject:Subject) WHERE subject.id IN $subjectIds DETACH DELETE subject',
 			[ 'subjectIds' => $subjectIds ]
 		);
 	}
@@ -259,13 +259,12 @@ readonly class Neo4jProjectionStore implements GraphDatabasePlugin {
 	 */
 	private function reduceSubjectToStub( TransactionInterface $transaction, SubjectId $subjectId ): void {
 		$transaction->run(
-			'MATCH (subject {id: $subjectId})
+			'MATCH (subject:Subject {id: $subjectId})
 				OPTIONAL MATCH ()-[hasSubject:HasSubject]->(subject)
 				OPTIONAL MATCH (subject)-[outgoingRelation]->()
 				DELETE hasSubject, outgoingRelation
 				WITH DISTINCT subject
-				SET subject = {id: $subjectId, wiki_id: $wikiId}
-				SET subject:Subject',
+				SET subject = {id: $subjectId, wiki_id: $wikiId}',
 			[ 'subjectId' => $subjectId->text, 'wikiId' => $this->wikiId ]
 		);
 

--- a/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectRelationUpdater.php
+++ b/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectRelationUpdater.php
@@ -33,7 +33,7 @@ class Neo4jSubjectRelationUpdater {
 	private function removeNonexistentRelations( array $relationIds ): void {
 		$this->transaction->run(
 			'
-				MATCH ({id: $subjectId})-[relation]->()
+				MATCH (:Subject {id: $subjectId})-[relation]->()
 				WHERE NOT relation.id IN $relationIds
 				DELETE relation',
 			[
@@ -45,8 +45,8 @@ class Neo4jSubjectRelationUpdater {
 
 	private function removeIfTypeOrTargetChanged( TypedRelation $relation ): void {
 		$this->transaction->run(
-			'MATCH (subject {id: $subjectId})-[oldRelation {id: $relationId}]->()
-			 WHERE oldRelation.type <> $relationType OR NOT (subject)-[oldRelation]->({id: $targetId})
+			'MATCH (subject:Subject {id: $subjectId})-[oldRelation {id: $relationId}]->()
+			 WHERE oldRelation.type <> $relationType OR NOT (subject)-[oldRelation]->(:Subject {id: $targetId})
 			 DELETE oldRelation',
 			[
 				'subjectId' => $this->subjectId->text,
@@ -61,11 +61,11 @@ class Neo4jSubjectRelationUpdater {
 		// A relation whose target Subject does not exist yet creates it as a stub: a node with only
 		// the id and wiki_id properties and the Subject label. ON CREATE keeps an already-existing
 		// target (a real Subject or an earlier stub) untouched. The stub is upgraded in place when the
-		// real Subject is later saved, since the save path also matches the node by id alone.
+		// real Subject is later saved, since the save path matches the same :Subject label and id.
 		$this->transaction->run(
-			'MERGE (subject {id: $subjectId})
-			 MERGE (target {id: $targetId})
-			 ON CREATE SET target:Subject, target.wiki_id = $wikiId
+			'MERGE (subject:Subject {id: $subjectId})
+			 MERGE (target:Subject {id: $targetId})
+			 ON CREATE SET target.wiki_id = $wikiId
 			 MERGE (subject)-[relation:' . Cypher::escape( $relation->type->text ) . ' {id: $relationId}]->(target)
 			 SET relation = $relationProperties',
 			[

--- a/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectUpdater.php
+++ b/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectUpdater.php
@@ -34,16 +34,22 @@ class Neo4jSubjectUpdater {
 			return;
 		}
 
-		// Note: the below method calls might need to be in this order
+		// updateNodeProperties must stay first: it is what brings the node into existence, and the
+		// steps after it match that node as a :Subject. Reordering it after any of them would have
+		// them create a second, label-less node for the same id.
 		$this->updateNodeProperties( $subject );
 		$this->updateRelations( $subject, $schema );
 		$this->updateHasSubjectRelation( $subject, $isMainSubject );
 		$this->updateNodeLabels( $subject );
 	}
 
+	/**
+	 * Creates the node with the :Subject label rather than adding the label later, so that every
+	 * subsequent match of it can be label-scoped and use the :Subject(id) uniqueness index.
+	 */
 	private function updateNodeProperties( Subject $subject ): void {
 		$this->transaction->run(
-			'MERGE (n {id: $id}) SET n = $props',
+			'MERGE (n:Subject {id: $id}) SET n = $props',
 			[
 				'id' => $subject->id->text,
 				'props' => array_merge(
@@ -109,7 +115,7 @@ class Neo4jSubjectUpdater {
 
 	private function updateHasSubjectRelation( Subject $subject, bool $isMainSubject ): void {
 		$this->transaction->run(
-			'MATCH (page:Page {id: $pageId, wiki_id: $wikiId}), (subject {id: $subjectId})
+			'MATCH (page:Page {id: $pageId, wiki_id: $wikiId}), (subject:Subject {id: $subjectId})
 					MERGE (page)-[:HasSubject {isMain: $isMainSubject}]->(subject)',
 			[
 				'pageId' => $this->pageId->id,
@@ -130,7 +136,7 @@ class Neo4jSubjectUpdater {
 
 		if ( $labelsToAdd !== [] ) {
 			$this->transaction->run(
-				'MATCH (n {id: $id}) SET n:' . Cypher::buildLabelList( $labelsToAdd ),
+				'MATCH (n:Subject {id: $id}) SET n:' . Cypher::buildLabelList( $labelsToAdd ),
 				[ 'id' => $subject->id->text ]
 			);
 		}

--- a/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectUpdater.php
+++ b/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectUpdater.php
@@ -34,9 +34,9 @@ class Neo4jSubjectUpdater {
 			return;
 		}
 
-		// updateNodeProperties must stay first: it is what brings the node into existence, and the
-		// steps after it match that node as a :Subject. Reordering it after any of them would have
-		// them create a second, label-less node for the same id.
+		// updateNodeProperties must precede updateHasSubjectRelation and updateNodeLabels: those two only
+		// MATCH the subject's node, and this is the step that creates it for every subject. Move it after
+		// them and a subject with no relations silently loses its page link and its Schema label.
 		$this->updateNodeProperties( $subject );
 		$this->updateRelations( $subject, $schema );
 		$this->updateHasSubjectRelation( $subject, $isMainSubject );

--- a/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectUpdater.php
+++ b/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectUpdater.php
@@ -44,8 +44,7 @@ class Neo4jSubjectUpdater {
 	}
 
 	/**
-	 * Creates the node with the :Subject label rather than adding the label later, so that every
-	 * subsequent match of it can be label-scoped and use the :Subject(id) uniqueness index.
+	 * Creates the node with the :Subject label: the later steps of the save match it by that label.
 	 */
 	private function updateNodeProperties( Subject $subject ): void {
 		$this->transaction->run(

--- a/tests/phpunit/EntryPoints/UpdaterInitializesGraphDatabasesTest.php
+++ b/tests/phpunit/EntryPoints/UpdaterInitializesGraphDatabasesTest.php
@@ -9,6 +9,7 @@ use ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiHooks;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\ThrowingGraphDatabasePlugin;
+use TestLogger;
 
 /**
  * Guards the update.php path: an ordinary install or upgrade must establish the store-level structures
@@ -62,6 +63,12 @@ class UpdaterInitializesGraphDatabasesTest extends NeoWikiIntegrationTestCase {
 		$this->assertSame( [ 'Page wiki_id id', 'Subject id' ], $this->constraintNames() );
 	}
 
+	public function testASuccessfulUpdateReportsCompletion(): void {
+		NeoWikiHooks::initializeGraphDatabases( $this->newUpdater() );
+
+		$this->assertSame( "Initializing NeoWiki graph databases...done.\n", $this->report );
+	}
+
 	public function testUpdateReportsAFailingBackendInsteadOfAborting(): void {
 		$this->registerGraphDatabasePlugins( new ThrowingGraphDatabasePlugin() );
 
@@ -71,25 +78,96 @@ class UpdaterInitializesGraphDatabasesTest extends NeoWikiIntegrationTestCase {
 	}
 
 	/**
-	 * A client reports an unreachable server by quoting the connection URI it tried, credentials and
-	 * all, and this report goes to the operator's terminal and to deployment logs.
+	 * update.php --quiet discards everything written to the updater, so the report on its own leaves a
+	 * wiki whose backends never initialized with no trace anywhere.
 	 */
-	public function testTheReportOfAFailingBackendCarriesNoCredentials(): void {
-		$this->registerGraphDatabasePlugins( new ThrowingGraphDatabasePlugin(
-			"Cannot connect to any server on alias: bolt with Uris: ('bolt://neo4j:sekrit@neo:7687')"
-		) );
+	public function testAFailingBackendIsAlsoLogged(): void {
+		$logger = new TestLogger( true );
+		$this->setLogger( 'NeoWiki', $logger );
+		$this->registerGraphDatabasePlugins( new ThrowingGraphDatabasePlugin() );
 
 		NeoWikiHooks::initializeGraphDatabases( $this->newUpdater() );
 
-		$this->assertStringNotContainsString( 'sekrit', $this->report );
+		$buffer = $logger->getBuffer();
+		$this->assertCount( 1, $buffer );
+		$this->assertSame( 'error', $buffer[0][0] );
+		$this->assertStringContainsString( ThrowingGraphDatabasePlugin::FAILURE_MESSAGE, $buffer[0][1] );
+	}
+
+	/**
+	 * A client reports an unreachable server by quoting the connection URI it tried, credentials and
+	 * all, and this report goes to the operator's terminal and to deployment logs.
+	 *
+	 * @dataProvider credentialBearingMessageProvider
+	 */
+	public function testTheReportOfAFailingBackendCarriesNoCredentials( string $backendMessage, string $password ): void {
+		$logger = new TestLogger( true );
+		$this->setLogger( 'NeoWiki', $logger );
+		$this->registerGraphDatabasePlugins( new ThrowingGraphDatabasePlugin( $backendMessage ) );
+
+		NeoWikiHooks::initializeGraphDatabases( $this->newUpdater() );
+
+		$this->assertStringNotContainsString( $password, $this->report );
 		$this->assertStringContainsString( 'bolt://neo:7687', $this->report );
+		$this->assertStringNotContainsString( $password, $logger->getBuffer()[0][1] );
+	}
+
+	/**
+	 * A password is not limited to the characters that are safe in a URI, and the client quotes back
+	 * whatever it was handed. Each shape below defeated a redaction anchored to the first `/` or `@`:
+	 * the slash one leaked the password in full, the at-sign one leaked all but its first character.
+	 *
+	 * @return iterable<string, array{string, string}>
+	 */
+	public static function credentialBearingMessageProvider(): iterable {
+		yield 'plain password' => [
+			"Cannot connect to any server on alias: bolt with Uris: ('bolt://neo4j:sekrit@neo:7687')",
+			'sekrit'
+		];
+		yield 'password containing a slash' => [
+			'Unable to parse URI: bolt://neo4j:se/krit@neo:7687',
+			'se/krit'
+		];
+		yield 'password containing an at sign' => [
+			"Cannot connect to any server on alias: bolt with Uris: ('bolt://neo4j:se@krit@neo:7687')",
+			'se@krit'
+		];
+		yield 'password containing a quote' => [
+			"Cannot connect to any server on alias: bolt with Uris: ('bolt://neo4j:se'krit@neo:7687')",
+			"se'krit"
+		];
+		yield 'two connection URIs in one message' => [
+			"Cannot connect to any server on alias: bolt with Uris: ('bolt://neo4j:sekrit@neo:7687', "
+				. "'neo4j+s://neo4j:sekrit@neo:7687')",
+			'sekrit'
+		];
+	}
+
+	/**
+	 * A message that carries no credentials has to reach the operator intact: it is the only thing that
+	 * says why the run failed, and the actionable causes — a duplicate id, a user without the rights to
+	 * write schema — say so in prose rather than in a URI.
+	 */
+	public function testACredentialFreeReasonIsReportedVerbatim(): void {
+		$reason = 'Both Node(162) and Node(163) have the label `Subject` and property `id` = "abc"';
+		$this->registerGraphDatabasePlugins( new ThrowingGraphDatabasePlugin( $reason ) );
+
+		NeoWikiHooks::initializeGraphDatabases( $this->newUpdater() );
+
+		$this->assertStringContainsString( $reason, $this->report );
 	}
 
 	/**
 	 * Records what is registered on it and what it is asked to output, into the fields of this test.
+	 *
+	 * getDB() returns the test database rather than the mock's null, because the registration test
+	 * hands this double to every extension's LoadExtensionSchemaUpdates handler, and the ones that
+	 * inspect the connection would otherwise fatal on code that has nothing to do with NeoWiki.
 	 */
 	private function newUpdater(): DatabaseUpdater {
 		$updater = $this->createMock( DatabaseUpdater::class );
+
+		$updater->method( 'getDB' )->willReturn( $this->getDb() );
 
 		$updater->method( 'addExtensionUpdate' )->willReturnCallback(
 			function ( array $update ): void {

--- a/tests/phpunit/EntryPoints/UpdaterInitializesGraphDatabasesTest.php
+++ b/tests/phpunit/EntryPoints/UpdaterInitializesGraphDatabasesTest.php
@@ -22,64 +22,84 @@ use ProfessionalWiki\NeoWiki\Tests\TestDoubles\ThrowingGraphDatabasePlugin;
  */
 class UpdaterInitializesGraphDatabasesTest extends NeoWikiIntegrationTestCase {
 
+	/**
+	 * @var mixed[] The updates registered on the updater built by newUpdater().
+	 */
+	private array $registeredUpdates;
+
+	private string $report;
+
 	protected function setUp(): void {
 		parent::setUp();
 		$this->setUpNeo4j();
+		$this->registeredUpdates = [];
+		$this->report = '';
 	}
 
 	protected function tearDown(): void {
 		parent::tearDown();
-		// One test rebuilds the singleton with an extra plugin registered; reset it so later tests get
+		// Some tests rebuild the singleton with an extra plugin registered; reset it so later tests get
 		// a clean instance rebuilt without the temporary hook.
 		NeoWikiExtension::resetInstance();
 	}
 
-	public function testUpdaterRegistersGraphDatabaseInitialization(): void {
-		$updater = $this->recordingUpdater( $updates );
+	/**
+	 * Runs the hook the way MediaWiki does, through the registration in extension.json, so that losing
+	 * that registration fails here rather than silently disconnecting update.php from the graph stores.
+	 */
+	public function testTheSchemaUpdaterHookRegistersGraphDatabaseInitialization(): void {
+		$this->getServiceContainer()->getHookContainer()->run(
+			'LoadExtensionSchemaUpdates',
+			[ $this->newUpdater() ]
+		);
 
-		NeoWikiHooks::onLoadExtensionSchemaUpdates( $updater );
-
-		$this->assertContains( [ [ NeoWikiHooks::class, 'initializeGraphDatabases' ] ], $updates );
+		$this->assertContains( [ [ NeoWikiHooks::class, 'initializeGraphDatabases' ] ], $this->registeredUpdates );
 	}
 
 	public function testUpdateCreatesTheDefaultConstraints(): void {
-		NeoWikiHooks::initializeGraphDatabases( $this->reportingUpdater( $report ) );
+		NeoWikiHooks::initializeGraphDatabases( $this->newUpdater() );
 
 		$this->assertSame( [ 'Page wiki_id id', 'Subject id' ], $this->constraintNames() );
 	}
 
-	public function testUpdateReportsAnUnreachableBackendInsteadOfAborting(): void {
+	public function testUpdateReportsAFailingBackendInsteadOfAborting(): void {
 		$this->registerGraphDatabasePlugins( new ThrowingGraphDatabasePlugin() );
 
-		NeoWikiHooks::initializeGraphDatabases( $this->reportingUpdater( $report ) );
+		NeoWikiHooks::initializeGraphDatabases( $this->newUpdater() );
 
-		$this->assertStringContainsString( ThrowingGraphDatabasePlugin::FAILURE_MESSAGE, $report );
+		$this->assertStringContainsString( ThrowingGraphDatabasePlugin::FAILURE_MESSAGE, $this->report );
 	}
 
 	/**
-	 * @param mixed[]|null $updates Filled with the updates registered on the returned updater.
+	 * A client reports an unreachable server by quoting the connection URI it tried, credentials and
+	 * all, and this report goes to the operator's terminal and to deployment logs.
 	 */
-	private function recordingUpdater( ?array &$updates ): DatabaseUpdater {
-		$updates = [];
+	public function testTheReportOfAFailingBackendCarriesNoCredentials(): void {
+		$this->registerGraphDatabasePlugins( new ThrowingGraphDatabasePlugin(
+			"Cannot connect to any server on alias: bolt with Uris: ('bolt://neo4j:sekrit@neo:7687')"
+		) );
+
+		NeoWikiHooks::initializeGraphDatabases( $this->newUpdater() );
+
+		$this->assertStringNotContainsString( 'sekrit', $this->report );
+		$this->assertStringContainsString( 'bolt://neo:7687', $this->report );
+	}
+
+	/**
+	 * Records what is registered on it and what it is asked to output, into the fields of this test.
+	 */
+	private function newUpdater(): DatabaseUpdater {
 		$updater = $this->createMock( DatabaseUpdater::class );
+
 		$updater->method( 'addExtensionUpdate' )->willReturnCallback(
-			static function ( array $update ) use ( &$updates ): void {
-				$updates[] = $update;
+			function ( array $update ): void {
+				$this->registeredUpdates[] = $update;
 			}
 		);
 
-		return $updater;
-	}
-
-	/**
-	 * @param string|null $report Filled with everything the returned updater was asked to output.
-	 */
-	private function reportingUpdater( ?string &$report ): DatabaseUpdater {
-		$report = '';
-		$updater = $this->createMock( DatabaseUpdater::class );
 		$updater->method( 'output' )->willReturnCallback(
-			static function ( string $text ) use ( &$report ): void {
-				$report .= $text;
+			function ( string $text ): void {
+				$this->report .= $text;
 			}
 		);
 
@@ -87,6 +107,9 @@ class UpdaterInitializesGraphDatabasesTest extends NeoWikiIntegrationTestCase {
 	}
 
 	/**
+	 * The constraints themselves are specified by Neo4jConstraintUpdaterTest; their names are asserted
+	 * here only to show that this path reached them.
+	 *
 	 * @return string[]
 	 */
 	private function constraintNames(): array {

--- a/tests/phpunit/EntryPoints/UpdaterInitializesGraphDatabasesTest.php
+++ b/tests/phpunit/EntryPoints/UpdaterInitializesGraphDatabasesTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints;
+
+use MediaWiki\Installer\DatabaseUpdater;
+use ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiHooks;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\ThrowingGraphDatabasePlugin;
+
+/**
+ * Guards the update.php path: an ordinary install or upgrade must establish the store-level structures
+ * the backends need, since the incremental per-edit projection creates none and RebuildGraphDatabases
+ * is not part of that routine. The Neo4j uniqueness constraints are what the projection's id lookups
+ * seek on, so a wiki that never got them pays a scan per lookup.
+ *
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiHooks::onLoadExtensionSchemaUpdates
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiHooks::initializeGraphDatabases
+ * @group Database
+ */
+class UpdaterInitializesGraphDatabasesTest extends NeoWikiIntegrationTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->setUpNeo4j();
+	}
+
+	protected function tearDown(): void {
+		parent::tearDown();
+		// One test rebuilds the singleton with an extra plugin registered; reset it so later tests get
+		// a clean instance rebuilt without the temporary hook.
+		NeoWikiExtension::resetInstance();
+	}
+
+	public function testUpdaterRegistersGraphDatabaseInitialization(): void {
+		$updater = $this->recordingUpdater( $updates );
+
+		NeoWikiHooks::onLoadExtensionSchemaUpdates( $updater );
+
+		$this->assertContains( [ [ NeoWikiHooks::class, 'initializeGraphDatabases' ] ], $updates );
+	}
+
+	public function testUpdateCreatesTheDefaultConstraints(): void {
+		NeoWikiHooks::initializeGraphDatabases( $this->reportingUpdater( $report ) );
+
+		$this->assertSame( [ 'Page wiki_id id', 'Subject id' ], $this->constraintNames() );
+	}
+
+	public function testUpdateReportsAnUnreachableBackendInsteadOfAborting(): void {
+		$this->registerGraphDatabasePlugins( new ThrowingGraphDatabasePlugin() );
+
+		NeoWikiHooks::initializeGraphDatabases( $this->reportingUpdater( $report ) );
+
+		$this->assertStringContainsString( ThrowingGraphDatabasePlugin::FAILURE_MESSAGE, $report );
+	}
+
+	/**
+	 * @param mixed[]|null $updates Filled with the updates registered on the returned updater.
+	 */
+	private function recordingUpdater( ?array &$updates ): DatabaseUpdater {
+		$updates = [];
+		$updater = $this->createMock( DatabaseUpdater::class );
+		$updater->method( 'addExtensionUpdate' )->willReturnCallback(
+			static function ( array $update ) use ( &$updates ): void {
+				$updates[] = $update;
+			}
+		);
+
+		return $updater;
+	}
+
+	/**
+	 * @param string|null $report Filled with everything the returned updater was asked to output.
+	 */
+	private function reportingUpdater( ?string &$report ): DatabaseUpdater {
+		$report = '';
+		$updater = $this->createMock( DatabaseUpdater::class );
+		$updater->method( 'output' )->willReturnCallback(
+			static function ( string $text ) use ( &$report ): void {
+				$report .= $text;
+			}
+		);
+
+		return $updater;
+	}
+
+	/**
+	 * @return string[]
+	 */
+	private function constraintNames(): array {
+		return array_map(
+			static fn ( $record ) => $record->get( 'name' ),
+			$this->readGraph( 'SHOW CONSTRAINTS YIELD name ORDER BY name' )->toArray()
+		);
+	}
+
+}

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStoreTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStoreTest.php
@@ -393,6 +393,30 @@ class Neo4jProjectionStoreTest extends NeoWikiIntegrationTestCase {
 		$this->assertRelationExists( self::GUID_2, 'LocatedIn', self::GUID_1, 'rTestNQS1111rr1' );
 	}
 
+	/**
+	 * A save creates the subject's node and then matches it again to attach its relations, its page and
+	 * its schema label. Every one of those matches addresses it as a :Subject, so the node has to carry
+	 * that label from creation: were the label added at the end of the save instead, the relation step
+	 * would not find the node it just created and would create a second one under the same id.
+	 */
+	public function testSavingANewSubjectWithARelationCreatesASingleNodeForIt(): void {
+		$store = $this->newProjectionStoreWithLocationRelation();
+
+		$store->savePage( TestPage::build(
+			id: 2,
+			mainSubject: $this->buildSubjectWithLocationRelation( self::GUID_2, self::GUID_1, 'rTestNQS1111rr1' ),
+		) );
+
+		$this->assertNodeCountWithId( self::GUID_2, 1 );
+	}
+
+	private function assertNodeCountWithId( string $id, int $expected ): void {
+		// Deliberately unlabeled, so a node that failed to get the Subject label still counts.
+		$result = $this->readGraph( 'MATCH (node {id: $id}) RETURN count(node) AS count', [ 'id' => $id ] );
+
+		$this->assertSame( $expected, $result->first()->toRecursiveArray()['count'] );
+	}
+
 	public function testReducingReferencedSubjectToStubKeepsIncomingRelationsButStripsOutgoingRelationsAndProperties(): void {
 		$store = $this->newProjectionStoreWithLocationRelation();
 

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStoreTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStoreTest.php
@@ -407,14 +407,14 @@ class Neo4jProjectionStoreTest extends NeoWikiIntegrationTestCase {
 			mainSubject: $this->buildSubjectWithLocationRelation( self::GUID_2, self::GUID_1, 'rTestNQS1111rr1' ),
 		) );
 
-		$this->assertNodeCountWithId( self::GUID_2, 1 );
+		$this->assertSingleNodeWithId( self::GUID_2 );
 	}
 
-	private function assertNodeCountWithId( string $id, int $expected ): void {
+	private function assertSingleNodeWithId( string $id ): void {
 		// Deliberately unlabeled, so a node that failed to get the Subject label still counts.
 		$result = $this->readGraph( 'MATCH (node {id: $id}) RETURN count(node) AS count', [ 'id' => $id ] );
 
-		$this->assertSame( $expected, $result->first()->toRecursiveArray()['count'] );
+		$this->assertSame( 1, $result->first()->toRecursiveArray()['count'] );
 	}
 
 	public function testReducingReferencedSubjectToStubKeepsIncomingRelationsButStripsOutgoingRelationsAndProperties(): void {

--- a/tests/phpunit/TestDoubles/ThrowingGraphDatabasePlugin.php
+++ b/tests/phpunit/TestDoubles/ThrowingGraphDatabasePlugin.php
@@ -17,16 +17,25 @@ class ThrowingGraphDatabasePlugin implements GraphDatabasePlugin {
 
 	public const string FAILURE_MESSAGE = 'projection backend unreachable';
 
+	/**
+	 * @param string $message What the backend reports on failure. A real client quotes the connection
+	 *        URI it tried, so tests about how NeoWiki relays that message pass one in.
+	 */
+	public function __construct(
+		private readonly string $message = self::FAILURE_MESSAGE
+	) {
+	}
+
 	public function initialize(): void {
-		throw new RuntimeException( self::FAILURE_MESSAGE );
+		throw new RuntimeException( $this->message );
 	}
 
 	public function savePage( Page $page ): void {
-		throw new RuntimeException( self::FAILURE_MESSAGE );
+		throw new RuntimeException( $this->message );
 	}
 
 	public function deletePage( PageId $pageId ): void {
-		throw new RuntimeException( self::FAILURE_MESSAGE );
+		throw new RuntimeException( $this->message );
 	}
 
 }


### PR DESCRIPTION
Nearly every Subject operation in the Neo4j projection matched nodes without a label — `MERGE (n {id: $id})`,
`MATCH (subject {id: ...})`. Neo4j indexes are label-scoped, so none of them could use the index behind the
`:Subject(id)` uniqueness constraint: they planned as `AllNodesScan`, which makes the cost of writing one Subject grow
with the size of the whole graph. [ADR 29](https://github.com/ProfessionalWiki/NeoWiki/blob/master/docs/adr/029-scalability-targets.md)
puts 1 million Subjects in the "great" tier; a per-Subject full scan cannot meet that.

Two things were needed.

**Label the matches.** Every Subject node carries the `:Subject` label, stubs included — both stub-creating paths set
it — so scoping the matches to it changes no semantics and a stub is still upgraded in place. The one ordering
constraint this introduces is that `updateNodeProperties` now creates the node *with* the label, rather than
`updateNodeLabels` adding it at the end of the save, because the relation and page-link steps in between match the
node as a `:Subject`. `testSavingANewSubjectWithARelationCreatesASingleNodeForIt` guards that — labeling the
downstream matches but not the creating `MERGE` gives two nodes under one id.

**Create the constraints on ordinary wikis.** Only `RebuildGraphDatabases.php` ever created them, and that only runs
when an operator explicitly invokes it, so a wiki built up edit by edit had no index to seek and labeled matches would
still have planned as `NodeByLabelScan`. `initialize()` now also runs from `LoadExtensionSchemaUpdates`, so
`update.php` creates them — the step the install docs already tell operators to run. It stays idempotent, and reports
rather than aborts when a backend fails, since MediaWiki's own schema changes are the point of that run. That report
strips credentials: the Neo4j client names an unreachable server by quoting the connection URI it tried, password and
all. `UpdaterInitializesGraphDatabasesTest` pins the whole path through MediaWiki's real hook container — losing the
`extension.json` registration, the constraints, the carry-on-failure behavior, or the credential stripping each fails
a test.

`EXPLAIN` leaf operators on the dev stack (Neo4j 2026.05.0). Eleven of the twelve query sites are Subject-anchored,
and all eleven move together:

| | unlabeled (before) | labeled, no constraint | labeled + constraint |
|---|---|---|---|
| the eleven Subject-anchored sites | `AllNodesScan` | `NodeByLabelScan` | `NodeUniqueIndexSeek` / `MergeUniqueNode` |
| `Neo4jPageIdentifiersLookup` | `NodeByLabelScan` over `:Page` | `NodeByLabelScan` | `NodeUniqueIndexSeek` |

Both halves are load-bearing: labeling alone only narrows the scan, and the constraint alone is unreachable. Timing
the hottest site (`updateNodeProperties`) against a seeded graph, median of 200 runs:

| Subjects in graph | before | after |
|---|---|---|
| 1,000 | 2.30 ms | 2.00 ms |
| 10,000 | 2.88 ms | 1.89 ms |
| 50,000 | 7.16 ms | 1.81 ms |

The "after" column is flat; the "before" column tracks graph size.

Two things for whoever merges this:

- **It overlaps https://github.com/ProfessionalWiki/NeoWiki/pull/1171** (orphan stub sweep), which rewrites parts of
  `Neo4jProjectionStore` and edits one line in each of `removeNonexistentRelations` and `removeIfTypeOrTargetChanged`
  that this branch also changes. Edits here are one label per changed line, so the resolution is as small as it can
  be, but it will not be automatic. The queries #1171 adds — including an entirely unanchored
  `MATCH (subject)-[]->(target)` — want the same treatment once the second of the two PRs merges.
- **No migration.** A labeled `MERGE` would duplicate a label-less Subject node rather than update it. Every path
  that creates one on master labels it inside the same transaction, so none can exist; and
  `RebuildGraphDatabases.php` normalises the graph regardless.

Known gap: once the nodes carry the label, removing `:Subject` from any single *lookup* is behaviourally invisible, so
the labels themselves are unguarded — only the creating `MERGE` is. Guarding them would mean asserting on query plans,
which pins the change to Neo4j's operator vocabulary.

Considered and omitted:

- **Renaming `Neo4jNodeLabels`** to something Subject-specific. Its queries are Subject-scoped now and its docblock
  says so; the rename would widen the #1171 conflict surface for a naming gain.
- **Per-plugin isolation on the update path.** A plugin that always throws stops the ones registered after it from
  initializing on that run — pre-existing on the rebuild path, and the bundled SPARQL backend's `initialize()` is a
  no-op (as is the RedHerb example's). `extending.md` now states it so third-party authors can see it.
- **Lazy per-request constraint creation.** It costs a round trip on every save, and Neo4j rejects schema and data
  operations in one transaction.
- **A second no-graph-backend test** for the update path. `RebuildGraphDatabasesTest::testInitializingGraphDatabasesDoesNotThrowWithoutABackend`
  already covers the shared `getGraphDatabasePlugin()->initialize()` call.

> <sub>AI-authored — Claude Code, `Opus 5 (max)`; commissioned by @JeroenDeDauw, detailed spec naming the intended approach and the ordering trap, no redirections, then one AI review round that found a credential leak in the new failure output and an untested hook registration, and a fact-checked prose pass on this description; diff not yet human-reviewed; every added guard confirmed failing against the mutation it exists for, full local PHPUnit suite (2093 tests) plus phpcs and phpstan green, EXPLAIN plans and timings measured on the worktree's dev stack, and the constraint bootstrap verified by a real `update.php` run against a graph with no constraints.</sub>
