### PR TITLE
Point the demo-data guide at commands that work

### DIFF
--- a/DemoData/AGENTS.md
+++ b/DemoData/AGENTS.md
@@ -159,12 +159,12 @@ From the repo root:
 # whose source files are gone. Enough on its own after renames or deletions.
 make import-demo-data
 
-# Full clean-slate reset (wipes the DB and Neo4j volumes, recreates the dev stack). Rarely needed.
+# Wipes the wiki database and Neo4j, then reseeds. Rarely needed.
 make reset
 
-# Reproject the Neo4j graph if Cypher results look stale.
+# Reproject the graph stores if Cypher or SPARQL results look stale.
 make rebuild-graph-databases
 ```
 
-A successful import ends with `Import finished` and zero `FAILED` lines. The wiki runs at
-`http://localhost:8484/`.
+A successful import ends with `Import finished` and zero `FAILED` lines. The wiki runs at the
+port `make dev` printed (default `http://localhost:8484/`).

--- a/DemoData/AGENTS.md
+++ b/DemoData/AGENTS.md
@@ -21,7 +21,7 @@ partners, knowledge managers, MediaWiki ecosystem evaluators, and live-demo audi
 
 `ImportDemoData.php` reseeds the demo set: it creates and updates pages from these directories, and
 deletes pages a previous import created whose source file is now gone. So renaming or removing a
-file and re-importing is enough — no `make reinstall-db` needed. Only pages the import itself created
+file and re-importing is enough — no `make reset` needed. Only pages the import itself created
 are pruned; a page someone else created — like `Main_Page`, which the installer creates and the
 import merely overwrites — is never deleted, even if its source file is removed.
 
@@ -157,10 +157,10 @@ From the repo root:
 ```sh
 # Reseeds the demo set: creates/updates pages and deletes ones the import previously created
 # whose source files are gone. Enough on its own after renames or deletions.
-make load-test-data
+make import-demo-data
 
-# Full clean-slate reset (drops the wiki database first). Rarely needed.
-make reinstall-db && make load-test-data
+# Full clean-slate reset (wipes the DB and Neo4j volumes, recreates the dev stack). Rarely needed.
+make reset
 
 # Reproject the Neo4j graph if Cypher results look stale.
 make rebuild-graph-databases

--- a/Makefile
+++ b/Makefile
@@ -258,10 +258,13 @@ load-neo4j-users:
 		"echo \"CREATE USER $(NEO4J_USERNAME_READ) SET PASSWORD '$(NEO4J_PASSWORD_READ)' CHANGE NOT REQUIRED; GRANT ROLE reader TO $(NEO4J_USERNAME_READ);\" | cypher-shell -u neo4j -p $(NEO4J_PASSWORD) -a bolt://localhost:7687"
 
 # Dev-only: wait for and seed the test_neo instance. Not called from prod or CI flows.
+# IF NOT EXISTS because test-neo4j-data is declared in the dev compose file and so
+# survives `make remove` (which loads the base file only): on a stack that has run
+# before, the user is already there and a bare CREATE USER would abort `make reset`.
 setup-test-neo:
 	$(EXEC_MW_ROOT) bash -c '/wait-for-it.sh test_neo:7689 -t 60'
 	$(DC_DEV) exec -T test_neo bash -c \
-		"echo \"CREATE USER mediawiki_read SET PASSWORD 'mediawiki_read' CHANGE NOT REQUIRED; GRANT ROLE reader TO mediawiki_read;\" | cypher-shell -u neo4j -p password -a bolt://localhost:7689"
+		"echo \"CREATE USER mediawiki_read IF NOT EXISTS SET PASSWORD 'mediawiki_read' CHANGE NOT REQUIRED; GRANT ROLE reader TO mediawiki_read;\" | cypher-shell -u neo4j -p password -a bolt://localhost:7689"
 
 # ---- Composer ----------------------------------------------------------------
 


### PR DESCRIPTION
`DemoData/AGENTS.md` was added in #814 naming `load-test-data` and `reinstall-db`. Both had been deleted from the dev-environment repo's Makefile days earlier, and neither ever existed here as a target, so the guide's `make` instructions have never worked in the repo the file lives in. The current targets are `import-demo-data` and `reset`.

Corrected along with the names:

- `reset` reseeds the demo data — which the two-command form it replaced made visible and a bare `make reset` does not. "Full clean-slate" also over-claimed: the QLever index volume is declared in the dev compose file, so `make remove` never sees it and it survives.
- `rebuild-graph-databases` rebuilds every configured backend's projection, not only Neo4j.
- The wiki port is auto-allocated, so `8484` is the default rather than the address, and is wrong in every worktree.

`make reset` then turned out to abort before the reseed it now promises. `remove` loads the base compose file only, so `test-neo4j-data` survives it, and `setup-test-neo` failed issuing a bare `CREATE USER` against an instance that already had that user — taking `reset` down two steps before the import and leaving the wiki installed but empty. `IF NOT EXISTS` makes the step idempotent.

> <sub>AI-authored — Claude Code, `Opus 5 (max)`; one-line ask from @JeroenDeDauw, then an AI review pass and one round of adjustments at his request; diff not yet human-reviewed; ran `make reset` end-to-end before and after the Makefile fix (aborted leaving a 1-page wiki → exit 0, 120 pages reseeded), plus `make import-demo-data`, `make phpunit` (2143 pass) and `make cs` locally.</sub>