### PR TITLE
Restore Recent changes and its keyboard shortcut in the demo main menu

### DIFF
--- a/DemoData/AGENTS.md
+++ b/DemoData/AGENTS.md
@@ -24,9 +24,6 @@ file and re-importing is enough — no `make reinstall-db` needed. Only pages th
 are pruned; a page someone else created — like `Main_Page`, which the installer creates and the
 import merely overwrites — is never deleted, even if its source file is removed.
 
-`MediaWiki/Sidebar.wikitext` links to `SPARQL queries`. Drop that line when seeding a wiki without a
-SPARQL store, or the main menu shows a red link.
-
 ## Filename and ID conventions
 
 - **Filenames must match the entity's label exactly**, including UTF-8 accents and apostrophes.
@@ -70,6 +67,12 @@ Subject, relation, and option IDs:
    `SparqlPage/` or `EdmSparqlPage/` renders as a redlink wherever the import skipped it. Keep the
    whole sentence inside `{{#ifexist:Target|...}}` so it disappears with its target, and keep the space
    between two such sentences outside the braces — ParserFunctions trims its arguments.
+6. **Sidebar labels double as element ids.** In `MediaWiki/Sidebar.wikitext` the second field becomes
+   the link's `n-<field>` id, which is what carries MediaWiki's accesskey and tooltip. Write
+   `recentchanges-url|recentchanges`, not `Special:RecentChanges|Recent changes`, or the keyboard
+   shortcut disappears with no other visible change. A sidebar line is transformed before it is split
+   on the pipe, so `{{#ifexist:}}` works there too — write the pipe as `{{!}}`, and an entry whose
+   target is missing drops out of the menu entirely.
 
 ## Cypher gotchas
 

--- a/DemoData/MediaWiki/Sidebar.wikitext
+++ b/DemoData/MediaWiki/Sidebar.wikitext
@@ -1,5 +1,5 @@
 * Demo tour
-** Main Page|Main page
+** mainpage|mainpage-description
 ** Museum collection|Museum collection
 ** ACME Inc|ACME Inc
 ** Research catalog|Research catalog
@@ -9,8 +9,10 @@
 ** Special:Schemas|Schemas
 ** Subject views|Subject views
 ** RDF and ontology mappings|RDF and ontology mappings
-** SPARQL queries|SPARQL queries
+** {{#ifexist:SPARQL queries|SPARQL queries{{!}}SPARQL queries|}}
 ** Developers|Developers hub
 * About NeoWiki
 ** https://neowiki.ai|NeoWiki website
 ** https://github.com/ProfessionalWiki/NeoWiki/issues|Issue tracker
+* This wiki
+** recentchanges-url|recentchanges


### PR DESCRIPTION
MediaWiki derives a sidebar link's element id from the label field, and the accesskey and tooltip hang off that id, so `Special:RecentChanges|Recent changes` yields a link with no shortcut. The canonical `recentchanges-url|recentchanges` restores Alt+Shift+R, and `mainpage|mainpage-description` restores Alt+Shift+Z on the main page entry.

Recent changes gets a trailing "This wiki" section rather than a place among the demo pages: it is wiki plumbing, useful to whoever maintains the demo rather than to a first-time visitor.

The SPARQL entry now goes through `{{#ifexist:}}`, as gotcha 5 prescribes for conditionally imported pages. A sidebar line is transformed before it is split on the pipe, so an entry whose target is missing drops out of the menu entirely: no red link, and no line for maintainers to delete by hand.

Verified on a worktree wiki: `n-recentchanges` carries `accesskey="r"` and `n-mainpage-description` carries `accesskey="z"`; with the SPARQL target present the entry renders normally, and pointed at a missing page it disappears rather than leaving an empty link. Vector 2022 renders no icons in the main menu, so the icons core associates with these two ids change nothing visually.

Touches `DemoData/AGENTS.md` in a different region than https://github.com/ProfessionalWiki/NeoWiki/pull/1184, so whichever merges second may want a rebase.

> <sub>AI-authored — Claude Code, `Opus 5 (max)`; @JeroenDeDauw reported the missing entry and its dead keybinding after deploying the sidebar; diff not yet human-reviewed; no production code changed, both accesskeys and both `{{#ifexist:}}` branches checked against a running wiki.</sub>