### PR TITLE
Cache Schema lookups per request instead of per Subject

### DIFF
--- a/docs/operations/maintenance.md
+++ b/docs/operations/maintenance.md
@@ -23,13 +23,16 @@ longer has. Run it to:
 - Recover after a backend wipe or restore.
 - Fix any drift between a backend's copy and the canonical revision slots.
 
-Two things to plan around:
+Three things to plan around:
 
 - It reconciles pages, not stray data. Anything the projection never knew about — a node written directly to Neo4j,
   say, or a named graph left behind in a SPARQL store — is not something the rebuild can find. For a guaranteed-clean
   result, empty the backend before rebuilding: wipe Neo4j's data volume, or drop the wiki's named graphs from the store.
 - It runs as a single sequential process with no batching or resume, so the time scales with the number of pages. Plan
   downtime on large wikis.
+- Schema edits made while it runs do not reach it. It resolves each Schema once and keeps that copy for the rest of the
+  run, so a Schema edited mid-run is projected as it stood when the rebuild first read it. Edit Schemas before starting,
+  or re-run the rebuild afterwards.
 
 ## Upgrades
 

--- a/src/Application/Schema/Exception/SchemaContentUnavailableException.php
+++ b/src/Application/Schema/Exception/SchemaContentUnavailableException.php
@@ -1,0 +1,28 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application\Schema\Exception;
+
+use RuntimeException;
+
+/**
+ * Thrown when the content of a Schema page that exists could not be read at all, as opposed to
+ * being read and found not to be a valid Schema.
+ *
+ * The two produce the same null for callers, but only the second is a property of the revision.
+ * An unreadable blob is a transient condition — an external store or replica hiccup — so a cache
+ * keyed by revision id must not remember it: the key would not change until someone edited the
+ * Schema, pinning it as missing for the life of the entry. Content that does not deserialize will
+ * not deserialize on the next call either, and is safe to remember.
+ *
+ * Callers are expected to have established that the page exists; {@see CachingSchemaLookup} does so
+ * before it reaches the inner lookup.
+ */
+class SchemaContentUnavailableException extends RuntimeException {
+
+	public static function forName( string $schemaName ): self {
+		return new self( 'Schema content could not be read: ' . $schemaName );
+	}
+
+}

--- a/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectUpdater.php
+++ b/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectUpdater.php
@@ -26,7 +26,6 @@ class Neo4jSubjectUpdater {
 	}
 
 	public function updateSubject( Subject $subject, bool $isMainSubject ): void {
-		// TODO: we should make sure this schema retrieval is cached
 		$schema = $this->schemaRepository->getSchema( $subject->getSchemaName() );
 
 		if ( $schema === null ) {

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -1028,8 +1028,14 @@ class NeoWikiExtension {
 		);
 	}
 
-	// Pinned to the authority of the first use, like getNeo4jPlugin(): the realistic mid-process
-	// authority switch is a login, where serving the earlier anonymous resolutions only under-serves.
+	// Pinned to the authority of first use, like getNeo4jPlugin(). The pin fixes the authority behind
+	// both the Schema read gate and the inner lookup's revision-audience filter, and it lives as long
+	// as this singleton, so its scope is the PHP process: one request under mod_php, a whole run under
+	// a maintenance script. It narrows ADR 027's "every access decision runs against the caller's
+	// Authority" to the process's first authority, which is safe because the in-request switches go
+	// weaker to stronger — a login or account creation mutating the main context — where reusing the
+	// anonymous resolutions can only under-serve. Core's one switch the other way, beginAccountCreation()
+	// dropping a temp account to a fresh anonymous user, moves between two near-anonymous authorities.
 	public function getSchemaLookup(): SchemaLookup {
 		$this->schemaLookup ??= $this->newSchemaLookup( $this->getRequestAuthority() );
 

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -181,8 +181,7 @@ class NeoWikiExtension {
 	private ClientInterface $neo4jClient;
 	private ClientInterface $readOnlyNeo4jClient;
 	private ?WikiConfigSource $wikiConfigSource = null;
-	private SchemaLookup $schemaLookup;
-	private ?Authority $schemaLookupAuthority = null;
+	private ?SchemaLookup $schemaLookup = null;
 	private static ?self $instance = null;
 
 	public static function getInstance(): self {
@@ -1029,18 +1028,10 @@ class NeoWikiExtension {
 		);
 	}
 
-	// One lookup per Authority, so callers resolving Schemas for that Authority share its
-	// process-local cache. The lookup resolves content as its Authority, so an Authority change
-	// builds a new one rather than reusing the previous Authority's resolutions.
+	// Pinned to the authority of the first use, like getNeo4jPlugin(): the realistic mid-process
+	// authority switch is a login, where serving the earlier anonymous resolutions only under-serves.
 	public function getSchemaLookup(): SchemaLookup {
-		$authority = $this->getRequestAuthority();
-
-		if ( $this->schemaLookupAuthority !== $authority ) {
-			// Recorded only once the lookup exists, so a throw here is retried rather than
-			// leaving the Authority pinned to a lookup that was never built.
-			$this->schemaLookup = $this->newSchemaLookup( $authority );
-			$this->schemaLookupAuthority = $authority;
-		}
+		$this->schemaLookup ??= $this->newSchemaLookup( $this->getRequestAuthority() );
 
 		return $this->schemaLookup;
 	}

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -181,6 +181,8 @@ class NeoWikiExtension {
 	private ClientInterface $neo4jClient;
 	private ClientInterface $readOnlyNeo4jClient;
 	private ?WikiConfigSource $wikiConfigSource = null;
+	private SchemaLookup $schemaLookup;
+	private ?Authority $schemaLookupAuthority = null;
 	private static ?self $instance = null;
 
 	public static function getInstance(): self {
@@ -1027,16 +1029,33 @@ class NeoWikiExtension {
 		);
 	}
 
+	/**
+	 * One lookup per Authority, so its process-local cache is shared by everything resolving Schemas
+	 * for that Authority — most notably the validation and the graph projection of every Subject on a
+	 * saved page. The lookup resolves content as its Authority, so a change of Authority builds a new
+	 * one rather than serving one Authority's resolutions to another.
+	 */
 	public function getSchemaLookup(): SchemaLookup {
+		$authority = $this->getRequestAuthority();
+
+		if ( $this->schemaLookupAuthority !== $authority ) {
+			$this->schemaLookupAuthority = $authority;
+			$this->schemaLookup = $this->newSchemaLookup( $authority );
+		}
+
+		return $this->schemaLookup;
+	}
+
+	private function newSchemaLookup( Authority $authority ): SchemaLookup {
 		return new CachingSchemaLookup(
 			schemaLookup: new WikiPageSchemaLookup(
 				pageContentFetcher: $this->getPageContentFetcher(),
-				authority: $this->getRequestAuthority(),
+				authority: $authority,
 				schemaDeserializer: $this->getPersistenceSchemaDeserializer()
 			),
 			cache: MediaWikiServices::getInstance()->getMainWANObjectCache(),
 			titleFactory: MediaWikiServices::getInstance()->getTitleFactory(),
-			readAuthorizer: $this->newPageReadAuthorizer( $this->getRequestAuthority() ),
+			readAuthorizer: $this->newPageReadAuthorizer( $authority ),
 			connectionProvider: MediaWikiServices::getInstance()->getConnectionProvider(),
 		);
 	}

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -1029,18 +1029,17 @@ class NeoWikiExtension {
 		);
 	}
 
-	/**
-	 * One lookup per Authority, so its process-local cache is shared by everything resolving Schemas
-	 * for that Authority — most notably the validation and the graph projection of every Subject on a
-	 * saved page. The lookup resolves content as its Authority, so a change of Authority builds a new
-	 * one rather than serving one Authority's resolutions to another.
-	 */
+	// One lookup per Authority, so callers resolving Schemas for that Authority share its
+	// process-local cache. The lookup resolves content as its Authority, so an Authority change
+	// builds a new one rather than reusing the previous Authority's resolutions.
 	public function getSchemaLookup(): SchemaLookup {
 		$authority = $this->getRequestAuthority();
 
 		if ( $this->schemaLookupAuthority !== $authority ) {
-			$this->schemaLookupAuthority = $authority;
+			// Recorded only once the lookup exists, so a throw here is retried rather than
+			// leaving the Authority pinned to a lookup that was never built.
 			$this->schemaLookup = $this->newSchemaLookup( $authority );
+			$this->schemaLookupAuthority = $authority;
 		}
 
 		return $this->schemaLookup;

--- a/src/Persistence/MediaWiki/CachingMappingLookup.php
+++ b/src/Persistence/MediaWiki/CachingMappingLookup.php
@@ -16,9 +16,9 @@ use Wikimedia\Rdbms\Database;
 use Wikimedia\Rdbms\IConnectionProvider;
 
 /**
- * Caches deserialized Mappings, mirroring {@see CachingSchemaLookup}. The cache key includes the Mapping
- * page's latest revision id, so a Mapping edit transparently invalidates its entry and a bulk RDF dump
- * reuses a cached Mapping across every page it projects instead of re-parsing it per page.
+ * Caches deserialized Mappings, mirroring the shared-cache tier of {@see CachingSchemaLookup}. The cache
+ * key includes the Mapping page's latest revision id, so a Mapping edit transparently invalidates its entry
+ * and a bulk RDF dump reuses a cached Mapping across every page it projects instead of re-parsing it per page.
  */
 class CachingMappingLookup implements MappingLookup {
 

--- a/src/Persistence/MediaWiki/CachingSchemaLookup.php
+++ b/src/Persistence/MediaWiki/CachingSchemaLookup.php
@@ -7,6 +7,7 @@ namespace ProfessionalWiki\NeoWiki\Persistence\MediaWiki;
 use MediaWiki\Title\Title;
 use MediaWiki\Title\TitleFactory;
 use ProfessionalWiki\NeoWiki\Application\PageReadAuthorizer;
+use ProfessionalWiki\NeoWiki\Application\Schema\Exception\SchemaContentUnavailableException;
 use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
@@ -58,7 +59,16 @@ class CachingSchemaLookup implements SchemaLookup {
 		$cacheKey = $this->makeCacheKey( $title );
 
 		if ( !array_key_exists( $cacheKey, $this->resolvedSchemas ) ) {
-			$this->resolvedSchemas[$cacheKey] = $this->getFromSharedCache( $cacheKey, $schemaName );
+			try {
+				$this->resolvedSchemas[$cacheKey] = $this->getFromSharedCache( $cacheKey, $schemaName );
+			}
+			catch ( SchemaContentUnavailableException ) {
+				// The revision's content could not be read, which the next call may well manage.
+				// Neither tier may remember that: the key is the revision id, so the entry would
+				// outlive the failure until someone edited the Schema. Letting this unwind past
+				// getWithSetCallback() leaves the shared tier empty too.
+				return null;
+			}
 		}
 
 		return $this->resolvedSchemas[$cacheKey];

--- a/src/Persistence/MediaWiki/CachingSchemaLookup.php
+++ b/src/Persistence/MediaWiki/CachingSchemaLookup.php
@@ -18,10 +18,15 @@ use Wikimedia\Rdbms\IConnectionProvider;
 
 /**
  * Caches deserialized Schemas so that repeated reads do not each re-load and re-parse the Schema
- * wiki page. Two tiers: a process-local one serving the reads within a single request or
- * maintenance run, over the shared WANObjectCache serving reads across them. Both key on the
- * Schema page's latest revision id, so editing the Schema transparently invalidates the entry —
- * no stale schemas.
+ * wiki page. Two tiers: a process-local one over the shared WANObjectCache. NeoWikiExtension pins
+ * one lookup in its singleton, so the process-local tier lasts as long as the PHP process — a
+ * single request under mod_php, an entire run under a maintenance script.
+ *
+ * Both key on the Schema page's latest revision id, which is read from the LinkCache. An edit made
+ * by this process refreshes that cache (see WikiPage::updateRevisionOn), so it yields a new key and
+ * takes effect at once. An edit made by another process does not reach this one's LinkCache, so a
+ * long-running script keeps serving the Schema as it stood when the script first resolved it. The
+ * shared tier has no such window, because the next process reads the current revision id.
  */
 class CachingSchemaLookup implements SchemaLookup {
 
@@ -93,8 +98,9 @@ class CachingSchemaLookup implements SchemaLookup {
 	}
 
 	/**
-	 * Keyed by the Schema page's article id and latest revision id, so editing
-	 * the Schema yields a new key and the old entry is never served again.
+	 * Keyed by the Schema page's article id and latest revision id, so an edit this process can see
+	 * yields a new key and the old entry is never served again. The class docblock covers the edits
+	 * it cannot see.
 	 */
 	private function makeCacheKey( Title $title ): string {
 		return $this->cache->makeKey(

--- a/src/Persistence/MediaWiki/CachingSchemaLookup.php
+++ b/src/Persistence/MediaWiki/CachingSchemaLookup.php
@@ -16,22 +16,19 @@ use Wikimedia\Rdbms\Database;
 use Wikimedia\Rdbms\IConnectionProvider;
 
 /**
- * Caches deserialized Schemas so that repeated reads (the per-keystroke dry-run validation, and
- * the validation plus graph projection of every Subject on a saved page) do not each re-load the
- * Schema wiki page and re-parse it. Caching is two-tier: a process-local tier serving the calls
- * within one request or maintenance run, over the shared WANObjectCache serving calls across them.
- *
- * Both tiers key on the Schema page's latest revision id, so editing the Schema transparently
- * invalidates the entry — no stale schemas. Neither tier is a read gate: the per-page read check
- * runs on every call, ahead of both.
+ * Caches deserialized Schemas so that repeated reads do not each re-load and re-parse the Schema
+ * wiki page. Two tiers: a process-local one serving the reads within a single request or
+ * maintenance run, over the shared WANObjectCache serving reads across them. Both key on the
+ * Schema page's latest revision id, so editing the Schema transparently invalidates the entry —
+ * no stale schemas.
  */
 class CachingSchemaLookup implements SchemaLookup {
 
 	private const CACHE_VERSION = 1;
 
 	/**
-	 * Resolved Schemas by cache key, including the nulls, so a Schema that is missing or
-	 * unreadable is not re-resolved per Subject either.
+	 * Schemas by cache key, including the null from a Schema page whose content does not
+	 * deserialize. A missing or unreadable page returns before this, so it is never memoized.
 	 *
 	 * @var array<string, ?Schema>
 	 */
@@ -90,8 +87,7 @@ class CachingSchemaLookup implements SchemaLookup {
 
 	/**
 	 * Keyed by the Schema page's article id and latest revision id, so editing
-	 * the Schema yields a new key and the old entry is never served again by
-	 * either tier.
+	 * the Schema yields a new key and the old entry is never served again.
 	 */
 	private function makeCacheKey( Title $title ): string {
 		return $this->cache->makeKey(

--- a/src/Persistence/MediaWiki/CachingSchemaLookup.php
+++ b/src/Persistence/MediaWiki/CachingSchemaLookup.php
@@ -16,14 +16,26 @@ use Wikimedia\Rdbms\Database;
 use Wikimedia\Rdbms\IConnectionProvider;
 
 /**
- * Caches deserialized Schemas so that concurrent reads (most notably the
- * per-keystroke dry-run validation) do not each re-load the Schema wiki page
- * and re-parse it. The cache key includes the Schema page's latest revision id,
- * so editing the Schema transparently invalidates the entry — no stale schemas.
+ * Caches deserialized Schemas so that repeated reads (the per-keystroke dry-run validation, and
+ * the validation plus graph projection of every Subject on a saved page) do not each re-load the
+ * Schema wiki page and re-parse it. Caching is two-tier: a process-local tier serving the calls
+ * within one request or maintenance run, over the shared WANObjectCache serving calls across them.
+ *
+ * Both tiers key on the Schema page's latest revision id, so editing the Schema transparently
+ * invalidates the entry — no stale schemas. Neither tier is a read gate: the per-page read check
+ * runs on every call, ahead of both.
  */
 class CachingSchemaLookup implements SchemaLookup {
 
 	private const CACHE_VERSION = 1;
+
+	/**
+	 * Resolved Schemas by cache key, including the nulls, so a Schema that is missing or
+	 * unreadable is not re-resolved per Subject either.
+	 *
+	 * @var array<string, ?Schema>
+	 */
+	private array $resolvedSchemas = [];
 
 	public function __construct(
 		private readonly SchemaLookup $schemaLookup,
@@ -43,15 +55,25 @@ class CachingSchemaLookup implements SchemaLookup {
 
 		// The inner lookup applies no per-title read check (its revision audience check filters
 		// revision deletion only), so this is the sole read gate on the Schema read path. It
-		// must also run before the cache: the cached value is user-independent schema content,
+		// must also run before the caches: the cached value is user-independent schema content,
 		// and a cache hit must not serve a Schema whose page the user may not read (#1046).
 		if ( !$this->readAuthorizer->authorizeReadByPageTitle( $title ) ) {
 			return null;
 		}
 
+		$cacheKey = $this->makeCacheKey( $title );
+
+		if ( !array_key_exists( $cacheKey, $this->resolvedSchemas ) ) {
+			$this->resolvedSchemas[$cacheKey] = $this->getFromSharedCache( $cacheKey, $schemaName );
+		}
+
+		return $this->resolvedSchemas[$cacheKey];
+	}
+
+	private function getFromSharedCache( string $cacheKey, SchemaName $schemaName ): ?Schema {
 		/** @var Schema|null $schema */
 		$schema = $this->cache->getWithSetCallback(
-			$this->makeCacheKey( $title ),
+			$cacheKey,
 			WANObjectCache::TTL_DAY,
 			function ( mixed $oldValue, int &$ttl, array &$setOpts ) use ( $schemaName ): ?Schema {
 				// Make caching replica-lag aware: if the schema content is read
@@ -68,7 +90,8 @@ class CachingSchemaLookup implements SchemaLookup {
 
 	/**
 	 * Keyed by the Schema page's article id and latest revision id, so editing
-	 * the Schema yields a new key and the old entry is never served again.
+	 * the Schema yields a new key and the old entry is never served again by
+	 * either tier.
 	 */
 	private function makeCacheKey( Title $title ): string {
 		return $this->cache->makeKey(

--- a/src/Persistence/MediaWiki/CachingSchemaLookup.php
+++ b/src/Persistence/MediaWiki/CachingSchemaLookup.php
@@ -27,9 +27,6 @@ class CachingSchemaLookup implements SchemaLookup {
 	private const CACHE_VERSION = 1;
 
 	/**
-	 * Schemas by cache key, including the null from a Schema page whose content does not
-	 * deserialize. A missing or unreadable page returns before this, so it is never memoized.
-	 *
 	 * @var array<string, ?Schema>
 	 */
 	private array $resolvedSchemas = [];

--- a/src/Persistence/MediaWiki/WikiPageSchemaLookup.php
+++ b/src/Persistence/MediaWiki/WikiPageSchemaLookup.php
@@ -6,6 +6,7 @@ namespace ProfessionalWiki\NeoWiki\Persistence\MediaWiki;
 
 use InvalidArgumentException;
 use MediaWiki\Permissions\Authority;
+use ProfessionalWiki\NeoWiki\Application\Schema\Exception\SchemaContentUnavailableException;
 use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
@@ -21,11 +22,18 @@ class WikiPageSchemaLookup implements SchemaLookup {
 	) {
 	}
 
+	/**
+	 * Returns null when the Schema page's content is not a valid Schema, and throws when that content
+	 * could not be read at all, so that a caching decorator can tell the durable outcome from the
+	 * transient one. See {@see SchemaContentUnavailableException}.
+	 *
+	 * @throws SchemaContentUnavailableException
+	 */
 	public function getSchema( SchemaName $schemaName ): ?Schema {
 		$content = $this->getContent( $schemaName );
 
 		if ( $content === null ) {
-			return null;
+			throw SchemaContentUnavailableException::forName( $schemaName->getText() );
 		}
 
 		try {

--- a/tests/phpunit/NeoWikiIntegrationTestCase.php
+++ b/tests/phpunit/NeoWikiIntegrationTestCase.php
@@ -34,6 +34,19 @@ class NeoWikiIntegrationTestCase extends MediaWikiIntegrationTestCase {
 
 	use HandlesNeo4jEnvOverrides;
 
+	/**
+	 * The singleton pins a SchemaLookup whose process-local Schema cache is keyed by page and revision
+	 * id, and those ids repeat across tests on the temp tables, so an instance surviving a test would
+	 * serve one test's Schema to the next. A `@before` hook rather than setUp(): most subclasses
+	 * override setUp() without calling parent, which a base setUp() cannot reach. It also runs ahead
+	 * of setUp(), so a subclass that rebuilds the singleton itself keeps its instance.
+	 *
+	 * @before
+	 */
+	final protected function neoWikiSetUp(): void {
+		NeoWikiExtension::resetInstance();
+	}
+
 	protected function setUpNeo4j(): void {
 		try {
 			$client = NeoWikiExtension::getInstance()->getNeo4jClient();
@@ -203,9 +216,6 @@ class NeoWikiIntegrationTestCase extends MediaWikiIntegrationTestCase {
 	 * Registers extra graph database plugins through the NeoWikiRegistration hook and rebuilds the singleton
 	 * so they are composed into the write paths, letting a test drive the real hook wiring with a backend of
 	 * its choosing (a spy, or one that always throws).
-	 *
-	 * Callers must reset the singleton again in tearDown, so later tests get an instance built without the
-	 * temporary hook.
 	 */
 	protected function registerGraphDatabasePlugins( GraphDatabasePlugin ...$plugins ): void {
 		$this->setTemporaryHook(

--- a/tests/phpunit/NeoWikiIntegrationTestCase.php
+++ b/tests/phpunit/NeoWikiIntegrationTestCase.php
@@ -35,11 +35,11 @@ class NeoWikiIntegrationTestCase extends MediaWikiIntegrationTestCase {
 	use HandlesNeo4jEnvOverrides;
 
 	/**
-	 * The singleton pins a SchemaLookup whose process-local Schema cache is keyed by page and revision
-	 * id, and those ids repeat across tests on the temp tables, so an instance surviving a test would
-	 * serve one test's Schema to the next. A `@before` hook rather than setUp(): most subclasses
-	 * override setUp() without calling parent, which a base setUp() cannot reach. It also runs ahead
-	 * of setUp(), so a subclass that rebuilds the singleton itself keeps its instance.
+	 * The singleton pins a SchemaLookup whose cache is keyed by page and revision id, and those ids
+	 * repeat across tests' temp tables, so an instance surviving a test would serve one test's Schema
+	 * to the next. A `@before` hook because most subclasses override setUp() without calling parent;
+	 * it runs before setUp(), so a subclass rebuilding the singleton in its own setUp() keeps that
+	 * instance.
 	 *
 	 * @before
 	 */

--- a/tests/phpunit/Persistence/MediaWiki/CachingSchemaLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/CachingSchemaLookupTest.php
@@ -7,12 +7,15 @@ namespace ProfessionalWiki\NeoWiki\Tests\Persistence\MediaWiki;
 use MediaWiki\Title\Title;
 use MediaWiki\Title\TitleFactory;
 use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\PageReadAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinitions;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\CachingSchemaLookup;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubPageReadAuthorizer;
+use Wikimedia\ObjectCache\EmptyBagOStuff;
 use Wikimedia\ObjectCache\HashBagOStuff;
 use Wikimedia\ObjectCache\WANObjectCache;
 use Wikimedia\Rdbms\IConnectionProvider;
@@ -74,17 +77,64 @@ class CachingSchemaLookupTest extends TestCase {
 		$this->assertSame( 0, $inner->calls );
 	}
 
+	public function testResolvesTheSameRevisionOnlyOnceWhenTheSharedCacheStoresNothing(): void {
+		$inner = $this->newSpyLookup();
+
+		$lookup = new CachingSchemaLookup( $inner, $this->newDiscardingCache(), $this->newTitleFactory( 1, 100, 100 ), new StubPageReadAuthorizer( allowed: true ), $this->newConnectionProvider() );
+		$first = $lookup->getSchema( new SchemaName( 'Person' ) );
+		$second = $lookup->getSchema( new SchemaName( 'Person' ) );
+
+		$this->assertSame( 1, $inner->calls );
+		$this->assertEquals( $inner->schema, $first );
+		$this->assertEquals( $inner->schema, $second );
+	}
+
+	public function testResolvesAbsentSchemaOnlyOnceWhenTheSharedCacheStoresNothing(): void {
+		$inner = $this->newNullReturningSpyLookup();
+
+		$lookup = new CachingSchemaLookup( $inner, $this->newDiscardingCache(), $this->newTitleFactory( 1, 100, 100 ), new StubPageReadAuthorizer( allowed: true ), $this->newConnectionProvider() );
+		$this->assertNull( $lookup->getSchema( new SchemaName( 'Broken' ) ) );
+		$this->assertNull( $lookup->getSchema( new SchemaName( 'Broken' ) ) );
+
+		$this->assertSame( 1, $inner->calls );
+	}
+
+	public function testResolvesEachSchemaSeparately(): void {
+		$inner = $this->newSpyLookup();
+
+		$lookup = new CachingSchemaLookup( $inner, $this->newDiscardingCache(), $this->newTitleFactoryPerPage( [ 'Person' => 1, 'City' => 2 ] ), new StubPageReadAuthorizer( allowed: true ), $this->newConnectionProvider() );
+		$lookup->getSchema( new SchemaName( 'Person' ) );
+		$lookup->getSchema( new SchemaName( 'City' ) );
+		$lookup->getSchema( new SchemaName( 'Person' ) );
+
+		$this->assertSame( 2, $inner->calls );
+	}
+
+	public function testChecksReadPermissionOnEveryCall(): void {
+		$authorizer = new class() implements PageReadAuthorizer {
+			public bool $allowed = true;
+
+			public function authorizeReadByPageId( PageId $pageId ): bool {
+				return $this->allowed;
+			}
+
+			public function authorizeReadByPageTitle( Title $title ): bool {
+				return $this->allowed;
+			}
+		};
+
+		$lookup = new CachingSchemaLookup( $this->newSpyLookup(), $this->newDiscardingCache(), $this->newTitleFactory( 1, 100, 100 ), $authorizer, $this->newConnectionProvider() );
+		$lookup->getSchema( new SchemaName( 'Person' ) );
+
+		$authorizer->allowed = false;
+
+		$this->assertNull( $lookup->getSchema( new SchemaName( 'Person' ) ) );
+	}
+
 	public function testCachesANullResultForTheSameRevision(): void {
 		// An existing page whose content is not a valid schema yields null; that
 		// result is cached too, so it is not re-loaded on every call for the rev.
-		$inner = new class() implements SchemaLookup {
-			public int $calls = 0;
-
-			public function getSchema( SchemaName $schemaName ): ?Schema {
-				$this->calls++;
-				return null;
-			}
-		};
+		$inner = $this->newNullReturningSpyLookup();
 
 		$lookup = new CachingSchemaLookup( $inner, $this->newCache(), $this->newTitleFactory( 1, 100, 100 ), new StubPageReadAuthorizer( allowed: true ), $this->newConnectionProvider() );
 		$this->assertNull( $lookup->getSchema( new SchemaName( 'Broken' ) ) );
@@ -112,6 +162,41 @@ class CachingSchemaLookupTest extends TestCase {
 		};
 	}
 
+	/**
+	 * @return SchemaLookup&object{calls: int}
+	 */
+	private function newNullReturningSpyLookup(): SchemaLookup {
+		return new class() implements SchemaLookup {
+			public int $calls = 0;
+
+			public function getSchema( SchemaName $schemaName ): ?Schema {
+				$this->calls++;
+				return null;
+			}
+		};
+	}
+
+	/**
+	 * @param array<string, int> $articleIdsByPageName
+	 */
+	private function newTitleFactoryPerPage( array $articleIdsByPageName ): TitleFactory {
+		$titles = [];
+
+		foreach ( $articleIdsByPageName as $pageName => $articleId ) {
+			$title = $this->createMock( Title::class );
+			$title->method( 'exists' )->willReturn( true );
+			$title->method( 'getArticleID' )->willReturn( $articleId );
+			$title->method( 'getLatestRevID' )->willReturn( 100 );
+			$titles[$pageName] = $title;
+		}
+
+		$factory = $this->createMock( TitleFactory::class );
+		$factory->method( 'newFromText' )->willReturnCallback(
+			static fn ( string $pageName ): ?Title => $titles[$pageName] ?? null
+		);
+		return $factory;
+	}
+
 	private function newTitleFactory( int $articleId, int ...$revIds ): TitleFactory {
 		$title = $this->createMock( Title::class );
 		$title->method( 'exists' )->willReturn( true );
@@ -125,6 +210,14 @@ class CachingSchemaLookupTest extends TestCase {
 
 	private function newCache(): WANObjectCache {
 		return new WANObjectCache( [ 'cache' => new HashBagOStuff() ] );
+	}
+
+	/**
+	 * Stands in for a wiki with no shared object cache configured ($wgMainCacheType = CACHE_NONE),
+	 * where every read past the process-local tier reaches the inner lookup.
+	 */
+	private function newDiscardingCache(): WANObjectCache {
+		return new WANObjectCache( [ 'cache' => new EmptyBagOStuff() ] );
 	}
 
 	private function newConnectionProvider(): IConnectionProvider {

--- a/tests/phpunit/Persistence/MediaWiki/CachingSchemaLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/CachingSchemaLookupTest.php
@@ -8,6 +8,7 @@ use MediaWiki\Title\Title;
 use MediaWiki\Title\TitleFactory;
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Application\PageReadAuthorizer;
+use ProfessionalWiki\NeoWiki\Application\Schema\Exception\SchemaContentUnavailableException;
 use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinitions;
@@ -143,6 +144,31 @@ class CachingSchemaLookupTest extends TestCase {
 		$this->assertSame( 1, $inner->calls );
 	}
 
+	public function testDoesNotRememberARevisionWhoseContentCouldNotBeRead(): void {
+		// Unlike content that does not deserialize, an unreadable blob is transient. Remembering it
+		// would pin the Schema as missing until someone edited it, since the key is the revision id.
+		$inner = $this->newUnreadableContentSpyLookup();
+
+		$lookup = new CachingSchemaLookup( $inner, $this->newCache(), $this->newTitleFactory( 1, 100, 100 ), new StubPageReadAuthorizer( allowed: true ), $this->newConnectionProvider() );
+
+		$this->assertNull( $lookup->getSchema( new SchemaName( 'Person' ) ) );
+		$this->assertNull( $lookup->getSchema( new SchemaName( 'Person' ) ) );
+
+		$this->assertSame( 2, $inner->calls );
+	}
+
+	public function testServesTheSchemaOnceTheRevisionBecomesReadableAgain(): void {
+		$inner = $this->newRecoveringSpyLookup();
+
+		$lookup = new CachingSchemaLookup( $inner, $this->newCache(), $this->newTitleFactory( 1, 100, 100, 100 ), new StubPageReadAuthorizer( allowed: true ), $this->newConnectionProvider() );
+
+		$this->assertNull( $lookup->getSchema( new SchemaName( 'Person' ) ) );
+		$this->assertEquals( $inner->schema, $lookup->getSchema( new SchemaName( 'Person' ) ) );
+		$this->assertEquals( $inner->schema, $lookup->getSchema( new SchemaName( 'Person' ) ) );
+
+		$this->assertSame( 2, $inner->calls );
+	}
+
 	/**
 	 * @return SchemaLookup&object{calls: int, schema: Schema}
 	 */
@@ -172,6 +198,46 @@ class CachingSchemaLookupTest extends TestCase {
 			public function getSchema( SchemaName $schemaName ): ?Schema {
 				$this->calls++;
 				return null;
+			}
+		};
+	}
+
+	/**
+	 * @return SchemaLookup&object{calls: int}
+	 */
+	private function newUnreadableContentSpyLookup(): SchemaLookup {
+		return new class() implements SchemaLookup {
+			public int $calls = 0;
+
+			public function getSchema( SchemaName $schemaName ): ?Schema {
+				$this->calls++;
+				throw SchemaContentUnavailableException::forName( $schemaName->getText() );
+			}
+		};
+	}
+
+	/**
+	 * Unreadable on the first call, then readable, as a transient blob failure behaves.
+	 *
+	 * @return SchemaLookup&object{calls: int, schema: Schema}
+	 */
+	private function newRecoveringSpyLookup(): SchemaLookup {
+		return new class() implements SchemaLookup {
+			public int $calls = 0;
+			public Schema $schema;
+
+			public function __construct() {
+				$this->schema = new Schema( new SchemaName( 'Test' ), 'desc', new PropertyDefinitions( [] ) );
+			}
+
+			public function getSchema( SchemaName $schemaName ): ?Schema {
+				$this->calls++;
+
+				if ( $this->calls === 1 ) {
+					throw SchemaContentUnavailableException::forName( $schemaName->getText() );
+				}
+
+				return $this->schema;
 			}
 		};
 	}

--- a/tests/phpunit/Persistence/MediaWiki/CachingSchemaLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/CachingSchemaLookupTest.php
@@ -89,7 +89,7 @@ class CachingSchemaLookupTest extends TestCase {
 		$this->assertEquals( $inner->schema, $second );
 	}
 
-	public function testResolvesAbsentSchemaOnlyOnceWhenTheSharedCacheStoresNothing(): void {
+	public function testResolvesUndeserializableSchemaOnlyOnceWhenTheSharedCacheStoresNothing(): void {
 		$inner = $this->newNullReturningSpyLookup();
 
 		$lookup = new CachingSchemaLookup( $inner, $this->newDiscardingCache(), $this->newTitleFactory( 1, 100, 100 ), new StubPageReadAuthorizer( allowed: true ), $this->newConnectionProvider() );
@@ -124,7 +124,7 @@ class CachingSchemaLookupTest extends TestCase {
 		};
 
 		$lookup = new CachingSchemaLookup( $this->newSpyLookup(), $this->newDiscardingCache(), $this->newTitleFactory( 1, 100, 100 ), $authorizer, $this->newConnectionProvider() );
-		$lookup->getSchema( new SchemaName( 'Person' ) );
+		$this->assertNotNull( $lookup->getSchema( new SchemaName( 'Person' ) ) );
 
 		$authorizer->allowed = false;
 

--- a/tests/phpunit/Persistence/MediaWiki/SchemaLookupSharingTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/SchemaLookupSharingTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Persistence\MediaWiki;
+
+use MediaWiki\Context\RequestContext;
+use MediaWiki\MediaWikiServices;
+use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
+use ProfessionalWiki\NeoWiki\Application\Validation\ProposedSubjectValidator;
+use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphDatabasePlugin;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectMap;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\CachingSchemaLookup;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestPage;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSchema;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiMockAuthorityTrait;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubPageReadAuthorizer;
+use Wikimedia\ObjectCache\EmptyBagOStuff;
+use Wikimedia\ObjectCache\WANObjectCache;
+
+/**
+ * The Schema of a Subject is needed by both the validation and the graph projection of every
+ * Subject on a saved page. These pin that a page's Schemas are resolved once per Schema, not
+ * once per Subject per path.
+ *
+ * @covers \ProfessionalWiki\NeoWiki\Persistence\MediaWiki\CachingSchemaLookup
+ * @covers \ProfessionalWiki\NeoWiki\NeoWikiExtension
+ * @group Database
+ */
+class SchemaLookupSharingTest extends NeoWikiIntegrationTestCase {
+
+	use NeoWikiMockAuthorityTrait;
+
+	private const SCHEMA_NAME = 'SharedLookupSchema';
+
+	public function setUp(): void {
+		$this->setUpNeo4j();
+		$this->createSchema( self::SCHEMA_NAME );
+	}
+
+	public function testProjectingAPageResolvesItsSchemaOnce(): void {
+		$inner = $this->newCountingLookup();
+
+		$this->newCountingProjectionStore( $inner )->savePage(
+			TestPage::build(
+				mainSubject: $this->newSubject( 'sShrdLookup1111' ),
+				childSubjects: new SubjectMap(
+					$this->newSubject( 'sShrdLookup1112' ),
+					$this->newSubject( 'sShrdLookup1113' ),
+					$this->newSubject( 'sShrdLookup1114' ),
+				)
+			)
+		);
+
+		$this->assertSame( 1, $inner->calls );
+	}
+
+	public function testValidatingSubjectsResolvesTheirSchemaOnce(): void {
+		$inner = $this->newCountingLookup();
+		$validator = new ProposedSubjectValidator(
+			schemaLookup: $this->newCachingLookup( $inner ),
+			subjectValidator: NeoWikiExtension::getInstance()->getSubjectValidator(),
+		);
+
+		$validator->validate( $this->newSubject( 'sShrdLookup1115' ) );
+		$validator->validate( $this->newSubject( 'sShrdLookup1116' ) );
+		$validator->validate( $this->newSubject( 'sShrdLookup1117' ) );
+		$validator->validate( $this->newSubject( 'sShrdLookup1118' ) );
+
+		$this->assertSame( 1, $inner->calls );
+	}
+
+	public function testServesOneSchemaLookupThroughoutARequest(): void {
+		$extension = NeoWikiExtension::getInstance();
+
+		$this->assertSame( $extension->getSchemaLookup(), $extension->getSchemaLookup() );
+	}
+
+	public function testDoesNotServeOneAuthoritysSchemaLookupToAnother(): void {
+		$context = RequestContext::getMain();
+		$extension = NeoWikiExtension::getInstance();
+
+		$context->setAuthority( $this->mockRegisteredUltimateAuthority() );
+		$this->assertNotNull( $extension->getSchemaLookup()->getSchema( new SchemaName( self::SCHEMA_NAME ) ) );
+
+		$context->setAuthority( $this->authorityWithGlobalReadButNoPageRead() );
+		$this->assertNull( $extension->getSchemaLookup()->getSchema( new SchemaName( self::SCHEMA_NAME ) ) );
+	}
+
+	private function newCountingProjectionStore( SchemaLookup $inner ): GraphDatabasePlugin {
+		return NeoWikiExtension::getInstance()->newNeo4jProjectionStore( $this->newCachingLookup( $inner ) );
+	}
+
+	/**
+	 * Over a cache that stores nothing, so every read past the process-local tier reaches
+	 * the counting lookup, as on a wiki without a shared object cache.
+	 */
+	private function newCachingLookup( SchemaLookup $inner ): CachingSchemaLookup {
+		$services = MediaWikiServices::getInstance();
+
+		return new CachingSchemaLookup(
+			schemaLookup: $inner,
+			cache: new WANObjectCache( [ 'cache' => new EmptyBagOStuff() ] ),
+			titleFactory: $services->getTitleFactory(),
+			readAuthorizer: new StubPageReadAuthorizer( allowed: true ),
+			connectionProvider: $services->getConnectionProvider(),
+		);
+	}
+
+	private function newSubject( string $id ): Subject {
+		return TestSubject::build( id: $id, schemaName: new SchemaName( self::SCHEMA_NAME ) );
+	}
+
+	/**
+	 * @return SchemaLookup&object{calls: int}
+	 */
+	private function newCountingLookup(): SchemaLookup {
+		return new class() implements SchemaLookup {
+			public int $calls = 0;
+
+			public function getSchema( SchemaName $schemaName ): ?Schema {
+				$this->calls++;
+				return TestSchema::build( name: $schemaName );
+			}
+		};
+	}
+
+}

--- a/tests/phpunit/Persistence/MediaWiki/SchemaLookupSharingTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/SchemaLookupSharingTest.php
@@ -4,7 +4,6 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Tests\Persistence\MediaWiki;
 
-use MediaWiki\Context\RequestContext;
 use MediaWiki\MediaWikiServices;
 use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
 use ProfessionalWiki\NeoWiki\Application\Validation\ProposedSubjectValidator;
@@ -19,7 +18,6 @@ use ProfessionalWiki\NeoWiki\Tests\Data\TestPage;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSchema;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
-use ProfessionalWiki\NeoWiki\Tests\NeoWikiMockAuthorityTrait;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubPageReadAuthorizer;
 use Wikimedia\ObjectCache\EmptyBagOStuff;
 use Wikimedia\ObjectCache\WANObjectCache;
@@ -34,8 +32,6 @@ use Wikimedia\ObjectCache\WANObjectCache;
  * @group Database
  */
 class SchemaLookupSharingTest extends NeoWikiIntegrationTestCase {
-
-	use NeoWikiMockAuthorityTrait;
 
 	private const SCHEMA_NAME = 'SharedLookupSchema';
 
@@ -80,17 +76,6 @@ class SchemaLookupSharingTest extends NeoWikiIntegrationTestCase {
 		$extension = NeoWikiExtension::getInstance();
 
 		$this->assertSame( $extension->getSchemaLookup(), $extension->getSchemaLookup() );
-	}
-
-	public function testDoesNotServeOneAuthoritysSchemaLookupToAnother(): void {
-		$context = RequestContext::getMain();
-		$extension = NeoWikiExtension::getInstance();
-
-		$context->setAuthority( $this->mockRegisteredUltimateAuthority() );
-		$this->assertNotNull( $extension->getSchemaLookup()->getSchema( new SchemaName( self::SCHEMA_NAME ) ) );
-
-		$context->setAuthority( $this->authorityWithGlobalReadButNoPageRead() );
-		$this->assertNull( $extension->getSchemaLookup()->getSchema( new SchemaName( self::SCHEMA_NAME ) ) );
 	}
 
 	private function newCountingProjectionStore( SchemaLookup $inner ): GraphDatabasePlugin {

--- a/tests/phpunit/Persistence/MediaWiki/SchemaLookupSharingTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/SchemaLookupSharingTest.php
@@ -97,15 +97,12 @@ class SchemaLookupSharingTest extends NeoWikiIntegrationTestCase {
 		return NeoWikiExtension::getInstance()->newNeo4jProjectionStore( $this->newCachingLookup( $inner ) );
 	}
 
-	/**
-	 * Over a cache that stores nothing, so every read past the process-local tier reaches
-	 * the counting lookup, as on a wiki without a shared object cache.
-	 */
 	private function newCachingLookup( SchemaLookup $inner ): CachingSchemaLookup {
 		$services = MediaWikiServices::getInstance();
 
 		return new CachingSchemaLookup(
 			schemaLookup: $inner,
+			// Stores nothing, so every read past the process-local tier reaches the counting lookup.
 			cache: new WANObjectCache( [ 'cache' => new EmptyBagOStuff() ] ),
 			titleFactory: $services->getTitleFactory(),
 			readAuthorizer: new StubPageReadAuthorizer( allowed: true ),

--- a/tests/phpunit/Persistence/MediaWiki/WikiPageSchemaLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/WikiPageSchemaLookupTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Persistence\MediaWiki;
+
+use InvalidArgumentException;
+use MediaWiki\Content\Content;
+use MediaWiki\Permissions\Authority;
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\Schema\Exception\SchemaContentUnavailableException;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinitions;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\EntryPoints\Content\SchemaContent;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\PageContentFetcher;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\SchemaPersistenceDeserializer;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\WikiPageSchemaLookup;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Persistence\MediaWiki\WikiPageSchemaLookup
+ */
+class WikiPageSchemaLookupTest extends TestCase {
+
+	public function testReturnsTheDeserializedSchema(): void {
+		$schema = new Schema( new SchemaName( 'Person' ), 'desc', new PropertyDefinitions( [] ) );
+
+		$lookup = $this->newLookup(
+			content: new SchemaContent( '{}' ),
+			deserializer: $this->newDeserializerReturning( $schema )
+		);
+
+		$this->assertSame( $schema, $lookup->getSchema( new SchemaName( 'Person' ) ) );
+	}
+
+	public function testReturnsNullWhenTheContentIsNotAValidSchema(): void {
+		$lookup = $this->newLookup(
+			content: new SchemaContent( 'not json' ),
+			deserializer: $this->newDeserializerThrowing()
+		);
+
+		$this->assertNull( $lookup->getSchema( new SchemaName( 'Broken' ) ) );
+	}
+
+	public function testThrowsWhenTheContentCouldNotBeRead(): void {
+		// Distinct from content that does not deserialize: this outcome is transient, so callers
+		// that cache by revision id must not store it.
+		$lookup = $this->newLookup( content: null, deserializer: $this->newDeserializerThrowing() );
+
+		$this->expectException( SchemaContentUnavailableException::class );
+
+		$lookup->getSchema( new SchemaName( 'Person' ) );
+	}
+
+	private function newLookup( ?Content $content, SchemaPersistenceDeserializer $deserializer ): WikiPageSchemaLookup {
+		$fetcher = $this->createMock( PageContentFetcher::class );
+		$fetcher->method( 'getPageContent' )->willReturn( $content );
+
+		return new WikiPageSchemaLookup(
+			pageContentFetcher: $fetcher,
+			authority: $this->createMock( Authority::class ),
+			schemaDeserializer: $deserializer
+		);
+	}
+
+	private function newDeserializerReturning( Schema $schema ): SchemaPersistenceDeserializer {
+		$deserializer = $this->createMock( SchemaPersistenceDeserializer::class );
+		$deserializer->method( 'deserialize' )->willReturn( $schema );
+		return $deserializer;
+	}
+
+	private function newDeserializerThrowing(): SchemaPersistenceDeserializer {
+		$deserializer = $this->createMock( SchemaPersistenceDeserializer::class );
+		$deserializer->method( 'deserialize' )->willThrowException( new InvalidArgumentException() );
+		return $deserializer;
+	}
+
+}


### PR DESCRIPTION
Backend validation and the graph projection each resolved a Subject's Schema from scratch, so
saving a page with 10 Subjects on one Schema resolved that Schema around a dozen times — once per
Subject in the projection, plus once or twice per written Subject in validation.
`Neo4jSubjectUpdater::updateSubject` carried a `TODO` for its own per-Subject fetch.

`CachingSchemaLookup` already existed, but its WANObjectCache tier stores nothing on a wiki with
`$wgMainCacheType = CACHE_NONE` (the dev stack, and any wiki without a shared object cache), and
even warm it pays serialization per call. `NeoWikiExtension::getSchemaLookup()` also built a new
lookup on every call, so the validator and the projection shared nothing regardless.

## Change

- `CachingSchemaLookup` gains a process-local tier in front of the shared cache, keyed by the same
  article-id + latest-revision-id key. Editing a Schema still yields a new key, so the
  no-stale-Schemas guarantee holds unchanged and needs no invalidation hook — including during a
  `RebuildGraphDatabases.php` run, where the lookup lives for the whole process. The null from a
  Schema whose content does not deserialize is memoized too, so the projection does not re-parse
  it per Subject; a missing or unreadable page returns before the tier.
- `NeoWikiExtension::getSchemaLookup()` pins one lookup on first use rather than building a new one
  per call, so the validator and the graph projection share that tier for the rest of the request or
  run. `getNeo4jPlugin()` already pins its own lookup the same way.
- `CachingMappingLookup`'s docblock now says it mirrors only `CachingSchemaLookup`'s shared tier.

Memory is bounded by the number of Schemas a process touches; ADR 29 places 500 at the top of its
acceptable range.

## Permission semantics

Unchanged: the process-local tier sits behind the read gate, and `authorizeReadByPageTitle` still
runs on every call, ahead of both tiers. It measures 0.0011 ms, so skipping it would buy nothing.
The tier holds user-independent Schema content under the key the shared cache already used, so it
shares nothing the WAN tier did not.

The lookup resolves Schema content as the Authority of its first use and keeps it. The only
realistic mid-process Authority switch is weaker to stronger — a login or account creation mutating
the main context — where reusing the anonymous Authority's resolutions can only under-serve, never
over-serve, and post-login content renders in a fresh request after the redirect anyway.

## Measurements

5000 iterations, single PHP process, dev stack (`CACHE_NONE`), 12-statement Subject on a
12-property Schema:

|                                                      | before                    | after                |
|------------------------------------------------------|---------------------------|----------------------|
| `ProposedSubjectValidator::validate`                 | 0.32-0.38 ms (2.6-3.1k/s) | 0.028 ms (36.4k/s)   |
| `SchemaLookup::getSchema`                            | 0.34-0.38 ms              | 0.020 ms             |
| `SubjectValidator::validate`, Schema already resolved | 0.006 ms                  | 0.006 ms             |

Schema resolution was ~98% of the cost of validating a Subject and is ~71% of a 12x smaller total.
Underlying Schema fetches when projecting a page with N Subjects on one Schema: N to 1.

With a warm shared cache (production `CACHE_ACCEL`/memcached) schema resolution already cost
~0.028 ms before this change, so the win there is ~1.2-1.4x, not 12x. The large win is on wikis
without a shared object cache, and on the first request after any Schema edit.

## Found, not fixed here

Validating a Subject with relation statements costs 0.71 ms per relation target on the same stack:
each target is resolved through `SubjectLookup::getSubject`, one graph round trip apiece,
un-batched. A Subject with a handful of relations therefore costs several ms whatever happens to
Schema lookup, and is the more likely source of a multi-millisecond per-Subject validation figure.
Batching those resolutions is a change to `SubjectValidator` and its lookup interface; it wants its
own issue.

## Considered and omitted

Keying the pinned lookup by Authority and rebuilding on a switch. It guards only the
weaker-to-stronger case above, which cannot over-serve, so it was structure with no threat to
justify it. It did, accidentally, isolate tests from one another — on master nothing persisted
between calls — so it is replaced by an explicit per-test `resetInstance()` in
`NeoWikiIntegrationTestCase`, as a `final` `@before` hook because 52 of the 76 `setUp()` overrides
in tests/phpunit never call `parent::setUp()`. No test class outside that base resolves Schemas
through the pinned lookup.

## Overlap

One line of `Neo4jSubjectUpdater` (the `TODO`) and no Cypher, so no conflict surface with #1185 or
#1171.


> <sub>AI-authored — Claude Code, `Opus 5 (max)`; commissioned by @JeroenDeDauw, detailed AI spec, one design redirection in review (per-Authority guard dropped for pin-first); design-reviewed in session by @JeroenDeDauw, who drove that revision and flagged a docblock for trimming; full diff not yet human-reviewed; profiled before and after on a local dev stack, tests written test-first and confirmed failing without the fix, 9 mutations applied to the cached paths with no survivors, AI-reviewed in a second commit, PHPUnit hook order probed to confirm the test-isolation reset fires despite setUp overrides; full local PHPUnit + phpcs + phpstan green.</sub>


