### PR TITLE
Fix the parameterised Lua query example to match the Schema as a label

### DIFF
--- a/docs/authoring/lua-api.md
+++ b/docs/authoring/lua-api.md
@@ -221,10 +221,11 @@ end
 ```
 
 ```lua
--- Parameterised — always prefer this over concatenating values into the query.
+-- Parameterised — always prefer this over concatenating values into the query. The Schema is the
+-- node's label, not a property, and Cypher parameters cannot supply labels.
 local rows = nw.query(
-    'MATCH (s:Subject {schema: $schema}) WHERE s.`Valid` = $valid RETURN s.name, s.`Expiry date`',
-    { schema = 'ISMS Document', valid = 'Yes' }
+    'MATCH (s:Subject:`ISMS Document`) WHERE s.`Valid` = $valid RETURN s.name, s.`Expiry date`',
+    { valid = 'Yes' }
 )
 ```
 

--- a/docs/authoring/lua-api.md
+++ b/docs/authoring/lua-api.md
@@ -221,8 +221,7 @@ end
 ```
 
 ```lua
--- Parameterised — always prefer this over concatenating values into the query. The Schema is the
--- node's label, not a property, and Cypher parameters cannot supply labels.
+-- Prefer parameterized queries over concatenating values into queries.
 local rows = nw.query(
     'MATCH (s:Subject:`ISMS Document`) WHERE s.`Valid` = $valid RETURN s.name, s.`Expiry date`',
     { valid = 'Yes' }

--- a/docs/authoring/lua-api.md
+++ b/docs/authoring/lua-api.md
@@ -223,7 +223,7 @@ end
 ```lua
 -- Prefer parameterized queries over concatenating values into queries.
 local rows = nw.query(
-    'MATCH (s:Subject:`ISMS Document`) WHERE s.`Valid` = $valid RETURN s.name, s.`Expiry date`',
+    'MATCH (s:Subject:`ISMS Document`) WHERE $valid IN s.`Valid` RETURN s.name AS name, s.`Expiry date`[0] AS expiry',
     { valid = 'Yes' }
 )
 ```


### PR DESCRIPTION
The parameterised query example filtered on a `schema` node property that does not exist — the Schema is the node's
label (`:Subject:ISMS Document`, see the [Graph Model](https://github.com/ProfessionalWiki/NeoWiki/blob/master/docs/api/graph-model.md#subject-nodes)) —
so the example returned nothing. Cypher parameters cannot supply labels, so the label is written literally and the
value stays parameterised, which is also the idiomatic shape for real queries.

> <sub>AI-authored — Claude Code, `Fable 5 (max)`; pre-existing doc bug surfaced during an AI review round on #1185, fix requested by @JeroenDeDauw, no revisions; not yet human-reviewed; corrected query verified against the documented graph model.</sub>
