### PR TITLE
Review fixes for #1199: reachable RedHerb messages and two tests that could not fail

### DIFF
--- a/tests/RedHerb/extension.json
+++ b/tests/RedHerb/extension.json
@@ -159,8 +159,8 @@
 				"redherb-card-edit-subject",
 				"redherb-card-edit-schema",
 				"redherb-card-edit-layout",
-				"neowiki-field-invalid-hex",
-				"neowiki-field-not-in-palette",
+				"neowiki-field-invalid-color",
+				"neowiki-field-invalid-option",
 				"neowiki-field-required"
 			]
 		}

--- a/tests/RedHerb/i18n/en.json
+++ b/tests/RedHerb/i18n/en.json
@@ -35,6 +35,5 @@
 	"redherb-card-edit-subject": "Edit subject",
 	"redherb-card-edit-schema": "Edit schema",
 	"redherb-card-edit-layout": "Edit layout",
-	"neowiki-field-invalid-hex": "Please enter a 6-digit hex color like #ff5733.",
-	"neowiki-field-not-in-palette": "This color is not in the allowed palette."
+	"neowiki-field-invalid-color": "\"$1\" is not a valid color. Enter a 6-digit hex color like #ff5733."
 }

--- a/tests/RedHerb/i18n/qqq.json
+++ b/tests/RedHerb/i18n/qqq.json
@@ -35,6 +35,5 @@
 	"redherb-card-edit-subject": "Label of the button on the RedHerb card View Type that opens the subject editor dialog.",
 	"redherb-card-edit-schema": "Label of the link on the RedHerb card View Type that opens the Subject's Schema page for editing.",
 	"redherb-card-edit-layout": "Label of the link on the RedHerb card View Type that opens the Layout page for editing.",
-	"neowiki-field-invalid-hex": "Validation error shown when a Color input value is not a valid 6-digit hex code.",
-	"neowiki-field-not-in-palette": "Validation error shown when a Color input value is not one of the property's allowed palette entries."
+	"neowiki-field-invalid-color": "Validation error shown when a Color input value is not a valid 6-digit hex code. Corresponds to ColorType's <code>invalid-color</code> violation code. $1 is the offending value."
 }

--- a/tests/phpunit/Domain/PropertyType/Types/DateTimeTypeValidateTest.php
+++ b/tests/phpunit/Domain/PropertyType/Types/DateTimeTypeValidateTest.php
@@ -5,9 +5,11 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Tests\Domain\PropertyType\Types;
 
 use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeRegistry;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\Types\DateTimeType;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\DateTimeProperty;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinition;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
 use ProfessionalWiki\NeoWiki\Domain\Value\NumberValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
@@ -175,6 +177,7 @@ class DateTimeTypeValidateTest extends TestCase {
 		$this->assertSame( 'min-value', $violations[0]->code );
 		$this->assertSame( [ '2025-01-01T00:00:00Z' ], $violations[0]->args );
 		$this->assertNull( $violations[0]->propertyName );
+		$this->assertSame( Severity::Warning, $violations[0]->severity );
 	}
 
 	public function testAfterMaximumReturnsMaxValue(): void {
@@ -187,6 +190,44 @@ class DateTimeTypeValidateTest extends TestCase {
 		$this->assertSame( 'max-value', $violations[0]->code );
 		$this->assertSame( [ '2025-12-31T23:59:59Z' ], $violations[0]->args );
 		$this->assertNull( $violations[0]->propertyName );
+		$this->assertSame( Severity::Warning, $violations[0]->severity );
+	}
+
+	/**
+	 * Unlike NumberType, the bound severities reach checkMinimum()/checkMaximum() as arguments
+	 * rather than being read at the raise site. Each test therefore leaves the other bound
+	 * unannotated, so swapping the two arguments hands the violation the sibling's warning.
+	 */
+	public function testMinValueViolationUsesErrorWhenMinimumAnnotated(): void {
+		$definition = PropertyDefinition::fromJson(
+			[
+				'type' => 'dateTime',
+				'minimum' => [ 'value' => '2025-01-01T00:00:00Z', 'severity' => 'error' ],
+				'maximum' => '2025-12-31T23:59:59Z',
+			],
+			PropertyTypeRegistry::withCoreTypes(),
+		);
+
+		$violations = $this->type->validate( new StringValue( '2024-12-31T23:59:59Z' ), $definition );
+
+		$this->assertSame( 'min-value', $violations[0]->code );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
+	}
+
+	public function testMaxValueViolationUsesErrorWhenMaximumAnnotated(): void {
+		$definition = PropertyDefinition::fromJson(
+			[
+				'type' => 'dateTime',
+				'minimum' => '2025-01-01T00:00:00Z',
+				'maximum' => [ 'value' => '2025-12-31T23:59:59Z', 'severity' => 'error' ],
+			],
+			PropertyTypeRegistry::withCoreTypes(),
+		);
+
+		$violations = $this->type->validate( new StringValue( '2026-01-01T00:00:00Z' ), $definition );
+
+		$this->assertSame( 'max-value', $violations[0]->code );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
 	}
 
 	public function testEqualToBoundsReturnsNoViolations(): void {

--- a/tests/phpunit/Domain/PropertyType/Types/DateTypeValidateTest.php
+++ b/tests/phpunit/Domain/PropertyType/Types/DateTypeValidateTest.php
@@ -5,9 +5,11 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Tests\Domain\PropertyType\Types;
 
 use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeRegistry;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\Types\DateType;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\DateProperty;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinition;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
 use ProfessionalWiki\NeoWiki\Domain\Value\NumberValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
@@ -125,6 +127,7 @@ class DateTypeValidateTest extends TestCase {
 
 		$this->assertSame( 'min-value', $violations[0]->code );
 		$this->assertSame( [ '2025-01-01' ], $violations[0]->args );
+		$this->assertSame( Severity::Warning, $violations[0]->severity );
 	}
 
 	public function testAfterMaximumReturnsMaxValue(): void {
@@ -135,6 +138,44 @@ class DateTypeValidateTest extends TestCase {
 
 		$this->assertSame( 'max-value', $violations[0]->code );
 		$this->assertSame( [ '2025-12-31' ], $violations[0]->args );
+		$this->assertSame( Severity::Warning, $violations[0]->severity );
+	}
+
+	/**
+	 * Unlike NumberType, the bound severities reach checkMinimum()/checkMaximum() as arguments
+	 * rather than being read at the raise site. Each test therefore leaves the other bound
+	 * unannotated, so swapping the two arguments hands the violation the sibling's warning.
+	 */
+	public function testMinValueViolationUsesErrorWhenMinimumAnnotated(): void {
+		$definition = PropertyDefinition::fromJson(
+			[
+				'type' => 'date',
+				'minimum' => [ 'value' => '2025-01-01', 'severity' => 'error' ],
+				'maximum' => '2025-12-31',
+			],
+			PropertyTypeRegistry::withCoreTypes(),
+		);
+
+		$violations = $this->type->validate( new StringValue( '2024-12-31' ), $definition );
+
+		$this->assertSame( 'min-value', $violations[0]->code );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
+	}
+
+	public function testMaxValueViolationUsesErrorWhenMaximumAnnotated(): void {
+		$definition = PropertyDefinition::fromJson(
+			[
+				'type' => 'date',
+				'minimum' => '2025-01-01',
+				'maximum' => [ 'value' => '2025-12-31', 'severity' => 'error' ],
+			],
+			PropertyTypeRegistry::withCoreTypes(),
+		);
+
+		$violations = $this->type->validate( new StringValue( '2026-01-01' ), $definition );
+
+		$this->assertSame( 'max-value', $violations[0]->code );
+		$this->assertSame( Severity::Error, $violations[0]->severity );
 	}
 
 	public function testEqualToBoundsReturnsNoViolations(): void {

--- a/tests/phpunit/Persistence/MediaWiki/SchemaContentValidatorTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/SchemaContentValidatorTest.php
@@ -289,6 +289,34 @@ JSON
 	}
 
 	/**
+	 * The positive `options` case above cannot fail on its own: the property definition schema
+	 * sets `additionalProperties: true`, so dropping the `options` $ref would still accept the
+	 * object form. These two pin that the $ref is actually wired up — without it a typo'd
+	 * severity saves cleanly and then throws on every subsequent read of the Schema page.
+	 */
+	public function testOptionsObjectFormWithInvalidSeverityFailsValidation(): void {
+		$validator = SchemaContentValidator::newInstance();
+
+		$this->assertFalse(
+			$validator->validate(
+				$this->schemaWithProperty(
+					'{ "type": "select", "multiple": false, "options": { "value": [ { "id": "opt_a", "label": "A" } ], "severity": "eror" } }'
+				)
+			)
+		);
+	}
+
+	public function testOptionsObjectFormMissingValueFailsValidation(): void {
+		$validator = SchemaContentValidator::newInstance();
+
+		$this->assertFalse(
+			$validator->validate(
+				$this->schemaWithProperty( '{ "type": "select", "multiple": false, "options": { "severity": "error" } }' )
+			)
+		);
+	}
+
+	/**
 	 * The boolean object form implies true and carries no value key. Permitting a stray
 	 * one would let "value": false round-trip back as true, silently flipping the Constraint.
 	 */


### PR DESCRIPTION
Review fixes for https://github.com/ProfessionalWiki/NeoWiki/pull/1199, one concern per commit.

* **Point RedHerb's messages at the code `ColorType` actually emits.** The formatter looks up `neowiki-field-<code>`, and `ColorType` emits `invalid-color`, `invalid-option` and `required`. RedHerb defined and registered `neowiki-field-invalid-hex` and `neowiki-field-not-in-palette` — which no code path produces — and nothing for `invalid-color`, so that violation rendered as a raw `⧼neowiki-field-invalid-color⧽`. Harmless while `invalid-color` was a never-blocking warning; now that #1199 gives it a fixed `error`, it is the visible text of a `422` in the example plugin authors are told to copy. The dead hex message is renamed and now interpolates the value `ColorType` already passes in `args`; the unreachable palette message is dropped; `neowiki-field-invalid-option` joins the `neowiki-field-required` entry that was already there.

* **Make the object-form `options` validator test able to fail.** The property-definition subschema sets `additionalProperties: true`, so `testOptionsWithSeverityObjectFormPassesValidation` passes whether or not the `options` `$ref` is wired up — an undeclared key accepts anything. Unlike `required` and `maximum`, `options` had no paired negative test. Adds the invalid-severity and missing-value cases mirroring the existing scalar-constraint pair. Without the `$ref`, `{"options": {"value": [...], "severity": "eror"}}` saves cleanly and then throws from `SeverityNormalizer::extract` on every subsequent read of that Schema page.

* **Pin annotated bound severities on Date and DateTime.** `NumberType` reads `severityOf( 'minimum' )` inline at the raise site and the suite pins it; `DateType`/`DateTimeType` instead pass the severities into `checkMinimum()`/`checkMaximum()` as arguments, an extra hop where swapping the two arguments or hardcoding a severity in the helper survived the whole suite — each file's only severity assertion was on the fixed-`error` `invalid-date`/`invalid-datetime` case. Each new test annotates one bound and leaves the sibling unannotated, so a swap hands the violation the sibling's `warning`. The unannotated default is now pinned on the existing bound tests too.

## Verification

Full PHPUnit suite green on this branch (`1996 tests, 4821 assertions, 4 skipped` — up from `1990`/`4807` on #1199), phpcs and phpstan clean.

Both new test groups were mutation-tested rather than merely run:

| Mutation | Expected | Observed |
|---|---|---|
| `"options": { "$ref": … }` → `"options": true` | the two new `options` tests fail | exactly those 2 fail, other 23 pass |
| swap the `severityOf` arguments in `DateType`/`DateTimeType` | the annotated-bound tests fail | 2 failures in each file |

The first mutation leaving the pre-existing positive test green is the defect being fixed.

## Manual Browser Check

Only the first commit is user-visible, and only through RedHerb.

1. Enable RedHerb and create a Schema with a `color` property, e.g. `{ "type": "color", "required": true }`.
2. Add a Subject using that Schema and enter an invalid value such as `not-a-color` in the colour field.
3. **Expected:** the field error reads `"not-a-color" is not a valid color. Enter a 6-digit hex color like #ff5733.` — before this branch it rendered as the raw key `⧼neowiki-field-invalid-color⧽`.
4. Set an `allowedColors` palette, enter a valid hex outside it, and confirm the `invalid-option` message still resolves (it comes from core, and is now registered explicitly).

Note the ResourceLoader message cache: clear `MediaWikiModuleStore*` in localStorage, or the old message set is served.

## Left out

Deliberately not in scope, all raised in the same review and reported separately:

* The `ColorType` empty-string gap (`strings === []` classifies `''` as malformed rather than absent, so it skips `required` and raises a now-blocking `invalid-color`). Confirmed real and confirmed **not** introduced by #1199 — the same input was rejected before #1147 as well. Low severity: no shipped client can emit `[""]`, since `newStringValue` trims and filters empty parts, and enforcement is off by default. Worth its own fix because RedHerb is the copied example.
* Backend items against #1147: `SeverityNormalizer::apply()` re-emitting boolean `false` as the value-less object form (reads back as `true`) on custom Constraint keys; `additionalProperties: true` letting an invalid severity on a custom key pass save validation and then silently delete the property via the bare `catch` in `SchemaPersistenceDeserializer`; `scalarConstraint` lacking the `additionalProperties: false` its boolean sibling has.
* `docs/api/subject-format.md` promising that a value "empty for its type" is dropped without error, which core does not honour for `""`.

<sub>AI-authored — Claude Code, `Opus 5 (1M context)`: findings from a three-lens review panel on #1199 with each claim independently re-verified against source; the headline finding was demoted after an eight-agent adversarial workflow showed its causal story was wrong. Fixes implemented and mutation-tested as tabulated above.</sub>
