### PR TITLE
Editing reads via repositories; Subject writes return the persisted state

### DIFF
--- a/docs/adr/016-frontend-state-management.md
+++ b/docs/adr/016-frontend-state-management.md
@@ -2,7 +2,7 @@
 
 Date: 2025-04-17
 
-Status: Accepted. Extended by [ADR 30](030-frontend-store-registry-semantics.md), which adds fetching and invalidation semantics.
+Status: Accepted. Amended by [ADR 30](030-frontend-store-registry-semantics.md), which adds fetching and invalidation semantics and scopes the editing-UI rule to reads.
 
 ## Context
 

--- a/docs/adr/030-frontend-store-registry-semantics.md
+++ b/docs/adr/030-frontend-store-registry-semantics.md
@@ -2,115 +2,100 @@
 
 Date: 2026-07-31
 
-Status: Accepted
+Status: Draft
 
-Amends [ADR 16](016-frontend-state-management.md), which settles which components read the
-stores but is silent on fetching, caching and invalidation: its editing-UI rule now applies
-to reads, while mutations and validation still go through store actions.
+Amends [ADR 16](016-frontend-state-management.md), which settles which components read the stores but is silent on
+fetching, caching and invalidation. Its editing-UI rule now applies to reads; mutations and validation still go through
+store actions.
 
 ## Context
 
-The frontend keeps server state in Pinia stores (`SchemaStore`, `LayoutStore`, `SubjectStore`).
-Each store grew the same trio of actions: `fetchX`, `getOrFetchX` and `saveX`. The trio treated
-the store as a cache: reads consulted stored values to avoid fetches, and saves wrote the
-client's object through. An invalidation model was never decided
-([#1211](https://github.com/ProfessionalWiki/NeoWiki/issues/1211)). Reads assigned awaited
-results to shared state unconditionally
-([#1177](https://github.com/ProfessionalWiki/NeoWiki/issues/1177)), writes invalidated only on
-their own success path, and deletes invalidated nothing. The components already routed around
-the cache: editing flows fetched fresh data before opening, and two flows reloaded the whole
-page as their invalidation primitive.
+The frontend keeps server state in Pinia stores (`SchemaStore`, `LayoutStore`, `SubjectStore`). Each store grew the
+same trio of actions — `fetchX`, `getOrFetchX` and `saveX` — treating the store as a cache: reads consulted stored
+values to avoid fetches, and saves wrote the client's object through. An invalidation model was never decided
+([#1211](https://github.com/ProfessionalWiki/NeoWiki/issues/1211)). Reads assigned awaited results to shared state
+unconditionally ([#1177](https://github.com/ProfessionalWiki/NeoWiki/issues/1177)), writes invalidated only on their
+own success path, and deletes invalidated nothing. The components already routed around the cache: editing flows
+fetched fresh data before opening, and two flows reloaded the whole page as their invalidation primitive.
 
-A client-side cache can only be consistent with the session's own writes. Edits from other tabs
-and other users stay invisible until the client fetches again. Query libraries such as TanStack
-Query and Pinia Colada default to treating cached data as immediately stale for the same
-reason.
+A client-side cache can only be consistent with the session's own writes. Edits from other tabs and other users stay
+invisible until the client fetches again. Query libraries such as TanStack Query and Pinia Colada default to treating
+cached data as immediately stale for the same reason.
 
 ## Decision
 
-Stores are page-scoped registries of server state, not caches. A registry holds the page payload
-seeded at load and what acknowledged mutations put there: for Subjects the mutation response's
-canonical entity, for Schemas and Layouts the authored object the save committed.
+Stores are page-scoped registries of server state, not caches. A registry holds the page payload seeded at load and
+what acknowledged mutations put there: for Subjects the mutation response's canonical entity, for Schemas and Layouts
+the authored object the save committed.
 
-1. **Reads are explicit.** `getX` reads the registry synchronously, over that page payload and
-   those writes. Editing UIs always open on freshly fetched data, read through the repositories
-   and taken as props ([ADR 16](016-frontend-state-management.md)); they still call store
-   actions to mutate and to validate. That fetch is the job of the code that opens the editor and
-   stays out of the stores: a display catches up on commit, not on open. The store API offers no
-   fetch-on-miss reads, with two exceptions:
-   - `SubjectStore.getOrFetchSubject` resolves display labels over the seeded page payload, which
-     bundles referenced Subjects precisely so N relation displays do not fire N requests.
-   - `SchemaStore.fetchAllSchemaSummaries` lets concurrent callers share one in-flight
-     pagination. Results are not retained, so every new caller cohort fetches fresh data.
-2. **Mutations keep the registry consistent with the session's own writes, on every path.**
-   Each store has a `mutationEpoch` counter that is bumped when the backend acknowledges a
-   write. Saves write through, deletes remove the entity from all registry state, and
-   invalidation that must survive a rejected save runs in a `finally` block. A Subject write
-   answers with the persisted Subject — carrying the page context the editor's copy lacks — and
-   the Schema it instantiates, so its write-through never uses the client's copy. A
-   mutation must also detach any derived in-flight request slot its store holds, so the next
-   caller starts a fresh request instead of joining one that predates the write — `SchemaStore`'s
-   `summariesRequest` slot (behind `fetchAllSchemaSummaries`) is the current instance: both
-   `saveSchema` and `removeSchema` null it out. Where a store holds both a listing and the
-   entity map that listing's ids resolve through, a write that changes membership must keep the
-   two in lockstep at every synchronous point: no id the listing still names may be missing
-   from the map. `SubjectStore.deleteSubject`/`pageSubjects` is the current instance — the map
-   entry is dropped only once `pageSubjects` itself no longer lists the id, so a render caught
-   between the two writes never sees a name `getSubject` cannot resolve.
-3. **Asynchronous write-backs are epoch-guarded.** Every store write that follows a server read
-   snapshots that store's `mutationEpoch` beforehand and discards the write when the epoch moved,
-   because a response that raced a mutation may predate that mutation. Page seeding
-   (`StoreStateLoader`), `SubjectStore.loadPageSubjects`, `getOrFetchSubject`'s miss path and the
-   Schema a Subject write bundles all follow it. A write into more than one store snapshots and
-   guards each store's epoch separately. The epoch is store-wide by design: discarding an
+1. **Reads are explicit.** `getX` reads the registry synchronously. Editing UIs always open on freshly fetched data:
+   read through the repositories and passed in as props ([ADR 16](016-frontend-state-management.md)). They still call
+   store actions to mutate and to validate. That fetch is the job of the code that opens the editor: a display catches
+   up on commit, not on open. The store API offers no fetch-on-miss reads, with one exception, plus one read that
+   always fetches:
+   - `SubjectStore.getOrFetchSubject` resolves display labels over the seeded page payload, which bundles referenced
+     Subjects so N relation displays do not fire N requests.
+   - `SchemaStore.fetchAllSchemaSummaries` lets concurrent callers share one in-flight pagination. Results are not
+     retained, so every new caller cohort fetches fresh data.
+2. **Mutations keep the registry consistent with the session's own writes, on every path.** Each store has a
+   `mutationEpoch` counter, bumped when the backend acknowledges a write. Saves write through, deletes remove the
+   entity from all registry state — at the latest on the next successful refresh — and invalidation that must survive
+   a rejected save runs in a `finally` block. Three further obligations:
+   - The store records the Subject write's response, not the client's copy: the response carries the persisted Subject
+     with the page context the editor's copy lacks, plus the Schema the Subject instantiates.
+   - A mutation must detach any derived in-flight request slot its store holds, so the next caller starts a fresh
+     request instead of joining one that predates the write. Current instance: `SchemaStore`'s `summariesRequest`,
+     which both `saveSchema` and `removeSchema` null out.
+   - Where a store holds both a listing and the entity map that listing's ids resolve through, a write that changes
+     membership must keep the two in lockstep at every synchronous point: no id the listing still names may be missing
+     from the map. Current instance: `SubjectStore.deleteSubject` drops the map entry only once `pageSubjects` no
+     longer lists the id, so no render sees a name `getSubject` cannot resolve.
+3. **Asynchronous write-backs are epoch-guarded.** Every store write that follows a server read snapshots that store's
+   `mutationEpoch` beforehand and discards the write when the epoch moved, because a response that raced a mutation
+   may predate that mutation. Page seeding (`StoreStateLoader`), `SubjectStore.loadPageSubjects`,
+   `getOrFetchSubject`'s miss path and the Schema bundled with a Subject write all follow this rule. A write into more
+   than one store snapshots and guards each store's epoch separately. The epoch is store-wide by design: discarding an
    unrelated in-flight fetch costs one refetch and keeps the rule simple.
 
-The epoch guard covers store write-backs only; ordering component-local async state — a debounced
-validation run, a picker's in-flight request, an editor's schema fetch — remains each component's
-own job. The `requestSequence` counter in `useSubjectValidation` (mirrored in `SchemaCreator.vue`,
-`LayoutCreator.vue`, `SubjectLookup.vue` and `SubjectCreatorDialog.vue`) applies the same
-discard-the-stale-response idea to local refs instead of store state.
+The epoch guard covers store write-backs only. Ordering component-local async state — a debounced validation run, an
+editor's schema fetch — remains each component's own job: the `requestSequence` counter in `useSubjectValidation`,
+mirrored in the creator and lookup components, applies the same discard-the-stale-response idea to local refs instead
+of store state.
 
-Store action names follow a fixed vocabulary. `getX` reads the registry synchronously; the
-`fetchX` entity reads are gone, since reads for editing belong to the repositories. `removeX` is a
-local registry removal after a delete another code path already executed server-side: Schema and
-Layout deletion goes through the shared `DeletePageDialog`, so `removeSchema`/`removeLayout` tell
-the store its copy is gone. `fetchAllSchemaSummaries` returns its data directly, nothing retains it.
+Store action names follow a fixed vocabulary. The `fetchX` entity reads are gone, since reads for editing belong to the
+repositories. `removeX` is a local registry removal after another code path already deleted the entity server-side:
+Schema and Layout deletion goes through the shared `DeletePageDialog`, so `removeSchema`/`removeLayout` tell the store
+its copy is gone. `fetchAllSchemaSummaries` returns its data directly; nothing retains it.
 
-Reloading the page remains legitimate where server-rendered output must reflect a change, because
-no store update can refresh views the wiki rendered. The Subject-creation flow reloads for this
-reason.
+Reloading the page remains legitimate where server-rendered output must reflect a change: no store update can refresh
+views the wiki rendered. The Subject-creation flow reloads for this reason.
 
 ## Consequences
 
-* Fetching a Schema, Layout or Subject to edit is the caller's job, not a store action. Extensions
-  read through the repositories and pass the result down; RedHerb demonstrates it.
-* Schema pickers fetch summaries per mount cohort. A few requests per dialog open, bounded by the
-  scale targets in [ADR 29](029-scalability-targets.md), buy freshness: Schemas created or deleted
-  elsewhere appear without a reload.
+* Fetching a Schema, Layout or Subject to edit is the caller's job, not a store action. Extensions read through the
+  repositories and pass the result down; RedHerb demonstrates it.
+* Schema pickers fetch summaries per mount cohort. A few requests per dialog open — bounded by the scale targets in
+  [ADR 29](029-scalability-targets.md) — buy freshness: Schemas created or deleted elsewhere appear without a reload.
 * New store actions must follow the three rules above; the store test suites show the shape.
 
 ## Alternatives Considered
 
 ### Making the cache correct
 
-Epoch-guarding every read and invalidating on every mutation while keeping the `getOrFetch`
-semantics. Rejected because it hand-rolls the hard parts of a query library to protect cache hits
-that stay session-stale anyway, and every future action would have to remember the discipline.
+Epoch-guarding every read and invalidating on every mutation while keeping the `getOrFetch` semantics. Rejected because
+it hand-rolls the hard parts of a query library to protect cache hits that stay session-stale anyway, and every future
+action would have to remember the discipline.
 
 ### Stores as the single data-access façade
 
-Routing editing reads through store fetch actions, so all server reads have one entry point.
-Rejected because it puts values only one component needs into shared state, which forces onto
-every fetch an epoch guard and a caller contract where a resolved fetch may have written
-nothing to the registry, and because
-[ADR 16](016-frontend-state-management.md) already decided editing UIs do not use the stores.
+Routing editing reads through store fetch actions, so all server reads have one entry point. Rejected on two counts: it
+puts values only one component needs into shared state — every fetch would then need an epoch guard, and callers would
+have to handle a resolved fetch that wrote nothing to the registry — and [ADR 16](016-frontend-state-management.md)
+already decided editing UIs do not use the stores.
 
 ### Adopting a query library (TanStack Query or Pinia Colada)
 
-Such a library solves invalidation, deduplication and response ordering declaratively.
-Rejected because it would add another shared singleton that the frontend-extension
-externalisation contract must cover, for request volumes that the scale targets in
-[ADR 29](029-scalability-targets.md) do not justify. Revisit this choice when a measured
-request-volume problem appears; the migration path is the library, not more hand-rolled cache
-machinery.
+Such a library solves invalidation, deduplication and response ordering declaratively. Rejected because it would add
+another shared singleton that NeoWiki must provide to frontend extensions, for request volumes that the scale targets
+in [ADR 29](029-scalability-targets.md) do not justify. Revisit this choice when a measured request-volume problem
+appears; the migration path is the library, not more hand-rolled cache machinery.

--- a/docs/adr/030-frontend-store-registry-semantics.md
+++ b/docs/adr/030-frontend-store-registry-semantics.md
@@ -28,8 +28,9 @@ reason.
 
 ## Decision
 
-Stores are page-scoped registries of server state, not caches. A registry holds only what the
-server said — the page payload seeded at load, and what mutation responses returned.
+Stores are page-scoped registries of server state, not caches. A registry holds the page payload
+seeded at load and what acknowledged mutations put there: for Subjects the mutation response's
+canonical entity, for Schemas and Layouts the authored object the save committed.
 
 1. **Reads are explicit.** `getX` reads the registry synchronously, over that page payload and
    those writes. Editing UIs always open on freshly fetched data, read through the repositories
@@ -44,10 +45,9 @@ server said — the page payload seeded at load, and what mutation responses ret
 2. **Mutations keep the registry consistent with the session's own writes, on every path.**
    Each store has a `mutationEpoch` counter that is bumped when the backend acknowledges a
    write. Saves write through, deletes remove the entity from all registry state, and
-   invalidation that must survive a rejected save runs in a `finally` block. A save writes the
-   response's entity through, never the client's: a Subject write answers with the persisted
-   Subject — carrying the page context the editor's copy lacks — and the Schema it instantiates.
-   Schema and Layout saves write the authored object through; the editor is its sole author. A
+   invalidation that must survive a rejected save runs in a `finally` block. A Subject write
+   answers with the persisted Subject — carrying the page context the editor's copy lacks — and
+   the Schema it instantiates, so its write-through never uses the client's copy. A
    mutation must also detach any derived in-flight request slot its store holds, so the next
    caller starts a fresh request instead of joining one that predates the write — `SchemaStore`'s
    `summariesRequest` slot (behind `fetchAllSchemaSummaries`) is the current instance: both

--- a/docs/adr/030-frontend-store-registry-semantics.md
+++ b/docs/adr/030-frontend-store-registry-semantics.md
@@ -1,11 +1,12 @@
 # Frontend Stores Are Registries, Not Caches
 
-Date: 2026-07-29
+Date: 2026-07-31
 
 Status: Accepted
 
-Extends [ADR 16](016-frontend-state-management.md), which settles which components read the
-stores but is silent on fetching, caching and invalidation.
+Amends [ADR 16](016-frontend-state-management.md), which settles which components read the
+stores but is silent on fetching, caching and invalidation: its editing-UI rule now applies
+to reads, while mutations and validation still go through store actions.
 
 ## Context
 
@@ -28,14 +29,17 @@ reason.
 ## Decision
 
 Stores are page-scoped registries of server state, not caches. A registry holds the page
-payload seeded at load, the session's own acknowledged writes, and explicitly fetched values.
+payload seeded at load and the session's own acknowledged writes.
 
-1. **Reads are explicit.** `fetchX` always calls the backend and records the result. `getX`
-   reads the registry synchronously. The store API offers no fetch-on-miss reads, with two
-   exceptions:
-   - `SubjectStore.getOrFetchSubject` resolves display labels over the deliberately seeded
-     page payload. Referenced Subjects arrive bundled with the page payload precisely so that
-     N relation displays do not fire N requests.
+1. **Reads are explicit.** `getX` reads the registry synchronously, over that page payload and
+   those writes. Editing UIs always open on freshly fetched data, read through the repositories
+   and taken as props ([ADR 16](016-frontend-state-management.md)); they still call store
+   actions to mutate and to validate. That fetch is the job of the code that opens the editor.
+   A host that renders from the stores installs what it fetched into them, unless a save-path
+   re-sync already keeps its display current (as on the manage-subjects page). The store API
+   offers no fetch-on-miss reads, with two exceptions:
+   - `SubjectStore.getOrFetchSubject` resolves display labels over the seeded page payload,
+     which bundles referenced Subjects precisely so N relation displays do not fire N requests.
    - `SchemaStore.fetchAllSchemaSummaries` lets concurrent callers share one in-flight
      pagination. Results are not retained, so every new caller cohort fetches fresh data.
 2. **Mutations keep the registry consistent with the session's own writes, on every path.**
@@ -51,32 +55,26 @@ payload seeded at load, the session's own acknowledged writes, and explicitly fe
    from the map. `SubjectStore.deleteSubject`/`pageSubjects` is the current instance — the map
    entry is dropped only once `pageSubjects` itself no longer lists the id, so a render caught
    between the two writes never sees a name `getSubject` cannot resolve.
-3. **Asynchronous write-backs are epoch-guarded.** Every fetch that writes into a store
-   snapshots that store's `mutationEpoch` before awaiting and discards the write into it when
-   the epoch moved, because a response that raced a mutation may predate that mutation. A fetch
-   that writes into more than one store snapshots and guards each store's epoch separately —
-   `SubjectStore.loadPageSubjects` and `StoreStateLoader.loadForSubject` both snapshot the
-   Subject and Schema stores' epochs up front and apply each write only if its own store's
-   epoch still matches by the time the response lands. The epoch is store-wide by design:
-   discarding an unrelated in-flight fetch costs one refetch and keeps the rule simple.
+3. **Asynchronous write-backs are epoch-guarded.** Every store write that follows a server read
+   snapshots that store's `mutationEpoch` beforehand and discards the write when the epoch moved,
+   because a response that raced a mutation may predate that mutation. Page seeding
+   (`StoreStateLoader`), `SubjectStore.loadPageSubjects`, `getOrFetchSubject`'s miss path and the
+   hosts that install what their editor-open fetch returned all follow it. A write into more than
+   one store snapshots and guards each store's epoch separately. The epoch is store-wide by
+   design: discarding an unrelated in-flight fetch costs one refetch and keeps the rule simple.
 
 The epoch guard covers store write-backs only; ordering component-local async state — a
-debounced validation run, a picker's in-flight request — remains each component's own job. The
-`requestSequence` counter in `useSubjectValidation` (mirrored in `SchemaCreator.vue`,
-`LayoutCreator.vue` and `SubjectLookup.vue`) applies the same discard-the-stale-response idea to
-local refs instead of store state.
+debounced validation run, a picker's in-flight request, an editor's schema fetch — remains each
+component's own job. The `requestSequence` counter in `useSubjectValidation` (mirrored in
+`SchemaCreator.vue`, `LayoutCreator.vue`, `SubjectLookup.vue` and `SubjectCreatorDialog.vue`)
+applies the same discard-the-stale-response idea to local refs instead of store state.
 
-Store action names follow a fixed vocabulary. `fetchX` hits the network, returns nothing, and
-records into the registry. `getX` reads the registry synchronously. `saveX` and `deleteSubject`
-are the server mutations. `removeX` is a local registry removal after a delete some other code
-path already executed server-side — Schema and Layout deletion goes through the shared
-`DeletePageDialog`, not a store action, so `removeSchema`/`removeLayout` exist to tell the store
-its copy is now gone. `fetchAllSchemaSummaries` is the deliberate exception that returns data
-directly: its results are not retained in the registry, so returning them is the only way
-callers see them at all.
-
-Editing UIs always open on freshly fetched data. That obligation sits with the code that opens
-the editor.
+Store action names follow a fixed vocabulary. `getX` reads the registry synchronously; the
+`fetchX` entity reads are gone, since reads for editing belong to the repositories. `removeX`
+is a local registry removal after a delete another code path already executed server-side:
+Schema and Layout deletion goes through the shared `DeletePageDialog`, so
+`removeSchema`/`removeLayout` tell the store its copy is gone. `fetchAllSchemaSummaries`
+returns its data directly because nothing retains it.
 
 Reloading the page remains legitimate where server-rendered output must reflect a change,
 because no store update can refresh views that the wiki rendered. The Subject-creation flow
@@ -84,14 +82,12 @@ reloads for this reason.
 
 ## Consequences
 
-* The public store API offers no fetch-on-miss reads for Schemas or Layouts
-  (`getOrFetchSchema` and `getOrFetchLayout` were removed). Extensions fetch explicitly and
-  read the registry; the RedHerb example extension demonstrates the pattern.
+* Fetching a Schema, Layout or Subject to edit is the caller's job, not a store action.
+  Extensions read through the repositories and pass the result down; RedHerb demonstrates it.
 * Schema pickers fetch summaries per mount cohort. A few requests per dialog open, bounded by
   the scale targets in [ADR 29](029-scalability-targets.md), buy freshness: Schemas created or
   deleted elsewhere appear without a reload.
-* New store actions must follow the three rules above. The store test suites demonstrate the
-  expected shape.
+* New store actions must follow the three rules above; the store test suites show the shape.
 
 ## Alternatives Considered
 
@@ -101,6 +97,14 @@ Epoch-guarding every read and invalidating on every mutation while keeping the `
 semantics. Rejected because it hand-rolls the hard parts of a query library to protect cache
 hits that stay session-stale anyway, and because every future action would have to remember
 the discipline.
+
+### Stores as the single data-access façade
+
+Routing editing reads through store fetch actions, so all server reads have one entry point.
+Rejected because it puts values only one component needs into shared state, which forces onto
+every fetch an epoch guard and a caller contract where a resolved fetch may have written
+nothing to the registry, and because
+[ADR 16](016-frontend-state-management.md) already decided editing UIs do not use the stores.
 
 ### Adopting a query library (TanStack Query or Pinia Colada)
 

--- a/docs/adr/030-frontend-store-registry-semantics.md
+++ b/docs/adr/030-frontend-store-registry-semantics.md
@@ -28,26 +28,28 @@ reason.
 
 ## Decision
 
-Stores are page-scoped registries of server state, not caches. A registry holds the page
-payload seeded at load and the session's own acknowledged writes.
+Stores are page-scoped registries of server state, not caches. A registry holds only what the
+server said — the page payload seeded at load, and what mutation responses returned.
 
 1. **Reads are explicit.** `getX` reads the registry synchronously, over that page payload and
    those writes. Editing UIs always open on freshly fetched data, read through the repositories
    and taken as props ([ADR 16](016-frontend-state-management.md)); they still call store
-   actions to mutate and to validate. That fetch is the job of the code that opens the editor.
-   A host that renders from the stores installs what it fetched into them, unless a save-path
-   re-sync already keeps its display current (as on the manage-subjects page). The store API
-   offers no fetch-on-miss reads, with two exceptions:
-   - `SubjectStore.getOrFetchSubject` resolves display labels over the seeded page payload,
-     which bundles referenced Subjects precisely so N relation displays do not fire N requests.
+   actions to mutate and to validate. That fetch is the job of the code that opens the editor and
+   stays out of the stores: a display catches up on commit, not on open. The store API offers no
+   fetch-on-miss reads, with two exceptions:
+   - `SubjectStore.getOrFetchSubject` resolves display labels over the seeded page payload, which
+     bundles referenced Subjects precisely so N relation displays do not fire N requests.
    - `SchemaStore.fetchAllSchemaSummaries` lets concurrent callers share one in-flight
      pagination. Results are not retained, so every new caller cohort fetches fresh data.
 2. **Mutations keep the registry consistent with the session's own writes, on every path.**
    Each store has a `mutationEpoch` counter that is bumped when the backend acknowledges a
    write. Saves write through, deletes remove the entity from all registry state, and
-   invalidation that must survive a rejected save runs in a `finally` block. A mutation must
-   also detach any derived in-flight request slot its store holds, so the next caller starts a
-   fresh request instead of joining one that predates the write — `SchemaStore`'s
+   invalidation that must survive a rejected save runs in a `finally` block. A save writes the
+   response's entity through, never the client's: a Subject write answers with the persisted
+   Subject — carrying the page context the editor's copy lacks — and the Schema it instantiates.
+   Schema and Layout saves write the authored object through; the editor is its sole author. A
+   mutation must also detach any derived in-flight request slot its store holds, so the next
+   caller starts a fresh request instead of joining one that predates the write — `SchemaStore`'s
    `summariesRequest` slot (behind `fetchAllSchemaSummaries`) is the current instance: both
    `saveSchema` and `removeSchema` null it out. Where a store holds both a listing and the
    entity map that listing's ids resolve through, a write that changes membership must keep the
@@ -59,34 +61,33 @@ payload seeded at load and the session's own acknowledged writes.
    snapshots that store's `mutationEpoch` beforehand and discards the write when the epoch moved,
    because a response that raced a mutation may predate that mutation. Page seeding
    (`StoreStateLoader`), `SubjectStore.loadPageSubjects`, `getOrFetchSubject`'s miss path and the
-   hosts that install what their editor-open fetch returned all follow it. A write into more than
-   one store snapshots and guards each store's epoch separately. The epoch is store-wide by
-   design: discarding an unrelated in-flight fetch costs one refetch and keeps the rule simple.
+   Schema a Subject write bundles all follow it. A write into more than one store snapshots and
+   guards each store's epoch separately. The epoch is store-wide by design: discarding an
+   unrelated in-flight fetch costs one refetch and keeps the rule simple.
 
-The epoch guard covers store write-backs only; ordering component-local async state — a
-debounced validation run, a picker's in-flight request, an editor's schema fetch — remains each
-component's own job. The `requestSequence` counter in `useSubjectValidation` (mirrored in
-`SchemaCreator.vue`, `LayoutCreator.vue`, `SubjectLookup.vue` and `SubjectCreatorDialog.vue`)
-applies the same discard-the-stale-response idea to local refs instead of store state.
+The epoch guard covers store write-backs only; ordering component-local async state — a debounced
+validation run, a picker's in-flight request, an editor's schema fetch — remains each component's
+own job. The `requestSequence` counter in `useSubjectValidation` (mirrored in `SchemaCreator.vue`,
+`LayoutCreator.vue`, `SubjectLookup.vue` and `SubjectCreatorDialog.vue`) applies the same
+discard-the-stale-response idea to local refs instead of store state.
 
 Store action names follow a fixed vocabulary. `getX` reads the registry synchronously; the
-`fetchX` entity reads are gone, since reads for editing belong to the repositories. `removeX`
-is a local registry removal after a delete another code path already executed server-side:
-Schema and Layout deletion goes through the shared `DeletePageDialog`, so
-`removeSchema`/`removeLayout` tell the store its copy is gone. `fetchAllSchemaSummaries`
-returns its data directly because nothing retains it.
+`fetchX` entity reads are gone, since reads for editing belong to the repositories. `removeX` is a
+local registry removal after a delete another code path already executed server-side: Schema and
+Layout deletion goes through the shared `DeletePageDialog`, so `removeSchema`/`removeLayout` tell
+the store its copy is gone. `fetchAllSchemaSummaries` returns its data directly, nothing retains it.
 
-Reloading the page remains legitimate where server-rendered output must reflect a change,
-because no store update can refresh views that the wiki rendered. The Subject-creation flow
-reloads for this reason.
+Reloading the page remains legitimate where server-rendered output must reflect a change, because
+no store update can refresh views the wiki rendered. The Subject-creation flow reloads for this
+reason.
 
 ## Consequences
 
-* Fetching a Schema, Layout or Subject to edit is the caller's job, not a store action.
-  Extensions read through the repositories and pass the result down; RedHerb demonstrates it.
-* Schema pickers fetch summaries per mount cohort. A few requests per dialog open, bounded by
-  the scale targets in [ADR 29](029-scalability-targets.md), buy freshness: Schemas created or
-  deleted elsewhere appear without a reload.
+* Fetching a Schema, Layout or Subject to edit is the caller's job, not a store action. Extensions
+  read through the repositories and pass the result down; RedHerb demonstrates it.
+* Schema pickers fetch summaries per mount cohort. A few requests per dialog open, bounded by the
+  scale targets in [ADR 29](029-scalability-targets.md), buy freshness: Schemas created or deleted
+  elsewhere appear without a reload.
 * New store actions must follow the three rules above; the store test suites show the shape.
 
 ## Alternatives Considered
@@ -94,9 +95,8 @@ reloads for this reason.
 ### Making the cache correct
 
 Epoch-guarding every read and invalidating on every mutation while keeping the `getOrFetch`
-semantics. Rejected because it hand-rolls the hard parts of a query library to protect cache
-hits that stay session-stale anyway, and because every future action would have to remember
-the discipline.
+semantics. Rejected because it hand-rolls the hard parts of a query library to protect cache hits
+that stay session-stale anyway, and every future action would have to remember the discipline.
 
 ### Stores as the single data-access façade
 

--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -26,9 +26,11 @@ may read (see [Cursor pagination](#cursor-pagination)): a restricted Schema, Lay
 one that does not exist, and no total count is reported, so nothing about restricted rows can be inferred from the
 pagination.
 
-Subject write endpoints require per-page `edit` permission and answer `403` on denial. The write endpoints keyed by
-page id ([Pages and Subjects](#pages-and-subjects)) answer the same `404` for a page you may not read as for a page id
-that does not exist.
+Subject write endpoints require per-page `edit` permission and answer `403` when you may read the page but not edit it.
+Denial of `read` answers `404` instead, so that a page you may not read stays indistinguishable from one that is absent.
+The write endpoints keyed by page id ([Pages and Subjects](#pages-and-subjects)) return that `404` for a page you may
+not read and for a page id that does not exist; `PUT /neowiki/v0/subject/{subjectId}` returns it for a Subject on a page
+you may not read and for a Subject id that does not exist.
 
 The Cypher query endpoint is gated only by the `neowiki-query` right, with no per-page filtering (see
 [Query API](query-api.md)).

--- a/docs/api/subject-format.md
+++ b/docs/api/subject-format.md
@@ -176,6 +176,29 @@ dropped without error. For schema/value validation outcomes see [Validation Code
 A relation may omit `id`; the server generates one. The Subject's `id`, `schema`, and page fields are immutable
 and ignored if sent.
 
+### Write responses
+
+Creating and writing a Subject both answer with the Subject as persisted and the Schema it instantiates, so a
+client does not have to re-read after a write:
+
+```json
+{
+  "status": "updated",
+  "subjectId": "s1demo5sssssss1",
+  "violations": [],
+  "subject": { "id": "s1demo5sssssss1", "label": "Updated Label", "schema": "Company", "pageId": 42,
+               "pageTitle": "Help:Installation", "pageNamespaceId": 12, "statements": {} },
+  "schema": { "description": "A company", "propertyDefinitions": {} }
+}
+```
+
+`subject` is the same shape `GET /subject/{subjectId}?expand=page` serves, so it reflects any normalisation the
+write applied. Its page fields are omitted when the server cannot resolve the Subject's page.
+
+`schema` carries no name of its own — that is the Subject's `schema` field — and is absent when the Schema does
+not exist or its page is unreadable. It is the Schema as of the write, which may define properties the client's
+copy does not.
+
 ## Complete example
 
 A page about Berlin with a main Subject and a child Subject for population data:

--- a/docs/extending/extending.md
+++ b/docs/extending/extending.md
@@ -321,9 +321,11 @@ configuration (Display Rules and Settings) from the layout store using `layoutNa
 references it renders through your component instead of the built-in infobox.
 
 The `redherb-card` example reuses NeoWiki's own building blocks rather than rendering values by hand: the subject,
-schema, and layout stores; `nw.resolveDisplayProperties` together with the value-display component registry to
-render each value through its Property Type's component; and the shared `nw.SubjectEditorDialog` for editing when
-`canEditSubject` is true.
+schema, and layout stores for display; `nw.resolveDisplayProperties` together with the value-display component
+registry to render each value through its Property Type's component; and the shared `nw.SubjectEditorDialog` for
+editing when `canEditSubject` is true. Editing reads go through the repositories your component injects
+(`nw.NeoWikiServices.getSubjectRepository()`, `getSchemaRepository()`), not the stores, and reach the dialog as
+props; the card writes what it fetched back into the stores it renders from, so its display shows the fresh data.
 
 Full example: [`resources/init.js`](https://github.com/ProfessionalWiki/NeoWiki/blob/master/tests/RedHerb/resources/init.js)
 with [`RedHerbCard.vue`](https://github.com/ProfessionalWiki/NeoWiki/blob/master/tests/RedHerb/resources/RedHerbCard.vue).

--- a/docs/extending/extending.md
+++ b/docs/extending/extending.md
@@ -325,7 +325,8 @@ schema, and layout stores for display; `nw.resolveDisplayProperties` together wi
 registry to render each value through its Property Type's component; and the shared `nw.SubjectEditorDialog` for
 editing when `canEditSubject` is true. Editing reads go through the repositories your component injects
 (`nw.NeoWikiServices.getSubjectRepository()`, `getSchemaRepository()`), not the stores, and reach the dialog as
-props; the card writes what it fetched back into the stores it renders from, so its display shows the fresh data.
+props. Saving updates the stores on its own: a Subject write answers with the Subject as persisted and the Schema
+it instantiates, and `nw.useSubjectStore()` records both.
 
 Full example: [`resources/init.js`](https://github.com/ProfessionalWiki/NeoWiki/blob/master/tests/RedHerb/resources/init.js)
 with [`RedHerbCard.vue`](https://github.com/ProfessionalWiki/NeoWiki/blob/master/tests/RedHerb/resources/RedHerbCard.vue).

--- a/extension.json
+++ b/extension.json
@@ -591,7 +591,6 @@
 				"neowiki-layouts-column-type",
 				"neowiki-layouts-column-description",
 				"neowiki-layouts-empty",
-				"neowiki-layouts-edit-stale-error",
 				"neowiki-special-mappings",
 				"neowiki-mappings-column-name",
 				"neowiki-mappings-column-schemas",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -255,7 +255,6 @@
 	"neowiki-layouts-column-type": "View type",
 	"neowiki-layouts-column-description": "Description",
 	"neowiki-layouts-empty": "No layouts have been created yet.",
-	"neowiki-layouts-edit-stale-error": "Could not load the layout. Please try again.",
 
 	"neowiki-special-mappings": "Ontology mappings",
 	"neowiki-mappings-column-name": "Name",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -153,7 +153,6 @@
 	"neowiki-layouts-column-type": "Column header for the view type in the layouts list table on [[Special:Layouts]].",
 	"neowiki-layouts-column-description": "Column header for layout description in the layouts list table on [[Special:Layouts]].",
 	"neowiki-layouts-empty": "Message shown when no layouts exist yet on [[Special:Layouts]].",
-	"neowiki-layouts-edit-stale-error": "Error notification shown on [[Special:Layouts]] when the layout could not be opened for editing because its data changed while loading (a concurrent save was detected).",
 
 	"neowiki-special-mappings": "Title and description of the [[Special:Mappings]] page, which lists the ontology mapping pages.",
 	"neowiki-mappings-column-name": "Column header for mapping name in the mappings list table on [[Special:Mappings]].",

--- a/resources/ext.neowiki/src/NeoWikiExtension.ts
+++ b/resources/ext.neowiki/src/NeoWikiExtension.ts
@@ -260,6 +260,7 @@ export class NeoWikiExtension {
 			this.getMediaWiki().util.wikiScript( 'rest' ),
 			this.newHttpClient(),
 			this.getSubjectDeserializer(),
+			new SchemaDeserializer(),
 			this.getRevisionId(),
 		);
 	}

--- a/resources/ext.neowiki/src/NeoWikiServices.ts
+++ b/resources/ext.neowiki/src/NeoWikiServices.ts
@@ -5,6 +5,7 @@ import { SubjectPermissionHints } from '@/application/SubjectPermissionHints.ts'
 import { NeoWikiExtension } from '@/NeoWikiExtension.ts';
 import { PropertyTypeRegistry } from '@/domain/PropertyType.ts';
 import { SchemaRepository } from '@/application/SchemaRepository.ts';
+import { SubjectRepository } from '@/domain/SubjectRepository.ts';
 import { SubjectLabelSearch } from '@/domain/SubjectLabelSearch.ts';
 import { ViewTypeRegistry } from '@/ViewTypeRegistry.ts';
 import { LayoutPermissionHints } from '@/application/LayoutPermissionHints.ts';
@@ -17,6 +18,7 @@ export enum Service { // TODO: make private
 	SubjectPermissionHints = 'SubjectPermissionHints',
 	PropertyTypeRegistry = 'PropertyTypeRegistry',
 	SchemaRepository = 'SchemaRepository',
+	SubjectRepository = 'SubjectRepository',
 	SubjectLabelSearch = 'SubjectLabelSearch',
 	ViewTypeRegistry = 'ViewTypeRegistry',
 	LayoutPermissionHints = 'LayoutPermissionHints',
@@ -41,6 +43,7 @@ export class NeoWikiServices {
 			[ Service.SubjectPermissionHints ]: neoWiki.newSubjectPermissionHints(),
 			[ Service.PropertyTypeRegistry ]: neoWiki.getPropertyTypeRegistry(),
 			[ Service.SchemaRepository ]: neoWiki.getSchemaRepository(),
+			[ Service.SubjectRepository ]: neoWiki.getSubjectRepository(),
 			[ Service.SubjectLabelSearch ]: neoWiki.getSubjectLabelSearch(),
 			[ Service.ViewTypeRegistry ]: neoWiki.getViewTypeRegistry(),
 			[ Service.LayoutPermissionHints ]: neoWiki.newLayoutPermissionHints(),
@@ -67,6 +70,10 @@ export class NeoWikiServices {
 
 	public static getSchemaRepository(): SchemaRepository {
 		return inject( Service.SchemaRepository ) as SchemaRepository;
+	}
+
+	public static getSubjectRepository(): SubjectRepository {
+		return inject( Service.SubjectRepository ) as SubjectRepository;
 	}
 
 	public static getSubjectLabelSearch(): SubjectLabelSearch {

--- a/resources/ext.neowiki/src/components/LayoutDisplay/LayoutDisplay.vue
+++ b/resources/ext.neowiki/src/components/LayoutDisplay/LayoutDisplay.vue
@@ -78,6 +78,7 @@ const currentLayout = shallowRef<Layout>( props.layout );
 const { canEditLayout, checkEditPermission } = useLayoutPermissions();
 const componentRegistry = NeoWikiServices.getComponentRegistry();
 const schemaRepo = NeoWikiServices.getSchemaRepository();
+const layoutRepo = NeoWikiServices.getLayoutRepository();
 const schemaProperties = shallowRef<PropertyDefinition[]>( [] );
 
 watch( () => props.layout, ( newLayout ) => {
@@ -136,8 +137,7 @@ const layoutStore = useLayoutStore();
 
 async function openEditor(): Promise<void> {
 	try {
-		await layoutStore.fetchLayout( currentLayout.value.getName() );
-		currentLayout.value = layoutStore.getLayout( currentLayout.value.getName() )!;
+		currentLayout.value = await layoutRepo.getLayout( currentLayout.value.getName() );
 		isEditorOpen.value = true;
 	} catch ( error ) {
 		mw.notify(

--- a/resources/ext.neowiki/src/components/LayoutsPage/LayoutsPage.vue
+++ b/resources/ext.neowiki/src/components/LayoutsPage/LayoutsPage.vue
@@ -104,6 +104,7 @@ import { cdxIconAdd, cdxIconEdit, cdxIconTrash } from '@wikimedia/codex-icons';
 import { NeoWikiExtension } from '@/NeoWikiExtension.ts';
 import { useCursorPagination } from '@/composables/useCursorPagination.ts';
 import { useLayoutPermissions } from '@/composables/useLayoutPermissions.ts';
+import { NeoWikiServices } from '@/NeoWikiServices.ts';
 import { useLayoutStore } from '@/stores/LayoutStore.ts';
 import { Layout } from '@/domain/Layout.ts';
 import LayoutCreatorDialog from './LayoutCreatorDialog.vue';
@@ -129,6 +130,7 @@ const totalRows = ref<number | undefined>( undefined );
 const { cursorFor, recordNextCursor } = useCursorPagination();
 const { canCreateLayouts, canEditLayout: canEditLayouts, checkCreatePermission, checkEditPermission } = useLayoutPermissions();
 const layoutStore = useLayoutStore();
+const layoutRepo = NeoWikiServices.getLayoutRepository();
 
 const isEditorOpen = ref( false );
 const editingLayout = shallowRef<Layout | null>( null );
@@ -226,21 +228,10 @@ async function openEditor( layoutName: string ): Promise<void> {
 		editingLayout.value = null;
 		await nextTick();
 
-		await Promise.all( [
-			layoutStore.fetchLayout( layoutName ),
+		const [ layout ] = await Promise.all( [
+			layoutRepo.getLayout( layoutName ),
 			fetchLayouts( lastOffset.value, pageSize.value )
 		] );
-
-		const layout = layoutStore.getLayout( layoutName );
-		if ( layout === undefined ) {
-			// The epoch guard discarded this fetch's write-back (a mutation landed
-			// mid-flight), so the store has no fresh data for this layout. Don't open
-			// the editor on stale/null data; the user can retry the edit. SchemasPage's
-			// equivalent throws into its catch below instead (getSchema throws rather than
-			// returning undefined); this converges the two on showing the same kind of toast.
-			mw.notify( mw.msg( 'neowiki-layouts-edit-stale-error' ), { type: 'error' } );
-			return;
-		}
 
 		editingLayout.value = layout;
 		isEditorOpen.value = true;

--- a/resources/ext.neowiki/src/components/SchemaDisplay/SchemaDisplay.vue
+++ b/resources/ext.neowiki/src/components/SchemaDisplay/SchemaDisplay.vue
@@ -91,6 +91,7 @@ const props = defineProps( {
 } );
 
 const schemaStore = useSchemaStore();
+const schemaRepo = NeoWikiServices.getSchemaRepository();
 const { canEditSchema, checkEditPermission } = useSchemaPermissions();
 
 const isEditorOpen = shallowRef( false );
@@ -139,8 +140,7 @@ function getTypeLabel( propertyType: string ): string {
 
 async function openEditor(): Promise<void> {
 	try {
-		await schemaStore.fetchSchema( currentSchema.value.getName() );
-		currentSchema.value = schemaStore.getSchema( currentSchema.value.getName() );
+		currentSchema.value = await schemaRepo.getSchema( currentSchema.value.getName() );
 		isEditorOpen.value = true;
 	} catch ( error ) {
 		mw.notify(

--- a/resources/ext.neowiki/src/components/SchemasPage/SchemasPage.vue
+++ b/resources/ext.neowiki/src/components/SchemasPage/SchemasPage.vue
@@ -99,6 +99,7 @@ import { cdxIconAdd, cdxIconEdit, cdxIconTrash } from '@wikimedia/codex-icons';
 import { NeoWikiExtension } from '@/NeoWikiExtension.ts';
 import { useCursorPagination } from '@/composables/useCursorPagination.ts';
 import { useSchemaPermissions } from '@/composables/useSchemaPermissions.ts';
+import { NeoWikiServices } from '@/NeoWikiServices.ts';
 import { useSchemaStore } from '@/stores/SchemaStore.ts';
 import { Schema } from '@/domain/Schema.ts';
 import type { SchemaSummary } from '@/application/SchemaLookup.ts';
@@ -125,6 +126,7 @@ const totalRows = ref<number | undefined>( undefined );
 const { cursorFor, recordNextCursor } = useCursorPagination();
 const { canEditSchema, canCreateSchemas, checkEditPermission, checkCreatePermission } = useSchemaPermissions();
 const schemaStore = useSchemaStore();
+const schemaRepo = NeoWikiServices.getSchemaRepository();
 
 const isEditorOpen = ref( false );
 const editingSchema = shallowRef<Schema | null>( null );
@@ -204,15 +206,12 @@ async function openEditor( schemaName: string ): Promise<void> {
 		editingSchema.value = null;
 		await nextTick();
 
-		await Promise.all( [
-			schemaStore.fetchSchema( schemaName ),
+		const [ schema ] = await Promise.all( [
+			schemaRepo.getSchema( schemaName ),
 			fetchSchemas( lastOffset.value, pageSize.value )
 		] );
-		// getSchema throws rather than returning undefined on a miss (e.g. the epoch guard
-		// discarded fetchSchema's write-back), so a genuine miss lands in the catch below instead
-		// of ever reaching this assignment — unlike LayoutsPage, which checks getLayout's result
-		// explicitly because that getter can return undefined.
-		editingSchema.value = schemaStore.getSchema( schemaName );
+
+		editingSchema.value = schema;
 		isEditorOpen.value = true;
 	} catch ( error ) {
 		mw.notify(

--- a/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
@@ -184,6 +184,7 @@ import { useChangeDetection } from '@/composables/useChangeDetection.ts';
 import { useCloseConfirmation } from '@/composables/useCloseConfirmation.ts';
 import { useSubjectValidation } from '@/composables/useSubjectValidation.ts';
 import { NeoWikiExtension } from '@/NeoWikiExtension.ts';
+import { NeoWikiServices } from '@/NeoWikiServices.ts';
 import { setPendingNotification } from '@/presentation/PendingNotification.ts';
 
 const props = defineProps<{
@@ -200,8 +201,13 @@ const schemaCreatorRef = ref<SchemaCreatorExposes | null>( null );
 
 const draftSchema = shallowRef<Schema | null>( null );
 
+// Guards loadedSchema against a stale schema fetch: picking a different schema, and leaving the
+// picked one (going back, or the dialog closing), both invalidate an in-flight response.
+let requestSequence = 0;
+
 const subjectStore = useSubjectStore();
 const schemaStore = useSchemaStore();
+const schemaRepo = NeoWikiServices.getSchemaRepository();
 const { canCreateSchemas, checkCreatePermission } = useSchemaPermissions();
 const { hasChanged, markChanged, resetChanged } = useChangeDetection();
 
@@ -373,10 +379,21 @@ async function onSchemaSelected( schemaName: string ): Promise<void> {
 	subjectLabel.value = String( mw.config.get( 'wgTitle' ) ?? '' );
 	markChanged();
 
+	const currentSequence = ++requestSequence;
+
 	try {
-		await schemaStore.fetchSchema( schemaName );
-		loadedSchema.value = schemaStore.getSchema( schemaName );
+		const schema = await schemaRepo.getSchema( schemaName );
+
+		if ( currentSequence !== requestSequence ) {
+			return;
+		}
+
+		loadedSchema.value = schema;
 	} catch ( error ) {
+		if ( currentSequence !== requestSequence ) {
+			return;
+		}
+
 		console.error( 'Failed to load schema:', error );
 		loadedSchema.value = null;
 	}
@@ -421,6 +438,7 @@ watch( () => subjectStore.subjectCreatorOpen, async ( isOpen ) => {
 } );
 
 function resetForm(): void {
+	requestSequence++;
 	selectedSchemaName.value = null;
 	loadedSchema.value = null;
 	draftSchema.value = null;
@@ -431,6 +449,7 @@ function resetForm(): void {
 }
 
 function goBack(): void {
+	requestSequence++;
 	selectedSchemaName.value = null;
 	loadedSchema.value = null;
 	subjectLabel.value = '';

--- a/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditorDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditorDialog.vue
@@ -62,18 +62,14 @@
 			</CdxMessage>
 
 			<SubjectEditor
-				v-if="statements"
 				ref="subjectEditorRef"
 				:statements="statements"
-				:schema="loadedSchema as Schema"
+				:schema="currentSchema"
 				:server-violations="serverViolations"
 				@change="handleEditorChange"
 				@focusout="handleEditorBlur"
 				@clear-server-violation="handleClearViolation"
 			/>
-			<div v-else>
-				Loading schema... <!-- Or some other loading indicator -->
-			</div>
 
 			<!-- TODO: We should make this into a component-->
 			<template #footer>
@@ -87,9 +83,8 @@
 		</CdxDialog>
 
 		<SchemaEditorDialog
-			v-if="loadedSchema"
 			:open="isSchemaEditorOpen"
-			:initial-schema="loadedSchema as Schema"
+			:initial-schema="currentSchema"
 			:on-save="props.onSaveSchema"
 			@saved="onSchemaSaved"
 			@update:open="isSchemaEditorOpen = $event"
@@ -104,7 +99,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, nextTick, computed, watch } from 'vue';
+import { ref, shallowRef, nextTick, computed, watch } from 'vue';
 import SubjectEditor from '@/components/SubjectEditor/SubjectEditor.vue';
 import SummaryAction from '@/components/common/SummaryAction.vue';
 import I18nSlot from '@/components/common/I18nSlot.vue';
@@ -112,7 +107,6 @@ import { CdxButton, CdxDialog, CdxIcon, CdxMessage } from '@wikimedia/codex';
 import { cdxIconClose } from '@wikimedia/codex-icons';
 import { StatementList } from '@/domain/StatementList.ts';
 import { Subject } from '@/domain/Subject.ts';
-import { useSchemaStore } from '@/stores/SchemaStore.ts';
 import { useSubjectStore } from '@/stores/SubjectStore.ts';
 import { Schema } from '@/domain/Schema.ts';
 import SchemaEditorDialog from '@/components/SchemaEditor/SchemaEditorDialog.vue';
@@ -130,6 +124,7 @@ type SubjectSaveHandler = ( subject: Subject, comment: string ) => Promise<void>
 
 const props = defineProps<{
 	subject: Subject;
+	schema: Schema;
 	onSave: SubjectSaveHandler;
 	onSaveSchema: SchemaSaveHandler;
 	open: boolean;
@@ -137,7 +132,6 @@ const props = defineProps<{
 
 const emit = defineEmits( [ 'update:open' ] );
 
-const schemaStore = useSchemaStore();
 const subjectStore = useSubjectStore();
 
 interface SubjectEditorInstance {
@@ -146,7 +140,9 @@ interface SubjectEditorInstance {
 
 const isSchemaEditorOpen = ref( false );
 const subjectEditorRef = ref<SubjectEditorInstance | null>( null );
-const loadedSchema = ref<Schema | null>( null );
+// Mirrors the prop so a schema saved through the nested SchemaEditorDialog takes effect here
+// without waiting for the host to pass a new one down.
+const currentSchema = shallowRef<Schema>( props.schema );
 const { canEditSchema, checkEditPermission } = useSchemaPermissions();
 const { hasChanged, markChanged, resetChanged } = useChangeDetection();
 
@@ -200,7 +196,7 @@ const anchorlessViolations = computed<SubjectViolation[]>( () => {
 	// raw subject — otherwise a violation on a missing-but-rendered field
 	// would be wrongly banner-routed even though the field is on screen.
 	const renderedPropertyNames = new Set(
-		[ ...( statements.value ?? [] ) ].map( ( s ) => s.propertyName.toString() )
+		[ ...statements.value ].map( ( s ) => s.propertyName.toString() )
 	);
 	return serverViolations.value.filter( ( v ) => {
 		if ( v.propertyName === null ) {
@@ -249,31 +245,16 @@ watch( subjectEditorRef, ( editor ) => {
 	}
 } );
 
-watch( () => props.subject, async ( newSubject ) => {
-	if ( newSubject ) {
-		await checkEditPermission( newSubject.getSchemaName() );
-		loadSchema();
-	}
+watch( () => props.subject, ( newSubject ) => {
+	checkEditPermission( newSubject.getSchemaName() );
 }, { immediate: true } );
 
-function loadSchema(): void {
-	try {
-		// Deliberately a registry read, not a fetch: hosts guarantee the schema is
-		// loaded (page seeding plus a fresh fetch in their openEditor), and this
-		// dialog is mounted inside every editable Infobox, so fetching here would
-		// fire a request per view at page load.
-		loadedSchema.value = schemaStore.getSchema( props.subject.getSchemaName() );
-	} catch ( error ) {
-		console.error( 'Failed to load schema:', error );
-		mw.notify(
-			`Failed to load schema ${ props.subject.getSchemaName() }: ${ error instanceof Error ? error.message : String( error ) }`,
-			{ type: 'error' }
-		);
-	}
-}
+watch( () => props.schema, ( newSchema ) => {
+	currentSchema.value = newSchema;
+} );
 
-const statements = computed( (): StatementList | null =>
-	loadedSchema.value?.statementsFrom( props.subject.getStatements() ) ?? null
+const statements = computed( (): StatementList =>
+	currentSchema.value.statementsFrom( props.subject.getStatements() )
 );
 
 const handleSave = async ( summary: string ): Promise<void> => {
@@ -316,7 +297,7 @@ const handleSave = async ( summary: string ): Promise<void> => {
 };
 
 const onSchemaSaved = ( schema: Schema ): void => {
-	loadedSchema.value = schema;
+	currentSchema.value = schema;
 };
 
 defineExpose( { hasChanged } );

--- a/resources/ext.neowiki/src/components/SubjectsManager/SubjectsManagerPage.vue
+++ b/resources/ext.neowiki/src/components/SubjectsManager/SubjectsManagerPage.vue
@@ -426,9 +426,10 @@
 		/>
 
 		<SubjectEditorDialog
-			v-if="editingSubject !== null"
+			v-if="editingSubject !== null && editingSchema !== null"
 			v-model:open="editorOpen"
 			:subject="editingSubject as Subject"
+			:schema="editingSchema as Schema"
 			:on-save="handleEditSave"
 			:on-save-schema="handleSchemaSave"
 		/>
@@ -458,7 +459,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref, nextTick } from 'vue';
+import { computed, onMounted, onUnmounted, ref, shallowRef, nextTick } from 'vue';
 import {
 	CdxButton,
 	CdxDialog,
@@ -477,6 +478,7 @@ import {
 	cdxIconPushPin,
 	cdxIconTrash
 } from '@wikimedia/codex-icons';
+import { NeoWikiServices } from '@/NeoWikiServices.ts';
 import { useSubjectStore } from '@/stores/SubjectStore.ts';
 import { useSchemaStore } from '@/stores/SchemaStore.ts';
 import { useSubjectPermissions } from '@/composables/useSubjectPermissions.ts';
@@ -505,6 +507,8 @@ const subjectIriBase = ( mw.config.get( 'wgNeoWikiSubjectIriBase' ) as string | 
 
 const subjectStore = useSubjectStore();
 const schemaStore = useSchemaStore();
+const subjectRepo = NeoWikiServices.getSubjectRepository();
+const schemaRepo = NeoWikiServices.getSchemaRepository();
 const {
 	canCreateMainSubject,
 	canCreateChildSubject,
@@ -543,20 +547,19 @@ function scrollBehavior(): 'auto' | 'smooth' {
 	return window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches ? 'auto' : 'smooth';
 }
 
-const editingSubjectId = ref<SubjectId | null>( null );
+// Editor state is component-local (ADR 16): the dialog opens on data fetched straight from the
+// repositories, not on the store the list below renders from.
+const editingSubject = shallowRef<Subject | null>( null );
+const editingSchema = shallowRef<Schema | null>( null );
 const editorOpen = ref( false );
 
 const deleteConfirmOpen = ref( false );
 const deletingSubject = ref<Subject | null>( null );
 
-// Read subjects through the reactive store so refreshes (e.g. on openEditor) flow into the list.
+// Read subjects through the reactive store so the session's own writes flow into the list.
 const subjects = computed<Subject[]>( () =>
 	subjectStore.pageSubjects?.getSubjects()
 		.map( ( s ) => subjectStore.getSubject( s.getId() ) ) ?? []
-);
-
-const editingSubject = computed<Subject | null>( () =>
-	editingSubjectId.value === null ? null : subjectStore.getSubject( editingSubjectId.value )
 );
 
 const canCreate = computed( () => canCreateMainSubject.value || canCreateChildSubject.value );
@@ -836,14 +839,15 @@ async function demoteFromMain(): Promise<void> {
 
 async function openEditor( subject: Subject ): Promise<void> {
 	try {
-		// Refresh both subject and schema so the editor never opens against stale data
+		// Fetch both subject and schema so the editor never opens against stale data
 		// (e.g. after the subject or its schema was edited in another tab).
-		await Promise.all( [
-			subjectStore.fetchSubject( subject.getId() ),
-			schemaStore.fetchSchema( subject.getSchemaName() )
+		const [ freshSubject, schema ] = await Promise.all( [
+			subjectRepo.getSubject( subject.getId() ),
+			schemaRepo.getSchema( subject.getSchemaName() )
 		] );
 
-		editingSubjectId.value = subject.getId();
+		editingSubject.value = freshSubject;
+		editingSchema.value = schema;
 		editorOpen.value = true;
 	} catch ( error ) {
 		mw.notify(

--- a/resources/ext.neowiki/src/components/Views/Infobox.vue
+++ b/resources/ext.neowiki/src/components/Views/Infobox.vue
@@ -29,9 +29,10 @@
 				<CdxIcon :icon="cdxIconEdit" />
 			</CdxButton>
 			<SubjectEditorDialog
-				v-if="canEditSubject"
+				v-if="editingSubject !== null && editingSchema !== null"
 				v-model:open="isEditorOpen"
-				:subject="subject"
+				:subject="editingSubject as Subject"
+				:schema="editingSchema as Schema"
 				:on-save="handleSaveSubject"
 				:on-save-schema="handleSaveSchema"
 			/>
@@ -59,7 +60,7 @@
 </template>
 
 <script setup lang="ts">
-import { Component, computed, ref } from 'vue';
+import { Component, computed, ref, shallowRef } from 'vue';
 import { Subject } from '@/domain/Subject.ts';
 import { Schema } from '@/domain/Schema.ts';
 import { useSchemaStore } from '@/stores/SchemaStore.ts';
@@ -77,18 +78,41 @@ const props = defineProps<ViewProps>();
 const subjectStore = useSubjectStore();
 const schemaStore = useSchemaStore();
 const layoutStore = useLayoutStore();
+const subjectRepo = NeoWikiServices.getSubjectRepository();
+const schemaRepo = NeoWikiServices.getSchemaRepository();
 
 const isEditorOpen = ref( false );
+// The dialog edits its own copy rather than the registry entry (ADR 16).
+const editingSubject = shallowRef<Subject | null>( null );
+const editingSchema = shallowRef<Schema | null>( null );
 
 const subject = computed( () => subjectStore.getSubject( props.subjectId ) ); // TODO: handle not found
 const schema = computed( () => schemaStore.getSchema( subject.value.getSchemaName() ) ); // TODO: handle not found
 
 async function openEditor(): Promise<void> {
 	try {
-		await Promise.all( [
-			schemaStore.fetchSchema( subject.value.getSchemaName() ),
-			subjectStore.fetchSubject( props.subjectId )
+		const schemaName = subject.value.getSchemaName();
+		const subjectEpoch = subjectStore.mutationEpoch;
+		const schemaEpoch = schemaStore.mutationEpoch;
+
+		const [ freshSubject, freshSchema ] = await Promise.all( [
+			subjectRepo.getSubject( props.subjectId ),
+			schemaRepo.getSchema( schemaName )
 		] );
+
+		// This view renders from the registries, so publish the server truth we just fetched into
+		// them: otherwise a schema another session changed stays invisible here, and a value saved
+		// against a property this display does not know about renders as nothing. Each write is
+		// epoch-guarded against its own store (ADR 30 rule 3).
+		if ( subjectEpoch === subjectStore.mutationEpoch ) {
+			subjectStore.setSubject( freshSubject );
+		}
+		if ( schemaEpoch === schemaStore.mutationEpoch ) {
+			schemaStore.setSchema( schemaName, freshSchema );
+		}
+
+		editingSubject.value = freshSubject;
+		editingSchema.value = freshSchema;
 		isEditorOpen.value = true;
 	} catch ( error ) {
 		mw.notify(

--- a/resources/ext.neowiki/src/components/Views/Infobox.vue
+++ b/resources/ext.neowiki/src/components/Views/Infobox.vue
@@ -82,7 +82,8 @@ const subjectRepo = NeoWikiServices.getSubjectRepository();
 const schemaRepo = NeoWikiServices.getSchemaRepository();
 
 const isEditorOpen = ref( false );
-// The dialog edits its own copy rather than the registry entry (ADR 16).
+// The dialog edits its own copy rather than the registry entry (ADR 16). The display below stays
+// on the stores until a save, whose response carries the Subject and Schema as persisted.
 const editingSubject = shallowRef<Subject | null>( null );
 const editingSchema = shallowRef<Schema | null>( null );
 
@@ -91,25 +92,10 @@ const schema = computed( () => schemaStore.getSchema( subject.value.getSchemaNam
 
 async function openEditor(): Promise<void> {
 	try {
-		const schemaName = subject.value.getSchemaName();
-		const subjectEpoch = subjectStore.mutationEpoch;
-		const schemaEpoch = schemaStore.mutationEpoch;
-
 		const [ freshSubject, freshSchema ] = await Promise.all( [
 			subjectRepo.getSubject( props.subjectId ),
-			schemaRepo.getSchema( schemaName )
+			schemaRepo.getSchema( subject.value.getSchemaName() )
 		] );
-
-		// This view renders from the registries, so publish the server truth we just fetched into
-		// them: otherwise a schema another session changed stays invisible here, and a value saved
-		// against a property this display does not know about renders as nothing. Each write is
-		// epoch-guarded against its own store (ADR 30 rule 3).
-		if ( subjectEpoch === subjectStore.mutationEpoch ) {
-			subjectStore.setSubject( freshSubject );
-		}
-		if ( schemaEpoch === schemaStore.mutationEpoch ) {
-			schemaStore.setSchema( schemaName, freshSchema );
-		}
 
 		editingSubject.value = freshSubject;
 		editingSchema.value = freshSchema;

--- a/resources/ext.neowiki/src/domain/SubjectRepository.ts
+++ b/resources/ext.neowiki/src/domain/SubjectRepository.ts
@@ -2,15 +2,28 @@ import { SubjectId } from '@/domain/SubjectId';
 import type { SubjectLookup } from '@/domain/SubjectLookup';
 import { InMemorySubjectLookup } from '@/domain/SubjectLookup';
 import type { StatementList } from '@/domain/StatementList';
-import type { SchemaName } from '@/domain/Schema';
+import type { Schema, SchemaName } from '@/domain/Schema';
 import { PageSubjects } from '@/domain/PageSubjects';
 import type { Subject } from '@/domain/Subject';
+import { SubjectWithContext } from '@/domain/SubjectWithContext';
+import { PageIdentifiers } from '@/domain/PageIdentifiers';
 import type { DeserializedPageSubjects } from '@/persistence/PageSubjectsDeserializer';
 import type { SubjectViolation } from '@/domain/SubjectViolation';
 
 export interface SubjectWithReferencedSubjects {
 	requestedSubject: Subject;
 	referencedSubjects: Subject[];
+}
+
+/**
+ * What a Subject write returns: the Subject as the server persisted it, carrying the context
+ * (page identifiers) and normalisation a client-built copy cannot reproduce, plus the Schema it
+ * is an instance of, so a display can render the saved values even when the Schema changed
+ * out of band. The Schema is null when the server could not resolve it.
+ */
+export interface SubjectWriteResult {
+	subject: SubjectWithContext;
+	schema: Schema | null;
 }
 
 export interface SubjectRepository extends SubjectLookup {
@@ -39,7 +52,7 @@ export interface SubjectRepository extends SubjectLookup {
 		schemaName: SchemaName,
 		statements: StatementList,
 		comment?: string
-	): Promise<SubjectId>;
+	): Promise<SubjectWriteResult>;
 
 	createChildSubject(
 		pageId: number,
@@ -47,10 +60,14 @@ export interface SubjectRepository extends SubjectLookup {
 		schemaName: SchemaName,
 		statements: StatementList,
 		comment?: string
-	): Promise<SubjectId>;
+	): Promise<SubjectWriteResult>;
 
-	// TODO: return something to indicate status
-	updateSubject( id: SubjectId, label: string, statements: StatementList, comment?: string ): Promise<object>;
+	updateSubject(
+		id: SubjectId,
+		label: string,
+		statements: StatementList,
+		comment?: string
+	): Promise<SubjectWriteResult>;
 
 	deleteSubject( id: SubjectId, comment?: string ): Promise<boolean>;
 
@@ -92,16 +109,40 @@ export class StubSubjectRepository extends InMemorySubjectLookup implements Subj
 		return Promise.resolve();
 	}
 
-	public createMainSubject( _pageId: number, _label: string, _schemaName: string, _statements: StatementList, _comment?: string ): Promise<SubjectId> {
-		return Promise.resolve( new SubjectId( 's11111111111111' ) );
+	public createMainSubject( pageId: number, label: string, schemaName: string, statements: StatementList, _comment?: string ): Promise<SubjectWriteResult> {
+		return Promise.resolve( this.newWriteResult( new SubjectId( 's11111111111111' ), pageId, label, schemaName, statements ) );
 	}
 
-	public createChildSubject( _pageId: number, _label: string, _schemaName: string, _statements: StatementList, _comment?: string ): Promise<SubjectId> {
-		return Promise.resolve( new SubjectId( 's11111111111112' ) );
+	public createChildSubject( pageId: number, label: string, schemaName: string, statements: StatementList, _comment?: string ): Promise<SubjectWriteResult> {
+		return Promise.resolve( this.newWriteResult( new SubjectId( 's11111111111112' ), pageId, label, schemaName, statements ) );
 	}
 
-	public updateSubject( _id: SubjectId, _label: string, _statements: StatementList, _comment?: string ): Promise<object> {
-		return Promise.resolve( {} );
+	public async updateSubject( id: SubjectId, label: string, statements: StatementList, _comment?: string ): Promise<SubjectWriteResult> {
+		const existing = await this.getSubject( id );
+
+		return {
+			subject: new SubjectWithContext(
+				id,
+				label,
+				existing.getSchemaName(),
+				statements,
+				new PageIdentifiers( 0, 'page-title' ),
+			),
+			schema: null,
+		};
+	}
+
+	private newWriteResult(
+		id: SubjectId,
+		pageId: number,
+		label: string,
+		schemaName: string,
+		statements: StatementList,
+	): SubjectWriteResult {
+		return {
+			subject: new SubjectWithContext( id, label, schemaName, statements, new PageIdentifiers( pageId, 'page-title' ) ),
+			schema: null,
+		};
 	}
 
 	public deleteSubject( id: SubjectId, _comment?: string ): Promise<boolean> {

--- a/resources/ext.neowiki/src/domain/SubjectRepository.ts
+++ b/resources/ext.neowiki/src/domain/SubjectRepository.ts
@@ -16,13 +16,22 @@ export interface SubjectWithReferencedSubjects {
 }
 
 /**
- * What a Subject write returns: the Subject as the server persisted it, carrying the context
- * (page identifiers) and normalisation a client-built copy cannot reproduce, plus the Schema it
- * is an instance of, so a display can render the saved values even when the Schema changed
- * out of band. The Schema is null when the server could not resolve it.
+ * What a Subject write returns.
  */
 export interface SubjectWriteResult {
-	subject: SubjectWithContext;
+	/** The id the server assigned or confirmed. Always known. */
+	subjectId: SubjectId;
+	/**
+	 * The Subject as the server persisted it, carrying the page context and normalisation a
+	 * client-built copy cannot reproduce. Null when the response omitted the page identifiers,
+	 * which a Subject on an unresolvable page does: recording it would put a Subject with no page
+	 * behind links that need one, so callers keep whatever copy they already had.
+	 */
+	subject: SubjectWithContext | null;
+	/**
+	 * The Schema the Subject instantiates, so a display can render values saved against a
+	 * property the Schema gained out of band. Null when the server could not resolve it.
+	 */
 	schema: Schema | null;
 }
 
@@ -120,16 +129,7 @@ export class StubSubjectRepository extends InMemorySubjectLookup implements Subj
 	public async updateSubject( id: SubjectId, label: string, statements: StatementList, _comment?: string ): Promise<SubjectWriteResult> {
 		const existing = await this.getSubject( id );
 
-		return {
-			subject: new SubjectWithContext(
-				id,
-				label,
-				existing.getSchemaName(),
-				statements,
-				new PageIdentifiers( 0, 'page-title' ),
-			),
-			schema: null,
-		};
+		return this.newWriteResult( id, 0, label, existing.getSchemaName(), statements );
 	}
 
 	private newWriteResult(
@@ -140,6 +140,7 @@ export class StubSubjectRepository extends InMemorySubjectLookup implements Subj
 		statements: StatementList,
 	): SubjectWriteResult {
 		return {
+			subjectId: id,
 			subject: new SubjectWithContext( id, label, schemaName, statements, new PageIdentifiers( pageId, 'page-title' ) ),
 			schema: null,
 		};

--- a/resources/ext.neowiki/src/persistence/RestSubjectRepository.ts
+++ b/resources/ext.neowiki/src/persistence/RestSubjectRepository.ts
@@ -64,23 +64,29 @@ export class RestSubjectRepository implements SubjectRepository {
 		private readonly mediaWikiRestApiUrl: string,
 		private readonly httpClient: HttpClient,
 		private readonly subjectDeserializer: SubjectDeserializer,
+		private readonly schemaDeserializer: SchemaDeserializer,
 		private readonly revisionId?: number,
-		private readonly schemaDeserializer: SchemaDeserializer = new SchemaDeserializer(),
 	) {
 	}
 
 	/**
 	 * A write answers with the Subject as persisted and the Schema it instantiates. The Schema
 	 * name is not repeated in the schema body — it is the Subject's own `schema` field.
+	 *
+	 * The page identifiers are omitted when the server could not resolve the Subject's page.
+	 * Deserializing that would mint a Subject whose page id is undefined, which anything
+	 * rendering a link to it would then follow; report no Subject instead, so the caller keeps
+	 * the copy it already had.
 	 */
 	private deserializeWriteResult( json: SubjectWriteResponseJson ): SubjectWriteResult {
-		const subject = this.subjectDeserializer.deserialize( json.subject );
+		const hasPageContext = json.subject.pageId !== undefined && json.subject.pageTitle !== undefined;
 
 		return {
-			subject,
+			subjectId: new SubjectId( json.subject.id ),
+			subject: hasPageContext ? this.subjectDeserializer.deserialize( json.subject ) : null,
 			schema: json.schema === undefined ?
 				null :
-				this.schemaDeserializer.deserialize( subject.getSchemaName(), json.schema ),
+				this.schemaDeserializer.deserialize( json.subject.schema, json.schema ),
 		};
 	}
 

--- a/resources/ext.neowiki/src/persistence/RestSubjectRepository.ts
+++ b/resources/ext.neowiki/src/persistence/RestSubjectRepository.ts
@@ -1,4 +1,4 @@
-import type { SubjectRepository, SubjectWithReferencedSubjects } from '@/domain/SubjectRepository';
+import type { SubjectRepository, SubjectWithReferencedSubjects, SubjectWriteResult } from '@/domain/SubjectRepository';
 import { SubjectId } from '@/domain/SubjectId';
 import type { SubjectDeserializer } from '@/persistence/SubjectDeserializer';
 import {
@@ -8,6 +8,7 @@ import {
 } from '@/persistence/PageSubjectsDeserializer';
 import { StatementList, statementsToJson } from '@/domain/StatementList';
 import { type SchemaName } from '@/domain/Schema';
+import { SchemaDeserializer } from '@/persistence/SchemaDeserializer';
 import type { HttpClient } from '@/infrastructure/HttpClient/HttpClient';
 import type { Subject } from '@/domain/Subject';
 import type { SubjectViolation } from '@/domain/SubjectViolation';
@@ -52,6 +53,11 @@ type SubjectBundleJson = {
 	subjects: Record<string, SubjectJson>;
 };
 
+type SubjectWriteResponseJson = {
+	subject: SubjectJson;
+	schema?: Record<string, unknown>;
+};
+
 export class RestSubjectRepository implements SubjectRepository {
 
 	public constructor(
@@ -59,7 +65,23 @@ export class RestSubjectRepository implements SubjectRepository {
 		private readonly httpClient: HttpClient,
 		private readonly subjectDeserializer: SubjectDeserializer,
 		private readonly revisionId?: number,
+		private readonly schemaDeserializer: SchemaDeserializer = new SchemaDeserializer(),
 	) {
+	}
+
+	/**
+	 * A write answers with the Subject as persisted and the Schema it instantiates. The Schema
+	 * name is not repeated in the schema body — it is the Subject's own `schema` field.
+	 */
+	private deserializeWriteResult( json: SubjectWriteResponseJson ): SubjectWriteResult {
+		const subject = this.subjectDeserializer.deserialize( json.subject );
+
+		return {
+			subject,
+			schema: json.schema === undefined ?
+				null :
+				this.schemaDeserializer.deserialize( subject.getSchemaName(), json.schema ),
+		};
 	}
 
 	public async getPageSubjects( pageId: number ): Promise<DeserializedPageSubjects> {
@@ -185,7 +207,7 @@ export class RestSubjectRepository implements SubjectRepository {
 		schemaName: SchemaName,
 		statements: StatementList,
 		comment?: string,
-	): Promise<SubjectId> {
+	): Promise<SubjectWriteResult> {
 		const payload = {
 			label: label,
 			schema: schemaName,
@@ -209,8 +231,7 @@ export class RestSubjectRepository implements SubjectRepository {
 			throw new Error( 'Error creating main subject' );
 		}
 
-		const data = await response.json();
-		return new SubjectId( data.subjectId );
+		return this.deserializeWriteResult( await response.json() as SubjectWriteResponseJson );
 	}
 
 	public async createChildSubject(
@@ -219,7 +240,7 @@ export class RestSubjectRepository implements SubjectRepository {
 		schemaName: SchemaName,
 		statements: StatementList,
 		comment?: string,
-	): Promise<SubjectId> {
+	): Promise<SubjectWriteResult> {
 		const payload = {
 			label: label,
 			schema: schemaName,
@@ -243,11 +264,10 @@ export class RestSubjectRepository implements SubjectRepository {
 			throw new Error( 'Error creating child subject' );
 		}
 
-		const data = await response.json();
-		return new SubjectId( data.subjectId );
+		return this.deserializeWriteResult( await response.json() as SubjectWriteResponseJson );
 	}
 
-	public async updateSubject( id: SubjectId, label: string, statements: StatementList, comment?: string ): Promise<object> {
+	public async updateSubject( id: SubjectId, label: string, statements: StatementList, comment?: string ): Promise<SubjectWriteResult> {
 		const response = await this.httpClient.put(
 			`${ this.mediaWikiRestApiUrl }/neowiki/v0/subject/${ id.text }`,
 			{
@@ -268,7 +288,7 @@ export class RestSubjectRepository implements SubjectRepository {
 			throw new Error( 'Error updating subject' );
 		}
 
-		return await response.json();
+		return this.deserializeWriteResult( await response.json() as SubjectWriteResponseJson );
 	}
 
 	public async deleteSubject( id: SubjectId, comment?: string ): Promise<boolean> {

--- a/resources/ext.neowiki/src/stores/LayoutStore.ts
+++ b/resources/ext.neowiki/src/stores/LayoutStore.ts
@@ -14,18 +14,6 @@ export const useLayoutStore = defineStore( 'layout', {
 		setLayout( name: string, layout: Layout ): void {
 			this.layouts.set( name, layout );
 		},
-		// A resolved call may have recorded nothing: the epoch guard below discards the write-back
-		// when a mutation landed mid-flight, leaving the registry unchanged. Callers must read the
-		// result via getLayout afterwards and handle a miss (getLayout can return undefined),
-		// rather than assuming this call alone guarantees fresh data is present.
-		async fetchLayout( name: string ): Promise<void> {
-			const epoch = this.mutationEpoch;
-			const layout = await NeoWikiExtension.getInstance().getLayoutRepository().getLayout( name );
-			if ( epoch !== this.mutationEpoch ) {
-				return;
-			}
-			this.setLayout( name, layout );
-		},
 		async saveLayout( layout: Layout, comment?: string ): Promise<void> {
 			await NeoWikiExtension.getInstance().getLayoutRepository().saveLayout( layout, comment );
 			this.mutationEpoch++;

--- a/resources/ext.neowiki/src/stores/SchemaStore.ts
+++ b/resources/ext.neowiki/src/stores/SchemaStore.ts
@@ -61,18 +61,6 @@ export const useSchemaStore = defineStore( 'schema', {
 		setSchema( name: string, schema: Schema ): void { // TODO: just take Schema
 			this.schemas.set( name, schema );
 		},
-		// A resolved call may have recorded nothing: the epoch guard below discards the write-back
-		// when a mutation landed mid-flight, leaving the registry unchanged. Callers must read the
-		// result via getSchema afterwards and handle a miss, rather than assuming this call alone
-		// guarantees fresh data is present.
-		async fetchSchema( name: string ): Promise<void> {
-			const epoch = this.mutationEpoch;
-			const schema = await NeoWikiExtension.getInstance().getSchemaRepository().getSchema( name );
-			if ( epoch !== this.mutationEpoch ) {
-				return;
-			}
-			this.setSchema( name, schema );
-		},
 		// Always fetches. Concurrent callers (e.g. several relation-property pickers
 		// mounting in the same render) share one in-flight pagination rather than each
 		// running a full one; results are not retained, so each new caller cohort gets
@@ -93,7 +81,7 @@ export const useSchemaStore = defineStore( 'schema', {
 			}
 		},
 		// Checks existence via the schema-names search (a 200 response) rather
-		// than fetchSchema, which 404s for a missing name — those 404s are
+		// than a schema fetch, which 404s for a missing name — those 404s are
 		// avoidable console/network noise when checking a not-yet-created name.
 		// The name is normalised so e.g. "person" or "Foo_Bar" matches the
 		// existing "Person" / "Foo Bar" the same way a save would.

--- a/resources/ext.neowiki/src/stores/SubjectStore.ts
+++ b/resources/ext.neowiki/src/stores/SubjectStore.ts
@@ -70,8 +70,11 @@ export const useSubjectStore = defineStore( 'subject', {
 
 			this.mutationEpoch++;
 			// The response Subject, not the one passed in: only the server's copy carries the page
-			// context and the normalisation the write applied.
-			this.setSubject( result.subject );
+			// context and the normalisation the write applied. A response without that context
+			// records nothing and leaves the previous copy in place.
+			if ( result.subject !== null ) {
+				this.setSubject( result.subject );
+			}
 			recordBundledSchema( result.schema, schemaEpoch );
 		},
 		async deleteSubject( subjectId: SubjectId, comment?: string ): Promise<void> {
@@ -132,10 +135,12 @@ export const useSubjectStore = defineStore( 'subject', {
 			);
 
 			this.mutationEpoch++;
-			this.setSubject( result.subject );
+			if ( result.subject !== null ) {
+				this.setSubject( result.subject );
+			}
 			recordBundledSchema( result.schema, schemaEpoch );
 
-			return result.subject.getId();
+			return result.subjectId;
 		},
 		async createChildSubject( pageId: number, label: string, schemaName: SchemaName, statements: StatementList, comment?: string ): Promise<SubjectId> {
 			const schemaEpoch = useSchemaStore().mutationEpoch;
@@ -149,10 +154,12 @@ export const useSubjectStore = defineStore( 'subject', {
 			);
 
 			this.mutationEpoch++;
-			this.setSubject( result.subject );
+			if ( result.subject !== null ) {
+				this.setSubject( result.subject );
+			}
 			recordBundledSchema( result.schema, schemaEpoch );
 
-			return result.subject.getId();
+			return result.subjectId;
 		},
 
 		openSubjectCreator(): void {

--- a/resources/ext.neowiki/src/stores/SubjectStore.ts
+++ b/resources/ext.neowiki/src/stores/SubjectStore.ts
@@ -31,25 +31,17 @@ export const useSubjectStore = defineStore( 'subject', {
 		setSubject( subject: Subject ): void { // TODO: just take Subject
 			this.subjects.set( subject.getId().text, subject );
 		},
-		// A resolved call may have recorded nothing: the epoch guard below discards the write-back
-		// when a mutation landed mid-flight, leaving the registry unchanged. Callers must read the
-		// result via getSubject afterwards and handle a miss (getSubject throws), rather than
-		// assuming this call alone guarantees fresh data is present.
-		async fetchSubject( id: SubjectId ): Promise<void> {
-			const epoch = this.mutationEpoch;
-			const subject = await NeoWikiExtension.getInstance().getSubjectRepository().getSubject( id );
-			if ( epoch !== this.mutationEpoch ) {
-				return;
-			}
-			this.setSubject( subject );
-		},
 		// Display-only read over the seeded registry: returns the page-payload /
 		// own-write value when present and fetches only on a genuine miss (e.g. a
 		// Subject picked from search that the page does not reference). Editors must
-		// not use this — always fetch fresh before opening an editor (see ADR 30).
+		// not use this — they read through the repositories (see ADR 30).
 		async getOrFetchSubject( id: SubjectId ): Promise<Subject> {
 			if ( !this.subjects.has( id.text ) ) {
-				await this.fetchSubject( id );
+				const epoch = this.mutationEpoch;
+				const subject = await NeoWikiExtension.getInstance().getSubjectRepository().getSubject( id );
+				if ( epoch === this.mutationEpoch ) {
+					this.setSubject( subject );
+				}
 			}
 			return this.getSubject( id );
 		},

--- a/resources/ext.neowiki/src/stores/SubjectStore.ts
+++ b/resources/ext.neowiki/src/stores/SubjectStore.ts
@@ -2,13 +2,26 @@ import { defineStore } from 'pinia';
 import { SubjectId } from '@/domain/SubjectId';
 import { Subject } from '@/domain/Subject';
 import { NeoWikiExtension } from '@/NeoWikiExtension';
-import { SchemaName } from '@/domain/Schema.ts';
+import { Schema, SchemaName } from '@/domain/Schema.ts';
 import { StatementList } from '@/domain/StatementList.ts';
-import { PageIdentifiers } from '@/domain/PageIdentifiers.ts';
-import { SubjectWithContext } from '@/domain/SubjectWithContext.ts';
 import { PageSubjects } from '@/domain/PageSubjects.ts';
 import { SubjectViolation } from '@/domain/SubjectViolation.ts';
 import { useSchemaStore } from '@/stores/SchemaStore.ts';
+
+/**
+ * A Subject write answers with the Schema the Subject instantiates, so a display can render the
+ * saved values even when the Schema gained a property out of band. That Schema is a server read
+ * riding along with the write, not the write's own result, so it takes the read guard (ADR 30
+ * rule 3): the caller snapshots the Schema epoch before awaiting and passes it here.
+ */
+function recordBundledSchema( schema: Schema | null, epochBeforeRequest: number ): void {
+	const schemaStore = useSchemaStore();
+
+	if ( schema !== null && epochBeforeRequest === schemaStore.mutationEpoch ) {
+		schemaStore.setSchema( schema.getName(), schema );
+	}
+}
+
 export const useSubjectStore = defineStore( 'subject', {
 	state: () => ( {
 		subjects: new Map<string, Subject>(),
@@ -46,9 +59,20 @@ export const useSubjectStore = defineStore( 'subject', {
 			return this.getSubject( id );
 		},
 		async updateSubject( subject: Subject, comment?: string ): Promise<void> {
-			await NeoWikiExtension.getInstance().getSubjectRepository().updateSubject( subject.getId(), subject.getLabel(), subject.getStatements(), comment );
+			const schemaEpoch = useSchemaStore().mutationEpoch;
+
+			const result = await NeoWikiExtension.getInstance().getSubjectRepository().updateSubject(
+				subject.getId(),
+				subject.getLabel(),
+				subject.getStatements(),
+				comment,
+			);
+
 			this.mutationEpoch++;
-			this.setSubject( subject );
+			// The response Subject, not the one passed in: only the server's copy carries the page
+			// context and the normalisation the write applied.
+			this.setSubject( result.subject );
+			recordBundledSchema( result.schema, schemaEpoch );
 		},
 		async deleteSubject( subjectId: SubjectId, comment?: string ): Promise<void> {
 			await NeoWikiExtension.getInstance().getSubjectRepository().deleteSubject( subjectId, comment );
@@ -97,51 +121,38 @@ export const useSubjectStore = defineStore( 'subject', {
 			return NeoWikiExtension.getInstance().getSubjectRepository().validateSubjectUpdate( id, label, statements );
 		},
 		async createMainSubject( pageId: number, label: string, schemaName: SchemaName, statements: StatementList, comment?: string ): Promise<SubjectId> {
-			const subjectId = await NeoWikiExtension.getInstance().getSubjectRepository().createMainSubject(
+			const schemaEpoch = useSchemaStore().mutationEpoch;
+
+			const result = await NeoWikiExtension.getInstance().getSubjectRepository().createMainSubject(
 				pageId,
 				label,
 				schemaName,
 				statements,
 				comment,
 			);
-			this.mutationEpoch++;
 
-			this.setSubject(
-				new SubjectWithContext(
-					subjectId,
-					label,
-					schemaName,
-					statements,
-					// FIXME: 'page-title', assuming we need to actually set the Subject here.
-					// Perhaps we are better off getting the entire thing from the backend.
-					// Maybe the backend should respond with the entire thing instead of just the ID.
-					// Getting the subject from the backend is safer, since we avoid inconsistencies in
-					// case normalization happened or someone else edited as well.
-					new PageIdentifiers( pageId, 'page-title' ),
-				),
-			);
-			return subjectId;
+			this.mutationEpoch++;
+			this.setSubject( result.subject );
+			recordBundledSchema( result.schema, schemaEpoch );
+
+			return result.subject.getId();
 		},
 		async createChildSubject( pageId: number, label: string, schemaName: SchemaName, statements: StatementList, comment?: string ): Promise<SubjectId> {
-			const subjectId = await NeoWikiExtension.getInstance().getSubjectRepository().createChildSubject(
+			const schemaEpoch = useSchemaStore().mutationEpoch;
+
+			const result = await NeoWikiExtension.getInstance().getSubjectRepository().createChildSubject(
 				pageId,
 				label,
 				schemaName,
 				statements,
 				comment,
 			);
-			this.mutationEpoch++;
 
-			this.setSubject(
-				new SubjectWithContext(
-					subjectId,
-					label,
-					schemaName,
-					statements,
-					new PageIdentifiers( pageId, 'page-title' ),
-				),
-			);
-			return subjectId;
+			this.mutationEpoch++;
+			this.setSubject( result.subject );
+			recordBundledSchema( result.schema, schemaEpoch );
+
+			return result.subject.getId();
 		},
 
 		openSubjectCreator(): void {

--- a/resources/ext.neowiki/tests/NeoWikiTestServices.ts
+++ b/resources/ext.neowiki/tests/NeoWikiTestServices.ts
@@ -1,6 +1,8 @@
 import { NeoWikiServices, Service } from '@/NeoWikiServices.ts';
 import { NeoWikiExtension } from '@/NeoWikiExtension.ts';
 import { InMemorySchemaRepository } from '@/application/SchemaRepository.ts';
+import { InMemoryLayoutLookup } from '@/application/LayoutLookup.ts';
+import { StubSubjectRepository } from '@/domain/SubjectRepository.ts';
 import type { SubjectLabelSearch } from '@/domain/SubjectLabelSearch.ts';
 
 export class NeoWikiTestServices extends NeoWikiServices {
@@ -14,8 +16,12 @@ export class NeoWikiTestServices extends NeoWikiServices {
 			[ Service.SubjectPermissionHints ]: neoWiki.newSubjectPermissionHints(),
 			[ Service.PropertyTypeRegistry ]: neoWiki.getPropertyTypeRegistry(),
 			[ Service.SchemaRepository ]: new InMemorySchemaRepository( [] ),
+			[ Service.SubjectRepository ]: new StubSubjectRepository( [] ),
 			[ Service.SubjectLabelSearch ]: { searchSubjectLabels: () => Promise.resolve( [] ) } as SubjectLabelSearch,
 			[ Service.ViewTypeRegistry ]: neoWiki.getViewTypeRegistry(),
+			[ Service.LayoutPermissionHints ]: neoWiki.newLayoutPermissionHints(),
+			[ Service.LayoutRepository ]: new InMemoryLayoutLookup( [] ),
+			[ Service.MappingPermissionHints ]: neoWiki.newMappingPermissionHints(),
 		};
 	}
 

--- a/resources/ext.neowiki/tests/components/LayoutDisplay/LayoutDisplay.spec.ts
+++ b/resources/ext.neowiki/tests/components/LayoutDisplay/LayoutDisplay.spec.ts
@@ -1,0 +1,137 @@
+import { mount, VueWrapper, flushPromises } from '@vue/test-utils';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { ref } from 'vue';
+import LayoutDisplay from '@/components/LayoutDisplay/LayoutDisplay.vue';
+import LayoutDisplayHeader from '@/components/LayoutDisplay/LayoutDisplayHeader.vue';
+import LayoutEditorDialog from '@/components/LayoutEditor/LayoutEditorDialog.vue';
+import { Layout, type DisplayRule } from '@/domain/Layout.ts';
+import { NeoWikiExtension } from '@/NeoWikiExtension.ts';
+import { Service } from '@/NeoWikiServices.ts';
+import { setupMwMock, createI18nMock } from '../../VueTestHelpers.ts';
+import { PropertyName } from '@/domain/PropertyDefinition.ts';
+import { newSchema } from '@/TestHelpers.ts';
+
+const checkEditPermissionMock = vi.fn();
+const canEditLayoutRef = ref( false );
+
+vi.mock( '@/composables/useLayoutPermissions.ts', () => ( {
+	useLayoutPermissions: () => ( {
+		canEditLayout: canEditLayoutRef,
+		checkEditPermission: checkEditPermissionMock,
+	} ),
+} ) );
+
+const getLayoutMock = vi.fn();
+const getSchemaMock = vi.fn();
+
+function newLayout( description: string, displayRules: DisplayRule[] = [] ): Layout {
+	return new Layout( 'CompanyInfo', 'Company', 'infobox', description, displayRules, {} );
+}
+
+function mountComponent( layout: Layout ): VueWrapper {
+	setupMwMock( { functions: [ 'msg', 'notify' ] } );
+
+	return mount( LayoutDisplay, {
+		props: { layout },
+		global: {
+			plugins: [ createPinia() ],
+			mocks: { $i18n: createI18nMock() },
+			provide: {
+				[ Service.ComponentRegistry ]: NeoWikiExtension.getInstance().getTypeSpecificComponentRegistry(),
+				[ Service.LayoutRepository ]: { getLayout: getLayoutMock },
+				[ Service.SchemaRepository ]: { getSchema: getSchemaMock },
+			},
+			stubs: {
+				CdxIcon: true,
+				LayoutDisplayHeader: true,
+				LayoutEditorDialog: true,
+			},
+		},
+	} );
+}
+
+describe( 'LayoutDisplay', () => {
+	beforeEach( () => {
+		setActivePinia( createPinia() );
+		canEditLayoutRef.value = false;
+		checkEditPermissionMock.mockClear();
+		getLayoutMock.mockReset();
+		getSchemaMock.mockReset().mockResolvedValue( newSchema( { title: 'Company' } ) );
+	} );
+
+	it( 'passes layout and canEditLayout to the header component', () => {
+		const layout = newLayout( 'Company overview' );
+
+		const header = mountComponent( layout ).findComponent( LayoutDisplayHeader );
+
+		expect( header.props( 'layout' ) ).toStrictEqual( layout );
+		expect( header.props( 'canEditLayout' ) ).toBe( false );
+	} );
+
+	it( 'renders a row per display rule', () => {
+		const wrapper = mountComponent( newLayout( '', [
+			{ property: new PropertyName( 'Website' ) },
+			{ property: new PropertyName( 'Founded' ), displayAttributes: { precision: 0 } },
+		] ) );
+
+		const rows = wrapper.findAll( 'tbody tr' );
+		expect( rows ).toHaveLength( 2 );
+		expect( rows[ 0 ].text() ).toContain( 'Website' );
+		expect( rows[ 1 ].text() ).toContain( 'Founded' );
+	} );
+
+	it( 'shows the empty message when the layout has no display rules', () => {
+		const wrapper = mountComponent( newLayout( '' ) );
+
+		expect( wrapper.text() ).toContain( 'neowiki-layout-display-no-rules' );
+	} );
+
+	it( 'renders LayoutEditorDialog only with edit permission', () => {
+		expect( mountComponent( newLayout( '' ) ).findComponent( LayoutEditorDialog ).exists() ).toBe( false );
+
+		canEditLayoutRef.value = true;
+
+		expect( mountComponent( newLayout( '' ) ).findComponent( LayoutEditorDialog ).exists() ).toBe( true );
+	} );
+
+	it( 'opens the editor on the layout fetched from the repository', async () => {
+		canEditLayoutRef.value = true;
+		// A description the prop does not carry, so the assertion can only pass if the dialog
+		// received the repository's layout rather than the one passed in.
+		const fetched = newLayout( 'from the repository' );
+		getLayoutMock.mockResolvedValue( fetched );
+
+		const wrapper = mountComponent( newLayout( 'stale' ) );
+		await wrapper.findComponent( LayoutDisplayHeader ).vm.$emit( 'edit' );
+		await flushPromises();
+
+		expect( getLayoutMock ).toHaveBeenCalledWith( 'CompanyInfo' );
+		const dialog = wrapper.findComponent( LayoutEditorDialog );
+		expect( dialog.props( 'open' ) ).toBe( true );
+		expect( dialog.props( 'initialLayout' ) ).toStrictEqual( fetched );
+	} );
+
+	it( 'reports a failed layout fetch instead of opening the editor', async () => {
+		canEditLayoutRef.value = true;
+		getLayoutMock.mockRejectedValue( new Error( 'Unknown layout: CompanyInfo' ) );
+
+		const wrapper = mountComponent( newLayout( '' ) );
+		await wrapper.findComponent( LayoutDisplayHeader ).vm.$emit( 'edit' );
+		await flushPromises();
+
+		expect( wrapper.findComponent( LayoutEditorDialog ).props( 'open' ) ).toBe( false );
+		expect( mw.notify ).toHaveBeenCalledWith( 'Unknown layout: CompanyInfo', { type: 'error' } );
+	} );
+
+	it( 'shows the saved layout once the editor reports a save', async () => {
+		canEditLayoutRef.value = true;
+		const saved = newLayout( 'saved' );
+
+		const wrapper = mountComponent( newLayout( 'before' ) );
+		await wrapper.findComponent( LayoutEditorDialog ).vm.$emit( 'saved', saved );
+		await flushPromises();
+
+		expect( wrapper.findComponent( LayoutDisplayHeader ).props( 'layout' ) ).toStrictEqual( saved );
+	} );
+} );

--- a/resources/ext.neowiki/tests/components/LayoutsPage/LayoutsPage.spec.ts
+++ b/resources/ext.neowiki/tests/components/LayoutsPage/LayoutsPage.spec.ts
@@ -7,6 +7,7 @@ import DeletePageDialog from '@/components/common/DeletePageDialog.vue';
 import LayoutEditorDialog from '@/components/LayoutEditor/LayoutEditorDialog.vue';
 import { createI18nMock, findNextPageButton, setupMwMock } from '../../VueTestHelpers.ts';
 import { CdxButton } from '@wikimedia/codex';
+import { Service } from '@/NeoWikiServices.ts';
 import { useLayoutStore } from '@/stores/LayoutStore.ts';
 import { Layout } from '@/domain/Layout.ts';
 
@@ -40,9 +41,10 @@ vi.mock( '@/composables/useLayoutPermissions.ts', () => ( {
 	} ),
 } ) );
 
-// The store is real (backed by Pinia). Most tests never drive the editor path
-// (fetchLayout/getLayout), so those actions never reach the network here; the test that does
-// drive it overrides fetchLayout directly on the store instance instead of hitting the network.
+// The store is real (backed by Pinia) so removeLayout/getLayout exercise their actual
+// semantics. The editor reads through the repository, which is mocked here so the edit
+// path never reaches the network.
+const getLayoutMock = vi.fn();
 
 vi.mock( '@/NeoWikiExtension.ts', () => ( {
 	NeoWikiExtension: {
@@ -91,6 +93,9 @@ function mountComponent( summaries: LayoutSummary[] = [], nextCursor: string | n
 		global: {
 			plugins: [ pinia ],
 			mocks: { $i18n: createI18nMock() },
+			provide: {
+				[ Service.LayoutRepository ]: { getLayout: getLayoutMock },
+			},
 			stubs: {
 				LayoutCreatorDialog: true,
 				LayoutEditorDialog: true,
@@ -115,6 +120,7 @@ describe( 'LayoutsPage', () => {
 		canEditLayoutRef.value = false;
 		checkCreatePermissionMock.mockClear();
 		checkEditPermissionMock.mockClear();
+		getLayoutMock.mockReset();
 		layoutsResponse = { layouts: [], nextCursor: null };
 
 		pinia = createPinia();
@@ -186,12 +192,28 @@ describe( 'LayoutsPage', () => {
 		expect( wrapper.find( 'a[href="/wiki/Layout:CompanyOverview"]' ).exists() ).toBe( false );
 	} );
 
-	it( 'does not open the editor when the epoch guard discarded the fetchLayout write-back', async () => {
+	it( 'opens the editor on the layout fetched from the repository', async () => {
 		canEditLayoutRef.value = true;
-		// Simulates the epoch guard discarding fetchLayout's write-back (a mutation landed
-		// mid-flight): the fetch resolves but never seeds the store, so getLayout keeps
-		// returning undefined for this layout.
-		layoutStore.fetchLayout = vi.fn().mockResolvedValue( undefined );
+		// A description the store copy does not have, so the assertion can only pass if the
+		// dialog received the repository's layout rather than a registry read.
+		const fetched = new Layout( 'CompanyOverview', 'Company', 'infobox', 'from the repository', [], {} );
+		getLayoutMock.mockResolvedValue( fetched );
+		layoutStore.setLayout( 'CompanyOverview', newLayout( 'CompanyOverview' ) );
+		const wrapper = mountComponent( [ sampleLayout ] );
+		await flushPromises();
+
+		await findEditButtons( wrapper )[ 0 ].trigger( 'click' );
+		await flushPromises();
+
+		expect( getLayoutMock ).toHaveBeenCalledWith( 'CompanyOverview' );
+		const dialog = wrapper.findComponent( LayoutEditorDialog );
+		expect( dialog.props( 'open' ) ).toBe( true );
+		expect( dialog.props( 'initialLayout' ) ).toStrictEqual( fetched );
+	} );
+
+	it( 'reports a failed layout fetch instead of opening the editor', async () => {
+		canEditLayoutRef.value = true;
+		getLayoutMock.mockRejectedValue( new Error( 'Unknown layout: CompanyOverview' ) );
 		const wrapper = mountComponent( [ sampleLayout ] );
 		await flushPromises();
 
@@ -199,7 +221,7 @@ describe( 'LayoutsPage', () => {
 		await flushPromises();
 
 		expect( wrapper.findComponent( LayoutEditorDialog ).exists() ).toBe( false );
-		expect( mw.notify ).toHaveBeenCalledWith( 'neowiki-layouts-edit-stale-error', { type: 'error' } );
+		expect( mw.notify ).toHaveBeenCalledWith( 'Unknown layout: CompanyOverview', { type: 'error' } );
 	} );
 
 	it( 'disables next when a full page ends the listing', async () => {

--- a/resources/ext.neowiki/tests/components/SchemaDisplay/SchemaDisplay.spec.ts
+++ b/resources/ext.neowiki/tests/components/SchemaDisplay/SchemaDisplay.spec.ts
@@ -14,7 +14,6 @@ import { NeoWikiExtension } from '@/NeoWikiExtension.ts';
 import { Service } from '@/NeoWikiServices.ts';
 import { setupMwMock, createI18nMock } from '../../VueTestHelpers.ts';
 import { newSchema } from '@/TestHelpers.ts';
-import { useSchemaStore } from '@/stores/SchemaStore.ts';
 
 const checkEditPermissionMock = vi.fn();
 const canEditSchemaRef = ref( false );
@@ -26,16 +25,19 @@ vi.mock( '@/composables/useSchemaPermissions.ts', () => ( {
 	} ),
 } ) );
 
-function mountComponent( schema: Schema, pinia = createPinia() ): VueWrapper {
+const getSchemaMock = vi.fn();
+
+function mountComponent( schema: Schema ): VueWrapper {
 	setupMwMock( { functions: [ 'msg' ] } );
 
 	return mount( SchemaDisplay, {
 		props: { schema },
 		global: {
-			plugins: [ pinia ],
+			plugins: [ createPinia() ],
 			mocks: { $i18n: createI18nMock() },
 			provide: {
 				[ Service.ComponentRegistry ]: NeoWikiExtension.getInstance().getTypeSpecificComponentRegistry(),
+				[ Service.SchemaRepository ]: { getSchema: getSchemaMock },
 			},
 			stubs: {
 				CdxIcon: true,
@@ -52,6 +54,7 @@ describe( 'SchemaDisplay', () => {
 		setActivePinia( createPinia() );
 		canEditSchemaRef.value = false;
 		checkEditPermissionMock.mockClear();
+		getSchemaMock.mockReset();
 	} );
 
 	it( 'passes schema and canEditSchema to header component', () => {
@@ -161,25 +164,23 @@ describe( 'SchemaDisplay', () => {
 		expect( wrapper.findComponent( SchemaEditorDialog ).exists() ).toBe( false );
 	} );
 
-	it( 'fetches latest schema and opens dialog when header emits edit event', async () => {
+	it( 'opens the dialog on the schema fetched from the repository when the header emits edit', async () => {
 		canEditSchemaRef.value = true;
 		setupMwMock( { functions: [ 'msg', 'notify' ] } );
 
-		const schema = newSchema();
-		const pinia = createPinia();
-		setActivePinia( pinia );
+		const schema = newSchema( { title: 'Person', description: 'stale' } );
+		const fetched = newSchema( { title: 'Person', description: 'from the repository' } );
+		getSchemaMock.mockResolvedValue( fetched );
 
-		const store = useSchemaStore();
-		store.fetchSchema = vi.fn().mockResolvedValue( undefined );
-		store.setSchema( schema.getName(), schema );
-
-		const wrapper = mountComponent( schema, pinia );
+		const wrapper = mountComponent( schema );
 		expect( wrapper.findComponent( SchemaEditorDialog ).props( 'open' ) ).toBe( false );
 
 		await wrapper.findComponent( SchemaDisplayHeader ).vm.$emit( 'edit' );
 		await flushPromises();
 
-		expect( store.fetchSchema ).toHaveBeenCalledWith( schema.getName() );
-		expect( wrapper.findComponent( SchemaEditorDialog ).props( 'open' ) ).toBe( true );
+		expect( getSchemaMock ).toHaveBeenCalledWith( 'Person' );
+		const dialog = wrapper.findComponent( SchemaEditorDialog );
+		expect( dialog.props( 'open' ) ).toBe( true );
+		expect( dialog.props( 'initialSchema' ) ).toStrictEqual( fetched );
 	} );
 } );

--- a/resources/ext.neowiki/tests/components/SchemasPage/SchemasPage.spec.ts
+++ b/resources/ext.neowiki/tests/components/SchemasPage/SchemasPage.spec.ts
@@ -10,6 +10,7 @@ import { createI18nMock, findNextPageButton, setupMwMock } from '../../VueTestHe
 import { CdxButton } from '@wikimedia/codex';
 import { Schema } from '@/domain/Schema.ts';
 import { PropertyDefinitionList } from '@/domain/PropertyDefinitionList.ts';
+import { Service } from '@/NeoWikiServices.ts';
 import { useSchemaStore } from '@/stores/SchemaStore.ts';
 import { newSchema } from '@/TestHelpers.ts';
 
@@ -32,10 +33,9 @@ vi.mock( '@/composables/useSchemaPermissions.ts', () => ( {
 } ) );
 
 // The store is real (backed by Pinia) so removeSchema/getSchema exercise their actual
-// semantics; only fetchSchema is overridden per test to avoid a real network call. getSchema
-// is a Pinia getter (read-only), so tests that need it to resolve seed the map via setSchema
-// instead of mocking the getter itself.
-const fetchSchemaMock = vi.fn();
+// semantics. The editor reads through the repository, which is mocked here so the edit
+// path never reaches the network.
+const getSchemaMock = vi.fn();
 
 vi.mock( '@/NeoWikiExtension.ts', () => ( {
 	NeoWikiExtension: {
@@ -91,6 +91,9 @@ function mountComponent( summaries: unknown[] = [], nextCursor: string | null = 
 		global: {
 			plugins: [ pinia ],
 			mocks: { $i18n: createI18nMock() },
+			provide: {
+				[ Service.SchemaRepository ]: { getSchema: getSchemaMock },
+			},
 			stubs: {
 				SchemaCreatorDialog: SchemaCreatorDialogStub,
 				SchemaEditorDialog: SchemaEditorDialogStub,
@@ -107,13 +110,12 @@ describe( 'SchemasPage', () => {
 		canEditSchemaRef.value = false;
 		checkCreatePermissionMock.mockClear();
 		checkEditPermissionMock.mockClear();
-		fetchSchemaMock.mockClear();
+		getSchemaMock.mockReset();
 		schemasResponse = { schemas: [], nextCursor: null };
 
 		pinia = createPinia();
 		setActivePinia( pinia );
 		schemaStore = useSchemaStore();
-		schemaStore.fetchSchema = fetchSchemaMock;
 	} );
 
 	it( 'shows create button when user has create permission', async () => {
@@ -227,10 +229,13 @@ describe( 'SchemasPage', () => {
 		expect( findDeleteButtons( wrapper ) ).toHaveLength( 0 );
 	} );
 
-	it( 'opens editor dialog when edit button is clicked', async () => {
+	it( 'opens the editor on the schema fetched from the repository', async () => {
 		canEditSchemaRef.value = true;
-		const mockSchema = new Schema( 'Person', '', new PropertyDefinitionList( [] ) );
-		schemaStore.setSchema( 'Person', mockSchema );
+		// A description the store copy does not have, so the assertion can only pass if the
+		// dialog received the repository's schema rather than a registry read.
+		const fetched = new Schema( 'Person', 'from the repository', new PropertyDefinitionList( [] ) );
+		getSchemaMock.mockResolvedValue( fetched );
+		schemaStore.setSchema( 'Person', new Schema( 'Person', 'stale', new PropertyDefinitionList( [] ) ) );
 
 		const wrapper = mountComponent( [
 			{ name: 'Person', description: '', propertyCount: 3 },
@@ -240,14 +245,31 @@ describe( 'SchemasPage', () => {
 		await findEditButtons( wrapper )[ 0 ].trigger( 'click' );
 		await flushPromises();
 
-		expect( fetchSchemaMock ).toHaveBeenCalledWith( 'Person' );
-		expect( wrapper.findComponent( SchemaEditorDialog ).props( 'open' ) ).toBe( true );
+		expect( getSchemaMock ).toHaveBeenCalledWith( 'Person' );
+		const dialog = wrapper.findComponent( SchemaEditorDialog );
+		expect( dialog.props( 'open' ) ).toBe( true );
+		expect( dialog.props( 'initialSchema' ) ).toStrictEqual( fetched );
+	} );
+
+	it( 'reports a failed schema fetch instead of opening the editor', async () => {
+		canEditSchemaRef.value = true;
+		getSchemaMock.mockRejectedValue( new Error( 'Unknown schema: Person' ) );
+
+		const wrapper = mountComponent( [
+			{ name: 'Person', description: '', propertyCount: 3 },
+		] );
+		await flushPromises();
+
+		await findEditButtons( wrapper )[ 0 ].trigger( 'click' );
+		await flushPromises();
+
+		expect( wrapper.findComponent( SchemaEditorDialog ).exists() ).toBe( false );
+		expect( mw.notify ).toHaveBeenCalledWith( 'Unknown schema: Person', { type: 'error' } );
 	} );
 
 	it( 'does not render SchemaEditorDialog when user lacks edit permission', async () => {
 		canEditSchemaRef.value = true;
-		const mockSchema = new Schema( 'Person', '', new PropertyDefinitionList( [] ) );
-		schemaStore.setSchema( 'Person', mockSchema );
+		getSchemaMock.mockResolvedValue( new Schema( 'Person', '', new PropertyDefinitionList( [] ) ) );
 
 		const wrapper = mountComponent( [
 			{ name: 'Person', description: '', propertyCount: 3 },

--- a/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
@@ -119,6 +119,7 @@ describe( 'SubjectCreatorDialog', () => {
 	let subjectStore: ReturnType<typeof useSubjectStore>;
 	let schemaStore: ReturnType<typeof useSchemaStore>;
 	const canCreateSchemas = ref( true );
+	const getSchemaMock = vi.fn();
 
 	const mountComponent = (
 		stubs: Record<string, any> = {},
@@ -154,6 +155,7 @@ describe( 'SubjectCreatorDialog', () => {
 				provide: {
 					[ Service.ComponentRegistry ]: NeoWikiExtension.getInstance().getTypeSpecificComponentRegistry(),
 					[ Service.PropertyTypeRegistry ]: NeoWikiExtension.getInstance().getPropertyTypeRegistry(),
+					[ Service.SchemaRepository ]: { getSchema: getSchemaMock },
 				},
 				mocks: {
 					$i18n: createI18nMock(),
@@ -166,6 +168,10 @@ describe( 'SubjectCreatorDialog', () => {
 		wrapper.findComponent( { name: 'CdxToggleButtonGroup' } )
 			.vm.$emit( 'update:modelValue', 'new' );
 		await flushPromises();
+	}
+
+	async function goBack( wrapper: VueWrapper ): Promise<void> {
+		await wrapper.find( '.ext-neowiki-subject-creator-back-button' ).trigger( 'click' );
 	}
 
 	async function clickContinue( wrapper: VueWrapper ): Promise<void> {
@@ -201,9 +207,10 @@ describe( 'SubjectCreatorDialog', () => {
 		subjectStore.validateSubject = vi.fn().mockResolvedValue( [] );
 
 		schemaStore = useSchemaStore();
-		schemaStore.setSchema( SCHEMA_NAME, newSchema( { title: SCHEMA_NAME } ) );
-		schemaStore.fetchSchema = vi.fn().mockResolvedValue( undefined );
 		schemaStore.saveSchema = vi.fn().mockResolvedValue( undefined );
+
+		// The dialog reads the picked schema through the injected repository, not the store.
+		getSchemaMock.mockReset().mockResolvedValue( newSchema( { title: SCHEMA_NAME } ) );
 
 		canCreateSchemas.value = true;
 		( useSchemaPermissions as any ).mockReturnValue( {
@@ -269,6 +276,65 @@ describe( 'SubjectCreatorDialog', () => {
 
 		expect( wrapper.find( '.subject-editor-stub' ).exists() ).toBe( false );
 		expect( wrapper.find( '.edit-summary-stub' ).exists() ).toBe( false );
+	} );
+
+	it( 'loads the picked schema through the repository', async () => {
+		const picked = newSchema( { title: SCHEMA_NAME, description: 'from the repository' } );
+		getSchemaMock.mockResolvedValue( picked );
+		const wrapper = mountComponent();
+
+		await wrapper.findComponent( SchemaPicker ).vm.$emit( 'select', SCHEMA_NAME );
+		await flushPromises();
+
+		expect( getSchemaMock ).toHaveBeenCalledWith( SCHEMA_NAME );
+		expect( wrapper.findComponent( SubjectEditor ).props( 'schema' ) ).toStrictEqual( picked );
+	} );
+
+	it( 'ignores a schema fetch that a re-pick after going back overtook', async () => {
+		// The back button appears as soon as a schema is picked, so the user can go back and pick
+		// another one while the first fetch is still in flight.
+		const first = newSchema( { title: 'First' } );
+		const second = newSchema( { title: 'Second' } );
+		let resolveFirst!: ( schema: Schema ) => void;
+		getSchemaMock
+			.mockReturnValueOnce( new Promise<Schema>( ( resolve ) => {
+				resolveFirst = resolve;
+			} ) )
+			.mockResolvedValueOnce( second );
+		const wrapper = mountComponent();
+
+		// The first fetch stays in flight until the end.
+		wrapper.findComponent( SchemaPicker ).vm.$emit( 'select', 'First' );
+		await flushPromises();
+
+		await goBack( wrapper );
+		await wrapper.findComponent( SchemaPicker ).vm.$emit( 'select', 'Second' );
+		await flushPromises();
+
+		resolveFirst( first );
+		await flushPromises();
+
+		expect( wrapper.findComponent( SubjectEditor ).props( 'schema' ) ).toStrictEqual( second );
+	} );
+
+	it( 'ignores a schema fetch that going back invalidated', async () => {
+		let resolveFirst!: ( schema: Schema ) => void;
+		getSchemaMock.mockReturnValueOnce( new Promise<Schema>( ( resolve ) => {
+			resolveFirst = resolve;
+		} ) );
+		const wrapper = mountComponent();
+
+		wrapper.findComponent( SchemaPicker ).vm.$emit( 'select', 'First' );
+		await flushPromises();
+
+		await goBack( wrapper );
+		await switchToNewSchema( wrapper );
+		await clickContinue( wrapper );
+
+		resolveFirst( newSchema( { title: 'First' } ) );
+		await flushPromises();
+
+		expect( wrapper.findComponent( SubjectEditor ).props( 'schema' ).getName() ).toBe( NEW_SCHEMA_NAME );
 	} );
 
 	it( 'shows label input and SubjectEditor after schema selection', async () => {

--- a/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditorDialog.spec.ts
@@ -7,8 +7,9 @@ import { StatementList } from '@/domain/StatementList.ts';
 import { NeoWikiExtension } from '@/NeoWikiExtension.ts';
 import { Schema } from '@/domain/Schema.ts';
 import { PropertyDefinitionList } from '@/domain/PropertyDefinitionList.ts';
+import { createPropertyDefinitionFromJson } from '@/domain/PropertyDefinition.ts';
+import { TextType } from '@/domain/propertyTypes/Text.ts';
 import { createPinia, setActivePinia } from 'pinia';
-import { useSchemaStore } from '@/stores/SchemaStore.ts';
 import { useSubjectStore } from '@/stores/SubjectStore.ts';
 import { Service } from '@/NeoWikiServices.ts';
 import SchemaEditorDialog from '@/components/SchemaEditor/SchemaEditorDialog.vue';
@@ -55,7 +56,6 @@ describe( 'SubjectEditorDialog', () => {
 	} );
 
 	let pinia: ReturnType<typeof createPinia>;
-	let schemaStore;
 	let schemaPermissionHints: any;
 
 	const mockSchema = new Schema(
@@ -75,6 +75,7 @@ describe( 'SubjectEditorDialog', () => {
 		canEditSchema: boolean,
 		stubs: Record<string, any>,
 		onSave?: ( subject: any, comment: string ) => Promise<void>,
+		schema: Schema = mockSchema,
 	): VueWrapper => {
 		schemaPermissionHints = {
 			canEditSchema: vi.fn().mockResolvedValue( canEditSchema ),
@@ -83,6 +84,7 @@ describe( 'SubjectEditorDialog', () => {
 		return mount( SubjectEditorDialog, {
 			props: {
 				subject: mockSubject,
+				schema,
 				onSave: onSave ?? vi.fn(),
 				onSaveSchema: vi.fn(),
 				open: true,
@@ -109,12 +111,57 @@ describe( 'SubjectEditorDialog', () => {
 		pinia = createPinia();
 		setActivePinia( pinia );
 
-		schemaStore = useSchemaStore();
-		schemaStore.setSchema( 'TestSchema', mockSchema );
-
 		// The dry-run validation runs alongside the live validators; stub it so
 		// it does not reach the network and stays out of the way of these tests.
 		useSubjectStore().validateSubjectUpdate = vi.fn().mockResolvedValue( [] );
+	} );
+
+	function schemaWithProperty( propertyName: string ): Schema {
+		return new Schema(
+			'TestSchema',
+			'A test schema',
+			new PropertyDefinitionList( [
+				createPropertyDefinitionFromJson( propertyName, { type: TextType.typeName } ),
+			] ),
+		);
+	}
+
+	function editedPropertyNames( wrapper: VueWrapper ): string[] {
+		const statements = wrapper.findComponent( SubjectEditor ).props( 'statements' ) as StatementList;
+		return [ ...statements ].map( ( s ) => s.propertyName.toString() );
+	}
+
+	it( 'materialises one editable statement per property of the schema prop', async () => {
+		const wrapper = mountComponent(
+			false, { SubjectEditor: SubjectEditorStub }, undefined, schemaWithProperty( 'name' ),
+		);
+		await flushPromises();
+
+		expect( editedPropertyNames( wrapper ) ).toEqual( [ 'name' ] );
+	} );
+
+	it( 'follows the schema prop when the host replaces it', async () => {
+		const wrapper = mountComponent(
+			false, { SubjectEditor: SubjectEditorStub }, undefined, schemaWithProperty( 'name' ),
+		);
+		await flushPromises();
+
+		await wrapper.setProps( { schema: schemaWithProperty( 'nickname' ) } );
+
+		expect( editedPropertyNames( wrapper ) ).toEqual( [ 'nickname' ] );
+	} );
+
+	it( 'follows a schema saved through the nested schema editor', async () => {
+		const wrapper = mountComponent(
+			false, { SubjectEditor: SubjectEditorStub, SchemaEditorDialog: true }, undefined,
+			schemaWithProperty( 'name' ),
+		);
+		await flushPromises();
+
+		wrapper.findComponent( SchemaEditorDialog ).vm.$emit( 'saved', schemaWithProperty( 'nickname' ) );
+		await flushPromises();
+
+		expect( editedPropertyNames( wrapper ) ).toEqual( [ 'nickname' ] );
 	} );
 
 	it( 'renders schema as a link when user has edit permissions', async () => {

--- a/resources/ext.neowiki/tests/components/SubjectsManager/SubjectsManagerPage.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectsManager/SubjectsManagerPage.spec.ts
@@ -12,6 +12,9 @@ import { StatementList } from '@/domain/StatementList.ts';
 import { PageSubjects } from '@/domain/PageSubjects.ts';
 import { subjectRowDomId } from '@/presentation/subjectRowAnchor.ts';
 import SummaryAction from '@/components/common/SummaryAction.vue';
+import SubjectEditorDialog from '@/components/SubjectEditor/SubjectEditorDialog.vue';
+import { Service } from '@/NeoWikiServices.ts';
+import { newSchema } from '@/TestHelpers.ts';
 
 // Two subject-id-shaped ids (s + 14 base58 chars), so the deep-link fragment parser accepts them.
 const ID_A = 's1aaaaaaaaaaaa1';
@@ -61,21 +64,25 @@ vi.mock( '@/stores/SubjectStore.ts', async ( importOriginal ) => {
 
 vi.mock( '@/stores/SchemaStore.ts', () => ( {
 	useSchemaStore: () => ( {
-		fetchSchema: vi.fn(),
 		saveSchema: vi.fn(),
 		getSchema: vi.fn(),
 	} ),
 } ) );
 
-// A module-level ref (rather than one freshly created per useSubjectPermissions() call) so the
-// delete-flow tests below can flip it on; every other describe block leaves it at the default off.
+// Module-level refs (rather than ones freshly created per useSubjectPermissions() call) so the
+// edit- and delete-flow tests below can flip them on; every other describe leaves them off.
 const canDeleteSubjectRef = ref( false );
+const canEditSubjectRef = ref( false );
+
+// openEditor reads through the injected repositories; the edit-flow describe below arms these.
+const getSubjectRepoMock = vi.fn();
+const getSchemaRepoMock = vi.fn();
 
 vi.mock( '@/composables/useSubjectPermissions.ts', () => ( {
 	useSubjectPermissions: () => ( {
 		canCreateMainSubject: ref( false ),
 		canCreateChildSubject: ref( false ),
-		canEditSubject: ref( false ),
+		canEditSubject: canEditSubjectRef,
 		canDeleteSubject: canDeleteSubjectRef,
 		checkPermissions: vi.fn().mockResolvedValue( undefined ),
 	} ),
@@ -122,6 +129,10 @@ async function mountPage(): Promise<VueWrapper> {
 		global: {
 			plugins: [ pinia ],
 			mocks: { $i18n: createI18nMock() },
+			provide: {
+				[ Service.SubjectRepository ]: { getSubject: getSubjectRepoMock },
+				[ Service.SchemaRepository ]: { getSchema: getSchemaRepoMock },
+			},
 			stubs: { CdxIcon: true, CdxDialog: CdxDialogStub },
 		},
 	} );
@@ -324,6 +335,67 @@ describe( 'SubjectsManagerPage row copy-link action', () => {
 		expect( mw.notify ).toHaveBeenCalledWith( 'neowiki-managesubjects-link-copied', { type: 'success' } );
 	} );
 
+} );
+
+describe( 'SubjectsManagerPage edit flow', () => {
+
+	beforeEach( () => {
+		storeSubjects = [ subject( ID_A ) ];
+		mainSubjectId = null;
+		canEditSubjectRef.value = true;
+		window.location.hash = '';
+		Element.prototype.scrollIntoView = vi.fn();
+		window.matchMedia = vi.fn().mockReturnValue( { matches: false } ) as unknown as typeof window.matchMedia;
+
+		getSubjectRepoMock.mockReset();
+		getSchemaRepoMock.mockReset();
+	} );
+
+	afterEach( () => {
+		document.body.innerHTML = '';
+		window.location.hash = '';
+		canEditSubjectRef.value = false;
+		vi.restoreAllMocks();
+	} );
+
+	it( 'opens the editor on the subject and schema fetched from the repositories', async () => {
+		// Values the store stub does not hold, so the assertions can only pass if the dialog was
+		// handed the repositories' data rather than a registry read.
+		const freshSubject = new Subject(
+			new SubjectId( ID_A ),
+			'Fetched label',
+			'Person',
+			new StatementList( [] ),
+		);
+		const freshSchema = newSchema( { title: 'Person' } );
+		getSubjectRepoMock.mockResolvedValue( freshSubject );
+		getSchemaRepoMock.mockResolvedValue( freshSchema );
+
+		const wrapper = await mountPage();
+
+		await wrapper.find( '[aria-label="neowiki-managesubjects-row-edit"]' ).trigger( 'click' );
+		await flushPromises();
+
+		expect( getSubjectRepoMock ).toHaveBeenCalledWith( expect.objectContaining( { text: ID_A } ) );
+		expect( getSchemaRepoMock ).toHaveBeenCalledWith( 'Person' );
+		const dialog = wrapper.findComponent( SubjectEditorDialog );
+		expect( dialog.props( 'open' ) ).toBe( true );
+		expect( dialog.props( 'subject' ) ).toStrictEqual( freshSubject );
+		expect( dialog.props( 'schema' ) ).toStrictEqual( freshSchema );
+	} );
+
+	it( 'reports a failed fetch instead of opening the editor', async () => {
+		getSubjectRepoMock.mockRejectedValue( new Error( 'Unknown subject' ) );
+		getSchemaRepoMock.mockResolvedValue( newSchema( { title: 'Person' } ) );
+
+		const wrapper = await mountPage();
+
+		await wrapper.find( '[aria-label="neowiki-managesubjects-row-edit"]' ).trigger( 'click' );
+		await flushPromises();
+
+		expect( wrapper.findComponent( SubjectEditorDialog ).exists() ).toBe( false );
+		expect( mw.notify ).toHaveBeenCalledWith( 'Unknown subject', { type: 'error' } );
+	} );
 } );
 
 describe( 'SubjectsManagerPage delete flow', () => {

--- a/resources/ext.neowiki/tests/components/Views/Infobox.spec.ts
+++ b/resources/ext.neowiki/tests/components/Views/Infobox.spec.ts
@@ -17,6 +17,8 @@ import { createPinia, setActivePinia } from 'pinia';
 import { useSchemaStore } from '@/stores/SchemaStore.ts';
 import { Service } from '@/NeoWikiServices.ts';
 import { useSubjectStore } from '@/stores/SubjectStore.ts';
+import { SubjectWithContext } from '@/domain/SubjectWithContext.ts';
+import { PageIdentifiers } from '@/domain/PageIdentifiers.ts';
 import type { SubjectRepository } from '@/domain/SubjectRepository.ts';
 import SubjectEditorDialog from '@/components/SubjectEditor/SubjectEditorDialog.vue';
 import { CdxButton } from '@wikimedia/codex';
@@ -219,13 +221,19 @@ describe( 'Infobox', () => {
 				createPropertyDefinitionFromJson( 'Cost centre', { type: TextType.typeName } ),
 			] ),
 		);
-		const savedSubject = new Subject(
+		// What the editor hands to onSave: a plain Subject, without the page context the registry
+		// entry carries, and here also without the statement the server ends up storing.
+		const clientCopy = new Subject(
+			mockSubject.getId(), 'Test Subject', 'TestSchema', new StatementList( [] ),
+		);
+		const persistedSubject = new SubjectWithContext(
 			mockSubject.getId(),
 			'Test Subject',
 			'TestSchema',
 			new StatementList( [
 				new Statement( new PropertyName( 'Cost centre' ), TextType.typeName, newStringValue( 'CC-42' ) ),
 			] ),
+			new PageIdentifiers( 7, 'Some page' ),
 		);
 
 		async function openEditorAndSave( wrapper: VueWrapper ): Promise<void> {
@@ -236,14 +244,20 @@ describe( 'Infobox', () => {
 
 			const onSave = wrapper.findComponent( SubjectEditorDialog ).props( 'onSave' ) as
 				( subject: Subject, comment: string ) => Promise<void>;
-			await onSave( savedSubject, 'summary' );
+			await onSave( clientCopy, 'summary' );
 			await flushPromises();
 		}
 
 		it( 'renders the value once the save answers with the Subject and its Schema', async () => {
-			getSubjectMock.mockResolvedValue( savedSubject );
+			// Both halves of the response are load-bearing here: the value lives only on the
+			// response Subject, and only the response Schema defines the property it sits under.
+			getSubjectMock.mockResolvedValue( clientCopy );
 			getSchemaMock.mockResolvedValue( schemaWithCostCentre );
-			updateSubjectMock.mockResolvedValue( { subject: savedSubject, schema: schemaWithCostCentre } );
+			updateSubjectMock.mockResolvedValue( {
+				subjectId: mockSubject.getId(),
+				subject: persistedSubject,
+				schema: schemaWithCostCentre,
+			} );
 
 			const wrapper = mountComponent( mockSubject, true );
 			await openEditorAndSave( wrapper );
@@ -253,17 +267,37 @@ describe( 'Infobox', () => {
 		} );
 
 		it( 'renders the Subject the save returned, not the one handed to it', async () => {
-			const canonical = new Subject(
+			const canonical = new SubjectWithContext(
 				mockSubject.getId(), 'Server label', 'TestSchema', new StatementList( [] ),
+				new PageIdentifiers( 7, 'Some page' ),
 			);
-			getSubjectMock.mockResolvedValue( savedSubject );
+			getSubjectMock.mockResolvedValue( clientCopy );
 			getSchemaMock.mockResolvedValue( mockSchema );
-			updateSubjectMock.mockResolvedValue( { subject: canonical, schema: null } );
+			updateSubjectMock.mockResolvedValue( {
+				subjectId: mockSubject.getId(),
+				subject: canonical,
+				schema: null,
+			} );
 
 			const wrapper = mountComponent( mockSubject, true );
 			await openEditorAndSave( wrapper );
 
 			expect( wrapper.find( '.ext-neowiki-infobox__title' ).text() ).toBe( 'Server label' );
+		} );
+
+		it( 'leaves the display alone when the save answers without page context', async () => {
+			getSubjectMock.mockResolvedValue( clientCopy );
+			getSchemaMock.mockResolvedValue( mockSchema );
+			updateSubjectMock.mockResolvedValue( {
+				subjectId: mockSubject.getId(),
+				subject: null,
+				schema: null,
+			} );
+
+			const wrapper = mountComponent( mockSubject, true );
+			await openEditorAndSave( wrapper );
+
+			expect( wrapper.find( '.ext-neowiki-infobox__title' ).text() ).toBe( 'Test Subject' );
 		} );
 	} );
 } );

--- a/resources/ext.neowiki/tests/components/Views/Infobox.spec.ts
+++ b/resources/ext.neowiki/tests/components/Views/Infobox.spec.ts
@@ -34,6 +34,8 @@ describe( 'Infobox', () => {
 	let pinia: ReturnType<typeof createPinia>;
 	let schemaStore: any;
 	let subjectStore: any;
+	const getSubjectMock = vi.fn();
+	const getSchemaMock = vi.fn();
 
 	const mockSchema = new Schema(
 		'TestSchema',
@@ -79,6 +81,8 @@ describe( 'Infobox', () => {
 				[ Service.ComponentRegistry ]: NeoWikiExtension.getInstance().getTypeSpecificComponentRegistry(),
 				[ Service.SchemaPermissionHints ]: NeoWikiExtension.getInstance().newSchemaPermissionHints(),
 				[ Service.PropertyTypeRegistry ]: NeoWikiExtension.getInstance().getPropertyTypeRegistry(),
+				[ Service.SubjectRepository ]: { getSubject: getSubjectMock },
+				[ Service.SchemaRepository ]: { getSchema: getSchemaMock },
 			},
 		},
 	} );
@@ -93,6 +97,10 @@ describe( 'Infobox', () => {
 		subjectStore = useSubjectStore();
 		subjectStore.setSubject( mockSubject );
 		subjectStore.validateSubjectUpdate = vi.fn().mockResolvedValue( [] );
+
+		// openEditor reads through the injected repositories, not the stores the display renders from.
+		getSubjectMock.mockReset();
+		getSchemaMock.mockReset();
 	} );
 
 	it( 'renders the title correctly', () => {
@@ -151,22 +159,33 @@ describe( 'Infobox', () => {
 		expect( editButton.exists() ).toBe( true );
 	} );
 
-	it( 'fetches latest schema and subject before opening dialog when edit button is clicked', async () => {
-		schemaStore.fetchSchema = vi.fn().mockResolvedValue( undefined );
-		subjectStore.fetchSubject = vi.fn().mockResolvedValue( undefined );
+	it( 'opens the dialog on the subject and schema fetched from the repositories', async () => {
+		// Values the stores do not hold, so the assertions can only pass if the dialog was
+		// handed the repositories' data rather than a registry read.
+		const freshSubject = new Subject(
+			mockSubject.getId(),
+			'Fetched Subject',
+			'TestSchema',
+			new StatementList( [] ),
+		);
+		const freshSchema = new Schema( 'TestSchema', 'Fetched schema', new PropertyDefinitionList( [] ) );
+		getSubjectMock.mockResolvedValue( freshSubject );
+		getSchemaMock.mockResolvedValue( freshSchema );
 
 		const wrapper = mountComponent( mockSubject, true );
 
-		const dialog = wrapper.findComponent( SubjectEditorDialog );
-		expect( dialog.props( 'open' ) ).toBe( false );
+		expect( wrapper.findComponent( SubjectEditorDialog ).exists() ).toBe( false );
 
 		const editButton = wrapper.findComponent( { name: 'CdxButton', props: { 'aria-label': 'neowiki-infobox-edit-link' } } );
 		await editButton.trigger( 'click' );
 		await flushPromises();
 
-		expect( schemaStore.fetchSchema ).toHaveBeenCalledWith( mockSubject.getSchemaName() );
-		expect( subjectStore.fetchSubject ).toHaveBeenCalledWith( mockSubject.getId() );
+		expect( getSubjectMock ).toHaveBeenCalledWith( mockSubject.getId() );
+		expect( getSchemaMock ).toHaveBeenCalledWith( 'TestSchema' );
+		const dialog = wrapper.findComponent( SubjectEditorDialog );
 		expect( dialog.props( 'open' ) ).toBe( true );
+		expect( dialog.props( 'subject' ) ).toStrictEqual( freshSubject );
+		expect( dialog.props( 'schema' ) ).toStrictEqual( freshSchema );
 	} );
 
 	it( 'renders schema name as a link to the Schema page', () => {
@@ -175,5 +194,100 @@ describe( 'Infobox', () => {
 		const schemaLink = wrapper.find( '.ext-neowiki-infobox__schema a' );
 		expect( schemaLink.text() ).toBe( 'TestSchema' );
 		expect( schemaLink.attributes( 'href' ) ).toBe( '/wiki/Schema:TestSchema' );
+	} );
+
+	describe( 'publishing the editor-open fetch into the stores', () => {
+		// This view renders from the stores, so what openEditor fetched has to land there too:
+		// otherwise a property another session added stays unrenderable and a value saved against
+		// it is invisible until reload.
+		const schemaWithCostCentre = new Schema(
+			'TestSchema',
+			'A test schema',
+			new PropertyDefinitionList( [
+				createPropertyDefinitionFromJson( 'Cost centre', { type: TextType.typeName } ),
+			] ),
+		);
+		// The infobox renders a value only when the schema it holds defines that property, so a
+		// subject carrying a value for a property the stale schema lacks renders as nothing.
+		const subjectWithCostCentre = new Subject(
+			mockSubject.getId(),
+			'Test Subject',
+			'TestSchema',
+			new StatementList( [
+				new Statement( new PropertyName( 'Cost centre' ), TextType.typeName, newStringValue( 'CC-42' ) ),
+			] ),
+		);
+		const relabelledSubject = new Subject(
+			mockSubject.getId(), 'Relabelled', 'TestSchema', new StatementList( [] ),
+		);
+
+		async function openEditor( wrapper: VueWrapper ): Promise<void> {
+			await wrapper.findComponent(
+				{ name: 'CdxButton', props: { 'aria-label': 'neowiki-infobox-edit-link' } },
+			).trigger( 'click' );
+			await flushPromises();
+		}
+
+		it( 'renders a value whose property only the fetched schema defines', async () => {
+			getSubjectMock.mockResolvedValue( subjectWithCostCentre );
+			getSchemaMock.mockResolvedValue( schemaWithCostCentre );
+
+			const wrapper = mountComponent( mockSubject, true );
+			await openEditor( wrapper );
+
+			expect( schemaStore.getSchema( 'TestSchema' ) ).toStrictEqual( schemaWithCostCentre );
+			expect( wrapper.text() ).toContain( 'Cost centre' );
+			expect( wrapper.text() ).toContain( 'CC-42' );
+		} );
+
+		it( 'renders the fetched subject after the editor opens', async () => {
+			getSubjectMock.mockResolvedValue( relabelledSubject );
+			getSchemaMock.mockResolvedValue( mockSchema );
+
+			const wrapper = mountComponent( mockSubject, true );
+			await openEditor( wrapper );
+
+			expect( wrapper.find( '.ext-neowiki-infobox__title' ).text() ).toBe( 'Relabelled' );
+		} );
+
+		it( 'discards the schema it fetched when a schema mutation lands mid-fetch', async () => {
+			const saved = new Schema( 'TestSchema', 'Saved elsewhere', new PropertyDefinitionList( [] ) );
+			let resolveSchema!: ( schema: Schema ) => void;
+			getSubjectMock.mockResolvedValue( mockSubject );
+			getSchemaMock.mockReturnValue( new Promise<Schema>( ( resolve ) => {
+				resolveSchema = resolve;
+			} ) );
+
+			const wrapper = mountComponent( mockSubject, true );
+			await openEditor( wrapper );
+
+			schemaStore.mutationEpoch++;
+			schemaStore.setSchema( 'TestSchema', saved );
+			resolveSchema( schemaWithCostCentre );
+			await flushPromises();
+
+			expect( schemaStore.getSchema( 'TestSchema' ) ).toStrictEqual( saved );
+		} );
+
+		it( 'discards the subject it fetched when a subject mutation lands mid-fetch', async () => {
+			const saved = new Subject(
+				mockSubject.getId(), 'Saved elsewhere', 'TestSchema', new StatementList( [] ),
+			);
+			let resolveSubject!: ( subject: Subject ) => void;
+			getSchemaMock.mockResolvedValue( mockSchema );
+			getSubjectMock.mockReturnValue( new Promise<Subject>( ( resolve ) => {
+				resolveSubject = resolve;
+			} ) );
+
+			const wrapper = mountComponent( mockSubject, true );
+			await openEditor( wrapper );
+
+			subjectStore.mutationEpoch++;
+			subjectStore.setSubject( saved );
+			resolveSubject( relabelledSubject );
+			await flushPromises();
+
+			expect( subjectStore.getSubject( mockSubject.getId() ) ).toStrictEqual( saved );
+		} );
 	} );
 } );

--- a/resources/ext.neowiki/tests/components/Views/Infobox.spec.ts
+++ b/resources/ext.neowiki/tests/components/Views/Infobox.spec.ts
@@ -1,5 +1,5 @@
 import { mount, VueWrapper, flushPromises } from '@vue/test-utils';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import Infobox from '@/components/Views/Infobox.vue';
 import { Subject } from '@/domain/Subject.ts';
 import { SubjectId } from '@/domain/SubjectId.ts';
@@ -17,6 +17,7 @@ import { createPinia, setActivePinia } from 'pinia';
 import { useSchemaStore } from '@/stores/SchemaStore.ts';
 import { Service } from '@/NeoWikiServices.ts';
 import { useSubjectStore } from '@/stores/SubjectStore.ts';
+import type { SubjectRepository } from '@/domain/SubjectRepository.ts';
 import SubjectEditorDialog from '@/components/SubjectEditor/SubjectEditorDialog.vue';
 import { CdxButton } from '@wikimedia/codex';
 import { createI18nMock, setupMwMock } from '../../VueTestHelpers.ts';
@@ -36,6 +37,7 @@ describe( 'Infobox', () => {
 	let subjectStore: any;
 	const getSubjectMock = vi.fn();
 	const getSchemaMock = vi.fn();
+	const updateSubjectMock = vi.fn();
 
 	const mockSchema = new Schema(
 		'TestSchema',
@@ -101,6 +103,16 @@ describe( 'Infobox', () => {
 		// openEditor reads through the injected repositories, not the stores the display renders from.
 		getSubjectMock.mockReset();
 		getSchemaMock.mockReset();
+
+		// Saving goes through SubjectStore, which reaches its repository off the extension
+		// singleton rather than through injection.
+		updateSubjectMock.mockReset();
+		vi.spyOn( NeoWikiExtension.getInstance(), 'getSubjectRepository' )
+			.mockReturnValue( { updateSubject: updateSubjectMock } as unknown as SubjectRepository );
+	} );
+
+	afterEach( () => {
+		vi.restoreAllMocks();
 	} );
 
 	it( 'renders the title correctly', () => {
@@ -196,10 +208,10 @@ describe( 'Infobox', () => {
 		expect( schemaLink.attributes( 'href' ) ).toBe( '/wiki/Schema:TestSchema' );
 	} );
 
-	describe( 'publishing the editor-open fetch into the stores', () => {
-		// This view renders from the stores, so what openEditor fetched has to land there too:
-		// otherwise a property another session added stays unrenderable and a value saved against
-		// it is invisible until reload.
+	describe( 'rendering a Subject saved against an out-of-band Schema change', () => {
+		// The display renders a value only when the Schema it holds defines that property, so a save
+		// against a Schema that gained a property in another session has to bring both the Subject and
+		// that Schema back — otherwise the value the user just entered is invisible until reload.
 		const schemaWithCostCentre = new Schema(
 			'TestSchema',
 			'A test schema',
@@ -207,9 +219,7 @@ describe( 'Infobox', () => {
 				createPropertyDefinitionFromJson( 'Cost centre', { type: TextType.typeName } ),
 			] ),
 		);
-		// The infobox renders a value only when the schema it holds defines that property, so a
-		// subject carrying a value for a property the stale schema lacks renders as nothing.
-		const subjectWithCostCentre = new Subject(
+		const savedSubject = new Subject(
 			mockSubject.getId(),
 			'Test Subject',
 			'TestSchema',
@@ -217,77 +227,43 @@ describe( 'Infobox', () => {
 				new Statement( new PropertyName( 'Cost centre' ), TextType.typeName, newStringValue( 'CC-42' ) ),
 			] ),
 		);
-		const relabelledSubject = new Subject(
-			mockSubject.getId(), 'Relabelled', 'TestSchema', new StatementList( [] ),
-		);
 
-		async function openEditor( wrapper: VueWrapper ): Promise<void> {
+		async function openEditorAndSave( wrapper: VueWrapper ): Promise<void> {
 			await wrapper.findComponent(
 				{ name: 'CdxButton', props: { 'aria-label': 'neowiki-infobox-edit-link' } },
 			).trigger( 'click' );
 			await flushPromises();
+
+			const onSave = wrapper.findComponent( SubjectEditorDialog ).props( 'onSave' ) as
+				( subject: Subject, comment: string ) => Promise<void>;
+			await onSave( savedSubject, 'summary' );
+			await flushPromises();
 		}
 
-		it( 'renders a value whose property only the fetched schema defines', async () => {
-			getSubjectMock.mockResolvedValue( subjectWithCostCentre );
+		it( 'renders the value once the save answers with the Subject and its Schema', async () => {
+			getSubjectMock.mockResolvedValue( savedSubject );
 			getSchemaMock.mockResolvedValue( schemaWithCostCentre );
+			updateSubjectMock.mockResolvedValue( { subject: savedSubject, schema: schemaWithCostCentre } );
 
 			const wrapper = mountComponent( mockSubject, true );
-			await openEditor( wrapper );
+			await openEditorAndSave( wrapper );
 
-			expect( schemaStore.getSchema( 'TestSchema' ) ).toStrictEqual( schemaWithCostCentre );
 			expect( wrapper.text() ).toContain( 'Cost centre' );
 			expect( wrapper.text() ).toContain( 'CC-42' );
 		} );
 
-		it( 'renders the fetched subject after the editor opens', async () => {
-			getSubjectMock.mockResolvedValue( relabelledSubject );
-			getSchemaMock.mockResolvedValue( mockSchema );
-
-			const wrapper = mountComponent( mockSubject, true );
-			await openEditor( wrapper );
-
-			expect( wrapper.find( '.ext-neowiki-infobox__title' ).text() ).toBe( 'Relabelled' );
-		} );
-
-		it( 'discards the schema it fetched when a schema mutation lands mid-fetch', async () => {
-			const saved = new Schema( 'TestSchema', 'Saved elsewhere', new PropertyDefinitionList( [] ) );
-			let resolveSchema!: ( schema: Schema ) => void;
-			getSubjectMock.mockResolvedValue( mockSubject );
-			getSchemaMock.mockReturnValue( new Promise<Schema>( ( resolve ) => {
-				resolveSchema = resolve;
-			} ) );
-
-			const wrapper = mountComponent( mockSubject, true );
-			await openEditor( wrapper );
-
-			schemaStore.mutationEpoch++;
-			schemaStore.setSchema( 'TestSchema', saved );
-			resolveSchema( schemaWithCostCentre );
-			await flushPromises();
-
-			expect( schemaStore.getSchema( 'TestSchema' ) ).toStrictEqual( saved );
-		} );
-
-		it( 'discards the subject it fetched when a subject mutation lands mid-fetch', async () => {
-			const saved = new Subject(
-				mockSubject.getId(), 'Saved elsewhere', 'TestSchema', new StatementList( [] ),
+		it( 'renders the Subject the save returned, not the one handed to it', async () => {
+			const canonical = new Subject(
+				mockSubject.getId(), 'Server label', 'TestSchema', new StatementList( [] ),
 			);
-			let resolveSubject!: ( subject: Subject ) => void;
+			getSubjectMock.mockResolvedValue( savedSubject );
 			getSchemaMock.mockResolvedValue( mockSchema );
-			getSubjectMock.mockReturnValue( new Promise<Subject>( ( resolve ) => {
-				resolveSubject = resolve;
-			} ) );
+			updateSubjectMock.mockResolvedValue( { subject: canonical, schema: null } );
 
 			const wrapper = mountComponent( mockSubject, true );
-			await openEditor( wrapper );
+			await openEditorAndSave( wrapper );
 
-			subjectStore.mutationEpoch++;
-			subjectStore.setSubject( saved );
-			resolveSubject( relabelledSubject );
-			await flushPromises();
-
-			expect( subjectStore.getSubject( mockSubject.getId() ) ).toStrictEqual( saved );
+			expect( wrapper.find( '.ext-neowiki-infobox__title' ).text() ).toBe( 'Server label' );
 		} );
 	} );
 } );

--- a/resources/ext.neowiki/tests/persistence/RestSubjectRepository.neo4j.spec.ts
+++ b/resources/ext.neowiki/tests/persistence/RestSubjectRepository.neo4j.spec.ts
@@ -13,12 +13,14 @@ import { UrlType } from '@/domain/propertyTypes/Url';
 import { NeoWikiExtension } from '@/NeoWikiExtension';
 import { SubjectWithContext } from '@/domain/SubjectWithContext.ts';
 import { ValidationFailedError } from '@/persistence/ValidationFailedError';
+import { SchemaDeserializer } from '@/persistence/SchemaDeserializer';
 
 function newRepository( apiUrl: string, httpClient: InMemoryHttpClient ): RestSubjectRepository {
 	return new RestSubjectRepository(
 		apiUrl,
 		httpClient,
 		NeoWikiExtension.getInstance().getSubjectDeserializer(),
+		new SchemaDeserializer(),
 	);
 }
 
@@ -318,8 +320,8 @@ describe( 'RestSubjectRepository', () => {
 
 			const result = await repository.createMainSubject( 42, 'John Doe', 'Employee', new StatementList( [] ) );
 
-			expect( result.subject.getId().text ).toEqual( 's33333333333333' );
-			expect( result.subject.getLabel() ).toEqual( 'John Doe' );
+			expect( result.subjectId.text ).toEqual( 's33333333333333' );
+			expect( result.subject?.getLabel() ).toEqual( 'John Doe' );
 			expect( result.schema ).toBeNull();
 		} );
 
@@ -358,9 +360,25 @@ describe( 'RestSubjectRepository', () => {
 			);
 
 			// The page context is what a client-built copy cannot reproduce, so it is the point.
-			expect( result.subject.getPageIdentifiers().getPageId() ).toEqual( 42 );
+			expect( result.subject?.getPageIdentifiers().getPageId() ).toEqual( 42 );
 			expect( result.schema?.getName() ).toEqual( 'Employee' );
 			expect( result.schema?.getDescription() ).toEqual( 'An employee' );
+		} );
+
+		it( 'reports no subject when the response omitted the page identifiers', async () => {
+			// The server omits them for a Subject whose page it cannot resolve. Deserializing that
+			// would mint a Subject with an undefined page id for links to follow.
+			const withoutPage = writeResponseJson();
+			delete ( withoutPage.subject as Record<string, unknown> ).pageId;
+			delete ( withoutPage.subject as Record<string, unknown> ).pageTitle;
+
+			const result = await newRepository( 'https://example.com/rest.php', new InMemoryHttpClient( {
+				'https://example.com/rest.php/neowiki/v0/subject/s11111111111111':
+					new Response( JSON.stringify( withoutPage ), { status: 200 } ),
+			} ) ).updateSubject( new SubjectId( 's11111111111111' ), 'Updated', new StatementList( [] ) );
+
+			expect( result.subject ).toBeNull();
+			expect( result.subjectId.text ).toEqual( 's33333333333333' );
 		} );
 
 		it( 'sends a PUT request', async () => {
@@ -442,7 +460,7 @@ describe( 'RestSubjectRepository', () => {
 
 			const result = await repository.createChildSubject( 42, 'John Doe', 'Employee', new StatementList( [] ) );
 
-			expect( result.subject.getId().text ).toEqual( 's33333333333333' );
+			expect( result.subjectId.text ).toEqual( 's33333333333333' );
 		} );
 
 	} );
@@ -525,7 +543,7 @@ describe( 'RestSubjectRepository', () => {
 				[ subjectUrl ]: new Response( JSON.stringify( writeResponseJson() ), { status: 200 } ),
 			} ) ).updateSubject( new SubjectId( 's11111111111111' ), 'Updated', new StatementList( [] ) );
 
-			expect( result.subject.getId().text ).toEqual( 's33333333333333' );
+			expect( result.subjectId.text ).toEqual( 's33333333333333' );
 		} );
 
 		it( 'throws generic Error on 500', async () => {

--- a/resources/ext.neowiki/tests/persistence/RestSubjectRepository.neo4j.spec.ts
+++ b/resources/ext.neowiki/tests/persistence/RestSubjectRepository.neo4j.spec.ts
@@ -47,6 +47,24 @@ const mockResponse = {
 	},
 };
 
+// The Subject write endpoints answer with the Subject as persisted plus the Schema it
+// instantiates, in the same shape the read endpoints use.
+function writeResponseJson( overrides: Record<string, unknown> = {} ): Record<string, unknown> {
+	return {
+		status: 'updated',
+		subject: {
+			id: 's33333333333333',
+			label: 'John Doe',
+			schema: 'Employee',
+			pageId: 42,
+			pageTitle: 'Employees',
+			pageNamespaceId: 0,
+			statements: {},
+		},
+		...overrides,
+	};
+}
+
 describe( 'RestSubjectRepository', () => {
 
 	describe( 'getSubject', () => {
@@ -290,36 +308,19 @@ describe( 'RestSubjectRepository', () => {
 			).rejects.toThrowError( 'Error creating main subject' );
 		} );
 
-		it( 'creates new main subject', async () => {
-			const mockSubjectResponse = {
-				subject: {
-					id: 's33333333333333',
-					label: 'John Doe',
-					schema: 'Employee',
-					properties: new StatementList( [
-						new Statement( new PropertyName( 'label' ), TextType.typeName, newStringValue( 'John Doe' ) ),
-						new Statement( new PropertyName( 'WorkUrl' ), UrlType.typeName, newStringValue( 'https://pro.wiki' ) ),
-					] ),
-				},
-			};
-
+		it( 'returns the created subject as the server persisted it', async () => {
 			const inMemoryHttpClient = new InMemoryHttpClient( {
 				'https://example.com/rest.php/neowiki/v0/page/42/mainSubject':
-					new Response( JSON.stringify( { subjectId: 's33333333333333' } ), { status: 200 } ),
+					new Response( JSON.stringify( writeResponseJson() ), { status: 200 } ),
 			} );
 
 			const repository = newRepository( 'https://example.com/rest.php', inMemoryHttpClient );
 
-			const subjectId = await repository.createMainSubject(
-				42,
-				mockSubjectResponse.subject.label,
-				mockSubjectResponse.subject.schema,
-				mockSubjectResponse.subject.properties,
-			);
+			const result = await repository.createMainSubject( 42, 'John Doe', 'Employee', new StatementList( [] ) );
 
-			expect( subjectId.text ).toEqual( mockSubjectResponse.subject.id );
-
-			// TODO: check that it is actually the main subject?
+			expect( result.subject.getId().text ).toEqual( 's33333333333333' );
+			expect( result.subject.getLabel() ).toEqual( 'John Doe' );
+			expect( result.schema ).toBeNull();
 		} );
 
 	} );
@@ -339,36 +340,33 @@ describe( 'RestSubjectRepository', () => {
 			).rejects.toThrowError( 'Error updating subject' );
 		} );
 
-		it( 'returns original request', async () => {
-			const mockUpdateResponse = {
-				properties: new StatementList( [
-					new Statement( new PropertyName( 'label' ), TextType.typeName, newStringValue( 'John Doe' ) ),
-					new Statement( new PropertyName( 'WorkUrl' ), UrlType.typeName, newStringValue( 'https://pro.wiki' ) ),
-				] ),
-				comment: 'Edit comment',
-			};
-
+		it( 'returns the subject and schema the server answered with', async () => {
 			const inMemoryHttpClient = new InMemoryHttpClient( {
 				'https://example.com/rest.php/neowiki/v0/subject/s11111111111111':
-					new Response( JSON.stringify( mockUpdateResponse ), { status: 200 } ),
+					new Response( JSON.stringify( writeResponseJson( {
+						schema: { description: 'An employee', propertyDefinitions: {} },
+					} ) ), { status: 200 } ),
 			} );
 
 			const repository = newRepository( 'https://example.com/rest.php', inMemoryHttpClient );
 
-			const response = await repository.updateSubject(
+			const result = await repository.updateSubject(
 				new SubjectId( 's11111111111111' ),
 				'Subject label',
-				mockUpdateResponse.properties,
-				mockUpdateResponse.comment,
+				new StatementList( [] ),
+				'Edit comment',
 			);
 
-			expect( response ).toEqual( mockUpdateResponse );
+			// The page context is what a client-built copy cannot reproduce, so it is the point.
+			expect( result.subject.getPageIdentifiers().getPageId() ).toEqual( 42 );
+			expect( result.schema?.getName() ).toEqual( 'Employee' );
+			expect( result.schema?.getDescription() ).toEqual( 'An employee' );
 		} );
 
 		it( 'sends a PUT request', async () => {
 			const inMemoryHttpClient = new InMemoryHttpClient( {
 				'https://example.com/rest.php/neowiki/v0/subject/s11111111111111':
-					new Response( JSON.stringify( {} ), { status: 200 } ),
+					new Response( JSON.stringify( writeResponseJson() ), { status: 200 } ),
 			} );
 			const putSpy = vi.spyOn( inMemoryHttpClient, 'put' );
 			const patchSpy = vi.spyOn( inMemoryHttpClient, 'patch' );
@@ -434,36 +432,17 @@ describe( 'RestSubjectRepository', () => {
 			).rejects.toThrowError( 'Error creating child subject' );
 		} );
 
-		it( 'creates new child subject', async () => {
-			const mockSubjectResponse = {
-				subject: {
-					id: 's33333333333333',
-					label: 'John Doe',
-					schema: 'Employee',
-					properties: new StatementList( [
-						new Statement( new PropertyName( 'label' ), TextType.typeName, newStringValue( 'John Doe' ) ),
-						new Statement( new PropertyName( 'WorkUrl' ), UrlType.typeName, newStringValue( 'https://pro.wiki' ) ),
-					] ),
-				},
-			};
-
+		it( 'returns the created subject as the server persisted it', async () => {
 			const inMemoryHttpClient = new InMemoryHttpClient( {
 				'https://example.com/rest.php/neowiki/v0/page/42/childSubjects':
-					new Response( JSON.stringify( { subjectId: 's33333333333333' } ), { status: 200 } ),
+					new Response( JSON.stringify( writeResponseJson( { status: 'created' } ) ), { status: 200 } ),
 			} );
 
 			const repository = newRepository( 'https://example.com/rest.php', inMemoryHttpClient );
 
-			const subjectId = await repository.createChildSubject(
-				42,
-				mockSubjectResponse.subject.label,
-				mockSubjectResponse.subject.schema,
-				mockSubjectResponse.subject.properties,
-			);
+			const result = await repository.createChildSubject( 42, 'John Doe', 'Employee', new StatementList( [] ) );
 
-			expect( subjectId.text ).toEqual( mockSubjectResponse.subject.id );
-
-			// TODO: check that it is not the main subject?
+			expect( result.subject.getId().text ).toEqual( 's33333333333333' );
 		} );
 
 	} );
@@ -542,12 +521,11 @@ describe( 'RestSubjectRepository', () => {
 		} );
 
 		it( 'resolves normally on 200 (existing behaviour preserved)', async () => {
-			const mockResponse = { label: 'Updated' };
-			const response = await newRepository( 'https://example.com/rest.php', new InMemoryHttpClient( {
-				[ subjectUrl ]: new Response( JSON.stringify( mockResponse ), { status: 200 } ),
+			const result = await newRepository( 'https://example.com/rest.php', new InMemoryHttpClient( {
+				[ subjectUrl ]: new Response( JSON.stringify( writeResponseJson() ), { status: 200 } ),
 			} ) ).updateSubject( new SubjectId( 's11111111111111' ), 'Updated', new StatementList( [] ) );
 
-			expect( response ).toEqual( mockResponse );
+			expect( result.subject.getId().text ).toEqual( 's33333333333333' );
 		} );
 
 		it( 'throws generic Error on 500', async () => {

--- a/resources/ext.neowiki/tests/stores/LayoutStore.spec.ts
+++ b/resources/ext.neowiki/tests/stores/LayoutStore.spec.ts
@@ -3,7 +3,6 @@ import { createPinia, setActivePinia } from 'pinia';
 import { useLayoutStore } from '@/stores/LayoutStore.ts';
 import { Layout } from '@/domain/Layout.ts';
 import { NeoWikiExtension } from '@/NeoWikiExtension.ts';
-import { InMemoryLayoutLookup } from '@/application/LayoutLookup.ts';
 
 vi.mock( '@/NeoWikiExtension.ts', () => ( {
 	NeoWikiExtension: {
@@ -36,39 +35,35 @@ describe( 'LayoutStore', () => {
 		expect( store.getLayout( 'FinancialOverview' ) ).toEqual( layout );
 	} );
 
-	it( 'fetches and stores a layout via fetchLayout', async () => {
-		const layout = newLayout( 'CompanyInfo' );
-		const layoutLookup = new InMemoryLayoutLookup( [ layout ] );
-		vi.mocked( NeoWikiExtension.getInstance ).mockReturnValue( {
-			getLayoutRepository: () => layoutLookup,
-		} as unknown as NeoWikiExtension );
-
-		const store = useLayoutStore();
-		await store.fetchLayout( 'CompanyInfo' );
-
-		expect( store.getLayout( 'CompanyInfo' ) ).toEqual( layout );
-	} );
-
-	it( 'discards a fetch that a save overtook', async () => {
-		let resolveFetch!: ( layout: Layout ) => void;
-		const pending = new Promise<Layout>( ( resolve ) => {
-			resolveFetch = resolve;
-		} );
-		const saved = new Layout( 'CompanyInfo', 'Company', 'infobox', 'saved', [], {} );
+	it( 'writes the saved layout into the registry', async () => {
+		const saved = newLayout( 'CompanyInfo' );
 		vi.mocked( NeoWikiExtension.getInstance ).mockReturnValue( {
 			getLayoutRepository: () => ( {
-				getLayout: () => pending,
 				saveLayout: vi.fn().mockResolvedValue( undefined ),
 			} ),
 		} as unknown as NeoWikiExtension );
 		const store = useLayoutStore();
 
-		const request = store.fetchLayout( 'CompanyInfo' );
 		await store.saveLayout( saved );
-		resolveFetch( new Layout( 'CompanyInfo', 'Company', 'infobox', 'pre-save', [], {} ) );
-		await request;
 
 		expect( store.getLayout( 'CompanyInfo' ) ).toStrictEqual( saved );
+	} );
+
+	it( 'bumps the mutation epoch once the backend acknowledges the save', async () => {
+		// The epoch is what makes concurrent write-backs into this store discard themselves
+		// (ADR 30 rule 3); LayoutStore's only such writer lives in StoreStateLoader, so the
+		// counter is asserted here rather than through it.
+		vi.mocked( NeoWikiExtension.getInstance ).mockReturnValue( {
+			getLayoutRepository: () => ( {
+				saveLayout: vi.fn().mockResolvedValue( undefined ),
+			} ),
+		} as unknown as NeoWikiExtension );
+		const store = useLayoutStore();
+		const before = store.mutationEpoch;
+
+		await store.saveLayout( newLayout( 'CompanyInfo' ) );
+
+		expect( store.mutationEpoch ).not.toBe( before );
 	} );
 
 	it( 'does not write through when the repository rejects the save', async () => {

--- a/resources/ext.neowiki/tests/stores/SchemaStore.spec.ts
+++ b/resources/ext.neowiki/tests/stores/SchemaStore.spec.ts
@@ -3,7 +3,6 @@ import { createPinia, setActivePinia } from 'pinia';
 import { normalizeSchemaName, useSchemaStore } from '@/stores/SchemaStore.ts';
 import { NeoWikiExtension } from '@/NeoWikiExtension.ts';
 import { newSchema } from '@/TestHelpers.ts';
-import type { Schema } from '@/domain/Schema.ts';
 import type { SchemaSummary, SchemaSummaryPage } from '@/application/SchemaLookup.ts';
 
 interface Deferred<T> {
@@ -172,59 +171,6 @@ describe( 'SchemaStore fetchAllSchemaSummaries', () => {
 		await preSaveRequest;
 		expect( await retryRequest ).toEqual( [ summary( 'Alpha' ) ] );
 		expect( getSchemaSummaries ).toHaveBeenCalledTimes( 2 );
-	} );
-
-} );
-
-describe( 'SchemaStore fetchSchema', () => {
-
-	beforeEach( () => {
-		setActivePinia( createPinia() );
-	} );
-
-	afterEach( () => {
-		vi.restoreAllMocks();
-	} );
-
-	it( 'stores the fetched schema', async () => {
-		const schema = newSchema( { title: 'Person' } );
-		withRepository( { getSchema: vi.fn().mockResolvedValue( schema ) } );
-		const store = useSchemaStore();
-
-		await store.fetchSchema( 'Person' );
-
-		expect( store.getSchema( 'Person' ) ).toStrictEqual( schema );
-	} );
-
-	it( 'discards a fetch that a save overtook', async () => {
-		const preSave = newSchema( { title: 'Person', description: 'pre-save' } );
-		const saved = newSchema( { title: 'Person', description: 'saved' } );
-		const fetch = deferred<Schema>();
-		withRepository( {
-			getSchema: vi.fn().mockReturnValueOnce( fetch.promise ),
-			saveSchema: vi.fn().mockResolvedValue( undefined ),
-		} );
-		const store = useSchemaStore();
-
-		const request = store.fetchSchema( 'Person' );
-		await store.saveSchema( saved );
-		fetch.resolve( preSave );
-		await request;
-
-		expect( store.getSchema( 'Person' ) ).toStrictEqual( saved );
-	} );
-
-	it( 'discards a fetch that a removal overtook', async () => {
-		const fetch = deferred<Schema>();
-		withRepository( { getSchema: vi.fn().mockReturnValueOnce( fetch.promise ) } );
-		const store = useSchemaStore();
-
-		const request = store.fetchSchema( 'Person' );
-		store.removeSchema( 'Person' );
-		fetch.resolve( newSchema( { title: 'Person' } ) );
-		await request;
-
-		expect( () => store.getSchema( 'Person' ) ).toThrow( 'Unknown schema: Person' );
 	} );
 
 } );

--- a/resources/ext.neowiki/tests/stores/SubjectStore.spec.ts
+++ b/resources/ext.neowiki/tests/stores/SubjectStore.spec.ts
@@ -8,6 +8,7 @@ import { PageIdentifiers } from '@/domain/PageIdentifiers.ts';
 import { SubjectId } from '@/domain/SubjectId';
 import { Subject } from '@/domain/Subject';
 import { useSchemaStore } from '@/stores/SchemaStore.ts';
+import { StatementList } from '@/domain/StatementList.ts';
 
 describe( 'SubjectStore — subjectCreatorOpen', () => {
 	beforeEach( () => {
@@ -177,7 +178,7 @@ describe( 'SubjectStore ordering guards', () => {
 		} );
 		withSubjectRepository( {
 			getSubject: () => pending,
-			updateSubject: vi.fn().mockResolvedValue( undefined ),
+			updateSubject: vi.fn().mockResolvedValue( { subject: updated, schema: null } ),
 		} );
 		const store = useSubjectStore();
 
@@ -211,7 +212,7 @@ describe( 'SubjectStore ordering guards', () => {
 		} );
 		withSubjectRepository( {
 			getPageSubjects: () => pending,
-			updateSubject: vi.fn().mockResolvedValue( undefined ),
+			updateSubject: vi.fn().mockResolvedValue( { subject: updated, schema: null } ),
 		} );
 		const store = useSubjectStore();
 
@@ -254,6 +255,99 @@ describe( 'SubjectStore ordering guards', () => {
 
 		expect( schemaStore.getSchema( 'Person' ) ).toStrictEqual( saved );
 		expect( subjectStore.pageSubjects?.getPageId() ).toBe( 7 );
+	} );
+
+} );
+
+describe( 'SubjectStore write results', () => {
+
+	const id = new SubjectId( 's11111111111111' );
+
+	beforeEach( () => {
+		setActivePinia( createPinia() );
+	} );
+
+	afterEach( () => {
+		vi.restoreAllMocks();
+	} );
+
+	it( 'records the Subject the update returned, not the one it was given', async () => {
+		// The caller's copy is a plain Subject built by the editor; only the server's carries the
+		// page context and whatever normalisation the write applied.
+		const sent = newSubject( { id: id.text, label: 'as typed' } );
+		const canonical = newSubject( { id: id.text, label: 'as persisted' } );
+		withSubjectRepository( {
+			updateSubject: vi.fn().mockResolvedValue( { subject: canonical, schema: null } ),
+		} );
+		const store = useSubjectStore();
+
+		await store.updateSubject( sent );
+
+		expect( store.getSubject( id ) ).toStrictEqual( canonical );
+	} );
+
+	it( 'records the Schema the update bundled', async () => {
+		const schema = newSchema( { title: 'Person', description: 'as persisted' } );
+		withSubjectRepository( {
+			updateSubject: vi.fn().mockResolvedValue( {
+				subject: newSubject( { id: id.text } ),
+				schema,
+			} ),
+		} );
+		const subjectStore = useSubjectStore();
+
+		await subjectStore.updateSubject( newSubject( { id: id.text } ) );
+
+		expect( useSchemaStore().getSchema( 'Person' ) ).toStrictEqual( schema );
+	} );
+
+	it( 'discards the bundled Schema when a Schema mutation landed while the save was in flight', async () => {
+		const bundled = newSchema( { title: 'Person', description: 'bundled with the save' } );
+		const savedElsewhere = newSchema( { title: 'Person', description: 'saved elsewhere' } );
+		let resolveUpdate!: ( result: unknown ) => void;
+		const repositories = {
+			getSubjectRepository: () => ( {
+				updateSubject: () => new Promise( ( resolve ) => {
+					resolveUpdate = resolve;
+				} ),
+			} ),
+			getSchemaRepository: () => ( { saveSchema: vi.fn().mockResolvedValue( undefined ) } ),
+		};
+		vi.spyOn( NeoWikiExtension, 'getInstance' ).mockReturnValue( repositories as unknown as NeoWikiExtension );
+		const subjectStore = useSubjectStore();
+		const schemaStore = useSchemaStore();
+
+		const request = subjectStore.updateSubject( newSubject( { id: id.text } ) );
+		await schemaStore.saveSchema( savedElsewhere );
+		resolveUpdate( { subject: newSubject( { id: id.text } ), schema: bundled } );
+		await request;
+
+		expect( schemaStore.getSchema( 'Person' ) ).toStrictEqual( savedElsewhere );
+	} );
+
+	it( 'records the Subject the creation returned', async () => {
+		const created = newSubject( { id: id.text, label: 'as persisted' } );
+		withSubjectRepository( {
+			createMainSubject: vi.fn().mockResolvedValue( { subject: created, schema: null } ),
+		} );
+		const store = useSubjectStore();
+
+		const returnedId = await store.createMainSubject( 7, 'as typed', 'Person', new StatementList( [] ) );
+
+		expect( returnedId ).toStrictEqual( id );
+		expect( store.getSubject( id ) ).toStrictEqual( created );
+	} );
+
+	it( 'records the Subject a child creation returned', async () => {
+		const created = newSubject( { id: id.text, label: 'as persisted' } );
+		withSubjectRepository( {
+			createChildSubject: vi.fn().mockResolvedValue( { subject: created, schema: null } ),
+		} );
+		const store = useSubjectStore();
+
+		await store.createChildSubject( 7, 'as typed', 'Person', new StatementList( [] ) );
+
+		expect( store.getSubject( id ) ).toStrictEqual( created );
 	} );
 
 } );

--- a/resources/ext.neowiki/tests/stores/SubjectStore.spec.ts
+++ b/resources/ext.neowiki/tests/stores/SubjectStore.spec.ts
@@ -9,6 +9,7 @@ import { SubjectId } from '@/domain/SubjectId';
 import { Subject } from '@/domain/Subject';
 import { useSchemaStore } from '@/stores/SchemaStore.ts';
 import { StatementList } from '@/domain/StatementList.ts';
+import type { Schema } from '@/domain/Schema.ts';
 
 describe( 'SubjectStore — subjectCreatorOpen', () => {
 	beforeEach( () => {
@@ -33,6 +34,10 @@ describe( 'SubjectStore — subjectCreatorOpen', () => {
 		expect( store.subjectCreatorOpen ).toBe( false );
 	} );
 } );
+
+function writeResult( subject: Subject | null, schema: Schema | null = null ): Record<string, unknown> {
+	return { subjectId: new SubjectId( 's11111111111111' ), subject, schema };
+}
 
 function withSubjectRepository( repository: Record<string, unknown> ): void {
 	vi.spyOn( NeoWikiExtension, 'getInstance' ).mockReturnValue(
@@ -178,7 +183,7 @@ describe( 'SubjectStore ordering guards', () => {
 		} );
 		withSubjectRepository( {
 			getSubject: () => pending,
-			updateSubject: vi.fn().mockResolvedValue( { subject: updated, schema: null } ),
+			updateSubject: vi.fn().mockResolvedValue( writeResult( updated ) ),
 		} );
 		const store = useSubjectStore();
 
@@ -212,7 +217,7 @@ describe( 'SubjectStore ordering guards', () => {
 		} );
 		withSubjectRepository( {
 			getPageSubjects: () => pending,
-			updateSubject: vi.fn().mockResolvedValue( { subject: updated, schema: null } ),
+			updateSubject: vi.fn().mockResolvedValue( writeResult( updated ) ),
 		} );
 		const store = useSubjectStore();
 
@@ -277,7 +282,7 @@ describe( 'SubjectStore write results', () => {
 		const sent = newSubject( { id: id.text, label: 'as typed' } );
 		const canonical = newSubject( { id: id.text, label: 'as persisted' } );
 		withSubjectRepository( {
-			updateSubject: vi.fn().mockResolvedValue( { subject: canonical, schema: null } ),
+			updateSubject: vi.fn().mockResolvedValue( writeResult( canonical ) ),
 		} );
 		const store = useSubjectStore();
 
@@ -289,10 +294,7 @@ describe( 'SubjectStore write results', () => {
 	it( 'records the Schema the update bundled', async () => {
 		const schema = newSchema( { title: 'Person', description: 'as persisted' } );
 		withSubjectRepository( {
-			updateSubject: vi.fn().mockResolvedValue( {
-				subject: newSubject( { id: id.text } ),
-				schema,
-			} ),
+			updateSubject: vi.fn().mockResolvedValue( writeResult( newSubject( { id: id.text } ), schema ) ),
 		} );
 		const subjectStore = useSubjectStore();
 
@@ -319,7 +321,7 @@ describe( 'SubjectStore write results', () => {
 
 		const request = subjectStore.updateSubject( newSubject( { id: id.text } ) );
 		await schemaStore.saveSchema( savedElsewhere );
-		resolveUpdate( { subject: newSubject( { id: id.text } ), schema: bundled } );
+		resolveUpdate( writeResult( newSubject( { id: id.text } ), bundled ) );
 		await request;
 
 		expect( schemaStore.getSchema( 'Person' ) ).toStrictEqual( savedElsewhere );
@@ -328,7 +330,7 @@ describe( 'SubjectStore write results', () => {
 	it( 'records the Subject the creation returned', async () => {
 		const created = newSubject( { id: id.text, label: 'as persisted' } );
 		withSubjectRepository( {
-			createMainSubject: vi.fn().mockResolvedValue( { subject: created, schema: null } ),
+			createMainSubject: vi.fn().mockResolvedValue( writeResult( created ) ),
 		} );
 		const store = useSubjectStore();
 
@@ -338,10 +340,23 @@ describe( 'SubjectStore write results', () => {
 		expect( store.getSubject( id ) ).toStrictEqual( created );
 	} );
 
+	it( 'keeps the previous copy when the response omitted the page context', async () => {
+		// A Subject without page identifiers cannot back the links that read it, so the registry
+		// keeps what it had rather than recording a page-less copy.
+		const seeded = newSubject( { id: id.text, label: 'seeded' } );
+		withSubjectRepository( { updateSubject: vi.fn().mockResolvedValue( writeResult( null ) ) } );
+		const store = useSubjectStore();
+		store.setSubject( seeded );
+
+		await store.updateSubject( newSubject( { id: id.text, label: 'as typed' } ) );
+
+		expect( store.getSubject( id ) ).toStrictEqual( seeded );
+	} );
+
 	it( 'records the Subject a child creation returned', async () => {
 		const created = newSubject( { id: id.text, label: 'as persisted' } );
 		withSubjectRepository( {
-			createChildSubject: vi.fn().mockResolvedValue( { subject: created, schema: null } ),
+			createChildSubject: vi.fn().mockResolvedValue( writeResult( created ) ),
 		} );
 		const store = useSubjectStore();
 

--- a/resources/ext.neowiki/tests/stores/SubjectStore.spec.ts
+++ b/resources/ext.neowiki/tests/stores/SubjectStore.spec.ts
@@ -168,7 +168,7 @@ describe( 'SubjectStore ordering guards', () => {
 		vi.restoreAllMocks();
 	} );
 
-	it( 'discards a fetch that a mutation overtook', async () => {
+	it( 'discards a getOrFetchSubject miss-path fetch that a mutation overtook', async () => {
 		const stale = newSubject( { id: 's11111111111111', label: 'stale' } );
 		const updated = newSubject( { id: 's11111111111111', label: 'updated' } );
 		let resolveFetch!: ( subject: Subject ) => void;
@@ -181,12 +181,25 @@ describe( 'SubjectStore ordering guards', () => {
 		} );
 		const store = useSubjectStore();
 
-		const request = store.fetchSubject( new SubjectId( 's11111111111111' ) );
+		const request = store.getOrFetchSubject( new SubjectId( 's11111111111111' ) );
 		await store.updateSubject( updated );
 		resolveFetch( stale );
-		await request;
 
+		expect( await request ).toStrictEqual( updated );
 		expect( store.getSubject( new SubjectId( 's11111111111111' ) ) ).toStrictEqual( updated );
+	} );
+
+	it( 'does not fetch when getOrFetchSubject finds the subject in the registry', async () => {
+		const seeded = newSubject( { id: 's11111111111111', label: 'seeded' } );
+		const getSubject = vi.fn();
+		withSubjectRepository( { getSubject } );
+		const store = useSubjectStore();
+		store.setSubject( seeded );
+
+		const result = await store.getOrFetchSubject( new SubjectId( 's11111111111111' ) );
+
+		expect( result ).toStrictEqual( seeded );
+		expect( getSubject ).not.toHaveBeenCalled();
 	} );
 
 	it( 'discards loadPageSubjects subject writes when a mutation lands mid-flight', async () => {

--- a/src/Application/Actions/CreateSubject/CreateSubjectAction.php
+++ b/src/Application/Actions/CreateSubject/CreateSubjectAction.php
@@ -6,7 +6,9 @@ namespace ProfessionalWiki\NeoWiki\Application\Actions\CreateSubject;
 
 use InvalidArgumentException;
 use ProfessionalWiki\NeoWiki\Application\PageIdentifiersLookup;
+use ProfessionalWiki\NeoWiki\Application\PageIdentifiersResolver;
 use ProfessionalWiki\NeoWiki\Application\PageReadAuthorizer;
+use ProfessionalWiki\NeoWiki\Application\Queries\GetSubject\GetSubjectResponseItem;
 use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
 use ProfessionalWiki\NeoWiki\Application\SelectStatementResolver;
 use ProfessionalWiki\NeoWiki\Application\StatementListBuilder;
@@ -14,6 +16,7 @@ use ProfessionalWiki\NeoWiki\Application\SubjectWriteAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\SubjectRepository;
 use ProfessionalWiki\NeoWiki\Application\Validation\ProposedSubjectValidator;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
@@ -36,6 +39,7 @@ readonly class CreateSubjectAction {
 		private SelectStatementResolver $selectStatementResolver,
 		private ProposedSubjectValidator $proposedSubjectValidator,
 		private PageIdentifiersLookup $pageIdentifiersLookup,
+		private PageIdentifiersResolver $pageIdentifiersResolver,
 		private bool $validationEnforced,
 	) {
 	}
@@ -60,7 +64,9 @@ readonly class CreateSubjectAction {
 			throw new RuntimeException( 'You do not have the necessary permissions to create this subject' );
 		}
 
-		$subject = $this->buildSubject( $request );
+		$schema = $this->schemaLookup->getSchema( new SchemaName( $request->schemaName ) );
+
+		$subject = $this->buildSubject( $request, $schema );
 
 		if ( $request->id !== null && $this->subjectIdIsInUse( $subject->id ) ) {
 			$this->presenter->presentSubjectAlreadyExists();
@@ -96,7 +102,17 @@ readonly class CreateSubjectAction {
 			return;
 		}
 
-		$this->presenter->presentCreated( $subject->id->text, $violations );
+		// The page identifiers come from the page id the request named, not from the subject -> page
+		// index: that index is the graph projection, which a read replica may not carry yet for the
+		// revision just written.
+		$this->presenter->presentCreated(
+			GetSubjectResponseItem::fromSubject(
+				$subject,
+				$this->pageIdentifiersResolver->getIdentifiersOfPage( $pageId )
+			),
+			$schema,
+			$violations
+		);
 	}
 
 	/**
@@ -110,11 +126,11 @@ readonly class CreateSubjectAction {
 		) );
 	}
 
-	private function buildSubject( CreateSubjectRequest $request ): Subject {
+	private function buildSubject( CreateSubjectRequest $request, ?Schema $schema ): Subject {
 		$schemaName = new SchemaName( $request->schemaName );
 		$label = new SubjectLabel( $request->label );
 		$statements = $this->statementListBuilder->build(
-			$this->resolveSelectValues( $schemaName, $request->statements )
+			$this->resolveSelectValues( $schema, $request->statements )
 		);
 
 		if ( $request->id === null ) {
@@ -147,9 +163,7 @@ readonly class CreateSubjectAction {
 	 *
 	 * @return array<string, mixed>
 	 */
-	private function resolveSelectValues( SchemaName $schemaName, array $statements ): array {
-		$schema = $this->schemaLookup->getSchema( $schemaName );
-
+	private function resolveSelectValues( ?Schema $schema, array $statements ): array {
 		if ( $schema === null ) {
 			return $statements;
 		}

--- a/src/Application/Actions/CreateSubject/CreateSubjectPresenter.php
+++ b/src/Application/Actions/CreateSubject/CreateSubjectPresenter.php
@@ -4,12 +4,20 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Application\Actions\CreateSubject;
 
+use ProfessionalWiki\NeoWiki\Application\Queries\GetSubject\GetSubjectResponseItem;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
 
 interface CreateSubjectPresenter {
 
-	/** @param Violation[] $violations */
-	public function presentCreated( string $subjectId, array $violations ): void;
+	/**
+	 * Receives the persisted Subject, not the request: the server normalizes labels and Statements
+	 * on the way in, so this is the state a subsequent read returns. A null Schema means the Subject
+	 * names a Schema that does not exist.
+	 *
+	 * @param Violation[] $violations
+	 */
+	public function presentCreated( GetSubjectResponseItem $subject, ?Schema $schema, array $violations ): void;
 
 	public function presentSubjectAlreadyExists(): void;
 

--- a/src/Application/Actions/ReplaceSubject/ReplaceSubjectAction.php
+++ b/src/Application/Actions/ReplaceSubject/ReplaceSubjectAction.php
@@ -6,6 +6,7 @@ namespace ProfessionalWiki\NeoWiki\Application\Actions\ReplaceSubject;
 
 use InvalidArgumentException;
 use ProfessionalWiki\NeoWiki\Application\PageIdentifiersLookup;
+use ProfessionalWiki\NeoWiki\Application\PageReadAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\Queries\GetSubject\GetSubjectResponseItem;
 use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
 use ProfessionalWiki\NeoWiki\Application\SelectStatementResolver;
@@ -25,6 +26,7 @@ readonly class ReplaceSubjectAction {
 
 	public function __construct(
 		private SubjectRepository $subjectRepository,
+		private PageReadAuthorizer $readAuthorizer,
 		private SubjectWriteAuthorizer $writeAuthorizer,
 		private StatementListBuilder $statementListBuilder,
 		private SchemaLookup $schemaLookup,
@@ -44,11 +46,18 @@ readonly class ReplaceSubjectAction {
 			throw new InvalidArgumentException( 'SubjectLabel cannot be empty' );
 		}
 
-		// Null identifiers (unresolvable Subject) make the authorizer fall back to the global 'edit'
-		// right. This cannot bypass page protection: an unresolvable Subject is not found below
-		// (getSubject returns null), so the request 404s before any write rather than touching a
-		// protected page.
+		// Null identifiers (unresolvable Subject) skip the read gate below and make the write
+		// authorizer fall back to the global 'edit' right. Neither can bypass page protection: an
+		// unresolvable Subject is not found below (getSubject returns null), so the request 404s
+		// before any write rather than touching a protected page.
 		$pageIdentifiers = $this->pageIdentifiersLookup->getPageIdOfSubject( $subjectId );
+
+		// Gate on read before write: a page the caller may not read answers exactly like a Subject
+		// that does not exist, so restricted pages cannot be told apart from absent ones - and the
+		// page title and namespace this endpoint returns never reach a caller denied the page.
+		if ( $pageIdentifiers !== null && !$this->readAuthorizer->authorizeReadByPageId( $pageIdentifiers->getId() ) ) {
+			throw SubjectNotFoundException::forId( $subjectId );
+		}
 
 		if ( !$this->writeAuthorizer->authorize( $pageIdentifiers?->getId() ) ) {
 			throw new SubjectEditNotAuthorizedException();

--- a/src/Application/Actions/ReplaceSubject/ReplaceSubjectAction.php
+++ b/src/Application/Actions/ReplaceSubject/ReplaceSubjectAction.php
@@ -46,20 +46,22 @@ readonly class ReplaceSubjectAction {
 			throw new InvalidArgumentException( 'SubjectLabel cannot be empty' );
 		}
 
-		// Null identifiers (unresolvable Subject) skip the read gate below and make the write
-		// authorizer fall back to the global 'edit' right. Neither can bypass page protection: an
-		// unresolvable Subject is not found below (getSubject returns null), so the request 404s
-		// before any write rather than touching a protected page.
 		$pageIdentifiers = $this->pageIdentifiersLookup->getPageIdOfSubject( $subjectId );
 
 		// Gate on read before write: a page the caller may not read answers exactly like a Subject
 		// that does not exist, so restricted pages cannot be told apart from absent ones - and the
-		// page title and namespace this endpoint returns never reach a caller denied the page.
-		if ( $pageIdentifiers !== null && !$this->readAuthorizer->authorizeReadByPageId( $pageIdentifiers->getId() ) ) {
+		// page title and namespace this endpoint returns never reach a caller denied the page. An
+		// unresolvable Subject takes that same path, since it has no page to authorize against.
+		// Reaching the write check with null identifiers would answer 403 where a restricted page
+		// answers 404, telling a caller who lacks the wiki-global 'edit' right which of the
+		// Subject ids they hold exist. Only a Subject on a page the caller can read (its existence
+		// already public) proceeds to the write check and its 403.
+		if ( $pageIdentifiers === null
+			|| !$this->readAuthorizer->authorizeReadByPageId( $pageIdentifiers->getId() ) ) {
 			throw SubjectNotFoundException::forId( $subjectId );
 		}
 
-		if ( !$this->writeAuthorizer->authorize( $pageIdentifiers?->getId() ) ) {
+		if ( !$this->writeAuthorizer->authorize( $pageIdentifiers->getId() ) ) {
 			throw new SubjectEditNotAuthorizedException();
 		}
 

--- a/src/Application/Actions/ReplaceSubject/ReplaceSubjectAction.php
+++ b/src/Application/Actions/ReplaceSubject/ReplaceSubjectAction.php
@@ -6,6 +6,7 @@ namespace ProfessionalWiki\NeoWiki\Application\Actions\ReplaceSubject;
 
 use InvalidArgumentException;
 use ProfessionalWiki\NeoWiki\Application\PageIdentifiersLookup;
+use ProfessionalWiki\NeoWiki\Application\Queries\GetSubject\GetSubjectResponseItem;
 use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
 use ProfessionalWiki\NeoWiki\Application\SelectStatementResolver;
 use ProfessionalWiki\NeoWiki\Application\StatementListBuilder;
@@ -14,7 +15,7 @@ use ProfessionalWiki\NeoWiki\Application\Subject\Exception\SubjectNotFoundExcept
 use ProfessionalWiki\NeoWiki\Application\SubjectWriteAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\SubjectRepository;
 use ProfessionalWiki\NeoWiki\Application\Validation\ProposedSubjectValidator;
-use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
@@ -43,12 +44,13 @@ readonly class ReplaceSubjectAction {
 			throw new InvalidArgumentException( 'SubjectLabel cannot be empty' );
 		}
 
-		// A null pageId (unresolvable Subject) makes the authorizer fall back to the global 'edit' right.
-		// This cannot bypass page protection: an unresolvable Subject is not found below (getSubject
-		// returns null), so the request 404s before any write rather than touching a protected page.
-		$pageId = $this->pageIdentifiersLookup->getPageIdOfSubject( $subjectId )?->getId();
+		// Null identifiers (unresolvable Subject) make the authorizer fall back to the global 'edit'
+		// right. This cannot bypass page protection: an unresolvable Subject is not found below
+		// (getSubject returns null), so the request 404s before any write rather than touching a
+		// protected page.
+		$pageIdentifiers = $this->pageIdentifiersLookup->getPageIdOfSubject( $subjectId );
 
-		if ( !$this->writeAuthorizer->authorize( $pageId ) ) {
+		if ( !$this->writeAuthorizer->authorize( $pageIdentifiers?->getId() ) ) {
 			throw new SubjectEditNotAuthorizedException();
 		}
 
@@ -58,11 +60,13 @@ readonly class ReplaceSubjectAction {
 			throw SubjectNotFoundException::forId( $subjectId );
 		}
 
+		$schema = $this->schemaLookup->getSchema( $subject->getSchemaName() );
+
 		$priorViolations = $this->proposedSubjectValidator->validate( $subject );
 
 		$subject->setLabel( new SubjectLabel( $label ) );
 		$subject->setStatements(
-			$this->statementListBuilder->build( $this->resolveStatements( $subject, $statements ) )
+			$this->statementListBuilder->build( $this->resolveStatements( $schema, $statements ) )
 		);
 
 		$proposedViolations = $this->proposedSubjectValidator->validate( $subject );
@@ -79,7 +83,13 @@ readonly class ReplaceSubjectAction {
 
 		$this->subjectRepository->updateSubject( $subject, $comment );
 
-		$this->presenter->presentUpdated( $subjectId->text, $proposedViolations );
+		// The mutated Subject is the persisted state: the builder and the resolver above already
+		// normalized what the request supplied.
+		$this->presenter->presentUpdated(
+			GetSubjectResponseItem::fromSubject( $subject, $pageIdentifiers ),
+			$schema,
+			$proposedViolations
+		);
 	}
 
 	/**
@@ -87,9 +97,7 @@ readonly class ReplaceSubjectAction {
 	 *
 	 * @return array<string, mixed>
 	 */
-	private function resolveStatements( Subject $subject, array $statements ): array {
-		$schema = $this->schemaLookup->getSchema( $subject->getSchemaName() );
-
+	private function resolveStatements( ?Schema $schema, array $statements ): array {
 		if ( $schema === null ) {
 			return $statements;
 		}

--- a/src/Application/Actions/ReplaceSubject/ReplaceSubjectPresenter.php
+++ b/src/Application/Actions/ReplaceSubject/ReplaceSubjectPresenter.php
@@ -4,14 +4,20 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Application\Actions\ReplaceSubject;
 
+use ProfessionalWiki\NeoWiki\Application\Queries\GetSubject\GetSubjectResponseItem;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
 
 interface ReplaceSubjectPresenter {
 
 	/**
+	 * Receives the persisted Subject, not the request: the server normalizes labels and Statements
+	 * on the way in, so this is the state a subsequent read returns. A null Schema means the Subject
+	 * names a Schema that does not exist.
+	 *
 	 * @param Violation[] $violations
 	 */
-	public function presentUpdated( string $subjectId, array $violations ): void;
+	public function presentUpdated( GetSubjectResponseItem $subject, ?Schema $schema, array $violations ): void;
 
 	/**
 	 * Called when validation enforcement rejects an edit that would introduce

--- a/src/Application/PageIdentifiersResolver.php
+++ b/src/Application/PageIdentifiersResolver.php
@@ -1,0 +1,22 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application;
+
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageIdentifiers;
+
+/**
+ * Answers what a page id identifies, from the wiki itself rather than from the graph projection.
+ * Callers that hold a page id use this instead of {@see PageIdentifiersLookup}: it needs no graph
+ * round trip, and it answers for a page written moments ago, which a graph read replica may not.
+ */
+interface PageIdentifiersResolver {
+
+	/**
+	 * Null when no page carries this id.
+	 */
+	public function getIdentifiersOfPage( PageId $pageId ): ?PageIdentifiers;
+
+}

--- a/src/Application/Queries/GetPageSubjects/GetPageSubjectsQuery.php
+++ b/src/Application/Queries/GetPageSubjects/GetPageSubjectsQuery.php
@@ -11,10 +11,8 @@ use ProfessionalWiki\NeoWiki\Application\SubjectLookup;
 use ProfessionalWiki\NeoWiki\Application\PageReadAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\SubjectRepository;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
-use ProfessionalWiki\NeoWiki\Domain\Page\PageIdentifiers;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
-use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Presentation\SchemaPresentationSerializer;
 
@@ -44,14 +42,14 @@ readonly class GetPageSubjectsQuery {
 		$subjectItems = [];
 
 		if ( $mainSubject !== null ) {
-			$subjectItems[$mainSubject->id->text] = $this->buildResponseItem(
+			$subjectItems[$mainSubject->id->text] = GetSubjectResponseItem::fromSubject(
 				$mainSubject,
 				$this->pageIdentifiersLookup->getPageIdOfSubject( $mainSubject->id )
 			);
 		}
 
 		foreach ( $pageSubjects->getChildSubjects()->asArray() as $childSubject ) {
-			$subjectItems[$childSubject->id->text] = $this->buildResponseItem(
+			$subjectItems[$childSubject->id->text] = GetSubjectResponseItem::fromSubject(
 				$childSubject,
 				$this->pageIdentifiersLookup->getPageIdOfSubject( $childSubject->id )
 			);
@@ -75,18 +73,6 @@ readonly class GetPageSubjectsQuery {
 				referencedSubjects: $referencedSubjectItems,
 				schemas: $schemas,
 			)
-		);
-	}
-
-	private function buildResponseItem( Subject $subject, ?PageIdentifiers $pageIdentifiers ): GetSubjectResponseItem {
-		return new GetSubjectResponseItem(
-			id: $subject->id->text,
-			label: $subject->label->text,
-			schemaName: $subject->getSchemaName()->getText(),
-			statements: $this->arrayifyStatements( $subject->getStatements() ),
-			pageId: $pageIdentifiers?->getId()->id,
-			pageTitle: $pageIdentifiers?->getTitle(),
-			pageNamespaceId: $pageIdentifiers?->getNamespaceId(),
 		);
 	}
 
@@ -120,7 +106,7 @@ readonly class GetPageSubjectsQuery {
 					continue;
 				}
 
-				$referenced[$referencedId->text] = $this->buildResponseItem( $referencedSubject, $pageIdentifiers );
+				$referenced[$referencedId->text] = GetSubjectResponseItem::fromSubject( $referencedSubject, $pageIdentifiers );
 			}
 		}
 
@@ -151,22 +137,6 @@ readonly class GetPageSubjectsQuery {
 		}
 
 		return $schemas;
-	}
-
-	/**
-	 * @return array<string, mixed>
-	 */
-	private function arrayifyStatements( StatementList $statements ): array {
-		$array = [];
-
-		foreach ( $statements->asArray() as $statement ) {
-			$array[$statement->getPropertyName()->text] = [
-				'propertyType' => $statement->getPropertyType(),
-				'value' => $statement->getValue()->toScalars()
-			];
-		}
-
-		return $array;
 	}
 
 }

--- a/src/Application/Queries/GetSubject/GetSubjectQuery.php
+++ b/src/Application/Queries/GetSubject/GetSubjectQuery.php
@@ -8,7 +8,6 @@ use ProfessionalWiki\NeoWiki\Application\PageIdentifiersLookup;
 use ProfessionalWiki\NeoWiki\Application\SubjectLookup;
 use ProfessionalWiki\NeoWiki\Application\PageReadAuthorizer;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageIdentifiers;
-use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 
@@ -89,30 +88,10 @@ readonly class GetSubjectQuery {
 		bool $includePageIdentifiers,
 		?PageIdentifiers $pageIdentifiers
 	): GetSubjectResponseItem {
-		$includedIdentifiers = $includePageIdentifiers ? $pageIdentifiers : null;
-
-		return new GetSubjectResponseItem(
-			id: $subject->id->text,
-			label: $subject->label->text,
-			schemaName: $subject->getSchemaName()->getText(),
-			statements: $this->arrayifyStatements( $subject->getStatements() ),
-			pageId: $includedIdentifiers?->getId()->id,
-			pageTitle: $includedIdentifiers?->getTitle(),
-			pageNamespaceId: $includedIdentifiers?->getNamespaceId(),
+		return GetSubjectResponseItem::fromSubject(
+			$subject,
+			$includePageIdentifiers ? $pageIdentifiers : null
 		);
-	}
-
-	private function arrayifyStatements( StatementList $statements ): array {
-		$array = [];
-
-		foreach ( $statements->asArray() as $statement ) {
-			$array[$statement->getPropertyName()->text] = [
-				'propertyType' => $statement->getPropertyType(),
-				'value' => $statement->getValue()->toScalars()
-			];
-		}
-
-		return $array;
 	}
 
 }

--- a/src/Application/Queries/GetSubject/GetSubjectResponseItem.php
+++ b/src/Application/Queries/GetSubject/GetSubjectResponseItem.php
@@ -4,6 +4,10 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Application\Queries\GetSubject;
 
+use ProfessionalWiki\NeoWiki\Domain\Page\PageIdentifiers;
+use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
+use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
+
 readonly class GetSubjectResponseItem {
 
 	public function __construct(
@@ -18,6 +22,38 @@ readonly class GetSubjectResponseItem {
 		public ?string $pageTitle,
 		public ?int $pageNamespaceId,
 	) {
+	}
+
+	/**
+	 * Null page identifiers leave the page fields unset, which is how a Subject whose hosting page
+	 * cannot be resolved, or whose identifiers were not requested, is represented.
+	 */
+	public static function fromSubject( Subject $subject, ?PageIdentifiers $pageIdentifiers ): self {
+		return new self(
+			id: $subject->id->text,
+			label: $subject->label->text,
+			schemaName: $subject->getSchemaName()->getText(),
+			statements: self::arrayifyStatements( $subject->getStatements() ),
+			pageId: $pageIdentifiers?->getId()->id,
+			pageTitle: $pageIdentifiers?->getTitle(),
+			pageNamespaceId: $pageIdentifiers?->getNamespaceId(),
+		);
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	private static function arrayifyStatements( StatementList $statements ): array {
+		$array = [];
+
+		foreach ( $statements->asArray() as $statement ) {
+			$array[$statement->getPropertyName()->text] = [
+				'propertyType' => $statement->getPropertyType(),
+				'value' => $statement->getValue()->toScalars()
+			];
+		}
+
+		return $array;
 	}
 
 }

--- a/src/Infrastructure/TitleBasedPageIdentifiersResolver.php
+++ b/src/Infrastructure/TitleBasedPageIdentifiersResolver.php
@@ -1,0 +1,35 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Infrastructure;
+
+use MediaWiki\Title\TitleFactory;
+use ProfessionalWiki\NeoWiki\Application\PageIdentifiersResolver;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageIdentifiers;
+
+class TitleBasedPageIdentifiersResolver implements PageIdentifiersResolver {
+
+	public function __construct(
+		private readonly TitleFactory $titleFactory
+	) {
+	}
+
+	public function getIdentifiersOfPage( PageId $pageId ): ?PageIdentifiers {
+		$title = $this->titleFactory->newFromID( $pageId->id );
+
+		if ( $title === null ) {
+			return null;
+		}
+
+		// The prefixed text is what the graph projection stores as the page name, so a Subject
+		// served from either source carries the same title.
+		return new PageIdentifiers(
+			id: $pageId,
+			title: $title->getPrefixedText(),
+			namespaceId: $title->getNamespace(),
+		);
+	}
+
+}

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -1161,6 +1161,7 @@ class NeoWikiExtension {
 	public function newReplaceSubjectAction( ReplaceSubjectPresenter $presenter, Authority $authority ): ReplaceSubjectAction {
 		return new ReplaceSubjectAction(
 			subjectRepository: $this->getSubjectRepository(),
+			readAuthorizer: $this->newPageReadAuthorizer( $authority ),
 			writeAuthorizer: $this->newSubjectWriteAuthorizer( $authority ),
 			statementListBuilder: $this->getStatementListBuilder(),
 			schemaLookup: $this->getSchemaLookup(),

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -36,6 +36,7 @@ use ProfessionalWiki\NeoWiki\Application\WikiConfig\ConfigValidator;
 use ProfessionalWiki\NeoWiki\Application\WikiConfig\WikiConfigLookup;
 use ProfessionalWiki\NeoWiki\Application\WikiConfig\WikiConfigSource;
 use ProfessionalWiki\NeoWiki\Application\PageIdentifiersLookup;
+use ProfessionalWiki\NeoWiki\Application\PageIdentifiersResolver;
 use ProfessionalWiki\NeoWiki\Application\PageSubjectsLookup;
 use ProfessionalWiki\NeoWiki\Application\SubjectContentRepository;
 use ProfessionalWiki\NeoWiki\Application\Queries\GetSchema\GetSchemaPresenter;
@@ -113,6 +114,7 @@ use ProfessionalWiki\NeoWiki\EntryPoints\REST\ValidateSubjectApi;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\ValidateSubjectUpdateApi;
 use ProfessionalWiki\NeoWiki\Infrastructure\AuthorityBasedPageReadAuthorizer;
 use ProfessionalWiki\NeoWiki\Infrastructure\AuthorityBasedSubjectAuthorizer;
+use ProfessionalWiki\NeoWiki\Infrastructure\TitleBasedPageIdentifiersResolver;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\DatabaseDeletedSubjectPageIdsLookup;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\DatabaseSchemaNameLookup;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\MediaWikiWikiConfigSource;
@@ -912,7 +914,14 @@ class NeoWikiExtension {
 			selectStatementResolver: $this->getSelectStatementResolver(),
 			proposedSubjectValidator: $this->getProposedSubjectValidator(),
 			pageIdentifiersLookup: $this->getPageIdentifiersLookup(),
+			pageIdentifiersResolver: $this->getPageIdentifiersResolver(),
 			validationEnforced: $this->isValidationEnforced(),
+		);
+	}
+
+	private function getPageIdentifiersResolver(): PageIdentifiersResolver {
+		return new TitleBasedPageIdentifiersResolver(
+			MediaWikiServices::getInstance()->getTitleFactory()
 		);
 	}
 

--- a/src/Presentation/RestCreateSubjectPresenter.php
+++ b/src/Presentation/RestCreateSubjectPresenter.php
@@ -5,12 +5,21 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Presentation;
 
 use ProfessionalWiki\NeoWiki\Application\Actions\CreateSubject\CreateSubjectPresenter;
+use ProfessionalWiki\NeoWiki\Application\Queries\GetSubject\GetSubjectResponseItem;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
 
 class RestCreateSubjectPresenter implements CreateSubjectPresenter {
 
 	private array $apiResponse = [];
 	private int $statusCode = 201;
+	private readonly SubjectPresentationSerializer $subjectSerializer;
+	private readonly SchemaPresentationSerializer $schemaSerializer;
+
+	public function __construct() {
+		$this->subjectSerializer = new SubjectPresentationSerializer();
+		$this->schemaSerializer = new SchemaPresentationSerializer();
+	}
 
 	public function getJsonArray(): array {
 		return $this->apiResponse;
@@ -23,12 +32,18 @@ class RestCreateSubjectPresenter implements CreateSubjectPresenter {
 	/**
 	 * @param Violation[] $violations
 	 */
-	public function presentCreated( string $subjectId, array $violations ): void {
+	public function presentCreated( GetSubjectResponseItem $subject, ?Schema $schema, array $violations ): void {
 		$this->apiResponse = [
 			'status' => 'created',
-			'subjectId' => $subjectId,
+			'subjectId' => $subject->id,
 			'violations' => ViolationSerializer::serializeMany( $violations ),
+			'subject' => $this->subjectSerializer->serialize( $subject ),
 		];
+
+		if ( $schema !== null ) {
+			$this->apiResponse['schema'] = $this->schemaSerializer->toArray( $schema );
+		}
+
 		$this->statusCode = 201;
 	}
 

--- a/src/Presentation/RestGetPageSubjectsPresenter.php
+++ b/src/Presentation/RestGetPageSubjectsPresenter.php
@@ -11,6 +11,11 @@ use ProfessionalWiki\NeoWiki\Application\Queries\GetSubject\GetSubjectResponseIt
 class RestGetPageSubjectsPresenter implements GetPageSubjectsPresenter {
 
 	private array $apiResponse = [];
+	private readonly SubjectPresentationSerializer $subjectSerializer;
+
+	public function __construct() {
+		$this->subjectSerializer = new SubjectPresentationSerializer();
+	}
 
 	public function getJsonArray(): array {
 		return $this->apiResponse;
@@ -42,21 +47,7 @@ class RestGetPageSubjectsPresenter implements GetPageSubjectsPresenter {
 		$map = [];
 
 		foreach ( $subjects as $subject ) {
-			$entry = [
-				'id' => $subject->id,
-				'label' => $subject->label,
-				'schema' => $subject->schemaName,
-			];
-
-			if ( $subject->pageId !== null ) {
-				$entry['pageId'] = $subject->pageId;
-				$entry['pageTitle'] = $subject->pageTitle;
-				$entry['pageNamespaceId'] = $subject->pageNamespaceId;
-			}
-
-			$entry['statements'] = $subject->statements;
-
-			$map[$subject->id] = $entry;
+			$map[$subject->id] = $this->subjectSerializer->serialize( $subject );
 		}
 
 		return $map;

--- a/src/Presentation/RestGetSubjectPresenter.php
+++ b/src/Presentation/RestGetSubjectPresenter.php
@@ -11,6 +11,11 @@ use ProfessionalWiki\NeoWiki\Application\Queries\GetSubject\GetSubjectResponseIt
 class RestGetSubjectPresenter implements GetSubjectPresenter {
 
 	private array $apiResponse = [];
+	private readonly SubjectPresentationSerializer $subjectSerializer;
+
+	public function __construct() {
+		$this->subjectSerializer = new SubjectPresentationSerializer();
+	}
 
 	public function getJsonArray(): array {
 		return $this->apiResponse;
@@ -30,19 +35,7 @@ class RestGetSubjectPresenter implements GetSubjectPresenter {
 		$map = [];
 
 		foreach ( $subjects as $subject ) {
-			$map[$subject->id] = [
-				'id' => $subject->id,
-				'label' => $subject->label,
-				'schema' => $subject->schemaName,
-			];
-
-			if ( $subject->pageId !== null ) {
-				$map[$subject->id]['pageId'] = $subject->pageId;
-				$map[$subject->id]['pageTitle'] = $subject->pageTitle;
-				$map[$subject->id]['pageNamespaceId'] = $subject->pageNamespaceId;
-			}
-
-			$map[$subject->id]['statements'] = $subject->statements;
+			$map[$subject->id] = $this->subjectSerializer->serialize( $subject );
 		}
 
 		return $map;

--- a/src/Presentation/RestReplaceSubjectPresenter.php
+++ b/src/Presentation/RestReplaceSubjectPresenter.php
@@ -5,12 +5,21 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Presentation;
 
 use ProfessionalWiki\NeoWiki\Application\Actions\ReplaceSubject\ReplaceSubjectPresenter;
+use ProfessionalWiki\NeoWiki\Application\Queries\GetSubject\GetSubjectResponseItem;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
 
 class RestReplaceSubjectPresenter implements ReplaceSubjectPresenter {
 
 	private array $apiResponse = [];
 	private int $statusCode = 200;
+	private readonly SubjectPresentationSerializer $subjectSerializer;
+	private readonly SchemaPresentationSerializer $schemaSerializer;
+
+	public function __construct() {
+		$this->subjectSerializer = new SubjectPresentationSerializer();
+		$this->schemaSerializer = new SchemaPresentationSerializer();
+	}
 
 	public function getJsonArray(): array {
 		return $this->apiResponse;
@@ -23,12 +32,18 @@ class RestReplaceSubjectPresenter implements ReplaceSubjectPresenter {
 	/**
 	 * @param Violation[] $violations
 	 */
-	public function presentUpdated( string $subjectId, array $violations ): void {
+	public function presentUpdated( GetSubjectResponseItem $subject, ?Schema $schema, array $violations ): void {
 		$this->apiResponse = [
 			'status' => 'updated',
-			'subjectId' => $subjectId,
+			'subjectId' => $subject->id,
 			'violations' => ViolationSerializer::serializeMany( $violations ),
+			'subject' => $this->subjectSerializer->serialize( $subject ),
 		];
+
+		if ( $schema !== null ) {
+			$this->apiResponse['schema'] = $this->schemaSerializer->toArray( $schema );
+		}
+
 		$this->statusCode = 200;
 	}
 

--- a/src/Presentation/SchemaPresentationSerializer.php
+++ b/src/Presentation/SchemaPresentationSerializer.php
@@ -15,18 +15,23 @@ use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
 class SchemaPresentationSerializer {
 
 	public function serialize( Schema $schema ): string {
-		$data = [
-			'description' => $schema->getDescription(),
-			'propertyDefinitions' => $this->propertiesToJson( $schema->getAllProperties() ),
-		];
-
-		$json = json_encode( $data );
+		$json = json_encode( $this->toArray( $schema ) );
 
 		if ( $json === false ) {
 			throw new \RuntimeException( 'Failed to JSON encode schema data' );
 		}
 
 		return $json;
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function toArray( Schema $schema ): array {
+		return [
+			'description' => $schema->getDescription(),
+			'propertyDefinitions' => $this->propertiesToJson( $schema->getAllProperties() ),
+		];
 	}
 
 	private function propertiesToJson( PropertyDefinitions $properties ): array {

--- a/src/Presentation/SubjectPresentationSerializer.php
+++ b/src/Presentation/SubjectPresentationSerializer.php
@@ -1,0 +1,36 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Presentation;
+
+use ProfessionalWiki\NeoWiki\Application\Queries\GetSubject\GetSubjectResponseItem;
+
+/**
+ * The one Subject shape the web API serves, so a Subject returned by a write endpoint is
+ * interchangeable with the same Subject read back.
+ */
+class SubjectPresentationSerializer {
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function serialize( GetSubjectResponseItem $item ): array {
+		$entry = [
+			'id' => $item->id,
+			'label' => $item->label,
+			'schema' => $item->schemaName,
+		];
+
+		if ( $item->pageId !== null ) {
+			$entry['pageId'] = $item->pageId;
+			$entry['pageTitle'] = $item->pageTitle;
+			$entry['pageNamespaceId'] = $item->pageNamespaceId;
+		}
+
+		$entry['statements'] = $item->statements;
+
+		return $entry;
+	}
+
+}

--- a/tests/RedHerb/resources/RedHerbCard.vue
+++ b/tests/RedHerb/resources/RedHerbCard.vue
@@ -183,23 +183,13 @@ module.exports = exports = {
 
 		// Editing UIs read through the repositories rather than the stores
 		// (NeoWiki ADR 30 / ADR 16): the stores hold page state, not editor state.
-		// This card renders from the stores, so it also publishes what it fetched
-		// back into them — epoch-guarded, so a mutation that lands mid-fetch wins.
+		// Saving updates the stores, because the write answers with the Subject and
+		// Schema as the server has them.
 		function openEditor() {
-			const schemaName = subject.value.getSchemaName();
-			const subjectEpoch = subjectStore.mutationEpoch;
-			const schemaEpoch = schemaStore.mutationEpoch;
-
 			Promise.all( [
 				subjectRepo.getSubject( props.subjectId ),
-				schemaRepo.getSchema( schemaName )
+				schemaRepo.getSchema( subject.value.getSchemaName() )
 			] ).then( ( [ freshSubject, freshSchema ] ) => {
-				if ( subjectEpoch === subjectStore.mutationEpoch ) {
-					subjectStore.setSubject( freshSubject );
-				}
-				if ( schemaEpoch === schemaStore.mutationEpoch ) {
-					schemaStore.setSchema( schemaName, freshSchema );
-				}
 				editingSubject.value = freshSubject;
 				editingSchema.value = freshSchema;
 				editorOpen.value = true;

--- a/tests/RedHerb/resources/RedHerbCard.vue
+++ b/tests/RedHerb/resources/RedHerbCard.vue
@@ -76,9 +76,10 @@
 			</dl>
 		</div>
 		<subject-editor-dialog
-			v-if="canEditSubject"
+			v-if="editingSubject && editingSchema"
 			:open="editorOpen"
-			:subject="subject"
+			:subject="editingSubject"
+			:schema="editingSchema"
 			:on-save="handleSaveSubject"
 			:on-save-schema="handleSaveSchema"
 			@update:open="editorOpen = $event"
@@ -95,10 +96,11 @@ const nw = require( 'ext.neowiki' );
 // the "document control" header BlueSpice shows on controlled documents. It
 // demonstrates assembling NeoWiki's building blocks from a separate extension:
 // the ViewProps contract ( subjectId, canEditSubject, layoutName ); the
-// subject / schema / layout stores; resolveDisplayProperties + the value-display
+// subject / schema / layout stores for display; the repositories for the editing
+// reads ( NeoWiki ADR 30 / ADR 16 ); resolveDisplayProperties + the value-display
 // component registry to render each value with its property type's component;
-// and the shared SubjectEditorDialog for editing, shown only when the contract
-// reports canEditSubject. It also reads the Layout's settings — a
+// and the shared SubjectEditorDialog for editing, reachable only through the edit
+// button the contract's canEditSubject gates. It also reads the Layout's settings — a
 // fullWidthProperties list — to decide which properties span the full width
 // instead of sitting in a column. NeoWiki populates the stores before mounting.
 // @vue/component
@@ -117,8 +119,13 @@ module.exports = exports = {
 		const schemaStore = nw.useSchemaStore();
 		const layoutStore = nw.useLayoutStore();
 		const componentRegistry = nw.NeoWikiServices.getComponentRegistry();
+		const subjectRepo = nw.NeoWikiServices.getSubjectRepository();
+		const schemaRepo = nw.NeoWikiServices.getSchemaRepository();
 
 		const editorOpen = vue.ref( false );
+		// The dialog edits its own copy rather than the registry entry.
+		const editingSubject = vue.shallowRef( null );
+		const editingSchema = vue.shallowRef( null );
 
 		const subject = vue.computed( () => subjectStore.getSubject( props.subjectId ) );
 
@@ -174,11 +181,27 @@ module.exports = exports = {
 			return componentRegistry.getValueDisplayComponent( propertyType );
 		}
 
+		// Editing UIs read through the repositories rather than the stores
+		// (NeoWiki ADR 30 / ADR 16): the stores hold page state, not editor state.
+		// This card renders from the stores, so it also publishes what it fetched
+		// back into them — epoch-guarded, so a mutation that lands mid-fetch wins.
 		function openEditor() {
+			const schemaName = subject.value.getSchemaName();
+			const subjectEpoch = subjectStore.mutationEpoch;
+			const schemaEpoch = schemaStore.mutationEpoch;
+
 			Promise.all( [
-				schemaStore.fetchSchema( subject.value.getSchemaName() ),
-				subjectStore.fetchSubject( props.subjectId )
-			] ).then( () => {
+				subjectRepo.getSubject( props.subjectId ),
+				schemaRepo.getSchema( schemaName )
+			] ).then( ( [ freshSubject, freshSchema ] ) => {
+				if ( subjectEpoch === subjectStore.mutationEpoch ) {
+					subjectStore.setSubject( freshSubject );
+				}
+				if ( schemaEpoch === schemaStore.mutationEpoch ) {
+					schemaStore.setSchema( schemaName, freshSchema );
+				}
+				editingSubject.value = freshSubject;
+				editingSchema.value = freshSchema;
 				editorOpen.value = true;
 			} ).catch( ( error ) => {
 				mw.notify(
@@ -202,6 +225,8 @@ module.exports = exports = {
 			schemaUrl: schemaUrl,
 			layoutSections: layoutSections,
 			editorOpen: editorOpen,
+			editingSubject: editingSubject,
+			editingSchema: editingSchema,
 			valueComponent: valueComponent,
 			openEditor: openEditor,
 			handleSaveSubject: handleSaveSubject,

--- a/tests/RedHerb/resources/createChild/CreateChildDialog.vue
+++ b/tests/RedHerb/resources/createChild/CreateChildDialog.vue
@@ -42,16 +42,18 @@ module.exports = exports = {
 	},
 	setup: function () {
 		const open = vue.inject( DIALOG_OPEN_KEY );
-		const schemaStore = nw.useSchemaStore();
 		const subjectStore = nw.useSubjectStore();
+		const schemaRepo = nw.NeoWikiServices.getSchemaRepository();
 
 		const label = vue.ref( '' );
 		const editorRef = vue.ref( null );
 		const loadedSchema = vue.shallowRef( null );
 
+		// Editing UIs read through the repositories rather than the stores
+		// (NeoWiki ADR 30 / ADR 16): the stores hold page state, not editor state.
 		function loadSchema() {
-			schemaStore.fetchSchema( SCHEMA_NAME ).then( () => {
-				loadedSchema.value = schemaStore.getSchema( SCHEMA_NAME );
+			schemaRepo.getSchema( SCHEMA_NAME ).then( ( schema ) => {
+				loadedSchema.value = schema;
 			} ).catch( ( err ) => {
 				loadedSchema.value = null;
 				mw.log.error( err );

--- a/tests/RedHerb/resources/editMainSubject/EditMainSubjectDialog.vue
+++ b/tests/RedHerb/resources/editMainSubject/EditMainSubjectDialog.vue
@@ -40,8 +40,9 @@ module.exports = exports = {
 	},
 	setup: function () {
 		const state = vue.inject( DIALOG_STATE_KEY );
-		const schemaStore = nw.useSchemaStore();
 		const subjectStore = nw.useSubjectStore();
+		const schemaRepo = nw.NeoWikiServices.getSchemaRepository();
+		const subjectRepo = nw.NeoWikiServices.getSubjectRepository();
 
 		const label = vue.ref( '' );
 		const editorRef = vue.ref( null );
@@ -61,15 +62,15 @@ module.exports = exports = {
 
 		function loadSubjectAndSchema( subjectIdText ) {
 			const subjectId = new nw.SubjectId( subjectIdText );
-			// Editors always open on freshly fetched data (NeoWiki ADR 30);
-			// getOrFetchSubject would reuse the page-load payload here.
-			subjectStore.fetchSubject( subjectId )
-				.then( () => {
-					const subject = subjectStore.getSubject( subjectId );
+			// Editing UIs read through the repositories rather than the stores
+			// (NeoWiki ADR 30 / ADR 16), so the editor always opens on freshly
+			// fetched data instead of the page-load payload the stores hold.
+			subjectRepo.getSubject( subjectId )
+				.then( ( subject ) => {
 					loadedSubject.value = subject;
 					label.value = subject.getLabel();
-					return schemaStore.fetchSchema( subject.getSchemaName() ).then( () => {
-						loadedSchema.value = schemaStore.getSchema( subject.getSchemaName() );
+					return schemaRepo.getSchema( subject.getSchemaName() ).then( ( schema ) => {
+						loadedSchema.value = schema;
 					} );
 				} )
 				.catch( ( err ) => {

--- a/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
@@ -34,6 +34,7 @@ use ProfessionalWiki\NeoWiki\Application\SubjectWriteAuthorizer;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestRelation;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestStatement;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemoryPageIdentifiersLookup;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemoryPageIdentifiersResolver;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySchemaLookup;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectLookup;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectRepository;
@@ -58,6 +59,7 @@ class CreateSubjectActionTest extends TestCase {
 	private SubjectWriteAuthorizer $authorizer;
 	private InMemorySchemaLookup $schemaLookup;
 	private InMemoryPageIdentifiersLookup $pageIdentifiersLookup;
+	private InMemoryPageIdentifiersResolver $pageIdentifiersResolver;
 
 	public function setUp(): void {
 		$this->subjectRepository = new InMemorySubjectRepository();
@@ -67,6 +69,9 @@ class CreateSubjectActionTest extends TestCase {
 		$this->authorizer = new SpySubjectWriteAuthorizer( allowed: true );
 		$this->schemaLookup = new InMemorySchemaLookup();
 		$this->pageIdentifiersLookup = new InMemoryPageIdentifiersLookup();
+		$this->pageIdentifiersResolver = new InMemoryPageIdentifiersResolver( [
+			new PageIdentifiers( new PageId( 1 ), 'Help:Bunnies', 12 )
+		] );
 	}
 
 	private function newCreateSubjectAction( bool $validationEnforced = false ): CreateSubjectAction {
@@ -91,6 +96,7 @@ class CreateSubjectActionTest extends TestCase {
 				),
 			),
 			$this->pageIdentifiersLookup,
+			$this->pageIdentifiersResolver,
 			$validationEnforced,
 		);
 	}
@@ -744,6 +750,87 @@ class CreateSubjectActionTest extends TestCase {
 		);
 
 		$this->assertSame( 'presentSubjectAlreadyExists', $this->presenterSpy->result );
+	}
+
+	public function testPresentsTheServerNormalizedSubject(): void {
+		$this->registerSelectSchema();
+		$this->subjectRepository->savePageSubjects( PageSubjects::newEmpty(), new PageId( 1 ) );
+
+		$this->newCreateSubjectAction()->createSubject(
+			new CreateSubjectRequest(
+				pageId: 1,
+				isMainSubject: true,
+				label: 'Some Label',
+				schemaName: self::SELECT_SCHEMA_NAME,
+				statements: [
+					'Status' => [ 'propertyType' => 'select', 'value' => 'Approved' ],
+				]
+			)
+		);
+
+		$this->assertSame( 's' . self::STUB_ID, $this->presenterSpy->subject?->id );
+		$this->assertSame( 'Some Label', $this->presenterSpy->subject?->label );
+		$this->assertSame( self::SELECT_SCHEMA_NAME, $this->presenterSpy->subject?->schemaName );
+		$this->assertSame(
+			// The label the request supplied was resolved to the option id.
+			[ 'Status' => [ 'propertyType' => 'select', 'value' => [ 'opt_approved' ] ] ],
+			$this->presenterSpy->subject?->statements
+		);
+	}
+
+	public function testPresentsThePageIdentifiersOfTheTargetPage(): void {
+		$this->subjectRepository->savePageSubjects( PageSubjects::newEmpty(), new PageId( 1 ) );
+
+		$this->newCreateSubjectAction()->createSubject(
+			new CreateSubjectRequest(
+				pageId: 1,
+				isMainSubject: true,
+				label: 'Some Label',
+				schemaName: 'some-schema',
+				statements: []
+			)
+		);
+
+		$this->assertSame( 1, $this->presenterSpy->subject?->pageId );
+		$this->assertSame( 'Help:Bunnies', $this->presenterSpy->subject?->pageTitle );
+		$this->assertSame( 12, $this->presenterSpy->subject?->pageNamespaceId );
+	}
+
+	public function testPresentsTheSchemaTheSubjectInstantiates(): void {
+		$this->registerSelectSchema();
+		$this->subjectRepository->savePageSubjects( PageSubjects::newEmpty(), new PageId( 1 ) );
+
+		$this->newCreateSubjectAction()->createSubject(
+			new CreateSubjectRequest(
+				pageId: 1,
+				isMainSubject: true,
+				label: 'Some Label',
+				schemaName: self::SELECT_SCHEMA_NAME,
+				statements: []
+			)
+		);
+
+		$this->assertSame(
+			self::SELECT_SCHEMA_NAME,
+			$this->presenterSpy->schema?->getName()->getText()
+		);
+	}
+
+	public function testPresentsNoSchemaWhenTheNamedSchemaDoesNotExist(): void {
+		$this->registerSelectSchema();
+		$this->subjectRepository->savePageSubjects( PageSubjects::newEmpty(), new PageId( 1 ) );
+
+		$this->newCreateSubjectAction()->createSubject(
+			new CreateSubjectRequest(
+				pageId: 1,
+				isMainSubject: true,
+				label: 'Some Label',
+				schemaName: 'NonexistentSchema',
+				statements: []
+			)
+		);
+
+		$this->assertNull( $this->presenterSpy->schema );
 	}
 
 	public function testCreateWithoutSuppliedIdSkipsTheGraphInUseCheck(): void {

--- a/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/CreateSubjectActionTest.php
@@ -69,8 +69,12 @@ class CreateSubjectActionTest extends TestCase {
 		$this->authorizer = new SpySubjectWriteAuthorizer( allowed: true );
 		$this->schemaLookup = new InMemorySchemaLookup();
 		$this->pageIdentifiersLookup = new InMemoryPageIdentifiersLookup();
+		// The page the requests target sits between two others, so neither a hardcoded
+		// main-namespace id nor an implementation answering with some other seeded page passes.
 		$this->pageIdentifiersResolver = new InMemoryPageIdentifiersResolver( [
-			new PageIdentifiers( new PageId( 1 ), 'Help:Bunnies', 12 )
+			new PageIdentifiers( new PageId( 2 ), 'Carrots', 0 ),
+			new PageIdentifiers( new PageId( 1 ), 'Help:Bunnies', 12 ),
+			new PageIdentifiers( new PageId( 3 ), 'Talk:Hutches', 1 ),
 		] );
 	}
 

--- a/tests/phpunit/Application/Actions/CreateSubjectPresenterSpy.php
+++ b/tests/phpunit/Application/Actions/CreateSubjectPresenterSpy.php
@@ -5,19 +5,27 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Tests\Application\Actions;
 
 use ProfessionalWiki\NeoWiki\Application\Actions\CreateSubject\CreateSubjectPresenter;
+use ProfessionalWiki\NeoWiki\Application\Queries\GetSubject\GetSubjectResponseItem;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
 
 class CreateSubjectPresenterSpy implements CreateSubjectPresenter {
 
 	public string $result = '';
 
+	public ?GetSubjectResponseItem $subject = null;
+
+	public ?Schema $schema = null;
+
 	/** @var Violation[] */
 	public array $violations = [];
 
 	public bool $validationFailed = false;
 
-	public function presentCreated( string $subjectId, array $violations ): void {
-		$this->result = $subjectId;
+	public function presentCreated( GetSubjectResponseItem $subject, ?Schema $schema, array $violations ): void {
+		$this->result = $subject->id;
+		$this->subject = $subject;
+		$this->schema = $schema;
 		$this->violations = $violations;
 	}
 

--- a/tests/phpunit/Application/Actions/ReplaceSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/ReplaceSubjectActionTest.php
@@ -300,6 +300,65 @@ class ReplaceSubjectActionTest extends TestCase {
 		$this->assertSame( 'Status', $violations[0]->propertyName?->text );
 	}
 
+	public function testPresentsTheServerNormalizedSubject(): void {
+		$this->registerSchemaWithSelect();
+		$this->subjectRepository->updateSubject( TestSubject::build(
+			id: new SubjectId( self::SUBJECT_ID ),
+			label: new SubjectLabel( 'Original Label' ),
+			schemaName: new SchemaName( self::SCHEMA_NAME ),
+		) );
+
+		$this->newAction()->replace(
+			new SubjectId( self::SUBJECT_ID ),
+			'New Label',
+			[ 'Status' => [ 'propertyType' => 'select', 'value' => 'Approved' ] ],
+			null
+		);
+
+		$this->assertSame( self::SUBJECT_ID, $this->presenterSpy->subject?->id );
+		$this->assertSame( 'New Label', $this->presenterSpy->subject?->label );
+		$this->assertSame( self::SCHEMA_NAME, $this->presenterSpy->subject?->schemaName );
+		$this->assertSame(
+			// The label the request supplied was resolved to the option id.
+			[ 'Status' => [ 'propertyType' => 'select', 'value' => [ 'opt_approved' ] ] ],
+			$this->presenterSpy->subject?->statements
+		);
+	}
+
+	public function testPresentsThePageIdentifiersOfTheHostingPage(): void {
+		$this->subjectRepository->updateSubject( TestSubject::build( id: new SubjectId( self::SUBJECT_ID ) ) );
+
+		$this->newAction()->replace( new SubjectId( self::SUBJECT_ID ), 'Label', [], null );
+
+		$this->assertSame( 7, $this->presenterSpy->subject?->pageId );
+		$this->assertSame( 'Test page', $this->presenterSpy->subject?->pageTitle );
+		$this->assertSame( 0, $this->presenterSpy->subject?->pageNamespaceId );
+	}
+
+	public function testPresentsTheSchemaTheSubjectInstantiates(): void {
+		$this->registerSchemaWithSelect();
+		$this->subjectRepository->updateSubject( TestSubject::build(
+			id: new SubjectId( self::SUBJECT_ID ),
+			schemaName: new SchemaName( self::SCHEMA_NAME ),
+		) );
+
+		$this->newAction()->replace( new SubjectId( self::SUBJECT_ID ), 'Label', [], null );
+
+		$this->assertSame( self::SCHEMA_NAME, $this->presenterSpy->schema?->getName()->getText() );
+	}
+
+	public function testPresentsNoSchemaWhenTheNamedSchemaDoesNotExist(): void {
+		$this->registerSchemaWithSelect();
+		$this->subjectRepository->updateSubject( TestSubject::build(
+			id: new SubjectId( self::SUBJECT_ID ),
+			schemaName: new SchemaName( 'NonexistentSchema' ),
+		) );
+
+		$this->newAction()->replace( new SubjectId( self::SUBJECT_ID ), 'Label', [], null );
+
+		$this->assertNull( $this->presenterSpy->schema );
+	}
+
 	public function testReplaceWithMissingSchemaPresentsSchemaNotFound(): void {
 		$subject = TestSubject::build(
 			id: new SubjectId( self::SUBJECT_ID ),

--- a/tests/phpunit/Application/Actions/ReplaceSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/ReplaceSubjectActionTest.php
@@ -6,6 +6,7 @@ namespace ProfessionalWiki\NeoWiki\Tests\Application\Actions;
 
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Application\Actions\ReplaceSubject\ReplaceSubjectAction;
+use ProfessionalWiki\NeoWiki\Application\PageReadAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\SelectStatementResolver;
 use ProfessionalWiki\NeoWiki\Application\SelectValueResolver;
 use ProfessionalWiki\NeoWiki\Application\StatementListBuilder;
@@ -39,6 +40,7 @@ use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectLookup;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectRepository;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpySubjectWriteAuthorizer;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubIdGenerator;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubPageReadAuthorizer;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\Application\Actions\ReplaceSubject\ReplaceSubjectAction
@@ -46,6 +48,8 @@ use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubIdGenerator;
 class ReplaceSubjectActionTest extends TestCase {
 
 	private const string SUBJECT_ID = 's11111111111127';
+	private const string SUBJECT_ID_ON_EARLIER_PAGE = 's11111111111126';
+	private const string SUBJECT_ID_ON_LATER_PAGE = 's11111111111128';
 	private const string SCHEMA_NAME = 'TestSchema';
 
 	private InMemorySubjectRepository $subjectRepository;
@@ -61,6 +65,7 @@ class ReplaceSubjectActionTest extends TestCase {
 	private function newAction(
 		?SubjectWriteAuthorizer $authorizer = null,
 		bool $validationEnforced = false,
+		?PageReadAuthorizer $readAuthorizer = null,
 	): ReplaceSubjectAction {
 		$registry = PropertyTypeRegistry::withCoreTypes();
 		$builder = new StatementListBuilder(
@@ -69,6 +74,7 @@ class ReplaceSubjectActionTest extends TestCase {
 		);
 		return new ReplaceSubjectAction(
 			subjectRepository: $this->subjectRepository,
+			readAuthorizer: $readAuthorizer ?? new StubPageReadAuthorizer( allowed: true ),
 			writeAuthorizer: $authorizer ?? new SpySubjectWriteAuthorizer( allowed: true ),
 			statementListBuilder: $builder,
 			schemaLookup: $this->schemaLookup,
@@ -82,8 +88,13 @@ class ReplaceSubjectActionTest extends TestCase {
 			),
 			presenter: $this->presenterSpy,
 			validationEnforced: $validationEnforced,
+			// The Subject under test sits on a namespaced page between two others, so neither a
+			// hardcoded main-namespace id nor an implementation answering with some other seeded
+			// page passes.
 			pageIdentifiersLookup: new InMemoryPageIdentifiersLookup( [
-				[ new SubjectId( self::SUBJECT_ID ), new PageIdentifiers( new PageId( 7 ), 'Test page', 0 ) ]
+				[ new SubjectId( self::SUBJECT_ID_ON_EARLIER_PAGE ), new PageIdentifiers( new PageId( 6 ), 'Earlier page', 0 ) ],
+				[ new SubjectId( self::SUBJECT_ID ), new PageIdentifiers( new PageId( 7 ), 'Help:Test page', 12 ) ],
+				[ new SubjectId( self::SUBJECT_ID_ON_LATER_PAGE ), new PageIdentifiers( new PageId( 8 ), 'Talk:Later page', 1 ) ],
 			] ),
 		);
 	}
@@ -195,6 +206,37 @@ class ReplaceSubjectActionTest extends TestCase {
 		$this->expectException( SubjectEditNotAuthorizedException::class );
 
 		$action->replace( new SubjectId( self::SUBJECT_ID ), 'Label', [], null );
+	}
+
+	public function testUnreadablePageAnswersNotFound(): void {
+		// The caller may edit the page but may not read it. Answering anything other than not-found
+		// would confirm the Subject exists, and hand out the page title and namespace with it.
+		$this->subjectRepository->updateSubject( TestSubject::build( id: new SubjectId( self::SUBJECT_ID ) ) );
+
+		$action = $this->newAction( readAuthorizer: new StubPageReadAuthorizer( allowed: false ) );
+
+		$this->expectException( SubjectNotFoundException::class );
+		$this->expectExceptionMessage( 'Subject not found: ' . self::SUBJECT_ID );
+
+		$action->replace( new SubjectId( self::SUBJECT_ID ), 'New Label', [], null );
+	}
+
+	public function testUnreadablePageIsRejectedBeforeTheWrite(): void {
+		$this->subjectRepository->updateSubject( TestSubject::build(
+			id: new SubjectId( self::SUBJECT_ID ),
+			label: new SubjectLabel( 'Original Label' ),
+		) );
+
+		try {
+			$this->newAction( readAuthorizer: new StubPageReadAuthorizer( allowed: false ) )
+				->replace( new SubjectId( self::SUBJECT_ID ), 'New Label', [], null );
+		} catch ( SubjectNotFoundException ) {
+		}
+
+		$this->assertSame(
+			'Original Label',
+			$this->subjectRepository->getSubject( new SubjectId( self::SUBJECT_ID ) )->getLabel()->text
+		);
 	}
 
 	public function testNonExistentSubjectThrows(): void {
@@ -331,8 +373,8 @@ class ReplaceSubjectActionTest extends TestCase {
 		$this->newAction()->replace( new SubjectId( self::SUBJECT_ID ), 'Label', [], null );
 
 		$this->assertSame( 7, $this->presenterSpy->subject?->pageId );
-		$this->assertSame( 'Test page', $this->presenterSpy->subject?->pageTitle );
-		$this->assertSame( 0, $this->presenterSpy->subject?->pageNamespaceId );
+		$this->assertSame( 'Help:Test page', $this->presenterSpy->subject?->pageTitle );
+		$this->assertSame( 12, $this->presenterSpy->subject?->pageNamespaceId );
 	}
 
 	public function testPresentsTheSchemaTheSubjectInstantiates(): void {

--- a/tests/phpunit/Application/Actions/ReplaceSubjectPresenterSpy.php
+++ b/tests/phpunit/Application/Actions/ReplaceSubjectPresenterSpy.php
@@ -5,19 +5,27 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Tests\Application\Actions;
 
 use ProfessionalWiki\NeoWiki\Application\Actions\ReplaceSubject\ReplaceSubjectPresenter;
+use ProfessionalWiki\NeoWiki\Application\Queries\GetSubject\GetSubjectResponseItem;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
 
 class ReplaceSubjectPresenterSpy implements ReplaceSubjectPresenter {
 
 	public string $subjectId = '';
 
+	public ?GetSubjectResponseItem $subject = null;
+
+	public ?Schema $schema = null;
+
 	/** @var Violation[] */
 	public array $violations = [];
 
 	public bool $validationFailed = false;
 
-	public function presentUpdated( string $subjectId, array $violations ): void {
-		$this->subjectId = $subjectId;
+	public function presentUpdated( GetSubjectResponseItem $subject, ?Schema $schema, array $violations ): void {
+		$this->subjectId = $subject->id;
+		$this->subject = $subject;
+		$this->schema = $schema;
 		$this->violations = $violations;
 	}
 

--- a/tests/phpunit/Application/Queries/GetSubject/GetSubjectResponseItemTest.php
+++ b/tests/phpunit/Application/Queries/GetSubject/GetSubjectResponseItemTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Application\Queries\GetSubject;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\Queries\GetSubject\GetSubjectResponseItem;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageIdentifiers;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
+use ProfessionalWiki\NeoWiki\Domain\Value\NumberValue;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestStatement;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Application\Queries\GetSubject\GetSubjectResponseItem
+ */
+class GetSubjectResponseItemTest extends TestCase {
+
+	public function testFromSubjectCopiesSubjectIdentity(): void {
+		$item = GetSubjectResponseItem::fromSubject(
+			TestSubject::build(
+				id: 's1demo1aaaaaaa1',
+				label: new SubjectLabel( 'ACME Corp' ),
+				schemaName: new SchemaName( 'Organization' ),
+			),
+			null
+		);
+
+		$this->assertSame( 's1demo1aaaaaaa1', $item->id );
+		$this->assertSame( 'ACME Corp', $item->label );
+		$this->assertSame( 'Organization', $item->schemaName );
+	}
+
+	public function testFromSubjectArrayifiesStatementsByPropertyName(): void {
+		$item = GetSubjectResponseItem::fromSubject(
+			TestSubject::build(
+				statements: new StatementList( [
+					TestStatement::build( property: 'Animal', value: 'bunny' ),
+					TestStatement::build( property: 'Fluff', value: new NumberValue( 9001 ), propertyType: 'number' ),
+				] )
+			),
+			null
+		);
+
+		$this->assertSame(
+			[
+				'Animal' => [ 'propertyType' => 'text', 'value' => [ 'bunny' ] ],
+				'Fluff' => [ 'propertyType' => 'number', 'value' => 9001 ],
+			],
+			$item->statements
+		);
+	}
+
+	public function testFromSubjectWithoutPageIdentifiersLeavesPageFieldsNull(): void {
+		$item = GetSubjectResponseItem::fromSubject( TestSubject::build(), null );
+
+		$this->assertNull( $item->pageId );
+		$this->assertNull( $item->pageTitle );
+		$this->assertNull( $item->pageNamespaceId );
+	}
+
+	public function testFromSubjectCopiesPageIdentifiers(): void {
+		$item = GetSubjectResponseItem::fromSubject(
+			TestSubject::build(),
+			new PageIdentifiers( new PageId( 42 ), 'Help:Bunnies', 12 )
+		);
+
+		$this->assertSame( 42, $item->pageId );
+		$this->assertSame( 'Help:Bunnies', $item->pageTitle );
+		$this->assertSame( 12, $item->pageNamespaceId );
+	}
+
+}

--- a/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
@@ -144,6 +144,29 @@ class CreateSubjectApiTest extends NeoWikiIntegrationTestCase {
 		);
 	}
 
+	/**
+	 * The same parity, on a page whose title tells the Title accessors apart: getPrefixedText()
+	 * ("Help:Some page") differs from getText(), getDBkey() and getPrefixedDBkey(). On a
+	 * main-namespace title without spaces they all coincide, so the wrong one would pass unnoticed.
+	 */
+	public function testCreatedResponseCarriesTheSubjectEntryTheReadEndpointServesForANamespacedTitle(): void {
+		$this->createSchema( 'Employee' );
+
+		$response = $this->executeCreate(
+			$this->pageIdOfNewPage( 'Help:Some page' ),
+			$this->validBody(),
+			isMainSubject: true
+		);
+
+		$responseData = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertSame( 'Help:Some page', $responseData['subject']['pageTitle'] );
+		$this->assertSame(
+			$this->readSubjectEntryFromApi( $responseData['subjectId'] ),
+			$responseData['subject']
+		);
+	}
+
 	public function testCreatedResponseCarriesTheSchemaBodyTheReadEndpointServes(): void {
 		$this->createSchema( 'Employee' );
 

--- a/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/CreateSubjectApiTest.php
@@ -16,6 +16,8 @@ use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectMap;
 use ProfessionalWiki\NeoWiki\Domain\Value\NumberValue;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\CreateSubjectApi;
+use ProfessionalWiki\NeoWiki\EntryPoints\REST\GetPageSubjectsApi;
+use ProfessionalWiki\NeoWiki\EntryPoints\REST\GetSubjectApi;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Presentation\CsrfValidator;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestStatement;
@@ -119,6 +121,85 @@ class CreateSubjectApiTest extends NeoWikiIntegrationTestCase {
 
 		$this->editPage( $title, 'Whatever wikitext' );
 		return MediaWikiServices::getInstance()->getWikiPageFactory()->newFromTitle( $title )->getId();
+	}
+
+	/**
+	 * The point of bundling the Subject is that the client can store server truth instead of its own
+	 * copy, so the entry must be the one the read endpoint serves, down to the page identifiers the
+	 * client cannot know.
+	 */
+	public function testCreatedResponseCarriesTheSubjectEntryTheReadEndpointServes(): void {
+		$this->createSchema( 'Employee' );
+
+		$response = $this->executeHandler(
+			$this->newCreateSubjectApi(),
+			$this->createValidRequestData()
+		);
+
+		$responseData = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertSame(
+			$this->readSubjectEntryFromApi( $responseData['subjectId'] ),
+			$responseData['subject']
+		);
+	}
+
+	public function testCreatedResponseCarriesTheSchemaBodyTheReadEndpointServes(): void {
+		$this->createSchema( 'Employee' );
+
+		$response = $this->executeHandler(
+			$this->newCreateSubjectApi(),
+			$this->createValidRequestData()
+		);
+
+		$responseData = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertSame(
+			$this->readSchemaBodyFromApi( 'CreateSubjectApiTest', 'Employee' ),
+			$responseData['schema']
+		);
+	}
+
+	public function testCreatedResponseOmitsTheSchemaWhenTheSchemaIsMissing(): void {
+		$response = $this->executeHandler(
+			$this->newCreateSubjectApi(),
+			$this->createRequestData( [
+				'label' => 'Test subject',
+				'schema' => 'NoSuchSchema',
+				'statements' => [],
+			] )
+		);
+
+		$responseData = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertArrayHasKey( 'subject', $responseData );
+		$this->assertArrayNotHasKey( 'schema', $responseData );
+	}
+
+	private function readSubjectEntryFromApi( string $subjectId ): array {
+		$response = $this->executeHandler(
+			new GetSubjectApi(),
+			new RequestData( [
+				'method' => 'GET',
+				'pathParams' => [ 'subjectId' => $subjectId ],
+				'queryParams' => [ 'expand' => 'page' ],
+			] )
+		);
+
+		return json_decode( $response->getBody()->getContents(), true )['subjects'][$subjectId];
+	}
+
+	private function readSchemaBodyFromApi( string $pageName, string $schemaName ): array {
+		$response = $this->executeHandler(
+			new GetPageSubjectsApi(),
+			new RequestData( [
+				'method' => 'GET',
+				'pathParams' => [ 'pageId' => Title::newFromText( $pageName )->getId() ],
+				'queryParams' => [ 'expand' => 'schemas' ],
+			] )
+		);
+
+		return json_decode( $response->getBody()->getContents(), true )['schemas'][$schemaName];
 	}
 
 	public function testReadableButNotEditablePageReturns403(): void {

--- a/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
@@ -468,11 +468,46 @@ class ReplaceSubjectApiTest extends NeoWikiIntegrationTestCase {
 
 		$responseData = json_decode( $response->getBody()->getContents(), true );
 
-		// The very shape testNonExistentSubjectReturns404 asserts: a caller holding a harvested
-		// Subject id learns nothing about whether it exists, nor which page carries it.
+		// A caller holding a harvested Subject id learns nothing about whether it exists, nor
+		// which page carries it. The companion test below pins that against an absent id for
+		// this same caller, which is what makes the two indistinguishable.
 		$this->assertSame( 404, $response->getStatusCode() );
 		$this->assertSame( 'error', $responseData['status'] );
 		$this->assertSame( 'Subject not found: sTestSA11111111', $responseData['message'] );
+	}
+
+	public function testAbsentAndUnreadableSubjectsAnswerAlikeForOneCaller(): void {
+		$this->createPages();
+
+		// One Authority for both requests. Comparing responses obtained under two different
+		// Authorities says nothing about what any single caller can tell apart, and this caller
+		// holds no wiki-global 'edit' right, so an absent id has no page to authorize against.
+		$authority = $this->authorityWithGlobalReadButNoPageRead();
+
+		$unreadable = $this->executeHandler(
+			$this->newReplaceSubjectApi(),
+			$this->createRequestDataFor( 'sTestSA11111111', $this->validBody() ),
+			authority: $authority
+		);
+
+		$absent = $this->executeHandler(
+			$this->newReplaceSubjectApi(),
+			$this->createRequestDataFor( 'sDoesNotExist99', $this->validBody() ),
+			authority: $authority
+		);
+
+		$unreadableData = json_decode( $unreadable->getBody()->getContents(), true );
+		$absentData = json_decode( $absent->getBody()->getContents(), true );
+
+		$this->assertSame( 404, $unreadable->getStatusCode() );
+		$this->assertSame( $unreadable->getStatusCode(), $absent->getStatusCode() );
+		$this->assertSame( $unreadableData['status'], $absentData['status'] );
+
+		// The echoed id is the one the caller supplied, so only that may differ.
+		$this->assertSame(
+			str_replace( 'sTestSA11111111', '<id>', $unreadableData['message'] ),
+			str_replace( 'sDoesNotExist99', '<id>', $absentData['message'] )
+		);
 	}
 
 	public function testCommentIsAccepted(): void {

--- a/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
@@ -7,8 +7,8 @@ namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\REST;
 use MediaWiki\Rest\HttpException;
 use MediaWiki\Rest\RequestData;
 use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
-use MediaWiki\Tests\Unit\Permissions\MockAuthorityTrait;
 use MediaWiki\Title\Title;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiMockAuthorityTrait;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
@@ -30,7 +30,9 @@ use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
 class ReplaceSubjectApiTest extends NeoWikiIntegrationTestCase {
 
 	use HandlerTestTrait;
-	use MockAuthorityTrait;
+	use NeoWikiMockAuthorityTrait;
+
+	private const string NAMESPACED_PAGE_SUBJECT_ID = 'sTestSA11111177';
 
 	public function testHappyPathReturns200WithUpdatedStatus(): void {
 		$this->createPages();
@@ -66,6 +68,32 @@ class ReplaceSubjectApiTest extends NeoWikiIntegrationTestCase {
 
 		$this->assertSame(
 			$this->readSubjectEntryFromApi( 'sTestSA11111111' ),
+			$responseData['subject']
+		);
+	}
+
+	/**
+	 * The same parity, on a page whose title tells the Title accessors apart: getPrefixedText()
+	 * ("Help:Some page") differs from getText(), getDBkey() and getPrefixedDBkey(). On a
+	 * main-namespace title without spaces they all coincide, so the wrong one would pass unnoticed.
+	 */
+	public function testUpdatedResponseCarriesTheSubjectEntryTheReadEndpointServesForANamespacedTitle(): void {
+		$this->createNamespacedPage();
+
+		$response = $this->executeHandler(
+			$this->newReplaceSubjectApi(),
+			$this->createRequestDataFor( self::NAMESPACED_PAGE_SUBJECT_ID, [
+				'label' => 'Subject on a namespaced page',
+				'statements' => [],
+			] )
+		);
+
+		$responseData = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertSame( 'Help:Some page', $responseData['subject']['pageTitle'] );
+		$this->assertSame( 12, $responseData['subject']['pageNamespaceId'] );
+		$this->assertSame(
+			$this->readSubjectEntryFromApi( self::NAMESPACED_PAGE_SUBJECT_ID ),
 			$responseData['subject']
 		);
 	}
@@ -413,19 +441,38 @@ class ReplaceSubjectApiTest extends NeoWikiIntegrationTestCase {
 		);
 	}
 
-	public function testPermissionDeniedReturns403(): void {
+	public function testReadableButNotEditablePageReturns403(): void {
 		$this->createPages();
 
+		// The caller can read the page - so its existence is already public - but cannot edit it.
 		$response = $this->executeHandler(
 			$this->newReplaceSubjectApi(),
 			$this->createValidRequestData(),
-			authority: $this->mockAnonAuthorityWithPermissions( [] )
+			authority: $this->authorityWithGlobalEditButNoPageEdit()
 		);
 
 		$responseData = json_decode( $response->getBody()->getContents(), true );
 
 		$this->assertSame( 403, $response->getStatusCode() );
 		$this->assertSame( 'error', $responseData['status'] );
+	}
+
+	public function testSubjectOnAnUnreadablePageAnswersLikeAnAbsentSubject(): void {
+		$this->createPages();
+
+		$response = $this->executeHandler(
+			$this->newReplaceSubjectApi(),
+			$this->createValidRequestData(),
+			authority: $this->authorityWithGlobalReadButNoPageRead()
+		);
+
+		$responseData = json_decode( $response->getBody()->getContents(), true );
+
+		// The very shape testNonExistentSubjectReturns404 asserts: a caller holding a harvested
+		// Subject id learns nothing about whether it exists, nor which page carries it.
+		$this->assertSame( 404, $response->getStatusCode() );
+		$this->assertSame( 'error', $responseData['status'] );
+		$this->assertSame( 'Subject not found: sTestSA11111111', $responseData['message'] );
 	}
 
 	public function testCommentIsAccepted(): void {
@@ -495,6 +542,17 @@ class ReplaceSubjectApiTest extends NeoWikiIntegrationTestCase {
 		);
 	}
 
+	private function createNamespacedPage(): void {
+		$this->createSchema( TestSubject::DEFAULT_SCHEMA_ID );
+		$this->createPageWithSubjects(
+			'Help:Some page',
+			mainSubject: TestSubject::build(
+				id: self::NAMESPACED_PAGE_SUBJECT_ID,
+				label: new SubjectLabel( 'Test subject ' . self::NAMESPACED_PAGE_SUBJECT_ID ),
+			)
+		);
+	}
+
 	private function newReplaceSubjectApi(): ReplaceSubjectApi {
 		$csrfValidatorStub = $this->createStub( CsrfValidator::class );
 		$csrfValidatorStub->method( 'verifyCsrfToken' )->willReturn( true );
@@ -509,10 +567,14 @@ class ReplaceSubjectApiTest extends NeoWikiIntegrationTestCase {
 	}
 
 	private function createRequestData( array $body ): RequestData {
+		return $this->createRequestDataFor( 'sTestSA11111111', $body );
+	}
+
+	private function createRequestDataFor( string $subjectId, array $body ): RequestData {
 		return new RequestData( [
 			'method' => 'PUT',
 			'pathParams' => [
-				'subjectId' => 'sTestSA11111111',
+				'subjectId' => $subjectId,
 			],
 			'bodyContents' => json_encode( $body ),
 			'headers' => [

--- a/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
@@ -12,6 +12,7 @@ use MediaWiki\Title\Title;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
+use ProfessionalWiki\NeoWiki\EntryPoints\REST\GetPageSubjectsApi;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\GetSubjectApi;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\ReplaceSubjectApi;
 use ProfessionalWiki\NeoWiki\Presentation\CsrfValidator;
@@ -46,6 +47,104 @@ class ReplaceSubjectApiTest extends NeoWikiIntegrationTestCase {
 		$this->assertSame( 'sTestSA11111111', $responseData['subjectId'] );
 		$this->assertArrayHasKey( 'violations', $responseData );
 		$this->assertSame( [], $responseData['violations'] );
+	}
+
+	/**
+	 * The point of bundling the Subject is that the client can store server truth instead of its own
+	 * copy, so the entry must be the one the read endpoint serves, down to the page identifiers the
+	 * client cannot know.
+	 */
+	public function testUpdatedResponseCarriesTheSubjectEntryTheReadEndpointServes(): void {
+		$this->createPages();
+
+		$response = $this->executeHandler(
+			$this->newReplaceSubjectApi(),
+			$this->createValidRequestData()
+		);
+
+		$responseData = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertSame(
+			$this->readSubjectEntryFromApi( 'sTestSA11111111' ),
+			$responseData['subject']
+		);
+	}
+
+	public function testUpdatedResponseCarriesTheSchemaBodyTheReadEndpointServes(): void {
+		$this->createPages();
+
+		$response = $this->executeHandler(
+			$this->newReplaceSubjectApi(),
+			$this->createValidRequestData()
+		);
+
+		$responseData = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertSame(
+			$this->readSchemaBodyFromApi( 'ReplaceSubjectApiTest', TestSubject::DEFAULT_SCHEMA_ID ),
+			$responseData['schema']
+		);
+	}
+
+	public function testUpdatedResponseOmitsTheSchemaWhenTheSchemaIsMissing(): void {
+		$this->createSchema( 'GoneSchema' );
+		$this->createPageWithSubjects(
+			'ReplaceSubjectApiGoneSchemaTest',
+			mainSubject: TestSubject::build(
+				id: 'sTestSA11111166',
+				label: new SubjectLabel( 'Orphaned subject' ),
+				schemaName: new SchemaName( 'GoneSchema' ),
+			)
+		);
+		$this->deletePage(
+			$this->getServiceContainer()->getWikiPageFactory()->newFromTitle(
+				Title::newFromText( 'GoneSchema', NeoWikiExtension::NS_SCHEMA )
+			)
+		);
+
+		$response = $this->executeHandler(
+			$this->newReplaceSubjectApi(),
+			new RequestData( [
+				'method' => 'PUT',
+				'pathParams' => [ 'subjectId' => 'sTestSA11111166' ],
+				'bodyContents' => json_encode( [
+					'label' => 'Still orphaned',
+					'statements' => [],
+				] ),
+				'headers' => [ 'Content-Type' => 'application/json' ],
+			] )
+		);
+
+		$responseData = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertArrayHasKey( 'subject', $responseData );
+		$this->assertArrayNotHasKey( 'schema', $responseData );
+	}
+
+	private function readSubjectEntryFromApi( string $subjectId ): array {
+		$response = $this->executeHandler(
+			new GetSubjectApi(),
+			new RequestData( [
+				'method' => 'GET',
+				'pathParams' => [ 'subjectId' => $subjectId ],
+				'queryParams' => [ 'expand' => 'page' ],
+			] )
+		);
+
+		return json_decode( $response->getBody()->getContents(), true )['subjects'][$subjectId];
+	}
+
+	private function readSchemaBodyFromApi( string $pageName, string $schemaName ): array {
+		$response = $this->executeHandler(
+			new GetPageSubjectsApi(),
+			new RequestData( [
+				'method' => 'GET',
+				'pathParams' => [ 'pageId' => Title::newFromText( $pageName )->getId() ],
+				'queryParams' => [ 'expand' => 'schemas' ],
+			] )
+		);
+
+		return json_decode( $response->getBody()->getContents(), true )['schemas'][$schemaName];
 	}
 
 	public function testResponseIncludesViolationsWhenRequiredPropertyMissing(): void {

--- a/tests/phpunit/Infrastructure/TitleBasedPageIdentifiersResolverTest.php
+++ b/tests/phpunit/Infrastructure/TitleBasedPageIdentifiersResolverTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Infrastructure;
+
+use MediaWiki\Title\Title;
+use MediaWiki\Title\TitleFactory;
+use MediaWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageIdentifiers;
+use ProfessionalWiki\NeoWiki\Infrastructure\TitleBasedPageIdentifiersResolver;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Infrastructure\TitleBasedPageIdentifiersResolver
+ */
+class TitleBasedPageIdentifiersResolverTest extends MediaWikiIntegrationTestCase {
+
+	private const int PAGE_ID = 42;
+
+	private function newResolver( ?Title $title ): TitleBasedPageIdentifiersResolver {
+		$titleFactory = $this->createStub( TitleFactory::class );
+		$titleFactory->method( 'newFromID' )->willReturn( $title );
+
+		return new TitleBasedPageIdentifiersResolver( $titleFactory );
+	}
+
+	public function testResolvesThePrefixedTitleAndNamespace(): void {
+		$resolver = $this->newResolver( Title::makeTitle( NS_HELP, 'Bunnies' ) );
+
+		$this->assertEquals(
+			new PageIdentifiers( new PageId( self::PAGE_ID ), 'Help:Bunnies', NS_HELP ),
+			$resolver->getIdentifiersOfPage( new PageId( self::PAGE_ID ) )
+		);
+	}
+
+	public function testUnresolvablePageIdYieldsNull(): void {
+		$resolver = $this->newResolver( null );
+
+		$this->assertNull( $resolver->getIdentifiersOfPage( new PageId( self::PAGE_ID ) ) );
+	}
+
+}

--- a/tests/phpunit/Presentation/RestCreateSubjectPresenterTest.php
+++ b/tests/phpunit/Presentation/RestCreateSubjectPresenterTest.php
@@ -5,7 +5,13 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Tests\Presentation;
 
 use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\Queries\GetSubject\GetSubjectResponseItem;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Property\TextProperty;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinitions;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyName;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
 use ProfessionalWiki\NeoWiki\Presentation\RestCreateSubjectPresenter;
 
@@ -14,33 +20,125 @@ use ProfessionalWiki\NeoWiki\Presentation\RestCreateSubjectPresenter;
  */
 class RestCreateSubjectPresenterTest extends TestCase {
 
+	private function newSubject( ?int $pageId = 42 ): GetSubjectResponseItem {
+		return new GetSubjectResponseItem(
+			id: 's1demo1aaaaaaa1',
+			label: 'ACME Corp',
+			schemaName: 'Organization',
+			statements: [ 'Animal' => [ 'propertyType' => 'text', 'value' => [ 'bunny' ] ] ],
+			pageId: $pageId,
+			pageTitle: $pageId === null ? null : 'ACME Corp',
+			pageNamespaceId: $pageId === null ? null : 0,
+		);
+	}
+
+	private function newSchema(): Schema {
+		return new Schema(
+			name: new SchemaName( 'Organization' ),
+			description: 'Companies and the like',
+			properties: new PropertyDefinitions( [
+				'Animal' => new TextProperty(
+					core: new PropertyCore( description: 'Mascot', required: false, default: null ),
+					multiple: false,
+					uniqueItems: false,
+					minLength: null,
+					maxLength: null,
+				),
+			] )
+		);
+	}
+
 	public function testPresentCreatedYields201WithSerializedViolations(): void {
 		$presenter = new RestCreateSubjectPresenter();
 
-		$presenter->presentCreated( 's1demo1aaaaaaa1', [
+		$presenter->presentCreated( $this->newSubject(), null, [
 			new Violation( propertyName: new PropertyName( 'Status' ), code: 'required' ),
 		] );
 
 		$this->assertSame( 201, $presenter->getStatusCode() );
+		$this->assertSame( 'created', $presenter->getJsonArray()['status'] );
+		$this->assertSame( 's1demo1aaaaaaa1', $presenter->getJsonArray()['subjectId'] );
 		$this->assertSame(
-			[
-				'status' => 'created',
-				'subjectId' => 's1demo1aaaaaaa1',
-				'violations' => [
-					[ 'propertyName' => 'Status', 'code' => 'required', 'args' => [] ],
-				],
-			],
-			$presenter->getJsonArray()
+			[ [ 'propertyName' => 'Status', 'code' => 'required', 'args' => [] ] ],
+			$presenter->getJsonArray()['violations']
 		);
 	}
 
 	public function testPresentCreatedWithNoViolationsYieldsEmptyViolationsArray(): void {
 		$presenter = new RestCreateSubjectPresenter();
 
-		$presenter->presentCreated( 's1demo1aaaaaaa1', [] );
+		$presenter->presentCreated( $this->newSubject(), null, [] );
 
 		$this->assertSame( 201, $presenter->getStatusCode() );
 		$this->assertSame( [], $presenter->getJsonArray()['violations'] );
+	}
+
+	public function testPresentCreatedIncludesTheCanonicalSubjectWithItsPageIdentifiers(): void {
+		$presenter = new RestCreateSubjectPresenter();
+
+		$presenter->presentCreated( $this->newSubject(), null, [] );
+
+		$this->assertSame(
+			[
+				'id' => 's1demo1aaaaaaa1',
+				'label' => 'ACME Corp',
+				'schema' => 'Organization',
+				'pageId' => 42,
+				'pageTitle' => 'ACME Corp',
+				'pageNamespaceId' => 0,
+				'statements' => [ 'Animal' => [ 'propertyType' => 'text', 'value' => [ 'bunny' ] ] ],
+			],
+			$presenter->getJsonArray()['subject']
+		);
+	}
+
+	public function testPresentCreatedOmitsPageKeysWhenTheHostingPageIsUnresolved(): void {
+		$presenter = new RestCreateSubjectPresenter();
+
+		$presenter->presentCreated( $this->newSubject( pageId: null ), null, [] );
+
+		$this->assertSame(
+			[
+				'id' => 's1demo1aaaaaaa1',
+				'label' => 'ACME Corp',
+				'schema' => 'Organization',
+				'statements' => [ 'Animal' => [ 'propertyType' => 'text', 'value' => [ 'bunny' ] ] ],
+			],
+			$presenter->getJsonArray()['subject']
+		);
+	}
+
+	public function testPresentCreatedIncludesTheSchemaBodyWithoutItsName(): void {
+		$presenter = new RestCreateSubjectPresenter();
+
+		$presenter->presentCreated( $this->newSubject(), $this->newSchema(), [] );
+
+		$this->assertSame(
+			[
+				'description' => 'Companies and the like',
+				'propertyDefinitions' => [
+					'Animal' => [
+						'type' => 'text',
+						'description' => 'Mascot',
+						'required' => false,
+						'default' => null,
+						'multiple' => false,
+						'uniqueItems' => false,
+						'minLength' => null,
+						'maxLength' => null,
+					],
+				],
+			],
+			$presenter->getJsonArray()['schema']
+		);
+	}
+
+	public function testPresentCreatedOmitsTheSchemaKeyWhenTheSchemaIsMissing(): void {
+		$presenter = new RestCreateSubjectPresenter();
+
+		$presenter->presentCreated( $this->newSubject(), null, [] );
+
+		$this->assertArrayNotHasKey( 'schema', $presenter->getJsonArray() );
 	}
 
 	public function testPresentSubjectAlreadyExistsYields409ErrorWithoutViolations(): void {

--- a/tests/phpunit/Presentation/RestReplaceSubjectPresenterTest.php
+++ b/tests/phpunit/Presentation/RestReplaceSubjectPresenterTest.php
@@ -5,7 +5,13 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Tests\Presentation;
 
 use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\Queries\GetSubject\GetSubjectResponseItem;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Property\TextProperty;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyCore;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinitions;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyName;
+use ProfessionalWiki\NeoWiki\Domain\Schema\Schema;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
 use ProfessionalWiki\NeoWiki\Presentation\RestReplaceSubjectPresenter;
 
@@ -14,35 +20,129 @@ use ProfessionalWiki\NeoWiki\Presentation\RestReplaceSubjectPresenter;
  */
 class RestReplaceSubjectPresenterTest extends TestCase {
 
+	private function newSubject( ?int $pageId = 42 ): GetSubjectResponseItem {
+		return new GetSubjectResponseItem(
+			id: 's1demo1aaaaaaa1',
+			label: 'ACME Corp',
+			schemaName: 'Organization',
+			statements: [ 'Animal' => [ 'propertyType' => 'text', 'value' => [ 'bunny' ] ] ],
+			pageId: $pageId,
+			pageTitle: $pageId === null ? null : 'ACME Corp',
+			pageNamespaceId: $pageId === null ? null : 0,
+		);
+	}
+
+	private function newSchema(): Schema {
+		return new Schema(
+			name: new SchemaName( 'Organization' ),
+			description: 'Companies and the like',
+			properties: new PropertyDefinitions( [
+				'Animal' => new TextProperty(
+					core: new PropertyCore( description: 'Mascot', required: false, default: null ),
+					multiple: false,
+					uniqueItems: false,
+					minLength: null,
+					maxLength: null,
+				),
+			] )
+		);
+	}
+
 	public function testPresentUpdatedYields200WithSerializedViolations(): void {
 		$presenter = new RestReplaceSubjectPresenter();
 
-		$presenter->presentUpdated( 's1demo1aaaaaaa1', [
+		$presenter->presentUpdated( $this->newSubject(), null, [
 			new Violation( propertyName: new PropertyName( 'Status' ), code: 'required' ),
 			new Violation( propertyName: null, code: 'schema-not-found', args: [ 'Person' ] ),
 		] );
 
 		$this->assertSame( 200, $presenter->getStatusCode() );
+		$this->assertSame( 'updated', $presenter->getJsonArray()['status'] );
+		$this->assertSame( 's1demo1aaaaaaa1', $presenter->getJsonArray()['subjectId'] );
 		$this->assertSame(
 			[
-				'status' => 'updated',
-				'subjectId' => 's1demo1aaaaaaa1',
-				'violations' => [
-					[ 'propertyName' => 'Status', 'code' => 'required', 'args' => [] ],
-					[ 'propertyName' => null, 'code' => 'schema-not-found', 'args' => [ 'Person' ] ],
-				],
+				[ 'propertyName' => 'Status', 'code' => 'required', 'args' => [] ],
+				[ 'propertyName' => null, 'code' => 'schema-not-found', 'args' => [ 'Person' ] ],
 			],
-			$presenter->getJsonArray()
+			$presenter->getJsonArray()['violations']
 		);
 	}
 
 	public function testPresentUpdatedWithNoViolationsYieldsEmptyViolationsArray(): void {
 		$presenter = new RestReplaceSubjectPresenter();
 
-		$presenter->presentUpdated( 's1demo1aaaaaaa1', [] );
+		$presenter->presentUpdated( $this->newSubject(), null, [] );
 
 		$this->assertSame( 200, $presenter->getStatusCode() );
 		$this->assertSame( [], $presenter->getJsonArray()['violations'] );
+	}
+
+	public function testPresentUpdatedIncludesTheCanonicalSubjectWithItsPageIdentifiers(): void {
+		$presenter = new RestReplaceSubjectPresenter();
+
+		$presenter->presentUpdated( $this->newSubject(), null, [] );
+
+		$this->assertSame(
+			[
+				'id' => 's1demo1aaaaaaa1',
+				'label' => 'ACME Corp',
+				'schema' => 'Organization',
+				'pageId' => 42,
+				'pageTitle' => 'ACME Corp',
+				'pageNamespaceId' => 0,
+				'statements' => [ 'Animal' => [ 'propertyType' => 'text', 'value' => [ 'bunny' ] ] ],
+			],
+			$presenter->getJsonArray()['subject']
+		);
+	}
+
+	public function testPresentUpdatedOmitsPageKeysWhenTheHostingPageIsUnresolved(): void {
+		$presenter = new RestReplaceSubjectPresenter();
+
+		$presenter->presentUpdated( $this->newSubject( pageId: null ), null, [] );
+
+		$this->assertSame(
+			[
+				'id' => 's1demo1aaaaaaa1',
+				'label' => 'ACME Corp',
+				'schema' => 'Organization',
+				'statements' => [ 'Animal' => [ 'propertyType' => 'text', 'value' => [ 'bunny' ] ] ],
+			],
+			$presenter->getJsonArray()['subject']
+		);
+	}
+
+	public function testPresentUpdatedIncludesTheSchemaBodyWithoutItsName(): void {
+		$presenter = new RestReplaceSubjectPresenter();
+
+		$presenter->presentUpdated( $this->newSubject(), $this->newSchema(), [] );
+
+		$this->assertSame(
+			[
+				'description' => 'Companies and the like',
+				'propertyDefinitions' => [
+					'Animal' => [
+						'type' => 'text',
+						'description' => 'Mascot',
+						'required' => false,
+						'default' => null,
+						'multiple' => false,
+						'uniqueItems' => false,
+						'minLength' => null,
+						'maxLength' => null,
+					],
+				],
+			],
+			$presenter->getJsonArray()['schema']
+		);
+	}
+
+	public function testPresentUpdatedOmitsTheSchemaKeyWhenTheSchemaIsMissing(): void {
+		$presenter = new RestReplaceSubjectPresenter();
+
+		$presenter->presentUpdated( $this->newSubject(), null, [] );
+
+		$this->assertArrayNotHasKey( 'schema', $presenter->getJsonArray() );
 	}
 
 	public function testPresentValidationFailedYields422WithErrorBody(): void {

--- a/tests/phpunit/Presentation/SubjectPresentationSerializerTest.php
+++ b/tests/phpunit/Presentation/SubjectPresentationSerializerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Presentation;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\Queries\GetSubject\GetSubjectResponseItem;
+use ProfessionalWiki\NeoWiki\Presentation\SubjectPresentationSerializer;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Presentation\SubjectPresentationSerializer
+ */
+class SubjectPresentationSerializerTest extends TestCase {
+
+	private function newItem( ?int $pageId, ?string $pageTitle = null, ?int $pageNamespaceId = null ): GetSubjectResponseItem {
+		return new GetSubjectResponseItem(
+			id: 's1demo1aaaaaaa1',
+			label: 'ACME Corp',
+			schemaName: 'Organization',
+			statements: [ 'Animal' => [ 'propertyType' => 'text', 'value' => [ 'bunny' ] ] ],
+			pageId: $pageId,
+			pageTitle: $pageTitle,
+			pageNamespaceId: $pageNamespaceId,
+		);
+	}
+
+	public function testSerializesPageIdentifiersBetweenSchemaAndStatements(): void {
+		$this->assertSame(
+			[
+				'id' => 's1demo1aaaaaaa1',
+				'label' => 'ACME Corp',
+				'schema' => 'Organization',
+				'pageId' => 42,
+				'pageTitle' => 'Help:Bunnies',
+				'pageNamespaceId' => 12,
+				'statements' => [ 'Animal' => [ 'propertyType' => 'text', 'value' => [ 'bunny' ] ] ],
+			],
+			( new SubjectPresentationSerializer() )->serialize( $this->newItem( 42, 'Help:Bunnies', 12 ) )
+		);
+	}
+
+	public function testOmitsPageKeysWhenThePageIsUnresolved(): void {
+		$this->assertSame(
+			[
+				'id' => 's1demo1aaaaaaa1',
+				'label' => 'ACME Corp',
+				'schema' => 'Organization',
+				'statements' => [ 'Animal' => [ 'propertyType' => 'text', 'value' => [ 'bunny' ] ] ],
+			],
+			( new SubjectPresentationSerializer() )->serialize( $this->newItem( null ) )
+		);
+	}
+
+}

--- a/tests/phpunit/TestDoubles/InMemoryPageIdentifiersResolver.php
+++ b/tests/phpunit/TestDoubles/InMemoryPageIdentifiersResolver.php
@@ -1,0 +1,35 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\TestDoubles;
+
+use ProfessionalWiki\NeoWiki\Application\PageIdentifiersResolver;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageIdentifiers;
+
+class InMemoryPageIdentifiersResolver implements PageIdentifiersResolver {
+
+	/**
+	 * @var array<int, PageIdentifiers>
+	 */
+	private array $pageIdentifiers = [];
+
+	/**
+	 * @param PageIdentifiers[] $pageIdentifiers
+	 */
+	public function __construct( array $pageIdentifiers = [] ) {
+		foreach ( $pageIdentifiers as $identifiers ) {
+			$this->addIdentifiers( $identifiers );
+		}
+	}
+
+	public function addIdentifiers( PageIdentifiers $pageIdentifiers ): void {
+		$this->pageIdentifiers[$pageIdentifiers->getId()->id] = $pageIdentifiers;
+	}
+
+	public function getIdentifiersOfPage( PageId $pageId ): ?PageIdentifiers {
+		return $this->pageIdentifiers[$pageId->id] ?? null;
+	}
+
+}


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1215

## Summary

Editing reads already ran through store fetch actions before #1215; keeping them there is what forced the epoch
guard's "resolved but may have recorded nothing" contract onto every fetch, and a stale-data error toast on
Special:Layouts for a situation users should never see. This PR makes two moves, recorded in
[ADR 30](https://github.com/ProfessionalWiki/NeoWiki/blob/refactor/1211-reads-via-repositories/docs/adr/030-frontend-store-registry-semantics.md)
(which now amends
[ADR 16](https://github.com/ProfessionalWiki/NeoWiki/blob/refactor/1211-reads-via-repositories/docs/adr/016-frontend-state-management.md):
its editing-UI rule applies to reads; mutations and validation still go through store actions):

1. **Editing reads go through the repositories.** `fetchSchema`, `fetchLayout` and `fetchSubject` are gone from
   the stores; the code that opens an editor fetches via the repository and passes props. `SubjectEditorDialog`
   now takes the schema as a required prop — breaking for third-party hosts of the exported dialog. It mirrors
   the prop internally, so a schema saved through the nested schema editor applies without the host passing a
   new one down. `getOrFetchSubject` keeps its epoch guard inline on the miss path; `SubjectCreatorDialog`
   picks up a `requestSequence` guard for its now-local schema fetch. Components acquire repositories via
   `NeoWikiServices` injection (the pre-existing idiom); `Service.SubjectRepository` is newly registered.
2. **Subject writes answer with the persisted state.** The create and replace endpoints return the canonical
   Subject as stored — byte-identical to the read endpoints' output, asserted end to end — plus the Schema it
   instantiates, so clients need not re-fetch after a write. Additive for existing API consumers; documented in
   [`docs/api/subject-format.md`](https://github.com/ProfessionalWiki/NeoWiki/blob/refactor/1211-reads-via-repositories/docs/api/subject-format.md).
   Replace also gains the read gate create already had, so an unreadable page is indistinguishable from an
   absent one on every subject write.
3. **The registry holds only server-produced Subjects.** Store write-throughs record the mutation response's
   entity — which carries the page context the editor's client-built copy lacks, closing the bug class where a
   save put a context-less Subject in the registry and broke relation-label rendering — and the bundled Schema
   lands epoch-guarded. Schema and Layout saves still write the authored object through; the editor is its sole
   author. Displays catch up on commit: a schema changed in another session renders after your next save, and
   cancelling an editor leaves the display on page-load state.

#1215's mutation core is untouched: `removeSchema`/`removeLayout`, the `deleteSubject` re-sync invariant, the
summaries in-flight dedup, and the epoch guards on the seeding paths all stay as they are on the base branch.

Also fixed on the way, previously unreported: opening an editor on a subject and then deleting that subject
crashed the manage-subjects page (`editingSubject` was a store-read computed over a possibly-deleted id; it is
now local state), and an editor save could revert a label renamed in another tab whenever the epoch guard
discarded `openEditor`'s refresh (the save now starts from the fetched subject). The
`neowiki-layouts-edit-stale-error` message is removed together with the code path that showed it, and infobox
editors now run their validation dry-run when opened (the dialog mounts open, which the existing dry-run
watcher was written for).

## Merge notes

- Squash workflow: merge this into the #1215 branch before that PR lands (or rebase onto master after).
- Merging to master conflicts in `RestCreateSubjectPresenterTest.php` / `RestReplaceSubjectPresenterTest.php`:
  master's #1147 added `severity` to the expected violation arrays these tests rewrite. Keep both sides — the
  new `subject`/`schema` assertions *and* the `severity` keys.

## Manual browser check

1. Infobox pencil → edit → save: the new values render immediately, no reload.
2. In a second tab, add a property to the schema; in the first tab open the infobox editor, fill the new field,
   save: the value renders without a reload. Cancel instead of save: the display keeps its page-load state.
3. Special:Schemas / Special:Layouts: edit opens on fresh data.
4. `?action=subjects`: edit and delete a child subject; the listing stays correct with no reload.

<sub>AI-authored — Claude Code; implementation and fixes `Opus 5 (max)` from written specs; independent AI code-review and text-review passes (`Opus 5 (max)`) with findings applied; orchestration and final review `Fable 5 (max)`. PHPUnit (2190) + phpcs/phpstan + vitest (1197) + build + lint green locally and in CI; the review pass verified the save/cancel flows over live HTTP and in the browser, including the byte-identity of write responses with the read endpoints on a namespaced page.</sub>
