### PR TITLE
Review follow-ups for #1182: cover the release guard's resolve path

### DIFF
--- a/resources/ext.neowiki/src/stores/SchemaStore.ts
+++ b/resources/ext.neowiki/src/stores/SchemaStore.ts
@@ -14,6 +14,28 @@ export function normalizeSchemaName( name: string ): string {
 	return collapsed.charAt( 0 ).toUpperCase() + collapsed.slice( 1 );
 }
 
+// Pages through the summaries endpoint (capped at 50) by following the response's
+// cursor until it is null. The cursor, not the page length, decides whether more
+// pages follow: a page can come back shorter than requested when a readable Schema
+// fails to load (malformed). Deliberately not a store action: it neither reads nor
+// maintains the cache, so exposing it alongside getAllSchemaSummaries would offer
+// callers a way to page the whole endpoint while bypassing both the cache and the
+// invalidation guard.
+async function fetchAllSchemaSummaries(): Promise<SchemaSummary[]> {
+	const repository = NeoWikiExtension.getInstance().getSchemaRepository();
+	const pageSize = 50;
+	const summaries: SchemaSummary[] = [];
+	let cursor: string | null = null;
+
+	do {
+		const page = await repository.getSchemaSummaries( cursor, pageSize );
+		summaries.push( ...page.schemas );
+		cursor = page.nextCursor;
+	} while ( cursor !== null );
+
+	return summaries;
+}
+
 export const useSchemaStore = defineStore( 'schema', {
 	state: () => ( {
 		schemas: new Map<string, Schema>(),
@@ -57,7 +79,7 @@ export const useSchemaStore = defineStore( 'schema', {
 			}
 
 			if ( this.summariesRequest === null ) {
-				this.summariesRequest = this.fetchAllSchemaSummaries();
+				this.summariesRequest = fetchAllSchemaSummaries();
 			}
 
 			const request = this.summariesRequest;
@@ -75,24 +97,6 @@ export const useSchemaStore = defineStore( 'schema', {
 					this.summariesRequest = null;
 				}
 			}
-		},
-		// Pages through the summaries endpoint (capped at 50) by following the response's
-		// cursor until it is null. The cursor, not the page length, decides whether more
-		// pages follow: a page can come back shorter than requested when a readable Schema
-		// fails to load (malformed).
-		async fetchAllSchemaSummaries(): Promise<SchemaSummary[]> {
-			const repository = NeoWikiExtension.getInstance().getSchemaRepository();
-			const pageSize = 50;
-			const summaries: SchemaSummary[] = [];
-			let cursor: string | null = null;
-
-			do {
-				const page = await repository.getSchemaSummaries( cursor, pageSize );
-				summaries.push( ...page.schemas );
-				cursor = page.nextCursor;
-			} while ( cursor !== null );
-
-			return summaries;
 		},
 		// Checks existence via the schema-names search (a 200 response) rather
 		// than getOrFetchSchema, which 404s for a missing name — those 404s are

--- a/resources/ext.neowiki/tests/stores/SchemaStore.spec.ts
+++ b/resources/ext.neowiki/tests/stores/SchemaStore.spec.ts
@@ -36,11 +36,11 @@ describe( 'normalizeSchemaName', () => {
 
 describe( 'SchemaStore getAllSchemaSummaries', () => {
 
-	function summary( name: string ): { name: string; description: string; propertyCount: number } {
+	function summary( name: string ): SchemaSummary {
 		return { name, description: '', propertyCount: 0 };
 	}
 
-	function manySummaries( count: number, prefix: string ): ReturnType<typeof summary>[] {
+	function manySummaries( count: number, prefix: string ): SchemaSummary[] {
 		return Array.from( { length: count }, ( _value, index ) => summary( `${ prefix }${ index }` ) );
 	}
 

--- a/resources/ext.neowiki/tests/stores/SchemaStore.spec.ts
+++ b/resources/ext.neowiki/tests/stores/SchemaStore.spec.ts
@@ -217,4 +217,28 @@ describe( 'SchemaStore getAllSchemaSummaries', () => {
 		expect( getSchemaSummaries ).toHaveBeenCalledTimes( 2 );
 	} );
 
+	it( 'lets later callers share the replacement request when an invalidated one succeeds', async () => {
+		const afterSave = [ summary( 'Alpha' ), summary( 'Beta' ) ];
+		const invalidatedPage = deferred<SchemaSummaryPage>();
+		const currentPage = deferred<SchemaSummaryPage>();
+		const getSchemaSummaries = vi.fn()
+			.mockReturnValueOnce( invalidatedPage.promise )
+			.mockReturnValueOnce( currentPage.promise )
+			.mockResolvedValue( lastPage( [ summary( 'Redundant fetch' ) ] ) );
+		withRepository( { getSchemaSummaries, saveSchema: vi.fn().mockResolvedValue( undefined ) } );
+		const store = useSchemaStore();
+
+		const invalidatedRequest = store.getAllSchemaSummaries();
+		await store.saveSchema( newSchema( { title: 'Beta' } ) );
+		const currentRequest = store.getAllSchemaSummaries();
+		invalidatedPage.resolve( lastPage( [ summary( 'Stale' ) ] ) );
+		await invalidatedRequest;
+		const laterRequest = store.getAllSchemaSummaries();
+		currentPage.resolve( lastPage( afterSave ) );
+		await currentRequest;
+
+		expect( await laterRequest ).toEqual( afterSave );
+		expect( getSchemaSummaries ).toHaveBeenCalledTimes( 2 );
+	} );
+
 } );


### PR DESCRIPTION
Three findings from a review of #1182. No behaviour change to the fix itself.

**Cover the slot-release guard on the resolve path.** #1182 guards two things: an invalidated
request must not write the cache, and it must not release the slot a replacement request took.
The second guard was only pinned for an invalidated request that *fails*. Releasing the slot
unconditionally on success, keeping the guard only on the failure path, left the whole suite
green:

```ts
if ( this.summariesRequest === request ) { this.allSummaries = summaries; }
this.summariesRequest = null;              // unguarded release on success
return summaries;
} catch ( error ) {
    if ( this.summariesRequest === request ) { this.summariesRequest = null; }
    throw error;
}
```

That mutant is the second symptom #1182 describes: caller A starts pagination P1, a save
invalidates and clears the slot, caller B starts replacement P2, then P1 *succeeds* and nulls
the slot P2 owns — so a caller arriving before P2 finishes runs a redundant third pagination
and the cache is written by whichever lands last. The new test is the resolve-path twin of the
existing failure test; it fails against that mutant and passes against the fix.

**Take `fetchAllSchemaSummaries` out of the store's action surface.** Once the guard moved into
`getAllSchemaSummaries`, the function neither reads nor maintains the cache, but it stayed a
Pinia action and `public-api.ts` re-exports the store — so the documented extension surface
advertised a way to page the whole summaries endpoint while bypassing both the cache and the
invalidation guard. Before the guard moved, that same call at least warmed the cache, so the
refactor made the wrong choice strictly worse. It uses no store state, so it becomes a
module-level function alongside `normalizeSchemaName`. Nothing else called it.

**Type the summary test helpers as `SchemaSummary`.** The spec already imports the type for
`lastPage`; the hand-written structural copy in `summary()` was a second spelling that stops
tracking it if a field is added.

No manual browser check: this changes store internals and tests only, with no reachable
behaviour difference — `fetchAllSchemaSummaries` had no other caller, and the added test does
not touch production code.

Verification: `make ts-test` 1151 passed / 114 files (was 1150), `make ts-lint` clean,
`make ts-build` clean. The new test was confirmed to fail against the mutant above and pass
against the fix, in an isolated worktree.

> <sub>AI-authored — Claude Code, `Opus 5 (1M context)`; review of #1182 by four parallel reviewer agents plus an independent mutation check by the coordinator, findings then implemented directly; diff not yet human-reviewed; the surviving mutant was reproduced and the new test verified to kill it, full vitest suite plus lint and build green locally.</sub>
