### PR TITLE
Run Renovate for dependency updates

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,30 @@
+name: Renovate
+
+on:
+  schedule:
+    - cron: '17 2 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: renovate
+  cancel-in-progress: true
+
+jobs:
+  renovate:
+    name: "Renovate"
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Run Renovate
+        uses: renovatebot/github-action@v46.2.0
+        with:
+          token: ${{ secrets.RENOVATE_TOKEN_PROWIKIEXPERTS }}
+        env:
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_GIT_AUTHOR: "ProWikiExperts <73494570+ProWikiExperts@users.noreply.github.com>"

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,10 @@
     "config:recommended",
     ":maintainLockFilesWeekly"
   ],
+  "description": "config:recommended ignores **/tests/**, which would leave the RedHerb example extension and its lock file unmanaged. RedHerb is a shipped project that happens to live under tests/, so that exclusion is dropped.",
+  "ignorePresets": [
+    ":ignoreModulesAndTests"
+  ],
   "minimumReleaseAge": "3 days",
   "dependencyDashboard": true,
   "prConcurrentLimit": 5,

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":maintainLockFilesWeekly"
+  ],
+  "minimumReleaseAge": "3 days",
+  "dependencyDashboard": true,
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 0,
+  "major": {
+    "description": "Major upgrades are real work rather than a version bump: an eslint or vitest major reshapes configuration and tests, and a mediawiki-codesniffer major rewrites the ruleset. They are surfaced on the dependency dashboard and only get a pull request once ticked there.",
+    "dependencyDashboardApproval": true
+  },
+  "packageRules": [
+    {
+      "description": "One rolling pull request for npm minor and patch updates across the root, frontend and RedHerb projects, rather than one per package. The whole toolchain is covered by CI, so a batch either passes or names the package that broke it.",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "npm dependencies"
+    },
+    {
+      "description": "The same for composer: runtime and dev requirements move together in one pull request.",
+      "matchManagers": ["composer"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "composer dependencies"
+    },
+    {
+      "description": "A workflow edit should never ride along in a dependency pull request, so actions get their own group.",
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions"
+    },
+    {
+      "description": "Image tags in the dev stack and the Dockerfile choose the PHP, database and Node versions development and CI run on, so even a minor bump (php:8.3-apache to php:8.4-apache) is an environment decision rather than a dependency update. Those go to the dashboard; patch bumps still flow as ordinary pull requests.",
+      "matchManagers": ["dockerfile", "docker-compose"],
+      "matchUpdateTypes": ["minor"],
+      "dependencyDashboardApproval": true
+    },
+    {
+      "description": "Our own image floats by design: CI pushes :latest and the dev stack pulls it. Matched by namespace rather than by the :latest tag, so an accidental :latest on a third-party image is still surfaced.",
+      "matchPackageNames": ["ghcr.io/professionalwiki/**"],
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
Supersedes https://github.com/ProfessionalWiki/NeoWiki/pull/1221

Adds a nightly Renovate run and its configuration, modelled on the one DockerWiki uses. Nothing proposes dependency
updates here today: Dependabot version updates are off, and its security updates only fire once an advisory lands.

The configuration keeps the pull request volume low. npm and composer minor and patch updates each roll into one
grouped pull request, GitHub Actions get their own, and majors go to the dependency dashboard instead of straight to a
pull request. Image tags in the dev stack are treated that way from minor upwards, because they choose the PHP,
database and Node versions development and CI run on.

`:maintainLockFilesWeekly` regenerates the npm lock files every Monday. That is what moves nested transitive packages,
the drift behind the brace-expansion and js-yaml alerts.

Needs `RENOVATE_TOKEN_PROWIKIEXPERTS` to be readable from this repository. The workflow is otherwise the one DockerWiki
runs, on the current action release.

> <sub>AI-authored — Claude Code, `Opus 5 (max)`; asked to replace the bespoke lockfile workflow in #1221 with Renovate after pointing at DockerWiki's setup; no revisions; diff not yet human-reviewed; `renovate-config-validator` passes on the config, but Renovate itself has not run against this repository.</sub>