### PR TITLE
Support MediaWiki 1.44 through 1.47

### DIFF
--- a/.github/workflows/ci-php.yml
+++ b/.github/workflows/ci-php.yml
@@ -21,12 +21,27 @@ jobs:
   test:
     name: "PHPUnit: MW ${{ matrix.mw }}, PHP ${{ matrix.php }}"
 
+    continue-on-error: ${{ matrix.experimental }}
+
     strategy:
       fail-fast: false
       matrix:
         include:
           - mw: 'REL1_43'
             php: '8.3'
+            experimental: false
+          - mw: 'REL1_44'
+            php: '8.3'
+            experimental: false
+          - mw: 'REL1_45'
+            php: '8.3'
+            experimental: false
+          - mw: 'REL1_46'
+            php: '8.4'
+            experimental: false
+          - mw: 'master'
+            php: '8.5'
+            experimental: true
 
     runs-on: ubuntu-latest
 
@@ -76,7 +91,7 @@ jobs:
             mediawiki
             !mediawiki/extensions/
             !mediawiki/vendor/
-          key: mw_${{ matrix.mw }}-php${{ matrix.php }}
+          key: mw_${{ matrix.mw }}-php${{ matrix.php }}-v2
 
       - name: Cache Composer cache
         uses: actions/cache@v5
@@ -146,7 +161,8 @@ jobs:
           echo "QLever did not become ready in time; dumping logs:"; docker logs test_qlever; exit 1
 
       - name: Run PHPUnit
-        run: php tests/phpunit/phpunit.php -c extensions/NeoWiki/phpunit.xml.dist
+        run: composer phpunit
+        working-directory: mediawiki/extensions/NeoWiki
 
   phpcs:
     name: "PHPCS with PHP 8.3"
@@ -203,7 +219,7 @@ jobs:
             mediawiki
             !mediawiki/extensions/
             !mediawiki/vendor/
-          key: mw_${{ matrix.mw }}-php${{ matrix.php }}
+          key: mw_${{ matrix.mw }}-php${{ matrix.php }}-v2
 
       - name: Cache Composer cache
         uses: actions/cache@v5

--- a/.github/workflows/installMediaWiki.sh
+++ b/.github/workflows/installMediaWiki.sh
@@ -3,10 +3,9 @@
 MW_BRANCH=$1
 EXTENSION_NAME=$2
 
-wget https://github.com/wikimedia/mediawiki/archive/$MW_BRANCH.tar.gz -nv
-
-tar -zxf $MW_BRANCH.tar.gz
-mv mediawiki-$MW_BRANCH mediawiki
+# Cloned rather than fetched as a tarball: phpunit.xml.template is export-ignore'd
+# in MediaWiki's .gitattributes, and `composer phpunit:config` needs it.
+git clone --depth 1 --branch "$MW_BRANCH" https://github.com/wikimedia/mediawiki.git mediawiki
 
 cd mediawiki
 
@@ -45,4 +44,4 @@ cat <<EOT >> composer.local.json
 EOT
 
 cd extensions
-git clone -b $MW_BRANCH https://gerrit.wikimedia.org/r/p/mediawiki/extensions/Scribunto.git --depth 1
+git clone -b $MW_BRANCH https://github.com/wikimedia/mediawiki-extensions-Scribunto.git Scribunto --depth 1

--- a/Makefile
+++ b/Makefile
@@ -295,9 +295,9 @@ cs: phpcs stan ## Run code style checks (phpcs + phpstan)
 phpunit: ## Run PHPUnit (use filter=X for a single test)
 ifeq ($(INSIDE_CONTAINER),1)
 ifdef filter
-	php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist --filter $(filter) < /dev/null
+	composer phpunit -- --filter $(filter) < /dev/null
 else
-	php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist < /dev/null
+	composer phpunit < /dev/null
 endif
 else
 ifdef filter
@@ -309,7 +309,7 @@ endif
 
 perf: ## Run performance test group
 ifeq ($(INSIDE_CONTAINER),1)
-	php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist --group Performance < /dev/null
+	composer phpunit -- --group Performance < /dev/null
 else
 	$(EXEC_MW) bash -c 'cd extensions/NeoWiki && make perf' < /dev/null
 endif

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,9 @@
 			"ProfessionalWiki\\NeoWiki\\Tests\\": "tests/phpunit/"
 		}
 	},
+	"scripts": {
+		"phpunit": "cd ${MW_INSTALL_PATH:-../..} && (composer phpunit:config 2>/dev/null || true) && vendor/bin/phpunit -c extensions/NeoWiki/phpunit.xml.dist --bootstrap tests/phpunit/bootstrap.php"
+	},
 	"config": {
 		"allow-plugins": {
 			"composer/installers": true,

--- a/src/EntryPoints/Content/LayoutContentHandler.php
+++ b/src/EntryPoints/Content/LayoutContentHandler.php
@@ -55,7 +55,7 @@ class LayoutContentHandler extends JsonContentHandler {
 		ContentParseParams $cpoParams,
 		ParserOutput &$parserOutput
 	): void {
-		$parserOutput->setRawText( '' );
+		$parserOutput->setContentHolderText( '' );
 	}
 
 	public function makeEmptyContent(): LayoutContent {

--- a/src/EntryPoints/Content/MappingContentHandler.php
+++ b/src/EntryPoints/Content/MappingContentHandler.php
@@ -98,7 +98,7 @@ class MappingContentHandler extends JsonContentHandler {
 
 		$rendering = $builder->build( $mapping );
 
-		$parserOutput->setRawText( $rendering->html );
+		$parserOutput->setContentHolderText( $rendering->html );
 		$this->registerLinks( $parserOutput, $rendering );
 		$parserOutput->addModuleStyles( [ 'mediawiki.content.json', 'ext.neowiki.styles' ] );
 	}

--- a/src/EntryPoints/Content/SchemaContentHandler.php
+++ b/src/EntryPoints/Content/SchemaContentHandler.php
@@ -55,7 +55,7 @@ class SchemaContentHandler extends JsonContentHandler {
 		ContentParseParams $cpoParams,
 		ParserOutput &$parserOutput
 	): void {
-		$parserOutput->setRawText( '' );
+		$parserOutput->setContentHolderText( '' );
 	}
 
 	public function makeEmptyContent(): SchemaContent {

--- a/src/EntryPoints/Content/SubjectContentHandler.php
+++ b/src/EntryPoints/Content/SubjectContentHandler.php
@@ -25,7 +25,7 @@ class SubjectContentHandler extends JsonContentHandler {
 		ContentParseParams $cpoParams,
 		ParserOutput &$parserOutput
 	): void {
-		$parserOutput->setRawText( '' );
+		$parserOutput->setContentHolderText( '' );
 	}
 
 	/**

--- a/src/EntryPoints/SpecialPages/SpecialNeoJson.php
+++ b/src/EntryPoints/SpecialPages/SpecialNeoJson.php
@@ -16,7 +16,11 @@ use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 class SpecialNeoJson extends SpecialPage {
 
 	public function __construct() {
-		parent::__construct( 'NeoJson', listed: false );
+		parent::__construct( 'NeoJson' );
+	}
+
+	public function isListed(): bool {
+		return false;
 	}
 
 	/**

--- a/src/Infrastructure/ProductionIdGenerator.php
+++ b/src/Infrastructure/ProductionIdGenerator.php
@@ -15,7 +15,7 @@ class ProductionIdGenerator implements IdGenerator {
 	private Randomizer $randomizer;
 	private Clock $clock;
 
-	public function __construct( Randomizer $randomizer = null, Clock $clock = null ) {
+	public function __construct( ?Randomizer $randomizer = null, ?Clock $clock = null ) {
 		$this->randomizer = $randomizer ?? new Randomizer();
 		$this->clock = $clock ?? new SystemClock();
 	}

--- a/src/Persistence/MediaWiki/PageContentFetcher.php
+++ b/src/Persistence/MediaWiki/PageContentFetcher.php
@@ -35,7 +35,7 @@ class PageContentFetcher {
 			return null;
 		}
 
-		$revision = $this->revisionLookup->getRevisionByTitle( $titleValue );
+		$revision = $this->revisionLookup->getRevisionByTitle( Title::newFromLinkTarget( $titleValue ) );
 
 		try {
 			return $revision?->getContent( $slotName, RevisionRecord::FOR_THIS_USER, $authority );

--- a/tests/phpunit/Application/RebuildPathPropagatesProjectionFailureTest.php
+++ b/tests/phpunit/Application/RebuildPathPropagatesProjectionFailureTest.php
@@ -28,7 +28,6 @@ class RebuildPathPropagatesProjectionFailureTest extends NeoWikiIntegrationTestC
 		parent::setUp();
 		$this->setUpNeo4j();
 		$this->createSchema( TestSubject::DEFAULT_SCHEMA_ID );
-		$this->markPageTableAsUsed();
 	}
 
 	protected function tearDown(): void {

--- a/tests/phpunit/Data/TestPage.php
+++ b/tests/phpunit/Data/TestPage.php
@@ -18,7 +18,7 @@ class TestPage {
 
 	public static function build(
 		?int $id = null,
-		PageProperties $properties = null,
+		?PageProperties $properties = null,
 		?Subject $mainSubject = null,
 		SubjectMap $childSubjects = new SubjectMap()
 	): Page {

--- a/tests/phpunit/Data/TestRelation.php
+++ b/tests/phpunit/Data/TestRelation.php
@@ -18,7 +18,7 @@ class TestRelation {
 	public const string DEFAULT_TARGET_ID = 'srt555555555555';
 
 	public static function build(
-		string|RelationId $id = null,
+		string|RelationId|null $id = null,
 		string $targetId = self::DEFAULT_TARGET_ID, // TODO: also generate predictable IDs
 		array|RelationProperties $properties = []
 	): Relation {

--- a/tests/phpunit/EntryPoints/AutoRenderMainSubjectTest.php
+++ b/tests/phpunit/EntryPoints/AutoRenderMainSubjectTest.php
@@ -23,7 +23,6 @@ class AutoRenderMainSubjectTest extends NeoWikiIntegrationTestCase {
 		parent::setUp();
 		$this->setUpNeo4j();
 		$this->createSchema( TestSubject::DEFAULT_SCHEMA_ID );
-		$this->markPageTableAsUsed();
 	}
 
 	public function testDoesNotAutoRenderMainSubjectWhenConfigDisabled(): void {

--- a/tests/phpunit/EntryPoints/Content/MappingContentHandlerParserOutputTest.php
+++ b/tests/phpunit/EntryPoints/Content/MappingContentHandlerParserOutputTest.php
@@ -32,7 +32,7 @@ class MappingContentHandlerParserOutputTest extends MediaWikiIntegrationTestCase
 	}
 
 	private function render( string $json, string $name = 'EDM' ): string {
-		return $this->parserOutput( $json, $name )->getRawText();
+		return $this->parserOutput( $json, $name )->getContentHolderText();
 	}
 
 	public function testMappingJsonIsVisibleOnTheReadTab(): void {
@@ -134,7 +134,7 @@ class MappingContentHandlerParserOutputTest extends MediaWikiIntegrationTestCase
 
 		$parserOutput = $this->parserOutput( $json );
 
-		$this->assertStringNotContainsString( 'href="javascript:', $parserOutput->getRawText() );
+		$this->assertStringNotContainsString( 'href="javascript:', $parserOutput->getContentHolderText() );
 		$this->assertArrayNotHasKey( 'javascript:alert(1)', $parserOutput->getExternalLinks() );
 	}
 
@@ -159,7 +159,7 @@ class MappingContentHandlerParserOutputTest extends MediaWikiIntegrationTestCase
 		$parserOutput = $this->parserOutput( $this->mappingWithSchema( 'Person' ) );
 
 		$this->assertTrue( $this->registersLocalLink( $parserOutput, NeoWikiExtension::NS_SCHEMA, 'Person' ) );
-		$this->assertStringNotContainsString( 'redlink', $parserOutput->getRawText() );
+		$this->assertStringNotContainsString( 'redlink', $parserOutput->getContentHolderText() );
 	}
 
 	/**
@@ -175,8 +175,8 @@ class MappingContentHandlerParserOutputTest extends MediaWikiIntegrationTestCase
 
 		$parserOutput = $this->parserOutput( $this->mappingWithSchema( 'Person_x' ) );
 
-		$this->assertStringContainsString( '<span>Person_x</span>', $parserOutput->getRawText() );
-		$this->assertStringNotContainsString( 'Schema:Person_x', $parserOutput->getRawText() );
+		$this->assertStringContainsString( '<span>Person_x</span>', $parserOutput->getContentHolderText() );
+		$this->assertStringNotContainsString( 'Schema:Person_x', $parserOutput->getContentHolderText() );
 		$this->assertFalse( $this->registersLocalLink( $parserOutput, NeoWikiExtension::NS_SCHEMA, 'Person_x' ) );
 	}
 

--- a/tests/phpunit/EntryPoints/ExtensionGraphDatabasePluginDispatchTest.php
+++ b/tests/phpunit/EntryPoints/ExtensionGraphDatabasePluginDispatchTest.php
@@ -39,7 +39,6 @@ class ExtensionGraphDatabasePluginDispatchTest extends NeoWikiIntegrationTestCas
 
 		$this->setUpNeo4j();
 		$this->createSchema( TestSubject::DEFAULT_SCHEMA_ID );
-		$this->markPageTableAsUsed();
 	}
 
 	public function testRegisteredExtensionPluginReceivesSaveAndDeleteEvents(): void {

--- a/tests/phpunit/EntryPoints/HookPathIsolatesProjectionFailureTest.php
+++ b/tests/phpunit/EntryPoints/HookPathIsolatesProjectionFailureTest.php
@@ -37,7 +37,6 @@ class HookPathIsolatesProjectionFailureTest extends NeoWikiIntegrationTestCase {
 		parent::setUp();
 		$this->setUpNeo4j();
 		$this->createSchema( TestSubject::DEFAULT_SCHEMA_ID );
-		$this->markPageTableAsUsed();
 	}
 
 	protected function tearDown(): void {

--- a/tests/phpunit/EntryPoints/ImportGraphProjectionTest.php
+++ b/tests/phpunit/EntryPoints/ImportGraphProjectionTest.php
@@ -22,7 +22,6 @@ class ImportGraphProjectionTest extends NeoWikiIntegrationTestCase {
 		parent::setUp();
 		$this->setUpNeo4j();
 		$this->createSchema( TestSubject::DEFAULT_SCHEMA_ID );
-		$this->markPageTableAsUsed();
 	}
 
 	public function testImportedPageProjectsItsSubjects(): void {

--- a/tests/phpunit/EntryPoints/NamespacedPageGraphProjectionTest.php
+++ b/tests/phpunit/EntryPoints/NamespacedPageGraphProjectionTest.php
@@ -24,7 +24,6 @@ class NamespacedPageGraphProjectionTest extends NeoWikiIntegrationTestCase {
 		parent::setUp();
 		$this->setUpNeo4j();
 		$this->createSchema( TestSubject::DEFAULT_SCHEMA_ID );
-		$this->markPageTableAsUsed();
 	}
 
 	public function testPageNodeNameIncludesNamespacePrefix(): void {

--- a/tests/phpunit/EntryPoints/OnRevisionCreatedHandlerTest.php
+++ b/tests/phpunit/EntryPoints/OnRevisionCreatedHandlerTest.php
@@ -31,7 +31,6 @@ class OnRevisionCreatedHandlerTest extends NeoWikiIntegrationTestCase {
 		parent::setUp();
 		$this->setUpNeo4j();
 		$this->createSchema( TestSubject::DEFAULT_SCHEMA_ID );
-		$this->markPageTableAsUsed();
 		$this->graphStore = new SpyGraphDatabasePlugin();
 	}
 

--- a/tests/phpunit/EntryPoints/PageMoveGraphProjectionTest.php
+++ b/tests/phpunit/EntryPoints/PageMoveGraphProjectionTest.php
@@ -24,7 +24,6 @@ class PageMoveGraphProjectionTest extends NeoWikiIntegrationTestCase {
 		parent::setUp();
 		$this->setUpNeo4j();
 		$this->createSchema( TestSubject::DEFAULT_SCHEMA_ID );
-		$this->markPageTableAsUsed();
 	}
 
 	public function testMovingPageUpdatesGraphNodeName(): void {

--- a/tests/phpunit/EntryPoints/REST/ModuleSpecHandlerNeoWikiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ModuleSpecHandlerNeoWikiTest.php
@@ -8,13 +8,16 @@ use MediaWiki\Config\ServiceOptions;
 use MediaWiki\Registration\ExtensionRegistry;
 use MediaWiki\Rest\BasicAccess\StaticBasicAuthorizer;
 use MediaWiki\Rest\Handler\ModuleSpecHandler;
+use MediaWiki\Rest\Module\ModuleManager;
 use MediaWiki\Rest\Reporter\MWErrorReporter;
 use MediaWiki\Rest\RequestData;
 use MediaWiki\Rest\ResponseFactory;
 use MediaWiki\Rest\Router;
 use MediaWiki\Rest\Validator\Validator;
+use MediaWiki\Session\SessionManager;
 use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+use ReflectionMethod;
 use Wikimedia\Message\ITextFormatter;
 use Wikimedia\Message\MessageSpecifier;
 
@@ -28,6 +31,31 @@ use Wikimedia\Message\MessageSpecifier;
  */
 class ModuleSpecHandlerNeoWikiTest extends NeoWikiIntegrationTestCase {
 	use HandlerTestTrait;
+
+	/**
+	 * ModuleManager exists from MediaWiki 1.46, a release before Router started taking one, so the
+	 * Router's own signature is what decides which of the two it wants.
+	 */
+	private function routerTakesModuleManager(): bool {
+		$firstParameter = ( new ReflectionMethod( Router::class, '__construct' ) )->getParameters()[0];
+
+		return $firstParameter->getType()?->getName() !== 'array';
+	}
+
+	private function routeSource( ResponseFactory $responseFactory ): mixed {
+		if ( !$this->routerTakesModuleManager() ) {
+			return [];
+		}
+
+		$services = $this->getServiceContainer();
+
+		return new ModuleManager(
+			new ServiceOptions( ModuleManager::CONSTRUCTOR_OPTIONS, $services->getMainConfig() ),
+			ExtensionRegistry::getInstance()->getAttribute( 'RestModuleFiles' ),
+			$services->getLocalServerObjectCache(),
+			$responseFactory
+		);
+	}
 
 	private function buildRouter(): Router {
 		$services = $this->getServiceContainer();
@@ -45,12 +73,14 @@ class ModuleSpecHandlerNeoWikiTest extends NeoWikiIntegrationTestCase {
 			}
 		};
 
+		$responseFactory = new ResponseFactory( [ $formatter ] );
+
 		return new Router(
-			[],
+			$this->routeSource( $responseFactory ),
 			ExtensionRegistry::getInstance()->getAttribute( 'RestRoutes' ),
 			new ServiceOptions( Router::CONSTRUCTOR_OPTIONS, $services->getMainConfig() ),
 			$services->getLocalServerObjectCache(),
-			new ResponseFactory( [ $formatter ] ),
+			$responseFactory,
 			new StaticBasicAuthorizer(),
 			$authority,
 			$objectFactory,
@@ -61,12 +91,22 @@ class ModuleSpecHandlerNeoWikiTest extends NeoWikiIntegrationTestCase {
 		);
 	}
 
+	private function newModuleSpecHandler(): ModuleSpecHandler {
+		$config = $this->getServiceContainer()->getMainConfig();
+
+		if ( ( new ReflectionMethod( ModuleSpecHandler::class, '__construct' ) )->getNumberOfParameters() > 1 ) {
+			return new ModuleSpecHandler( $config, SessionManager::singleton() );
+		}
+
+		return new ModuleSpecHandler( $config );
+	}
+
 	/**
 	 * @return array<string, mixed>
 	 */
 	private function fetchSpec(): array {
 		$response = $this->executeHandler(
-			new ModuleSpecHandler( $this->getServiceContainer()->getMainConfig() ),
+			$this->newModuleSpecHandler(),
 			new RequestData( [
 				'method' => 'GET',
 				// '-' is the ExtraRoutesModule hack: ModuleSpecHandler maps '-' to the empty module prefix,

--- a/tests/phpunit/EntryPoints/RdfAutodiscoveryLinksTest.php
+++ b/tests/phpunit/EntryPoints/RdfAutodiscoveryLinksTest.php
@@ -23,7 +23,6 @@ class RdfAutodiscoveryLinksTest extends NeoWikiIntegrationTestCase {
 		parent::setUp();
 		$this->setUpNeo4j();
 		$this->createSchema( TestSubject::DEFAULT_SCHEMA_ID );
-		$this->markPageTableAsUsed();
 	}
 
 	public function testAdvertisesTurtleAndTrigExportsForPageWithSubjects(): void {

--- a/tests/phpunit/EntryPoints/Scribunto/NeoWikiLibraryTest.php
+++ b/tests/phpunit/EntryPoints/Scribunto/NeoWikiLibraryTest.php
@@ -11,12 +11,18 @@ if ( !class_exists( \MediaWiki\Extension\Scribunto\Tests\Engines\LuaCommon\LuaEn
 /**
  * Lua integration tests for the mw.neowiki Scribunto library.
  *
- * Tests run against all available Lua engines (LuaSandbox and LuaStandalone)
- * via the suite() method inherited from LuaEngineTestBase.
- *
  * @group Lua
  * @group Database
  */
 class NeoWikiLibraryTest extends NeoWikiLibraryTestBase {
+
+	/**
+	 * Scribunto 1.46 onwards has each concrete test class name one engine. LuaStandalone is the
+	 * pick because it needs no PHP extension and so is present wherever the suite runs, not
+	 * because the library is specific to it.
+	 */
+	protected function getEngineName(): string {
+		return 'LuaStandalone';
+	}
 
 }

--- a/tests/phpunit/EntryPoints/SpecialPages/SpecialNeoJsonTest.php
+++ b/tests/phpunit/EntryPoints/SpecialPages/SpecialNeoJsonTest.php
@@ -2,12 +2,12 @@
 
 namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\SpecialPages;
 
+use MediaWiki\Context\RequestContext;
 use MediaWiki\MainConfigNames;
 use MediaWiki\Page\PageIdentity;
 use MediaWiki\Permissions\Authority;
 use MediaWiki\Request\FauxRequest;
 use MediaWiki\Tests\Unit\Permissions\MockAuthorityTrait;
-use MediaWiki\User\User;
 use PermissionsError;
 use ProfessionalWiki\NeoWiki\EntryPoints\SpecialPages\SpecialNeoJson;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
@@ -71,7 +71,7 @@ class SpecialNeoJsonTest extends SpecialPageTestBase {
 		$user = $this->getTestUser()->getUser();
 
 		try {
-			$this->executeSpecialPage( $title->getPrefixedText(), $this->newJsonPost( $user ), null, $user );
+			$this->executeSpecialPage( $title->getPrefixedText(), $this->newJsonPost(), null, $user );
 			$this->fail( 'Expected a PermissionsError for a user who cannot edit the protected page' );
 		} catch ( PermissionsError ) {
 		}
@@ -88,9 +88,17 @@ class SpecialNeoJsonTest extends SpecialPageTestBase {
 		$title = $this->getExistingTestPage( 'NeoJsonRateLimitedTarget' )->getTitle();
 		$user = $this->getTestUser()->getUser();
 
+		// The Subject write takes its performer from the main request context.
+		RequestContext::getMain()->setUser( $user );
+
 		$this->assertTrue( $user->definitelyCan( 'edit', $title ), 'Precondition: the user has edit allowance left' );
 
-		$this->executeSpecialPage( $title->getPrefixedText(), $this->newJsonPost( $user ), null, $user );
+		$this->executeSpecialPage( $title->getPrefixedText(), $this->newJsonPost(), null, $user );
+
+		$this->assertNotNull(
+			NeoWikiExtension::getInstance()->newSubjectContentRepository()->getSubjectContentByPageTitle( $title ),
+			'Precondition: the POST wrote Subject content'
+		);
 
 		$this->assertFalse(
 			$user->definitelyCan( 'edit', $title ),
@@ -113,14 +121,11 @@ class SpecialNeoJsonTest extends SpecialPageTestBase {
 		);
 	}
 
-	private function newJsonPost( User $user ): FauxRequest {
-		return new FauxRequest(
-			[
-				'wpjson' => '[]',
-				'wpEditToken' => $user->getEditToken(),
-			],
-			wasPosted: true
-		);
+	/**
+	 * No wpEditToken: SpecialPageExecutor fills one in from the session the form's CSRF check reads.
+	 */
+	private function newJsonPost(): FauxRequest {
+		return new FauxRequest( [ 'wpjson' => '[]' ], wasPosted: true );
 	}
 
 	private function protectAgainstNonSysopEdits( WikiPage $page ): void {

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/EntryPoints/ParserFunction/CypherRawParserFunctionParsingTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/EntryPoints/ParserFunction/CypherRawParserFunctionParsingTest.php
@@ -39,11 +39,13 @@ class CypherRawParserFunctionParsingTest extends MediaWikiIntegrationTestCase {
 			}
 		);
 
+		$parserOptions = ParserOptions::newFromAnon();
+
 		return $parser->parse(
 			'{{#cypher_raw: MATCH (m:Museum) RETURN m.Website AS site }}',
 			Title::makeTitle( NS_MAIN, 'CypherRawParsingTest' ),
-			ParserOptions::newFromAnon()
-		)->getText();
+			$parserOptions
+		)->runOutputPipeline( $parserOptions, [] )->getContentHolderText();
 	}
 
 	private function queryServiceReturningWebsite(): Neo4jQueryService {

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jPageIdentifiersLookupTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jPageIdentifiersLookupTest.php
@@ -38,7 +38,7 @@ class Neo4jPageIdentifiersLookupTest extends NeoWikiIntegrationTestCase {
 		$this->assertNull( $this->newLookup()->getPageIdOfSubject( new SubjectId( self::GUID_404 ) ) );
 	}
 
-	private function newLookup( ClientInterface $client = null ): Neo4jPageIdentifiersLookup {
+	private function newLookup( ?ClientInterface $client = null ): Neo4jPageIdentifiersLookup {
 		return new Neo4jPageIdentifiersLookup(
 			client: $client ?? $this->getClient()
 		);

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectLabelLookupTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectLabelLookupTest.php
@@ -250,7 +250,7 @@ class Neo4jSubjectLabelLookupTest extends NeoWikiIntegrationTestCase {
 	}
 
 	private function newLookup(
-		ClientInterface $client = null,
+		?ClientInterface $client = null,
 		?PageReadAuthorizer $readAuthorizer = null
 	): Neo4jSubjectLabelLookup {
 		return new Neo4jSubjectLabelLookup(

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectUpdaterTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectUpdaterTest.php
@@ -54,7 +54,7 @@ class Neo4jSubjectUpdaterTest extends TestCase {
 		);
 	}
 
-	private function newSubjectUpdater( Neo4jValueBuilderRegistry $valueBuilderRegistry = null ): Neo4jSubjectUpdater {
+	private function newSubjectUpdater( ?Neo4jValueBuilderRegistry $valueBuilderRegistry = null ): Neo4jSubjectUpdater {
 		return new Neo4jSubjectUpdater(
 			$this->transaction,
 			$this->pageId,

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/EntryPoints/ParserFunction/SparqlRawParserFunctionParsingTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/EntryPoints/ParserFunction/SparqlRawParserFunctionParsingTest.php
@@ -36,11 +36,13 @@ class SparqlRawParserFunctionParsingTest extends MediaWikiIntegrationTestCase {
 			}
 		);
 
+		$parserOptions = ParserOptions::newFromAnon();
+
 		return $parser->parse(
 			'{{#sparql_raw: SELECT ?n WHERE { ?s ?p ?n } }}',
 			Title::makeTitle( NS_MAIN, 'SparqlRawParsingTest' ),
-			ParserOptions::newFromAnon()
-		)->getText();
+			$parserOptions
+		)->runOutputPipeline( $parserOptions, [] )->getContentHolderText();
 	}
 
 	public function testDatatypeIriSurvivesParsingUnchanged(): void {

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/Integration/QuerySparqlEndToEndTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/Integration/QuerySparqlEndToEndTest.php
@@ -66,7 +66,6 @@ class QuerySparqlEndToEndTest extends NeoWikiIntegrationTestCase {
 
 		$this->clearStore();
 		$this->createSchema( TestSubject::DEFAULT_SCHEMA_ID );
-		$this->markPageTableAsUsed();
 	}
 
 	protected function tearDown(): void {

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/SparqlGraphProjectionTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/SparqlGraphProjectionTest.php
@@ -41,7 +41,6 @@ class SparqlGraphProjectionTest extends NeoWikiIntegrationTestCase {
 		parent::setUp();
 		$this->captured = [];
 		$this->createSchema( TestSubject::DEFAULT_SCHEMA_ID );
-		$this->markPageTableAsUsed();
 	}
 
 	public function testConfiguredSparqlStoreReceivesPageEditAsGraphUpdate(): void {

--- a/tests/phpunit/Maintenance/RebuildGraphDatabasesTest.php
+++ b/tests/phpunit/Maintenance/RebuildGraphDatabasesTest.php
@@ -27,7 +27,6 @@ class RebuildGraphDatabasesTest extends NeoWikiIntegrationTestCase {
 		parent::setUp();
 		$this->setUpNeo4j();
 		$this->createSchema( TestSubject::DEFAULT_SCHEMA_ID );
-		$this->markPageTableAsUsed();
 	}
 
 	protected function tearDown(): void {

--- a/tests/phpunit/NeoWikiIntegrationTestCase.php
+++ b/tests/phpunit/NeoWikiIntegrationTestCase.php
@@ -78,7 +78,7 @@ class NeoWikiIntegrationTestCase extends MediaWikiIntegrationTestCase {
 		return $updater->saveRevision( CommentStoreComment::newUnsavedComment( 'TODO' ) );
 	}
 
-	protected function createSchema( string $name, string $json = null ): ?RevisionRecord {
+	protected function createSchema( string $name, ?string $json = null ): ?RevisionRecord {
 		$wikiPage = MediaWikiServices::getInstance()->getWikiPageFactory()->newFromTitle(
 			Title::newFromText( $name, NeoWikiExtension::NS_SCHEMA )
 		);

--- a/tests/phpunit/NeoWikiIntegrationTestCase.php
+++ b/tests/phpunit/NeoWikiIntegrationTestCase.php
@@ -12,6 +12,7 @@ use MediaWiki\Content\TextContent;
 use MediaWiki\Deferred\DeferredUpdates;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Revision\RevisionRecord;
+use MediaWiki\Tests\User\TempUser\TempUserTestTrait;
 use MediaWiki\Title\Title;
 use MediaWikiIntegrationTestCase;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphDatabasePlugin;
@@ -33,6 +34,7 @@ use WikiExporter;
 class NeoWikiIntegrationTestCase extends MediaWikiIntegrationTestCase {
 
 	use HandlesNeo4jEnvOverrides;
+	use TempUserTestTrait;
 
 	/**
 	 * The singleton pins a SchemaLookup whose cache is keyed by page and revision id, and those ids
@@ -45,6 +47,11 @@ class NeoWikiIntegrationTestCase extends MediaWikiIntegrationTestCase {
 	 */
 	final protected function neoWikiSetUp(): void {
 		NeoWikiExtension::resetInstance();
+
+		// These tests edit as anonymous users, and MediaWiki refuses to give an IP an actor once
+		// temporary accounts are on. How NeoWiki behaves for a temporary account is its own
+		// question, not one this suite answers, so the feature is off while it runs.
+		$this->disableAutoCreateTempUser();
 	}
 
 	protected function setUpNeo4j(): void {

--- a/tests/phpunit/NeoWikiIntegrationTestCase.php
+++ b/tests/phpunit/NeoWikiIntegrationTestCase.php
@@ -162,12 +162,6 @@ class NeoWikiIntegrationTestCase extends MediaWikiIntegrationTestCase {
 		DeferredUpdates::doUpdates();
 	}
 
-	protected function markPageTableAsUsed(): void {
-		if ( !in_array( 'page', $this->tablesUsed ) ) {
-			$this->tablesUsed[] = 'page';
-		}
-	}
-
 	/**
 	 * Bulk-inserts bare page rows — no revisions or content — straight into the page table with a
 	 * single multi-row insert. The keyset name-lookup generators read only page_id and page_title and

--- a/tests/phpunit/Persistence/MediaWiki/DatabaseDeletedSubjectPageIdsLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/DatabaseDeletedSubjectPageIdsLookupTest.php
@@ -21,7 +21,6 @@ class DatabaseDeletedSubjectPageIdsLookupTest extends NeoWikiIntegrationTestCase
 	protected function setUp(): void {
 		parent::setUp();
 		$this->createSchema( TestSubject::DEFAULT_SCHEMA_ID );
-		$this->markPageTableAsUsed();
 	}
 
 	public function testFindsTheSubjectPageThatNoLongerExists(): void {

--- a/tests/phpunit/Persistence/MediaWiki/DatabaseDeletedSubjectPageIdsLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/DatabaseDeletedSubjectPageIdsLookupTest.php
@@ -100,7 +100,7 @@ class DatabaseDeletedSubjectPageIdsLookupTest extends NeoWikiIntegrationTestCase
 	 */
 	private function archiveRevisionOfExistingPage( RevisionRecord $revision ): void {
 		$row = $this->getDb()->newSelectQueryBuilder()
-			->select( [ 'rev_actor', 'rev_comment_id', 'rev_timestamp', 'rev_len', 'rev_sha1' ] )
+			->select( [ 'rev_actor', 'rev_comment_id', 'rev_timestamp', 'rev_len' ] )
 			->from( 'revision' )
 			->where( [ 'rev_id' => $revision->getId() ] )
 			->caller( __METHOD__ )
@@ -117,7 +117,6 @@ class DatabaseDeletedSubjectPageIdsLookupTest extends NeoWikiIntegrationTestCase
 				'ar_comment_id' => $row->rev_comment_id,
 				'ar_timestamp' => $row->rev_timestamp,
 				'ar_len' => $row->rev_len,
-				'ar_sha1' => $row->rev_sha1,
 				'ar_minor_edit' => 0,
 				'ar_deleted' => 0,
 			] )

--- a/tests/phpunit/Persistence/MediaWiki/DatabaseLayoutNameLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/DatabaseLayoutNameLookupTest.php
@@ -28,8 +28,7 @@ class DatabaseLayoutNameLookupTest extends NeoWikiIntegrationTestCase {
 	private array $pageIds = [];
 
 	public function setUp(): void {
-		$this->tablesUsed[] = 'page';
-		$this->truncateTables( $this->tablesUsed, $this->db );
+		$this->truncateTables( [ 'page' ], $this->db );
 
 		foreach ( [ 'LayoutNameLookupTest1', 'LayoutNameLookupTest2', 'LayoutNameLookupTest3' ] as $name ) {
 			$this->pageIds[$name] = $this->createLayout( $name )->getPageId();

--- a/tests/phpunit/Persistence/MediaWiki/DatabaseMappingNameLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/DatabaseMappingNameLookupTest.php
@@ -28,8 +28,7 @@ class DatabaseMappingNameLookupTest extends NeoWikiIntegrationTestCase {
 	private array $pageIds = [];
 
 	public function setUp(): void {
-		$this->tablesUsed[] = 'page';
-		$this->truncateTables( $this->tablesUsed, $this->db );
+		$this->truncateTables( [ 'page' ], $this->db );
 
 		foreach ( [ 'MappingLookupTest1', 'MappingLookupTest2', 'MappingLookupTest3' ] as $name ) {
 			$this->pageIds[$name] = $this->createMapping( $name, '{"version":1,"schemas":{}}' )->getPageId();

--- a/tests/phpunit/Persistence/MediaWiki/DatabaseSchemaNameLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/DatabaseSchemaNameLookupTest.php
@@ -28,8 +28,7 @@ class DatabaseSchemaNameLookupTest extends NeoWikiIntegrationTestCase {
 	private array $pageIds = [];
 
 	public function setUp(): void {
-		$this->tablesUsed[] = 'page';
-		$this->truncateTables( $this->tablesUsed, $this->db );
+		$this->truncateTables( [ 'page' ], $this->db );
 
 		foreach ( [ 'SchemaNameLookupTest1', 'SchemaNameLookupTest21', 'SchemaNameLookupTest22', 'SchemaNameLookupTest3' ] as $name ) {
 			$this->pageIds[$name] = $this->createSchema( $name )->getPageId();

--- a/tests/phpunit/Persistence/MediaWiki/FirstRevisionAuthorPageTitlesLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/FirstRevisionAuthorPageTitlesLookupTest.php
@@ -20,10 +20,6 @@ use User;
  */
 class FirstRevisionAuthorPageTitlesLookupTest extends NeoWikiIntegrationTestCase {
 
-	protected function setUp(): void {
-		parent::setUp();
-	}
-
 	public function testReturnsAPageTheImporterCreated(): void {
 		$this->editAs( $this->importer(), 'Importer page', 'created by the importer' );
 

--- a/tests/phpunit/Persistence/MediaWiki/FirstRevisionAuthorPageTitlesLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/FirstRevisionAuthorPageTitlesLookupTest.php
@@ -22,7 +22,6 @@ class FirstRevisionAuthorPageTitlesLookupTest extends NeoWikiIntegrationTestCase
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->markPageTableAsUsed();
 	}
 
 	public function testReturnsAPageTheImporterCreated(): void {

--- a/tests/phpunit/Persistence/MediaWiki/MediaWikiPageDeleterTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/MediaWikiPageDeleterTest.php
@@ -14,10 +14,6 @@ use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
  */
 class MediaWikiPageDeleterTest extends NeoWikiIntegrationTestCase {
 
-	protected function setUp(): void {
-		parent::setUp();
-	}
-
 	public function testDeletesAnExistingPage(): void {
 		$title = $this->insertPage( 'Page to delete', 'content' )['title'];
 

--- a/tests/phpunit/Persistence/MediaWiki/MediaWikiPageDeleterTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/MediaWikiPageDeleterTest.php
@@ -16,7 +16,6 @@ class MediaWikiPageDeleterTest extends NeoWikiIntegrationTestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->markPageTableAsUsed();
 	}
 
 	public function testDeletesAnExistingPage(): void {

--- a/tests/phpunit/Persistence/MediaWiki/Subject/MediaWikiSubjectRepositoryTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/Subject/MediaWikiSubjectRepositoryTest.php
@@ -38,8 +38,7 @@ class MediaWikiSubjectRepositoryTest extends NeoWikiIntegrationTestCase {
 	}
 
 	private function createPages(): void {
-		$this->markPageTableAsUsed();
-		$this->truncateTables( $this->tablesUsed, $this->db );
+		$this->truncateTables( [ 'page' ], $this->db );
 
 		$this->createSchema( TestSubject::DEFAULT_SCHEMA_ID );
 

--- a/tests/phpunit/RedHerb/SpecialRedHerbContentPageCountTest.php
+++ b/tests/phpunit/RedHerb/SpecialRedHerbContentPageCountTest.php
@@ -22,7 +22,6 @@ class SpecialRedHerbContentPageCountTest extends NeoWikiIntegrationTestCase {
 		parent::setUp();
 		$this->setUpNeo4j();
 		$this->createSchema( TestSubject::DEFAULT_SCHEMA_ID );
-		$this->markPageTableAsUsed();
 	}
 
 	public function testCountsOnlyContentNamespacePagesTrackedInTheGraph(): void {


### PR DESCRIPTION
Makes the extension work on MediaWiki 1.44 through 1.47 and puts those versions under CI, which previously ran the minimum supported release and the development branch with nothing between them. Both defects fixed here live in that gap.

## CI

MediaWiki 1.46 removed the `tests/phpunit/phpunit.php` entry point the workflow invoked, so the runner becomes a composer script the workflow and the Makefile share. It runs unchanged on every targeted version: `composer phpunit:config` generates the config 1.46 and later require, and is tolerated as a no-op where that script does not exist.

The script keeps the extension's own `phpunit.xml.dist` and passes core's bootstrap explicitly, which the removed entry point used to inject. Selecting tests by path instead would inherit core's config, silently adopting its `forceCoversAnnotation`, `failOnWarning` and `failOnRisky` settings and dropping the `<env>` block that points the Neo4j and QLever tests at the right endpoints.

MediaWiki is cloned rather than unpacked, because `phpunit.xml.template` is `export-ignore`d and so absent from the archive while the generator that reads it is present. The `master` row is marked experimental so core breakage surfaces without blocking, matching the convention in Network, WikibaseFacetedSearch and Chameleon. PHPStan stays pinned to one version.

## Removed and changed MediaWiki APIs

`getText()` went in 1.45, and `setRawText()` and `getRawText()` in 1.47. `runOutputPipeline()`, `setContentHolderText()` and `getContentHolderText()` replace them and all three exist in 1.43, so no version branch is needed. Both forms drive the same output pipeline with the same stages and defaults, so the parser-function tests still assert against the same HTML.

Two constructor changes are decided by inspecting the API being adapted to rather than by a version string. Testing for the `ModuleManager` class would be wrong: it ships from 1.46, a release before `Router` accepts one, so the class is present while the old signature is still in force.

## Deprecations

Implicit nullable parameters gain their explicit `?Type`, required from PHP 8.4 and accepted since 7.1. `getRevisionByTitle()` receives a `Title` so it takes the `PageIdentity` path rather than the `LinkTarget` one deprecated in 1.45, and `SpecialNeoJson` overrides `isListed()` instead of passing the constructor flag deprecated in 1.46.

## Test environment

MediaWiki refuses to give an IP address an actor once temporary accounts are on, which the 1.47 test wiki has, so every anonymous edit the suite made threw. It now uses MediaWiki's `TempUserTestTrait` to pin the feature off. Whether NeoWiki behaves correctly *for* a temporary account is a separate question this does not answer.

`SpecialNeoJsonTest` no longer supplies its own `wpEditToken`. MediaWiki 1.44 moved `HTMLForm`'s CSRF check from the user's session onto the form context's request, which is the session `SpecialPageExecutor` mints its token from, and a form that rejects the token re-renders silently rather than raising. The rate-limit test was therefore green without the write it names ever running.

`markPageTableAsUsed()` is gone. `$tablesUsed` has been deprecated since 1.41 and 1.43 already detects changed tables by itself, so registering one had no effect on any supported version.

`NeoWikiLibraryTest` names its Lua engine. Scribunto's `LuaEngineTestBase` multiplexed a test class across every available engine through a static `suite()`; from 1.46 that mechanism is gone, `makeSuite()` returns an empty suite, and each concrete class names its engine through `getEngineName()`, which throws until overridden. The Lua cases therefore skipped rather than ran on 1.46 and master, and the suite still reported OK. LuaStandalone is the engine named because it needs no PHP extension and so is present wherever the suite runs. One class rather than a subclass per engine: a LuaSandbox subclass would only ever skip in CI, which installs no `luasandbox`. Scribunto 1.43 through 1.45 have no `getEngineName()` and still choose engines through `suite()`, so they are unaffected.

## Not covered

Four pre-existing issues this work surfaced are left for separate changes: `SpecialNeoJson` authorizes on its own authority but writes as the main request context's; the `onSubmit()` authorization rejection branch is unreachable from the current suite; NeoWiki's behaviour for a temporary account is untested; and `ModuleSpecHandlerNeoWikiTest` is `@coversNothing` because much of it asserts MediaWiki's contract rather than ours.

> <sub>AI-authored — Claude Code, `Opus 5 (xhigh)`; from an open question by @malberts on unblocking CI, steered over ~14 turns, with the scope split out of the now-closed #862 and the commits regrouped on request; UI spot-checked by @malberts, diff not line-reviewed; suite run locally against MediaWiki 1.43, 1.46 and 1.47, Playwright UI smoke tests on all three, CI green on all five matrix rows.</sub>


