### PR TITLE
Review fixes for #1188: unreadable-revision memoization and two overstated claims

### DIFF
--- a/docs/operations/maintenance.md
+++ b/docs/operations/maintenance.md
@@ -23,13 +23,16 @@ longer has. Run it to:
 - Recover after a backend wipe or restore.
 - Fix any drift between a backend's copy and the canonical revision slots.
 
-Two things to plan around:
+Three things to plan around:
 
 - It reconciles pages, not stray data. Anything the projection never knew about — a node written directly to Neo4j,
   say, or a named graph left behind in a SPARQL store — is not something the rebuild can find. For a guaranteed-clean
   result, empty the backend before rebuilding: wipe Neo4j's data volume, or drop the wiki's named graphs from the store.
 - It runs as a single sequential process with no batching or resume, so the time scales with the number of pages. Plan
   downtime on large wikis.
+- Schema edits made while it runs do not reach it. It resolves each Schema once and keeps that copy for the rest of the
+  run, so a Schema edited mid-run is projected as it stood when the rebuild first read it. Edit Schemas before starting,
+  or re-run the rebuild afterwards.
 
 ## Upgrades
 

--- a/src/Application/Schema/Exception/SchemaContentUnavailableException.php
+++ b/src/Application/Schema/Exception/SchemaContentUnavailableException.php
@@ -1,0 +1,28 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application\Schema\Exception;
+
+use RuntimeException;
+
+/**
+ * Thrown when the content of a Schema page that exists could not be read at all, as opposed to
+ * being read and found not to be a valid Schema.
+ *
+ * The two produce the same null for callers, but only the second is a property of the revision.
+ * An unreadable blob is a transient condition — an external store or replica hiccup — so a cache
+ * keyed by revision id must not remember it: the key would not change until someone edited the
+ * Schema, pinning it as missing for the life of the entry. Content that does not deserialize will
+ * not deserialize on the next call either, and is safe to remember.
+ *
+ * Callers are expected to have established that the page exists; {@see CachingSchemaLookup} does so
+ * before it reaches the inner lookup.
+ */
+class SchemaContentUnavailableException extends RuntimeException {
+
+	public static function forName( string $schemaName ): self {
+		return new self( 'Schema content could not be read: ' . $schemaName );
+	}
+
+}

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -1028,8 +1028,14 @@ class NeoWikiExtension {
 		);
 	}
 
-	// Pinned to the authority of the first use, like getNeo4jPlugin(): the realistic mid-process
-	// authority switch is a login, where serving the earlier anonymous resolutions only under-serves.
+	// Pinned to the authority of first use, like getNeo4jPlugin(). The pin fixes the authority behind
+	// both the Schema read gate and the inner lookup's revision-audience filter, and it lives as long
+	// as this singleton, so its scope is the PHP process: one request under mod_php, a whole run under
+	// a maintenance script. It narrows ADR 027's "every access decision runs against the caller's
+	// Authority" to the process's first authority, which is safe because the in-request switches go
+	// weaker to stronger — a login or account creation mutating the main context — where reusing the
+	// anonymous resolutions can only under-serve. Core's one switch the other way, beginAccountCreation()
+	// dropping a temp account to a fresh anonymous user, moves between two near-anonymous authorities.
 	public function getSchemaLookup(): SchemaLookup {
 		$this->schemaLookup ??= $this->newSchemaLookup( $this->getRequestAuthority() );
 

--- a/src/Persistence/MediaWiki/CachingSchemaLookup.php
+++ b/src/Persistence/MediaWiki/CachingSchemaLookup.php
@@ -7,6 +7,7 @@ namespace ProfessionalWiki\NeoWiki\Persistence\MediaWiki;
 use MediaWiki\Title\Title;
 use MediaWiki\Title\TitleFactory;
 use ProfessionalWiki\NeoWiki\Application\PageReadAuthorizer;
+use ProfessionalWiki\NeoWiki\Application\Schema\Exception\SchemaContentUnavailableException;
 use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
@@ -58,7 +59,16 @@ class CachingSchemaLookup implements SchemaLookup {
 		$cacheKey = $this->makeCacheKey( $title );
 
 		if ( !array_key_exists( $cacheKey, $this->resolvedSchemas ) ) {
-			$this->resolvedSchemas[$cacheKey] = $this->getFromSharedCache( $cacheKey, $schemaName );
+			try {
+				$this->resolvedSchemas[$cacheKey] = $this->getFromSharedCache( $cacheKey, $schemaName );
+			}
+			catch ( SchemaContentUnavailableException ) {
+				// The revision's content could not be read, which the next call may well manage.
+				// Neither tier may remember that: the key is the revision id, so the entry would
+				// outlive the failure until someone edited the Schema. Letting this unwind past
+				// getWithSetCallback() leaves the shared tier empty too.
+				return null;
+			}
 		}
 
 		return $this->resolvedSchemas[$cacheKey];

--- a/src/Persistence/MediaWiki/CachingSchemaLookup.php
+++ b/src/Persistence/MediaWiki/CachingSchemaLookup.php
@@ -18,10 +18,15 @@ use Wikimedia\Rdbms\IConnectionProvider;
 
 /**
  * Caches deserialized Schemas so that repeated reads do not each re-load and re-parse the Schema
- * wiki page. Two tiers: a process-local one serving the reads within a single request or
- * maintenance run, over the shared WANObjectCache serving reads across them. Both key on the
- * Schema page's latest revision id, so editing the Schema transparently invalidates the entry —
- * no stale schemas.
+ * wiki page. Two tiers: a process-local one over the shared WANObjectCache. NeoWikiExtension pins
+ * one lookup in its singleton, so the process-local tier lasts as long as the PHP process — a
+ * single request under mod_php, an entire run under a maintenance script.
+ *
+ * Both key on the Schema page's latest revision id, which is read from the LinkCache. An edit made
+ * by this process refreshes that cache (see WikiPage::updateRevisionOn), so it yields a new key and
+ * takes effect at once. An edit made by another process does not reach this one's LinkCache, so a
+ * long-running script keeps serving the Schema as it stood when the script first resolved it. The
+ * shared tier has no such window, because the next process reads the current revision id.
  */
 class CachingSchemaLookup implements SchemaLookup {
 
@@ -93,8 +98,9 @@ class CachingSchemaLookup implements SchemaLookup {
 	}
 
 	/**
-	 * Keyed by the Schema page's article id and latest revision id, so editing
-	 * the Schema yields a new key and the old entry is never served again.
+	 * Keyed by the Schema page's article id and latest revision id, so an edit this process can see
+	 * yields a new key and the old entry is never served again. The class docblock covers the edits
+	 * it cannot see.
 	 */
 	private function makeCacheKey( Title $title ): string {
 		return $this->cache->makeKey(

--- a/src/Persistence/MediaWiki/WikiPageSchemaLookup.php
+++ b/src/Persistence/MediaWiki/WikiPageSchemaLookup.php
@@ -6,6 +6,7 @@ namespace ProfessionalWiki\NeoWiki\Persistence\MediaWiki;
 
 use InvalidArgumentException;
 use MediaWiki\Permissions\Authority;
+use ProfessionalWiki\NeoWiki\Application\Schema\Exception\SchemaContentUnavailableException;
 use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
@@ -21,11 +22,18 @@ class WikiPageSchemaLookup implements SchemaLookup {
 	) {
 	}
 
+	/**
+	 * Returns null when the Schema page's content is not a valid Schema, and throws when that content
+	 * could not be read at all, so that a caching decorator can tell the durable outcome from the
+	 * transient one. See {@see SchemaContentUnavailableException}.
+	 *
+	 * @throws SchemaContentUnavailableException
+	 */
 	public function getSchema( SchemaName $schemaName ): ?Schema {
 		$content = $this->getContent( $schemaName );
 
 		if ( $content === null ) {
-			return null;
+			throw SchemaContentUnavailableException::forName( $schemaName->getText() );
 		}
 
 		try {

--- a/tests/phpunit/Persistence/MediaWiki/CachingSchemaLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/CachingSchemaLookupTest.php
@@ -8,6 +8,7 @@ use MediaWiki\Title\Title;
 use MediaWiki\Title\TitleFactory;
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Application\PageReadAuthorizer;
+use ProfessionalWiki\NeoWiki\Application\Schema\Exception\SchemaContentUnavailableException;
 use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinitions;
@@ -143,6 +144,31 @@ class CachingSchemaLookupTest extends TestCase {
 		$this->assertSame( 1, $inner->calls );
 	}
 
+	public function testDoesNotRememberARevisionWhoseContentCouldNotBeRead(): void {
+		// Unlike content that does not deserialize, an unreadable blob is transient. Remembering it
+		// would pin the Schema as missing until someone edited it, since the key is the revision id.
+		$inner = $this->newUnreadableContentSpyLookup();
+
+		$lookup = new CachingSchemaLookup( $inner, $this->newCache(), $this->newTitleFactory( 1, 100, 100 ), new StubPageReadAuthorizer( allowed: true ), $this->newConnectionProvider() );
+
+		$this->assertNull( $lookup->getSchema( new SchemaName( 'Person' ) ) );
+		$this->assertNull( $lookup->getSchema( new SchemaName( 'Person' ) ) );
+
+		$this->assertSame( 2, $inner->calls );
+	}
+
+	public function testServesTheSchemaOnceTheRevisionBecomesReadableAgain(): void {
+		$inner = $this->newRecoveringSpyLookup();
+
+		$lookup = new CachingSchemaLookup( $inner, $this->newCache(), $this->newTitleFactory( 1, 100, 100, 100 ), new StubPageReadAuthorizer( allowed: true ), $this->newConnectionProvider() );
+
+		$this->assertNull( $lookup->getSchema( new SchemaName( 'Person' ) ) );
+		$this->assertEquals( $inner->schema, $lookup->getSchema( new SchemaName( 'Person' ) ) );
+		$this->assertEquals( $inner->schema, $lookup->getSchema( new SchemaName( 'Person' ) ) );
+
+		$this->assertSame( 2, $inner->calls );
+	}
+
 	/**
 	 * @return SchemaLookup&object{calls: int, schema: Schema}
 	 */
@@ -172,6 +198,46 @@ class CachingSchemaLookupTest extends TestCase {
 			public function getSchema( SchemaName $schemaName ): ?Schema {
 				$this->calls++;
 				return null;
+			}
+		};
+	}
+
+	/**
+	 * @return SchemaLookup&object{calls: int}
+	 */
+	private function newUnreadableContentSpyLookup(): SchemaLookup {
+		return new class() implements SchemaLookup {
+			public int $calls = 0;
+
+			public function getSchema( SchemaName $schemaName ): ?Schema {
+				$this->calls++;
+				throw SchemaContentUnavailableException::forName( $schemaName->getText() );
+			}
+		};
+	}
+
+	/**
+	 * Unreadable on the first call, then readable, as a transient blob failure behaves.
+	 *
+	 * @return SchemaLookup&object{calls: int, schema: Schema}
+	 */
+	private function newRecoveringSpyLookup(): SchemaLookup {
+		return new class() implements SchemaLookup {
+			public int $calls = 0;
+			public Schema $schema;
+
+			public function __construct() {
+				$this->schema = new Schema( new SchemaName( 'Test' ), 'desc', new PropertyDefinitions( [] ) );
+			}
+
+			public function getSchema( SchemaName $schemaName ): ?Schema {
+				$this->calls++;
+
+				if ( $this->calls === 1 ) {
+					throw SchemaContentUnavailableException::forName( $schemaName->getText() );
+				}
+
+				return $this->schema;
 			}
 		};
 	}

--- a/tests/phpunit/Persistence/MediaWiki/WikiPageSchemaLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/WikiPageSchemaLookupTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Persistence\MediaWiki;
+
+use InvalidArgumentException;
+use MediaWiki\Content\Content;
+use MediaWiki\Permissions\Authority;
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\Schema\Exception\SchemaContentUnavailableException;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinitions;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\EntryPoints\Content\SchemaContent;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\PageContentFetcher;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\SchemaPersistenceDeserializer;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\WikiPageSchemaLookup;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Persistence\MediaWiki\WikiPageSchemaLookup
+ */
+class WikiPageSchemaLookupTest extends TestCase {
+
+	public function testReturnsTheDeserializedSchema(): void {
+		$schema = new Schema( new SchemaName( 'Person' ), 'desc', new PropertyDefinitions( [] ) );
+
+		$lookup = $this->newLookup(
+			content: new SchemaContent( '{}' ),
+			deserializer: $this->newDeserializerReturning( $schema )
+		);
+
+		$this->assertSame( $schema, $lookup->getSchema( new SchemaName( 'Person' ) ) );
+	}
+
+	public function testReturnsNullWhenTheContentIsNotAValidSchema(): void {
+		$lookup = $this->newLookup(
+			content: new SchemaContent( 'not json' ),
+			deserializer: $this->newDeserializerThrowing()
+		);
+
+		$this->assertNull( $lookup->getSchema( new SchemaName( 'Broken' ) ) );
+	}
+
+	public function testThrowsWhenTheContentCouldNotBeRead(): void {
+		// Distinct from content that does not deserialize: this outcome is transient, so callers
+		// that cache by revision id must not store it.
+		$lookup = $this->newLookup( content: null, deserializer: $this->newDeserializerThrowing() );
+
+		$this->expectException( SchemaContentUnavailableException::class );
+
+		$lookup->getSchema( new SchemaName( 'Person' ) );
+	}
+
+	private function newLookup( ?Content $content, SchemaPersistenceDeserializer $deserializer ): WikiPageSchemaLookup {
+		$fetcher = $this->createMock( PageContentFetcher::class );
+		$fetcher->method( 'getPageContent' )->willReturn( $content );
+
+		return new WikiPageSchemaLookup(
+			pageContentFetcher: $fetcher,
+			authority: $this->createMock( Authority::class ),
+			schemaDeserializer: $deserializer
+		);
+	}
+
+	private function newDeserializerReturning( Schema $schema ): SchemaPersistenceDeserializer {
+		$deserializer = $this->createMock( SchemaPersistenceDeserializer::class );
+		$deserializer->method( 'deserialize' )->willReturn( $schema );
+		return $deserializer;
+	}
+
+	private function newDeserializerThrowing(): SchemaPersistenceDeserializer {
+		$deserializer = $this->createMock( SchemaPersistenceDeserializer::class );
+		$deserializer->method( 'deserialize' )->willThrowException( new InvalidArgumentException() );
+		return $deserializer;
+	}
+
+}


### PR DESCRIPTION
## Stop remembering a Schema whose revision could not be read (16f7de4d)

`WikiPageSchemaLookup` returned `null` both for a revision whose content does not deserialize and
for one whose content could not be read at all. Only the first is a property of the revision:
`PageContentFetcher` returns `null` when it catches a `RevisionAccessException`, and
`RevisionRecord::getContent()` returns `null` on a `BadRevisionException` — both raised by
`RevisionStore::loadSlotContent` when the *blob* read fails, which is an external-store or replica
hiccup rather than bad data.

Since both tiers key on the revision id, remembering that `null` pinned the Schema as missing until
someone edited it. One failed blob read during a `RebuildGraphDatabases.php` run left every
remaining Subject on that Schema unprojected, `Neo4jSubjectUpdater` logging "Schema not found" for
each, and the script still exiting 0.

`WikiPageSchemaLookup` now throws `SchemaContentUnavailableException` for an unreadable revision and
keeps returning `null` for content that is not a valid Schema. `CachingSchemaLookup` catches it and
returns `null` without recording it. Letting it unwind past `getWithSetCallback()` leaves the shared
tier empty too, so the day-long entry that tier wrote for this case is gone as well — that half was
pre-existing, and the same change covers it.

Deliberately unchanged: content that does not deserialize is still memoized, which is what
`testResolvesUndeserializableSchemaOnlyOnceWhenTheSharedCacheStoresNothing` pins; and consumers
still see `null` for an unreadable revision, so `Neo4jSubjectUpdater` logs and skips exactly as
before. Whether a rebuild should instead fail loudly on an unreadable Schema is a separate question.

## Scope the no-stale-Schemas claim to the edits it actually covers (bea5db79)

The class docblock said both tiers key on the latest revision id "so editing the Schema
transparently invalidates the entry — no stale schemas", and `makeCacheKey()` said the old entry
"is never served again". That holds for the shared tier, whose next reader is a new process, and for
an edit made by the process doing the reading. It does not hold for the process-local tier against
an edit made elsewhere: the key comes from `Title::getLatestRevID()`, which reads the `LinkCache`,
and only `WikiPage::updateRevisionOn()` in *this* process refreshes it. A rebuild that runs for an
hour keeps serving each Schema as it stood when it first resolved it.

Also drops "within a single request or maintenance run" as the tier's lifetime — it lives in the
`NeoWikiExtension` singleton, so the real lifetime is the PHP process.

Documented in `docs/operations/maintenance.md` next to the existing rebuild caveats rather than
changed: reading the revision id with `READ_LATEST` would put a primary-database hit on every Schema
resolution, which is what this caching exists to avoid.

## State what the pinned authority actually fixes (b477dadd)

The comment said the pin serves "the earlier anonymous resolutions", which reads as though only
already-resolved content were reused. The pin also fixes the authority behind the Schema read gate
and behind the inner lookup's revision-audience filter, so the gate that runs on every call runs
against the process's first authority rather than the caller's current one. Two reviewers read the
old wording as claiming the current authority is re-checked.

ADR 027 (Access Control), which landed on master after #1188 was branched, states that every access
decision runs against the caller's `Authority`. Pinning narrows that, so the comment now says so at
the site that narrows it. It also drops the absolute "the realistic mid-process authority switch is a
login": core has one switch the other way, `AuthManager::beginAccountCreation()` dropping a temp
account to a fresh anonymous user. That moves between two near-anonymous authorities, so it does not
threaten the argument, but the old wording denied it existed.

## Not done here

- **#1188's description still carries both corrected claims** verbatim ("the no-stale-Schemas
  guarantee holds unchanged ... including during a `RebuildGraphDatabases.php` run", and "The only
  realistic mid-process Authority switch is weaker to stronger"). Left for @JeroenDeDauw to edit.
- **No note added to `docs/adr/027-access-control.md`.** The ADR is not on this branch, and merging
  master in to reach it would mix an unrelated merge into the series. The reconciliation lives in the
  code comment, which survives the merge.
- **Pre-existing, out of scope, worth their own issues:** `CachingMappingLookupTest` mocks `Title`
  without stubbing `getArticleID()`/`getLatestRevID()`, which have no native return type, so both its
  tests share the key `neowiki-mapping:1::` and emit `strtr(null)` deprecations. And `SchemaName`
  does no case normalization, so `person` and `Person` share a cache key.

## Verification

Run on an isolated dev stack at each commit: full `make phpunit` green (2102 tests, 5015 assertions,
4 skipped, 0 failures — 2097 before, +5 new), `make cs` (phpcs + phpstan) clean. The two
`CachingSchemaLookupTest` cases and the new `WikiPageSchemaLookupTest` were written first and
confirmed failing before the fix; the failure trace also confirmed empirically that WANObjectCache
propagates callback exceptions rather than caching around them.

> <sub>AI-authored — Claude Code, `Opus 5 (max)`; review of #1188 commissioned by @alistair3149, findings produced by a 25-agent adversarial review (20 raw, 18 refuted at source level, 2 survived) and the fixes authored from the survivors; full diff not yet human-reviewed; tests written test-first and confirmed failing without the fix, full local PHPUnit + phpcs + phpstan green at each commit.</sub>
