### PR TITLE
Stub the ids CachingMappingLookupTest's cache key is built from

### DIFF
--- a/tests/phpunit/Persistence/MediaWiki/CachingMappingLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/CachingMappingLookupTest.php
@@ -60,9 +60,16 @@ class CachingMappingLookupTest extends TestCase {
 		return $provider;
 	}
 
+	/**
+	 * Title::getArticleID() and getLatestRevID() have no native return type, so an un-stubbed mock
+	 * returns null for both and makeCacheKey() builds its key out of two empty components. Stub them
+	 * so the key is the shape production uses, as CachingSchemaLookupTest does.
+	 */
 	private function newTitleFactory(): TitleFactory {
 		$title = $this->createMock( Title::class );
 		$title->method( 'exists' )->willReturn( true );
+		$title->method( 'getArticleID' )->willReturn( 1 );
+		$title->method( 'getLatestRevID' )->willReturn( 100 );
 
 		$factory = $this->createMock( TitleFactory::class );
 		$factory->method( 'newFromText' )->willReturn( $title );


### PR DESCRIPTION
`Title::getArticleID()` and `getLatestRevID()` carry no native return type, so the un-stubbed mock in
`CachingMappingLookupTest::newTitleFactory()` returned `null` for both. `makeCacheKey()` therefore
built its key out of two empty components — every Title the test passes produced
`neowiki-mapping:1::` — and each run emitted two `strtr(): Passing null to parameter #1 ($string) of
type string is deprecated` notices from `BagOStuff::makeKeyInternal`.

Neither existing assertion was weakened by this. `testDeniedMappingIsNullAndDoesNotReachTheInnerLookup`
returns at the read gate before the key is built, and `testReadableMappingReachesTheInnerLookup` makes
a single call against a fresh `HashBagOStuff`. Both tests also use the same Mapping name, so the
degenerate key had nothing to collide with.

The reasons to fix it anyway:

- PHP 9 turns passing null to a non-nullable internal parameter into a `TypeError`, so this is a
  dated obligation rather than a preference.
- Two deprecation lines in every full-suite run are the noise that trains people to skim past
  deprecation output.
- A later test asserting that two Mappings get distinct cache keys would silently get a key that
  cannot distinguish anything.

Stubs both methods to the shape production uses, matching what
`CachingSchemaLookupTest::newTitleFactory()` already does.

## Verification

`make phpunit filter=Caching` — 13 tests, 30 assertions, green, and the two `strtr` deprecations are
gone (the same filter printed them before the change). `make phpcs` clean. I did not run the full
suite: this box is at 1.5 GiB available with two other dev stacks up, and a full run was OOM-killed.
The change is confined to one test file's private helper, which nothing else can reference.

> <sub>AI-authored — Claude Code, `Opus 5 (max)`; found while verifying an unrelated review of #1188, filed at @alistair3149's direction; test-double fix only, no production code touched; `make phpunit filter=Caching` and `make phpcs` green, full suite not run (see above).</sub>
