### PR TITLE
Review fixes for #1147: adopt severity in RedHerb and pin the enforcement semantics

### DIFF
--- a/docs/api/validation-codes.md
+++ b/docs/api/validation-codes.md
@@ -14,7 +14,8 @@ Violations are returned by:
   body against an existing Subject's Schema.
 - `POST /neowiki/v0/subject` and `PUT /neowiki/v0/subject/{subjectId}` — the write endpoints include
   the resulting `violations` array in their `201`/`200` success body. Whether a write with violations
-  is rejected is covered under [Blocking and enforcement](#blocking-and-enforcement).
+  is rejected is covered under
+  [Severity, blocking, and enforcement](#severity-blocking-and-enforcement).
 
 The `/validate` endpoints return `200 OK` with a `{violations: [...]}` body whenever the request is
 well-formed; violations in the body do not change the HTTP status. `400` is reserved for malformed

--- a/tests/RedHerb/extension.json
+++ b/tests/RedHerb/extension.json
@@ -159,8 +159,8 @@
 				"redherb-card-edit-subject",
 				"redherb-card-edit-schema",
 				"redherb-card-edit-layout",
-				"neowiki-field-invalid-hex",
-				"neowiki-field-not-in-palette",
+				"neowiki-field-invalid-color",
+				"neowiki-field-invalid-option",
 				"neowiki-field-required"
 			]
 		}

--- a/tests/RedHerb/i18n/en.json
+++ b/tests/RedHerb/i18n/en.json
@@ -35,6 +35,5 @@
 	"redherb-card-edit-subject": "Edit subject",
 	"redherb-card-edit-schema": "Edit schema",
 	"redherb-card-edit-layout": "Edit layout",
-	"neowiki-field-invalid-hex": "Please enter a 6-digit hex color like #ff5733.",
-	"neowiki-field-not-in-palette": "This color is not in the allowed palette."
+	"neowiki-field-invalid-color": "\"$1\" is not a valid color. Enter a 6-digit hex color like #ff5733."
 }

--- a/tests/RedHerb/i18n/qqq.json
+++ b/tests/RedHerb/i18n/qqq.json
@@ -35,6 +35,5 @@
 	"redherb-card-edit-subject": "Label of the button on the RedHerb card View Type that opens the subject editor dialog.",
 	"redherb-card-edit-schema": "Label of the link on the RedHerb card View Type that opens the Subject's Schema page for editing.",
 	"redherb-card-edit-layout": "Label of the link on the RedHerb card View Type that opens the Layout page for editing.",
-	"neowiki-field-invalid-hex": "Validation error shown when a Color input value is not a valid 6-digit hex code.",
-	"neowiki-field-not-in-palette": "Validation error shown when a Color input value is not one of the property's allowed palette entries."
+	"neowiki-field-invalid-color": "Validation error shown when a Color input value is not a valid 6-digit hex code. Corresponds to ColorType's <code>invalid-color</code> violation code. $1 is the offending value."
 }

--- a/tests/RedHerb/src/ColorType.php
+++ b/tests/RedHerb/src/ColorType.php
@@ -7,6 +7,7 @@ namespace ProfessionalWiki\RedHerb;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyType;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinition;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
 use ProfessionalWiki\NeoWiki\Domain\Value\NeoValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
@@ -47,7 +48,7 @@ class ColorType implements PropertyType {
 		}
 
 		if ( $definition->isRequired() && $value->strings === [] ) {
-			return [ new Violation( propertyName: null, code: 'required' ) ];
+			return [ new Violation( propertyName: null, code: 'required', severity: $definition->severityOf( 'required' ) ) ];
 		}
 
 		$allowed = $definition->getAllowedColors();
@@ -62,6 +63,7 @@ class ColorType implements PropertyType {
 					code: 'invalid-color',
 					args: [ $part ],
 					valuePartIndex: $index,
+					severity: Severity::Error,
 				);
 				continue;
 			}
@@ -72,6 +74,7 @@ class ColorType implements PropertyType {
 					code: 'invalid-option',
 					args: [ $part ],
 					valuePartIndex: $index,
+					severity: $definition->severityOf( 'allowedColors' ),
 				);
 			}
 		}

--- a/tests/phpunit/Application/Validation/SubjectValidatorTest.php
+++ b/tests/phpunit/Application/Validation/SubjectValidatorTest.php
@@ -19,6 +19,7 @@ use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Statement;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
 use ProfessionalWiki\NeoWiki\Domain\Value\NumberValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\RelationValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\UnregisteredTypeValue;
@@ -79,6 +80,7 @@ class SubjectValidatorTest extends TestCase {
 		$this->assertCount( 1, $violations );
 		$this->assertSame( 'label-required', $violations[0]->code );
 		$this->assertNull( $violations[0]->propertyName );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
 	}
 
 	public function testWhitespaceOnlyLabelReturnsLabelRequired(): void {
@@ -248,6 +250,7 @@ class SubjectValidatorTest extends TestCase {
 		$this->assertSame( 'type-mismatch', $violations[0]->code );
 		$this->assertEquals( new PropertyName( 'Age' ), $violations[0]->propertyName );
 		$this->assertSame( [ 'text', 'number' ], $violations[0]->args );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
 	}
 
 	public function testTypeMismatchSkipsPerTypeValidation(): void {

--- a/tests/phpunit/Domain/PropertyType/Types/DateTimeTypeValidateTest.php
+++ b/tests/phpunit/Domain/PropertyType/Types/DateTimeTypeValidateTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\Types\DateTimeType;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\DateTimeProperty;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
 use ProfessionalWiki\NeoWiki\Domain\Value\NumberValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
 
@@ -75,6 +76,7 @@ class DateTimeTypeValidateTest extends TestCase {
 		$this->assertCount( 1, $violations );
 		$this->assertSame( 'invalid-datetime', $violations[0]->code );
 		$this->assertNull( $violations[0]->propertyName );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
 	}
 
 	public function testYearOnlyReturnsInvalidDatetime(): void {

--- a/tests/phpunit/Domain/PropertyType/Types/DateTimeTypeValidateTest.php
+++ b/tests/phpunit/Domain/PropertyType/Types/DateTimeTypeValidateTest.php
@@ -5,9 +5,11 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Tests\Domain\PropertyType\Types;
 
 use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeRegistry;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\Types\DateTimeType;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\DateTimeProperty;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinition;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
 use ProfessionalWiki\NeoWiki\Domain\Value\NumberValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
@@ -175,6 +177,7 @@ class DateTimeTypeValidateTest extends TestCase {
 		$this->assertSame( 'min-value', $violations[0]->code );
 		$this->assertSame( [ '2025-01-01T00:00:00Z' ], $violations[0]->args );
 		$this->assertNull( $violations[0]->propertyName );
+		$this->assertSame( Severity::Warning, $violations[0]->severity );
 	}
 
 	public function testAfterMaximumReturnsMaxValue(): void {
@@ -187,6 +190,44 @@ class DateTimeTypeValidateTest extends TestCase {
 		$this->assertSame( 'max-value', $violations[0]->code );
 		$this->assertSame( [ '2025-12-31T23:59:59Z' ], $violations[0]->args );
 		$this->assertNull( $violations[0]->propertyName );
+		$this->assertSame( Severity::Warning, $violations[0]->severity );
+	}
+
+	/**
+	 * Unlike NumberType, the bound severities reach checkMinimum()/checkMaximum() as arguments
+	 * rather than being read at the raise site. Each test therefore leaves the other bound
+	 * unannotated, so swapping the two arguments hands the violation the sibling's warning.
+	 */
+	public function testMinValueViolationUsesErrorWhenMinimumAnnotated(): void {
+		$definition = PropertyDefinition::fromJson(
+			[
+				'type' => 'dateTime',
+				'minimum' => [ 'value' => '2025-01-01T00:00:00Z', 'severity' => 'error' ],
+				'maximum' => '2025-12-31T23:59:59Z',
+			],
+			PropertyTypeRegistry::withCoreTypes(),
+		);
+
+		$violations = $this->type->validate( new StringValue( '2024-12-31T23:59:59Z' ), $definition );
+
+		$this->assertSame( 'min-value', $violations[0]->code );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
+	}
+
+	public function testMaxValueViolationUsesErrorWhenMaximumAnnotated(): void {
+		$definition = PropertyDefinition::fromJson(
+			[
+				'type' => 'dateTime',
+				'minimum' => '2025-01-01T00:00:00Z',
+				'maximum' => [ 'value' => '2025-12-31T23:59:59Z', 'severity' => 'error' ],
+			],
+			PropertyTypeRegistry::withCoreTypes(),
+		);
+
+		$violations = $this->type->validate( new StringValue( '2026-01-01T00:00:00Z' ), $definition );
+
+		$this->assertSame( 'max-value', $violations[0]->code );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
 	}
 
 	public function testEqualToBoundsReturnsNoViolations(): void {

--- a/tests/phpunit/Domain/PropertyType/Types/DateTypeValidateTest.php
+++ b/tests/phpunit/Domain/PropertyType/Types/DateTypeValidateTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\Types\DateType;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\DateProperty;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
 use ProfessionalWiki\NeoWiki\Domain\Value\NumberValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
 
@@ -61,6 +62,7 @@ class DateTypeValidateTest extends TestCase {
 		);
 
 		$this->assertSame( 'invalid-date', $violations[0]->code );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
 	}
 
 	public function testYearOnlyReturnsInvalidDate(): void {

--- a/tests/phpunit/Domain/PropertyType/Types/DateTypeValidateTest.php
+++ b/tests/phpunit/Domain/PropertyType/Types/DateTypeValidateTest.php
@@ -5,9 +5,11 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Tests\Domain\PropertyType\Types;
 
 use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeRegistry;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\Types\DateType;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\DateProperty;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinition;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
 use ProfessionalWiki\NeoWiki\Domain\Value\NumberValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
@@ -125,6 +127,7 @@ class DateTypeValidateTest extends TestCase {
 
 		$this->assertSame( 'min-value', $violations[0]->code );
 		$this->assertSame( [ '2025-01-01' ], $violations[0]->args );
+		$this->assertSame( Severity::Warning, $violations[0]->severity );
 	}
 
 	public function testAfterMaximumReturnsMaxValue(): void {
@@ -135,6 +138,44 @@ class DateTypeValidateTest extends TestCase {
 
 		$this->assertSame( 'max-value', $violations[0]->code );
 		$this->assertSame( [ '2025-12-31' ], $violations[0]->args );
+		$this->assertSame( Severity::Warning, $violations[0]->severity );
+	}
+
+	/**
+	 * Unlike NumberType, the bound severities reach checkMinimum()/checkMaximum() as arguments
+	 * rather than being read at the raise site. Each test therefore leaves the other bound
+	 * unannotated, so swapping the two arguments hands the violation the sibling's warning.
+	 */
+	public function testMinValueViolationUsesErrorWhenMinimumAnnotated(): void {
+		$definition = PropertyDefinition::fromJson(
+			[
+				'type' => 'date',
+				'minimum' => [ 'value' => '2025-01-01', 'severity' => 'error' ],
+				'maximum' => '2025-12-31',
+			],
+			PropertyTypeRegistry::withCoreTypes(),
+		);
+
+		$violations = $this->type->validate( new StringValue( '2024-12-31' ), $definition );
+
+		$this->assertSame( 'min-value', $violations[0]->code );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
+	}
+
+	public function testMaxValueViolationUsesErrorWhenMaximumAnnotated(): void {
+		$definition = PropertyDefinition::fromJson(
+			[
+				'type' => 'date',
+				'minimum' => '2025-01-01',
+				'maximum' => [ 'value' => '2025-12-31', 'severity' => 'error' ],
+			],
+			PropertyTypeRegistry::withCoreTypes(),
+		);
+
+		$violations = $this->type->validate( new StringValue( '2026-01-01' ), $definition );
+
+		$this->assertSame( 'max-value', $violations[0]->code );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
 	}
 
 	public function testEqualToBoundsReturnsNoViolations(): void {

--- a/tests/phpunit/Domain/PropertyType/Types/NumberTypeValidateTest.php
+++ b/tests/phpunit/Domain/PropertyType/Types/NumberTypeValidateTest.php
@@ -117,6 +117,18 @@ class NumberTypeValidateTest extends TestCase {
 		$this->assertSame( Severity::Error, $violations[0]->severity );
 	}
 
+	public function testMinValueViolationUsesErrorWhenMinimumAnnotated(): void {
+		$definition = PropertyDefinition::fromJson(
+			[ 'type' => 'number', 'minimum' => [ 'value' => 0, 'severity' => 'error' ] ],
+			PropertyTypeRegistry::withCoreTypes(),
+		);
+
+		$violations = $this->type->validate( new NumberValue( -1 ), $definition );
+
+		$this->assertSame( 'min-value', $violations[0]->code );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
+	}
+
 	private function newProperty(
 		bool $required,
 		float|int|null $minimum = null,

--- a/tests/phpunit/Domain/PropertyType/Types/SelectTypeValidateTest.php
+++ b/tests/phpunit/Domain/PropertyType/Types/SelectTypeValidateTest.php
@@ -5,9 +5,12 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Tests\Domain\PropertyType\Types;
 
 use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeRegistry;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\Types\SelectType;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\SelectProperty;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinition;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
 use ProfessionalWiki\NeoWiki\Domain\Value\NumberValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
 
@@ -95,6 +98,29 @@ class SelectTypeValidateTest extends TestCase {
 		$this->assertNull( $violations[1]->propertyName );
 	}
 
+	public function testInvalidOptionUsesErrorWhenOptionsAnnotated(): void {
+		$definition = PropertyDefinition::fromJson(
+			[
+				'type' => 'select',
+				'multiple' => true,
+				'options' => [
+					'value' => [
+						[ 'id' => 'opt_a', 'label' => 'A' ],
+						[ 'id' => 'opt_b', 'label' => 'B' ],
+					],
+					'severity' => 'error',
+				],
+			],
+			PropertyTypeRegistry::withCoreTypes(),
+		);
+
+		$violations = $this->type->validate( new StringValue( 'opt_a', 'opt_c', 'opt_b' ), $definition );
+
+		$this->assertCount( 1, $violations );
+		$this->assertSame( 'invalid-option', $violations[0]->code );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
+	}
+
 	public function testSingleValueOnlyWhenMultipleIsFalseAndMoreThanOnePart(): void {
 		$violations = $this->type->validate(
 			new StringValue( 'red', 'green' ),
@@ -107,6 +133,7 @@ class SelectTypeValidateTest extends TestCase {
 		$singleViolation = array_values( array_filter( $violations, static fn( $v ) => $v->code === 'single-value-only' ) )[0];
 		$this->assertNull( $singleViolation->valuePartIndex );
 		$this->assertNull( $singleViolation->propertyName );
+		$this->assertSame( Severity::Error, $singleViolation->severity );
 	}
 
 	public function testMultipleTrueAndManyValidPartsReturnsNoViolations(): void {

--- a/tests/phpunit/Domain/PropertyType/Types/TextTypeValidateTest.php
+++ b/tests/phpunit/Domain/PropertyType/Types/TextTypeValidateTest.php
@@ -5,9 +5,12 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Tests\Domain\PropertyType\Types;
 
 use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeRegistry;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\Types\TextType;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\TextProperty;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinition;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
 use ProfessionalWiki\NeoWiki\Domain\Value\NumberValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
 
@@ -73,6 +76,18 @@ class TextTypeValidateTest extends TestCase {
 		$this->assertNull( $violations[0]->valuePartIndex );
 	}
 
+	public function testUniqueViolationUsesErrorWhenUniqueItemsAnnotated(): void {
+		$definition = PropertyDefinition::fromJson(
+			[ 'type' => 'text', 'multiple' => true, 'uniqueItems' => [ 'severity' => 'error' ] ],
+			PropertyTypeRegistry::withCoreTypes(),
+		);
+
+		$violations = $this->type->validate( new StringValue( 'foo', 'bar', 'foo' ), $definition );
+
+		$this->assertSame( 'unique', $violations[0]->code );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
+	}
+
 	public function testUniqueItemsWithAllDistinctReturnsNoViolation(): void {
 		$violations = $this->type->validate(
 			new StringValue( 'foo', 'bar', 'baz' ),
@@ -114,6 +129,18 @@ class TextTypeValidateTest extends TestCase {
 		$this->assertSame( 1, $violations[0]->valuePartIndex );
 	}
 
+	public function testMinLengthViolationUsesErrorWhenMinLengthAnnotated(): void {
+		$definition = PropertyDefinition::fromJson(
+			[ 'type' => 'text', 'multiple' => true, 'minLength' => [ 'value' => 3, 'severity' => 'error' ] ],
+			PropertyTypeRegistry::withCoreTypes(),
+		);
+
+		$violations = $this->type->validate( new StringValue( 'abc', 'ab' ), $definition );
+
+		$this->assertSame( 'min-length', $violations[0]->code );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
+	}
+
 	public function testPartLongerThanMaxLengthProducesMaxLengthViolation(): void {
 		$violations = $this->type->validate(
 			new StringValue( 'ok', 'toolong' ),
@@ -124,6 +151,18 @@ class TextTypeValidateTest extends TestCase {
 		$this->assertSame( 'max-length', $violations[0]->code );
 		$this->assertSame( [ 4 ], $violations[0]->args );
 		$this->assertSame( 1, $violations[0]->valuePartIndex );
+	}
+
+	public function testMaxLengthViolationUsesErrorWhenMaxLengthAnnotated(): void {
+		$definition = PropertyDefinition::fromJson(
+			[ 'type' => 'text', 'multiple' => true, 'maxLength' => [ 'value' => 4, 'severity' => 'error' ] ],
+			PropertyTypeRegistry::withCoreTypes(),
+		);
+
+		$violations = $this->type->validate( new StringValue( 'ok', 'toolong' ), $definition );
+
+		$this->assertSame( 'max-length', $violations[0]->code );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
 	}
 
 	public function testTrimmedLengthBelowMinimumProducesViolation(): void {

--- a/tests/phpunit/Domain/Schema/Property/SelectPropertyTest.php
+++ b/tests/phpunit/Domain/Schema/Property/SelectPropertyTest.php
@@ -52,6 +52,27 @@ JSON
 		);
 	}
 
+	public function testObjectFormOptionsSeverityIsStable(): void {
+		$this->assertSerializationDoesNotChange(
+			<<<JSON
+{
+	"type": "select",
+	"description": "Document status",
+	"required": false,
+	"default": null,
+	"options": {
+		"value": [
+			{ "id": "opt1", "label": "Draft" },
+			{ "id": "opt2", "label": "Review" }
+		],
+		"severity": "error"
+	},
+	"multiple": false
+}
+JSON
+		);
+	}
+
 	public function testExceptionOnLegacyStringOption(): void {
 		$this->expectException( InvalidArgumentException::class );
 		$this->fromJson(

--- a/tests/phpunit/Domain/Schema/Property/UnregisteredTypePropertyTest.php
+++ b/tests/phpunit/Domain/Schema/Property/UnregisteredTypePropertyTest.php
@@ -28,6 +28,25 @@ JSON
 		);
 	}
 
+	/**
+	 * The severity on a type-specific key the core knows nothing about must survive too:
+	 * the property is rebuilt from the normalized values, so re-serializing re-wraps the
+	 * key once rather than wrapping the already-wrapped object again.
+	 */
+	public function testObjectFormCustomConstraintSeverityRoundTripsForUnregisteredType(): void {
+		$this->assertSerializationDoesNotChange(
+			<<<JSON
+{
+	"type": "color",
+	"description": "",
+	"required": false,
+	"default": null,
+	"allowedColors": { "value": [ "#ff0000" ], "severity": "error" }
+}
+JSON
+		);
+	}
+
 	public function testUnannotatedUnregisteredTypeRoundTripsUnchanged(): void {
 		$this->assertSerializationDoesNotChange(
 			<<<JSON

--- a/tests/phpunit/Domain/Validation/SeverityNormalizerTest.php
+++ b/tests/phpunit/Domain/Validation/SeverityNormalizerTest.php
@@ -39,8 +39,9 @@ class SeverityNormalizerTest extends TestCase {
 		$this->assertSame( [ 'required' => Severity::Error ], $severities );
 	}
 
-	public function testReservedKeysAreNeverNormalized(): void {
-		$raw = [ 'type' => 'number', 'description' => 'x', 'default' => 5 ];
+	public function testReservedKeyCarryingSeverityIsNotNormalized(): void {
+		// 'high' is not a severity: normalizing this key would throw rather than pass it through.
+		$raw = [ 'type' => 'number', 'description' => 'x', 'default' => [ 'severity' => 'high' ] ];
 
 		[ $values, $severities ] = SeverityNormalizer::extract( $raw );
 

--- a/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
@@ -286,6 +286,32 @@ class CreateSubjectApiTest extends NeoWikiIntegrationTestCase {
 		$this->assertSame( 'Validation failed', $responseData['message'] );
 		$this->assertSame( 'Required', $responseData['violations'][0]['propertyName'] );
 		$this->assertSame( 'required', $responseData['violations'][0]['code'] );
+		$this->assertSame( 'error', $responseData['violations'][0]['severity'] );
+	}
+
+	public function testEnforcementAllowsUnannotatedConstraintViolation(): void {
+		$this->setMwGlobals( 'wgNeoWikiEnforceValidation', true );
+
+		$this->createSchema(
+			'UnannotatedSchema',
+			'{"title":"UnannotatedSchema","propertyDefinitions":{"Required":{"type":"text","required":true}}}'
+		);
+
+		$body = $this->validBody();
+		$body['schema'] = 'UnannotatedSchema';
+		$body['statements'] = [];
+
+		$response = $this->executeHandler(
+			$this->newCreateSubjectApi(),
+			$this->createRequestData( $body )
+		);
+
+		$responseData = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertSame( 201, $response->getStatusCode() );
+		$this->assertSame( 'created', $responseData['status'] );
+		$this->assertSame( 'required', $responseData['violations'][0]['code'] );
+		$this->assertSame( 'warning', $responseData['violations'][0]['severity'] );
 	}
 
 	public function testCreatesChildSubjectWithSuppliedId(): void {

--- a/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
@@ -341,6 +341,7 @@ class ReplaceSubjectApiTest extends NeoWikiIntegrationTestCase {
 		$this->assertNotEmpty( $responseData['violations'] );
 		$this->assertSame( 'Required', $responseData['violations'][0]['propertyName'] );
 		$this->assertSame( 'required', $responseData['violations'][0]['code'] );
+		$this->assertSame( 'error', $responseData['violations'][0]['severity'] );
 	}
 
 	private function createPages(): void {

--- a/tests/phpunit/Persistence/MediaWiki/SchemaContentValidatorTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/SchemaContentValidatorTest.php
@@ -237,6 +237,37 @@ JSON
 		$this->assertTrue( $valid );
 	}
 
+	public function testOptionsWithSeverityObjectFormPassesValidation(): void {
+		$validator = SchemaContentValidator::newInstance();
+
+		$valid = $validator->validate(
+			$this->schemaWithProperty(
+				'{ "type": "select", "multiple": false, "options": { "value": [ { "id": "opt_a", "label": "A" } ], "severity": "error" } }'
+			)
+		);
+
+		if ( !$valid ) {
+			$this->assertSame( [], $validator->getErrors() );
+		}
+
+		$this->assertTrue( $valid );
+	}
+
+	/**
+	 * `multiple` declares the value's shape rather than a Constraint, so the object form is
+	 * rejected at authoring time: the normalizer is deliberately key-agnostic and would
+	 * otherwise unwrap it into a severity nothing reads.
+	 */
+	public function testShapeKeyWithSeverityObjectFormFailsValidation(): void {
+		$validator = SchemaContentValidator::newInstance();
+
+		$this->assertFalse(
+			$validator->validate(
+				$this->schemaWithProperty( '{ "type": "text", "multiple": { "severity": "error" } }' )
+			)
+		);
+	}
+
 	public function testScalarConstraintWithInvalidSeverityStringFailsValidation(): void {
 		$validator = SchemaContentValidator::newInstance();
 

--- a/tests/phpunit/Persistence/MediaWiki/SchemaContentValidatorTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/SchemaContentValidatorTest.php
@@ -289,6 +289,34 @@ JSON
 	}
 
 	/**
+	 * The positive `options` case above cannot fail on its own: the property definition schema
+	 * sets `additionalProperties: true`, so dropping the `options` $ref would still accept the
+	 * object form. These two pin that the $ref is actually wired up — without it a typo'd
+	 * severity saves cleanly and then throws on every subsequent read of the Schema page.
+	 */
+	public function testOptionsObjectFormWithInvalidSeverityFailsValidation(): void {
+		$validator = SchemaContentValidator::newInstance();
+
+		$this->assertFalse(
+			$validator->validate(
+				$this->schemaWithProperty(
+					'{ "type": "select", "multiple": false, "options": { "value": [ { "id": "opt_a", "label": "A" } ], "severity": "eror" } }'
+				)
+			)
+		);
+	}
+
+	public function testOptionsObjectFormMissingValueFailsValidation(): void {
+		$validator = SchemaContentValidator::newInstance();
+
+		$this->assertFalse(
+			$validator->validate(
+				$this->schemaWithProperty( '{ "type": "select", "multiple": false, "options": { "severity": "error" } }' )
+			)
+		);
+	}
+
+	/**
 	 * The boolean object form implies true and carries no value key. Permitting a stray
 	 * one would let "value": false round-trip back as true, silently flipping the Constraint.
 	 */

--- a/tests/phpunit/Presentation/ViolationSerializerTest.php
+++ b/tests/phpunit/Presentation/ViolationSerializerTest.php
@@ -6,6 +6,7 @@ namespace ProfessionalWiki\NeoWiki\Tests\Presentation;
 
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyName;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
 use ProfessionalWiki\NeoWiki\Presentation\ViolationSerializer;
 
@@ -21,6 +22,7 @@ class ViolationSerializerTest extends TestCase {
 				code: 'invalid-url',
 				args: [ 'bad' ],
 				valuePartIndex: 2,
+				severity: Severity::Error,
 			)
 		);
 
@@ -29,7 +31,7 @@ class ViolationSerializerTest extends TestCase {
 				'propertyName' => 'Website',
 				'code' => 'invalid-url',
 				'args' => [ 'bad' ],
-				'severity' => 'warning',
+				'severity' => 'error',
 				'valuePartIndex' => 2,
 			],
 			$serialized

--- a/tests/phpunit/RedHerb/ColorTypeValidateTest.php
+++ b/tests/phpunit/RedHerb/ColorTypeValidateTest.php
@@ -5,7 +5,10 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Tests\RedHerb;
 
 use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeRegistry;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinition;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
 use ProfessionalWiki\NeoWiki\Domain\Value\NumberValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
 use ProfessionalWiki\RedHerb\ColorProperty;
@@ -33,6 +36,28 @@ class ColorTypeValidateTest extends TestCase {
 		$this->assertNull( $violations[0]->valuePartIndex );
 	}
 
+	public function testRequiredViolationDefaultsToWarningSeverity(): void {
+		$violations = $this->type->validate(
+			new StringValue(),
+			$this->newProperty( required: true ),
+		);
+
+		$this->assertSame( Severity::Warning, $violations[0]->severity );
+	}
+
+	public function testRequiredViolationUsesErrorWhenRequiredAnnotated(): void {
+		$violations = $this->type->validate(
+			new StringValue(),
+			$this->newProperty(
+				required: true,
+				constraintSeverities: [ 'required' => Severity::Error ],
+			),
+		);
+
+		$this->assertSame( 'required', $violations[0]->code );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
+	}
+
 	public function testValidHexReturnsNoViolations(): void {
 		$violations = $this->type->validate(
 			new StringValue( '#aabbcc' ),
@@ -52,6 +77,16 @@ class ColorTypeValidateTest extends TestCase {
 		$this->assertSame( 'invalid-color', $violations[0]->code );
 		$this->assertSame( [ '#xxx' ], $violations[0]->args );
 		$this->assertSame( 0, $violations[0]->valuePartIndex );
+	}
+
+	public function testInvalidColorViolationIsError(): void {
+		$violations = $this->type->validate(
+			new StringValue( 'notacolor' ),
+			$this->newProperty( required: false ),
+		);
+
+		$this->assertSame( 'invalid-color', $violations[0]->code );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
 	}
 
 	public function testMultipleInvalidHexProducesIndexedViolations(): void {
@@ -88,12 +123,57 @@ class ColorTypeValidateTest extends TestCase {
 		$this->assertSame( 1, $violations[0]->valuePartIndex );
 	}
 
+	public function testInvalidOptionViolationUsesErrorWhenAllowedColorsAnnotated(): void {
+		$violations = $this->type->validate(
+			new StringValue( '#aabbcc', '#112233', '#ddeeff' ),
+			$this->newProperty(
+				required: false,
+				allowedColors: [ '#aabbcc', '#ddeeff' ],
+				constraintSeverities: [ 'allowedColors' => Severity::Error ],
+			),
+		);
+
+		$this->assertCount( 1, $violations );
+		$this->assertSame( 'invalid-option', $violations[0]->code );
+		$this->assertSame( 1, $violations[0]->valuePartIndex );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
+	}
+
+	public function testSeverityOfCustomConstraintComesFromSchemaJson(): void {
+		$registry = new PropertyTypeRegistry();
+		$registry->registerType( new ColorType() );
+
+		$definition = PropertyDefinition::fromJson(
+			[
+				'type' => 'color',
+				'required' => true,
+				'allowedColors' => [ 'value' => [ '#ff0000' ], 'severity' => 'error' ],
+			],
+			$registry,
+		);
+
+		$violations = $this->type->validate( new StringValue( '#00ff00' ), $definition );
+
+		$this->assertSame( 'invalid-option', $violations[0]->code );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
+	}
+
 	/**
 	 * @param list<string> $allowedColors
+	 * @param array<string, Severity> $constraintSeverities
 	 */
-	private function newProperty( bool $required, array $allowedColors = [] ): ColorProperty {
+	private function newProperty(
+		bool $required,
+		array $allowedColors = [],
+		array $constraintSeverities = [],
+	): ColorProperty {
 		return ColorProperty::fromPartialJson(
-			new PropertyCore( description: '', required: $required, default: null ),
+			new PropertyCore(
+				description: '',
+				required: $required,
+				default: null,
+				constraintSeverities: $constraintSeverities,
+			),
 			[ 'allowedColors' => $allowedColors ],
 		);
 	}


### PR DESCRIPTION
Review fixes for https://github.com/ProfessionalWiki/NeoWiki/pull/1147, one concern per commit:

* **Fix a stale anchor** — `validation-codes.md` still linked the pre-rename `#blocking-and-enforcement` fragment.
* **Adopt Constraint severity in RedHerb's ColorType** — the worked example the new extension-author guidance cites did not follow it: `required` and `invalid-option` ignored author-annotated severities (now `severityOf( 'required' )` / `severityOf( 'allowedColors' )`), and `invalid-color` — blocking before #1147 — had silently become a never-blocking warning; it now carries the fixed `error` of its core analogues (`invalid-url`). Includes the extension-contract test proving a custom type's own Constraint key flows Schema JSON → severity map → violation.
* **Pin the enforcement severity semantics at the API level** — new test: enforcement on + unannotated `required` → `201` with a `warning` violation (ADR 26's headline behavior, previously untested end to end); the existing `422` tests now assert `severity: error` on the wire.
* **Pin severity stamping and object-form coverage across the suite** — severity assertions for the fixed-`error` conditions that had none (`label-required`, `type-mismatch`, `invalid-date`, `invalid-datetime`, select `single-value-only`); annotated-`error` tests for the uncovered authorable keys (`minimum`, `minLength`, `maxLength`, `uniqueItems`, `options`); object-form `options` save-validation + round-trip; the shape-key reject guard (`multiple`); an annotated custom-key round-trip for unregistered types; a serializer fixture that pinned a warning `invalid-url` production can never emit; and a reserved-key test that could not fail (its scalar fixture never matched the object-form discriminator).

Verified: full PHPUnit suite and phpcs/phpstan green on this branch and on a local merge with current master; behavior re-verified live over the REST API (enforcement on: unannotated constraint persists with `warning`, new `error` rejects with `422`, escalating a Constraint's severity does not retro-block an existing violation, `invalid-color` blocks again).

<sub>AI-authored — Claude Code, `Fable 5 (max)`: review via a five-lens agent panel (correctness, security, tests, design, edge cases) with each finding adversarially verified; fixes implemented by a delegated `Opus 4.8` agent, red→green TDD on the ColorType behavior change; verified as above.</sub>
