### PR TITLE
Treat an empty color part as absent rather than malformed

### DIFF
--- a/tests/RedHerb/src/ColorType.php
+++ b/tests/RedHerb/src/ColorType.php
@@ -66,7 +66,7 @@ class ColorType implements PropertyType {
 				$violations[] = new Violation(
 					propertyName: null,
 					code: 'invalid-color',
-					args: [ $color ],
+					args: [ $part ],
 					valuePartIndex: $index,
 				);
 				continue;
@@ -76,7 +76,7 @@ class ColorType implements PropertyType {
 				$violations[] = new Violation(
 					propertyName: null,
 					code: 'invalid-option',
-					args: [ $color ],
+					args: [ $part ],
 					valuePartIndex: $index,
 				);
 			}

--- a/tests/RedHerb/src/ColorType.php
+++ b/tests/RedHerb/src/ColorType.php
@@ -46,7 +46,7 @@ class ColorType implements PropertyType {
 			return [];
 		}
 
-		if ( $definition->isRequired() && $value->strings === [] ) {
+		if ( $definition->isRequired() && !$this->hasContent( $value ) ) {
 			return [ new Violation( propertyName: null, code: 'required' ) ];
 		}
 
@@ -56,27 +56,43 @@ class ColorType implements PropertyType {
 		$violations = [];
 
 		foreach ( $value->strings as $index => $part ) {
-			if ( preg_match( self::HEX_COLOR_REGEX, $part ) !== 1 ) {
+			$color = trim( $part );
+
+			if ( $color === '' ) {
+				continue;
+			}
+
+			if ( preg_match( self::HEX_COLOR_REGEX, $color ) !== 1 ) {
 				$violations[] = new Violation(
 					propertyName: null,
 					code: 'invalid-color',
-					args: [ $part ],
+					args: [ $color ],
 					valuePartIndex: $index,
 				);
 				continue;
 			}
 
-			if ( $allowedSet !== null && !isset( $allowedSet[$part] ) ) {
+			if ( $allowedSet !== null && !isset( $allowedSet[$color] ) ) {
 				$violations[] = new Violation(
 					propertyName: null,
 					code: 'invalid-option',
-					args: [ $part ],
+					args: [ $color ],
 					valuePartIndex: $index,
 				);
 			}
 		}
 
 		return $violations;
+	}
+
+	private function hasContent( StringValue $value ): bool {
+		foreach ( $value->strings as $part ) {
+			if ( trim( $part ) !== '' ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 }

--- a/tests/phpunit/RedHerb/ColorTypeValidateTest.php
+++ b/tests/phpunit/RedHerb/ColorTypeValidateTest.php
@@ -103,6 +103,16 @@ class ColorTypeValidateTest extends TestCase {
 		$this->assertSame( 0, $violations[0]->valuePartIndex );
 	}
 
+	public function testInvalidColorViolationReportsTheTrimmedValue(): void {
+		$violations = $this->type->validate(
+			new StringValue( ' #xxx ' ),
+			$this->newProperty( required: false ),
+		);
+
+		$this->assertCount( 1, $violations );
+		$this->assertSame( [ '#xxx' ], $violations[0]->args );
+	}
+
 	public function testMultipleInvalidHexProducesIndexedViolations(): void {
 		$violations = $this->type->validate(
 			new StringValue( '#aabbcc', 'red', '#xxx' ),
@@ -135,6 +145,15 @@ class ColorTypeValidateTest extends TestCase {
 		$this->assertSame( 'invalid-option', $violations[0]->code );
 		$this->assertSame( [ '#112233' ], $violations[0]->args );
 		$this->assertSame( 1, $violations[0]->valuePartIndex );
+	}
+
+	public function testWhitespacePaddedColorIsMatchedAgainstTheAllowList(): void {
+		$violations = $this->type->validate(
+			new StringValue( ' #aabbcc ' ),
+			$this->newProperty( required: false, allowedColors: [ '#aabbcc' ] ),
+		);
+
+		$this->assertSame( [], $violations );
 	}
 
 	/**

--- a/tests/phpunit/RedHerb/ColorTypeValidateTest.php
+++ b/tests/phpunit/RedHerb/ColorTypeValidateTest.php
@@ -55,6 +55,15 @@ class ColorTypeValidateTest extends TestCase {
 		$this->assertNull( $violations[0]->valuePartIndex );
 	}
 
+	public function testRequiredAndContentInALaterPartReturnsNoViolation(): void {
+		$violations = $this->type->validate(
+			new StringValue( '', '#aabbcc' ),
+			$this->newProperty( required: true ),
+		);
+
+		$this->assertSame( [], $violations );
+	}
+
 	public function testValidHexReturnsNoViolations(): void {
 		$violations = $this->type->validate(
 			new StringValue( '#aabbcc' ),
@@ -103,14 +112,14 @@ class ColorTypeValidateTest extends TestCase {
 		$this->assertSame( 0, $violations[0]->valuePartIndex );
 	}
 
-	public function testInvalidColorViolationReportsTheTrimmedValue(): void {
+	public function testInvalidColorViolationReportsThePartAsGiven(): void {
 		$violations = $this->type->validate(
 			new StringValue( ' #xxx ' ),
 			$this->newProperty( required: false ),
 		);
 
 		$this->assertCount( 1, $violations );
-		$this->assertSame( [ '#xxx' ], $violations[0]->args );
+		$this->assertSame( [ ' #xxx ' ], $violations[0]->args );
 	}
 
 	public function testMultipleInvalidHexProducesIndexedViolations(): void {
@@ -124,6 +133,17 @@ class ColorTypeValidateTest extends TestCase {
 		$this->assertSame( 1, $violations[0]->valuePartIndex );
 		$this->assertSame( 'invalid-color', $violations[1]->code );
 		$this->assertSame( 2, $violations[1]->valuePartIndex );
+	}
+
+	public function testSkippedEmptyPartDoesNotShiftLaterViolationIndexes(): void {
+		$violations = $this->type->validate(
+			new StringValue( '', '#xxx' ),
+			$this->newProperty( required: false ),
+		);
+
+		$this->assertCount( 1, $violations );
+		$this->assertSame( 'invalid-color', $violations[0]->code );
+		$this->assertSame( 1, $violations[0]->valuePartIndex );
 	}
 
 	public function testNonStringValueReturnsNoViolations(): void {

--- a/tests/phpunit/RedHerb/ColorTypeValidateTest.php
+++ b/tests/phpunit/RedHerb/ColorTypeValidateTest.php
@@ -33,9 +33,58 @@ class ColorTypeValidateTest extends TestCase {
 		$this->assertNull( $violations[0]->valuePartIndex );
 	}
 
+	public function testRequiredAndSingleEmptyStringPartReturnsRequiredViolation(): void {
+		$violations = $this->type->validate(
+			new StringValue( '' ),
+			$this->newProperty( required: true ),
+		);
+
+		$this->assertCount( 1, $violations );
+		$this->assertSame( 'required', $violations[0]->code );
+		$this->assertNull( $violations[0]->valuePartIndex );
+	}
+
+	public function testRequiredAndWhitespaceOnlyPartReturnsRequiredViolation(): void {
+		$violations = $this->type->validate(
+			new StringValue( '   ' ),
+			$this->newProperty( required: true ),
+		);
+
+		$this->assertCount( 1, $violations );
+		$this->assertSame( 'required', $violations[0]->code );
+		$this->assertNull( $violations[0]->valuePartIndex );
+	}
+
 	public function testValidHexReturnsNoViolations(): void {
 		$violations = $this->type->validate(
 			new StringValue( '#aabbcc' ),
+			$this->newProperty( required: false ),
+		);
+
+		$this->assertSame( [], $violations );
+	}
+
+	public function testWhitespacePaddedHexReturnsNoViolations(): void {
+		$violations = $this->type->validate(
+			new StringValue( ' #aabbcc ' ),
+			$this->newProperty( required: false ),
+		);
+
+		$this->assertSame( [], $violations );
+	}
+
+	public function testEmptyStringPartIsSkippedWithNoViolation(): void {
+		$violations = $this->type->validate(
+			new StringValue( '' ),
+			$this->newProperty( required: false ),
+		);
+
+		$this->assertSame( [], $violations );
+	}
+
+	public function testWhitespaceOnlyPartIsSkippedWithNoViolation(): void {
+		$violations = $this->type->validate(
+			new StringValue( '   ' ),
 			$this->newProperty( required: false ),
 		);
 


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/1208

RedHerb's ColorType tested emptiness with `$value->strings === []`, so a one-element StringValue holding `''` or
whitespace was neither empty nor a valid hex color: it skipped the `required` branch and raised `invalid-color`, a
code `Violation::isBlocking()` treats as blocking, so the write is rejected under `$wgNeoWikiEnforceValidation`.

An empty string part is absent data, not malformed data. Every core string-valued type classifies it that way: `text`
and `url` via a trim-based content check plus skipping empty parts, `date` and `dateTime` via `extractFirstString`.
ColorType now mirrors `url` on both halves, which also stops a whitespace-padded but otherwise valid `' #aabbcc '`
from being rejected. What the client sent is still what comes back in the violation `args`: the trimmed value is used
for the hex check and the allow-list lookup only, since `invalid-option` is a core code documented as carrying the
offending part and core SelectType passes it unchanged.

For a required property the write was already rejected either way, since `required` is blocking too; what changes
there is that the reported code now names the actual problem. The rejection itself goes away for an optional
property, and for a padded but valid color.

ColorType is the worked example that `docs/api/validation-codes.md` points plugin authors at, so a wrong emptiness
test propagates from there into third-party Property Types that do run under enforcement.

The content check lives in a `hasContent()` helper instead of being inlined the way UrlType has it, to stay under the
cyclomatic complexity limit phpcs enforces.

Note for whoever lands #1147: that branch rewrites the same three lines (adding `severity:` arguments) and still
carries the `=== []` test, so a conflict resolved in its favour silently undoes this.

> <sub>AI-authored — Claude Code, `Opus 5`; `/fix-issue` run against the issue as written, no redirection; diff not yet human-reviewed; new tests seen failing before the fix and passing after, mutation-tested, full PHPUnit suite plus phpcs and phpstan green locally and on CI.</sub>
