### PR TITLE
Move the Person-to-EDM example next to the RDF docs it walks through

### DIFF
--- a/DemoData/EdmSparqlPage/EDM_queries.wikitext
+++ b/DemoData/EdmSparqlPage/EDM_queries.wikitext
@@ -45,4 +45,4 @@ Each store entry names one projection, and several entries may point at one endp
 == Learn more ==
 
 * [https://neowiki.ai/docs/rdf/ontology-mapping Ontology mapping reference]
-* [https://neowiki.ai/docs/examples/person-to-edm Person-to-EDM worked example]
+* [https://neowiki.ai/docs/rdf/person-to-edm Person-to-EDM worked example]

--- a/DemoData/Page/RDF_and_ontology_mappings.wikitext
+++ b/DemoData/Page/RDF_and_ontology_mappings.wikitext
@@ -28,5 +28,5 @@ You don't need these links to reach an export: on any subject page, the Data tab
 * [[Special:Mappings]]: every ontology Mapping on this wiki
 * [https://neowiki.ai/docs/rdf/rdf-export RDF export reference]
 * [https://neowiki.ai/docs/rdf/ontology-mapping Ontology mapping reference]
-* [https://neowiki.ai/docs/examples/person-to-edm Person-to-EDM worked example]
+* [https://neowiki.ai/docs/rdf/person-to-edm Person-to-EDM worked example]
 * Tell us what you need from RDF and ontology mapping: [https://github.com/ProfessionalWiki/NeoWiki/discussions/996 join the discussion].

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -17,7 +17,7 @@ Every page sits in one genre. Write to that genre's reader and register.
 | --- | --- | --- |
 | `glossary.md`, `qualifiers-and-references.md` | New users and evaluators forming the mental model | Intended design; no dev-state caveats, no mechanism |
 | `api/` | API consumers deciding what a request or response means and what to do next | Wire-format vocabulary; no PHP class names |
-| `authoring/`, `rdf/`, `examples/` | Admins and integrators looking up exact behavior | Contracts, signatures, examples; no narration |
+| `authoring/`, `rdf/` | Admins and integrators looking up exact behavior | Contracts, signatures, examples; no narration |
 | `operations/` | Sysadmins keeping an instance healthy | Tasks and remedies; system model only where needed to act |
 | `extending/` | Extension developers, whose interface is our internal identifiers | Point at working RedHerb code over prose |
 | `adr/` | Maintainers recording a decision | A dated record: context, decision, consequences; not retro-edited apart from status links |

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,7 @@ Project Subjects to RDF, natively or mapped onto standard ontologies.
 
 * [RDF Export](rdf/rdf-export.md) — native RDF projection: config, IRI scheme, endpoint, bulk dump
 * [Ontology Mapping](rdf/ontology-mapping.md) — projecting into EDM, Dublin Core, … via Mapping pages
-* [Worked example: Person to EDM](examples/person-to-edm.md) — end-to-end mapping walkthrough with findings
+* [Worked example: Person to EDM](rdf/person-to-edm.md) — end-to-end mapping walkthrough with findings
 
 ## Extend NeoWiki
 
@@ -63,7 +63,7 @@ For contributors adding to these docs:
 * An HTTP API or a JSON data format → `api/`
 * RDF projection or ontology mapping → `rdf/`
 * Extending NeoWiki from another extension → `extending/`
-* A worked, end-to-end example → `examples/`
+* A worked, end-to-end example → alongside the docs for the surface it walks through
 * A sysadmin install, maintenance, or deployment guide → `operations/`
 * A numbered, dated decision → `adr/`
 * Work-in-progress exploration → `planning/` (not published to the website)

--- a/docs/operations/installation.md
+++ b/docs/operations/installation.md
@@ -258,7 +258,7 @@ $wgNeoWikiSparqlStores = [
 
 Sibling projections mint the same entity IRIs, so one query can combine data from both — the target ontology's terms
 alongside a property that ontology does not model. The
-[Person-to-EDM example](../examples/person-to-edm.md#querying-via-sparql) shows such a query.
+[Person-to-EDM example](../rdf/person-to-edm.md#querying-via-sparql) shows such a query.
 
 A newly added entry only receives pages saved from then on. Backfill it by
 [rebuilding the graph](maintenance.md#rebuilding-the-graph).

--- a/docs/planning/NativeRdfProjection.md
+++ b/docs/planning/NativeRdfProjection.md
@@ -12,7 +12,7 @@ Discussion: [#999](https://github.com/ProfessionalWiki/NeoWiki/discussions/999).
 > ([#1053](https://github.com/ProfessionalWiki/NeoWiki/issues/1053)) so sibling projections can share one store. See
 > the [RDF Export reference](../rdf/rdf-export.md). Ontology (sibling) projections build on this shared
 > infrastructure — see [OntologyMapping.md](OntologyMapping.md) and the worked
-> [Person → EDM example](../examples/person-to-edm.md). The [Sync Mechanism](#sync-mechanism) has shipped too: the
+> [Person → EDM example](../rdf/person-to-edm.md). The [Sync Mechanism](#sync-mechanism) has shipped too: the
 > SPARQL graph-store plugin (#586) projects each save and delete into a configured SPARQL 1.1 store (e.g. QLever) as
 > the per-page DROP/INSERT it defines.
 

--- a/docs/planning/OntologyMapping.md
+++ b/docs/planning/OntologyMapping.md
@@ -14,7 +14,7 @@ Discussion: [#996](https://github.com/ProfessionalWiki/NeoWiki/discussions/996).
 > ([#1065](https://github.com/ProfessionalWiki/NeoWiki/discussions/1065)) — and an ontology projection
 > selectable alongside the native one on the RDF export endpoint and `DumpRdf`. See the
 > [Ontology Mapping reference](../rdf/ontology-mapping.md) and the worked
-> [Person → EDM example](../examples/person-to-edm.md). The structural / node-synthesis
+> [Person → EDM example](../rdf/person-to-edm.md). The structural / node-synthesis
 > tier and the mapping-formalism question (Q1, [#995](https://github.com/ProfessionalWiki/NeoWiki/issues/995))
 > remain open; the stored `"version": 1` format is provisional. Provisional answers v1 gives to some open
 > questions below are noted inline.

--- a/docs/qualifiers-and-references.md
+++ b/docs/qualifiers-and-references.md
@@ -93,5 +93,5 @@ How a property renders is set by Display Attributes and [Layouts](glossary.md#la
 
 - [Glossary](glossary.md) — Subject, Statement, Relation, Schema, Layout
 - [Subject Format](api/subject-format.md) and [Graph Model](api/graph-model.md)
-- [Worked example: Person to EDM](examples/person-to-edm.md) — ontology mapping end to end; its CIDOC-CRM tier
+- [Worked example: Person to EDM](rdf/person-to-edm.md) — ontology mapping end to end; its CIDOC-CRM tier
   revisits intermediate-node modelling at the RDF level

--- a/docs/rdf/ontology-mapping.md
+++ b/docs/rdf/ontology-mapping.md
@@ -13,7 +13,7 @@ run at once: an export request selects one by name, and a SPARQL store can hold
 
 The design and its open questions live in [planning/OntologyMapping.md](../planning/OntologyMapping.md); this
 page is the as-built reference for the shipped v1. The
-[Person-to-EDM worked example](../examples/person-to-edm.md) walks through a Person Schema projected to EDM,
+[Person-to-EDM worked example](person-to-edm.md) walks through a Person Schema projected to EDM,
 with native and mapped output side by side and the current gaps.
 
 > **v1 scope.** It covers only *near-1:1* term substitution — a target class per Subject and one target

--- a/docs/rdf/person-to-edm.md
+++ b/docs/rdf/person-to-edm.md
@@ -1,10 +1,10 @@
 ---
-title: Person to EDM
-order: 1
+title: Person to EDM example
+order: 3
 ---
 # Worked example: projecting a Person to EDM
 
-End-to-end walkthrough of the [Ontology Mapping](../rdf/ontology-mapping.md) v1 projection: a NeoWiki-native `Person`
+End-to-end walkthrough of the [Ontology Mapping](ontology-mapping.md) v1 projection: a NeoWiki-native `Person`
 Schema, an EDM Mapping, and a demo page projected into
 [Europeana Data Model](https://pro.europeana.eu/page/edm-documentation) (EDM) RDF, shown against the native projection.
 
@@ -51,7 +51,7 @@ The demo `City` Schema ([`DemoData/Schema/City.json`](../../DemoData/Schema/City
 ## 2. The Mapping
 
 One Mapping page, **[`Mapping:EDM`](../../DemoData/Mapping/EDM.json)**, holds an entry per mapped Schema; its title
-(`EDM`) is the projection name (see [Ontology Mapping](../rdf/ontology-mapping.md) for the format). Abbreviated to the
+(`EDM`) is the projection name (see [Ontology Mapping](ontology-mapping.md) for the format). Abbreviated to the
 two entries this walkthrough uses — the shipped file also maps `Artwork` and `Artist` and declares the
 `dc`/`dcterms`/`foaf`/`xsd` prefixes those need:
 
@@ -90,7 +90,7 @@ its `Birth place` relation pointing at [`Málaga`](../../DemoData/Subject/Málag
 
 ## 4. Running the projection
 
-Per page, via the [RDF export endpoint](../rdf/rdf-export.md#endpoint) — the `projection` query parameter selects the
+Per page, via the [RDF export endpoint](rdf-export.md#endpoint) — the `projection` query parameter selects the
 vocabulary:
 
 ```sh
@@ -109,7 +109,7 @@ php maintenance/run.php NeoWiki:DumpRdf --projection=EDM > dump-edm.trig
 ## 5. Native vs EDM output
 
 Real output from the demo wiki (Turtle; shared prefix header trimmed — the `neo*` CURIEs are the
-[IRI scheme](../rdf/rdf-export.md#iri-scheme)). The **native** projection of `Pablo_Picasso` —
+[IRI scheme](rdf-export.md#iri-scheme)). The **native** projection of `Pablo_Picasso` —
 NeoWiki's own vocabulary, lossless, with page metadata and the two-layer relation:
 
 ```turtle

--- a/docs/rdf/rdf-export.md
+++ b/docs/rdf/rdf-export.md
@@ -11,7 +11,7 @@ The model is specified in [NativeRdfProjection.md](../planning/NativeRdfProjecti
 reference for the export surface.
 
 For an end-to-end example comparing the native and ontology-mapped output, see the
-[Person-to-EDM worked example](../examples/person-to-edm.md).
+[Person-to-EDM worked example](person-to-edm.md).
 
 ## Configuration
 


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1034

The website derives one sidebar group per directory here, so `examples/` rendered as a group of one, three groups away from the two pages the walkthrough links into. The docs landing page already lists it directly after RDF Export and Ontology Mapping — only the sidebar disagreed, and only because of the directory. #1034 collapsed a one-file `concepts/` directory for the same reason.

The sidebar title gains "example", since the group label no longer says the page is a walkthrough.

The published `/docs/examples/person-to-edm` URL needs a redirect, and the sidebar's now-dead `examples` group entry needs dropping; both live in the website repo and follow separately.

> <sub>AI-authored — Claude Code, `Opus 5 (max)`; question from @JeroenDeDauw about whether the page belongs in the RDF section, then "proceed as you think is best"; no redirections; diff not yet human-reviewed; every inbound link rewritten and resolved against the tree, site not rendered locally.</sub>