### PR TITLE
Name Attendance demo Subjects after what they record

### DIFF
--- a/DemoData/Subject/Musée_d'Orsay.json
+++ b/DemoData/Subject/Musée_d'Orsay.json
@@ -48,7 +48,7 @@
 			}
 		},
 		"sEpfwLY8VcdQZJL": {
-			"label": "2019",
+			"label": "Musée d'Orsay attendance 2019",
 			"schema": "Attendance",
 			"statements": {
 				"Year": {
@@ -66,7 +66,7 @@
 			}
 		},
 		"sEpfwLY8WnceT2y": {
-			"label": "2022",
+			"label": "Musée d'Orsay attendance 2022",
 			"schema": "Attendance",
 			"statements": {
 				"Year": {
@@ -84,7 +84,7 @@
 			}
 		},
 		"sEpfwLY8XjJ8gE1": {
-			"label": "2023",
+			"label": "Musée d'Orsay attendance 2023",
 			"schema": "Attendance",
 			"statements": {
 				"Year": {

--- a/DemoData/Subject/Rijksmuseum.json
+++ b/DemoData/Subject/Rijksmuseum.json
@@ -48,7 +48,7 @@
 			}
 		},
 		"sEpfwJLAtndAaaA": {
-			"label": "Rijksmuseum 2024",
+			"label": "Rijksmuseum attendance 2024",
 			"schema": "Attendance",
 			"statements": {
 				"Year": { "type": "number", "value": 2024 },
@@ -57,7 +57,7 @@
 			}
 		},
 		"sEpfwJLAtndBbbB": {
-			"label": "Rijksmuseum 2023",
+			"label": "Rijksmuseum attendance 2023",
 			"schema": "Attendance",
 			"statements": {
 				"Year": { "type": "number", "value": 2023 },
@@ -66,7 +66,7 @@
 			}
 		},
 		"sEpfwJLAtndCccC": {
-			"label": "Rijksmuseum 2022",
+			"label": "Rijksmuseum attendance 2022",
 			"schema": "Attendance",
 			"statements": {
 				"Year": { "type": "number", "value": 2022 },
@@ -75,7 +75,7 @@
 			}
 		},
 		"sEpfwJLAtndDddD": {
-			"label": "Rijksmuseum 2021",
+			"label": "Rijksmuseum attendance 2021",
 			"schema": "Attendance",
 			"statements": {
 				"Year": { "type": "number", "value": 2021 },
@@ -84,7 +84,7 @@
 			}
 		},
 		"sEpfwJLAtndEeeE": {
-			"label": "Rijksmuseum 2020",
+			"label": "Rijksmuseum attendance 2020",
 			"schema": "Attendance",
 			"statements": {
 				"Year": { "type": "number", "value": 2020 },


### PR DESCRIPTION
The per-year Attendance Subjects were labelled "Rijksmuseum 2024" on one museum page and a bare "2019" / "2022" / "2023" on the other, so neither said what the Subject holds. That label becomes the Subject node's `name` in the graph, so it is what a Cypher result, a search hit or a relation picker shows.

Both sets now read "<Museum> attendance <year>", following the "Birth of Johann Sebastian Bach" pattern the Bach corpus already uses for intermediate Subjects.

> <sub>AI-authored — Claude Code, `Opus 5 (max)`; one-line ask from @JeroenDeDauw, no revisions; diff not yet human-reviewed; verified on a local dev stack — demo import, subjects page render, and a Cypher query over the `Attendance` nodes all show the new labels with no leftovers.</sub>