### PR TITLE
Add REST endpoints for setting and removing one Statement

### DIFF
--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -29,8 +29,8 @@ pagination.
 Subject write endpoints require per-page `edit` permission and answer `403` when you may read the page but not edit it.
 Denial of `read` answers `404` instead, so that a page you may not read stays indistinguishable from one that is absent.
 The write endpoints keyed by page id ([Pages and Subjects](#pages-and-subjects)) return that `404` for a page you may
-not read and for a page id that does not exist; `PUT /neowiki/v0/subject/{subjectId}` returns it for a Subject on a page
-you may not read and for a Subject id that does not exist.
+not read and for a page id that does not exist; the write endpoints keyed by Subject id return it for a Subject on a
+page you may not read and for a Subject id that does not exist.
 
 The Cypher query endpoint is gated only by the `neowiki-query` right, with no per-page filtering (see
 [Query API](query-api.md)).

--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -55,6 +55,8 @@ Read, change, and validate Subjects. New Subjects are created on a page — see
 | `GET /neowiki/v0/entity/{subjectId}` | Dereference a Subject's concept URI. `303` to the Subject's RDF (`Accept: application/trig` or `text/turtle`) or to the hosting page (otherwise). See [Dereferencing subject IRIs](../rdf/rdf-export.md#dereferencing-subject-iris). |
 | `PUT /neowiki/v0/subject/{subjectId}` | Replace a Subject's label and statements. |
 | `DELETE /neowiki/v0/subject/{subjectId}` | Delete a Subject. |
+| `PUT /neowiki/v0/subject/{subjectId}/statements/{propertyName}` | Set one Statement, leaving the Subject's label and other Statements as they are. |
+| `DELETE /neowiki/v0/subject/{subjectId}/statements/{propertyName}` | Remove one Statement. |
 | `POST /neowiki/v0/subject/validate` | Check whether a new Subject is valid, without saving it. Returns `{violations: [...]}` — see [Validation codes](validation-codes.md). |
 | `POST /neowiki/v0/subject/{subjectId}/validate` | Check whether a change to a Subject is valid, without saving it. Returns `{violations: [...]}` — see [Validation codes](validation-codes.md). |
 | `POST /neowiki/v0/subject-ids` | Mint a batch of unused Subject IDs to assign on create, e.g. to wire relations across an interlinked import. Body `count` (1–1000). |

--- a/docs/api/subject-format.md
+++ b/docs/api/subject-format.md
@@ -201,14 +201,16 @@ Subject's label and its other Statements as they are:
 `DELETE` on the same path removes the Statement and takes only `comment`. Removing a Statement the Subject does
 not have succeeds and changes nothing.
 
+Violations in the response cover the whole Subject, not only the property written.
+
 `{propertyName}` is URL-encoded, so `Founded at` is `Founded%20at`. A property name containing `/` is not
 addressable this way on servers that reject `%2F` in paths; write those Statements with
 `PUT /subject/{subjectId}`.
 
 ### Write responses
 
-Creating and writing a Subject both answer with the Subject as persisted and the Schema it instantiates, so a
-client does not have to re-read after a write:
+Creating a Subject, writing one, and writing one of its Statements all answer with the Subject as persisted and
+the Schema it instantiates, so a client does not have to re-read after a write:
 
 ```json
 {

--- a/docs/api/subject-format.md
+++ b/docs/api/subject-format.md
@@ -171,7 +171,9 @@ The server mints the Subject ID unless you pass one:
 | `comment` | No | Edit summary. |
 
 On every endpoint that takes `statements`, an entry without `propertyType`, or whose value is empty for its type, is
-dropped without error. For schema/value validation outcomes see [Validation Codes](validation-codes.md).
+dropped without error. A value whose shape does not match its `propertyType` (see
+[Value formats](#value-formats)) is rejected with `400`. For schema/value validation outcomes see
+[Validation Codes](validation-codes.md).
 
 A relation may omit `id`; the server generates one. The Subject's `id`, `schema`, and page fields are immutable
 and ignored if sent.

--- a/docs/api/subject-format.md
+++ b/docs/api/subject-format.md
@@ -176,6 +176,33 @@ dropped without error. For schema/value validation outcomes see [Validation Code
 A relation may omit `id`; the server generates one. The Subject's `id`, `schema`, and page fields are immutable
 and ignored if sent.
 
+### Writing one Statement
+
+`PUT /rest.php/neowiki/v0/subject/{subjectId}/statements/{propertyName}` sets a single Statement, leaving the
+Subject's label and its other Statements as they are:
+
+```json
+{
+  "statement": {
+    "propertyType": "url",
+    "value": ["https://example.com"]
+  },
+  "comment": "Optional edit summary"
+}
+```
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `statement` | Yes | A [Statement object](#statement-object). `propertyType` may be omitted, and then takes the type the Subject's Schema currently gives the property; a property the Schema does not define is rejected with `400`. A value that is empty for its type removes the Statement. |
+| `comment` | No | Edit summary. |
+
+`DELETE` on the same path removes the Statement and takes only `comment`. Removing a Statement the Subject does
+not have succeeds and changes nothing.
+
+`{propertyName}` is URL-encoded, so `Founded at` is `Founded%20at`. A property name containing `/` is not
+addressable this way on servers that reject `%2F` in paths; write those Statements with
+`PUT /subject/{subjectId}`.
+
 ### Write responses
 
 Creating and writing a Subject both answer with the Subject as persisted and the Schema it instantiates, so a

--- a/docs/api/subject-format.md
+++ b/docs/api/subject-format.md
@@ -195,7 +195,7 @@ Subject's label and its other Statements as they are:
 
 | Field | Required | Notes |
 |-------|----------|-------|
-| `statement` | Yes | A [Statement object](#statement-object). `propertyType` may be omitted, and then takes the type the Subject's Schema currently gives the property; a property the Schema does not define is rejected with `400`. A value that is empty for its type removes the Statement. |
+| `statement` | Yes | A [Statement object](#statement-object) carrying a `value`. `propertyType` may be omitted, and then takes the type the Subject's Schema currently gives the property; a property the Schema does not define is rejected with `400`. A value that is empty for its type removes the Statement. |
 | `comment` | No | Edit summary. |
 
 `DELETE` on the same path removes the Statement and takes only `comment`. Removing a Statement the Subject does

--- a/extension.json
+++ b/extension.json
@@ -290,6 +290,16 @@
 			"factory": "ProfessionalWiki\\NeoWiki\\NeoWikiExtension::newDeleteSubjectApi"
 		},
 		{
+			"path": "/neowiki/v0/subject/{subjectId}/statements/{propertyName}",
+			"method": [ "PUT" ],
+			"factory": "ProfessionalWiki\\NeoWiki\\NeoWikiExtension::newSetStatementApi"
+		},
+		{
+			"path": "/neowiki/v0/subject/{subjectId}/statements/{propertyName}",
+			"method": [ "DELETE" ],
+			"factory": "ProfessionalWiki\\NeoWiki\\NeoWikiExtension::newRemoveStatementApi"
+		},
+		{
 			"path": "/neowiki/v0/subject/{subjectId}/rdf",
 			"method": [ "GET" ],
 			"factory": "ProfessionalWiki\\NeoWiki\\NeoWikiExtension::newExportSubjectRdfApi"

--- a/src/Application/Actions/UpdateStatement/UpdateStatementAction.php
+++ b/src/Application/Actions/UpdateStatement/UpdateStatementAction.php
@@ -6,6 +6,8 @@ namespace ProfessionalWiki\NeoWiki\Application\Actions\UpdateStatement;
 
 use InvalidArgumentException;
 use ProfessionalWiki\NeoWiki\Application\PageIdentifiersLookup;
+use ProfessionalWiki\NeoWiki\Application\PageReadAuthorizer;
+use ProfessionalWiki\NeoWiki\Application\Queries\GetSubject\GetSubjectResponseItem;
 use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
 use ProfessionalWiki\NeoWiki\Application\SelectStatementResolver;
 use ProfessionalWiki\NeoWiki\Application\StatementListBuilder;
@@ -14,6 +16,7 @@ use ProfessionalWiki\NeoWiki\Application\Subject\Exception\SubjectNotFoundExcept
 use ProfessionalWiki\NeoWiki\Application\SubjectRepository;
 use ProfessionalWiki\NeoWiki\Application\SubjectWriteAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\Validation\ProposedSubjectValidator;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageIdentifiers;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyName;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
 use ProfessionalWiki\NeoWiki\Domain\Statement;
@@ -30,6 +33,7 @@ readonly class UpdateStatementAction {
 
 	public function __construct(
 		private SubjectRepository $subjectRepository,
+		private PageReadAuthorizer $readAuthorizer,
 		private SubjectWriteAuthorizer $writeAuthorizer,
 		private StatementListBuilder $statementListBuilder,
 		private SchemaLookup $schemaLookup,
@@ -57,7 +61,8 @@ readonly class UpdateStatementAction {
 		mixed $value,
 		?string $comment
 	): void {
-		$subject = $this->getSubjectToEdit( $subjectId );
+		$pageIdentifiers = $this->getPageOfSubjectToEdit( $subjectId );
+		$subject = $this->getSubject( $subjectId );
 		$schema = $this->schemaLookup->getSchema( $subject->getSchemaName() );
 
 		$statement = $this->buildStatement( $schema, $propertyName, $propertyType, $value );
@@ -67,6 +72,8 @@ readonly class UpdateStatementAction {
 			$statement === null
 				? $subject->getStatements()->withoutStatement( $propertyName )
 				: $subject->getStatements()->withStatement( $statement ),
+			$schema,
+			$pageIdentifiers,
 			$comment
 		);
 	}
@@ -76,21 +83,42 @@ readonly class UpdateStatementAction {
 	 * @throws SubjectEditNotAuthorizedException
 	 */
 	public function removeStatement( SubjectId $subjectId, PropertyName $propertyName, ?string $comment ): void {
-		$subject = $this->getSubjectToEdit( $subjectId );
+		$pageIdentifiers = $this->getPageOfSubjectToEdit( $subjectId );
+		$subject = $this->getSubject( $subjectId );
 
-		$this->save( $subject, $subject->getStatements()->withoutStatement( $propertyName ), $comment );
+		$this->save(
+			$subject,
+			$subject->getStatements()->withoutStatement( $propertyName ),
+			$this->schemaLookup->getSchema( $subject->getSchemaName() ),
+			$pageIdentifiers,
+			$comment
+		);
 	}
 
-	private function getSubjectToEdit( SubjectId $subjectId ): Subject {
-		// A null pageId (unresolvable Subject) makes the authorizer fall back to the global 'edit' right.
-		// This cannot bypass page protection: an unresolvable Subject is not found below (getSubject
-		// returns null), so the request 404s before any write rather than touching a protected page.
-		$pageId = $this->pageIdentifiersLookup->getPageIdOfSubject( $subjectId )?->getId();
+	private function getPageOfSubjectToEdit( SubjectId $subjectId ): PageIdentifiers {
+		$pageIdentifiers = $this->pageIdentifiersLookup->getPageIdOfSubject( $subjectId );
 
-		if ( !$this->writeAuthorizer->authorize( $pageId ) ) {
+		// Gate on read before write: a page the caller may not read answers exactly like a Subject
+		// that does not exist, so restricted pages cannot be told apart from absent ones - and the
+		// page title and namespace this endpoint returns never reach a caller denied the page. An
+		// unresolvable Subject takes that same path, since it has no page to authorize against.
+		// Reaching the write check with null identifiers would answer 403 where a restricted page
+		// answers 404, telling a caller who lacks the wiki-global 'edit' right which of the
+		// Subject ids they hold exist. Only a Subject on a page the caller can read (its existence
+		// already public) proceeds to the write check and its 403.
+		if ( $pageIdentifiers === null
+			|| !$this->readAuthorizer->authorizeReadByPageId( $pageIdentifiers->getId() ) ) {
+			throw SubjectNotFoundException::forId( $subjectId );
+		}
+
+		if ( !$this->writeAuthorizer->authorize( $pageIdentifiers->getId() ) ) {
 			throw new SubjectEditNotAuthorizedException();
 		}
 
+		return $pageIdentifiers;
+	}
+
+	private function getSubject( SubjectId $subjectId ): Subject {
 		$subject = $this->subjectRepository->getSubject( $subjectId );
 
 		if ( $subject === null ) {
@@ -138,7 +166,13 @@ readonly class UpdateStatementAction {
 		);
 	}
 
-	private function save( Subject $subject, StatementList $statements, ?string $comment ): void {
+	private function save(
+		Subject $subject,
+		StatementList $statements,
+		?Schema $schema,
+		PageIdentifiers $pageIdentifiers,
+		?string $comment
+	): void {
 		$priorViolations = $this->proposedSubjectValidator->validate( $subject );
 
 		$proposedSubject = $subject->withStatements( $statements );
@@ -156,7 +190,13 @@ readonly class UpdateStatementAction {
 
 		$this->subjectRepository->updateSubject( $proposedSubject, $comment );
 
-		$this->presenter->presentUpdated( $proposedSubject->getId()->text, $proposedViolations );
+		// The proposed Subject is the persisted state: the builder and the resolver above already
+		// normalized what the request supplied.
+		$this->presenter->presentUpdated(
+			GetSubjectResponseItem::fromSubject( $proposedSubject, $pageIdentifiers ),
+			$schema,
+			$proposedViolations
+		);
 	}
 
 }

--- a/src/Application/Actions/UpdateStatement/UpdateStatementAction.php
+++ b/src/Application/Actions/UpdateStatement/UpdateStatementAction.php
@@ -1,0 +1,162 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application\Actions\UpdateStatement;
+
+use InvalidArgumentException;
+use ProfessionalWiki\NeoWiki\Application\PageIdentifiersLookup;
+use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
+use ProfessionalWiki\NeoWiki\Application\SelectStatementResolver;
+use ProfessionalWiki\NeoWiki\Application\StatementListBuilder;
+use ProfessionalWiki\NeoWiki\Application\Subject\Exception\SubjectEditNotAuthorizedException;
+use ProfessionalWiki\NeoWiki\Application\Subject\Exception\SubjectNotFoundException;
+use ProfessionalWiki\NeoWiki\Application\SubjectRepository;
+use ProfessionalWiki\NeoWiki\Application\SubjectWriteAuthorizer;
+use ProfessionalWiki\NeoWiki\Application\Validation\ProposedSubjectValidator;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyName;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
+use ProfessionalWiki\NeoWiki\Domain\Statement;
+use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
+use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
+use ProfessionalWiki\NeoWiki\Domain\Validation\ViolationDiff;
+
+/**
+ * Sets or removes one Statement of a Subject, leaving its other Statements and its label alone.
+ */
+readonly class UpdateStatementAction {
+
+	public function __construct(
+		private SubjectRepository $subjectRepository,
+		private SubjectWriteAuthorizer $writeAuthorizer,
+		private StatementListBuilder $statementListBuilder,
+		private SchemaLookup $schemaLookup,
+		private SelectStatementResolver $selectStatementResolver,
+		private ProposedSubjectValidator $proposedSubjectValidator,
+		private UpdateStatementPresenter $presenter,
+		private bool $validationEnforced,
+		private PageIdentifiersLookup $pageIdentifiersLookup,
+	) {
+	}
+
+	/**
+	 * @param string|null $propertyType The writer's type for the value. Falls back to the type the
+	 *  Subject's Schema currently gives the property.
+	 *
+	 * @throws InvalidArgumentException When no property type is given and none can be derived,
+	 *  or when a select value cannot be resolved.
+	 * @throws SubjectNotFoundException
+	 * @throws SubjectEditNotAuthorizedException
+	 */
+	public function setStatement(
+		SubjectId $subjectId,
+		PropertyName $propertyName,
+		?string $propertyType,
+		mixed $value,
+		?string $comment
+	): void {
+		$subject = $this->getSubjectToEdit( $subjectId );
+		$schema = $this->schemaLookup->getSchema( $subject->getSchemaName() );
+
+		$statement = $this->buildStatement( $schema, $propertyName, $propertyType, $value );
+
+		$this->save(
+			$subject,
+			$statement === null
+				? $subject->getStatements()->withoutStatement( $propertyName )
+				: $subject->getStatements()->withStatement( $statement ),
+			$comment
+		);
+	}
+
+	/**
+	 * @throws SubjectNotFoundException
+	 * @throws SubjectEditNotAuthorizedException
+	 */
+	public function removeStatement( SubjectId $subjectId, PropertyName $propertyName, ?string $comment ): void {
+		$subject = $this->getSubjectToEdit( $subjectId );
+
+		$this->save( $subject, $subject->getStatements()->withoutStatement( $propertyName ), $comment );
+	}
+
+	private function getSubjectToEdit( SubjectId $subjectId ): Subject {
+		// A null pageId (unresolvable Subject) makes the authorizer fall back to the global 'edit' right.
+		// This cannot bypass page protection: an unresolvable Subject is not found below (getSubject
+		// returns null), so the request 404s before any write rather than touching a protected page.
+		$pageId = $this->pageIdentifiersLookup->getPageIdOfSubject( $subjectId )?->getId();
+
+		if ( !$this->writeAuthorizer->authorize( $pageId ) ) {
+			throw new SubjectEditNotAuthorizedException();
+		}
+
+		$subject = $this->subjectRepository->getSubject( $subjectId );
+
+		if ( $subject === null ) {
+			throw SubjectNotFoundException::forId( $subjectId );
+		}
+
+		return $subject;
+	}
+
+	/**
+	 * Returns null when the value is empty for its type, which the write paths treat as
+	 * the Statement being absent.
+	 */
+	private function buildStatement(
+		?Schema $schema,
+		PropertyName $propertyName,
+		?string $propertyType,
+		mixed $value
+	): ?Statement {
+		$statements = [
+			$propertyName->text => [
+				'propertyType' => $propertyType ?? $this->getSchemaPropertyType( $schema, $propertyName ),
+				'value' => $value,
+			],
+		];
+
+		if ( $schema !== null ) {
+			$statements = $this->selectStatementResolver->resolve( $schema, $statements );
+		}
+
+		return $this->statementListBuilder->build( $statements )->getStatement( $propertyName );
+	}
+
+	/**
+	 * @throws InvalidArgumentException
+	 */
+	private function getSchemaPropertyType( ?Schema $schema, PropertyName $propertyName ): string {
+		if ( $schema !== null && $schema->hasProperty( $propertyName ) ) {
+			return $schema->getProperty( $propertyName )->getPropertyType();
+		}
+
+		throw new InvalidArgumentException(
+			"propertyType is required for \"{$propertyName->text}\": "
+				. "the Subject's Schema does not define the property"
+		);
+	}
+
+	private function save( Subject $subject, StatementList $statements, ?string $comment ): void {
+		$priorViolations = $this->proposedSubjectValidator->validate( $subject );
+
+		$proposedSubject = $subject->withStatements( $statements );
+		$proposedViolations = $this->proposedSubjectValidator->validate( $proposedSubject );
+
+		$newBlockingViolations = array_filter(
+			ViolationDiff::newViolations( $proposedViolations, $priorViolations ),
+			static fn ( Violation $v ): bool => $v->isBlocking()
+		);
+
+		if ( $this->validationEnforced && $newBlockingViolations !== [] ) {
+			$this->presenter->presentValidationFailed( $proposedViolations );
+			return;
+		}
+
+		$this->subjectRepository->updateSubject( $proposedSubject, $comment );
+
+		$this->presenter->presentUpdated( $proposedSubject->getId()->text, $proposedViolations );
+	}
+
+}

--- a/src/Application/Actions/UpdateStatement/UpdateStatementAction.php
+++ b/src/Application/Actions/UpdateStatement/UpdateStatementAction.php
@@ -46,18 +46,20 @@ readonly class UpdateStatementAction {
 	}
 
 	/**
-	 * @param string|null $propertyType The writer's type for the value. Falls back to the type the
-	 *  Subject's Schema currently gives the property.
+	 * @param mixed $propertyType The writer's type for the value, as the caller supplied it. Falls
+	 *  back to the type the Subject's Schema currently gives the property when null. Taken raw
+	 *  rather than as a string because the request body it comes from is unvalidated below its top
+	 *  level; the builder rejects anything that is not a string.
 	 *
-	 * @throws InvalidArgumentException When no property type is given and none can be derived,
-	 *  or when a select value cannot be resolved.
+	 * @throws InvalidArgumentException When the property type is not a string, when none is given
+	 *  and none can be derived, or when a select value cannot be resolved.
 	 * @throws SubjectNotFoundException
 	 * @throws SubjectEditNotAuthorizedException
 	 */
 	public function setStatement(
 		SubjectId $subjectId,
 		PropertyName $propertyName,
-		?string $propertyType,
+		mixed $propertyType,
 		mixed $value,
 		?string $comment
 	): void {
@@ -135,7 +137,7 @@ readonly class UpdateStatementAction {
 	private function buildStatement(
 		?Schema $schema,
 		PropertyName $propertyName,
-		?string $propertyType,
+		mixed $propertyType,
 		mixed $value
 	): ?Statement {
 		$statements = [

--- a/src/Application/Actions/UpdateStatement/UpdateStatementPresenter.php
+++ b/src/Application/Actions/UpdateStatement/UpdateStatementPresenter.php
@@ -4,14 +4,20 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Application\Actions\UpdateStatement;
 
+use ProfessionalWiki\NeoWiki\Application\Queries\GetSubject\GetSubjectResponseItem;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
 
 interface UpdateStatementPresenter {
 
 	/**
+	 * Receives the persisted Subject, not the request: the server normalizes Statements on the way
+	 * in, so this is the state a subsequent read returns. A null Schema means the Subject names a
+	 * Schema that does not exist.
+	 *
 	 * @param Violation[] $violations
 	 */
-	public function presentUpdated( string $subjectId, array $violations ): void;
+	public function presentUpdated( GetSubjectResponseItem $subject, ?Schema $schema, array $violations ): void;
 
 	/**
 	 * Called when validation enforcement rejects an edit that would introduce

--- a/src/Application/Actions/UpdateStatement/UpdateStatementPresenter.php
+++ b/src/Application/Actions/UpdateStatement/UpdateStatementPresenter.php
@@ -1,0 +1,24 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application\Actions\UpdateStatement;
+
+use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
+
+interface UpdateStatementPresenter {
+
+	/**
+	 * @param Violation[] $violations
+	 */
+	public function presentUpdated( string $subjectId, array $violations ): void;
+
+	/**
+	 * Called when validation enforcement rejects an edit that would introduce
+	 * new constraint violations relative to the Subject's prior state.
+	 *
+	 * @param Violation[] $violations
+	 */
+	public function presentValidationFailed( array $violations ): void;
+
+}

--- a/src/Application/SelectStatementResolver.php
+++ b/src/Application/SelectStatementResolver.php
@@ -62,11 +62,11 @@ readonly class SelectStatementResolver {
 				continue;
 			}
 
-			if ( !$schema->hasProperty( $propertyName ) ) {
+			if ( !$schema->hasProperty( (string)$propertyName ) ) {
 				continue;
 			}
 
-			$property = $schema->getProperty( $propertyName );
+			$property = $schema->getProperty( (string)$propertyName );
 
 			if ( !$property instanceof SelectProperty ) {
 				continue;
@@ -137,11 +137,11 @@ readonly class SelectStatementResolver {
 				continue;
 			}
 
-			if ( !$schema->hasProperty( $propertyName ) ) {
+			if ( !$schema->hasProperty( (string)$propertyName ) ) {
 				continue;
 			}
 
-			$property = $schema->getProperty( $propertyName );
+			$property = $schema->getProperty( (string)$propertyName );
 
 			if ( !$property instanceof SelectProperty ) {
 				continue;

--- a/src/Application/StatementListBuilder.php
+++ b/src/Application/StatementListBuilder.php
@@ -45,6 +45,11 @@ readonly class StatementListBuilder {
 			}
 
 			$propertyType = $entry['propertyType'];
+
+			if ( !is_string( $propertyType ) ) {
+				throw new InvalidArgumentException( "Property type of \"{$propertyName}\" must be a string" );
+			}
+
 			$value = $this->deserializeValue( (string)$propertyName, $propertyType, $entry['value'] ?? null );
 
 			if ( $value->isEmpty() ) {
@@ -52,7 +57,7 @@ readonly class StatementListBuilder {
 			}
 
 			$built[$propertyName] = new Statement(
-				property: new PropertyName( $propertyName ),
+				property: new PropertyName( (string)$propertyName ),
 				propertyType: $propertyType,
 				value: $value
 			);
@@ -67,6 +72,17 @@ readonly class StatementListBuilder {
 	private function deserializeValue( string $propertyName, string $propertyType, mixed $value ): NeoValue {
 		$valueType = $this->propertyTypeLookup->getType( $propertyType )?->getValueType()
 			?? ValueType::UnregisteredType;
+
+		// A JSON object reaches the list-shaped types as named arguments rather than as a type
+		// error: it would be stored as an object where every reader expects a list, and the graph
+		// projection cannot hold one. The value types cannot tell it apart from a list, so it is
+		// rejected before they see it.
+		if ( in_array( $valueType, [ ValueType::String, ValueType::Relation ], true )
+			&& is_array( $value ) && !array_is_list( $value ) ) {
+			throw new InvalidArgumentException(
+				"Value of \"{$propertyName}\" must be a list, not an object"
+			);
+		}
 
 		// The value types below declare what each shape accepts, so a value of the wrong shape
 		// arrives here as a TypeError. Every one of them comes from the caller's value, never from
@@ -92,13 +108,19 @@ readonly class StatementListBuilder {
 		$relations = [];
 
 		foreach ( $json as $relation ) {
-			if ( is_array( $relation ) ) {
-				$relations[] = new Relation(
-					id: $this->buildRelationId( $relation ),
-					targetId: new SubjectId( $relation['target'] ?? null ),
-					properties: new RelationProperties( $relation['properties'] ?? [] )
-				);
+			// Skipping an entry that is not a relation object would turn a list of bare target
+			// ids into an empty value, which the write paths read as the Statement being absent.
+			// Raised as a TypeError so it reaches the caller as the same bad-value report the
+			// constructors below produce for every other misshapen relation.
+			if ( !is_array( $relation ) ) {
+				throw new TypeError( 'Relation entry must be an object' );
 			}
+
+			$relations[] = new Relation(
+				id: $this->buildRelationId( $relation ),
+				targetId: new SubjectId( $relation['target'] ?? null ),
+				properties: new RelationProperties( $relation['properties'] ?? [] )
+			);
 		}
 
 		return new RelationValue( ...$relations );

--- a/src/Application/StatementListBuilder.php
+++ b/src/Application/StatementListBuilder.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Application;
 
+use InvalidArgumentException;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeLookup;
 use ProfessionalWiki\NeoWiki\Domain\Relation\Relation;
 use ProfessionalWiki\NeoWiki\Domain\Relation\RelationId;
@@ -20,6 +21,7 @@ use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\UnregisteredTypeValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\ValueType;
 use ProfessionalWiki\NeoWiki\Infrastructure\IdGenerator;
+use TypeError;
 
 readonly class StatementListBuilder {
 
@@ -31,6 +33,8 @@ readonly class StatementListBuilder {
 
 	/**
 	 * @param array<string, mixed> $statements
+	 *
+	 * @throws InvalidArgumentException When a value does not fit the property type it declares.
 	 */
 	public function build( array $statements ): StatementList {
 		$built = [];
@@ -41,7 +45,7 @@ readonly class StatementListBuilder {
 			}
 
 			$propertyType = $entry['propertyType'];
-			$value = $this->deserializeValue( $propertyType, $entry['value'] );
+			$value = $this->deserializeValue( (string)$propertyName, $propertyType, $entry['value'] ?? null );
 
 			if ( $value->isEmpty() ) {
 				continue;
@@ -57,17 +61,31 @@ readonly class StatementListBuilder {
 		return new StatementList( $built );
 	}
 
-	private function deserializeValue( string $propertyType, mixed $value ): NeoValue {
+	/**
+	 * @throws InvalidArgumentException
+	 */
+	private function deserializeValue( string $propertyName, string $propertyType, mixed $value ): NeoValue {
 		$valueType = $this->propertyTypeLookup->getType( $propertyType )?->getValueType()
 			?? ValueType::UnregisteredType;
 
-		return match ( $valueType ) {
-			ValueType::String => new StringValue( ...(array)$value ),
-			ValueType::Number => new NumberValue( $value ),
-			ValueType::Relation => $this->deserializeRelationValue( $value ),
-			ValueType::Boolean => new BooleanValue( $value ),
-			ValueType::UnregisteredType => new UnregisteredTypeValue( $propertyType, $value ),
-		};
+		// The value types below declare what each shape accepts, so a value of the wrong shape
+		// arrives here as a TypeError. Every one of them comes from the caller's value, never from
+		// internal state, so they are reported as bad input rather than escaping as a server error.
+		try {
+			return match ( $valueType ) {
+				ValueType::String => new StringValue( ...(array)$value ),
+				ValueType::Number => new NumberValue( $value ),
+				ValueType::Relation => $this->deserializeRelationValue( $value ),
+				ValueType::Boolean => new BooleanValue( $value ),
+				ValueType::UnregisteredType => new UnregisteredTypeValue( $propertyType, $value ),
+			};
+		} catch ( TypeError $e ) {
+			throw new InvalidArgumentException(
+				"Value of \"{$propertyName}\" does not fit property type \"{$propertyType}\"",
+				0,
+				$e
+			);
+		}
 	}
 
 	private function deserializeRelationValue( array $json ): RelationValue {
@@ -77,7 +95,7 @@ readonly class StatementListBuilder {
 			if ( is_array( $relation ) ) {
 				$relations[] = new Relation(
 					id: $this->buildRelationId( $relation ),
-					targetId: new SubjectId( $relation['target'] ),
+					targetId: new SubjectId( $relation['target'] ?? null ),
 					properties: new RelationProperties( $relation['properties'] ?? [] )
 				);
 			}

--- a/src/Domain/Subject/StatementList.php
+++ b/src/Domain/Subject/StatementList.php
@@ -113,4 +113,22 @@ readonly class StatementList {
 		return $this->statements[$property->text] ?? null;
 	}
 
+	/**
+	 * Replaces the Statement for the property, keeping its position in the list, or appends it
+	 * when the property has none yet.
+	 */
+	public function withStatement( Statement $statement ): self {
+		$statements = $this->statements;
+		$statements[$statement->getPropertyName()->text] = $statement;
+
+		return new self( $statements );
+	}
+
+	public function withoutStatement( PropertyName $property ): self {
+		$statements = $this->statements;
+		unset( $statements[$property->text] );
+
+		return new self( $statements );
+	}
+
 }

--- a/src/Domain/Subject/Subject.php
+++ b/src/Domain/Subject/Subject.php
@@ -78,4 +78,13 @@ class Subject {
 		$this->statements = $statements;
 	}
 
+	public function withStatements( StatementList $statements ): self {
+		return new self(
+			id: $this->id,
+			label: $this->label,
+			schemaName: $this->schemaName,
+			statements: $statements,
+		);
+	}
+
 }

--- a/src/EntryPoints/REST/RemoveStatementApi.php
+++ b/src/EntryPoints/REST/RemoveStatementApi.php
@@ -1,0 +1,94 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\EntryPoints\REST;
+
+use InvalidArgumentException;
+use MediaWiki\Rest\HttpException;
+use MediaWiki\Rest\Response;
+use MediaWiki\Rest\SimpleHandler;
+use ProfessionalWiki\NeoWiki\Application\Subject\Exception\SubjectEditNotAuthorizedException;
+use ProfessionalWiki\NeoWiki\Application\Subject\Exception\SubjectNotFoundException;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyName;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+use ProfessionalWiki\NeoWiki\Presentation\CsrfValidator;
+use ProfessionalWiki\NeoWiki\Presentation\RestUpdateStatementPresenter;
+use Wikimedia\ParamValidator\ParamValidator;
+
+class RemoveStatementApi extends SimpleHandler {
+
+	public function __construct(
+		private readonly CsrfValidator $csrfValidator
+	) {
+	}
+
+	/**
+	 * @throws HttpException
+	 */
+	public function run( string $subjectId, string $propertyName ): Response {
+		$this->csrfValidator->verifyCsrfToken();
+
+		// getValidatedBody() returns null when the request has no body.
+		$body = $this->getValidatedBody() ?? [];
+
+		$presenter = new RestUpdateStatementPresenter();
+
+		try {
+			NeoWikiExtension::getInstance()->newUpdateStatementAction( $presenter, $this->getAuthority() )->removeStatement(
+				new SubjectId( $subjectId ),
+				new PropertyName( $propertyName ),
+				$body['comment'] ?? null
+			);
+		} catch ( InvalidArgumentException $e ) {
+			return $this->getResponseFactory()->createHttpError( 400, [
+				'status' => 'error',
+				'message' => $e->getMessage(),
+			] );
+		} catch ( SubjectNotFoundException $e ) {
+			return $this->getResponseFactory()->createHttpError( 404, [
+				'status' => 'error',
+				'message' => $e->getMessage(),
+			] );
+		} catch ( SubjectEditNotAuthorizedException $e ) {
+			return $this->getResponseFactory()->createHttpError( 403, [
+				'status' => 'error',
+				'message' => $e->getMessage(),
+			] );
+		}
+
+		$response = $this->getResponseFactory()->createJson( $presenter->getJsonArray() );
+		$response->setStatus( $presenter->getStatusCode() );
+		return $response;
+	}
+
+	public function getParamSettings(): array {
+		return [
+			'subjectId' => [
+				self::PARAM_SOURCE => 'path',
+				ParamValidator::PARAM_TYPE => 'string',
+				ParamValidator::PARAM_REQUIRED => true,
+				self::PARAM_DESCRIPTION => 'Persistent identifier of the Subject. 15 characters, starting with "s".',
+			],
+			'propertyName' => [
+				self::PARAM_SOURCE => 'path',
+				ParamValidator::PARAM_TYPE => 'string',
+				ParamValidator::PARAM_REQUIRED => true,
+				self::PARAM_DESCRIPTION => 'Name of the property whose Statement is removed, URL-encoded.',
+			],
+		];
+	}
+
+	public function getBodyParamSettings(): array {
+		return [
+			'comment' => [
+				self::PARAM_SOURCE => 'body',
+				ParamValidator::PARAM_TYPE => 'string',
+				ParamValidator::PARAM_REQUIRED => false,
+				self::PARAM_DESCRIPTION => 'Optional edit summary.',
+			],
+		];
+	}
+
+}

--- a/src/EntryPoints/REST/SetStatementApi.php
+++ b/src/EntryPoints/REST/SetStatementApi.php
@@ -1,0 +1,102 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\EntryPoints\REST;
+
+use InvalidArgumentException;
+use MediaWiki\Rest\HttpException;
+use MediaWiki\Rest\Response;
+use MediaWiki\Rest\SimpleHandler;
+use ProfessionalWiki\NeoWiki\Application\Subject\Exception\SubjectEditNotAuthorizedException;
+use ProfessionalWiki\NeoWiki\Application\Subject\Exception\SubjectNotFoundException;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyName;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+use ProfessionalWiki\NeoWiki\Presentation\CsrfValidator;
+use ProfessionalWiki\NeoWiki\Presentation\RestUpdateStatementPresenter;
+use Wikimedia\ParamValidator\ParamValidator;
+
+class SetStatementApi extends SimpleHandler {
+
+	public function __construct(
+		private readonly CsrfValidator $csrfValidator
+	) {
+	}
+
+	/**
+	 * @throws HttpException
+	 */
+	public function run( string $subjectId, string $propertyName ): Response {
+		$this->csrfValidator->verifyCsrfToken();
+
+		$body = $this->getValidatedBody();
+		$statement = $body['statement'];
+
+		$presenter = new RestUpdateStatementPresenter();
+
+		try {
+			NeoWikiExtension::getInstance()->newUpdateStatementAction( $presenter, $this->getAuthority() )->setStatement(
+				new SubjectId( $subjectId ),
+				new PropertyName( $propertyName ),
+				$statement['propertyType'] ?? null,
+				$statement['value'] ?? null,
+				$body['comment'] ?? null
+			);
+		} catch ( InvalidArgumentException $e ) {
+			return $this->getResponseFactory()->createHttpError( 400, [
+				'status' => 'error',
+				'message' => $e->getMessage(),
+			] );
+		} catch ( SubjectNotFoundException $e ) {
+			return $this->getResponseFactory()->createHttpError( 404, [
+				'status' => 'error',
+				'message' => $e->getMessage(),
+			] );
+		} catch ( SubjectEditNotAuthorizedException $e ) {
+			return $this->getResponseFactory()->createHttpError( 403, [
+				'status' => 'error',
+				'message' => $e->getMessage(),
+			] );
+		}
+
+		$response = $this->getResponseFactory()->createJson( $presenter->getJsonArray() );
+		$response->setStatus( $presenter->getStatusCode() );
+		return $response;
+	}
+
+	public function getParamSettings(): array {
+		return [
+			'subjectId' => [
+				self::PARAM_SOURCE => 'path',
+				ParamValidator::PARAM_TYPE => 'string',
+				ParamValidator::PARAM_REQUIRED => true,
+				self::PARAM_DESCRIPTION => 'Persistent identifier of the Subject. 15 characters, starting with "s".',
+			],
+			'propertyName' => [
+				self::PARAM_SOURCE => 'path',
+				ParamValidator::PARAM_TYPE => 'string',
+				ParamValidator::PARAM_REQUIRED => true,
+				self::PARAM_DESCRIPTION => 'Name of the property the Statement belongs to, URL-encoded.',
+			],
+		];
+	}
+
+	public function getBodyParamSettings(): array {
+		return [
+			'statement' => [
+				self::PARAM_SOURCE => 'body',
+				ParamValidator::PARAM_TYPE => 'array',
+				ParamValidator::PARAM_REQUIRED => true,
+				self::PARAM_DESCRIPTION => 'The Statement to store, as `{"propertyType": ..., "value": ...}`. `propertyType` defaults to the type the Subject\'s Schema gives the property. A value that is empty for its type removes the Statement. Shape documented at https://neowiki.ai/docs/api/subject-format.',
+			],
+			'comment' => [
+				self::PARAM_SOURCE => 'body',
+				ParamValidator::PARAM_TYPE => 'string',
+				ParamValidator::PARAM_REQUIRED => false,
+				self::PARAM_DESCRIPTION => 'Optional edit summary.',
+			],
+		];
+	}
+
+}

--- a/src/EntryPoints/REST/SetStatementApi.php
+++ b/src/EntryPoints/REST/SetStatementApi.php
@@ -33,6 +33,16 @@ class SetStatementApi extends SimpleHandler {
 		$body = $this->getValidatedBody();
 		$statement = $body['statement'];
 
+		// The body validator types `statement` but nothing inside it, so the value has to be
+		// required here. Without this, an absent value reads as an empty one and removes the
+		// Statement, so a client that drops the key is told its write succeeded.
+		if ( !array_key_exists( 'value', $statement ) ) {
+			return $this->getResponseFactory()->createHttpError( 400, [
+				'status' => 'error',
+				'message' => 'The "statement" parameter must have a "value".',
+			] );
+		}
+
 		$presenter = new RestUpdateStatementPresenter();
 
 		try {

--- a/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectUpdater.php
+++ b/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectUpdater.php
@@ -112,14 +112,16 @@ class Neo4jSubjectUpdater {
 	 * @return array<string, mixed>
 	 */
 	private function nodeProperties( Subject $subject ): array {
-		return array_merge(
-			$this->statementsToNodeProperties( $subject->getStatements() ),
-			[
-				'name' => $subject->label->text,
-				'id' => $subject->id->text,
-				'wiki_id' => $this->wikiId,
-			]
-		);
+		$properties = $this->statementsToNodeProperties( $subject->getStatements() );
+
+		// Assigned rather than array_merge()d: a property named like a decimal integer is an int
+		// key by then, and array_merge() renumbers those, which would file its value under a
+		// different property name.
+		$properties['name'] = $subject->label->text;
+		$properties['id'] = $subject->id->text;
+		$properties['wiki_id'] = $this->wikiId;
+
+		return $properties;
 	}
 
 	/**

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -28,6 +28,8 @@ use ProfessionalWiki\NeoWiki\Application\Actions\SetSubjectsOrdering\SetSubjects
 use ProfessionalWiki\NeoWiki\Application\Actions\SetSubjectsOrdering\SetSubjectsOrderingPresenter;
 use ProfessionalWiki\NeoWiki\Application\Actions\ReplaceSubject\ReplaceSubjectAction;
 use ProfessionalWiki\NeoWiki\Application\Actions\ReplaceSubject\ReplaceSubjectPresenter;
+use ProfessionalWiki\NeoWiki\Application\Actions\UpdateStatement\UpdateStatementAction;
+use ProfessionalWiki\NeoWiki\Application\Actions\UpdateStatement\UpdateStatementPresenter;
 use ProfessionalWiki\NeoWiki\Application\StatementListBuilder;
 use ProfessionalWiki\NeoWiki\Application\Validation\ProposedSubjectValidator;
 use ProfessionalWiki\NeoWiki\Application\Validation\SubjectValidator;
@@ -109,8 +111,10 @@ use ProfessionalWiki\NeoWiki\EntryPoints\REST\GetSubjectLabelsApi;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\MintSubjectIdsApi;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\REST\CypherQueryApi;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\REST\Neo4jRouteRegistration;
+use ProfessionalWiki\NeoWiki\EntryPoints\REST\RemoveStatementApi;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\ReplaceSubjectApi;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\SetMainSubjectApi;
+use ProfessionalWiki\NeoWiki\EntryPoints\REST\SetStatementApi;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\StartGraphStoreRebuildApi;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\SetSubjectsOrderingApi;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\ValidateSubjectApi;
@@ -1374,6 +1378,20 @@ class NeoWikiExtension {
 		);
 	}
 
+	public function newUpdateStatementAction( UpdateStatementPresenter $presenter, Authority $authority ): UpdateStatementAction {
+		return new UpdateStatementAction(
+			subjectRepository: $this->getSubjectRepository(),
+			writeAuthorizer: $this->newSubjectWriteAuthorizer( $authority ),
+			statementListBuilder: $this->getStatementListBuilder(),
+			schemaLookup: $this->getSchemaLookup(),
+			selectStatementResolver: $this->getSelectStatementResolver(),
+			proposedSubjectValidator: $this->getProposedSubjectValidator(),
+			presenter: $presenter,
+			validationEnforced: $this->isValidationEnforced(),
+			pageIdentifiersLookup: $this->getPageIdentifiersLookup(),
+		);
+	}
+
 	private function isValidationEnforced(): bool {
 		// Behavioral config is read live from MainConfig (like Neo4jQueryLimits), so the admin's
 		// LocalSettings value applies per request and tests can override it via overrideConfigValue()
@@ -1460,6 +1478,14 @@ class NeoWikiExtension {
 
 	public static function newDeleteSubjectApi(): DeleteSubjectApi {
 		return new DeleteSubjectApi( csrfValidator: self::getCsrfValidator() );
+	}
+
+	public static function newSetStatementApi(): SetStatementApi {
+		return new SetStatementApi( csrfValidator: self::getCsrfValidator() );
+	}
+
+	public static function newRemoveStatementApi(): RemoveStatementApi {
+		return new RemoveStatementApi( csrfValidator: self::getCsrfValidator() );
 	}
 
 	public static function newSetMainSubjectApi(): SetMainSubjectApi {

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -1381,6 +1381,7 @@ class NeoWikiExtension {
 	public function newUpdateStatementAction( UpdateStatementPresenter $presenter, Authority $authority ): UpdateStatementAction {
 		return new UpdateStatementAction(
 			subjectRepository: $this->getSubjectRepository(),
+			readAuthorizer: $this->newPageReadAuthorizer( $authority ),
 			writeAuthorizer: $this->newSubjectWriteAuthorizer( $authority ),
 			statementListBuilder: $this->getStatementListBuilder(),
 			schemaLookup: $this->getSchemaLookup(),

--- a/src/Persistence/MediaWiki/Subject/SubjectContentDataDeserializer.php
+++ b/src/Persistence/MediaWiki/Subject/SubjectContentDataDeserializer.php
@@ -67,7 +67,8 @@ class SubjectContentDataDeserializer {
 
 		foreach ( $jsonArray['statements'] ?? [] as $propertyName => $value ) {
 			if ( $value !== null ) {
-				$statements[] = $this->statementDeserializer->deserialize( $propertyName, $value );
+				// A property named like a decimal integer comes back from json_decode as an int key.
+				$statements[] = $this->statementDeserializer->deserialize( (string)$propertyName, $value );
 			}
 		}
 

--- a/src/Presentation/RestUpdateStatementPresenter.php
+++ b/src/Presentation/RestUpdateStatementPresenter.php
@@ -1,0 +1,47 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Presentation;
+
+use ProfessionalWiki\NeoWiki\Application\Actions\UpdateStatement\UpdateStatementPresenter;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
+
+class RestUpdateStatementPresenter implements UpdateStatementPresenter {
+
+	private array $apiResponse = [];
+	private int $statusCode = 200;
+
+	public function getJsonArray(): array {
+		return $this->apiResponse;
+	}
+
+	public function getStatusCode(): int {
+		return $this->statusCode;
+	}
+
+	/**
+	 * @param Violation[] $violations
+	 */
+	public function presentUpdated( string $subjectId, array $violations ): void {
+		$this->apiResponse = [
+			'status' => 'updated',
+			'subjectId' => $subjectId,
+			'violations' => ViolationSerializer::serializeMany( $violations ),
+		];
+		$this->statusCode = 200;
+	}
+
+	/**
+	 * @param Violation[] $violations
+	 */
+	public function presentValidationFailed( array $violations ): void {
+		$this->apiResponse = [
+			'status' => 'error',
+			'message' => 'Validation failed',
+			'violations' => ViolationSerializer::serializeMany( $violations ),
+		];
+		$this->statusCode = 422;
+	}
+
+}

--- a/src/Presentation/RestUpdateStatementPresenter.php
+++ b/src/Presentation/RestUpdateStatementPresenter.php
@@ -5,12 +5,21 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Presentation;
 
 use ProfessionalWiki\NeoWiki\Application\Actions\UpdateStatement\UpdateStatementPresenter;
+use ProfessionalWiki\NeoWiki\Application\Queries\GetSubject\GetSubjectResponseItem;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
 
 class RestUpdateStatementPresenter implements UpdateStatementPresenter {
 
 	private array $apiResponse = [];
 	private int $statusCode = 200;
+	private readonly SubjectPresentationSerializer $subjectSerializer;
+	private readonly SchemaPresentationSerializer $schemaSerializer;
+
+	public function __construct() {
+		$this->subjectSerializer = new SubjectPresentationSerializer();
+		$this->schemaSerializer = new SchemaPresentationSerializer();
+	}
 
 	public function getJsonArray(): array {
 		return $this->apiResponse;
@@ -23,12 +32,18 @@ class RestUpdateStatementPresenter implements UpdateStatementPresenter {
 	/**
 	 * @param Violation[] $violations
 	 */
-	public function presentUpdated( string $subjectId, array $violations ): void {
+	public function presentUpdated( GetSubjectResponseItem $subject, ?Schema $schema, array $violations ): void {
 		$this->apiResponse = [
 			'status' => 'updated',
-			'subjectId' => $subjectId,
+			'subjectId' => $subject->id,
 			'violations' => ViolationSerializer::serializeMany( $violations ),
+			'subject' => $this->subjectSerializer->serialize( $subject ),
 		];
+
+		if ( $schema !== null ) {
+			$this->apiResponse['schema'] = $this->schemaSerializer->toArray( $schema );
+		}
+
 		$this->statusCode = 200;
 	}
 

--- a/tests/phpunit/Application/Actions/UpdateStatementActionTest.php
+++ b/tests/phpunit/Application/Actions/UpdateStatementActionTest.php
@@ -1,0 +1,457 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Application\Actions;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\Actions\UpdateStatement\UpdateStatementAction;
+use ProfessionalWiki\NeoWiki\Application\SelectStatementResolver;
+use ProfessionalWiki\NeoWiki\Application\SelectValueResolver;
+use ProfessionalWiki\NeoWiki\Application\StatementListBuilder;
+use ProfessionalWiki\NeoWiki\Application\Subject\Exception\SubjectEditNotAuthorizedException;
+use ProfessionalWiki\NeoWiki\Application\Subject\Exception\SubjectNotFoundException;
+use ProfessionalWiki\NeoWiki\Application\SubjectWriteAuthorizer;
+use ProfessionalWiki\NeoWiki\Application\Validation\ProposedSubjectValidator;
+use ProfessionalWiki\NeoWiki\Application\Validation\SubjectValidator;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageIdentifiers;
+use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeRegistry;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Property\SelectOption;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Property\SelectProperty;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinitions;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyName;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
+use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestProperty;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestStatement;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemoryPageIdentifiersLookup;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySchemaLookup;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectLookup;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectRepository;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpySubjectWriteAuthorizer;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubIdGenerator;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Application\Actions\UpdateStatement\UpdateStatementAction
+ */
+class UpdateStatementActionTest extends TestCase {
+
+	private const string SUBJECT_ID = 's11111111111127';
+	private const string SCHEMA_NAME = 'TestSchema';
+
+	private InMemorySubjectRepository $subjectRepository;
+	private InMemorySchemaLookup $schemaLookup;
+	private UpdateStatementPresenterSpy $presenterSpy;
+
+	public function setUp(): void {
+		$this->subjectRepository = new InMemorySubjectRepository();
+		$this->schemaLookup = new InMemorySchemaLookup();
+		$this->presenterSpy = new UpdateStatementPresenterSpy();
+	}
+
+	private function newAction(
+		?SubjectWriteAuthorizer $authorizer = null,
+		bool $validationEnforced = false,
+	): UpdateStatementAction {
+		$registry = PropertyTypeRegistry::withCoreTypes();
+
+		return new UpdateStatementAction(
+			subjectRepository: $this->subjectRepository,
+			writeAuthorizer: $authorizer ?? new SpySubjectWriteAuthorizer( allowed: true ),
+			statementListBuilder: new StatementListBuilder(
+				propertyTypeLookup: $registry,
+				idGenerator: new StubIdGenerator( '11111111111127' )
+			),
+			schemaLookup: $this->schemaLookup,
+			selectStatementResolver: new SelectStatementResolver( new SelectValueResolver() ),
+			proposedSubjectValidator: new ProposedSubjectValidator(
+				schemaLookup: $this->schemaLookup,
+				subjectValidator: new SubjectValidator(
+					propertyTypeLookup: $registry,
+					subjectLookup: new InMemorySubjectLookup(),
+				),
+			),
+			presenter: $this->presenterSpy,
+			validationEnforced: $validationEnforced,
+			pageIdentifiersLookup: new InMemoryPageIdentifiersLookup( [
+				[ new SubjectId( self::SUBJECT_ID ), new PageIdentifiers( new PageId( 7 ), 'Test page', 0 ) ]
+			] ),
+		);
+	}
+
+	private function registerSchema( PropertyDefinitions $properties ): void {
+		$this->schemaLookup->updateSchema( new Schema(
+			name: new SchemaName( self::SCHEMA_NAME ),
+			description: '',
+			properties: $properties
+		) );
+	}
+
+	private function storeSubject( ?StatementList $statements = null, ?SchemaName $schemaName = null ): void {
+		$this->subjectRepository->updateSubject( TestSubject::build(
+			id: new SubjectId( self::SUBJECT_ID ),
+			label: new SubjectLabel( 'Original Label' ),
+			schemaName: $schemaName ?? new SchemaName( self::SCHEMA_NAME ),
+			statements: $statements,
+		) );
+	}
+
+	private function getStoredSubject(): Subject {
+		return $this->subjectRepository->getSubject( new SubjectId( self::SUBJECT_ID ) );
+	}
+
+	/**
+	 * @return array<int, mixed>
+	 */
+	private function getStoredValue( string $propertyName ): array {
+		return (array)$this->getStoredSubject()
+			->getStatements()
+			->getStatement( new PropertyName( $propertyName ) )
+			?->getValue()
+			->toScalars();
+	}
+
+	private function setStatement(
+		string $propertyName,
+		?string $propertyType,
+		mixed $value,
+		?string $comment = null
+	): void {
+		$this->newAction()->setStatement(
+			new SubjectId( self::SUBJECT_ID ),
+			new PropertyName( $propertyName ),
+			$propertyType,
+			$value,
+			$comment
+		);
+	}
+
+	public function testSetStatementStoresTheValue(): void {
+		$this->storeSubject();
+
+		$this->setStatement( 'Website', 'url', [ 'https://pro.wiki' ] );
+
+		$this->assertSame( [ 'https://pro.wiki' ], $this->getStoredValue( 'Website' ) );
+	}
+
+	public function testSetStatementReplacesTheValueOfAnExistingStatement(): void {
+		$this->storeSubject( new StatementList( [
+			TestStatement::build( property: 'Website', value: 'https://old.example', propertyType: 'url' ),
+		] ) );
+
+		$this->setStatement( 'Website', 'url', [ 'https://new.example' ] );
+
+		$this->assertSame( [ 'https://new.example' ], $this->getStoredValue( 'Website' ) );
+	}
+
+	public function testSetStatementLeavesTheOtherStatementsAlone(): void {
+		$this->storeSubject( new StatementList( [
+			TestStatement::build( property: 'Before', value: 'kept before' ),
+			TestStatement::build( property: 'Target', value: 'replaced' ),
+			TestStatement::build( property: 'After', value: 'kept after' ),
+		] ) );
+
+		$this->setStatement( 'Target', 'text', [ 'new' ] );
+
+		$this->assertSame( [ 'kept before' ], $this->getStoredValue( 'Before' ) );
+		$this->assertSame( [ 'kept after' ], $this->getStoredValue( 'After' ) );
+	}
+
+	public function testSetStatementLeavesTheLabelAlone(): void {
+		$this->storeSubject();
+
+		$this->setStatement( 'Website', 'url', [ 'https://pro.wiki' ] );
+
+		$this->assertSame( 'Original Label', $this->getStoredSubject()->getLabel()->text );
+	}
+
+	public function testPropertyTypeFallsBackToTheSchemaType(): void {
+		$this->registerSchema( new PropertyDefinitions( [ 'Website' => TestProperty::buildUrl() ] ) );
+		$this->storeSubject();
+
+		$this->setStatement( 'Website', null, [ 'https://pro.wiki' ] );
+
+		$this->assertSame(
+			'url',
+			$this->getStoredSubject()->getStatements()->getStatement( new PropertyName( 'Website' ) )->getPropertyType()
+		);
+	}
+
+	public function testGivenPropertyTypeWinsOverTheSchemaType(): void {
+		$this->registerSchema( new PropertyDefinitions( [ 'Website' => TestProperty::buildUrl() ] ) );
+		$this->storeSubject();
+
+		$this->setStatement( 'Website', 'text', [ 'not a url' ] );
+
+		$this->assertSame(
+			'text',
+			$this->getStoredSubject()->getStatements()->getStatement( new PropertyName( 'Website' ) )->getPropertyType()
+		);
+	}
+
+	public function testOmittedPropertyTypeThrowsWhenTheSchemaDoesNotDefineTheProperty(): void {
+		$this->registerSchema( new PropertyDefinitions( [ 'Website' => TestProperty::buildUrl() ] ) );
+		$this->storeSubject();
+
+		$action = $this->newAction();
+
+		$this->expectException( InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'Unlisted' );
+
+		$action->setStatement(
+			new SubjectId( self::SUBJECT_ID ),
+			new PropertyName( 'Unlisted' ),
+			null,
+			[ 'a value' ],
+			null
+		);
+	}
+
+	public function testSetStatementWithEmptyValueRemovesTheStatement(): void {
+		$this->storeSubject( new StatementList( [
+			TestStatement::build( property: 'Website', value: 'https://pro.wiki', propertyType: 'url' ),
+		] ) );
+
+		$this->setStatement( 'Website', 'url', [] );
+
+		$this->assertNull(
+			$this->getStoredSubject()->getStatements()->getStatement( new PropertyName( 'Website' ) )
+		);
+	}
+
+	public function testSelectValueIsResolvedToItsOptionId(): void {
+		$this->registerSchema( new PropertyDefinitions( [
+			'Status' => new SelectProperty(
+				core: new PropertyCore( description: '', required: false, default: null ),
+				options: [
+					new SelectOption( id: 'opt_draft', label: 'Draft' ),
+					new SelectOption( id: 'opt_approved', label: 'Approved' ),
+				],
+				multiple: false,
+			),
+		] ) );
+		$this->storeSubject();
+
+		$this->setStatement( 'Status', 'select', 'Approved' );
+
+		$this->assertSame( [ 'opt_approved' ], $this->getStoredValue( 'Status' ) );
+	}
+
+	public function testUnresolvableSelectValueThrows(): void {
+		$this->registerSchema( new PropertyDefinitions( [
+			'Status' => new SelectProperty(
+				core: new PropertyCore( description: '', required: false, default: null ),
+				options: [ new SelectOption( id: 'opt_draft', label: 'Draft' ) ],
+				multiple: false,
+			),
+		] ) );
+		$this->storeSubject();
+
+		$action = $this->newAction();
+
+		$this->expectException( InvalidArgumentException::class );
+
+		$action->setStatement(
+			new SubjectId( self::SUBJECT_ID ),
+			new PropertyName( 'Status' ),
+			'select',
+			'No such option',
+			null
+		);
+	}
+
+	public function testCommentIsForwarded(): void {
+		$this->storeSubject();
+
+		$this->setStatement( 'Website', 'url', [ 'https://pro.wiki' ], 'My edit summary' );
+
+		$this->assertSame( 'My edit summary', $this->subjectRepository->comments[self::SUBJECT_ID] );
+	}
+
+	public function testSetStatementAuthorizesAgainstTheSubjectsResolvedPage(): void {
+		$spy = new SpySubjectWriteAuthorizer( allowed: true );
+		$this->storeSubject();
+
+		$this->newAction( $spy )->setStatement(
+			new SubjectId( self::SUBJECT_ID ),
+			new PropertyName( 'Website' ),
+			'url',
+			[ 'https://pro.wiki' ],
+			null
+		);
+
+		$this->assertEquals( new PageId( 7 ), $spy->authorizedPageId );
+	}
+
+	public function testUnauthorizedSetThrows(): void {
+		$this->storeSubject();
+
+		$action = $this->newAction( new SpySubjectWriteAuthorizer( allowed: false ) );
+
+		$this->expectException( SubjectEditNotAuthorizedException::class );
+
+		$action->setStatement(
+			new SubjectId( self::SUBJECT_ID ),
+			new PropertyName( 'Website' ),
+			'url',
+			[ 'https://pro.wiki' ],
+			null
+		);
+	}
+
+	public function testSetOnNonExistentSubjectThrows(): void {
+		$action = $this->newAction();
+
+		$this->expectException( SubjectNotFoundException::class );
+
+		$action->setStatement(
+			new SubjectId( self::SUBJECT_ID ),
+			new PropertyName( 'Website' ),
+			'url',
+			[ 'https://pro.wiki' ],
+			null
+		);
+	}
+
+	public function testRemoveStatementDeletesOnlyTheNamedStatement(): void {
+		$this->storeSubject( new StatementList( [
+			TestStatement::build( property: 'Before' ),
+			TestStatement::build( property: 'Target' ),
+			TestStatement::build( property: 'After' ),
+		] ) );
+
+		$this->newAction()->removeStatement(
+			new SubjectId( self::SUBJECT_ID ),
+			new PropertyName( 'Target' ),
+			null
+		);
+
+		$this->assertSame(
+			[ 'Before', 'After' ],
+			array_keys( $this->getStoredSubject()->getStatements()->asArray() )
+		);
+	}
+
+	public function testRemoveStatementOfAbsentPropertyLeavesTheStatementsUnchanged(): void {
+		$this->storeSubject( new StatementList( [ TestStatement::build( property: 'Kept' ) ] ) );
+
+		$this->newAction()->removeStatement(
+			new SubjectId( self::SUBJECT_ID ),
+			new PropertyName( 'Absent' ),
+			null
+		);
+
+		$this->assertSame( [ 'Kept' ], array_keys( $this->getStoredSubject()->getStatements()->asArray() ) );
+	}
+
+	public function testUnauthorizedRemoveThrows(): void {
+		$this->storeSubject();
+
+		$action = $this->newAction( new SpySubjectWriteAuthorizer( allowed: false ) );
+
+		$this->expectException( SubjectEditNotAuthorizedException::class );
+
+		$action->removeStatement( new SubjectId( self::SUBJECT_ID ), new PropertyName( 'Website' ), null );
+	}
+
+	public function testRemoveOnNonExistentSubjectThrows(): void {
+		$action = $this->newAction();
+
+		$this->expectException( SubjectNotFoundException::class );
+
+		$action->removeStatement( new SubjectId( self::SUBJECT_ID ), new PropertyName( 'Website' ), null );
+	}
+
+	public function testViolationsOfUntouchedPropertiesArePresented(): void {
+		$this->registerSchema( new PropertyDefinitions( [
+			'Website' => TestProperty::buildUrl(),
+			'Required' => TestProperty::buildText( required: true ),
+		] ) );
+		$this->storeSubject();
+
+		$this->setStatement( 'Website', 'url', [ 'https://pro.wiki' ] );
+
+		$this->assertCount( 1, $this->presenterSpy->violations );
+		$this->assertSame( 'required', $this->presenterSpy->violations[0]->code );
+		$this->assertSame( self::SUBJECT_ID, $this->presenterSpy->subjectId );
+	}
+
+	public function testEnforcementOnRejectsAStatementThatIntroducesAViolation(): void {
+		$this->registerSchema( new PropertyDefinitions( [ 'Website' => TestProperty::buildUrl() ] ) );
+		$this->storeSubject( new StatementList( [
+			TestStatement::build( property: 'Website', value: 'https://pro.wiki', propertyType: 'url' ),
+		] ) );
+
+		$this->newAction( validationEnforced: true )->setStatement(
+			new SubjectId( self::SUBJECT_ID ),
+			new PropertyName( 'Website' ),
+			'url',
+			[ 'not-a-url' ],
+			null
+		);
+
+		$this->assertTrue( $this->presenterSpy->validationFailed );
+		$this->assertSame( [ 'https://pro.wiki' ], $this->getStoredValue( 'Website' ) );
+	}
+
+	public function testEnforcementOnRejectsRemovalOfARequiredStatement(): void {
+		$this->registerSchema( new PropertyDefinitions( [ 'Required' => TestProperty::buildText( required: true ) ] ) );
+		$this->storeSubject( new StatementList( [
+			TestStatement::build( property: 'Required', value: 'present' ),
+		] ) );
+
+		$this->newAction( validationEnforced: true )->removeStatement(
+			new SubjectId( self::SUBJECT_ID ),
+			new PropertyName( 'Required' ),
+			null
+		);
+
+		$this->assertTrue( $this->presenterSpy->validationFailed );
+		$this->assertSame( [ 'present' ], $this->getStoredValue( 'Required' ) );
+	}
+
+	public function testEnforcementOnAllowsAnEditThatOnlyKeepsPreExistingViolations(): void {
+		$this->registerSchema( new PropertyDefinitions( [
+			'Website' => TestProperty::buildUrl(),
+			'Required' => TestProperty::buildText( required: true ),
+		] ) );
+		$this->storeSubject();
+
+		$this->newAction( validationEnforced: true )->setStatement(
+			new SubjectId( self::SUBJECT_ID ),
+			new PropertyName( 'Website' ),
+			'url',
+			[ 'https://pro.wiki' ],
+			null
+		);
+
+		$this->assertFalse( $this->presenterSpy->validationFailed );
+		$this->assertSame( [ 'https://pro.wiki' ], $this->getStoredValue( 'Website' ) );
+	}
+
+	public function testMissingSchemaIsReportedAsANonBlockingViolation(): void {
+		$this->storeSubject( schemaName: new SchemaName( 'NonexistentSchema' ) );
+
+		$this->newAction( validationEnforced: true )->setStatement(
+			new SubjectId( self::SUBJECT_ID ),
+			new PropertyName( 'Website' ),
+			'url',
+			[ 'https://pro.wiki' ],
+			null
+		);
+
+		$this->assertFalse( $this->presenterSpy->validationFailed );
+		$this->assertCount( 1, $this->presenterSpy->violations );
+		$this->assertSame( 'schema-not-found', $this->presenterSpy->violations[0]->code );
+		$this->assertSame( [ 'https://pro.wiki' ], $this->getStoredValue( 'Website' ) );
+	}
+
+}

--- a/tests/phpunit/Application/Actions/UpdateStatementActionTest.php
+++ b/tests/phpunit/Application/Actions/UpdateStatementActionTest.php
@@ -7,6 +7,7 @@ namespace ProfessionalWiki\NeoWiki\Tests\Application\Actions;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Application\Actions\UpdateStatement\UpdateStatementAction;
+use ProfessionalWiki\NeoWiki\Application\PageReadAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\SelectStatementResolver;
 use ProfessionalWiki\NeoWiki\Application\SelectValueResolver;
 use ProfessionalWiki\NeoWiki\Application\StatementListBuilder;
@@ -20,12 +21,14 @@ use ProfessionalWiki\NeoWiki\Domain\Page\PageIdentifiers;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeRegistry;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\SelectOption;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Property\SelectProperty;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Property\TextProperty;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinitions;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyName;
 use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
@@ -37,6 +40,7 @@ use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySchemaLookup;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectLookup;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectRepository;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpySubjectWriteAuthorizer;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubPageReadAuthorizer;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubIdGenerator;
 
 /**
@@ -60,11 +64,13 @@ class UpdateStatementActionTest extends TestCase {
 	private function newAction(
 		?SubjectWriteAuthorizer $authorizer = null,
 		bool $validationEnforced = false,
+		?PageReadAuthorizer $readAuthorizer = null,
 	): UpdateStatementAction {
 		$registry = PropertyTypeRegistry::withCoreTypes();
 
 		return new UpdateStatementAction(
 			subjectRepository: $this->subjectRepository,
+			readAuthorizer: $readAuthorizer ?? new StubPageReadAuthorizer( allowed: true ),
 			writeAuthorizer: $authorizer ?? new SpySubjectWriteAuthorizer( allowed: true ),
 			statementListBuilder: new StatementListBuilder(
 				propertyTypeLookup: $registry,
@@ -81,9 +87,33 @@ class UpdateStatementActionTest extends TestCase {
 			),
 			presenter: $this->presenterSpy,
 			validationEnforced: $validationEnforced,
+			// The Subject under test sits on a namespaced page between two others, so neither a
+			// hardcoded main-namespace id nor an implementation answering with some other seeded
+			// page passes.
 			pageIdentifiersLookup: new InMemoryPageIdentifiersLookup( [
-				[ new SubjectId( self::SUBJECT_ID ), new PageIdentifiers( new PageId( 7 ), 'Test page', 0 ) ]
+				[ new SubjectId( 's11111111111126' ), new PageIdentifiers( new PageId( 6 ), 'Earlier page', 0 ) ],
+				[ new SubjectId( self::SUBJECT_ID ), new PageIdentifiers( new PageId( 7 ), 'Help:Test page', 12 ) ],
+				[ new SubjectId( 's11111111111128' ), new PageIdentifiers( new PageId( 8 ), 'Talk:Later page', 1 ) ],
 			] ),
+		);
+	}
+
+	/**
+	 * `required` at Error severity, so that missing it blocks a write under enforcement. The
+	 * shorthand form TestProperty builds defaults to Warning, which never blocks (ADR 26).
+	 */
+	private function newRequiredTextProperty(): TextProperty {
+		return new TextProperty(
+			core: new PropertyCore(
+				description: '',
+				required: true,
+				default: null,
+				constraintSeverities: [ 'required' => Severity::Error ],
+			),
+			multiple: false,
+			uniqueItems: false,
+			minLength: null,
+			maxLength: null,
 		);
 	}
 
@@ -321,6 +351,97 @@ class UpdateStatementActionTest extends TestCase {
 		);
 	}
 
+	public function testUnreadablePageAnswersNotFound(): void {
+		// The caller may edit the page but may not read it. Answering anything other than not-found
+		// would confirm the Subject exists, and hand out the page title and namespace with it.
+		$this->storeSubject();
+
+		$action = $this->newAction( readAuthorizer: new StubPageReadAuthorizer( allowed: false ) );
+
+		$this->expectException( SubjectNotFoundException::class );
+		$this->expectExceptionMessage( 'Subject not found: ' . self::SUBJECT_ID );
+
+		$action->setStatement(
+			new SubjectId( self::SUBJECT_ID ),
+			new PropertyName( 'Website' ),
+			'url',
+			[ 'https://pro.wiki' ],
+			null
+		);
+	}
+
+	public function testUnreadablePageIsRejectedBeforeTheWrite(): void {
+		$this->storeSubject( new StatementList( [
+			TestStatement::build( property: 'Website', value: 'https://pro.wiki', propertyType: 'url' ),
+		] ) );
+
+		try {
+			$this->newAction( readAuthorizer: new StubPageReadAuthorizer( allowed: false ) )->setStatement(
+				new SubjectId( self::SUBJECT_ID ),
+				new PropertyName( 'Website' ),
+				'url',
+				[ 'https://overwritten.example' ],
+				null
+			);
+		} catch ( SubjectNotFoundException ) {
+		}
+
+		$this->assertSame( [ 'https://pro.wiki' ], $this->getStoredValue( 'Website' ) );
+	}
+
+	public function testRemoveOnAnUnreadablePageAnswersNotFound(): void {
+		$this->storeSubject();
+
+		$action = $this->newAction( readAuthorizer: new StubPageReadAuthorizer( allowed: false ) );
+
+		$this->expectException( SubjectNotFoundException::class );
+
+		$action->removeStatement( new SubjectId( self::SUBJECT_ID ), new PropertyName( 'Website' ), null );
+	}
+
+	public function testPresentedSubjectCarriesThePersistedStatements(): void {
+		$this->storeSubject( new StatementList( [
+			TestStatement::build( property: 'Kept', value: 'kept' ),
+		] ) );
+
+		$this->setStatement( 'Website', 'url', [ 'https://pro.wiki' ] );
+
+		$this->assertSame(
+			[
+				'Kept' => [ 'propertyType' => 'text', 'value' => [ 'kept' ] ],
+				'Website' => [ 'propertyType' => 'url', 'value' => [ 'https://pro.wiki' ] ],
+			],
+			$this->presenterSpy->subject?->statements
+		);
+	}
+
+	public function testPresentedSubjectCarriesThePageItSitsOn(): void {
+		$this->storeSubject();
+
+		$this->setStatement( 'Website', 'url', [ 'https://pro.wiki' ] );
+
+		$this->assertSame( 7, $this->presenterSpy->subject?->pageId );
+		$this->assertSame( 'Help:Test page', $this->presenterSpy->subject?->pageTitle );
+		$this->assertSame( 12, $this->presenterSpy->subject?->pageNamespaceId );
+	}
+
+	public function testPresentedSchemaIsTheOneTheSubjectInstantiates(): void {
+		$this->registerSchema( new PropertyDefinitions( [ 'Website' => TestProperty::buildUrl() ] ) );
+		$this->storeSubject();
+
+		$this->setStatement( 'Website', 'url', [ 'https://pro.wiki' ] );
+
+		$this->assertSame( self::SCHEMA_NAME, $this->presenterSpy->schema?->getName()->getText() );
+	}
+
+	public function testNoSchemaIsPresentedWhenTheSubjectNamesAMissingOne(): void {
+		$this->storeSubject( schemaName: new SchemaName( 'NonexistentSchema' ) );
+
+		$this->setStatement( 'Website', 'url', [ 'https://pro.wiki' ] );
+
+		$this->assertNull( $this->presenterSpy->schema );
+	}
+
 	public function testRemoveStatementDeletesOnlyTheNamedStatement(): void {
 		$this->storeSubject( new StatementList( [
 			TestStatement::build( property: 'Before' ),
@@ -403,7 +524,7 @@ class UpdateStatementActionTest extends TestCase {
 	}
 
 	public function testEnforcementOnRejectsRemovalOfARequiredStatement(): void {
-		$this->registerSchema( new PropertyDefinitions( [ 'Required' => TestProperty::buildText( required: true ) ] ) );
+		$this->registerSchema( new PropertyDefinitions( [ 'Required' => $this->newRequiredTextProperty() ] ) );
 		$this->storeSubject( new StatementList( [
 			TestStatement::build( property: 'Required', value: 'present' ),
 		] ) );
@@ -421,7 +542,7 @@ class UpdateStatementActionTest extends TestCase {
 	public function testEnforcementOnAllowsAnEditThatOnlyKeepsPreExistingViolations(): void {
 		$this->registerSchema( new PropertyDefinitions( [
 			'Website' => TestProperty::buildUrl(),
-			'Required' => TestProperty::buildText( required: true ),
+			'Required' => $this->newRequiredTextProperty(),
 		] ) );
 		$this->storeSubject();
 

--- a/tests/phpunit/Application/Actions/UpdateStatementPresenterSpy.php
+++ b/tests/phpunit/Application/Actions/UpdateStatementPresenterSpy.php
@@ -5,19 +5,27 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Tests\Application\Actions;
 
 use ProfessionalWiki\NeoWiki\Application\Actions\UpdateStatement\UpdateStatementPresenter;
+use ProfessionalWiki\NeoWiki\Application\Queries\GetSubject\GetSubjectResponseItem;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
 
 class UpdateStatementPresenterSpy implements UpdateStatementPresenter {
 
 	public string $subjectId = '';
 
+	public ?GetSubjectResponseItem $subject = null;
+
+	public ?Schema $schema = null;
+
 	/** @var Violation[] */
 	public array $violations = [];
 
 	public bool $validationFailed = false;
 
-	public function presentUpdated( string $subjectId, array $violations ): void {
-		$this->subjectId = $subjectId;
+	public function presentUpdated( GetSubjectResponseItem $subject, ?Schema $schema, array $violations ): void {
+		$this->subjectId = $subject->id;
+		$this->subject = $subject;
+		$this->schema = $schema;
 		$this->violations = $violations;
 	}
 

--- a/tests/phpunit/Application/Actions/UpdateStatementPresenterSpy.php
+++ b/tests/phpunit/Application/Actions/UpdateStatementPresenterSpy.php
@@ -1,0 +1,29 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Application\Actions;
+
+use ProfessionalWiki\NeoWiki\Application\Actions\UpdateStatement\UpdateStatementPresenter;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
+
+class UpdateStatementPresenterSpy implements UpdateStatementPresenter {
+
+	public string $subjectId = '';
+
+	/** @var Violation[] */
+	public array $violations = [];
+
+	public bool $validationFailed = false;
+
+	public function presentUpdated( string $subjectId, array $violations ): void {
+		$this->subjectId = $subjectId;
+		$this->violations = $violations;
+	}
+
+	public function presentValidationFailed( array $violations ): void {
+		$this->validationFailed = true;
+		$this->violations = $violations;
+	}
+
+}

--- a/tests/phpunit/Application/SelectStatementResolverTest.php
+++ b/tests/phpunit/Application/SelectStatementResolverTest.php
@@ -26,11 +26,15 @@ class SelectStatementResolverTest extends TestCase {
 	}
 
 	private function newSchemaWithSelect( bool $multiple = false ): Schema {
+		return $this->newSchemaWithSelectNamed( 'Status', $multiple );
+	}
+
+	private function newSchemaWithSelectNamed( string $propertyName, bool $multiple ): Schema {
 		return new Schema(
 			name: new SchemaName( 'SomeSchema' ),
 			description: '',
 			properties: new PropertyDefinitions( [
-				'Status' => new SelectProperty(
+				$propertyName => new SelectProperty(
 					core: new PropertyCore( description: '', required: false, default: null ),
 					options: [
 						new SelectOption( id: 'opt1', label: 'Draft' ),
@@ -134,6 +138,30 @@ class SelectStatementResolverTest extends TestCase {
 		$resolved = $this->newResolver()->resolve( $this->newSchemaWithSelect(), $patch );
 
 		$this->assertSame( $patch, $resolved );
+	}
+
+	/**
+	 * PHP turns a decimal-integer array key into an int, so a select property named like a year
+	 * reaches the Schema lookups as one.
+	 */
+	public function testResolvesValueOfPropertyNamedLikeAnInteger(): void {
+		$patch = [
+			'2024' => [ 'propertyType' => 'select', 'value' => 'Draft' ],
+		];
+
+		$resolved = $this->newResolver()->resolve( $this->newSchemaWithSelectNamed( '2024', false ), $patch );
+
+		$this->assertSame( 'opt1', $resolved['2024']['value'] );
+	}
+
+	public function testResolveOrLeaveResolvesValueOfPropertyNamedLikeAnInteger(): void {
+		$patch = [
+			'2024' => [ 'propertyType' => 'select', 'value' => 'Draft' ],
+		];
+
+		$resolved = $this->newResolver()->resolveOrLeave( $this->newSchemaWithSelectNamed( '2024', false ), $patch );
+
+		$this->assertSame( 'opt1', $resolved['2024']['value'] );
 	}
 
 	public function testResolveOrLeaveResolvesKnownLabelToId(): void {

--- a/tests/phpunit/Application/StatementListBuilderTest.php
+++ b/tests/phpunit/Application/StatementListBuilderTest.php
@@ -110,6 +110,60 @@ class StatementListBuilderTest extends TestCase {
 		yield 'boolean given a string' => [ 'boolean', 'yes' ];
 		yield 'relation given a scalar' => [ 'relation', 'sTargetIdWanted' ];
 		yield 'relation target missing' => [ 'relation', [ [ 'properties' => [] ] ] ];
+		yield 'relation given a list of bare target ids' => [ 'relation', [ 'sTargetIdWanted' ] ];
+	}
+
+	/**
+	 * @dataProvider nonStringPropertyTypeProvider
+	 */
+	public function testNonStringPropertyTypeIsRejected( mixed $propertyType ): void {
+		$builder = $this->newBuilder();
+
+		$this->expectException( InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'Mistyped' );
+
+		$builder->build( [ 'Mistyped' => [ 'propertyType' => $propertyType, 'value' => 'yes' ] ] );
+	}
+
+	public static function nonStringPropertyTypeProvider(): iterable {
+		yield 'number' => [ 2019 ];
+		yield 'boolean' => [ true ];
+		yield 'array' => [ [ 'text' ] ];
+		yield 'object' => [ [ 'name' => 'text' ] ];
+	}
+
+	/**
+	 * PHP turns a decimal-integer array key into an int, so a property named like a year
+	 * reaches the value objects as one.
+	 */
+	public function testPropertyNameThatLooksLikeAnIntegerIsBuilt(): void {
+		$list = $this->newBuilder()->build( [ '2024' => [ 'propertyType' => 'text', 'value' => 'yes' ] ] );
+
+		$this->assertSame(
+			[ 'yes' ],
+			$list->getStatement( new PropertyName( '2024' ) )?->getValue()->toScalars()
+		);
+	}
+
+	/**
+	 * @dataProvider objectWhereAListIsExpectedProvider
+	 */
+	public function testObjectValueWhereAListIsExpectedIsRejected( string $propertyType, mixed $value ): void {
+		$builder = $this->newBuilder();
+
+		$this->expectException( InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'Objected' );
+
+		$builder->build( [ 'Objected' => [ 'propertyType' => $propertyType, 'value' => $value ] ] );
+	}
+
+	public static function objectWhereAListIsExpectedProvider(): iterable {
+		yield 'text given an object' => [ 'text', [ 'a' => 'yes' ] ];
+		yield 'url given an object' => [ 'url', [ 'a' => 'https://pro.wiki' ] ];
+		yield 'relation given one relation rather than a list' => [
+			'relation',
+			[ 'target' => 'sTargetIdWanted' ],
+		];
 	}
 
 	/**

--- a/tests/phpunit/Application/StatementListBuilderTest.php
+++ b/tests/phpunit/Application/StatementListBuilderTest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Tests\Application;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Application\StatementListBuilder;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeRegistry;
@@ -88,6 +89,27 @@ class StatementListBuilderTest extends TestCase {
 
 		$this->assertNotNull( $list->getStatement( new PropertyName( 'Wanted' ) ) );
 		$this->assertNull( $list->getStatement( new PropertyName( 'Unwanted' ) ) );
+	}
+
+	/**
+	 * @dataProvider valueNotFittingItsTypeProvider
+	 */
+	public function testValueNotFittingItsPropertyTypeIsRejected( string $propertyType, mixed $value ): void {
+		$builder = $this->newBuilder();
+
+		$this->expectException( InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'Mismatched' );
+
+		$builder->build( [ 'Mismatched' => [ 'propertyType' => $propertyType, 'value' => $value ] ] );
+	}
+
+	public static function valueNotFittingItsTypeProvider(): iterable {
+		yield 'text given a number' => [ 'text', 2019 ];
+		yield 'number given a string' => [ 'number', 'not a number' ];
+		yield 'number with no value' => [ 'number', null ];
+		yield 'boolean given a string' => [ 'boolean', 'yes' ];
+		yield 'relation given a scalar' => [ 'relation', 'sTargetIdWanted' ];
+		yield 'relation target missing' => [ 'relation', [ [ 'properties' => [] ] ] ];
 	}
 
 	/**

--- a/tests/phpunit/Domain/Subject/StatementListTest.php
+++ b/tests/phpunit/Domain/Subject/StatementListTest.php
@@ -155,6 +155,74 @@ class StatementListTest extends TestCase {
 		);
 	}
 
+	public function testWithStatementAddsStatementForNewProperty(): void {
+		$list = new StatementList( [ TestStatement::build( property: 'P1' ) ] );
+
+		$added = TestStatement::build( property: 'P2', value: 'added' );
+
+		$this->assertEquals(
+			[ 'P1', 'P2' ],
+			array_keys( $list->withStatement( $added )->asArray() )
+		);
+	}
+
+	public function testWithStatementReplacesStatementInPlace(): void {
+		$list = new StatementList( [
+			TestStatement::build( property: 'P1' ),
+			TestStatement::build( property: 'P2', value: 'old' ),
+			TestStatement::build( property: 'P3' ),
+		] );
+
+		$replaced = $list->withStatement( TestStatement::build( property: 'P2', value: 'new' ) );
+
+		$this->assertSame( [ 'P1', 'P2', 'P3' ], array_keys( $replaced->asArray() ) );
+		$this->assertSame(
+			[ 'new' ],
+			$replaced->getStatement( new PropertyName( 'P2' ) )->getValue()->toScalars()
+		);
+	}
+
+	public function testWithStatementLeavesTheOriginalUntouched(): void {
+		$list = new StatementList( [ TestStatement::build( property: 'P1', value: 'original' ) ] );
+
+		$list->withStatement( TestStatement::build( property: 'P1', value: 'replacement' ) );
+
+		$this->assertSame(
+			[ 'original' ],
+			$list->getStatement( new PropertyName( 'P1' ) )->getValue()->toScalars()
+		);
+	}
+
+	public function testWithoutStatementRemovesOnlyTheNamedProperty(): void {
+		$list = new StatementList( [
+			TestStatement::build( property: 'P1' ),
+			TestStatement::build( property: 'P2' ),
+			TestStatement::build( property: 'P3' ),
+		] );
+
+		$this->assertSame(
+			[ 'P1', 'P3' ],
+			array_keys( $list->withoutStatement( new PropertyName( 'P2' ) )->asArray() )
+		);
+	}
+
+	public function testWithoutStatementKeepsListUnchangedForUnknownProperty(): void {
+		$list = new StatementList( [ TestStatement::build( property: 'P1' ) ] );
+
+		$this->assertEquals(
+			$list,
+			$list->withoutStatement( new PropertyName( 'P2' ) )
+		);
+	}
+
+	public function testWithoutStatementLeavesTheOriginalUntouched(): void {
+		$list = new StatementList( [ TestStatement::build( property: 'P1' ) ] );
+
+		$list->withoutStatement( new PropertyName( 'P1' ) );
+
+		$this->assertNotNull( $list->getStatement( new PropertyName( 'P1' ) ) );
+	}
+
 	public function testConstructorThrowsOnNonStatement(): void {
 		$this->expectException( \InvalidArgumentException::class );
 

--- a/tests/phpunit/Domain/Subject/SubjectTest.php
+++ b/tests/phpunit/Domain/Subject/SubjectTest.php
@@ -47,4 +47,26 @@ class SubjectTest extends TestCase {
 		$this->assertSame( $newStatementList, $subject->getStatements() );
 	}
 
+	public function testWithStatementsKeepsIdLabelAndSchema(): void {
+		$subject = TestSubject::build( new SubjectId( TestSubject::ZERO_GUID ) );
+
+		$copy = $subject->withStatements( new StatementList( [] ) );
+
+		$this->assertSame( $subject->getId(), $copy->getId() );
+		$this->assertSame( $subject->getLabel(), $copy->getLabel() );
+		$this->assertSame( $subject->getSchemaName(), $copy->getSchemaName() );
+	}
+
+	public function testWithStatementsLeavesTheOriginalStatementsInPlace(): void {
+		$originalStatements = new StatementList( [
+			new Statement( new PropertyName( 'Original' ), 'text', new StringValue( 'hello' ) ),
+		] );
+		$subject = TestSubject::build( new SubjectId( TestSubject::ZERO_GUID ), statements: $originalStatements );
+
+		$copy = $subject->withStatements( new StatementList( [] ) );
+
+		$this->assertSame( $originalStatements, $subject->getStatements() );
+		$this->assertSame( [], $copy->getStatements()->asArray() );
+	}
+
 }

--- a/tests/phpunit/EntryPoints/REST/RemoveStatementApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/RemoveStatementApiTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\REST;
+
+use MediaWiki\Rest\RequestData;
+use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
+use MediaWiki\Tests\Unit\Permissions\MockAuthorityTrait;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
+use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
+use ProfessionalWiki\NeoWiki\EntryPoints\REST\RemoveStatementApi;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+use ProfessionalWiki\NeoWiki\Presentation\CsrfValidator;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestStatement;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\REST\RemoveStatementApi
+ * @group Database
+ */
+class RemoveStatementApiTest extends NeoWikiIntegrationTestCase {
+
+	use HandlerTestTrait;
+	use MockAuthorityTrait;
+
+	private const string SUBJECT_ID = 'sTestRS11111111';
+
+	private function createSubjectPage( ?string $schemaJson = null ): void {
+		$this->createSchema(
+			'RemoveStatementSchema',
+			$schemaJson ?? '{"title":"RemoveStatementSchema","propertyDefinitions":{"Website":{"type":"url"}}}'
+		);
+		$this->createPageWithSubjects(
+			'RemoveStatementApiTest',
+			mainSubject: TestSubject::build(
+				id: self::SUBJECT_ID,
+				label: new SubjectLabel( 'Professional Wiki' ),
+				schemaName: new SchemaName( 'RemoveStatementSchema' ),
+				statements: new StatementList( [
+					TestStatement::build( property: 'Website', value: 'https://pro.wiki', propertyType: 'url' ),
+					TestStatement::build( property: 'Founded at', value: 'kept' ),
+				] ),
+			)
+		);
+	}
+
+	private function newRemoveStatementApi(): RemoveStatementApi {
+		$csrfValidatorStub = $this->createStub( CsrfValidator::class );
+		$csrfValidatorStub->method( 'verifyCsrfToken' )->willReturn( true );
+
+		return new RemoveStatementApi( csrfValidator: $csrfValidatorStub );
+	}
+
+	private function newRequest(
+		string $propertyName,
+		array $body = [],
+		string $subjectId = self::SUBJECT_ID
+	): RequestData {
+		return new RequestData( [
+			'method' => 'DELETE',
+			'pathParams' => [
+				'subjectId' => $subjectId,
+				'propertyName' => $propertyName,
+			],
+			'bodyContents' => json_encode( $body ),
+			'headers' => [ 'Content-Type' => 'application/json' ],
+		] );
+	}
+
+	private function getSubjectFromRepository(): Subject {
+		$subject = NeoWikiExtension::getInstance()
+			->newSubjectRepository()
+			->getSubject( new SubjectId( self::SUBJECT_ID ) );
+
+		$this->assertNotNull( $subject );
+		return $subject;
+	}
+
+	/**
+	 * @return list<string> The property names of the Subject's Statements.
+	 */
+	private function getStoredPropertyNames(): array {
+		return array_keys( $this->getSubjectFromRepository()->getStatements()->asArray() );
+	}
+
+	public function testHappyPathReturns200WithUpdatedStatus(): void {
+		$this->createSubjectPage();
+
+		$response = $this->executeHandler(
+			$this->newRemoveStatementApi(),
+			$this->newRequest( 'Website' )
+		);
+
+		$responseData = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertSame( 200, $response->getStatusCode() );
+		$this->assertSame( 'updated', $responseData['status'] );
+		$this->assertSame( self::SUBJECT_ID, $responseData['subjectId'] );
+	}
+
+	public function testOnlyTheNamedStatementIsRemoved(): void {
+		$this->createSubjectPage();
+
+		$this->executeHandler(
+			$this->newRemoveStatementApi(),
+			$this->newRequest( 'Website' )
+		);
+
+		$this->assertSame( [ 'Founded at' ], $this->getStoredPropertyNames() );
+	}
+
+	public function testRemovingAnAbsentStatementLeavesTheSubjectUnchanged(): void {
+		$this->createSubjectPage();
+
+		$response = $this->executeHandler(
+			$this->newRemoveStatementApi(),
+			$this->newRequest( 'Never set' )
+		);
+
+		$this->assertSame( 200, $response->getStatusCode() );
+		$this->assertSame( [ 'Website', 'Founded at' ], $this->getStoredPropertyNames() );
+	}
+
+	public function testNonExistentSubjectReturns404(): void {
+		$response = $this->executeHandler(
+			$this->newRemoveStatementApi(),
+			$this->newRequest( 'Website', subjectId: 'sDoesNotExist99' )
+		);
+
+		$responseData = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertSame( 404, $response->getStatusCode() );
+		$this->assertSame( 'error', $responseData['status'] );
+	}
+
+	public function testMalformedSubjectIdReturns400(): void {
+		$response = $this->executeHandler(
+			$this->newRemoveStatementApi(),
+			$this->newRequest( 'Website', subjectId: 'not-a-subject-id' )
+		);
+
+		$this->assertSame( 400, $response->getStatusCode() );
+	}
+
+	public function testPermissionDeniedReturns403(): void {
+		$this->createSubjectPage();
+
+		$response = $this->executeHandler(
+			$this->newRemoveStatementApi(),
+			$this->newRequest( 'Website' ),
+			authority: $this->mockAnonAuthorityWithPermissions( [] )
+		);
+
+		$responseData = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertSame( 403, $response->getStatusCode() );
+		$this->assertSame( 'error', $responseData['status'] );
+	}
+
+	public function testCommentIsAccepted(): void {
+		$this->createSubjectPage();
+
+		$response = $this->executeHandler(
+			$this->newRemoveStatementApi(),
+			$this->newRequest( 'Website', [ 'comment' => 'My edit summary' ] )
+		);
+
+		$this->assertSame( 200, $response->getStatusCode() );
+	}
+
+	public function testEnforcementBlocksRemovingARequiredStatement(): void {
+		$this->setMwGlobals( 'wgNeoWikiEnforceValidation', true );
+		$this->createSubjectPage(
+			'{"title":"RemoveStatementSchema","propertyDefinitions":{"Website":{"type":"url","required":true}}}'
+		);
+
+		$response = $this->executeHandler(
+			$this->newRemoveStatementApi(),
+			$this->newRequest( 'Website' )
+		);
+
+		$responseData = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertSame( 422, $response->getStatusCode() );
+		$this->assertSame( 'Validation failed', $responseData['message'] );
+		$this->assertSame( [ 'Website', 'Founded at' ], $this->getStoredPropertyNames() );
+	}
+
+}

--- a/tests/phpunit/EntryPoints/REST/RemoveStatementApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/RemoveStatementApiTest.php
@@ -6,7 +6,6 @@ namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\REST;
 
 use MediaWiki\Rest\RequestData;
 use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
-use MediaWiki\Tests\Unit\Permissions\MockAuthorityTrait;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
@@ -18,6 +17,7 @@ use ProfessionalWiki\NeoWiki\Presentation\CsrfValidator;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestStatement;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiMockAuthorityTrait;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\EntryPoints\REST\RemoveStatementApi
@@ -26,7 +26,7 @@ use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
 class RemoveStatementApiTest extends NeoWikiIntegrationTestCase {
 
 	use HandlerTestTrait;
-	use MockAuthorityTrait;
+	use NeoWikiMockAuthorityTrait;
 
 	private const string SUBJECT_ID = 'sTestRS11111111';
 
@@ -147,19 +147,49 @@ class RemoveStatementApiTest extends NeoWikiIntegrationTestCase {
 		$this->assertSame( 400, $response->getStatusCode() );
 	}
 
-	public function testPermissionDeniedReturns403(): void {
+	public function testReadableButNotEditablePageReturns403(): void {
 		$this->createSubjectPage();
 
+		// The caller can read the page - so its existence is already public - but cannot edit it.
 		$response = $this->executeHandler(
 			$this->newRemoveStatementApi(),
 			$this->newRequest( 'Website' ),
-			authority: $this->mockAnonAuthorityWithPermissions( [] )
+			authority: $this->authorityWithGlobalEditButNoPageEdit()
 		);
 
 		$responseData = json_decode( $response->getBody()->getContents(), true );
 
 		$this->assertSame( 403, $response->getStatusCode() );
 		$this->assertSame( 'error', $responseData['status'] );
+	}
+
+	public function testSubjectOnAnUnreadablePageAnswersLikeAnAbsentSubject(): void {
+		$this->createSubjectPage();
+
+		// One Authority for both requests: comparing responses obtained under two different
+		// Authorities says nothing about what any single caller can tell apart.
+		$authority = $this->authorityWithGlobalReadButNoPageRead();
+
+		$unreadable = $this->executeHandler(
+			$this->newRemoveStatementApi(),
+			$this->newRequest( 'Website' ),
+			authority: $authority
+		);
+
+		$absent = $this->executeHandler(
+			$this->newRemoveStatementApi(),
+			$this->newRequest( 'Website', subjectId: 'sDoesNotExist99' ),
+			authority: $authority
+		);
+
+		$unreadableData = json_decode( $unreadable->getBody()->getContents(), true );
+		$absentData = json_decode( $absent->getBody()->getContents(), true );
+
+		// A caller holding a harvested Subject id learns nothing about whether it exists. The
+		// message names the id the caller supplied, so it carries nothing they did not send.
+		$this->assertSame( 404, $unreadable->getStatusCode() );
+		$this->assertSame( $unreadable->getStatusCode(), $absent->getStatusCode() );
+		$this->assertSame( $unreadableData['status'], $absentData['status'] );
 	}
 
 	public function testCommentIsAccepted(): void {
@@ -176,7 +206,8 @@ class RemoveStatementApiTest extends NeoWikiIntegrationTestCase {
 	public function testEnforcementBlocksRemovingARequiredStatement(): void {
 		$this->setMwGlobals( 'wgNeoWikiEnforceValidation', true );
 		$this->createSubjectPage(
-			'{"title":"RemoveStatementSchema","propertyDefinitions":{"Website":{"type":"url","required":true}}}'
+			'{"title":"RemoveStatementSchema","propertyDefinitions":'
+				. '{"Website":{"type":"url","required":{"severity":"error"}}}}'
 		);
 
 		$response = $this->executeHandler(

--- a/tests/phpunit/EntryPoints/REST/RemoveStatementApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/RemoveStatementApiTest.php
@@ -4,8 +4,10 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\REST;
 
+use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Rest\RequestData;
 use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
+use MediaWiki\Title\Title;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
@@ -201,6 +203,50 @@ class RemoveStatementApiTest extends NeoWikiIntegrationTestCase {
 		);
 
 		$this->assertSame( 200, $response->getStatusCode() );
+	}
+
+	public function testCommentBecomesTheEditSummary(): void {
+		$this->createSubjectPage();
+
+		$this->executeHandler(
+			$this->newRemoveStatementApi(),
+			$this->newRequest( 'Website', [ 'comment' => 'My edit summary' ] )
+		);
+
+		$this->assertSame(
+			'My edit summary',
+			$this->latestRevisionOfSubjectPage()->getComment()?->text
+		);
+	}
+
+	private function latestRevisionOfSubjectPage(): RevisionRecord {
+		$revision = $this->getServiceContainer()->getRevisionLookup()->getRevisionByTitle(
+			Title::newFromText( 'RemoveStatementApiTest' )
+		);
+
+		$this->assertNotNull( $revision );
+		return $revision;
+	}
+
+	public function testUpdatedResponseOmitsTheSchemaWhenTheSchemaIsMissing(): void {
+		$this->createSubjectPage();
+		$this->deletePage(
+			$this->getServiceContainer()->getWikiPageFactory()->newFromTitle(
+				Title::newFromText( 'RemoveStatementSchema', NeoWikiExtension::NS_SCHEMA )
+			)
+		);
+
+		$this->startFreshRequest();
+
+		$response = $this->executeHandler(
+			$this->newRemoveStatementApi(),
+			$this->newRequest( 'Website' )
+		);
+
+		$responseData = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertArrayHasKey( 'subject', $responseData );
+		$this->assertArrayNotHasKey( 'schema', $responseData );
 	}
 
 	public function testEnforcementBlocksRemovingARequiredStatement(): void {

--- a/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
@@ -129,6 +129,7 @@ class ReplaceSubjectApiTest extends NeoWikiIntegrationTestCase {
 				Title::newFromText( 'GoneSchema', NeoWikiExtension::NS_SCHEMA )
 			)
 		);
+		$this->startFreshRequest();
 
 		$response = $this->executeHandler(
 			$this->newReplaceSubjectApi(),
@@ -356,6 +357,7 @@ class ReplaceSubjectApiTest extends NeoWikiIntegrationTestCase {
 				Title::newFromText( 'OrphanSchema', NeoWikiExtension::NS_SCHEMA )
 			)
 		);
+		$this->startFreshRequest();
 
 		$response = $this->executeHandler(
 			$this->newReplaceSubjectApi(),
@@ -446,6 +448,21 @@ class ReplaceSubjectApiTest extends NeoWikiIntegrationTestCase {
 
 		$body = $this->validBody();
 		$body['statements'] = [ 'Founded at' => [ 'propertyType' => 'number', 'value' => 'not a number' ] ];
+
+		$response = $this->executeHandler(
+			$this->newReplaceSubjectApi(),
+			$this->createRequestData( $body )
+		);
+
+		$this->assertSame( 400, $response->getStatusCode() );
+		$this->assertSame( [], $this->getSubjectFromRepository( 'sTestSA11111111' )->getStatements()->asArray() );
+	}
+
+	public function testNonStringPropertyTypeReturns400(): void {
+		$this->createPages();
+
+		$body = $this->validBody();
+		$body['statements'] = [ 'Founded at' => [ 'propertyType' => [ 'number' ], 'value' => 2019 ] ];
 
 		$response = $this->executeHandler(
 			$this->newReplaceSubjectApi(),

--- a/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
@@ -441,6 +441,21 @@ class ReplaceSubjectApiTest extends NeoWikiIntegrationTestCase {
 		);
 	}
 
+	public function testStatementValueNotFittingItsPropertyTypeReturns400(): void {
+		$this->createPages();
+
+		$body = $this->validBody();
+		$body['statements'] = [ 'Founded at' => [ 'propertyType' => 'number', 'value' => 'not a number' ] ];
+
+		$response = $this->executeHandler(
+			$this->newReplaceSubjectApi(),
+			$this->createRequestData( $body )
+		);
+
+		$this->assertSame( 400, $response->getStatusCode() );
+		$this->assertSame( [], $this->getSubjectFromRepository( 'sTestSA11111111' )->getStatements()->asArray() );
+	}
+
 	public function testReadableButNotEditablePageReturns403(): void {
 		$this->createPages();
 

--- a/tests/phpunit/EntryPoints/REST/SetStatementApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/SetStatementApiTest.php
@@ -260,6 +260,82 @@ class SetStatementApiTest extends NeoWikiIntegrationTestCase {
 		$this->assertNull( $this->getStoredValue( 'Founded at' ) );
 	}
 
+	/**
+	 * The body validator types `statement` but not the keys inside it, so a non-string
+	 * `propertyType` reaches the action unchecked.
+	 *
+	 * @dataProvider nonStringPropertyTypeProvider
+	 */
+	public function testNonStringPropertyTypeReturns400( mixed $propertyType ): void {
+		$this->createSubjectPage();
+
+		$response = $this->executeHandler(
+			$this->newSetStatementApi(),
+			$this->newRequest( 'Website', [ 'statement' => [ 'propertyType' => $propertyType, 'value' => [ 'https://pro.wiki' ] ] ] )
+		);
+
+		$this->assertSame( 400, $response->getStatusCode() );
+		$this->assertNull( $this->getStoredValue( 'Website' ) );
+	}
+
+	public static function nonStringPropertyTypeProvider(): iterable {
+		yield 'number' => [ 2019 ];
+		yield 'boolean' => [ true ];
+		yield 'array' => [ [ 'url' ] ];
+	}
+
+	/**
+	 * A property named like a year is ordinary, and the name reaches the write path as an array
+	 * key, which PHP hands on as an int.
+	 */
+	public function testPropertyNameThatLooksLikeAnIntegerIsStored(): void {
+		$this->createSubjectPage();
+
+		$response = $this->executeHandler(
+			$this->newSetStatementApi(),
+			$this->newRequest( '2024', [ 'statement' => [ 'propertyType' => 'url', 'value' => [ 'https://pro.wiki' ] ] ] )
+		);
+
+		$this->assertSame( 200, $response->getStatusCode() );
+		$this->assertSame( [ 'https://pro.wiki' ], $this->getStoredValue( '2024' ) );
+	}
+
+	/**
+	 * A JSON object unpacks into the value objects as named arguments, so it used to be stored as
+	 * an object where every reader expects a list.
+	 */
+	public function testObjectValueWhereAListIsExpectedReturns400(): void {
+		$this->createSubjectPage( new StatementList( [
+			TestStatement::build( property: 'Website', value: 'https://pro.wiki', propertyType: 'url' ),
+		] ) );
+
+		$response = $this->executeHandler(
+			$this->newSetStatementApi(),
+			$this->newRequest( 'Website', [ 'statement' => [ 'propertyType' => 'url', 'value' => [ 'a' => 'https://evil.example' ] ] ] )
+		);
+
+		$this->assertSame( 400, $response->getStatusCode() );
+		$this->assertSame( [ 'https://pro.wiki' ], $this->getStoredValue( 'Website' ) );
+	}
+
+	/**
+	 * Without a value there is nothing to set. Treating the absent key as an empty value would
+	 * delete the Statement and answer 200, so a client that drops the key loses data silently.
+	 */
+	public function testStatementWithoutAValueKeyLeavesTheStatementAlone(): void {
+		$this->createSubjectPage( new StatementList( [
+			TestStatement::build( property: 'Website', value: 'https://pro.wiki', propertyType: 'url' ),
+		] ) );
+
+		$response = $this->executeHandler(
+			$this->newSetStatementApi(),
+			$this->newRequest( 'Website', [ 'statement' => [ 'propertyType' => 'url' ] ] )
+		);
+
+		$this->assertSame( 400, $response->getStatusCode() );
+		$this->assertSame( [ 'https://pro.wiki' ], $this->getStoredValue( 'Website' ) );
+	}
+
 	public function testStatementWithoutAValueReturns400(): void {
 		$this->createSubjectPage();
 

--- a/tests/phpunit/EntryPoints/REST/SetStatementApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/SetStatementApiTest.php
@@ -197,6 +197,29 @@ class SetStatementApiTest extends NeoWikiIntegrationTestCase {
 		$this->assertNull( $this->getStoredValue( 'Website' ) );
 	}
 
+	public function testValueNotFittingItsPropertyTypeReturns400(): void {
+		$this->createSubjectPage();
+
+		$response = $this->executeHandler(
+			$this->newSetStatementApi(),
+			$this->newRequest( 'Founded at', [ 'statement' => [ 'propertyType' => 'number', 'value' => 'not a number' ] ] )
+		);
+
+		$this->assertSame( 400, $response->getStatusCode() );
+		$this->assertNull( $this->getStoredValue( 'Founded at' ) );
+	}
+
+	public function testStatementWithoutAValueReturns400(): void {
+		$this->createSubjectPage();
+
+		$response = $this->executeHandler(
+			$this->newSetStatementApi(),
+			$this->newRequest( 'Founded at', [ 'statement' => [ 'propertyType' => 'number' ] ] )
+		);
+
+		$this->assertSame( 400, $response->getStatusCode() );
+	}
+
 	public function testMissingStatementReturns400(): void {
 		$this->createSubjectPage();
 

--- a/tests/phpunit/EntryPoints/REST/SetStatementApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/SetStatementApiTest.php
@@ -7,19 +7,20 @@ namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\REST;
 use MediaWiki\Rest\HttpException;
 use MediaWiki\Rest\RequestData;
 use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
-use MediaWiki\Tests\Unit\Permissions\MockAuthorityTrait;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyName;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
+use ProfessionalWiki\NeoWiki\EntryPoints\REST\GetSubjectApi;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\SetStatementApi;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Presentation\CsrfValidator;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestStatement;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiMockAuthorityTrait;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\EntryPoints\REST\SetStatementApi
@@ -28,7 +29,7 @@ use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
 class SetStatementApiTest extends NeoWikiIntegrationTestCase {
 
 	use HandlerTestTrait;
-	use MockAuthorityTrait;
+	use NeoWikiMockAuthorityTrait;
 
 	private const string SUBJECT_ID = 'sTestSS11111111';
 
@@ -101,6 +102,56 @@ class SetStatementApiTest extends NeoWikiIntegrationTestCase {
 		$this->assertSame( 'updated', $responseData['status'] );
 		$this->assertSame( self::SUBJECT_ID, $responseData['subjectId'] );
 		$this->assertSame( [], $responseData['violations'] );
+	}
+
+	/**
+	 * The point of bundling the Subject is that the client can store server truth instead of its own
+	 * copy, so the entry must be the one the read endpoint serves, down to the page identifiers the
+	 * client cannot know.
+	 */
+	public function testUpdatedResponseCarriesTheSubjectEntryTheReadEndpointServes(): void {
+		$this->createSubjectPage();
+
+		$response = $this->executeHandler(
+			$this->newSetStatementApi(),
+			$this->newRequest( 'Website', [ 'statement' => [ 'propertyType' => 'url', 'value' => [ 'https://pro.wiki' ] ] ] )
+		);
+
+		$responseData = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertSame(
+			$this->readSubjectEntryFromApi( self::SUBJECT_ID ),
+			$responseData['subject']
+		);
+	}
+
+	public function testUpdatedResponseCarriesTheSchemaTheSubjectInstantiates(): void {
+		$this->createSubjectPage();
+
+		$response = $this->executeHandler(
+			$this->newSetStatementApi(),
+			$this->newRequest( 'Website', [ 'statement' => [ 'propertyType' => 'url', 'value' => [ 'https://pro.wiki' ] ] ] )
+		);
+
+		$responseData = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertSame(
+			[ 'Website', 'Founded at' ],
+			array_keys( $responseData['schema']['propertyDefinitions'] )
+		);
+	}
+
+	private function readSubjectEntryFromApi( string $subjectId ): array {
+		$response = $this->executeHandler(
+			new GetSubjectApi(),
+			new RequestData( [
+				'method' => 'GET',
+				'pathParams' => [ 'subjectId' => $subjectId ],
+				'queryParams' => [ 'expand' => 'page' ],
+			] )
+		);
+
+		return json_decode( $response->getBody()->getContents(), true )['subjects'][$subjectId];
 	}
 
 	public function testStatementIsStored(): void {
@@ -261,19 +312,49 @@ class SetStatementApiTest extends NeoWikiIntegrationTestCase {
 		$this->assertSame( 'error', $responseData['status'] );
 	}
 
-	public function testPermissionDeniedReturns403(): void {
+	public function testReadableButNotEditablePageReturns403(): void {
 		$this->createSubjectPage();
 
+		// The caller can read the page - so its existence is already public - but cannot edit it.
 		$response = $this->executeHandler(
 			$this->newSetStatementApi(),
 			$this->newRequest( 'Website', [ 'statement' => [ 'propertyType' => 'url', 'value' => [ 'https://pro.wiki' ] ] ] ),
-			authority: $this->mockAnonAuthorityWithPermissions( [] )
+			authority: $this->authorityWithGlobalEditButNoPageEdit()
 		);
 
 		$responseData = json_decode( $response->getBody()->getContents(), true );
 
 		$this->assertSame( 403, $response->getStatusCode() );
 		$this->assertSame( 'error', $responseData['status'] );
+	}
+
+	public function testSubjectOnAnUnreadablePageAnswersLikeAnAbsentSubject(): void {
+		$this->createSubjectPage();
+
+		// One Authority for both requests: comparing responses obtained under two different
+		// Authorities says nothing about what any single caller can tell apart.
+		$authority = $this->authorityWithGlobalReadButNoPageRead();
+
+		$unreadable = $this->executeHandler(
+			$this->newSetStatementApi(),
+			$this->newRequest( 'Website', [ 'statement' => [ 'propertyType' => 'url', 'value' => [ 'https://pro.wiki' ] ] ] ),
+			authority: $authority
+		);
+
+		$absent = $this->executeHandler(
+			$this->newSetStatementApi(),
+			$this->newRequest( 'Website', [ 'statement' => [ 'propertyType' => 'url', 'value' => [ 'https://pro.wiki' ] ] ], subjectId: 'sDoesNotExist99' ),
+			authority: $authority
+		);
+
+		$unreadableData = json_decode( $unreadable->getBody()->getContents(), true );
+		$absentData = json_decode( $absent->getBody()->getContents(), true );
+
+		// A caller holding a harvested Subject id learns nothing about whether it exists. The
+		// message names the id the caller supplied, so it carries nothing they did not send.
+		$this->assertSame( 404, $unreadable->getStatusCode() );
+		$this->assertSame( $unreadable->getStatusCode(), $absent->getStatusCode() );
+		$this->assertSame( $unreadableData['status'], $absentData['status'] );
 	}
 
 	public function testCommentIsAccepted(): void {

--- a/tests/phpunit/EntryPoints/REST/SetStatementApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/SetStatementApiTest.php
@@ -1,0 +1,312 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\REST;
+
+use MediaWiki\Rest\HttpException;
+use MediaWiki\Rest\RequestData;
+use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
+use MediaWiki\Tests\Unit\Permissions\MockAuthorityTrait;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyName;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
+use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
+use ProfessionalWiki\NeoWiki\EntryPoints\REST\SetStatementApi;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+use ProfessionalWiki\NeoWiki\Presentation\CsrfValidator;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestStatement;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\REST\SetStatementApi
+ * @group Database
+ */
+class SetStatementApiTest extends NeoWikiIntegrationTestCase {
+
+	use HandlerTestTrait;
+	use MockAuthorityTrait;
+
+	private const string SUBJECT_ID = 'sTestSS11111111';
+
+	private function createSubjectPage( ?StatementList $statements = null ): void {
+		$this->createSchema(
+			'SetStatementSchema',
+			'{"title":"SetStatementSchema","propertyDefinitions":{"Website":{"type":"url"},"Founded at":{"type":"number"}}}'
+		);
+		$this->createPageWithSubjects(
+			'SetStatementApiTest',
+			mainSubject: TestSubject::build(
+				id: self::SUBJECT_ID,
+				label: new SubjectLabel( 'Professional Wiki' ),
+				schemaName: new SchemaName( 'SetStatementSchema' ),
+				statements: $statements,
+			)
+		);
+	}
+
+	private function newSetStatementApi(): SetStatementApi {
+		$csrfValidatorStub = $this->createStub( CsrfValidator::class );
+		$csrfValidatorStub->method( 'verifyCsrfToken' )->willReturn( true );
+
+		return new SetStatementApi( csrfValidator: $csrfValidatorStub );
+	}
+
+	private function newRequest( string $propertyName, array $body, string $subjectId = self::SUBJECT_ID ): RequestData {
+		return new RequestData( [
+			'method' => 'PUT',
+			'pathParams' => [
+				'subjectId' => $subjectId,
+				'propertyName' => $propertyName,
+			],
+			'bodyContents' => json_encode( $body ),
+			'headers' => [ 'Content-Type' => 'application/json' ],
+		] );
+	}
+
+	private function getSubjectFromRepository(): Subject {
+		$subject = NeoWikiExtension::getInstance()
+			->newSubjectRepository()
+			->getSubject( new SubjectId( self::SUBJECT_ID ) );
+
+		$this->assertNotNull( $subject );
+		return $subject;
+	}
+
+	/**
+	 * @return mixed The stored value, or null when the Subject has no Statement for the property.
+	 */
+	private function getStoredValue( string $propertyName ): mixed {
+		return $this->getSubjectFromRepository()
+			->getStatements()
+			->getStatement( new PropertyName( $propertyName ) )
+			?->getValue()
+			->toScalars();
+	}
+
+	public function testHappyPathReturns200WithUpdatedStatus(): void {
+		$this->createSubjectPage();
+
+		$response = $this->executeHandler(
+			$this->newSetStatementApi(),
+			$this->newRequest( 'Website', [ 'statement' => [ 'propertyType' => 'url', 'value' => [ 'https://pro.wiki' ] ] ] )
+		);
+
+		$responseData = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertSame( 200, $response->getStatusCode() );
+		$this->assertSame( 'updated', $responseData['status'] );
+		$this->assertSame( self::SUBJECT_ID, $responseData['subjectId'] );
+		$this->assertSame( [], $responseData['violations'] );
+	}
+
+	public function testStatementIsStored(): void {
+		$this->createSubjectPage();
+
+		$this->executeHandler(
+			$this->newSetStatementApi(),
+			$this->newRequest( 'Website', [ 'statement' => [ 'propertyType' => 'url', 'value' => [ 'https://pro.wiki' ] ] ] )
+		);
+
+		$this->assertSame( [ 'https://pro.wiki' ], $this->getStoredValue( 'Website' ) );
+	}
+
+	public function testMultiWordPropertyNameIsStoredVerbatim(): void {
+		$this->createSubjectPage();
+
+		$this->executeHandler(
+			$this->newSetStatementApi(),
+			$this->newRequest( 'Founded at', [ 'statement' => [ 'propertyType' => 'number', 'value' => 2019 ] ] )
+		);
+
+		$this->assertSame( 2019, $this->getStoredValue( 'Founded at' ) );
+	}
+
+	public function testOtherStatementsAndLabelAreLeftAlone(): void {
+		$this->createSubjectPage( new StatementList( [
+			TestStatement::build( property: 'Founded at', value: 'untouched' ),
+		] ) );
+
+		$this->executeHandler(
+			$this->newSetStatementApi(),
+			$this->newRequest( 'Website', [ 'statement' => [ 'propertyType' => 'url', 'value' => [ 'https://pro.wiki' ] ] ] )
+		);
+
+		$this->assertSame( [ 'untouched' ], $this->getStoredValue( 'Founded at' ) );
+		$this->assertSame( 'Professional Wiki', $this->getSubjectFromRepository()->getLabel()->text );
+	}
+
+	public function testPropertyTypeFallsBackToTheSchemaType(): void {
+		$this->createSubjectPage();
+
+		$this->executeHandler(
+			$this->newSetStatementApi(),
+			$this->newRequest( 'Website', [ 'statement' => [ 'value' => [ 'https://pro.wiki' ] ] ] )
+		);
+
+		$this->assertSame(
+			'url',
+			$this->getSubjectFromRepository()
+				->getStatements()
+				->getStatement( new PropertyName( 'Website' ) )
+				->getPropertyType()
+		);
+	}
+
+	public function testGivenPropertyTypeIsStoredOverTheSchemaType(): void {
+		$this->createSubjectPage();
+
+		$this->executeHandler(
+			$this->newSetStatementApi(),
+			$this->newRequest( 'Website', [ 'statement' => [ 'propertyType' => 'text', 'value' => [ 'not a url' ] ] ] )
+		);
+
+		$this->assertSame(
+			'text',
+			$this->getSubjectFromRepository()
+				->getStatements()
+				->getStatement( new PropertyName( 'Website' ) )
+				->getPropertyType()
+		);
+	}
+
+	public function testOmittedPropertyTypeForUnknownPropertyReturns400(): void {
+		$this->createSubjectPage();
+
+		$response = $this->executeHandler(
+			$this->newSetStatementApi(),
+			$this->newRequest( 'Not in the Schema', [ 'statement' => [ 'value' => [ 'a value' ] ] ] )
+		);
+
+		$this->assertSame( 400, $response->getStatusCode() );
+	}
+
+	public function testEmptyValueRemovesTheStatement(): void {
+		$this->createSubjectPage( new StatementList( [
+			TestStatement::build( property: 'Website', value: 'https://pro.wiki', propertyType: 'url' ),
+		] ) );
+
+		$this->executeHandler(
+			$this->newSetStatementApi(),
+			$this->newRequest( 'Website', [ 'statement' => [ 'propertyType' => 'url', 'value' => [] ] ] )
+		);
+
+		$this->assertNull( $this->getStoredValue( 'Website' ) );
+	}
+
+	public function testMissingStatementReturns400(): void {
+		$this->createSubjectPage();
+
+		$this->expectException( HttpException::class );
+		$this->expectExceptionCode( 400 );
+
+		$this->executeHandler(
+			$this->newSetStatementApi(),
+			$this->newRequest( 'Website', [ 'comment' => 'No statement here' ] )
+		);
+	}
+
+	public function testMalformedSubjectIdReturns400(): void {
+		$response = $this->executeHandler(
+			$this->newSetStatementApi(),
+			$this->newRequest(
+				'Website',
+				[ 'statement' => [ 'propertyType' => 'url', 'value' => [ 'https://pro.wiki' ] ] ],
+				subjectId: 'not-a-subject-id'
+			)
+		);
+
+		$this->assertSame( 400, $response->getStatusCode() );
+	}
+
+	public function testNonExistentSubjectReturns404(): void {
+		$response = $this->executeHandler(
+			$this->newSetStatementApi(),
+			$this->newRequest(
+				'Website',
+				[ 'statement' => [ 'propertyType' => 'url', 'value' => [ 'https://pro.wiki' ] ] ],
+				subjectId: 'sDoesNotExist99'
+			)
+		);
+
+		$responseData = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertSame( 404, $response->getStatusCode() );
+		$this->assertSame( 'error', $responseData['status'] );
+	}
+
+	public function testPermissionDeniedReturns403(): void {
+		$this->createSubjectPage();
+
+		$response = $this->executeHandler(
+			$this->newSetStatementApi(),
+			$this->newRequest( 'Website', [ 'statement' => [ 'propertyType' => 'url', 'value' => [ 'https://pro.wiki' ] ] ] ),
+			authority: $this->mockAnonAuthorityWithPermissions( [] )
+		);
+
+		$responseData = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertSame( 403, $response->getStatusCode() );
+		$this->assertSame( 'error', $responseData['status'] );
+	}
+
+	public function testCommentIsAccepted(): void {
+		$this->createSubjectPage();
+
+		$response = $this->executeHandler(
+			$this->newSetStatementApi(),
+			$this->newRequest( 'Website', [
+				'statement' => [ 'propertyType' => 'url', 'value' => [ 'https://pro.wiki' ] ],
+				'comment' => 'My edit summary',
+			] )
+		);
+
+		$this->assertSame( 200, $response->getStatusCode() );
+	}
+
+	public function testResponseIncludesViolationsOfUntouchedProperties(): void {
+		$this->createSchema(
+			'SetStatementViolationSchema',
+			'{"title":"SetStatementViolationSchema","propertyDefinitions":{"Website":{"type":"url"},"Status":{"type":"text","required":true}}}'
+		);
+		$this->createPageWithSubjects(
+			'SetStatementApiViolationTest',
+			mainSubject: TestSubject::build(
+				id: self::SUBJECT_ID,
+				label: new SubjectLabel( 'Missing Status' ),
+				schemaName: new SchemaName( 'SetStatementViolationSchema' ),
+			)
+		);
+
+		$response = $this->executeHandler(
+			$this->newSetStatementApi(),
+			$this->newRequest( 'Website', [ 'statement' => [ 'propertyType' => 'url', 'value' => [ 'https://pro.wiki' ] ] ] )
+		);
+
+		$responseData = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertSame( 200, $response->getStatusCode() );
+		$this->assertSame( 'required', $responseData['violations'][0]['code'] );
+		$this->assertSame( 'Status', $responseData['violations'][0]['propertyName'] );
+	}
+
+	public function testEnforcementBlockedReturns422(): void {
+		$this->setMwGlobals( 'wgNeoWikiEnforceValidation', true );
+		$this->createSubjectPage();
+
+		$response = $this->executeHandler(
+			$this->newSetStatementApi(),
+			$this->newRequest( 'Website', [ 'statement' => [ 'propertyType' => 'url', 'value' => [ 'not-a-url' ] ] ] )
+		);
+
+		$responseData = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertSame( 422, $response->getStatusCode() );
+		$this->assertSame( 'Validation failed', $responseData['message'] );
+		$this->assertNull( $this->getStoredValue( 'Website' ) );
+	}
+
+}

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/NumericPropertyNameProjectionTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/NumericPropertyNameProjectionTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\GraphDatabasePlugins\Neo4j\Persistence;
+
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestStatement;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+
+/**
+ * A property named like a decimal integer is an int array key by the time the node property map is
+ * assembled, so combining it with the map's fixed entries must not renumber it onto another name.
+ *
+ * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jSubjectUpdater
+ * @group Database
+ */
+class NumericPropertyNameProjectionTest extends NeoWikiIntegrationTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->setUpNeo4j();
+		$this->createSchema( 'NumericPropertyNameSchema' );
+	}
+
+	public function testPropertyNamedLikeAnIntegerKeepsItsNameInTheGraph(): void {
+		$this->createPageWithSubjectNamedProperty();
+
+		$this->assertSame(
+			[ 'yes' ],
+			$this->readSubjectProperty( '2024' )
+		);
+	}
+
+	public function testPropertyNamedLikeAnIntegerDoesNotDisplaceTheFixedNodeProperties(): void {
+		$this->createPageWithSubjectNamedProperty();
+
+		$this->assertSame( 'Numbered subject', $this->readSubjectProperty( 'name' ) );
+	}
+
+	private function createPageWithSubjectNamedProperty(): void {
+		$this->createPageWithSubjects(
+			'NumericPropertyNameTest',
+			mainSubject: TestSubject::build(
+				id: 'sTestNP11111111',
+				label: new SubjectLabel( 'Numbered subject' ),
+				schemaName: new SchemaName( 'NumericPropertyNameSchema' ),
+				statements: new StatementList( [
+					TestStatement::build( property: '2024', value: 'yes', propertyType: 'text' ),
+				] ),
+			)
+		);
+	}
+
+	private function readSubjectProperty( string $propertyName ): mixed {
+		$result = $this->readGraph(
+			'MATCH (subject:Subject {id: $id}) RETURN subject[$property] AS value',
+			[ 'id' => 'sTestNP11111111', 'property' => $propertyName ]
+		);
+
+		return $result->first()->toRecursiveArray()['value'];
+	}
+
+}

--- a/tests/phpunit/NeoWikiIntegrationTestCase.php
+++ b/tests/phpunit/NeoWikiIntegrationTestCase.php
@@ -358,6 +358,16 @@ class NeoWikiIntegrationTestCase extends MediaWikiIntegrationTestCase {
 		);
 	}
 
+	/**
+	 * Drops the state a real request would not inherit: MediaWiki's services, and the extension
+	 * singleton that pins the Schema lookup and its caches. A test that changes a page and then
+	 * reads it back otherwise depends on every cache in this process having noticed the change.
+	 */
+	protected function startFreshRequest(): void {
+		$this->resetServices();
+		NeoWikiExtension::resetInstance();
+	}
+
 	protected function readGraph( string $cypher, array $parameters = [] ): SummarizedResult {
 		return NeoWikiExtension::getInstance()->requireNeo4jPlugin()->getReadQueryEngine()->runReadQuery( $cypher, $parameters );
 	}


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/591

Third-party integrators can now change a single property without fetching and re-sending the whole Subject:

```
PUT    /neowiki/v0/subject/{subjectId}/statements/{propertyName}
DELETE /neowiki/v0/subject/{subjectId}/statements/{propertyName}
```

Both reuse the machinery behind `PUT /subject/{subjectId}`: its read-then-write authorization, select-value
resolution, and validation with enforcement. They answer with the same body it does, carrying the persisted Subject
and its Schema, and `422` under enforcement. Violations always cover the whole Subject, not just the property
written.

## Design decisions

**The body nests the Statement under a `statement` key** rather than putting `propertyType` and `value` at the top
level as the issue sketched:

```json
{ "statement": { "propertyType": "url", "value": ["https://example.com"] }, "comment": "..." }
```

MediaWiki's REST body validator types every declared field, and it has no type that accepts both the scalars and
the arrays a Statement value can be (`ArrayDef` rejects `2019`, and there is no "any" type). Every other endpoint
that carries values nests them inside an `array`-typed param for the same reason, so a top-level `value` would have
had to either reject numbers and booleans or bypass validation. The nesting also keeps the edit summary out of the
Statement's own field namespace.

**`propertyType` is optional** (the issue's first open question). When omitted, the type the Subject's Schema
currently gives the property is stored as the writer's schema, which is the honest answer for a client that did not
state one. A property the Schema does not define, sent without a type, is rejected with `400` rather than guessed
at. An explicitly sent type still wins, so writer's-schema drift stays expressible.

**A value that is empty for its type removes the Statement**, matching how the whole-Subject write treats one, so a
client that clears a field gets the same result on either endpoint. `DELETE` on a Statement the Subject does not
have succeeds and writes nothing; MediaWiki's null-edit handling means no revision is created.

**`UpdateStatementAction` builds the proposed Subject as a copy** (`Subject::withStatements`) instead of mutating
the loaded one, so a write that enforcement rejects leaves the Subject untouched by construction rather than by the
save never being reached.

## Type-mismatched values

Exercising the new endpoint surfaced a pre-existing hole in the shared `StatementListBuilder`: a value of the wrong
shape for the type it declares reached the typed value-object constructors, and the TypeError escaped as a `500`.
It was equally reachable through `PUT /subject/{subjectId}` before this branch, for a number sent to a `text`
property, a string sent to `number` or `boolean`, a scalar sent to `relation`, or a Statement carrying no `value`.

The builder now reports those as bad input, so both write endpoints answer `400` with the offending property and
type named. A new public endpoint that `500`s on a wrong-shaped value is not shippable, and putting the check
anywhere but the builder would duplicate the type knowledge that lives there, so the fix is in the shared class and
`PUT /subject/{subjectId}` improves with it.

## Answering like the whole-Subject write

Two write-path changes landed on master while this branch was open, and the single-Statement endpoints follow the
endpoint they sit beside on both.

A Subject on a page the caller cannot read answers not-found rather than reaching the write check, which would
answer `403` where a restricted page answers `404` and so tell a caller lacking the wiki-global `edit` right which
of the Subject ids they hold exist.

Write responses carry the persisted Subject and the Schema it instantiates. That matters more here than on the
whole-Subject write: a client using these endpoints has deliberately not fetched the Subject, so without the
bundle it would have to read one back.

## Property names in the path

`{propertyName}` is URL-encoded, so `Founded at` is `Founded%20at`. A property name containing `/` is not
addressable this way on servers that reject `%2F` in paths; the docs point those cases at `PUT /subject/{subjectId}`.

## Verification

Alongside the unit and integration tests, the endpoints were exercised over real HTTP against a local dev stack,
which covers the route registration, path decoding, and CSRF handling that handler tests bypass: set with an
explicit type, set with the type omitted, set through a URL-encoded multi-word property name, delete, delete again
(no second revision), `400` for an undefined property with no type, `400` for each type-mismatched value shape,
`404`, `403`, and `400` for a missing `statement`. Statement order and the Subject's other statements survived each
write, and the new routes appear in the generated OpenAPI spec. That run predates the rebase; the write-path
alignment above is covered by tests only.

Every new test was checked against mutations of the code it covers, including full removal of the set, remove,
authorization, read-gate, enforcement, select-resolution, property-type-fallback, and response-bundling logic.

Considered, omitted: a dedicated `RestUpdateStatementPresenter` unit test, since the API tests assert the presenter's
whole contract (both status codes and body shapes) through the real object.

