### PR TITLE
Batch Schema lookups, route prefix IRIs through LinkRenderer, and require canonical Schema names

### DIFF
--- a/src/EntryPoints/Content/MappingContentHandler.php
+++ b/src/EntryPoints/Content/MappingContentHandler.php
@@ -44,7 +44,7 @@ class MappingContentHandler extends JsonContentHandler {
 			$status->fatal( 'neowiki-mapping-name-invalid', $exception->getMessage() );
 		}
 
-		$validator = MappingContentValidator::newInstance();
+		$validator = MappingContentValidator::newInstance( MediaWikiServices::getInstance()->getTitleParser() );
 
 		if ( !$validator->validate( $content->getText() ) ) {
 			$status->fatal( 'neowiki-mapping-invalid', count( $validator->getErrors() ) );

--- a/src/EntryPoints/Content/MappingContentHandler.php
+++ b/src/EntryPoints/Content/MappingContentHandler.php
@@ -10,8 +10,10 @@ use MediaWiki\Content\JsonContentHandler;
 use MediaWiki\Content\Renderer\ContentParseParams;
 use MediaWiki\Content\ValidationParams;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Page\PageReference;
 use MediaWiki\Parser\ParserOutput;
 use MediaWiki\Title\Title;
+use MediaWiki\Title\TitleValue;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\MappingName;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\MappingContentValidator;
@@ -70,7 +72,7 @@ class MappingContentHandler extends JsonContentHandler {
 			$mapping = $content->getData()->getValue();
 
 			if ( $this->isRenderableMapping( $mapping ) ) {
-				$this->renderMapping( $content, $mapping, $parserOutput );
+				$this->renderMapping( $content, $mapping, $cpoParams->getPage(), $parserOutput );
 				return;
 			}
 		}
@@ -78,12 +80,19 @@ class MappingContentHandler extends JsonContentHandler {
 		parent::fillParserOutput( $content, $cpoParams, $parserOutput );
 	}
 
-	private function renderMapping( MappingContent $content, stdClass $mapping, ParserOutput $parserOutput ): void {
+	private function renderMapping(
+		MappingContent $content,
+		stdClass $mapping,
+		PageReference $page,
+		ParserOutput $parserOutput
+	): void {
 		$services = MediaWikiServices::getInstance();
 
 		$builder = new MappingPageHtmlBuilder(
 			$services->getLinkRenderer(),
 			$services->getTitleFactory(),
+			$services->getLinkBatchFactory(),
+			TitleValue::newFromPage( $page ),
 			static fn ( mixed $subtree ): string => $content->rootValueTable( $subtree )
 		);
 

--- a/src/Persistence/MediaWiki/MappingContentValidator.php
+++ b/src/Persistence/MediaWiki/MappingContentValidator.php
@@ -4,14 +4,19 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Persistence\MediaWiki;
 
+use InvalidArgumentException;
+use MediaWiki\Title\MalformedTitleException;
+use MediaWiki\Title\TitleParser;
 use Opis\JsonSchema\Errors\ErrorFormatter;
 use Opis\JsonSchema\Errors\ValidationError;
 use Opis\JsonSchema\Validator;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\CurieExpander;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use RuntimeException;
 
 /**
- * Validates the JSON of a Mapping page against the v1 format, in two stages:
+ * Validates the JSON of a Mapping page against the v1 format, in three stages:
  *
  *  1. Structural validation against mappingContentSchema.json (versioned, deliberately minimal).
  *  2. Semantic IRI-safety validation: every declared prefix namespace, and every class, predicate and
@@ -19,6 +24,11 @@ use RuntimeException;
  *     lesson). A term that cannot be resolved against the declared prefixes, or that would break out of
  *     its IRI, is rejected here rather than percent-encoded — a Mapping must reproduce the ontology's
  *     exact terms.
+ *  3. Schema-name validation: each key under `schemas` must be a usable Schema name written exactly as
+ *     its Schema page title. The projector matches keys against a Subject's Schema name byte for byte,
+ *     while a page lookup normalizes, so "Person_X" would resolve to the Schema page yet never project.
+ *     Requiring the canonical form keeps those two agreeing, and makes the read view's red or blue link
+ *     an honest signal of whether the Schema is there.
  */
 class MappingContentValidator {
 
@@ -27,7 +37,7 @@ class MappingContentValidator {
 	 */
 	private array $errors = [];
 
-	public static function newInstance(): self {
+	public static function newInstance( TitleParser $titleParser ): self {
 		$json = file_get_contents( __DIR__ . '/mappingContentSchema.json' );
 
 		if ( !is_string( $json ) ) {
@@ -40,11 +50,12 @@ class MappingContentValidator {
 			throw new RuntimeException( 'Failed to deserialize JSON Schema' );
 		}
 
-		return new self( $schema );
+		return new self( $schema, $titleParser );
 	}
 
 	private function __construct(
-		private object $jsonSchema
+		private object $jsonSchema,
+		private TitleParser $titleParser
 	) {
 	}
 
@@ -93,12 +104,41 @@ class MappingContentValidator {
 
 		$schemas = is_array( $data['schemas'] ?? null ) ? $data['schemas'] : [];
 		foreach ( $schemas as $schemaName => $entry ) {
+			$errors = array_merge( $errors, $this->schemaNameErrors( (string)$schemaName ) );
+
 			if ( is_array( $entry ) ) {
 				$errors = array_merge( $errors, $this->schemaErrors( (string)$schemaName, $entry, $expander ) );
 			}
 		}
 
 		return $errors;
+	}
+
+	/**
+	 * @return array<string, string>
+	 */
+	private function schemaNameErrors( string $schemaName ): array {
+		$pointer = '/schemas/' . $schemaName;
+
+		try {
+			new SchemaName( $schemaName );
+		}
+		catch ( InvalidArgumentException $exception ) {
+			return [ $pointer => 'The Schema name "' . $schemaName . '" cannot be used: ' . $exception->getMessage() . '.' ];
+		}
+
+		try {
+			$canonical = $this->titleParser->parseTitle( $schemaName, NeoWikiExtension::NS_SCHEMA )->getText();
+		}
+		catch ( MalformedTitleException ) {
+			return [ $pointer => 'The Schema name "' . $schemaName . '" is not a valid page name.' ];
+		}
+
+		if ( $canonical !== $schemaName ) {
+			return [ $pointer => 'The Schema name "' . $schemaName . '" must be written as "' . $canonical . '", exactly as its Schema page is titled.' ];
+		}
+
+		return [];
 	}
 
 	/**

--- a/src/Presentation/MappingPageHtmlBuilder.php
+++ b/src/Presentation/MappingPageHtmlBuilder.php
@@ -71,6 +71,10 @@ class MappingPageHtmlBuilder {
 	 * existence query. Without this, both LinkRenderer::makeLink (red or blue?) and ParserOutput::addLink
 	 * (which page id?) do their own lookup per schema, and the schemas list is unbounded user input.
 	 *
+	 * A name is only linked when it is already the canonical page title. Save validation enforces that,
+	 * but XML import does not, and linking a name the projector will never match would show a blue link
+	 * on a Schema that is not in fact mapped.
+	 *
 	 * @return array<string, Title>
 	 */
 	private function resolveSchemaTitles( stdClass $schemas ): array {
@@ -79,7 +83,7 @@ class MappingPageHtmlBuilder {
 		foreach ( get_object_vars( $schemas ) as $name => $schema ) {
 			$title = $this->titleFactory->makeTitleSafe( NeoWikiExtension::NS_SCHEMA, (string)$name );
 
-			if ( $title !== null ) {
+			if ( $title !== null && $title->getText() === (string)$name ) {
 				$titles[(string)$name] = $title;
 			}
 		}

--- a/src/Presentation/MappingPageHtmlBuilder.php
+++ b/src/Presentation/MappingPageHtmlBuilder.php
@@ -5,10 +5,12 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Presentation;
 
 use Closure;
+use MediaWiki\Cache\LinkBatchFactory;
 use MediaWiki\Html\Html;
 use MediaWiki\Linker\LinkRenderer;
 use MediaWiki\Linker\LinkTarget;
 use MediaWiki\Parser\Sanitizer;
+use MediaWiki\Title\Title;
 use MediaWiki\Title\TitleFactory;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use stdClass;
@@ -28,12 +30,18 @@ class MappingPageHtmlBuilder {
 	/** @var list<string> */
 	private array $externalLinks = [];
 
+	/** @var array<string, Title> Schema name => its Schema page, for names that form a valid title. */
+	private array $schemaTitles = [];
+
 	/**
+	 * @param LinkTarget $pageTitle The Mapping page being rendered, for title-specific external link attributes.
 	 * @param Closure(mixed): string $renderJsonTable Renders a JSON subtree as the core mw-json table.
 	 */
 	public function __construct(
 		private readonly LinkRenderer $linkRenderer,
 		private readonly TitleFactory $titleFactory,
+		private readonly LinkBatchFactory $linkBatchFactory,
+		private readonly LinkTarget $pageTitle,
 		private readonly Closure $renderJsonTable
 	) {
 	}
@@ -43,6 +51,8 @@ class MappingPageHtmlBuilder {
 		$this->externalLinks = [];
 
 		$schemas = $mapping->schemas;
+
+		$this->schemaTitles = $this->resolveSchemaTitles( $schemas );
 
 		$html = Html::rawElement(
 			'div',
@@ -54,6 +64,29 @@ class MappingPageHtmlBuilder {
 		);
 
 		return new MappingPageRendering( $html, $this->schemaLinks, $this->externalLinks );
+	}
+
+	/**
+	 * Resolves every schema name to its Schema page up front and primes the LinkCache with a single
+	 * existence query. Without this, both LinkRenderer::makeLink (red or blue?) and ParserOutput::addLink
+	 * (which page id?) do their own lookup per schema, and the schemas list is unbounded user input.
+	 *
+	 * @return array<string, Title>
+	 */
+	private function resolveSchemaTitles( stdClass $schemas ): array {
+		$titles = [];
+
+		foreach ( get_object_vars( $schemas ) as $name => $schema ) {
+			$title = $this->titleFactory->makeTitleSafe( NeoWikiExtension::NS_SCHEMA, (string)$name );
+
+			if ( $title !== null ) {
+				$titles[(string)$name] = $title;
+			}
+		}
+
+		$this->linkBatchFactory->newLinkBatch( $titles )->setCaller( __METHOD__ )->execute();
+
+		return $titles;
 	}
 
 	private function versionHtml( stdClass $mapping ): string {
@@ -108,7 +141,7 @@ class MappingPageHtmlBuilder {
 	}
 
 	private function schemaLinkHtml( string $name ): string {
-		$title = $this->titleFactory->makeTitleSafe( NeoWikiExtension::NS_SCHEMA, $name );
+		$title = $this->schemaTitles[$name] ?? null;
 
 		if ( $title === null ) {
 			return Html::element( 'span', [], $name );
@@ -191,9 +224,14 @@ class MappingPageHtmlBuilder {
 
 		$this->externalLinks[] = $iri;
 
-		return Html::element( 'a', [ 'class' => 'external', 'rel' => 'nofollow', 'href' => $iri ], $iri );
+		return $this->linkRenderer->makeExternalLink( $iri, $iri, $this->pageTitle );
 	}
 
+	/**
+	 * Namespace IRIs are arbitrary strings as far as the mapping format is concerned, and
+	 * LinkRenderer::makeExternalLink does no scheme validation, so anything that is not plainly a web
+	 * address stays unlinked rather than becoming an href.
+	 */
 	private function isLinkableUrl( string $url ): bool {
 		return preg_match( '#^(?:https?|ftps?)://#i', $url ) === 1;
 	}

--- a/tests/phpunit/EntryPoints/Content/MappingContentHandlerParserOutputTest.php
+++ b/tests/phpunit/EntryPoints/Content/MappingContentHandlerParserOutputTest.php
@@ -6,7 +6,7 @@ namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\Content;
 
 use MediaWiki\CommentStore\CommentStoreComment;
 use MediaWiki\Content\Renderer\ContentParseParams;
-use MediaWiki\Linker\LinkTarget;
+use MediaWiki\MainConfigNames;
 use MediaWiki\Parser\ParserOutput;
 use MediaWiki\Parser\ParserOutputLinkTypes;
 use MediaWiki\Title\Title;
@@ -40,17 +40,40 @@ class MappingContentHandlerParserOutputTest extends MediaWikiIntegrationTestCase
 	}
 
 	public function testPerSchemaSubtreeIsRenderedAsAJsonTable(): void {
-		$html = $this->render( $this->edm() );
+		$personSection = $this->schemaSection( $this->render( $this->edm() ), 'Person' );
 
-		$this->assertStringContainsString( 'mw-json', $html );
-		$this->assertStringContainsString( 'rdaGr2:dateOfBirth', $html );
+		$this->assertStringContainsString( 'mw-json', $personSection );
+		$this->assertStringContainsString( 'rdaGr2:dateOfBirth', $personSection );
+	}
+
+	public function testSchemaSectionContainsOnlyItsOwnSubtree(): void {
+		$citySection = $this->schemaSection( $this->render( $this->edm() ), 'City' );
+
+		$this->assertStringContainsString( 'edm:Place', $citySection );
+		$this->assertStringNotContainsString( 'rdaGr2:dateOfBirth', $citySection );
 	}
 
 	public function testEachSchemaSectionHasADeepLinkableId(): void {
-		$this->assertStringContainsString(
-			'id="ext-neowiki-mapping-schema-Person"',
-			$this->render( $this->edm() )
+		$html = $this->render( $this->edm() );
+
+		$this->assertStringContainsString( 'id="ext-neowiki-mapping-schema-Person"', $html );
+		$this->assertStringContainsString( 'id="ext-neowiki-mapping-schema-City"', $html );
+	}
+
+	public function testSchemaSectionsFollowDocumentOrder(): void {
+		$html = $this->render( $this->edm() );
+
+		$this->assertLessThan(
+			strpos( $html, 'id="ext-neowiki-mapping-schema-City"' ),
+			strpos( $html, 'id="ext-neowiki-mapping-schema-Person"' )
 		);
+	}
+
+	public function testOverviewRowsShowTheTargetClassAndMappedPropertyCount(): void {
+		$html = $this->render( $this->edm() );
+
+		$this->assertStringContainsString( '>Person</a></td><td>edm:Agent</td><td>4</td>', $html );
+		$this->assertStringContainsString( '>City</a></td><td>edm:Place</td><td>0</td>', $html );
 	}
 
 	public function testFormatVersionIsRenderedAsASubtleLine(): void {
@@ -85,6 +108,15 @@ class MappingContentHandlerParserOutputTest extends MediaWikiIntegrationTestCase
 
 		$this->assertStringContainsString( 'ext-neowiki-mapping-page__prefixes', $html );
 		$this->assertStringContainsString( 'href="http://www.europeana.eu/schemas/edm/"', $html );
+	}
+
+	public function testPrefixLinksHonorTheWikiExternalLinkConfiguration(): void {
+		$this->overrideConfigValue( MainConfigNames::NoFollowLinks, false );
+
+		$html = $this->render( $this->edm() );
+
+		$this->assertStringContainsString( 'href="http://www.europeana.eu/schemas/edm/"', $html );
+		$this->assertStringNotContainsString( 'rel="nofollow"', $html );
 	}
 
 	public function testPrefixIriWithAnUnsafeSchemeIsNotLinkified(): void {
@@ -146,8 +178,18 @@ class MappingContentHandlerParserOutputTest extends MediaWikiIntegrationTestCase
 	}
 
 	/**
-	 * @param array<int, array{link: LinkTarget, pageid?: int}> $links
+	 * The rendered HTML from the section heading of $name up to the next schema section, so assertions
+	 * about a schema's own subtree cannot be satisfied by another schema's section or by the header.
 	 */
+	private function schemaSection( string $html, string $name ): string {
+		$start = strpos( $html, 'id="ext-neowiki-mapping-schema-' . $name . '"' );
+		$this->assertIsInt( $start, "No section rendered for schema $name" );
+
+		$next = strpos( $html, 'id="ext-neowiki-mapping-schema-', $start + 1 );
+
+		return $next === false ? substr( $html, $start ) : substr( $html, $start, $next - $start );
+	}
+
 	private function registersLocalLink( ParserOutput $parserOutput, int $namespace, string $dbKey ): bool {
 		$matches = array_filter(
 			$parserOutput->getLinkList( ParserOutputLinkTypes::LOCAL ),

--- a/tests/phpunit/EntryPoints/Content/MappingContentHandlerParserOutputTest.php
+++ b/tests/phpunit/EntryPoints/Content/MappingContentHandlerParserOutputTest.php
@@ -63,10 +63,13 @@ class MappingContentHandlerParserOutputTest extends MediaWikiIntegrationTestCase
 	public function testSchemaSectionsFollowDocumentOrder(): void {
 		$html = $this->render( $this->edm() );
 
-		$this->assertLessThan(
-			strpos( $html, 'id="ext-neowiki-mapping-schema-City"' ),
-			strpos( $html, 'id="ext-neowiki-mapping-schema-Person"' )
-		);
+		$person = strpos( $html, 'id="ext-neowiki-mapping-schema-Person"' );
+		$city = strpos( $html, 'id="ext-neowiki-mapping-schema-City"' );
+
+		// Guarded, because assertLessThan( int, false ) compares as bool and would pass.
+		$this->assertIsInt( $person );
+		$this->assertIsInt( $city );
+		$this->assertLessThan( $city, $person );
 	}
 
 	public function testOverviewRowsShowTheTargetClassAndMappedPropertyCount(): void {
@@ -111,8 +114,11 @@ class MappingContentHandlerParserOutputTest extends MediaWikiIntegrationTestCase
 	}
 
 	public function testPrefixLinksHonorTheWikiExternalLinkConfiguration(): void {
-		$this->overrideConfigValue( MainConfigNames::NoFollowLinks, false );
+		// Both directions, so an anchor that simply never emits rel cannot pass.
+		$this->overrideConfigValue( MainConfigNames::NoFollowLinks, true );
+		$this->assertStringContainsString( 'rel="nofollow"', $this->render( $this->edm() ) );
 
+		$this->overrideConfigValue( MainConfigNames::NoFollowLinks, false );
 		$html = $this->render( $this->edm() );
 
 		$this->assertStringContainsString( 'href="http://www.europeana.eu/schemas/edm/"', $html );
@@ -162,12 +168,15 @@ class MappingContentHandlerParserOutputTest extends MediaWikiIntegrationTestCase
 	 * claim a mapping that does not exist.
 	 */
 	public function testSchemaNameThatIsNotTheCanonicalPageTitleIsNotLinked(): void {
-		$this->createSchemaPage( 'Person' );
+		// The page the non-canonical name normalizes to, so without the guard this would be a blue link
+		// claiming a mapping the projector will never make, rather than a red one.
+		$this->createSchemaPage( 'Person x' );
 		$this->getServiceContainer()->getLinkCache()->clear();
 
 		$parserOutput = $this->parserOutput( $this->mappingWithSchema( 'Person_x' ) );
 
 		$this->assertStringContainsString( '<span>Person_x</span>', $parserOutput->getRawText() );
+		$this->assertStringNotContainsString( 'Schema:Person_x', $parserOutput->getRawText() );
 		$this->assertFalse( $this->registersLocalLink( $parserOutput, NeoWikiExtension::NS_SCHEMA, 'Person_x' ) );
 	}
 

--- a/tests/phpunit/EntryPoints/Content/MappingContentHandlerParserOutputTest.php
+++ b/tests/phpunit/EntryPoints/Content/MappingContentHandlerParserOutputTest.php
@@ -156,6 +156,21 @@ class MappingContentHandlerParserOutputTest extends MediaWikiIntegrationTestCase
 		$this->assertStringNotContainsString( 'redlink', $parserOutput->getRawText() );
 	}
 
+	/**
+	 * Save validation rejects a name that is not its Schema page's title, but XML import does not. Such a
+	 * name resolves to an existing Schema page while the projector never matches it, so linking it would
+	 * claim a mapping that does not exist.
+	 */
+	public function testSchemaNameThatIsNotTheCanonicalPageTitleIsNotLinked(): void {
+		$this->createSchemaPage( 'Person' );
+		$this->getServiceContainer()->getLinkCache()->clear();
+
+		$parserOutput = $this->parserOutput( $this->mappingWithSchema( 'Person_x' ) );
+
+		$this->assertStringContainsString( '<span>Person_x</span>', $parserOutput->getRawText() );
+		$this->assertFalse( $this->registersLocalLink( $parserOutput, NeoWikiExtension::NS_SCHEMA, 'Person_x' ) );
+	}
+
 	public function testEmptySchemasShowAFriendlyEmptyState(): void {
 		$html = $this->render( '{ "version": 1, "prefixes": {}, "schemas": {} }' );
 

--- a/tests/phpunit/Persistence/MediaWiki/MappingContentValidatorTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/MappingContentValidatorTest.php
@@ -4,23 +4,27 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Tests\Persistence\MediaWiki;
 
-use PHPUnit\Framework\TestCase;
+use MediaWikiIntegrationTestCase;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\MappingContentValidator;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestData;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\Persistence\MediaWiki\MappingContentValidator
  */
-class MappingContentValidatorTest extends TestCase {
+class MappingContentValidatorTest extends MediaWikiIntegrationTestCase {
+
+	private function newValidator(): MappingContentValidator {
+		return MappingContentValidator::newInstance( $this->getServiceContainer()->getTitleParser() );
+	}
 
 	private function assertValid( string $json ): void {
-		$validator = MappingContentValidator::newInstance();
+		$validator = $this->newValidator();
 		$this->assertTrue( $validator->validate( $json ), 'Expected valid, got: ' . implode( '; ', $validator->getErrors() ) );
 		$this->assertSame( [], $validator->getErrors() );
 	}
 
 	private function assertInvalidAt( string $json, string $expectedErrorPointer ): void {
-		$validator = MappingContentValidator::newInstance();
+		$validator = $this->newValidator();
 		$this->assertFalse( $validator->validate( $json ) );
 		$this->assertArrayHasKey( $expectedErrorPointer, $validator->getErrors() );
 	}
@@ -69,6 +73,80 @@ class MappingContentValidatorTest extends TestCase {
 			{ "version": 2, "schemas": { "Person": { "subject": { "class": "edm:X" }, "properties": {} } }, "prefixes": { "edm": "http://europeana.eu/edm/" } }
 			JSON,
 			'/version'
+		);
+	}
+
+	/**
+	 * The projector matches a Schema name byte for byte against the name a Subject carries, while a page
+	 * lookup normalizes underscores and the leading capital. A key that only resolves after normalization
+	 * would link to its Schema page yet never project, so it is rejected with the form to use.
+	 */
+	public function testRejectsASchemaNameThatIsNotTheCanonicalPageTitle(): void {
+		foreach ( [ 'Birth_place', 'birth place', ' Person' ] as $schemaName ) {
+			$this->assertInvalidAt(
+				(string)json_encode( [
+					'version' => 1,
+					'schemas' => [
+						$schemaName => [
+							'subject' => [ 'class' => 'http://example.org/ns/Person' ],
+							'properties' => (object)[],
+						],
+					],
+				] ),
+				'/schemas/' . $schemaName
+			);
+		}
+	}
+
+	public function testSaysWhichFormANonCanonicalSchemaNameShouldTake(): void {
+		$validator = $this->newValidator();
+		$validator->validate( (string)json_encode( [
+			'version' => 1,
+			'schemas' => [
+				'Birth_place' => [
+					'subject' => [ 'class' => 'http://example.org/ns/Place' ],
+					'properties' => (object)[],
+				],
+			],
+		] ) );
+
+		$this->assertStringContainsString(
+			'must be written as "Birth place"',
+			$validator->getErrors()['/schemas/Birth_place'] ?? ''
+		);
+	}
+
+	public function testRejectsASchemaNameThatIsNotAValidPageTitle(): void {
+		$this->assertInvalidAt(
+			(string)json_encode( [
+				'version' => 1,
+				'schemas' => [
+					'Bad|Name' => [
+						'subject' => [ 'class' => 'http://example.org/ns/Person' ],
+						'properties' => (object)[],
+					],
+				],
+			] ),
+			'/schemas/Bad|Name'
+		);
+	}
+
+	/**
+	 * The deserializer drops a reserved name, so accepting one here would store an entry that renders as
+	 * a mapped Schema but projects nothing.
+	 */
+	public function testRejectsAReservedSchemaName(): void {
+		$this->assertInvalidAt(
+			(string)json_encode( [
+				'version' => 1,
+				'schemas' => [
+					'Page' => [
+						'subject' => [ 'class' => 'http://example.org/ns/Person' ],
+						'properties' => (object)[],
+					],
+				],
+			] ),
+			'/schemas/Page'
 		);
 	}
 


### PR DESCRIPTION
Follow-up to #1156, targeting its branch. From a review of that PR: five confirmed findings, plus a
sixth the review surfaced indirectly and which turned out to be the substantive one.

## Batched Schema page lookups

Rendering a Mapping page did two un-batched page lookups per mapped Schema — `LinkRenderer::makeLink`
calls `Title::isKnown()` to pick red or blue, and `ParserOutput::addLink` with no page id makes core
resolve the title itself (`includes/parser/ParserOutput.php:1331` carries its own *"T357048: This
actually kills performance; we should batch these"*). The `schemas` list is unbounded user input and
the page re-renders on every parser-cache miss. Names are now resolved up front and primed with a
single `LinkBatch`, so both callers read from the `LinkCache`.

## Prefix IRIs go through LinkRenderer

The anchors were hand-built with a hardcoded `rel="nofollow"`, ignoring `$wgNoFollowLinks`,
`$wgNoFollowNsExceptions` and `$wgNoFollowDomainExceptions`, and never running the
`LinkerMakeExternalLink` hook (SecureLinkFixer consumes it). They now use
`LinkRenderer::makeExternalLink`, following `SpecialLinkSearch.php:256`. Under default config the
emitted markup is byte-identical, so nothing changes visually.

The `isLinkableUrl` scheme guard stays — `makeExternalLink` writes `href` unconditionally, so it is
what keeps a `javascript:` namespace unlinked.

## Schema names must be written as their Schema page is titled

`Mapping::forSchema` matches a schema key against the name a Subject carries byte for byte, while a
page lookup normalizes underscores and the leading capital. A key written `Person_x` therefore
resolves to `Schema:Person x` for display and links to it in **blue**, but never matches a Subject,
so it silently projects nothing — and the docs state that link colour tells you whether the Schema
is there.

Rather than teach the display layer a second normalization rule, the two are made to agree by
construction: a schema key must already be the canonical page title, checked at save, with the error
naming the form to use. This also removes a case the format could express but nothing could consume —
two keys differing only by underscore resolve to one Schema page, which `Mapping.php:14` has always
documented as impossible.

Reserved and unusable names are rejected here too; the deserializer already drops them, so accepting
them at save stored an entry that rendered as a mapped Schema and projected nothing. XML import
bypasses `validateSave`, so the read view also declines to link a name that is not its page title.

No existing content is affected: every schema key in `DemoData/`, `docs/examples/` and the fixtures is
already canonical.

## Test gaps closed

Each was confirmed by mutation — all three mutants survived the suite as it stood:

| Mutation | Was | Now |
|---|---|---|
| render only the first schema section | passed | fails (3 tests) |
| dump the whole document under every heading | passed | fails |
| blank the overview's target class / zero its property count | passed | fails |

`testPerSchemaSubtreeIsRenderedAsAJsonTable` also asserted only that `mw-json` and a predicate string
appeared *somewhere* — both true on the base commit, before the feature existed. It now asserts
against the section fragment.

## Manual Browser Check

1. Open `Mapping:EDM` on a demo wiki.
2. The **Mapped schemas** table should list Person, Artist, Artwork and City as blue links, with
   target classes `edm:Agent`, `edm:Agent`, `edm:ProvidedCHO`, `edm:Place` and counts 4, 4, 5, 0.
3. Below it, four `<h2>` sections in that same order, each showing only its own JSON subtree.
4. Prefix IRIs under **Prefixes** are clickable and carry the external-link icon.
5. Edit the page and rename a schema key to `Person_x`. Saving must fail with an error naming
   `Person x` as the form to use. Restore the key.
6. Rename a key to a Schema that does not exist. It saves, and that row renders as a red link.

## Verification

`make cs` (phpcs + phpstan) clean. `filter=Mapping` 116 tests, `MappingContentValidatorTest` 23,
`MappingContentHandlerParserOutputTest` 21, plus `MappingContentHandlerValidateSaveTest`,
`MappingPersistenceDeserializer`, `OntologyMappingProjector`, `SchemaContentHandler` and nine of the
ten `Rdf` test classes — all green. Read view verified against the running dev wiki.

The full suite was **not** run to completion: `ExportSubjectRdfApiTest` hangs, and hangs identically
on the unmodified base branch. `CreateSubjectApiTest::testInterlinkedSubjectsCanBeCreatedInAnyOrder`
also fails identically on the base branch (host clock skew in `GlobalIdGenerator`). Neither is
attributable to this change; leaving both to CI.

> <sub>AI-authored — Claude Code, `Opus 5 (1M context)`; reviewed #1156 and implemented the accepted findings; diff not yet human-reviewed; phpcs, phpstan and the targeted PHPUnit filters above green locally, read view verified in the browser, full suite blocked by a pre-existing hang.</sub>
