### PR TITLE
Review follow-ups on the orphan-stub sweep

### DIFF
--- a/docs/api/graph-model.md
+++ b/docs/api/graph-model.md
@@ -99,6 +99,10 @@ Stubs arise in two ways:
 When the real Subject is later saved, its node is upgraded in place — matched by `id` alone, so the stub gains its
 properties and Schema label without creating a duplicate node.
 
+A write that strips a stub of its last incoming relation deletes the stub, whether that write removes the referring
+Subject, drops the Relation, or retargets it. Removing a set of Subjects referenced only by each other leaves none of
+them behind.
+
 ## Relationships
 
 ### HasSubject
@@ -124,7 +128,7 @@ backtick-escaped.
 | *(additional)* | scalar | Any properties from the Relation's property map |
 
 When a Subject is removed while other Subjects still reference it, its node is kept as a
-[stub](#stub-subject-nodes) so those incoming references remain valid.
+[stub](#stub-subject-nodes) for as long as those references last.
 
 ## Constraints
 

--- a/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStore.php
+++ b/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStore.php
@@ -285,6 +285,10 @@ readonly class Neo4jProjectionStore implements GraphDatabasePlugin {
 	}
 
 	/**
+	 * The :Subject label is what lets this seek the id constraint's index. Without it Neo4j has no
+	 * label to scope the lookup to and scans every relation in the graph. Every id reaching here comes
+	 * from getSubjectIdsByPageId, which matches (subject:Subject), so the label narrows nothing.
+	 *
 	 * @param string[] $subjectIds
 	 * @return string[]
 	 */
@@ -293,7 +297,7 @@ readonly class Neo4jProjectionStore implements GraphDatabasePlugin {
 		 * @var SummarizedResult $result
 		 */
 		$result = $transaction->run(
-			'MATCH (subject)-[]->(target)
+			'MATCH (subject:Subject)-[]->(target)
 				WHERE subject.id IN $subjectIds
 				RETURN DISTINCT target.id AS id',
 			[ 'subjectIds' => $subjectIds ]

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStoreTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStoreTest.php
@@ -593,18 +593,26 @@ class Neo4jProjectionStoreTest extends NeoWikiIntegrationTestCase {
 			mainSubject: $this->buildSubjectWithLocationRelation( self::GUID_2, self::GUID_1, 'rTestNQS1111rr1' ),
 		) );
 
-		// Re-saving GUID_1 under a schema the lookup does not know makes the projection skip it, so it
-		// keeps its data while losing its HasSubject relation.
+		// Re-saving GUID_1 under a schema this store's lookup does not know makes the projection skip it,
+		// so it keeps its data while losing its HasSubject relation. newProjectionStoreWithLocationRelation
+		// hands its store an InMemorySchemaLookup holding the default schema alone, so SCHEMA_ID_A does not
+		// resolve here despite setUp creating a Schema page for it: no store in this class reads those pages.
 		$store->savePage( TestPage::build(
 			id: 1,
 			mainSubject: TestSubject::build( id: self::GUID_1, schemaName: new SchemaName( self::SCHEMA_ID_A ) ),
 		) );
 
+		// The skip is what gives this test its teeth, so assert it happened rather than assuming it.
+		$this->assertSubjectIsNotStub( self::GUID_1 );
+		$this->assertHasNoIncomingHasSubjectRelation( self::GUID_1 );
+
 		// Removing GUID_2 takes GUID_1's last incoming relation with it, leaving a subject that has
 		// no incoming relation at all but still carries data.
 		$store->savePage( TestPage::build( id: 2 ) );
 
-		$this->assertSubjectExists( self::GUID_1 );
+		// Asserting the data survives, not merely the node: a sweep that reduced unreachable
+		// candidates to stubs instead of deleting them would leave a node behind either way.
+		$this->assertSubjectIsNotStub( self::GUID_1 );
 	}
 
 	public function testDroppingTheOnlyRelationToAStubDeletesTheStub(): void {
@@ -813,10 +821,38 @@ class Neo4jProjectionStoreTest extends NeoWikiIntegrationTestCase {
 		$this->assertTrue( $result->isEmpty(), "Subject {$subjectId} should not exist" );
 	}
 
-	private function assertSubjectExists( string $subjectId ): void {
-		$result = $this->readGraph( 'MATCH (subject {id: $id}) RETURN subject', [ 'id' => $subjectId ] );
+	/**
+	 * The inverse of assertSubjectIsStub: the node exists and still carries the data a stub sheds.
+	 * Asserting mere existence would not distinguish the two.
+	 */
+	private function assertSubjectIsNotStub( string $subjectId ): void {
+		$result = $this->readGraph(
+			'MATCH (subject {id: $id}) RETURN labels(subject) AS labels, subject.name AS name',
+			[ 'id' => $subjectId ]
+		);
 
 		$this->assertFalse( $result->isEmpty(), "Subject {$subjectId} should exist" );
+
+		$row = $result->first()->toRecursiveArray();
+
+		$this->assertNotNull( $row['name'], "Subject {$subjectId} should keep its name" );
+		$this->assertContains(
+			TestSubject::DEFAULT_SCHEMA_ID,
+			$row['labels'],
+			"Subject {$subjectId} should keep its Schema label"
+		);
+	}
+
+	private function assertHasNoIncomingHasSubjectRelation( string $subjectId ): void {
+		$result = $this->readGraph(
+			'MATCH (subject {id: $id}) RETURN EXISTS { ()-[:HasSubject]->(subject) } AS isLinked',
+			[ 'id' => $subjectId ]
+		);
+
+		$this->assertFalse(
+			$result->first()->toRecursiveArray()['isLinked'],
+			"Subject {$subjectId} should have no HasSubject relation"
+		);
 	}
 
 	public function testSavingPageAndThenDeletingItLeavesNoTrace(): void {

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStoreTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jProjectionStoreTest.php
@@ -642,6 +642,67 @@ class Neo4jProjectionStoreTest extends NeoWikiIntegrationTestCase {
 		$this->assertSubjectIsStub( self::GUID_3 );
 	}
 
+	public function testDroppingOneOfTwoRelationsToAStubKeepsIt(): void {
+		$store = $this->newProjectionStoreWithLocationRelation();
+
+		$this->saveTwoPagesReferencingStub( $store );
+
+		// Dropping page 1's relation makes the stub a sweep candidate, but page 2 still references it.
+		$store->savePage( TestPage::build( id: 1, mainSubject: TestSubject::build( id: self::GUID_1 ) ) );
+
+		$this->assertSubjectIsStub( self::GUID_3 );
+		$this->assertRelationExists( self::GUID_2, 'LocatedIn', self::GUID_3, 'rTestNQS1111rr2' );
+	}
+
+	public function testDeletingOneOfTwoPagesReferencingAStubKeepsIt(): void {
+		$store = $this->newProjectionStoreWithLocationRelation();
+
+		$this->saveTwoPagesReferencingStub( $store );
+
+		// Deleting page 1 removes GUID_1 outright, so the sweep gets the stub from the deleted
+		// subject's relation targets rather than from a relation edit. Page 2 still references it.
+		$store->deletePage( new PageId( 1 ) );
+
+		$this->assertSubjectIsStub( self::GUID_3 );
+		$this->assertRelationExists( self::GUID_2, 'LocatedIn', self::GUID_3, 'rTestNQS1111rr2' );
+	}
+
+	public function testStubbingOneOfTwoSubjectsReferencingAStubKeepsIt(): void {
+		$store = $this->newProjectionStoreWithLocationRelation();
+
+		$this->saveTwoPagesReferencingStub( $store );
+
+		// GUID_4 references GUID_1, so removing GUID_1 reduces it to a stub instead of deleting it.
+		// That drops its relation to GUID_3, which page 2 still references.
+		$store->savePage( TestPage::build(
+			id: 3,
+			mainSubject: $this->buildSubjectWithLocationRelation( self::GUID_4, self::GUID_1, 'rTestNQS1111rr3' ),
+		) );
+
+		$store->savePage( TestPage::build( id: 1 ) );
+
+		$this->assertSubjectIsStub( self::GUID_1 );
+		$this->assertSubjectIsStub( self::GUID_3 );
+		$this->assertRelationExists( self::GUID_2, 'LocatedIn', self::GUID_3, 'rTestNQS1111rr2' );
+	}
+
+	/**
+	 * GUID_1 and GUID_2 live on separate pages and both relate to GUID_3, which exists only as the
+	 * stub their relations created. Removing either referrer leaves the other one pointing at it.
+	 */
+	private function saveTwoPagesReferencingStub( GraphDatabasePlugin $store ): void {
+		$store->savePage( TestPage::build(
+			id: 1,
+			mainSubject: $this->buildSubjectWithLocationRelation( self::GUID_1, self::GUID_3, 'rTestNQS1111rr1' ),
+		) );
+		$store->savePage( TestPage::build(
+			id: 2,
+			mainSubject: $this->buildSubjectWithLocationRelation( self::GUID_2, self::GUID_3, 'rTestNQS1111rr2' ),
+		) );
+
+		$this->assertSubjectIsStub( self::GUID_3 );
+	}
+
 	private function newProjectionStoreWithLocationRelation( string $wikiId = self::WIKI_ID ): GraphDatabasePlugin {
 		$extension = NeoWikiExtension::getInstance();
 


### PR DESCRIPTION
Review follow-ups on the orphan-stub sweep. Four findings, one of which is load-bearing.

**The sweep's `NOT (stub)<--()` guard was pinned by nothing.** Removing the clause left the entire suite green.
Every candidate that had to survive in #1171's tests survived on the strength of `stub.name IS NULL` instead: each
one was either a stub with no incoming relation at all, or a data-bearing subject. Nothing exercised a candidate
that was a stub *and* kept a referrer — which is the case the clause exists for, and the case where dropping it
deletes a node other Subjects still point at. Three tests now cover it, one per source a candidate can come from:
a dropped relation (`removeNonexistentRelations`), a subject deleted outright (`relationTargetsOf`), and a subject
reduced to a stub (`reduceSubjectToStub`). Each fails with the clause removed.

**`relationTargetsOf` could not use the `:Subject(id)` index.** Its anchor was a bare `(subject)`, and Neo4j
property indexes are label-scoped, so the query planned as `DirectedAllRelationshipsScan` — every relation in the
graph — on a path #1171 exists to make proportional to the edit. With the label it plans as
`NodeUniqueIndexSeek UNIQUE subject:Subject(id)` where the constraint exists, and a `:Subject` label scan where it
does not — still bounded by the Subject count rather than the relation count. The result set cannot change: every id reaching `deleteSubjects`
comes from `getSubjectIdsByPageId`, which already matches `(subject:Subject)`, and nothing strips that label.

Worth knowing rather than fixing here: the three neighbouring queries on that path (`subjectIdsWithIncomingRelations`,
the `DETACH DELETE` in `deleteSubjects`, `reduceSubjectToStub`) match label-lessly too, as do the per-save queries in
`Neo4jSubjectUpdater` and `Neo4jSubjectRelationUpdater`. So this one label does not by itself make the removal path
index-backed, and #1171's cost argument is weaker than it reads — every save already runs several unindexed scans.
Labelling all of them is a separate change against master.

**The docs stopped describing stub deletion.** The statement landed in ab56bd85 on the #1171 branch and was dropped
in f55abc24 while the sweep moved to end-of-transaction. Only its last sentence — the per-wiki scoping — actually
became false, and that not until 8362a216. Meanwhile `graph-model.md` still promised that a Subject removed while
referenced "is reduced to a stub rather than deleted", which #1171's own
`testRemovingMutuallyReferencingSubjectsFromTheirPageDeletesBoth` contradicts. Restored, widened to cover relation
edits as well as removals, and without the wiki clause.

**`testRemovingASubjectLeavesAnUnlinkedFullSubjectAlone` asserted less than its name.** `assertSubjectExists` only
checked that a node with that id existed, so a sweep variant that reduced unreachable candidates to stubs instead of
deleting them would have passed while losing the subject's `name` and Schema label. It now asserts the node is still
data-bearing. Its discriminating setup — `SCHEMA_ID_A` being absent from the store's `InMemorySchemaLookup`, despite
`setUp` creating that schema for the *other* stores — was also unasserted, so the test could have quietly stopped
testing anything; the precondition is now pinned.

## Verification

- Full `make phpunit`: 2082 tests, 5047 assertions, 4 skipped, 0 failures.
- `make cs`: phpcs (614 files) and phpstan (283 files) clean.
- Mutation-tested: each of the three new tests fails with `AND NOT (stub)<--()` removed and passes with it present;
  `assertSubjectIsNotStub` fails when the sweep is mutated to stub candidates rather than delete them, where the
  replaced `assertSubjectExists` passed.
- Both query plans read off a live Neo4j with `EXPLAIN`, with and without the `:Subject(id)` constraint present.

> <sub>AI-authored — Claude Code, `Opus 5 (1M context)`; reviewed #1171, then implemented these follow-ups and adversarially reviewed the result, taking two of that review's four findings and rejecting two; diff not yet human-reviewed; regression tests written against the live stack and each confirmed failing under the mutation it guards.</sub>
