### PR TITLE
Match the list projection in the parameterised Lua query example

### DIFF
--- a/docs/authoring/lua-api.md
+++ b/docs/authoring/lua-api.md
@@ -223,7 +223,7 @@ end
 ```lua
 -- Prefer parameterized queries over concatenating values into queries.
 local rows = nw.query(
-    'MATCH (s:Subject:`ISMS Document`) WHERE s.`Valid` = $valid RETURN s.name, s.`Expiry date`',
+    'MATCH (s:Subject:`ISMS Document`) WHERE $valid IN s.`Valid` RETURN s.name AS name, s.`Expiry date`[0] AS expiry',
     { valid = 'Yes' }
 )
 ```


### PR DESCRIPTION
Targets #1187. That PR corrects the Schema label, but the same line it rewrites still returns nothing.

`text`, `url` and `select` properties project as `LIST<STRING>` and `date` as `LIST<DATE>` ([Graph Model](https://github.com/ProfessionalWiki/NeoWiki/blob/master/docs/api/graph-model.md#dynamic-properties)), so `` s.`Valid` = $valid `` compares a list against a string and silently matches zero rows, and `` RETURN s.`Expiry date` `` hands Lua a table where the property name implies a date string.

```diff
-'MATCH (s:Subject:`ISMS Document`) WHERE s.`Valid` = $valid RETURN s.name, s.`Expiry date`',
+'MATCH (s:Subject:`ISMS Document`) WHERE $valid IN s.`Valid` RETURN s.name AS name, s.`Expiry date`[0] AS expiry',
```

## Verification

An `ISMS Document` Schema (`Valid` text, `Expiry date` date) and a Subject with `Valid` set to `Yes` were created on a live instance, then both forms were run through `nw.query`:

| Form | Result |
| --- | --- |
| `` WHERE $valid IN s.`Valid` `` | `rowCount=1`, `row.name=ISMS Policy 2026`, `row.expiry=2027-03-31`, `type(row.expiry)=string` |
| `` WHERE s.`Valid` = $valid `` | `rowCount=0` |

Neo4j reports the stored types as `Valid :: LIST<STRING NOT NULL>` and `Expiry date :: LIST<DATE NOT NULL>`, with `` s.`Expiry date`[0] `` typed `DATE`.

## Considered, omitted

* **The `IN` fix alone** (97 chars, runs and matches) — leaves `` RETURN s.`Expiry date` `` handing back a Lua table where a date string is expected.
* **Dropping `AS name`** (110 chars) — asymmetric `RETURN` clause, and diverges from the aliased idiom in [query-api.md](https://github.com/ProfessionalWiki/NeoWiki/blob/master/docs/api/query-api.md).
* **`` head(s.`Expiry date`) `` instead of `[0]`** — 121 chars against 118, no gain.
* **Restoring the explanatory sentence** dropped in e4a6dc7e — `authoring/` is "Contracts, signatures, examples; no narration", and the list-projection fact already has its home in `api/graph-model.md`, linked from this page's Related Documentation.
* **Rewording the `-- Prefer parameterized queries ...` comment** — left unchanged; the repetition is cosmetic and the line was hand-edited in e4a6dc7e.
* **Aligning `parser-functions.md`**, which filters by Schema with `WHERE 'Company' IN labels(s)` rather than a label match — correct Cypher on another page, out of scope here.

<sub>AI-authored — Claude Code, `Opus 5`; defect found by AI review of #1187, fix and live verification by Claude Code; not yet human-reviewed; verified end-to-end through `nw.query` on a dev instance as tabulated above.</sub>
