### PR TITLE
Stop the schema selector getting stuck in a pending state

### DIFF
--- a/resources/ext.neowiki/src/components/common/SchemaPicker.vue
+++ b/resources/ext.neowiki/src/components/common/SchemaPicker.vue
@@ -1,8 +1,10 @@
 <template>
 	<div class="ext-neowiki-schema-picker">
-		<CdxCombobox
-			ref="comboboxRef"
-			v-model:selected="selectedSchema"
+		<CdxLookup
+			v-if="schemasLoaded"
+			ref="lookupRef"
+			v-model:selected="pickedSchema"
+			v-model:input-value="inputText"
 			:menu-items="menuItems"
 			:placeholder="$i18n( 'neowiki-schema-picker-placeholder' ).text()"
 			@input="filterSchemas"
@@ -13,10 +15,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue';
-import { CdxCombobox } from '@wikimedia/codex';
+import { computed, nextTick, ref, watch } from 'vue';
+import { CdxLookup } from '@wikimedia/codex';
 import type { MenuItemData } from '@wikimedia/codex';
-import { normalizeSchemaName, useSchemaStore } from '@/stores/SchemaStore.ts';
+import { useSchemaStore } from '@/stores/SchemaStore.ts';
 import type { SchemaSummary } from '@/application/SchemaLookup.ts';
 
 const props = defineProps<{
@@ -29,10 +31,12 @@ const emit = defineEmits<{
 }>();
 
 const schemaStore = useSchemaStore();
-const selectedSchema = ref<string>( props.selected ?? '' );
+const pickedSchema = ref<string | null>( props.selected ?? null );
+const inputText = ref<string | number>( props.selected ?? '' );
 const summaries = ref<SchemaSummary[]>( [] );
+const schemasLoaded = ref( false );
 const query = ref<string>( '' );
-const comboboxRef = ref<InstanceType<typeof CdxCombobox> | null>( null );
+const lookupRef = ref<InstanceType<typeof CdxLookup> | null>( null );
 
 const menuItems = computed<MenuItemData[]>( () => {
 	const matches = query.value === '' ?
@@ -45,53 +49,64 @@ const menuItems = computed<MenuItemData[]>( () => {
 	} ) );
 } );
 
-onMounted( async () => {
+// CdxLookup decides whether focus opens the menu from the menu items it was created
+// with, so the field is only rendered once the schemas are in. A picker whose schemas
+// failed to load still renders, so the field is never missing.
+async function loadSchemas(): Promise<void> {
 	try {
 		summaries.value = await schemaStore.getAllSchemaSummaries();
 	} catch ( error ) {
 		console.error( 'Failed to load schemas for the picker:', error );
 	}
-} );
+	schemasLoaded.value = true;
+}
+
+const schemasReady = loadSchemas();
 
 watch( () => props.selected, ( value ) => {
-	selectedSchema.value = value ?? '';
+	pickedSchema.value = selectableSchema( value ?? null );
+	inputText.value = value ?? '';
 } );
 
-function findSchema( name: string ): SchemaSummary | undefined {
-	const normalized = normalizeSchemaName( name );
-	return summaries.value.find( ( summary ) => summary.name === normalized );
+// CdxLookup takes the field's text for a selection from the matching menu entry and
+// empties the field when there is none, so it is only handed a schema it lists. The
+// field keeps showing the committed name either way.
+function selectableSchema( schemaName: string | null ): string | null {
+	return summaries.value.some( ( summary ) => summary.name === schemaName ) ? schemaName : null;
 }
 
-function filterSchemas( event: Event ): void {
-	query.value = ( event.target as HTMLInputElement ).value.trim().toLowerCase();
+function filterSchemas( value: string ): void {
+	query.value = value.trim().toLowerCase();
 }
 
-// CdxCombobox's `selected` tracks the typed text, not only menu picks, so only
-// commit it when it resolves to an exact existing schema. The name is matched the
-// way a save would normalise it (case-insensitive first letter, collapsed
-// whitespace), and the schema's canonical name is emitted rather than the raw input.
-// Resetting the filter on commit restores the full menu, so reopening the picker
-// without leaving the field browses every schema again rather than the stale filter.
-function onSelect( value: string ): void {
-	const schema = findSchema( value );
-	if ( schema && schema.name !== props.selected ) {
-		emit( 'select', schema.name );
-		query.value = '';
+// CdxLookup reports a selection only for a menu entry the user picks, and null while
+// they type, so a schema name typed out in full is not picked by itself. Resetting the
+// filter restores the full menu, so reopening the picker without leaving the field
+// browses every schema again rather than the last filter.
+function onSelect( schemaName: string | null ): void {
+	if ( schemaName === null ) {
+		return;
 	}
+
+	inputText.value = schemaName;
+	query.value = '';
+	emit( 'select', schemaName );
 }
 
-// On blur, snap `selected` back to the committed schema (empty for a target schema
-// that has not been set yet) so unconfirmed typing reverts and the field only ever
-// shows an existing schema. Clearing the query restores the full menu so the
-// committed label renders.
+// On blur, drop typing that was never picked: the field returns to the committed schema
+// (empty when none is set) and the menu to the full list.
 function reconcileOnBlur(): void {
-	selectedSchema.value = props.selected ?? '';
+	pickedSchema.value = selectableSchema( props.selected ?? null );
+	inputText.value = props.selected ?? '';
 	query.value = '';
 	emit( 'blur' );
 }
 
-function focus(): void {
-	const input = ( comboboxRef.value?.$el as HTMLElement )?.querySelector( 'input' );
+// Waits for the schemas so that focus lands on a field whose menu can open right away.
+async function focus(): Promise<void> {
+	await schemasReady;
+	await nextTick();
+	const input = ( lookupRef.value?.$el as HTMLElement )?.querySelector( 'input' );
 	input?.focus();
 }
 
@@ -99,7 +114,7 @@ defineExpose( { focus } );
 </script>
 
 <style lang="less">
-.ext-neowiki-schema-picker .cdx-combobox {
+.ext-neowiki-schema-picker .cdx-lookup {
 	width: 100%;
 }
 </style>

--- a/resources/ext.neowiki/src/components/common/SchemaPicker.vue
+++ b/resources/ext.neowiki/src/components/common/SchemaPicker.vue
@@ -3,13 +3,13 @@
 		<CdxLookup
 			v-if="schemasLoaded"
 			ref="lookupRef"
-			v-model:selected="pickedSchema"
+			v-model:selected="selectedSchema"
 			v-model:input-value="inputText"
 			:menu-items="menuItems"
 			:placeholder="$i18n( 'neowiki-schema-picker-placeholder' ).text()"
 			@input="filterSchemas"
 			@update:selected="onSelect"
-			@blur="reconcileOnBlur"
+			@blur="revertUncommittedTyping"
 		/>
 	</div>
 </template>
@@ -31,7 +31,7 @@ const emit = defineEmits<{
 }>();
 
 const schemaStore = useSchemaStore();
-const pickedSchema = ref<string | null>( props.selected ?? null );
+const selectedSchema = ref<string | null>( props.selected ?? null );
 const inputText = ref<string | number>( props.selected ?? '' );
 const summaries = ref<SchemaSummary[]>( [] );
 const schemasLoaded = ref( false );
@@ -50,8 +50,9 @@ const menuItems = computed<MenuItemData[]>( () => {
 } );
 
 // CdxLookup decides whether focus opens the menu from the menu items it was created
-// with, so the field is only rendered once the schemas are in. A picker whose schemas
-// failed to load still renders, so the field is never missing.
+// with, so the field is only rendered once the schemas have arrived. Loading them is
+// also marked done when the request fails, so a failure leaves a usable field rather
+// than none at all.
 async function loadSchemas(): Promise<void> {
 	try {
 		summaries.value = await schemaStore.getAllSchemaSummaries();
@@ -63,9 +64,12 @@ async function loadSchemas(): Promise<void> {
 
 const schemasReady = loadSchemas();
 
+// The filter is reset alongside the field: CdxLookup resolves a selection against the
+// menu as it currently stands, and would empty the field for a schema the filter hides.
 watch( () => props.selected, ( value ) => {
-	pickedSchema.value = selectableSchema( value ?? null );
+	selectedSchema.value = selectableSchema( value ?? null );
 	inputText.value = value ?? '';
+	query.value = '';
 } );
 
 // CdxLookup takes the field's text for a selection from the matching menu entry and
@@ -80,9 +84,12 @@ function filterSchemas( value: string ): void {
 }
 
 // CdxLookup reports a selection only for a menu entry the user picks, and null while
-// they type, so a schema name typed out in full is not picked by itself. Resetting the
-// filter restores the full menu, so reopening the picker without leaving the field
-// browses every schema again rather than the last filter.
+// they type, so a schema name typed out in full is not picked by itself.
+//
+// Setting the field text is load-bearing: left to do it itself, CdxLookup announces the
+// name as typed input, which would re-apply the filter cleared on the next line.
+// Restoring the full menu means reopening the picker without leaving the field browses
+// every schema again rather than the last filter.
 function onSelect( schemaName: string | null ): void {
 	if ( schemaName === null ) {
 		return;
@@ -90,13 +97,14 @@ function onSelect( schemaName: string | null ): void {
 
 	inputText.value = schemaName;
 	query.value = '';
-	emit( 'select', schemaName );
+
+	if ( schemaName !== props.selected ) {
+		emit( 'select', schemaName );
+	}
 }
 
-// On blur, drop typing that was never picked: the field returns to the committed schema
-// (empty when none is set) and the menu to the full list.
-function reconcileOnBlur(): void {
-	pickedSchema.value = selectableSchema( props.selected ?? null );
+function revertUncommittedTyping(): void {
+	selectedSchema.value = selectableSchema( props.selected ?? null );
 	inputText.value = props.selected ?? '';
 	query.value = '';
 	emit( 'blur' );

--- a/resources/ext.neowiki/src/components/common/SchemaPicker.vue
+++ b/resources/ext.neowiki/src/components/common/SchemaPicker.vue
@@ -7,7 +7,7 @@
 			v-model:input-value="inputText"
 			:menu-items="menuItems"
 			:placeholder="$i18n( 'neowiki-schema-picker-placeholder' ).text()"
-			@input="filterSchemas"
+			@input="recordTypedText"
 			@update:selected="onSelect"
 			@blur="revertUncommittedTyping"
 		/>
@@ -15,7 +15,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, ref, watch } from 'vue';
+import { computed, nextTick, ref, triggerRef, watch } from 'vue';
 import { CdxLookup } from '@wikimedia/codex';
 import type { MenuItemData } from '@wikimedia/codex';
 import { useSchemaStore } from '@/stores/SchemaStore.ts';
@@ -35,10 +35,8 @@ const selectedSchema = ref<string | null>( props.selected ?? null );
 const inputText = ref<string | number>( props.selected ?? '' );
 const summaries = ref<SchemaSummary[]>( [] );
 const schemasLoaded = ref( false );
-// The field's text as last typed, verbatim, or null when nothing has been typed since the
-// last commit. It holds the raw text rather than the filter it reduces to because
-// CdxLookup leaves the pending state each keystroke puts it in only once it is handed a
-// different menu-items array, so keystrokes that filter alike must still rebuild the menu.
+// The field's text as last typed, or null while the field shows the committed schema
+// rather than typing.
 const typedText = ref<string | null>( null );
 const lookupRef = ref<InstanceType<typeof CdxLookup> | null>( null );
 
@@ -84,8 +82,13 @@ function selectableSchema( schemaName: string | null ): string | null {
 	return summaries.value.some( ( summary ) => summary.name === schemaName ) ? schemaName : null;
 }
 
-function filterSchemas( value: string ): void {
+// CdxLookup takes a change to its menu items as the answer to the user's keystroke, and
+// marks the field as loading until one arrives. Every edit therefore has to produce a new
+// list, including an edit that leaves the text exactly as it found it: pasting a name over
+// its own selection, or a cancelled composition.
+function recordTypedText( value: string ): void {
 	typedText.value = value;
+	triggerRef( typedText );
 }
 
 // CdxLookup reports a selection only for a menu entry the user picks, and null while

--- a/resources/ext.neowiki/src/components/common/SchemaPicker.vue
+++ b/resources/ext.neowiki/src/components/common/SchemaPicker.vue
@@ -35,13 +35,18 @@ const selectedSchema = ref<string | null>( props.selected ?? null );
 const inputText = ref<string | number>( props.selected ?? '' );
 const summaries = ref<SchemaSummary[]>( [] );
 const schemasLoaded = ref( false );
-const query = ref<string>( '' );
+// The field's text as last typed, verbatim, or null when nothing has been typed since the
+// last commit. It holds the raw text rather than the filter it reduces to because
+// CdxLookup leaves the pending state each keystroke puts it in only once it is handed a
+// different menu-items array, so keystrokes that filter alike must still rebuild the menu.
+const typedText = ref<string | null>( null );
 const lookupRef = ref<InstanceType<typeof CdxLookup> | null>( null );
 
 const menuItems = computed<MenuItemData[]>( () => {
-	const matches = query.value === '' ?
+	const filter = ( typedText.value ?? '' ).trim().toLowerCase();
+	const matches = filter === '' ?
 		summaries.value :
-		summaries.value.filter( ( summary ) => summary.name.toLowerCase().includes( query.value ) );
+		summaries.value.filter( ( summary ) => summary.name.toLowerCase().includes( filter ) );
 	return matches.map( ( summary ) => ( {
 		label: summary.name,
 		value: summary.name,
@@ -69,7 +74,7 @@ const schemasReady = loadSchemas();
 watch( () => props.selected, ( value ) => {
 	selectedSchema.value = selectableSchema( value ?? null );
 	inputText.value = value ?? '';
-	query.value = '';
+	typedText.value = null;
 } );
 
 // CdxLookup takes the field's text for a selection from the matching menu entry and
@@ -80,7 +85,7 @@ function selectableSchema( schemaName: string | null ): string | null {
 }
 
 function filterSchemas( value: string ): void {
-	query.value = value.trim().toLowerCase();
+	typedText.value = value;
 }
 
 // CdxLookup reports a selection only for a menu entry the user picks, and null while
@@ -96,7 +101,7 @@ function onSelect( schemaName: string | null ): void {
 	}
 
 	inputText.value = schemaName;
-	query.value = '';
+	typedText.value = null;
 
 	if ( schemaName !== props.selected ) {
 		emit( 'select', schemaName );
@@ -106,7 +111,7 @@ function onSelect( schemaName: string | null ): void {
 function revertUncommittedTyping(): void {
 	selectedSchema.value = selectableSchema( props.selected ?? null );
 	inputText.value = props.selected ?? '';
-	query.value = '';
+	typedText.value = null;
 	emit( 'blur' );
 }
 

--- a/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
@@ -39,8 +39,8 @@ vi.mock( '@/composables/useSchemaPermissions.ts' );
 const SchemaPickerStub = {
 	template: '<div class="schema-lookup-stub"></div>',
 	emits: [ 'select' ],
-	methods: {
-		focus: vi.fn(),
+	setup() {
+		return { focus: vi.fn() };
 	},
 };
 
@@ -401,6 +401,30 @@ describe( 'SubjectCreatorDialog', () => {
 			expect.any( String ),
 			expect.objectContaining( { type: 'error' } ),
 		);
+	} );
+
+	describe( 'Existing schema flow', () => {
+		it( 'focuses SchemaPicker when the dialog opens', async () => {
+			const wrapper = mountComponent();
+
+			subjectStore.subjectCreatorOpen = true;
+			await flushPromises();
+
+			const pickerVm = wrapper.findComponent( SchemaPicker ).vm as any;
+			expect( pickerVm.focus ).toHaveBeenCalled();
+		} );
+
+		it( 'focuses SchemaPicker when switching back to "Use existing"', async () => {
+			const wrapper = mountComponent();
+			await switchToNewSchema( wrapper );
+
+			wrapper.findComponent( { name: 'CdxToggleButtonGroup' } )
+				.vm.$emit( 'update:modelValue', 'existing' );
+			await flushPromises();
+
+			const pickerVm = wrapper.findComponent( SchemaPicker ).vm as any;
+			expect( pickerVm.focus ).toHaveBeenCalled();
+		} );
 	} );
 
 	describe( 'Create new schema flow', () => {

--- a/resources/ext.neowiki/tests/components/common/SchemaPicker.spec.ts
+++ b/resources/ext.neowiki/tests/components/common/SchemaPicker.spec.ts
@@ -49,9 +49,12 @@ describe( 'SchemaPicker', () => {
 		return wrapper;
 	}
 
+	// Focused, because CdxMenu only opens on focus: assertions about what the list shows
+	// would otherwise pass against a list the user cannot see.
 	async function mountLoadedPicker( props: Record<string, unknown> = {} ): Promise<VueWrapper> {
 		const wrapper = mountPicker( props );
 		await flushPromises();
+		await focusField( wrapper );
 		return wrapper;
 	}
 
@@ -72,7 +75,7 @@ describe( 'SchemaPicker', () => {
 	}
 
 	function chosenSchema( wrapper: VueWrapper ): string | null {
-		const chosen = wrapper.find( '.cdx-menu-item--selected .cdx-menu-item__text__label' );
+		const chosen = wrapper.find( '[role="option"][aria-selected="true"] .cdx-menu-item__text__label' );
 		return chosen.exists() ? chosen.text() : null;
 	}
 
@@ -87,7 +90,7 @@ describe( 'SchemaPicker', () => {
 	}
 
 	async function clickSchema( wrapper: VueWrapper, name: string ): Promise<void> {
-		const item = wrapper.findAll( '.cdx-menu-item' )
+		const item = wrapper.findAll( '[role="option"]' )
 			.find( ( candidate ) => candidate.text().includes( name ) );
 		expect( item, `no menu entry for ${ name }` ).toBeDefined();
 		await item!.trigger( 'click' );
@@ -111,6 +114,14 @@ describe( 'SchemaPicker', () => {
 			const wrapper = await mountLoadedPicker();
 
 			await type( wrapper, 'off' );
+
+			expect( listedSchemas( wrapper ) ).toEqual( [ 'Office' ] );
+		} );
+
+		it( 'ignores whitespace around the typed text when filtering', async () => {
+			const wrapper = await mountLoadedPicker();
+
+			await type( wrapper, '  off  ' );
 
 			expect( listedSchemas( wrapper ) ).toEqual( [ 'Office' ] );
 		} );
@@ -163,6 +174,15 @@ describe( 'SchemaPicker', () => {
 			expect( wrapper.emitted( 'select' ) ).toBeFalsy();
 		} );
 
+		it( 'does not pick a schema whose name is typed out in full and confirmed with enter', async () => {
+			const wrapper = await mountLoadedPicker();
+
+			await type( wrapper, 'Office' );
+			await pressKey( wrapper, 'Enter' );
+
+			expect( wrapper.emitted( 'select' ) ).toBeFalsy();
+		} );
+
 		it( 'picks the schema whose menu entry is clicked', async () => {
 			const wrapper = await mountLoadedPicker();
 
@@ -174,11 +194,11 @@ describe( 'SchemaPicker', () => {
 		it( 'picks the schema highlighted with the arrow keys and confirmed with enter', async () => {
 			const wrapper = await mountLoadedPicker();
 
-			await focusField( wrapper );
+			await pressKey( wrapper, 'ArrowDown' );
 			await pressKey( wrapper, 'ArrowDown' );
 			await pressKey( wrapper, 'Enter' );
 
-			expect( wrapper.emitted( 'select' ) ).toEqual( [ [ 'Product' ] ] );
+			expect( wrapper.emitted( 'select' ) ).toEqual( [ [ 'Office' ] ] );
 		} );
 
 		it( 'picks the clicked schema when its name was already typed out in full', async () => {
@@ -193,12 +213,19 @@ describe( 'SchemaPicker', () => {
 		it( 'picks the confirmed schema when its name was already typed out in full', async () => {
 			const wrapper = await mountLoadedPicker();
 
-			await focusField( wrapper );
 			await type( wrapper, 'Office' );
 			await pressKey( wrapper, 'ArrowDown' );
 			await pressKey( wrapper, 'Enter' );
 
 			expect( wrapper.emitted( 'select' ) ).toEqual( [ [ 'Office' ] ] );
+		} );
+
+		it( 'reports nothing when the picked schema is already the committed one', async () => {
+			const wrapper = await mountLoadedPicker( { selected: 'Office' } );
+
+			await clickSchema( wrapper, 'Office' );
+
+			expect( wrapper.emitted( 'select' ) ).toBeFalsy();
 		} );
 
 		it( 'shows the picked schema in the field', async () => {
@@ -296,8 +323,7 @@ describe( 'SchemaPicker', () => {
 
 	describe( 'focusing', () => {
 		// The schemas are delivered only after focus() has been called, as they are over the
-		// network: focusing before they arrive is what used to leave the list closed until
-		// the user left the field and came back.
+		// network: the field must end up focused with its list open regardless.
 		it( 'lists every schema straight away when focused, without waiting for a second focus', async () => {
 			let deliverSchemas: ( summaries: typeof SUMMARIES ) => void = () => undefined;
 			schemaStore.getAllSchemaSummaries = vi.fn().mockReturnValue(
@@ -314,7 +340,7 @@ describe( 'SchemaPicker', () => {
 			await nextTick();
 
 			expect( document.activeElement ).toBe( field( wrapper ).element );
-			expect( wrapper.find( '.cdx-menu' ).isVisible() ).toBe( true );
+			expect( field( wrapper ).attributes( 'aria-expanded' ) ).toBe( 'true' );
 			expect( listedSchemas( wrapper ) ).toEqual( [ 'Product', 'Office', 'City' ] );
 		} );
 	} );

--- a/resources/ext.neowiki/tests/components/common/SchemaPicker.spec.ts
+++ b/resources/ext.neowiki/tests/components/common/SchemaPicker.spec.ts
@@ -304,6 +304,15 @@ describe( 'SchemaPicker', () => {
 			expect( fieldText( wrapper ) ).toBe( 'City' );
 		} );
 
+		it( 'shows a schema committed while a filter that hides it is active', async () => {
+			const wrapper = await mountLoadedPicker();
+
+			await type( wrapper, 'off' );
+			await wrapper.setProps( { selected: 'City' } );
+
+			expect( fieldText( wrapper ) ).toBe( 'City' );
+		} );
+
 		it( 'marks a newly committed schema as the chosen one in the list', async () => {
 			const wrapper = await mountLoadedPicker();
 

--- a/resources/ext.neowiki/tests/components/common/SchemaPicker.spec.ts
+++ b/resources/ext.neowiki/tests/components/common/SchemaPicker.spec.ts
@@ -71,6 +71,11 @@ describe( 'SchemaPicker', () => {
 		return wrapper.findAll( '.cdx-menu-item__text__description' ).map( ( d ) => d.text() );
 	}
 
+	function chosenSchema( wrapper: VueWrapper ): string | null {
+		const chosen = wrapper.find( '.cdx-menu-item--selected .cdx-menu-item__text__label' );
+		return chosen.exists() ? chosen.text() : null;
+	}
+
 	async function type( wrapper: VueWrapper, text: string ): Promise<void> {
 		await field( wrapper ).setValue( text );
 		await flushPromises();
@@ -254,6 +259,14 @@ describe( 'SchemaPicker', () => {
 			expect( fieldText( wrapper ) ).toBe( 'City' );
 		} );
 
+		it( 'marks a newly committed schema as the chosen one in the list', async () => {
+			const wrapper = await mountLoadedPicker();
+
+			await wrapper.setProps( { selected: 'City' } );
+
+			expect( chosenSchema( wrapper ) ).toBe( 'City' );
+		} );
+
 		it( 'shows a committed schema that is missing from the list', async () => {
 			const wrapper = await mountLoadedPicker();
 
@@ -282,10 +295,22 @@ describe( 'SchemaPicker', () => {
 	} );
 
 	describe( 'focusing', () => {
+		// The schemas are delivered only after focus() has been called, as they are over the
+		// network: focusing before they arrive is what used to leave the list closed until
+		// the user left the field and came back.
 		it( 'lists every schema straight away when focused, without waiting for a second focus', async () => {
+			let deliverSchemas: ( summaries: typeof SUMMARIES ) => void = () => undefined;
+			schemaStore.getAllSchemaSummaries = vi.fn().mockReturnValue(
+				new Promise( ( resolve ) => {
+					deliverSchemas = resolve;
+				} ),
+			);
 			const wrapper = mountPicker();
 
-			await ( wrapper.vm as unknown as { focus: () => Promise<void> } ).focus();
+			const focusing = ( wrapper.vm as unknown as { focus: () => Promise<void> } ).focus();
+			await nextTick();
+			deliverSchemas( SUMMARIES );
+			await focusing;
 			await nextTick();
 
 			expect( document.activeElement ).toBe( field( wrapper ).element );

--- a/resources/ext.neowiki/tests/components/common/SchemaPicker.spec.ts
+++ b/resources/ext.neowiki/tests/components/common/SchemaPicker.spec.ts
@@ -79,6 +79,14 @@ describe( 'SchemaPicker', () => {
 		return chosen.exists() ? chosen.text() : null;
 	}
 
+	// CdxLookup marks the field as loading on every keystroke and stops once it has a menu
+	// to show, so a field left marked is one whose keystroke never reached the menu. Codex
+	// renaming this class would leave the callers passing rather than failing, since a
+	// healthy field carries no modifier class at all.
+	function fieldMarkedLoading( wrapper: VueWrapper ): boolean {
+		return wrapper.find( '.cdx-lookup' ).classes().includes( 'cdx-lookup--pending' );
+	}
+
 	async function type( wrapper: VueWrapper, text: string ): Promise<void> {
 		await field( wrapper ).setValue( text );
 		await flushPromises();
@@ -160,6 +168,24 @@ describe( 'SchemaPicker', () => {
 			await type( wrapper, ' ' );
 
 			expect( field( wrapper ).attributes( 'aria-expanded' ) ).toBe( 'true' );
+		} );
+
+		it( 'stops marking the field as loading when a keystroke leaves the matches unchanged', async () => {
+			const wrapper = await mountLoadedPicker();
+
+			await type( wrapper, 'off' );
+			await type( wrapper, 'off ' );
+
+			expect( fieldMarkedLoading( wrapper ) ).toBe( false );
+		} );
+
+		it( 'stops marking the field as loading when an edit leaves the text unchanged', async () => {
+			const wrapper = await mountLoadedPicker();
+
+			await type( wrapper, 'off' );
+			await type( wrapper, 'off' );
+
+			expect( fieldMarkedLoading( wrapper ) ).toBe( false );
 		} );
 
 		it( 'lists no schemas and reports the failure when loading them fails', async () => {

--- a/resources/ext.neowiki/tests/components/common/SchemaPicker.spec.ts
+++ b/resources/ext.neowiki/tests/components/common/SchemaPicker.spec.ts
@@ -144,6 +144,24 @@ describe( 'SchemaPicker', () => {
 			expect( listedSchemas( wrapper ) ).toEqual( [ 'Product', 'Office', 'City' ] );
 		} );
 
+		it( 'opens the list again when the field is emptied after a schema was picked', async () => {
+			const wrapper = await mountLoadedPicker();
+
+			await clickSchema( wrapper, 'Office' );
+			await type( wrapper, '' );
+
+			expect( field( wrapper ).attributes( 'aria-expanded' ) ).toBe( 'true' );
+		} );
+
+		it( 'opens the list again when a space is typed into an empty field', async () => {
+			const wrapper = await mountLoadedPicker();
+
+			await pressKey( wrapper, 'Escape' );
+			await type( wrapper, ' ' );
+
+			expect( field( wrapper ).attributes( 'aria-expanded' ) ).toBe( 'true' );
+		} );
+
 		it( 'lists no schemas and reports the failure when loading them fails', async () => {
 			const consoleError = vi.spyOn( console, 'error' ).mockImplementation( () => undefined );
 			schemaStore.getAllSchemaSummaries = vi.fn().mockRejectedValue( new Error( 'load failed' ) );

--- a/resources/ext.neowiki/tests/components/common/SchemaPicker.spec.ts
+++ b/resources/ext.neowiki/tests/components/common/SchemaPicker.spec.ts
@@ -1,5 +1,5 @@
-import { mount, VueWrapper, flushPromises } from '@vue/test-utils';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DOMWrapper, mount, VueWrapper, flushPromises } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { nextTick } from 'vue';
 import SchemaPicker from '@/components/common/SchemaPicker.vue';
 import { createPinia, setActivePinia } from 'pinia';
@@ -8,46 +8,19 @@ import { createI18nMock } from '../../VueTestHelpers.ts';
 
 const $i18n = createI18nMock();
 
-const CdxComboboxStub = {
-	props: [ 'selected', 'menuItems' ],
-	emits: [ 'update:selected', 'input', 'blur' ],
-	template: '<div class="cdx-combobox-stub"></div>',
-};
-
 const SUMMARIES = [
 	{ name: 'Product', description: 'A product', propertyCount: 2 },
 	{ name: 'Office', description: 'A physical location', propertyCount: 4 },
 	{ name: 'City', description: '', propertyCount: 3 },
 ];
 
+// The picker is mounted with the real Codex component: which of a keystroke, a click
+// or a keyboard confirmation counts as picking a schema is decided by Codex, so a
+// stubbed field would only assert this component's own wiring back to itself.
 describe( 'SchemaPicker', () => {
 	let pinia: ReturnType<typeof createPinia>;
-	let schemaStore: any;
-
-	const mountComponent = ( props: Record<string, unknown> = {} ): VueWrapper => (
-		mount( SchemaPicker, {
-			props,
-			global: {
-				mocks: {
-					$i18n,
-				},
-				plugins: [ pinia ],
-				stubs: {
-					CdxCombobox: CdxComboboxStub,
-				},
-			},
-		} )
-	);
-
-	async function mountLoaded( props: Record<string, unknown> = {} ): Promise<VueWrapper> {
-		const wrapper = mountComponent( props );
-		await flushPromises();
-		return wrapper;
-	}
-
-	function typeText( combobox: VueWrapper, value: string ): void {
-		combobox.vm.$emit( 'input', { target: { value } } );
-	}
+	let schemaStore: ReturnType<typeof useSchemaStore>;
+	const wrappers: VueWrapper[] = [];
 
 	beforeEach( () => {
 		pinia = createPinia();
@@ -57,193 +30,267 @@ describe( 'SchemaPicker', () => {
 		schemaStore.getAllSchemaSummaries = vi.fn().mockResolvedValue( SUMMARIES );
 	} );
 
+	afterEach( () => {
+		wrappers.splice( 0 ).forEach( ( wrapper ) => wrapper.unmount() );
+	} );
+
+	// Attached to the document so focus lands on the field: jsdom ignores focus() on a
+	// detached element, which would silently skip the menu-opening behaviour.
+	function mountPicker( props: Record<string, unknown> = {} ): VueWrapper {
+		const wrapper = mount( SchemaPicker, {
+			props,
+			attachTo: document.body,
+			global: {
+				mocks: { $i18n },
+				plugins: [ pinia ],
+			},
+		} );
+		wrappers.push( wrapper );
+		return wrapper;
+	}
+
+	async function mountLoadedPicker( props: Record<string, unknown> = {} ): Promise<VueWrapper> {
+		const wrapper = mountPicker( props );
+		await flushPromises();
+		return wrapper;
+	}
+
+	function field( wrapper: VueWrapper ): DOMWrapper<HTMLInputElement> {
+		return wrapper.find( 'input' );
+	}
+
+	function fieldText( wrapper: VueWrapper ): string {
+		return field( wrapper ).element.value;
+	}
+
+	function listedSchemas( wrapper: VueWrapper ): string[] {
+		return wrapper.findAll( '.cdx-menu-item__text__label' ).map( ( label ) => label.text() );
+	}
+
+	function listedDescriptions( wrapper: VueWrapper ): string[] {
+		return wrapper.findAll( '.cdx-menu-item__text__description' ).map( ( d ) => d.text() );
+	}
+
+	async function type( wrapper: VueWrapper, text: string ): Promise<void> {
+		await field( wrapper ).setValue( text );
+		await flushPromises();
+	}
+
+	async function focusField( wrapper: VueWrapper ): Promise<void> {
+		await field( wrapper ).trigger( 'focus' );
+		await nextTick();
+	}
+
+	async function clickSchema( wrapper: VueWrapper, name: string ): Promise<void> {
+		const item = wrapper.findAll( '.cdx-menu-item' )
+			.find( ( candidate ) => candidate.text().includes( name ) );
+		expect( item, `no menu entry for ${ name }` ).toBeDefined();
+		await item!.trigger( 'click' );
+		await flushPromises();
+	}
+
+	async function pressKey( wrapper: VueWrapper, key: string ): Promise<void> {
+		await field( wrapper ).trigger( 'keydown', { key } );
+		await flushPromises();
+	}
+
 	describe( 'browsing and filtering', () => {
-		it( 'populates the menu with all schemas and their descriptions on mount', async () => {
-			const wrapper = await mountLoaded();
-			const combobox = wrapper.findComponent( CdxComboboxStub );
+		it( 'lists every schema with its description', async () => {
+			const wrapper = await mountLoadedPicker();
 
-			expect( combobox.props( 'menuItems' ) ).toEqual( [
-				{ label: 'Product', value: 'Product', description: 'A product' },
-				{ label: 'Office', value: 'Office', description: 'A physical location' },
-				{ label: 'City', value: 'City', description: undefined },
-			] );
+			expect( listedSchemas( wrapper ) ).toEqual( [ 'Product', 'Office', 'City' ] );
+			expect( listedDescriptions( wrapper ) ).toEqual( [ 'A product', 'A physical location' ] );
 		} );
 
-		it( 'filters the menu to schemas matching the typed text', async () => {
-			const wrapper = await mountLoaded();
-			const combobox = wrapper.findComponent( CdxComboboxStub );
+		it( 'lists only the schemas matching the typed text', async () => {
+			const wrapper = await mountLoadedPicker();
 
-			typeText( combobox, 'off' );
-			await nextTick();
+			await type( wrapper, 'off' );
 
-			expect( combobox.props( 'menuItems' ) ).toEqual( [
-				{ label: 'Office', value: 'Office', description: 'A physical location' },
-			] );
+			expect( listedSchemas( wrapper ) ).toEqual( [ 'Office' ] );
 		} );
 
-		it( 'shows all schemas again when the input is cleared', async () => {
-			const wrapper = await mountLoaded();
-			const combobox = wrapper.findComponent( CdxComboboxStub );
+		it( 'lists every schema again when the field is cleared', async () => {
+			const wrapper = await mountLoadedPicker();
 
-			typeText( combobox, 'off' );
-			typeText( combobox, '' );
-			await nextTick();
+			await type( wrapper, 'off' );
+			await type( wrapper, '' );
 
-			expect( combobox.props( 'menuItems' ) ).toHaveLength( 3 );
+			expect( listedSchemas( wrapper ) ).toEqual( [ 'Product', 'Office', 'City' ] );
 		} );
 
-		it( 'restores the full menu after a selection is committed', async () => {
-			const wrapper = await mountLoaded();
-			const combobox = wrapper.findComponent( CdxComboboxStub );
+		it( 'lists every schema again after one is picked', async () => {
+			const wrapper = await mountLoadedPicker();
 
-			typeText( combobox, 'off' );
-			await nextTick();
-			expect( combobox.props( 'menuItems' ) ).toHaveLength( 1 );
+			await type( wrapper, 'off' );
+			await clickSchema( wrapper, 'Office' );
 
-			combobox.vm.$emit( 'update:selected', 'Office' );
-			await nextTick();
-
-			expect( combobox.props( 'menuItems' ) ).toHaveLength( 3 );
+			expect( listedSchemas( wrapper ) ).toEqual( [ 'Product', 'Office', 'City' ] );
 		} );
 
-		it( 'leaves the menu empty without throwing when loading schemas fails', async () => {
+		it( 'lists no schemas and reports the failure when loading them fails', async () => {
 			const consoleError = vi.spyOn( console, 'error' ).mockImplementation( () => undefined );
 			schemaStore.getAllSchemaSummaries = vi.fn().mockRejectedValue( new Error( 'load failed' ) );
 
-			const wrapper = await mountLoaded();
-			const combobox = wrapper.findComponent( CdxComboboxStub );
+			const wrapper = await mountLoadedPicker();
 
-			expect( combobox.props( 'menuItems' ) ).toEqual( [] );
+			expect( listedSchemas( wrapper ) ).toEqual( [] );
+			expect( field( wrapper ).exists() ).toBe( true );
 			expect( consoleError ).toHaveBeenCalled();
 			consoleError.mockRestore();
 		} );
 	} );
 
-	describe( 'committing a selection', () => {
-		it( 'emits the schema when an exact schema name is selected', async () => {
-			const wrapper = await mountLoaded();
-			const combobox = wrapper.findComponent( CdxComboboxStub );
+	describe( 'picking a schema', () => {
+		it( 'does not pick a schema whose name is typed out in full', async () => {
+			const wrapper = await mountLoadedPicker();
 
-			combobox.vm.$emit( 'update:selected', 'Office' );
-
-			expect( wrapper.emitted( 'select' )?.[ 0 ] ).toEqual( [ 'Office' ] );
-		} );
-
-		it( 'does not emit for a value that is not a schema name', async () => {
-			const wrapper = await mountLoaded();
-			const combobox = wrapper.findComponent( CdxComboboxStub );
-
-			combobox.vm.$emit( 'update:selected', 'Off' );
+			await type( wrapper, 'Office' );
 
 			expect( wrapper.emitted( 'select' ) ).toBeFalsy();
 		} );
 
-		it( 'commits the canonical schema name when the input has surrounding whitespace', async () => {
-			const wrapper = await mountLoaded();
-			const combobox = wrapper.findComponent( CdxComboboxStub );
+		it( 'does not pick a schema while the typed text only partially matches one', async () => {
+			const wrapper = await mountLoadedPicker();
 
-			combobox.vm.$emit( 'update:selected', 'Office ' );
-
-			expect( wrapper.emitted( 'select' )?.[ 0 ] ).toEqual( [ 'Office' ] );
-		} );
-
-		it( 'commits the canonical schema name when the input differs only in case', async () => {
-			const wrapper = await mountLoaded();
-			const combobox = wrapper.findComponent( CdxComboboxStub );
-
-			combobox.vm.$emit( 'update:selected', 'office' );
-
-			expect( wrapper.emitted( 'select' )?.[ 0 ] ).toEqual( [ 'Office' ] );
-		} );
-
-		it( 'does not re-emit when the value already equals the committed schema', async () => {
-			const wrapper = await mountLoaded( { selected: 'Office' } );
-			const combobox = wrapper.findComponent( CdxComboboxStub );
-
-			combobox.vm.$emit( 'update:selected', 'Office' );
+			await type( wrapper, 'Offic' );
 
 			expect( wrapper.emitted( 'select' ) ).toBeFalsy();
+		} );
+
+		it( 'picks the schema whose menu entry is clicked', async () => {
+			const wrapper = await mountLoadedPicker();
+
+			await clickSchema( wrapper, 'Office' );
+
+			expect( wrapper.emitted( 'select' ) ).toEqual( [ [ 'Office' ] ] );
+		} );
+
+		it( 'picks the schema highlighted with the arrow keys and confirmed with enter', async () => {
+			const wrapper = await mountLoadedPicker();
+
+			await focusField( wrapper );
+			await pressKey( wrapper, 'ArrowDown' );
+			await pressKey( wrapper, 'Enter' );
+
+			expect( wrapper.emitted( 'select' ) ).toEqual( [ [ 'Product' ] ] );
+		} );
+
+		it( 'picks the clicked schema when its name was already typed out in full', async () => {
+			const wrapper = await mountLoadedPicker();
+
+			await type( wrapper, 'Office' );
+			await clickSchema( wrapper, 'Office' );
+
+			expect( wrapper.emitted( 'select' ) ).toEqual( [ [ 'Office' ] ] );
+		} );
+
+		it( 'picks the confirmed schema when its name was already typed out in full', async () => {
+			const wrapper = await mountLoadedPicker();
+
+			await focusField( wrapper );
+			await type( wrapper, 'Office' );
+			await pressKey( wrapper, 'ArrowDown' );
+			await pressKey( wrapper, 'Enter' );
+
+			expect( wrapper.emitted( 'select' ) ).toEqual( [ [ 'Office' ] ] );
+		} );
+
+		it( 'shows the picked schema in the field', async () => {
+			const wrapper = await mountLoadedPicker();
+
+			await type( wrapper, 'off' );
+			await clickSchema( wrapper, 'Office' );
+
+			expect( fieldText( wrapper ) ).toBe( 'Office' );
 		} );
 	} );
 
-	describe( 'rejecting invalid input', () => {
-		it( 'reverts to the committed schema and restores the menu on blur', async () => {
-			const wrapper = await mountLoaded( { selected: 'Product' } );
-			const combobox = wrapper.findComponent( CdxComboboxStub );
+	describe( 'reverting uncommitted typing', () => {
+		it( 'restores the committed schema in the field on blur', async () => {
+			const wrapper = await mountLoadedPicker( { selected: 'Product' } );
 
-			combobox.vm.$emit( 'update:selected', 'xyz' );
-			combobox.vm.$emit( 'blur' );
+			await type( wrapper, 'xyz' );
+			await field( wrapper ).trigger( 'blur' );
 			await nextTick();
 
-			expect( combobox.props( 'selected' ) ).toBe( 'Product' );
-			expect( combobox.props( 'menuItems' ) ).toHaveLength( 3 );
+			expect( fieldText( wrapper ) ).toBe( 'Product' );
+			expect( listedSchemas( wrapper ) ).toEqual( [ 'Product', 'Office', 'City' ] );
 			expect( wrapper.emitted( 'select' ) ).toBeFalsy();
 		} );
 
-		it( 'leaves a not-yet-set field empty on blur', async () => {
-			const wrapper = await mountLoaded();
-			const combobox = wrapper.findComponent( CdxComboboxStub );
+		it( 'empties a field that has no committed schema on blur', async () => {
+			const wrapper = await mountLoadedPicker();
 
-			combobox.vm.$emit( 'update:selected', 'xyz' );
-			combobox.vm.$emit( 'blur' );
+			await type( wrapper, 'xyz' );
+			await field( wrapper ).trigger( 'blur' );
 			await nextTick();
 
-			expect( combobox.props( 'selected' ) ).toBe( '' );
+			expect( fieldText( wrapper ) ).toBe( '' );
 			expect( wrapper.emitted( 'select' ) ).toBeFalsy();
 		} );
 
 		it( 'emits blur so the consumer can mark the field touched', async () => {
-			const wrapper = await mountLoaded();
-			const combobox = wrapper.findComponent( CdxComboboxStub );
+			const wrapper = await mountLoadedPicker();
 
-			combobox.vm.$emit( 'blur' );
+			await field( wrapper ).trigger( 'blur' );
 
 			expect( wrapper.emitted( 'blur' ) ).toBeTruthy();
 		} );
 	} );
 
-	describe( 'reflecting the selected prop', () => {
-		it( 'shows the selected schema in the field', () => {
-			const wrapper = mountComponent( { selected: 'Product' } );
-			const combobox = wrapper.findComponent( CdxComboboxStub );
+	describe( 'reflecting the committed schema', () => {
+		it( 'shows the schema it was given', async () => {
+			const wrapper = await mountLoadedPicker( { selected: 'Product' } );
 
-			expect( combobox.props( 'selected' ) ).toBe( 'Product' );
+			expect( fieldText( wrapper ) ).toBe( 'Product' );
 		} );
 
-		it( 'updates the field when the selected prop changes', async () => {
-			const wrapper = mountComponent();
-			const combobox = wrapper.findComponent( CdxComboboxStub );
+		it( 'shows a schema committed after it was created', async () => {
+			const wrapper = await mountLoadedPicker();
 
-			await wrapper.setProps( { selected: 'NewSchema' } );
-			expect( combobox.props( 'selected' ) ).toBe( 'NewSchema' );
+			await wrapper.setProps( { selected: 'City' } );
+
+			expect( fieldText( wrapper ) ).toBe( 'City' );
+		} );
+
+		it( 'shows a committed schema that is missing from the list', async () => {
+			const wrapper = await mountLoadedPicker();
+
+			await wrapper.setProps( { selected: 'Archived' } );
+
+			expect( fieldText( wrapper ) ).toBe( 'Archived' );
+		} );
+
+		it( 'keeps showing a committed schema that is missing from the list on blur', async () => {
+			const wrapper = await mountLoadedPicker( { selected: 'Archived' } );
+
+			await type( wrapper, 'xyz' );
+			await field( wrapper ).trigger( 'blur' );
+			await flushPromises();
+
+			expect( fieldText( wrapper ) ).toBe( 'Archived' );
+		} );
+
+		it( 'empties the field when the committed schema is cleared', async () => {
+			const wrapper = await mountLoadedPicker( { selected: 'Product' } );
 
 			await wrapper.setProps( { selected: null } );
-			expect( combobox.props( 'selected' ) ).toBe( '' );
+
+			expect( fieldText( wrapper ) ).toBe( '' );
 		} );
 	} );
 
-	it( 'exposes focus method', () => {
-		const CdxComboboxInputStub = {
-			template: '<div><input /></div>',
-		};
+	describe( 'focusing', () => {
+		it( 'lists every schema straight away when focused, without waiting for a second focus', async () => {
+			const wrapper = mountPicker();
 
-		const wrapper = mount( SchemaPicker, {
-			global: {
-				mocks: {
-					$i18n,
-				},
-				plugins: [ pinia ],
-				stubs: {
-					CdxCombobox: CdxComboboxInputStub,
-				},
-			},
+			await ( wrapper.vm as unknown as { focus: () => Promise<void> } ).focus();
+			await nextTick();
+
+			expect( document.activeElement ).toBe( field( wrapper ).element );
+			expect( wrapper.find( '.cdx-menu' ).isVisible() ).toBe( true );
+			expect( listedSchemas( wrapper ) ).toEqual( [ 'Product', 'Office', 'City' ] );
 		} );
-
-		const input = wrapper.find( 'input' );
-		const focusSpy = vi.spyOn( input.element, 'focus' );
-
-		( wrapper.vm as any ).focus();
-
-		expect( focusSpy ).toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1174

One regression that PR introduced by moving the selector from CdxCombobox to CdxLookup,
plus a test for a line it left uncovered. It targets that branch rather than master because
master has neither.

CdxLookup treats a change to its menu items as the answer to the user's keystroke, and
marks the field as loading until one arrives. Its own source says as much: the menu's
pending indicator is "meant to indicate that new menu items are being fetched or computed",
and the watcher that ends it reads a menu-items change as "in response to user input". The
picker was not always answering. Its filter held the typed text trimmed and lower-cased, so
any edit that left that form unchanged wrote the same string, the menu-items computed did
not re-evaluate, and CdxLookup went on waiting: a striped background on a field that is
loading nothing, surviving blur and refocus, clearing only on a later edit that did reach
the menu. The same silence keeps the list shut until you leave the field and return. A
single space typed into an empty field reaches it, as does emptying the field after picking
a schema, since picking already resets the filter. Every edit now invalidates the menu,
including one that leaves the text exactly as it found it: pasting a name over its own
selection, or a cancelled composition.

Separately, resetting the filter when the surrounding editor commits a schema had no test.
Removing that line left every test passing, while the field went blank for a schema the
active filter hides.

Reproduced in a browser against the dev wiki, on the subject creator and on a relation's
target schema, and confirmed absent from `master`, where CdxCombobox has no loading state
at all and so carries no such contract.

Considered, omitted: a guard against Codex renaming `cdx-lookup--pending`, which the two
loading-state tests name. A healthy field carries no modifier class, so an absence
assertion cannot tell a fixed field from a renamed class, and the only way to pin the name
is a test of Codex rather than of this component. Worth revisiting if the class moves.

> <sub>AI-authored — Claude Code, `Opus 5 (max)`; found and fixed during a review of #1174 requested by @malberts, no redirections; diff not yet human-reviewed, though @malberts has independently reproduced the regression on both surfaces; reproduced in a real browser before and after each fix, every fix pinned by a test seen failing first and by a distinct killed mutant, and the frontend suite plus ts-lint and vue-tsc green locally. Adversarial review of an earlier round found that it closed the reported paths but still let an edit that changes nothing strand the field; that is closed and covered here.</sub>
