### PR TITLE
Report the graph-database initialization failure completely and safely

### DIFF
--- a/src/Domain/GraphDatabase/GraphDatabasePlugin.php
+++ b/src/Domain/GraphDatabase/GraphDatabasePlugin.php
@@ -19,8 +19,9 @@ use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
  * - On maintenance rebuilds (RebuildGraphDatabases), the wiring propagates failures so they are
  *   reported truthfully per page instead of being silently swallowed. An initialize() failure
  *   propagates like any other rebuild failure.
- * - On update.php, the wiring likewise propagates, but the caller reports an initialize() failure
- *   and lets the update continue: MediaWiki's own schema changes are the point of that run.
+ * - On update.php, the wiring likewise propagates, but the caller reports an initialize() failure and
+ *   lets the update continue, since aborting there would only skip the schema updates of the
+ *   extensions queued after NeoWiki.
  *
  * The hook path never initializes.
  */

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -187,33 +187,61 @@ class NeoWikiHooks {
 	}
 
 	/**
-	 * A failing backend is reported rather than thrown: the update must proceed to MediaWiki's own
-	 * schema changes, and the graph is rebuildable derived state. The catch is also broader than the
-	 * hook path's deliberate TimeoutException/DBError re-throws, since there is no user operation here
-	 * to abort and everything reachable from initialize() belongs to the graph backends.
+	 * A failing backend is reported rather than thrown, and the update carries on: DatabaseUpdater runs
+	 * MediaWiki's own schema changes before it fires LoadExtensionSchemaUpdates, so a throw here would
+	 * not protect those — it would skip the updates of every extension queued after NeoWiki. The graph
+	 * is rebuildable derived state, so it is not worth that.
+	 *
+	 * The catch is broader than the hook path's deliberate TimeoutException/DBError re-throws, since
+	 * there is no user operation here to abort. It deliberately covers building the plugins as well as
+	 * initializing them, so that a wiki whose NeoWiki configuration is not readable yet — as during a
+	 * fresh install — still finishes its update.
 	 */
 	public static function initializeGraphDatabases( DatabaseUpdater $updater ): void {
-		$updater->output( "Initializing NeoWiki graph databases...\n" );
+		$updater->output( 'Initializing NeoWiki graph databases...' );
 
 		try {
 			NeoWikiExtension::getInstance()->getGraphDatabasePlugin()->initialize();
 		} catch ( Exception $e ) {
-			$updater->output(
-				'...failed to initialize the NeoWiki graph databases: '
-				. self::withoutCredentials( $e->getMessage() ) . "\n"
-				. "...the wiki is usable, but graph queries may be slow until this succeeds. Re-run\n"
-				. "...update.php once the cause is resolved.\n"
-			);
+			self::reportFailedGraphDatabaseInitialization( $updater, $e );
+			return;
 		}
+
+		$updater->output( "done.\n" );
+	}
+
+	private static function reportFailedGraphDatabaseInitialization( DatabaseUpdater $updater, Exception $e ): void {
+		$reason = self::withoutCredentials( $e->getMessage() );
+
+		$updater->output(
+			"failed.\n"
+			. '...' . $reason . "\n"
+			. "...Re-run update.php once the cause is resolved. While a backend is unreachable, Subject\n"
+			. "...editing and display and every graph read fail, and the edits made meanwhile are missing\n"
+			. "...from the projection: run RebuildGraphDatabases.php to reconcile it.\n"
+		);
+
+		// Logged as well, because update.php --quiet discards everything written to the updater, which
+		// would otherwise leave a failed initialization with no trace anywhere. The redacted reason
+		// rather than the exception, so that what is kept out of the terminal stays out of the log too.
+		LoggerFactory::getInstance( 'NeoWiki' )->error(
+			'NeoWiki failed to initialize its graph databases during update.php. The wiki is updated, but '
+			. 'the store-level structures its projection relies on are missing. Underlying error: ' . $reason
+		);
 	}
 
 	/**
 	 * Strips the userinfo out of any URI in a message. A backend client reports an unreachable server by
 	 * quoting the connection URI it tried, credentials included, and this message goes to the operator's
 	 * terminal and to deployment logs.
+	 *
+	 * The run is bounded only by whitespace and matched greedily up to its last `@`, because a password
+	 * may itself contain `/`, `@` or a quote: stopping at the first of those leaves the rest of it in
+	 * the message. The cost is that a credential-free URI whose path holds an `@` loses that path, which
+	 * is the right way round for a redaction.
 	 */
 	private static function withoutCredentials( string $message ): string {
-		return (string)preg_replace( '#://[^/@\s\'"]*@#', '://', $message );
+		return (string)preg_replace( '#(?<=://)\S*@#', '', $message );
 	}
 
 	public static function onParserFirstCallInit( Parser $parser ): void {

--- a/tests/phpunit/EntryPoints/UpdaterInitializesGraphDatabasesTest.php
+++ b/tests/phpunit/EntryPoints/UpdaterInitializesGraphDatabasesTest.php
@@ -9,6 +9,7 @@ use ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiHooks;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\ThrowingGraphDatabasePlugin;
+use TestLogger;
 
 /**
  * Guards the update.php path: an ordinary install or upgrade must establish the store-level structures
@@ -62,6 +63,12 @@ class UpdaterInitializesGraphDatabasesTest extends NeoWikiIntegrationTestCase {
 		$this->assertSame( [ 'Page wiki_id id', 'Subject id' ], $this->constraintNames() );
 	}
 
+	public function testASuccessfulUpdateReportsCompletion(): void {
+		NeoWikiHooks::initializeGraphDatabases( $this->newUpdater() );
+
+		$this->assertSame( "Initializing NeoWiki graph databases...done.\n", $this->report );
+	}
+
 	public function testUpdateReportsAFailingBackendInsteadOfAborting(): void {
 		$this->registerGraphDatabasePlugins( new ThrowingGraphDatabasePlugin() );
 
@@ -71,25 +78,96 @@ class UpdaterInitializesGraphDatabasesTest extends NeoWikiIntegrationTestCase {
 	}
 
 	/**
-	 * A client reports an unreachable server by quoting the connection URI it tried, credentials and
-	 * all, and this report goes to the operator's terminal and to deployment logs.
+	 * update.php --quiet discards everything written to the updater, so the report on its own leaves a
+	 * wiki whose backends never initialized with no trace anywhere.
 	 */
-	public function testTheReportOfAFailingBackendCarriesNoCredentials(): void {
-		$this->registerGraphDatabasePlugins( new ThrowingGraphDatabasePlugin(
-			"Cannot connect to any server on alias: bolt with Uris: ('bolt://neo4j:sekrit@neo:7687')"
-		) );
+	public function testAFailingBackendIsAlsoLogged(): void {
+		$logger = new TestLogger( true );
+		$this->setLogger( 'NeoWiki', $logger );
+		$this->registerGraphDatabasePlugins( new ThrowingGraphDatabasePlugin() );
 
 		NeoWikiHooks::initializeGraphDatabases( $this->newUpdater() );
 
-		$this->assertStringNotContainsString( 'sekrit', $this->report );
+		$buffer = $logger->getBuffer();
+		$this->assertCount( 1, $buffer );
+		$this->assertSame( 'error', $buffer[0][0] );
+		$this->assertStringContainsString( ThrowingGraphDatabasePlugin::FAILURE_MESSAGE, $buffer[0][1] );
+	}
+
+	/**
+	 * A client reports an unreachable server by quoting the connection URI it tried, credentials and
+	 * all, and this report goes to the operator's terminal and to deployment logs.
+	 *
+	 * @dataProvider credentialBearingMessageProvider
+	 */
+	public function testTheReportOfAFailingBackendCarriesNoCredentials( string $backendMessage, string $password ): void {
+		$logger = new TestLogger( true );
+		$this->setLogger( 'NeoWiki', $logger );
+		$this->registerGraphDatabasePlugins( new ThrowingGraphDatabasePlugin( $backendMessage ) );
+
+		NeoWikiHooks::initializeGraphDatabases( $this->newUpdater() );
+
+		$this->assertStringNotContainsString( $password, $this->report );
 		$this->assertStringContainsString( 'bolt://neo:7687', $this->report );
+		$this->assertStringNotContainsString( $password, $logger->getBuffer()[0][1] );
+	}
+
+	/**
+	 * A password is not limited to the characters that are safe in a URI, and the client quotes back
+	 * whatever it was handed. Each shape below defeated a redaction anchored to the first `/` or `@`:
+	 * the slash one leaked the password in full, the at-sign one leaked all but its first character.
+	 *
+	 * @return iterable<string, array{string, string}>
+	 */
+	public static function credentialBearingMessageProvider(): iterable {
+		yield 'plain password' => [
+			"Cannot connect to any server on alias: bolt with Uris: ('bolt://neo4j:sekrit@neo:7687')",
+			'sekrit'
+		];
+		yield 'password containing a slash' => [
+			'Unable to parse URI: bolt://neo4j:se/krit@neo:7687',
+			'se/krit'
+		];
+		yield 'password containing an at sign' => [
+			"Cannot connect to any server on alias: bolt with Uris: ('bolt://neo4j:se@krit@neo:7687')",
+			'se@krit'
+		];
+		yield 'password containing a quote' => [
+			"Cannot connect to any server on alias: bolt with Uris: ('bolt://neo4j:se'krit@neo:7687')",
+			"se'krit"
+		];
+		yield 'two connection URIs in one message' => [
+			"Cannot connect to any server on alias: bolt with Uris: ('bolt://neo4j:sekrit@neo:7687', "
+				. "'neo4j+s://neo4j:sekrit@neo:7687')",
+			'sekrit'
+		];
+	}
+
+	/**
+	 * A message that carries no credentials has to reach the operator intact: it is the only thing that
+	 * says why the run failed, and the actionable causes — a duplicate id, a user without the rights to
+	 * write schema — say so in prose rather than in a URI.
+	 */
+	public function testACredentialFreeReasonIsReportedVerbatim(): void {
+		$reason = 'Both Node(162) and Node(163) have the label `Subject` and property `id` = "abc"';
+		$this->registerGraphDatabasePlugins( new ThrowingGraphDatabasePlugin( $reason ) );
+
+		NeoWikiHooks::initializeGraphDatabases( $this->newUpdater() );
+
+		$this->assertStringContainsString( $reason, $this->report );
 	}
 
 	/**
 	 * Records what is registered on it and what it is asked to output, into the fields of this test.
+	 *
+	 * getDB() returns the test database rather than the mock's null, because the registration test
+	 * hands this double to every extension's LoadExtensionSchemaUpdates handler, and the ones that
+	 * inspect the connection would otherwise fatal on code that has nothing to do with NeoWiki.
 	 */
 	private function newUpdater(): DatabaseUpdater {
 		$updater = $this->createMock( DatabaseUpdater::class );
+
+		$updater->method( 'getDB' )->willReturn( $this->getDb() );
 
 		$updater->method( 'addExtensionUpdate' )->willReturnCallback(
 			function ( array $update ): void {


### PR DESCRIPTION
**The credential redaction missed three password shapes.** `withoutCredentials()` excluded `/`, `@`, whitespace
and quotes from the userinfo run, so the run stopped before the delimiting `@` whenever the password held one of
them. Reproduced against a real `update.php` run on the dev stack before fixing:

```
$wgNeoWikiNeo4jInternalWriteUrl = 'bolt://neo4j:hun/ter2secret@nonexistent-host:7687'

...failed to initialize the NeoWiki graph databases: Unable to parse URI: bolt://neo4j:hun/ter2secret@nonexistent-host:7687
```

| password contains | before | after |
|---|---|---|
| `/` — `openssl rand -base64` emits it routinely | printed in full | `bolt://nonexistent-host:7687` |
| `@` — a working config, since `parse_url` splits userinfo at the *last* `@` | `bolt://ssw0rd@neo:7687`, all but the first character | redacted |
| `'` or `"` | printed in full | redacted |

The run is now bounded only by whitespace and matched greedily to its last `@`, which covers all three. The
price is that a credential-free URI whose *path* holds an `@` loses that path — the right way round for a
redaction, and stated in the docblock. A data provider pins each shape. A separate test pins that a
credential-free reason still reaches the operator verbatim, because that is the case that says what to fix:
`Both Node(162) and Node(163) have the label 'Subject' and property 'id' = ...` is the whole diagnostic.

**The failure could vanish entirely.** `DatabaseUpdater::output()` returns immediately when the maintenance
script is quiet (`DatabaseUpdater.php:270-274`), and nothing else recorded the failure — so a deploy running
`update.php --quiet` against an unreachable backend left a wiki without its constraints and no trace anywhere,
while `docs/extending/extending.md` said the failure is reported. It is now also logged as an error on the
`NeoWiki` channel, the convention `FailureIsolatingGraphDatabasePlugin` already follows — which makes that
sentence true as it stands, so the guide is left alone. The redacted reason is logged rather than the exception,
so what is kept off the terminal stays out of the log too.

**The advice was wrong for the failure it was written for.** "The wiki is usable, but graph queries may be slow"
contradicts [`docs/operations/maintenance.md`](../blob/master/docs/operations/maintenance.md), which says an
unreachable backend fails Subject editing, Subject display and every graph read, and needs
`RebuildGraphDatabases.php` afterwards — re-running `update.php` alone does not recover the edits committed
meanwhile. The new wording covers both causes without overclaiming for the constraint-refused one, where the
backend is up and the wiki really is fine.

**Two docblock rationales were factually wrong.** `DatabaseUpdater::doUpdates()` completes the core update list
before it fires `LoadExtensionSchemaUpdates` (`DatabaseUpdater.php:546-551`), so a throw here never protected
MediaWiki's own schema changes; what it would skip is the updates of every extension queued after NeoWiki. And
the `try` covers *building* the plugins, not just `initialize()` — deliberate, because a fresh install cannot
read the extension's configuration yet, but the docblock claimed the opposite.

**The registration test handed a bare mock to every other extension.** It fires `LoadExtensionSchemaUpdates`
through the real `HookContainer`, so every loaded extension's handler runs against the double.
`DatabaseUpdater::getDB()` declares no return type, so the mock returned `null` and any handler dereferencing it
would fatal, failing this test on code that has nothing to do with NeoWiki. The double now returns the test
database. Preventative — no currently-loaded extension trips it, so unlike the others this one has no mutation
that reproduces it here.

**`...done.`** was missing, leaving the line dangling into the next updater's output. Every other step prints it.

Verified: full suite 2100 tests / 5013 assertions green, `phpcs` and `phpstan` clean, and each new guard confirmed
failing against the mutation it exists for (old regex → 3 of 5 provider cases fail; logger call removed → the log
test fails; `done.` removed → the completion test fails). Both `update.php` paths exercised for real against the
worktree's dev stack: constraints dropped and recreated, and the slash-password failure re-run with zero
occurrences of the password anywhere in the output.

Considered and omitted:

- **Hoisting `getGraphDatabasePlugin()` out of the `try`**, which would make the old docblock true. It would also
  abort a fresh install, where `NeoWikiExtension::getInstance()` throws a `ConfigException` because extension
  config defaults are not in `$GLOBALS` yet. The wide `try` is the right behaviour; the docblock was the defect.
- **Parsing the URI rather than pattern-matching it.** The message is free-form driver prose that happens to quote
  a URI, and one of the leaking cases is the driver reporting that it could *not* parse that URI.
- **A password containing whitespace is still not redacted.** Bounding the scan by anything looser than
  whitespace swallows unrelated text — `Cannot connect to bolt://neo:7687 for user@example.com` would lose its
  middle. A raw space is invalid in a URI, so this trades a real regression for a case the driver rejects anyway.
- **Reworking the three pre-existing paths that print the same driver message unredacted**
  (`Neo4jQueryService`, `RebuildGraphDatabases`, `FailureIsolatingGraphDatabasePlugin`). Out of scope for a
  follow-up to #1185, and the first of them returns the password in an anonymous REST response body, which wants
  its own issue rather than a drive-by.
- **The "No migration" claim in #1185's description.** `MERGE (target {id: $targetId})` created relation-target
  nodes with no label until #1080 landed on 2026-07-20, so "none can exist" does not hold for a graph older than
  that; the parent commit message's weaker wording was right. That is an edit to #1185's own description, not
  something this branch can carry.

<sub>AI-authored — Claude Code, `Opus 5 (1M context)`; commissioned by @alistair3149 to address findings 1-7 and 9 of a multi-agent review of #1185, no redirections; diff not yet human-reviewed; every added guard confirmed failing against the mutation it exists for, full local PHPUnit suite (2100 tests) plus phpcs and phpstan green, and both update.php paths verified against a live dev stack.</sub>
