### PR TITLE
Fix four current-state claims in ADR 27

### DIFF
--- a/docs/adr/027-access-control.md
+++ b/docs/adr/027-access-control.md
@@ -36,18 +36,18 @@ Constraints the model rests on:
 - **Per-subject ACLs are a non-goal.** There is no access control finer than the page: no recorded use case needs
   it, deployments separate sensitive data by page or wiki, and sub-page ACLs would complicate every read surface.
   Revisit only with a concrete use case.
-- **A denied read is indistinguishable from absent data.** Gated read surfaces answer with a `null`, an empty list, or
-  a `404` — never a `403` — and must not reveal existence through side channels such as counts
-  ([#1062](https://github.com/ProfessionalWiki/NeoWiki/issues/1062)). Write denials answer `403`, and must equally
-  not reveal whether an unreadable page exists ([#1061](https://github.com/ProfessionalWiki/NeoWiki/issues/1061)).
-  [rest-api.md](../api/rest-api.md) documents this per endpoint.
+- **A denied read is indistinguishable from absent data.** Read surfaces gated on the page's `read` permission answer
+  with a `null`, an empty list, or a `404` — never a `403` — and must not reveal existence through side channels such
+  as counts ([#1062](https://github.com/ProfessionalWiki/NeoWiki/issues/1062)). Write denials answer `403`, and must
+  equally not reveal whether an unreadable page exists
+  ([#1061](https://github.com/ProfessionalWiki/NeoWiki/issues/1061)). [rest-api.md](../api/rest-api.md) documents this
+  per endpoint.
 - **Page-attributable results are filtered per row.** Read surfaces whose results are traceable to an owning page
   resolve each row's page and drop rows the caller may not read. Because this costs one permission check per row,
   such surfaces must bound their result sizes.
 - **Graph projections carry scoping keys, not ACL state.** `wiki_id` and `namespaceId` let query authors scope
   queries ([ADR 22](022-multi-wiki-node-identity.md), [graph-model](../api/graph-model.md)). User groups and page
-  restrictions are never projected; the projected keys are revision-derived, so nothing in a store goes stale when
-  permissions change.
+  restrictions are never projected, so nothing in a store goes stale when permissions change.
 - **Raw query surfaces have whole-store read semantics.** A raw query surface executes a caller-supplied Cypher or
   SPARQL query; its result rows are not attributable to pages and are not trimmed. The REST query endpoints are gated
   by the wiki-level `neowiki-query` right; granting that right gives read access to everything the wiki projects into
@@ -63,11 +63,11 @@ Constraints the model rests on:
 ## Open decisions
 
 - **Parse-time read semantics.** Today the parse path is inconsistent
-  ([#1059](https://github.com/ProfessionalWiki/NeoWiki/issues/1059)): Schema/Mapping lookups are gated per user but
-  their output is parser-cached user-agnostically; subject accessors (`{{#neowiki_value}}` and the `nw` data
-  accessors) check only revision-deletion visibility, not page `read`; `{{#cypher_raw}}` and `nw.query` check
-  nothing. `{{#view}}` is the leak-free pattern: a placeholder rendered at parse time, data fetched per user over
-  REST. **TODO:** decide the parse-path rule and what it means for each surface.
+  ([#1059](https://github.com/ProfessionalWiki/NeoWiki/issues/1059)): Schema lookups are gated per user but their
+  output is parser-cached user-agnostically; subject accessors (`{{#neowiki_value}}` and the `nw` data accessors)
+  check only revision-deletion visibility, not page `read`; `{{#cypher_raw}}`, `{{#sparql_raw}}`, `nw.query` and
+  `nw.sparqlQuery` check nothing. `{{#view}}` is the leak-free pattern: a placeholder rendered at parse time, data
+  fetched per user over REST. **TODO:** decide the parse-path rule and what it means for each surface.
 - **Cross-wiki subject display.** Rendering a subject from another wiki goes through REST, not Cypher, so query-side
   scoping does not cover it. **TODO:** decide the check and the degradation behavior when the schema or subject is
   not accessible. Relates to [ADR 23](023-subject-sources.md).


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1134

Four claims about shipped behaviour that do not match master. Each was found by reviewing the ADR
against the code, then re-verified independently before landing here.

**The never-403 rule was unscoped.** "Gated read surfaces answer with a `null`, an empty list, or a
`404` — never a `403`" collides with the same ADR's line 52, which calls the REST query endpoints
"gated by the wiki-level `neowiki-query` right". Those are read surfaces —
`CypherQueryApi::needsWriteAccess()` returns false — and they answer 403 on denial, as
`query-api.md` documents for both the Cypher and SPARQL endpoints. The word "gated" does not
self-scope inside a document that also applies it to a wiki-level right, so the rule now names the
page `read` gate it describes. `grep -rn 403 src/` confirms those two are the only read paths
returning 403; every other 403 is a write path.

**`wiki_id` is not revision-derived.** It comes from `WikiMap::getCurrentWikiId()`, read once when
the config object is built and injected as a constructor field into the projection store, which
writes it into the node MERGE keys. `namespaceId` is genuinely revision-derived. The clause also
failed the ADR's own staleness test: a `$wgDBname` or prefix change produces no revision to sync on
either. Dropped rather than corrected, because the preceding clause already carries the conclusion.

**No parse path performs a Mapping lookup.** Mappings are page-stored and Mapping pages are of
course parsed, but the bullet is about a per-user-gated lookup of *another* page whose result lands
in the user-agnostic parser cache. The gated `CachingMappingLookup` is reached from exactly two
places: RDF projection resolution (the two RDF export endpoints, `DumpRdf.php`, and the save-time
`SparqlProjectionStore`) and `GetMappingSummariesApi`. Four parser functions exist tree-wide, none
of them Mapping, and the Lua library registers no Mapping accessor. Rendering a Mapping page
renders its own content — today through `JsonContentHandler`, and under #1156 through the new
`MappingContentHandler::fillParserOutput`, which reads `$content` rather than looking anything up —
so the ordinary page-view `read` check covers it either way. Only Schema lookups belong in that
inventory, and there the path is `nw.getSchema`, not the content handler, which renders nothing.

**The ungated raw-query list named only the Cypher half.** `{{#sparql_raw}}` and `nw.sparqlQuery`
reach `SparqlQueryService::execute()` passing only `SparqlQueryLimits::forUser()` — a timeout tier,
not a gate — exactly as their Cypher siblings do. #1059, cited at the start of that same sentence,
enumerates all four.

Considered, omitted: nothing else. Link integrity, the issue characterisations, the ADR 13/19/22/23
cross-references, the `authorizeRead` and per-row-filtering claims, the `neowiki-query` default
grant, and the projection/dump claims were all checked and hold.

One knock-on outside this PR: #1059 carries the same "Schema/Mapping lookups" wording and the same
Cypher-only list in its third bullet (self-labelled "final wording not human-reviewed"), so it wants
the same two corrections or it will disagree with the ADR that cites it.

> <sub>AI-authored — Claude Code, `Opus 5 (1M context)`; review of #1134 requested by @alistair3149, fixes then applied unattended. Findings came from a fan-out of six independent reviewers, each finding put to a separate agent prompted to refute it; only claims that survived that pass and that I then re-verified against master myself are here. Every other proposed finding was refuted and dropped. Docs-only change: no tests run, line-wrap width checked against the file's own convention.</sub>
