### PR TITLE
Prevent XSS via messages

### DIFF
--- a/resources/ext.neowiki/.eslintrc.cjs
+++ b/resources/ext.neowiki/.eslintrc.cjs
@@ -81,7 +81,9 @@ module.exports = {
 		'spaced-comment': 'off',
 		'no-tabs': 'off',
 		'@typescript-eslint/explicit-module-boundary-types': 'off',
-		'es-x/no-iterator': 'warn'
+		'es-x/no-iterator': 'warn',
+		// Messages can be overridden on-wiki, so v-html is an injection point, not a style preference.
+		'vue/no-v-html': 'error'
 	},
 	overrides: [
 		{

--- a/src/Presentation/ConfigDocumentationBuilder.php
+++ b/src/Presentation/ConfigDocumentationBuilder.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Presentation;
 
 use MediaWiki\Html\Html;
+use MediaWiki\Parser\Sanitizer;
 use MessageLocalizer;
 use ProfessionalWiki\NeoWiki\Application\WikiConfig\ConfigSchema;
 use ProfessionalWiki\NeoWiki\Application\WikiConfig\ConfigSetting;
@@ -73,8 +74,6 @@ class ConfigDocumentationBuilder {
 	}
 
 	private function renderRow( ConfigSetting $setting ): string {
-		// The key and the LocalSettings.php setting fill their whole cell, so they are plain text; only the
-		// accepted value carries inline <code> spans on the literal JSON values, emitted raw below.
 		return Html::rawElement(
 			'tr',
 			[],
@@ -86,10 +85,11 @@ class ConfigDocumentationBuilder {
 
 	/**
 	 * The accepted-value description as HTML. The boolean type message wraps the literal JSON values in
-	 * <code> spans, so it is emitted raw — it is a trusted static message with no parameters.
+	 * <code> spans, so the message text is markup and cannot be escaped wholesale; it is sanitized down to
+	 * the raw-HTML tags and attributes wikitext permits instead.
 	 */
 	private function describeValue( ConfigSetting $setting ): string {
-		return $this->messageLocalizer->msg( ...$setting->describe() )->text();
+		return Sanitizer::removeSomeTags( $this->messageLocalizer->msg( ...$setting->describe() )->text() );
 	}
 
 }

--- a/tests/RedHerb/.eslintrc.json
+++ b/tests/RedHerb/.eslintrc.json
@@ -6,6 +6,7 @@
 	],
 	"rules": {
 		"max-len": "off",
-		"compat/compat": "off"
+		"compat/compat": "off",
+		"vue/no-v-html": "error"
 	}
 }

--- a/tests/phpunit/Presentation/ConfigDocumentationBuilderTest.php
+++ b/tests/phpunit/Presentation/ConfigDocumentationBuilderTest.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Tests\Presentation;
 
 use MediaWiki\Context\RequestContext;
+use MediaWiki\MainConfigNames;
 use MediaWiki\Title\Title;
 use MediaWikiIntegrationTestCase;
 use ProfessionalWiki\NeoWiki\Application\WikiConfig\ConfigSchema;
@@ -12,6 +13,7 @@ use ProfessionalWiki\NeoWiki\Presentation\ConfigDocumentationBuilder;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\Presentation\ConfigDocumentationBuilder
+ * @group Database
  */
 class ConfigDocumentationBuilderTest extends MediaWikiIntegrationTestCase {
 
@@ -21,6 +23,11 @@ class ConfigDocumentationBuilderTest extends MediaWikiIntegrationTestCase {
 		$context->setTitle( Title::makeTitle( NS_MEDIAWIKI, 'NeoWiki' ) );
 
 		return new ConfigDocumentationBuilder( new ConfigSchema(), $context );
+	}
+
+	private function overrideAcceptedValueMessage( string $wikitext ): void {
+		$this->overrideConfigValue( MainConfigNames::UseDatabaseMessages, true );
+		$this->editPage( Title::makeTitle( NS_MEDIAWIKI, 'Neowiki-config-type-boolean' ), $wikitext );
 	}
 
 	public function testReferenceListsEverySettingAndTheLocalSettingsNameItOverrides(): void {
@@ -56,6 +63,24 @@ class ConfigDocumentationBuilderTest extends MediaWikiIntegrationTestCase {
 
 		$this->assertStringContainsString( '#' . ConfigDocumentationBuilder::ANCHOR, $html );
 		$this->assertStringContainsString( 'neowiki.ai/docs/operations/installation', $html );
+	}
+
+	public function testReferenceShowsScriptTagsFromAnOverriddenMessageAsText(): void {
+		$this->overrideAcceptedValueMessage( '<script>alert(1)</script>' );
+
+		$html = $this->newBuilder()->buildReference();
+
+		$this->assertStringNotContainsString( '<script', $html );
+		$this->assertStringContainsString( '&lt;script&gt;alert(1)&lt;/script&gt;', $html );
+	}
+
+	public function testReferenceDropsEventHandlersFromAnOverriddenMessage(): void {
+		$this->overrideAcceptedValueMessage( '<code onmouseover="alert(1)">yes</code>' );
+
+		$html = $this->newBuilder()->buildReference();
+
+		$this->assertStringNotContainsString( 'onmouseover', $html );
+		$this->assertStringContainsString( '<code>yes</code>', $html );
 	}
 
 }


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/286

The configuration reference on the on-wiki configuration page emitted the accepted-value message as raw HTML, so
`MediaWiki:Neowiki-config-type-boolean` could put a script tag in front of every reader of that page, logged in or
not. Writing that page needs `editinterface`, so this is an interface admin escalating against readers rather than
an open injection; the same key arriving as a translation in `i18n/` is the unprivileged route, and none ship today.
`Sanitizer::removeSomeTags` now escapes any tag wikitext would not allow as raw HTML and drops disallowed
attributes, so the `<code>` spans the message legitimately needs still render. Both routes converge on that one
sink, so one fix closes both, and the regression tests drive it through the on-wiki route.

It was the only place a message reached the page unsanitized. Everywhere else in the extension's PHP, RedHerb's
included, the text is escaped where it is emitted: by `Html::element`, by `->escaped()`, by `htmlspecialchars()` in
the raw query parser functions, or by the skin and Scribunto escaping what they are handed.

Sanitizing rather than parsing keeps the message's contract as documented in `qqq.json`: it is HTML, not wikitext.
Parsing would also close the hole, but it would reinterpret every translation as wikitext, so a leading space or a
pair of apostrophes would change how a translated string renders.

`vue/no-v-html` only warns by default, so it does not fail lint. Messages reach the frontend the same two ways, so
it is an error in both the extension's and RedHerb's eslint config. The `v-html` that prompted #285 left the tree
with `PropertyNameField.vue` in 5833878f; neither bundle now has a `v-html`, an `innerHTML`, or any equivalent sink,
and nothing suppresses the rule, so raising it changes no component.

Considered, omitted: neither side has an automated guard against the next unsanitized rendering, in PHP
(`Html::rawElement( ..., $msg->text() )`) or in TypeScript (`innerHTML`, which `vue/no-v-html` does not reach).
Psalm already runs here and has taint analysis, and `eslint-plugin-no-unsanitized` covers the other half; both are
CI changes rather than part of a fix.

## Screenshots (UI, Playwright)

| | |
|---|---|
| **Before.** `MediaWiki:Neowiki-config-type-boolean` overridden with a script tag: it runs for an anonymous reader of the configuration page. | <img width="1920" height="1080" alt="xss-before-fix" src="https://github.com/user-attachments/assets/16fc5b60-28c1-4470-8b58-535a12c7dca4" /> |
| **After.** The same override renders as text. | <img width="1920" height="1080" alt="xss-after-fix" src="https://github.com/user-attachments/assets/2108a1e4-af21-4c16-999e-82fabbfe6e1e" /> |
| **After, without an override.** The `<code>` spans in the shipped message are unaffected. | <img width="1920" height="1080" alt="reference-table-unchanged" src="https://github.com/user-attachments/assets/eee76785-308d-47a7-9767-853790b0a2d7" /> |

> <sub>AI-authored — Claude Code, `Opus 5 1M (xhigh)`; one-line ask from @malberts, redirected three times; diff read by @malberts; tests written failing first, both attack routes run locally, CI green.</sub>

<details><summary>Production notes</summary>

Verification: regression tests written failing first and mutation-checked; both attack routes exercised against the
pre-fix and post-fix code on a local stack; full PHP suite plus TypeScript and RedHerb test/build/lint green locally
and on CI. Two AI review passes after @malberts read the diff corrected the mitigation and the wording; their fixes
are the later commits on the branch.

</details>


