### PR TITLE
Surface Constraint severity in the frontend: parse the object form and style warnings

### DIFF
--- a/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
@@ -91,19 +91,7 @@
 				</template>
 			</CdxField>
 
-			<CdxMessage
-				v-if="anchorlessViolations.length > 0"
-				type="error"
-			>
-				<ul class="ext-neowiki-subject-editor__form-errors">
-					<li
-						v-for="( v, idx ) in anchorlessViolations"
-						:key="idx"
-					>
-						{{ formatViolationMessage( v ) }}
-					</li>
-				</ul>
-			</CdxMessage>
+			<SubjectViolationBanners :violations="anchorlessViolations" />
 
 			<SubjectEditor
 				v-if="statements"
@@ -171,8 +159,8 @@ import { Schema } from '@/domain/Schema.ts';
 import { StatementList } from '@/domain/StatementList.ts';
 import { withoutMissingValueViolations, type SubjectViolation } from '@/domain/SubjectViolation';
 import { ValidationFailedError } from '@/persistence/ValidationFailedError';
-import { CdxMessage } from '@wikimedia/codex';
 import SubjectEditor from '@/components/SubjectEditor/SubjectEditor.vue';
+import SubjectViolationBanners from '@/components/common/SubjectViolationBanners.vue';
 import SchemaCreator from '@/components/SchemaCreator/SchemaCreator.vue';
 import type { SchemaCreatorExposes } from '@/components/SchemaCreator/SchemaCreator.vue';
 import SummaryAction from '@/components/common/SummaryAction.vue';
@@ -317,10 +305,6 @@ const anchorlessViolations = computed<SubjectViolation[]>( () => {
 		return !renderedPropertyNames.has( v.propertyName );
 	} );
 } );
-
-function formatViolationMessage( v: SubjectViolation ): string {
-	return mw.message( `neowiki-field-${ v.code }`, ...( v.args as string[] ) ).text();
-}
 
 function handleClearViolation( payload: { propertyName: string; valuePartIndex: number | null } ): void {
 	serverViolations.value = serverViolations.value.filter(

--- a/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
@@ -91,19 +91,7 @@
 				</template>
 			</CdxField>
 
-			<CdxMessage
-				v-if="anchorlessViolations.length > 0"
-				type="error"
-			>
-				<ul class="ext-neowiki-subject-editor__form-errors">
-					<li
-						v-for="( v, idx ) in anchorlessViolations"
-						:key="idx"
-					>
-						{{ formatViolationMessage( v ) }}
-					</li>
-				</ul>
-			</CdxMessage>
+			<SubjectViolationBanners :violations="anchorlessViolations" />
 
 			<SubjectEditor
 				v-if="statements"
@@ -172,8 +160,8 @@ import { StatementList } from '@/domain/StatementList.ts';
 import { defaultSubjectLabel } from '@/domain/defaultSubjectLabel.ts';
 import { withoutMissingValueViolations, type SubjectViolation } from '@/domain/SubjectViolation';
 import { ValidationFailedError } from '@/persistence/ValidationFailedError';
-import { CdxMessage } from '@wikimedia/codex';
 import SubjectEditor from '@/components/SubjectEditor/SubjectEditor.vue';
+import SubjectViolationBanners from '@/components/common/SubjectViolationBanners.vue';
 import SchemaCreator from '@/components/SchemaCreator/SchemaCreator.vue';
 import type { SchemaCreatorExposes } from '@/components/SchemaCreator/SchemaCreator.vue';
 import SummaryAction from '@/components/common/SummaryAction.vue';
@@ -318,10 +306,6 @@ const anchorlessViolations = computed<SubjectViolation[]>( () => {
 		return !renderedPropertyNames.has( v.propertyName );
 	} );
 } );
-
-function formatViolationMessage( v: SubjectViolation ): string {
-	return mw.message( `neowiki-field-${ v.code }`, ...( v.args as string[] ) ).text();
-}
 
 function handleClearViolation( payload: { propertyName: string; valuePartIndex: number | null } ): void {
 	serverViolations.value = serverViolations.value.filter(

--- a/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditorDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditorDialog.vue
@@ -63,19 +63,7 @@
 				</CdxButton>
 			</template>
 
-			<CdxMessage
-				v-if="anchorlessViolations.length > 0"
-				type="error"
-			>
-				<ul class="ext-neowiki-subject-editor__form-errors">
-					<li
-						v-for="( v, idx ) in anchorlessViolations"
-						:key="idx"
-					>
-						{{ formatViolationMessage( v ) }}
-					</li>
-				</ul>
-			</CdxMessage>
+			<SubjectViolationBanners :violations="anchorlessViolations" />
 
 			<SubjectEditor
 				ref="subjectEditorRef"
@@ -117,9 +105,10 @@
 <script setup lang="ts">
 import { ref, shallowRef, nextTick, computed, watch } from 'vue';
 import SubjectEditor from '@/components/SubjectEditor/SubjectEditor.vue';
+import SubjectViolationBanners from '@/components/common/SubjectViolationBanners.vue';
 import SummaryAction from '@/components/common/SummaryAction.vue';
 import I18nSlot from '@/components/common/I18nSlot.vue';
-import { CdxButton, CdxDialog, CdxIcon, CdxMessage } from '@wikimedia/codex';
+import { CdxButton, CdxDialog, CdxIcon } from '@wikimedia/codex';
 import EditableText from '@/components/common/EditableText.vue';
 import { cdxIconClose } from '@wikimedia/codex-icons';
 import { StatementList } from '@/domain/StatementList.ts';
@@ -241,6 +230,8 @@ const anchorlessViolations = computed<SubjectViolation[]>( () => {
 	} );
 } );
 
+// The label violation renders in the header rather than in a banner, so it is
+// formatted here. It is always an error, so it carries no severity styling.
 function formatViolationMessage( v: SubjectViolation ): string {
 	return mw.message( `neowiki-field-${ v.code }`, ...( v.args as string[] ) ).text();
 }

--- a/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditorDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditorDialog.vue
@@ -47,19 +47,7 @@
 				</CdxButton>
 			</template>
 
-			<CdxMessage
-				v-if="anchorlessViolations.length > 0"
-				type="error"
-			>
-				<ul class="ext-neowiki-subject-editor__form-errors">
-					<li
-						v-for="( v, idx ) in anchorlessViolations"
-						:key="idx"
-					>
-						{{ formatViolationMessage( v ) }}
-					</li>
-				</ul>
-			</CdxMessage>
+			<SubjectViolationBanners :violations="anchorlessViolations" />
 
 			<SubjectEditor
 				ref="subjectEditorRef"
@@ -101,9 +89,10 @@
 <script setup lang="ts">
 import { ref, shallowRef, nextTick, computed, watch } from 'vue';
 import SubjectEditor from '@/components/SubjectEditor/SubjectEditor.vue';
+import SubjectViolationBanners from '@/components/common/SubjectViolationBanners.vue';
 import SummaryAction from '@/components/common/SummaryAction.vue';
 import I18nSlot from '@/components/common/I18nSlot.vue';
-import { CdxButton, CdxDialog, CdxIcon, CdxMessage } from '@wikimedia/codex';
+import { CdxButton, CdxDialog, CdxIcon } from '@wikimedia/codex';
 import { cdxIconClose } from '@wikimedia/codex-icons';
 import { StatementList } from '@/domain/StatementList.ts';
 import { Subject } from '@/domain/Subject.ts';
@@ -205,10 +194,6 @@ const anchorlessViolations = computed<SubjectViolation[]>( () => {
 		return !renderedPropertyNames.has( v.propertyName );
 	} );
 } );
-
-function formatViolationMessage( v: SubjectViolation ): string {
-	return mw.message( `neowiki-field-${ v.code }`, ...( v.args as string[] ) ).text();
-}
 
 function handleClearViolation( payload: { propertyName: string; valuePartIndex: number | null } ): void {
 	serverViolations.value = serverViolations.value.filter(

--- a/resources/ext.neowiki/src/components/Value/BooleanInput.vue
+++ b/resources/ext.neowiki/src/components/Value/BooleanInput.vue
@@ -1,7 +1,7 @@
 <template>
 	<CdxField
-		:status="validationError === null ? 'default' : 'error'"
-		:messages="validationError === null ? {} : { error: validationError }"
+		:status="validationStatus"
+		:messages="validationMessages"
 		:hide-label="!showFieldHeading"
 	>
 		<template
@@ -49,7 +49,7 @@ const props = withDefaults(
 
 const emit = defineEmits<ValueInputEmits>();
 
-const { validationError, clearServerViolation } = useFieldServerViolation(
+const { validationMessages, validationStatus, clearServerViolation } = useFieldServerViolation(
 	toRef( props, 'property' ),
 	toRef( props, 'serverViolations' ),
 	emit

--- a/resources/ext.neowiki/src/components/Value/DateInput.vue
+++ b/resources/ext.neowiki/src/components/Value/DateInput.vue
@@ -1,7 +1,7 @@
 <template>
 	<CdxField
-		:status="validationError === null ? 'default' : 'error'"
-		:messages="validationError === null ? {} : { error: validationError }"
+		:status="validationStatus"
+		:messages="validationMessages"
 		:optional="props.property.required === false"
 	>
 		<template #label>
@@ -49,7 +49,7 @@ const props = withDefaults(
 
 const emit = defineEmits<ValueInputEmits>();
 
-const { validationError, clearServerViolation } = useFieldServerViolation(
+const { validationMessages, validationStatus, clearServerViolation } = useFieldServerViolation(
 	toRef( props, 'property' ),
 	toRef( props, 'serverViolations' ),
 	emit,

--- a/resources/ext.neowiki/src/components/Value/DateTimeInput.vue
+++ b/resources/ext.neowiki/src/components/Value/DateTimeInput.vue
@@ -1,7 +1,7 @@
 <template>
 	<CdxField
-		:status="validationError === null ? 'default' : 'error'"
-		:messages="validationError === null ? {} : { error: validationError }"
+		:status="validationStatus"
+		:messages="validationMessages"
 		:optional="props.property.required === false"
 	>
 		<template #label>
@@ -49,7 +49,7 @@ const props = withDefaults(
 
 const emit = defineEmits<ValueInputEmits>();
 
-const { validationError, clearServerViolation } = useFieldServerViolation(
+const { validationMessages, validationStatus, clearServerViolation } = useFieldServerViolation(
 	toRef( props, 'property' ),
 	toRef( props, 'serverViolations' ),
 	emit,

--- a/resources/ext.neowiki/src/components/Value/NumberInput.vue
+++ b/resources/ext.neowiki/src/components/Value/NumberInput.vue
@@ -1,7 +1,7 @@
 <template>
 	<CdxField
-		:status="validationError === null ? 'default' : 'error'"
-		:messages="validationError === null ? {} : { error: validationError }"
+		:status="validationStatus"
+		:messages="validationMessages"
 		:optional="props.property.required === false"
 	>
 		<template #label>
@@ -49,7 +49,7 @@ const startIcon = NeoWikiServices.getComponentRegistry().getIcon( NumberType.typ
 
 const emit = defineEmits<ValueInputEmits>();
 
-const { validationError, clearServerViolation } = useFieldServerViolation(
+const { validationMessages, validationStatus, clearServerViolation } = useFieldServerViolation(
 	toRef( props, 'property' ),
 	toRef( props, 'serverViolations' ),
 	emit

--- a/resources/ext.neowiki/src/components/Value/RelationInput.vue
+++ b/resources/ext.neowiki/src/components/Value/RelationInput.vue
@@ -56,7 +56,7 @@ import { ValueInputEmits, ValueInputProps, ValueInputExposes } from '@/component
 import { RelationProperty, RelationType } from '@/domain/propertyTypes/Relation.ts';
 import { Value, ValueType, RelationValue, newRelation, relationValuesHaveSameTargets } from '@/domain/Value';
 import { NeoWikiServices } from '@/NeoWikiServices.ts';
-import { useServerViolations } from '@/composables/useServerViolations.ts';
+import { useServerViolations, violationStatus } from '@/composables/useServerViolations.ts';
 
 const props = withDefaults(
 	defineProps<ValueInputProps<RelationProperty>>(),
@@ -73,25 +73,25 @@ const emit = defineEmits<ValueInputEmits>();
 const internalValue = ref<RelationValue | undefined>( undefined );
 const singleHasUnmatchedText = ref( false );
 
-const { firstMessage, emitClears } = useServerViolations(
+const { firstMessages, emitClears } = useServerViolations(
 	toRef( props, 'property' ),
 	toRef( props, 'serverViolations' ),
 	emit
 );
 
-// One aggregate error for the whole property (NeoMultiLookupInput has no per-index slot).
+// One aggregate message for the whole property (NeoMultiLookupInput has no per-index slot).
 const displayedFieldMessages = computed( (): ValidationMessages => {
-	if ( singleHasUnmatchedText.value || firstMessage.value === null ) {
+	if ( singleHasUnmatchedText.value ) {
 		return {};
 	}
-	return { error: firstMessage.value };
+	return firstMessages.value;
 } );
 
-const fieldStatus = computed( (): 'error' | 'default' => {
+const fieldStatus = computed( (): 'default' | 'error' | 'warning' => {
 	if ( props.property.multiple || singleHasUnmatchedText.value ) {
 		return 'default';
 	}
-	return displayedFieldMessages.value.error !== undefined ? 'error' : 'default';
+	return violationStatus( displayedFieldMessages.value );
 } );
 
 function initializeInternalValue( value: Value | undefined ): void {

--- a/resources/ext.neowiki/src/components/Value/SelectInput.vue
+++ b/resources/ext.neowiki/src/components/Value/SelectInput.vue
@@ -1,7 +1,7 @@
 <template>
 	<CdxField
-		:status="validationError === null ? 'default' : 'error'"
-		:messages="validationError === null ? {} : { error: validationError }"
+		:status="violationStatus( validationMessages )"
+		:messages="validationMessages"
 		:optional="props.property.required === false"
 	>
 		<template #label>
@@ -49,7 +49,7 @@ import { cdxIconInfo } from '@wikimedia/codex-icons';
 import { newStringValue, StringValue, ValueType } from '@/domain/Value';
 import { resolveSelectLabel, SelectProperty } from '@/domain/propertyTypes/Select.ts';
 import { ValueInputEmits, ValueInputExposes, ValueInputProps } from '@/components/Value/ValueInputContract.ts';
-import { useServerViolations } from '@/composables/useServerViolations.ts';
+import { useServerViolations, violationStatus } from '@/composables/useServerViolations.ts';
 
 const props = withDefaults(
 	defineProps<ValueInputProps<SelectProperty>>(),
@@ -61,9 +61,10 @@ const props = withDefaults(
 
 const emit = defineEmits<ValueInputEmits>();
 
-// For Select (single and multi) the field shows one aggregate error — the first
-// relevant server violation — so an edit clears every held violation ('all').
-const { firstMessage: validationError, emitClears } = useServerViolations(
+// For Select (single and multi) the field shows one aggregate message — the first
+// relevant server violation, keyed by its severity — so an edit clears every held
+// violation ('all').
+const { firstMessages: validationMessages, emitClears } = useServerViolations(
 	toRef( props, 'property' ),
 	toRef( props, 'serverViolations' ),
 	emit

--- a/resources/ext.neowiki/src/components/Value/TextInput.vue
+++ b/resources/ext.neowiki/src/components/Value/TextInput.vue
@@ -2,7 +2,7 @@
 	<CdxField
 		:is-fieldset="true"
 		:messages="fieldMessages"
-		:status="fieldMessages.error && !props.property.multiple ? 'error' : 'default'"
+		:status="props.property.multiple ? 'default' : violationStatus( fieldMessages )"
 		:optional="props.property.required === false"
 	>
 		<template #label>
@@ -40,6 +40,7 @@ import NeoMultiTextInput from '@/components/common/NeoMultiTextInput.vue';
 import { TextProperty, TextType } from '@/domain/propertyTypes/Text.ts';
 import { ValueInputEmits, ValueInputExposes, ValueInputProps } from '@/components/Value/ValueInputContract';
 import { useStringValueInput } from '@/composables/useStringValueInput.ts';
+import { violationStatus } from '@/composables/useServerViolations.ts';
 import { NeoWikiServices } from '@/NeoWikiServices.ts';
 const props = withDefaults(
 	defineProps<ValueInputProps<TextProperty>>(),

--- a/resources/ext.neowiki/src/components/Value/UrlInput.vue
+++ b/resources/ext.neowiki/src/components/Value/UrlInput.vue
@@ -2,7 +2,7 @@
 	<CdxField
 		:is-fieldset="true"
 		:messages="fieldMessages"
-		:status="fieldMessages.error && !props.property.multiple ? 'error' : 'default'"
+		:status="props.property.multiple ? 'default' : violationStatus( fieldMessages )"
 		:optional="props.property.required === false"
 	>
 		<template #label>
@@ -40,6 +40,7 @@ import NeoMultiTextInput from '@/components/common/NeoMultiTextInput.vue';
 import { UrlProperty, UrlType } from '@/domain/propertyTypes/Url.ts';
 import { ValueInputEmits, ValueInputExposes, ValueInputProps } from '@/components/Value/ValueInputContract';
 import { useStringValueInput } from '@/composables/useStringValueInput.ts';
+import { violationStatus } from '@/composables/useServerViolations.ts';
 import { NeoWikiServices } from '@/NeoWikiServices.ts';
 const props = withDefaults(
 	defineProps<ValueInputProps<UrlProperty>>(),

--- a/resources/ext.neowiki/src/components/common/SubjectViolationBanners.vue
+++ b/resources/ext.neowiki/src/components/common/SubjectViolationBanners.vue
@@ -1,0 +1,53 @@
+<!-- eslint-disable vue/no-multiple-template-root -->
+<template>
+	<CdxMessage
+		v-if="errors.length > 0"
+		type="error"
+	>
+		<ul class="ext-neowiki-violation-banners__list">
+			<li
+				v-for="( violation, index ) in errors"
+				:key="index"
+			>
+				{{ format( violation ) }}
+			</li>
+		</ul>
+	</CdxMessage>
+
+	<CdxMessage
+		v-if="warnings.length > 0"
+		type="warning"
+	>
+		<ul class="ext-neowiki-violation-banners__list">
+			<li
+				v-for="( violation, index ) in warnings"
+				:key="index"
+			>
+				{{ format( violation ) }}
+			</li>
+		</ul>
+	</CdxMessage>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { CdxMessage } from '@wikimedia/codex';
+import type { SubjectViolation } from '@/domain/SubjectViolation';
+
+/**
+ * The aggregate banners of the subject dialogs: violations that no rendered
+ * field displays (subject-level ones, and ones on properties missing from the
+ * Schema), split into an error banner and a warning banner so an advisory
+ * finding does not read as a blocker.
+ */
+const props = defineProps<{
+	violations: readonly SubjectViolation[];
+}>();
+
+const errors = computed( () => props.violations.filter( ( v ) => v.severity === 'error' ) );
+const warnings = computed( () => props.violations.filter( ( v ) => v.severity === 'warning' ) );
+
+function format( violation: SubjectViolation ): string {
+	return mw.message( `neowiki-field-${ violation.code }`, ...( violation.args as string[] ) ).text();
+}
+</script>

--- a/resources/ext.neowiki/src/composables/useFieldServerViolation.ts
+++ b/resources/ext.neowiki/src/composables/useFieldServerViolation.ts
@@ -1,11 +1,13 @@
-import { ComputedRef, Ref } from 'vue';
+import { computed, ComputedRef, Ref } from 'vue';
+import { ValidationMessages } from '@wikimedia/codex';
 import { SubjectViolation } from '@/domain/SubjectViolation.ts';
 import { PropertyDefinition } from '@/domain/PropertyDefinition.ts';
 import { ValueInputEmitFunction } from '@/components/Value/ValueInputContract.ts';
-import { useServerViolations } from '@/composables/useServerViolations.ts';
+import { useServerViolations, violationStatus } from '@/composables/useServerViolations.ts';
 
 interface FieldServerViolation {
-	validationError: ComputedRef<string | null>;
+	validationMessages: ComputedRef<ValidationMessages>;
+	validationStatus: ComputedRef<'default' | 'error' | 'warning'>;
 	clearServerViolation: () => void;
 }
 
@@ -13,9 +15,9 @@ interface FieldServerViolation {
  * Field-level server-violation handling for the single-value inputs (Boolean,
  * Number, Date, DateTime). A thin adapter over useServerViolations: these
  * inputs have no per-part slot, so only the field-level violation (valuePartIndex
- * null/undefined) is displayed, and clearing passes an empty touched-index set
- * so exactly that violation is dropped — a per-index violation is neither shown
- * nor cleared here.
+ * null/undefined) is displayed — keyed by its severity, with the matching Codex
+ * status — and clearing passes an empty touched-index set so exactly that
+ * violation is dropped. A per-index violation is neither shown nor cleared here.
  *
  * @param property The field's Property Definition; violations are matched on its name.
  * @param serverViolations The violations passed to this input.
@@ -28,10 +30,11 @@ export function useFieldServerViolation<P extends PropertyDefinition>(
 	emit: ValueInputEmitFunction,
 	formatArg: ( arg: string ) => string = ( arg ) => arg,
 ): FieldServerViolation {
-	const { fieldLevelMessage, emitClears } = useServerViolations( property, serverViolations, emit, formatArg );
+	const { fieldLevelMessages, emitClears } = useServerViolations( property, serverViolations, emit, formatArg );
 
 	return {
-		validationError: fieldLevelMessage,
+		validationMessages: fieldLevelMessages,
+		validationStatus: computed( () => violationStatus( fieldLevelMessages.value ) ),
 		clearServerViolation: () => emitClears( [] ),
 	};
 }

--- a/resources/ext.neowiki/src/composables/useServerViolations.ts
+++ b/resources/ext.neowiki/src/composables/useServerViolations.ts
@@ -1,4 +1,5 @@
 import { computed, ComputedRef, Ref } from 'vue';
+import { ValidationMessages } from '@wikimedia/codex';
 import { SubjectViolation } from '@/domain/SubjectViolation.ts';
 import { PropertyDefinition } from '@/domain/PropertyDefinition.ts';
 import { ValueInputEmitFunction } from '@/components/Value/ValueInputContract.ts';
@@ -20,13 +21,39 @@ export type ClearScope = 'all' | readonly number[];
 export interface UseServerViolationsReturn {
 	relevant: () => readonly SubjectViolation[];
 	format: ( violation: SubjectViolation ) => string;
-	firstMessage: ComputedRef<string | null>;
-	fieldLevelMessage: ComputedRef<string | null>;
+	firstMessages: ComputedRef<ValidationMessages>;
+	fieldLevelMessages: ComputedRef<ValidationMessages>;
 	emitClears: ( touched: ClearScope ) => void;
 }
 
 function isFieldLevel( violation: SubjectViolation ): boolean {
 	return violation.valuePartIndex === null || violation.valuePartIndex === undefined;
+}
+
+/**
+ * The violation to display when several compete for one slot: the first error,
+ * so a blocker is never masked by an earlier advisory warning, else the first
+ * violation. The backend does not order violations by severity.
+ */
+export function preferErrorViolation(
+	violations: readonly SubjectViolation[],
+): SubjectViolation | undefined {
+	return violations.find( ( v ) => v.severity === 'error' ) ?? violations[ 0 ];
+}
+
+/**
+ * The Codex Field/input `status` matching a violation-messages object. CdxField
+ * only renders the message whose key equals the current status, so the two must
+ * be derived together. Error wins when both severities carry a message.
+ */
+export function violationStatus( messages: ValidationMessages ): 'default' | 'error' | 'warning' {
+	if ( messages.error !== undefined ) {
+		return 'error';
+	}
+	if ( messages.warning !== undefined ) {
+		return 'warning';
+	}
+	return 'default';
 }
 
 /**
@@ -68,15 +95,17 @@ export function useServerViolations<P extends PropertyDefinition>(
 		).text();
 	}
 
-	const firstMessage = computed<string | null>( () => {
-		const hit = relevant()[ 0 ];
-		return hit ? format( hit ) : null;
-	} );
+	function toMessages( hit: SubjectViolation | undefined ): ValidationMessages {
+		return hit ? { [ hit.severity ]: format( hit ) } : {};
+	}
 
-	const fieldLevelMessage = computed<string | null>( () => {
-		const hit = relevant().find( isFieldLevel );
-		return hit ? format( hit ) : null;
-	} );
+	const firstMessages = computed<ValidationMessages>(
+		() => toMessages( preferErrorViolation( relevant() ) ),
+	);
+
+	const fieldLevelMessages = computed<ValidationMessages>(
+		() => toMessages( preferErrorViolation( relevant().filter( isFieldLevel ) ) ),
+	);
 
 	function emitClears( touched: ClearScope ): void {
 		const held = relevant();
@@ -99,5 +128,5 @@ export function useServerViolations<P extends PropertyDefinition>(
 		}
 	}
 
-	return { relevant, format, firstMessage, fieldLevelMessage, emitClears };
+	return { relevant, format, firstMessages, fieldLevelMessages, emitClears };
 }

--- a/resources/ext.neowiki/src/composables/useStringValueInput.ts
+++ b/resources/ext.neowiki/src/composables/useStringValueInput.ts
@@ -8,7 +8,7 @@ import { PropertyType } from '@/domain/PropertyType.ts';
 import { NeoWikiServices } from '@/NeoWikiServices.ts';
 import { SubjectViolation } from '@/domain/SubjectViolation.ts';
 import { ValueInputEmitFunction } from '@/components/Value/ValueInputContract.ts';
-import { useServerViolations } from '@/composables/useServerViolations.ts';
+import { preferErrorViolation, useServerViolations } from '@/composables/useServerViolations.ts';
 
 interface UseStringValueInputReturn {
 	displayValues: ComputedRef<string[]>;
@@ -65,17 +65,17 @@ export function useStringValueInput<P extends MultiStringProperty>(
 
 	function mergeServerIntoInputMessages( baseMessages: ValidationMessages[] ): ValidationMessages[] {
 		const merged = [ ...baseMessages ];
+		const perIndex = new Map<number, SubjectViolation[]>();
 		for ( const v of relevant() ) {
-			if ( typeof v.valuePartIndex !== 'number' ) {
-				continue;
+			if ( typeof v.valuePartIndex === 'number' && v.valuePartIndex >= 0 && v.valuePartIndex < merged.length ) {
+				perIndex.set( v.valuePartIndex, [ ...( perIndex.get( v.valuePartIndex ) ?? [] ), v ] );
 			}
-			const i = v.valuePartIndex;
-			if ( i < 0 || i >= merged.length ) {
-				continue;
-			}
+		}
+		for ( const [ i, violations ] of perIndex ) {
 			const existing = merged[ i ];
-			if ( !existing || Object.keys( existing ).length === 0 ) {
-				merged[ i ] = { error: format( v ) };
+			const hit = preferErrorViolation( violations );
+			if ( hit && ( !existing || Object.keys( existing ).length === 0 ) ) {
+				merged[ i ] = { [ hit.severity ]: format( hit ) };
 			}
 		}
 		return merged;
@@ -86,15 +86,15 @@ export function useStringValueInput<P extends MultiStringProperty>(
 		// per-input slot to attach to, so we surface it through the field-level
 		// summary regardless of multi/single — otherwise something like a
 		// "required" violation on a multi-value property would silently vanish.
-		const fieldLevel = relevant().find(
+		const fieldLevel = preferErrorViolation( relevant().filter(
 			( v ) => v.valuePartIndex === null || v.valuePartIndex === undefined,
-		);
+		) );
 
 		if ( property.value.multiple ) {
 			// For multi: per-input server violations stay in their slots; only a
 			// server-sourced field-level violation surfaces in the summary slot.
 			if ( fieldLevel ) {
-				return { error: format( fieldLevel ) };
+				return { [ fieldLevel.severity ]: format( fieldLevel ) };
 			}
 			return {};
 		}
@@ -107,7 +107,7 @@ export function useStringValueInput<P extends MultiStringProperty>(
 		}
 
 		if ( fieldLevel ) {
-			return { error: format( fieldLevel ) };
+			return { [ fieldLevel.severity ]: format( fieldLevel ) };
 		}
 
 		return {};

--- a/resources/ext.neowiki/src/domain/PropertyDefinition.ts
+++ b/resources/ext.neowiki/src/domain/PropertyDefinition.ts
@@ -1,5 +1,7 @@
 import { Neo } from '@/Neo';
 import { PropertyTypeRegistry } from '@/domain/PropertyType';
+import type { Severity } from '@/domain/Severity';
+import { extractSeverities } from '@/domain/SeverityNormalizer';
 import { Value } from '@/domain/Value';
 import { ValueDeserializer } from '@/persistence/ValueDeserializer';
 
@@ -37,6 +39,14 @@ export interface PropertyDefinition {
 	readonly required: boolean;
 	readonly default?: Value;
 
+	/**
+	 * Severity per Constraint name for Constraints written in the object form
+	 * (ADR 26). Absent means every Constraint has the default `warning` severity;
+	 * the map is only set when at least one Constraint is annotated, so shorthand
+	 * Schemas produce domain objects identical to factory-built ones.
+	 */
+	readonly constraintSeverities?: Readonly<Record<string, Severity>>;
+
 }
 
 export interface MultiStringProperty extends PropertyDefinition {
@@ -61,25 +71,40 @@ export class PropertyDefinitionDeserializer {
 	) {}
 
 	public propertyDefinitionFromJson( name: string | PropertyName, json: any ): PropertyDefinition {
+		const [ values, severities ] = extractSeverities( json );
+
+		// Severity is a Constraint concept. Display Attributes are explicitly not
+		// Constraints (they are overridable per Layout), so a severity on one is
+		// meaningless. Drop it: left in the map it would make serialization re-emit
+		// the attribute in object form and break every consumer reading a scalar.
+		if ( this.registry.hasType( json.type ) ) {
+			for ( const attribute of this.registry.getType( json.type ).getDisplayAttributeNames() ) {
+				delete severities[ attribute ];
+			}
+		}
+
 		const base: PropertyDefinition = {
 			name: typeof name === 'string' ? new PropertyName( name ) : name,
 			type: json.type as string,
-			description: json.description ?? '',
-			required: json.required ?? false,
-			default: json.default !== undefined && json.default !== null ?
-				this.valueDeserializer.deserialize( json.default, json.type ) :
+			description: values.description as string ?? '',
+			required: values.required as boolean ?? false,
+			default: values.default !== undefined && values.default !== null ?
+				this.valueDeserializer.deserialize( values.default, json.type ) :
 				undefined,
+			...( Object.keys( severities ).length > 0 ? { constraintSeverities: severities } : {} ),
 		};
 
 		// A type owned by a disabled or failed extension is not registered. Degrade
 		// to the base definition so the rest of the Schema still loads and renders.
 		// Retain the original type-specific keys (constraints, display attributes)
-		// so they are not silently dropped when the Schema is later re-saved.
+		// so they are not silently dropped when the Schema is later re-saved. The
+		// normalized values (not the raw JSON) are spread so serialization re-wraps
+		// every annotated key through the same applySeverities path.
 		if ( !this.registry.hasType( json.type ) ) {
-			return { ...json, ...base };
+			return { ...values, ...base };
 		}
 
-		return this.registry.getType( json.type ).createPropertyDefinitionFromJson( base, json );
+		return this.registry.getType( json.type ).createPropertyDefinitionFromJson( base, values );
 	}
 
 }

--- a/resources/ext.neowiki/src/domain/Severity.ts
+++ b/resources/ext.neowiki/src/domain/Severity.ts
@@ -1,0 +1,10 @@
+/**
+ * Validation severity of a Constraint or a violation (ADR 26). Mirror of the
+ * backend's Severity enum (src/Domain/Validation/Severity.php). `warning` is
+ * the default everywhere a severity can be omitted.
+ */
+export type Severity = 'error' | 'warning';
+
+export function isSeverity( value: unknown ): value is Severity {
+	return value === 'error' || value === 'warning';
+}

--- a/resources/ext.neowiki/src/domain/SeverityNormalizer.ts
+++ b/resources/ext.neowiki/src/domain/SeverityNormalizer.ts
@@ -1,0 +1,91 @@
+import { isSeverity, type Severity } from '@/domain/Severity';
+
+/**
+ * Parses and serializes the two Schema-JSON forms a Constraint can take (ADR 26):
+ * a bare scalar/array (default `warning` severity) or an object `{ value, severity }`
+ * (booleans drop `value` and imply `true`; `options` carries the array in `value`).
+ * Mirror of the backend's SeverityNormalizer (src/Domain/Validation/SeverityNormalizer.php).
+ *
+ * A value is treated as object-form iff it is an object carrying a `severity` key.
+ * This is intentionally permissive: being type-agnostic is what lets a custom
+ * Property Type's own Constraint keys round-trip without any core change.
+ */
+
+/** Core keys handled outside the Constraint model; never severity-bearing. */
+const RESERVED = [ 'type', 'description', 'default' ];
+
+/**
+ * The core boolean Constraints, whose object form carries no `value` key (see
+ * docs/api/schema-format.md): `false` is representable only as the bare scalar.
+ */
+const VALUE_LESS_BOOLEAN_CONSTRAINTS = [ 'required', 'uniqueItems' ];
+
+/**
+ * Returns the property JSON with object-form Constraints unwrapped to their
+ * bare values, together with the name-to-severity map extracted from them.
+ */
+export function extractSeverities(
+	property: Record<string, unknown>,
+): [ Record<string, unknown>, Record<string, Severity> ] {
+	const values: Record<string, unknown> = { ...property };
+	const severities: Record<string, Severity> = {};
+
+	for ( const [ key, raw ] of Object.entries( property ) ) {
+		if ( RESERVED.includes( key ) ) {
+			continue;
+		}
+		if ( typeof raw !== 'object' || raw === null || !( 'severity' in raw ) ) {
+			continue;
+		}
+
+		const { severity } = raw as { severity: unknown };
+		if ( !isSeverity( severity ) ) {
+			throw new Error( 'Invalid severity: ' + JSON.stringify( severity ) );
+		}
+
+		// 'value' in raw, not ??: an explicit "value": null must stay null (the
+		// boolean object form is the one that legitimately omits the key). Only the
+		// custom keys of unregistered types actually round-trip such a null — the
+		// registered type parsers normalize null bounds to undefined, dropping the
+		// key and its annotation on re-save.
+		values[ key ] = 'value' in raw ? ( raw as { value: unknown } ).value : true;
+		severities[ key ] = severity;
+	}
+
+	return [ values, severities ];
+}
+
+/**
+ * Canonical output: re-wrap only `error`-annotated (present) keys; `warning` is the
+ * default and emits as shorthand, so unannotated Schemas round-trip byte-for-byte.
+ */
+export function applySeverities(
+	json: Record<string, unknown>,
+	severities: Readonly<Record<string, Severity>>,
+): Record<string, unknown> {
+	const result = { ...json };
+
+	for ( const [ key, severity ] of Object.entries( severities ) ) {
+		if ( severity === 'warning' || result[ key ] === undefined ) {
+			continue;
+		}
+
+		// Unchecking an annotated required/uniqueItems in the schema editor leaves
+		// the severity entry behind on a now-false value. Their object form cannot
+		// carry false, so drop the annotation rather than emit a form the backend
+		// rejects. The PHP mirror has no such branch: only the editor can create
+		// this state, since authoring-time validation forbids it in stored JSON.
+		if ( result[ key ] === false && VALUE_LESS_BOOLEAN_CONSTRAINTS.includes( key ) ) {
+			continue;
+		}
+
+		// Only `true` may drop the value key: extractSeverities reads the value-less
+		// form as true, so emitting it for `false` would flip a Constraint the author
+		// disabled.
+		result[ key ] = result[ key ] === true ?
+			{ severity } :
+			{ value: result[ key ], severity };
+	}
+
+	return result;
+}

--- a/resources/ext.neowiki/src/domain/SubjectViolation.ts
+++ b/resources/ext.neowiki/src/domain/SubjectViolation.ts
@@ -1,3 +1,5 @@
+import type { Severity } from '@/domain/Severity';
+
 /**
  * Frontend mirror of the backend's Violation wire shape (see
  * src/Domain/Validation/Violation.php). Read from the backend by the
@@ -11,11 +13,15 @@
  * single-value properties. For per-value violations on multi-value
  * properties (e.g. one bad URL among many), it identifies which entry
  * in the multi-input is at fault.
+ *
+ * severity decides styling and blocking (ADR 26): an `error` can be rejected
+ * under enforcement, a `warning` never blocks and renders as advisory.
  */
 export interface SubjectViolation {
 	readonly propertyName: string | null;
 	readonly code: string;
 	readonly args: readonly unknown[];
+	readonly severity: Severity;
 	readonly valuePartIndex: number | null;
 }
 

--- a/resources/ext.neowiki/src/persistence/SchemaSerializer.ts
+++ b/resources/ext.neowiki/src/persistence/SchemaSerializer.ts
@@ -1,6 +1,7 @@
 import { Schema } from '@/domain/Schema';
 import { PropertyDefinitionList } from '@/domain/PropertyDefinitionList';
 import { PropertyDefinition } from '@/domain/PropertyDefinition';
+import { applySeverities } from '@/domain/SeverityNormalizer';
 import { valueToJson } from '@/domain/Value';
 
 export class SchemaSerializer {
@@ -25,10 +26,13 @@ export class SchemaSerializer {
 	}
 
 	private serializePropertyDefinition( property: PropertyDefinition ): any {
-		const { name, ...propertyWithoutName } = property;
-		return {
-			...propertyWithoutName,
-			default: property.default !== undefined ? valueToJson( property.default ) : undefined,
-		};
+		const { name, constraintSeverities, ...propertyWithoutName } = property;
+		return applySeverities(
+			{
+				...propertyWithoutName,
+				default: property.default !== undefined ? valueToJson( property.default ) : undefined,
+			},
+			constraintSeverities ?? {},
+		);
 	}
 }

--- a/resources/ext.neowiki/src/persistence/violationParsing.ts
+++ b/resources/ext.neowiki/src/persistence/violationParsing.ts
@@ -1,3 +1,4 @@
+import { isSeverity } from '@/domain/Severity';
 import type { SubjectViolation } from '@/domain/SubjectViolation';
 
 export function isShapedAsViolation( raw: unknown ): raw is SubjectViolation {
@@ -9,11 +10,12 @@ export function isShapedAsViolation( raw: unknown ): raw is SubjectViolation {
 	const propertyNameOk = v.propertyName === null || typeof v.propertyName === 'string';
 	const codeOk = typeof v.code === 'string' && v.code.length > 0;
 	const argsOk = v.args === undefined || Array.isArray( v.args );
+	const severityOk = v.severity === undefined || isSeverity( v.severity );
 	const indexOk = v.valuePartIndex === undefined ||
 		v.valuePartIndex === null ||
 		typeof v.valuePartIndex === 'number';
 
-	return propertyNameOk && codeOk && argsOk && indexOk;
+	return propertyNameOk && codeOk && argsOk && severityOk && indexOk;
 }
 
 export function parseViolations( body: unknown ): SubjectViolation[] | null {
@@ -31,6 +33,9 @@ export function parseViolations( body: unknown ): SubjectViolation[] | null {
 		propertyName: v.propertyName,
 		code: v.code,
 		args: v.args ?? [],
+		// Warning is the wire default (ADR 26): a legacy body without the field
+		// must render as advisory, not blocking.
+		severity: v.severity ?? 'warning',
 		valuePartIndex: v.valuePartIndex ?? null,
 	} ) );
 }

--- a/resources/ext.neowiki/src/public-api.ts
+++ b/resources/ext.neowiki/src/public-api.ts
@@ -43,6 +43,8 @@ export * from './domain/PropertyDefinitionList';
 export * from './domain/PropertyType';
 export * from './domain/PropertyTypeRegistration';
 export * from './domain/Schema';
+export * from './domain/Severity';
+export * from './domain/SeverityNormalizer';
 export * from './domain/Statement';
 export * from './domain/StatementList';
 export * from './domain/Subject';

--- a/resources/ext.neowiki/tests/components/SchemaEditor/PropertyDefinitionEditor.spec.ts
+++ b/resources/ext.neowiki/tests/components/SchemaEditor/PropertyDefinitionEditor.spec.ts
@@ -2,7 +2,8 @@ import { VueWrapper } from '@vue/test-utils';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { CdxSelect } from '@wikimedia/codex';
 import PropertyDefinitionEditor from '@/components/SchemaEditor/PropertyDefinitionEditor.vue';
-import { newTextProperty } from '@/domain/propertyTypes/Text';
+import { newTextProperty, TextProperty } from '@/domain/propertyTypes/Text';
+import TextAttributesEditor from '@/components/SchemaEditor/Property/TextAttributesEditor.vue';
 import { SelectProperty } from '@/domain/propertyTypes/Select';
 import { PropertyDefinition } from '@/domain/PropertyDefinition';
 import { newStringValue } from '@/domain/Value';
@@ -53,5 +54,29 @@ describe( 'PropertyDefinitionEditor', () => {
 		await changeTypeTo( wrapper, 'select' );
 
 		expect( lastEmittedProperty( wrapper ).default ).toBeUndefined();
+	} );
+
+	it( 'keeps Constraint severities when an attribute is edited', async () => {
+		const wrapper = newWrapper( {
+			...newTextProperty( { name: 'Status', minLength: 2 } ),
+			constraintSeverities: { minLength: 'error' },
+		} );
+
+		await wrapper.findComponent( TextAttributesEditor ).vm.$emit( 'update:property', { minLength: 5 } );
+
+		const property = lastEmittedProperty( wrapper ) as TextProperty;
+		expect( property.minLength ).toBe( 5 );
+		expect( property.constraintSeverities ).toEqual( { minLength: 'error' } );
+	} );
+
+	it( 'drops Constraint severities when the type changes, like the other Constraint fields', async () => {
+		const wrapper = newWrapper( {
+			...newTextProperty( { name: 'Status' } ),
+			constraintSeverities: { minLength: 'error' },
+		} );
+
+		await changeTypeTo( wrapper, 'select' );
+
+		expect( lastEmittedProperty( wrapper ).constraintSeverities ).toBeUndefined();
 	} );
 } );

--- a/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
@@ -975,6 +975,7 @@ describe( 'SubjectCreatorDialog', () => {
 			propertyName: 'Color',
 			code: 'required',
 			args: [],
+			severity: 'error',
 			valuePartIndex: null,
 		};
 
@@ -1013,6 +1014,22 @@ describe( 'SubjectCreatorDialog', () => {
 			expect( wrapper.findComponent( CdxDialog ).props( 'open' ) ).toBe( true );
 		} );
 
+		it( 'does not treat a warning-only dry-run result as blocking the save', async () => {
+			subjectStore.validateSubject = vi.fn().mockResolvedValue( [ {
+				propertyName: null,
+				code: 'schema-not-found',
+				args: [ 'Person' ],
+				severity: 'warning',
+				valuePartIndex: null,
+			} ] );
+			const wrapper = mountComponent();
+
+			await openSelectSchemaAndSave( wrapper );
+
+			expect( subjectStore.createMainSubject ).toHaveBeenCalledTimes( 1 );
+			expect( reloadMock ).toHaveBeenCalled();
+		} );
+
 		it( 'shows the validation-failed toast with the subject label', async () => {
 			subjectStore.createMainSubject = vi.fn().mockRejectedValue(
 				new ValidationFailedError( [ violation ] ),
@@ -1032,6 +1049,7 @@ describe( 'SubjectCreatorDialog', () => {
 				propertyName: null,
 				code: 'schema-not-found',
 				args: [ 'Person' ],
+				severity: 'error',
 				valuePartIndex: null,
 			};
 			subjectStore.createMainSubject = vi.fn().mockRejectedValue(
@@ -1113,6 +1131,7 @@ describe( 'SubjectCreatorDialog', () => {
 			propertyName: 'Color',
 			code: 'max-length',
 			args: [ 5 ],
+			severity: 'error',
 			valuePartIndex: null,
 		};
 
@@ -1155,8 +1174,8 @@ describe( 'SubjectCreatorDialog', () => {
 
 		it( 'does not surface missing-value violations (required, label-required) from the dry-run; they wait for save', async () => {
 			subjectStore.validateSubject = vi.fn().mockResolvedValue( [
-				{ propertyName: 'Color', code: 'required', args: [], valuePartIndex: null },
-				{ propertyName: null, code: 'label-required', args: [], valuePartIndex: null },
+				{ propertyName: 'Color', code: 'required', args: [], severity: 'error', valuePartIndex: null },
+				{ propertyName: null, code: 'label-required', args: [], severity: 'error', valuePartIndex: null },
 			] );
 			const wrapper = mountComponent();
 			await selectSchema( wrapper );

--- a/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
@@ -1020,6 +1020,7 @@ describe( 'SubjectCreatorDialog', () => {
 			propertyName: 'Color',
 			code: 'required',
 			args: [],
+			severity: 'error',
 			valuePartIndex: null,
 		};
 
@@ -1058,6 +1059,22 @@ describe( 'SubjectCreatorDialog', () => {
 			expect( wrapper.findComponent( CdxDialog ).props( 'open' ) ).toBe( true );
 		} );
 
+		it( 'does not treat a warning-only dry-run result as blocking the save', async () => {
+			subjectStore.validateSubject = vi.fn().mockResolvedValue( [ {
+				propertyName: null,
+				code: 'schema-not-found',
+				args: [ 'Person' ],
+				severity: 'warning',
+				valuePartIndex: null,
+			} ] );
+			const wrapper = mountComponent();
+
+			await openSelectSchemaAndSave( wrapper );
+
+			expect( subjectStore.createMainSubject ).toHaveBeenCalledTimes( 1 );
+			expect( reloadMock ).toHaveBeenCalled();
+		} );
+
 		it( 'shows the validation-failed toast with the subject label', async () => {
 			subjectStore.createMainSubject = vi.fn().mockRejectedValue(
 				new ValidationFailedError( [ violation ] ),
@@ -1077,6 +1094,7 @@ describe( 'SubjectCreatorDialog', () => {
 				propertyName: null,
 				code: 'schema-not-found',
 				args: [ 'Person' ],
+				severity: 'error',
 				valuePartIndex: null,
 			};
 			subjectStore.createMainSubject = vi.fn().mockRejectedValue(
@@ -1158,6 +1176,7 @@ describe( 'SubjectCreatorDialog', () => {
 			propertyName: 'Color',
 			code: 'max-length',
 			args: [ 5 ],
+			severity: 'error',
 			valuePartIndex: null,
 		};
 
@@ -1200,8 +1219,8 @@ describe( 'SubjectCreatorDialog', () => {
 
 		it( 'does not surface missing-value violations (required, label-required) from the dry-run; they wait for save', async () => {
 			subjectStore.validateSubject = vi.fn().mockResolvedValue( [
-				{ propertyName: 'Color', code: 'required', args: [], valuePartIndex: null },
-				{ propertyName: null, code: 'label-required', args: [], valuePartIndex: null },
+				{ propertyName: 'Color', code: 'required', args: [], severity: 'error', valuePartIndex: null },
+				{ propertyName: null, code: 'label-required', args: [], severity: 'error', valuePartIndex: null },
 			] );
 			const wrapper = mountComponent();
 			await selectSchema( wrapper );

--- a/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditorDialog.spec.ts
@@ -16,7 +16,7 @@ import SchemaEditorDialog from '@/components/SchemaEditor/SchemaEditorDialog.vue
 import SubjectEditor from '@/components/SubjectEditor/SubjectEditor.vue';
 import SummaryAction from '@/components/common/SummaryAction.vue';
 import CloseConfirmationDialog from '@/components/common/CloseConfirmationDialog.vue';
-import { CdxDialog } from '@wikimedia/codex';
+import { CdxDialog, CdxMessage } from '@wikimedia/codex';
 import { createI18nMock, setupMwMock } from '../../VueTestHelpers.ts';
 import { ValidationFailedError } from '@/persistence/ValidationFailedError';
 import type { SubjectViolation } from '@/domain/SubjectViolation';
@@ -334,6 +334,7 @@ describe( 'SubjectEditorDialog', () => {
 				propertyName: 'name',
 				code: 'required',
 				args: [],
+				severity: 'error',
 				valuePartIndex: null,
 			};
 			const onSave = vi.fn().mockRejectedValue( new ValidationFailedError( [ violation ] ) );
@@ -354,6 +355,7 @@ describe( 'SubjectEditorDialog', () => {
 				propertyName: 'name',
 				code: 'required',
 				args: [],
+				severity: 'error',
 				valuePartIndex: null,
 			};
 			const onSave = vi.fn().mockRejectedValue( new ValidationFailedError( [ violation ] ) );
@@ -371,6 +373,7 @@ describe( 'SubjectEditorDialog', () => {
 				propertyName: 'name',
 				code: 'required',
 				args: [],
+				severity: 'error',
 				valuePartIndex: null,
 			};
 			const onSave = vi.fn().mockRejectedValue( new ValidationFailedError( [ violation ] ) );
@@ -391,6 +394,7 @@ describe( 'SubjectEditorDialog', () => {
 				propertyName: null,
 				code: 'schema-not-found',
 				args: [ 'Person' ],
+				severity: 'error',
 				valuePartIndex: null,
 			};
 			const onSave = vi.fn().mockRejectedValue( new ValidationFailedError( [ violation ] ) );
@@ -400,11 +404,65 @@ describe( 'SubjectEditorDialog', () => {
 			await wrapper.findComponent( SummaryAction ).vm.$emit( 'save', '' );
 			await flushPromises();
 
-			expect( wrapper.find( '.ext-neowiki-subject-editor__form-errors' ).exists() ).toBe( true );
+			expect( wrapper.find( '.ext-neowiki-violation-banners__list' ).exists() ).toBe( true );
 
 			const passedViolations = wrapper.findComponent( SubjectEditor ).props( 'serverViolations' ) as SubjectViolation[];
 			expect( passedViolations ).toHaveLength( 1 );
 			expect( passedViolations[ 0 ].propertyName ).toBeNull();
+		} );
+
+		it( 'splits banner violations by severity into an error and a warning message', async () => {
+			// Anchored to a property the schema no longer has, so it lands in the
+			// banner: the other subject-level error, label-required, renders in
+			// the dialog header instead.
+			const errorViolation: SubjectViolation = {
+				propertyName: 'name',
+				code: 'type-mismatch',
+				args: [ 'text', 'number' ],
+				severity: 'error',
+				valuePartIndex: null,
+			};
+			const warningViolation: SubjectViolation = {
+				propertyName: null,
+				code: 'schema-not-found',
+				args: [ 'Person' ],
+				severity: 'warning',
+				valuePartIndex: null,
+			};
+			const onSave = vi.fn().mockRejectedValue(
+				new ValidationFailedError( [ warningViolation, errorViolation ] ),
+			);
+			const wrapper = mountComponent( true, validationTestStubs, onSave );
+			await flushPromises();
+
+			await wrapper.findComponent( SummaryAction ).vm.$emit( 'save', '' );
+			await flushPromises();
+
+			const banners = wrapper.findAllComponents( CdxMessage );
+			expect( banners ).toHaveLength( 2 );
+			expect( banners[ 0 ].props( 'type' ) ).toBe( 'error' );
+			expect( banners[ 0 ].text() ).toContain( 'neowiki-field-type-mismatch' );
+			expect( banners[ 1 ].props( 'type' ) ).toBe( 'warning' );
+			expect( banners[ 1 ].text() ).toContain( 'neowiki-field-schema-not-found' );
+		} );
+
+		it( 'does not treat a warning-only dry-run result as blocking the save', async () => {
+			useSubjectStore().validateSubjectUpdate = vi.fn().mockResolvedValue( [ {
+				propertyName: null,
+				code: 'schema-not-found',
+				args: [ 'Person' ],
+				severity: 'warning',
+				valuePartIndex: null,
+			} ] );
+			const onSave = vi.fn().mockResolvedValue( undefined );
+			const wrapper = mountComponent( true, validationTestStubs, onSave );
+			await flushPromises();
+
+			await wrapper.findComponent( SummaryAction ).vm.$emit( 'save', '' );
+			await flushPromises();
+
+			expect( onSave ).toHaveBeenCalledTimes( 1 );
+			expect( wrapper.emitted( 'update:open' )?.[ 0 ] ).toEqual( [ false ] );
 		} );
 
 		it( 'drops the matching entry on clear-server-violation event from child', async () => {
@@ -412,6 +470,7 @@ describe( 'SubjectEditorDialog', () => {
 				propertyName: 'name',
 				code: 'required',
 				args: [],
+				severity: 'error',
 				valuePartIndex: null,
 			};
 			const onSave = vi.fn().mockRejectedValue( new ValidationFailedError( [ violation ] ) );
@@ -456,6 +515,7 @@ describe( 'SubjectEditorDialog', () => {
 			propertyName: 'name',
 			code: 'max-length',
 			args: [ 5 ],
+			severity: 'error',
 			valuePartIndex: null,
 		};
 
@@ -512,7 +572,7 @@ describe( 'SubjectEditorDialog', () => {
 
 		it( 'surfaces required violations from the dry-run; an existing subject flags missing required', async () => {
 			const requiredViolation: SubjectViolation = {
-				propertyName: 'name', code: 'required', args: [], valuePartIndex: null,
+				propertyName: 'name', code: 'required', args: [], severity: 'error', valuePartIndex: null,
 			};
 			useSubjectStore().validateSubjectUpdate = vi.fn().mockResolvedValue( [ requiredViolation ] );
 			const wrapper = mountComponent( true, validationTestStubs );
@@ -528,7 +588,7 @@ describe( 'SubjectEditorDialog', () => {
 
 		it( 'validates on open so an existing subject\'s violations surface without an edit', async () => {
 			const existingViolation: SubjectViolation = {
-				propertyName: 'name', code: 'required', args: [], valuePartIndex: null,
+				propertyName: 'name', code: 'required', args: [], severity: 'error', valuePartIndex: null,
 			};
 			const validate = vi.fn().mockResolvedValue( [ existingViolation ] );
 			useSubjectStore().validateSubjectUpdate = validate;
@@ -626,7 +686,7 @@ describe( 'SubjectEditorDialog', () => {
 
 		it( 'points assistive technology at the label error', async () => {
 			const labelRequired: SubjectViolation = {
-				propertyName: null, code: 'label-required', args: [], valuePartIndex: null,
+				propertyName: null, code: 'label-required', args: [], severity: 'error', valuePartIndex: null,
 			};
 			useSubjectStore().validateSubjectUpdate = vi.fn().mockResolvedValue( [ labelRequired ] );
 			const wrapper = mountComponent( false, validationTestStubs );
@@ -642,7 +702,7 @@ describe( 'SubjectEditorDialog', () => {
 
 		it( 'keeps the rename input open in error state when the label is committed blank', async () => {
 			const labelRequired: SubjectViolation = {
-				propertyName: null, code: 'label-required', args: [], valuePartIndex: null,
+				propertyName: null, code: 'label-required', args: [], severity: 'error', valuePartIndex: null,
 			};
 			useSubjectStore().validateSubjectUpdate = vi.fn().mockResolvedValue( [ labelRequired ] );
 			const wrapper = mountComponent( false, validationTestStubs );
@@ -657,7 +717,7 @@ describe( 'SubjectEditorDialog', () => {
 
 		it( 'routes the label-required violation to the title area instead of the banner', async () => {
 			const labelRequired: SubjectViolation = {
-				propertyName: null, code: 'label-required', args: [], valuePartIndex: null,
+				propertyName: null, code: 'label-required', args: [], severity: 'error', valuePartIndex: null,
 			};
 			useSubjectStore().validateSubjectUpdate = vi.fn().mockResolvedValue( [ labelRequired ] );
 			const wrapper = mountComponent( false, validationTestStubs );
@@ -665,7 +725,7 @@ describe( 'SubjectEditorDialog', () => {
 
 			expect( wrapper.find( '.ext-neowiki-subject-editor-dialog__label-error' ).text() )
 				.toContain( 'neowiki-field-label-required' );
-			expect( wrapper.find( '.ext-neowiki-subject-editor__form-errors' ).exists() ).toBe( false );
+			expect( wrapper.find( '.ext-neowiki-violation-banners__list' ).exists() ).toBe( false );
 		} );
 
 		it( 'follows the label when the host replaces the subject', async () => {

--- a/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditorDialog.spec.ts
@@ -16,7 +16,7 @@ import SchemaEditorDialog from '@/components/SchemaEditor/SchemaEditorDialog.vue
 import SubjectEditor from '@/components/SubjectEditor/SubjectEditor.vue';
 import SummaryAction from '@/components/common/SummaryAction.vue';
 import CloseConfirmationDialog from '@/components/common/CloseConfirmationDialog.vue';
-import { CdxDialog } from '@wikimedia/codex';
+import { CdxDialog, CdxMessage } from '@wikimedia/codex';
 import { createI18nMock, setupMwMock } from '../../VueTestHelpers.ts';
 import { ValidationFailedError } from '@/persistence/ValidationFailedError';
 import type { SubjectViolation } from '@/domain/SubjectViolation';
@@ -334,6 +334,7 @@ describe( 'SubjectEditorDialog', () => {
 				propertyName: 'name',
 				code: 'required',
 				args: [],
+				severity: 'error',
 				valuePartIndex: null,
 			};
 			const onSave = vi.fn().mockRejectedValue( new ValidationFailedError( [ violation ] ) );
@@ -354,6 +355,7 @@ describe( 'SubjectEditorDialog', () => {
 				propertyName: 'name',
 				code: 'required',
 				args: [],
+				severity: 'error',
 				valuePartIndex: null,
 			};
 			const onSave = vi.fn().mockRejectedValue( new ValidationFailedError( [ violation ] ) );
@@ -371,6 +373,7 @@ describe( 'SubjectEditorDialog', () => {
 				propertyName: 'name',
 				code: 'required',
 				args: [],
+				severity: 'error',
 				valuePartIndex: null,
 			};
 			const onSave = vi.fn().mockRejectedValue( new ValidationFailedError( [ violation ] ) );
@@ -391,6 +394,7 @@ describe( 'SubjectEditorDialog', () => {
 				propertyName: null,
 				code: 'schema-not-found',
 				args: [ 'Person' ],
+				severity: 'error',
 				valuePartIndex: null,
 			};
 			const onSave = vi.fn().mockRejectedValue( new ValidationFailedError( [ violation ] ) );
@@ -400,11 +404,62 @@ describe( 'SubjectEditorDialog', () => {
 			await wrapper.findComponent( SummaryAction ).vm.$emit( 'save', '' );
 			await flushPromises();
 
-			expect( wrapper.find( '.ext-neowiki-subject-editor__form-errors' ).exists() ).toBe( true );
+			expect( wrapper.find( '.ext-neowiki-violation-banners__list' ).exists() ).toBe( true );
 
 			const passedViolations = wrapper.findComponent( SubjectEditor ).props( 'serverViolations' ) as SubjectViolation[];
 			expect( passedViolations ).toHaveLength( 1 );
 			expect( passedViolations[ 0 ].propertyName ).toBeNull();
+		} );
+
+		it( 'splits banner violations by severity into an error and a warning message', async () => {
+			const errorViolation: SubjectViolation = {
+				propertyName: null,
+				code: 'label-required',
+				args: [],
+				severity: 'error',
+				valuePartIndex: null,
+			};
+			const warningViolation: SubjectViolation = {
+				propertyName: null,
+				code: 'schema-not-found',
+				args: [ 'Person' ],
+				severity: 'warning',
+				valuePartIndex: null,
+			};
+			const onSave = vi.fn().mockRejectedValue(
+				new ValidationFailedError( [ warningViolation, errorViolation ] ),
+			);
+			const wrapper = mountComponent( true, validationTestStubs, onSave );
+			await flushPromises();
+
+			await wrapper.findComponent( SummaryAction ).vm.$emit( 'save', '' );
+			await flushPromises();
+
+			const banners = wrapper.findAllComponents( CdxMessage );
+			expect( banners ).toHaveLength( 2 );
+			expect( banners[ 0 ].props( 'type' ) ).toBe( 'error' );
+			expect( banners[ 0 ].text() ).toContain( 'neowiki-field-label-required' );
+			expect( banners[ 1 ].props( 'type' ) ).toBe( 'warning' );
+			expect( banners[ 1 ].text() ).toContain( 'neowiki-field-schema-not-found' );
+		} );
+
+		it( 'does not treat a warning-only dry-run result as blocking the save', async () => {
+			useSubjectStore().validateSubjectUpdate = vi.fn().mockResolvedValue( [ {
+				propertyName: null,
+				code: 'schema-not-found',
+				args: [ 'Person' ],
+				severity: 'warning',
+				valuePartIndex: null,
+			} ] );
+			const onSave = vi.fn().mockResolvedValue( undefined );
+			const wrapper = mountComponent( true, validationTestStubs, onSave );
+			await flushPromises();
+
+			await wrapper.findComponent( SummaryAction ).vm.$emit( 'save', '' );
+			await flushPromises();
+
+			expect( onSave ).toHaveBeenCalledTimes( 1 );
+			expect( wrapper.emitted( 'update:open' )?.[ 0 ] ).toEqual( [ false ] );
 		} );
 
 		it( 'drops the matching entry on clear-server-violation event from child', async () => {
@@ -412,6 +467,7 @@ describe( 'SubjectEditorDialog', () => {
 				propertyName: 'name',
 				code: 'required',
 				args: [],
+				severity: 'error',
 				valuePartIndex: null,
 			};
 			const onSave = vi.fn().mockRejectedValue( new ValidationFailedError( [ violation ] ) );
@@ -456,6 +512,7 @@ describe( 'SubjectEditorDialog', () => {
 			propertyName: 'name',
 			code: 'max-length',
 			args: [ 5 ],
+			severity: 'error',
 			valuePartIndex: null,
 		};
 
@@ -512,7 +569,7 @@ describe( 'SubjectEditorDialog', () => {
 
 		it( 'surfaces required violations from the dry-run; an existing subject flags missing required', async () => {
 			const requiredViolation: SubjectViolation = {
-				propertyName: 'name', code: 'required', args: [], valuePartIndex: null,
+				propertyName: 'name', code: 'required', args: [], severity: 'error', valuePartIndex: null,
 			};
 			useSubjectStore().validateSubjectUpdate = vi.fn().mockResolvedValue( [ requiredViolation ] );
 			const wrapper = mountComponent( true, validationTestStubs );
@@ -528,7 +585,7 @@ describe( 'SubjectEditorDialog', () => {
 
 		it( 'validates on open so an existing subject\'s violations surface without an edit', async () => {
 			const existingViolation: SubjectViolation = {
-				propertyName: 'name', code: 'required', args: [], valuePartIndex: null,
+				propertyName: 'name', code: 'required', args: [], severity: 'error', valuePartIndex: null,
 			};
 			const validate = vi.fn().mockResolvedValue( [ existingViolation ] );
 			useSubjectStore().validateSubjectUpdate = validate;

--- a/resources/ext.neowiki/tests/components/Value/BooleanInput.spec.ts
+++ b/resources/ext.neowiki/tests/components/Value/BooleanInput.spec.ts
@@ -147,7 +147,7 @@ describe( 'BooleanInput', () => {
 			return newWrapper( {
 				property: newBooleanProperty( { name: 'Foo' } ),
 				serverViolations: [
-					{ propertyName: 'Foo', code: 'type-mismatch', args: [ 'string', 'boolean' ], valuePartIndex: null },
+					{ propertyName: 'Foo', code: 'type-mismatch', args: [ 'string', 'boolean' ], severity: 'error', valuePartIndex: null },
 				],
 			} );
 		}
@@ -158,6 +158,19 @@ describe( 'BooleanInput', () => {
 			const field = wrapper.findComponent( CdxField );
 			expect( field.props( 'status' ) ).toBe( 'error' );
 			expect( field.props( 'messages' ) ).toEqual( { error: 'neowiki-field-type-mismatch' } );
+		} );
+
+		it( 'shows a warning violation with the warning status', () => {
+			const wrapper = newWrapper( {
+				property: newBooleanProperty( { name: 'Foo' } ),
+				serverViolations: [
+					{ propertyName: 'Foo', code: 'required', args: [], severity: 'warning', valuePartIndex: null },
+				],
+			} );
+
+			const field = wrapper.findComponent( CdxField );
+			expect( field.props( 'status' ) ).toBe( 'warning' );
+			expect( field.props( 'messages' ) ).toEqual( { warning: 'neowiki-field-required' } );
 		} );
 
 		it( 'emits clear-server-violation when the user edits the field', async () => {

--- a/resources/ext.neowiki/tests/components/Value/DateInput.spec.ts
+++ b/resources/ext.neowiki/tests/components/Value/DateInput.spec.ts
@@ -83,7 +83,7 @@ describe( 'DateInput', () => {
 			modelValue: newStringValue( '2025-06-15' ),
 			property: newDateProperty( { name: 'Foo', required: true } ),
 			serverViolations: [
-				{ propertyName: 'Foo', code: 'required', args: [], valuePartIndex: null },
+				{ propertyName: 'Foo', code: 'required', args: [], severity: 'error', valuePartIndex: null },
 			],
 		} );
 
@@ -164,7 +164,7 @@ describe( 'DateInput', () => {
 			const wrapper = newWrapper( {
 				property: newDateProperty( { name: 'Foo' } ),
 				serverViolations: [
-					{ propertyName: 'Foo', code: 'type-mismatch', args: [ 'date', 'number' ], valuePartIndex: null },
+					{ propertyName: 'Foo', code: 'type-mismatch', args: [ 'date', 'number' ], severity: 'error', valuePartIndex: null },
 				],
 			} );
 
@@ -172,11 +172,23 @@ describe( 'DateInput', () => {
 			expect( wrapper.findComponent( CdxField ).props( 'messages' ) ).toHaveProperty( 'error', 'neowiki-field-type-mismatch' );
 		} );
 
+		it( 'shows a warning violation with the warning status', () => {
+			const wrapper = newWrapper( {
+				property: newDateProperty( { name: 'Foo' } ),
+				serverViolations: [
+					{ propertyName: 'Foo', code: 'required', args: [], severity: 'warning', valuePartIndex: null },
+				],
+			} );
+
+			expect( wrapper.findComponent( CdxField ).props( 'status' ) ).toBe( 'warning' );
+			expect( wrapper.findComponent( CdxField ).props( 'messages' ) ).toHaveProperty( 'warning', 'neowiki-field-required' );
+		} );
+
 		it( 'emits clear-server-violation when the user edits the field', async () => {
 			const wrapper = newWrapper( {
 				property: newDateProperty( { name: 'Foo' } ),
 				serverViolations: [
-					{ propertyName: 'Foo', code: 'type-mismatch', args: [ 'date', 'number' ], valuePartIndex: null },
+					{ propertyName: 'Foo', code: 'type-mismatch', args: [ 'date', 'number' ], severity: 'error', valuePartIndex: null },
 				],
 			} );
 
@@ -192,7 +204,7 @@ describe( 'DateInput', () => {
 			newWrapper( {
 				property: newDateProperty( { name: 'Foo' } ),
 				serverViolations: [
-					{ propertyName: 'Foo', code: 'min-value', args: [ minimum ], valuePartIndex: null },
+					{ propertyName: 'Foo', code: 'min-value', args: [ minimum ], severity: 'error', valuePartIndex: null },
 				],
 			} );
 

--- a/resources/ext.neowiki/tests/components/Value/DateTimeInput.spec.ts
+++ b/resources/ext.neowiki/tests/components/Value/DateTimeInput.spec.ts
@@ -87,7 +87,7 @@ describe( 'DateTimeInput', () => {
 			modelValue: newStringValue( '2025-06-15T14:00:00Z' ),
 			property: newDateTimeProperty( { name: 'Foo', required: true } ),
 			serverViolations: [
-				{ propertyName: 'Foo', code: 'required', args: [], valuePartIndex: null },
+				{ propertyName: 'Foo', code: 'required', args: [], severity: 'error', valuePartIndex: null },
 			],
 		} );
 
@@ -189,7 +189,7 @@ describe( 'DateTimeInput', () => {
 			const wrapper = newWrapper( {
 				property: newDateTimeProperty( { name: 'Foo' } ),
 				serverViolations: [
-					{ propertyName: 'Foo', code: 'type-mismatch', args: [ 'dateTime', 'string' ], valuePartIndex: null },
+					{ propertyName: 'Foo', code: 'type-mismatch', args: [ 'dateTime', 'string' ], severity: 'error', valuePartIndex: null },
 				],
 			} );
 
@@ -197,11 +197,23 @@ describe( 'DateTimeInput', () => {
 			expect( wrapper.findComponent( CdxField ).props( 'messages' ) ).toHaveProperty( 'error', 'neowiki-field-type-mismatch' );
 		} );
 
+		it( 'shows a warning violation with the warning status', () => {
+			const wrapper = newWrapper( {
+				property: newDateTimeProperty( { name: 'Foo' } ),
+				serverViolations: [
+					{ propertyName: 'Foo', code: 'required', args: [], severity: 'warning', valuePartIndex: null },
+				],
+			} );
+
+			expect( wrapper.findComponent( CdxField ).props( 'status' ) ).toBe( 'warning' );
+			expect( wrapper.findComponent( CdxField ).props( 'messages' ) ).toHaveProperty( 'warning', 'neowiki-field-required' );
+		} );
+
 		it( 'emits clear-server-violation when the user edits the field', async () => {
 			const wrapper = newWrapper( {
 				property: newDateTimeProperty( { name: 'Foo' } ),
 				serverViolations: [
-					{ propertyName: 'Foo', code: 'type-mismatch', args: [ 'dateTime', 'string' ], valuePartIndex: null },
+					{ propertyName: 'Foo', code: 'type-mismatch', args: [ 'dateTime', 'string' ], severity: 'error', valuePartIndex: null },
 				],
 			} );
 
@@ -217,7 +229,7 @@ describe( 'DateTimeInput', () => {
 			newWrapper( {
 				property: newDateTimeProperty( { name: 'Foo' } ),
 				serverViolations: [
-					{ propertyName: 'Foo', code: 'min-value', args: [ minimum ], valuePartIndex: null },
+					{ propertyName: 'Foo', code: 'min-value', args: [ minimum ], severity: 'error', valuePartIndex: null },
 				],
 			} );
 

--- a/resources/ext.neowiki/tests/components/Value/NumberInput.spec.ts
+++ b/resources/ext.neowiki/tests/components/Value/NumberInput.spec.ts
@@ -81,7 +81,7 @@ describe( 'NumberInput', () => {
 			const wrapper = newWrapper( {
 				property: newNumberProperty( { name: 'Foo' } ),
 				serverViolations: [
-					{ propertyName: 'Foo', code: 'type-mismatch', args: [ 'number', 'string' ], valuePartIndex: null },
+					{ propertyName: 'Foo', code: 'type-mismatch', args: [ 'number', 'string' ], severity: 'error', valuePartIndex: null },
 				],
 			} );
 
@@ -89,11 +89,23 @@ describe( 'NumberInput', () => {
 			expect( wrapper.findComponent( CdxField ).props( 'messages' ) ).toHaveProperty( 'error', 'neowiki-field-type-mismatch' );
 		} );
 
+		it( 'shows a warning violation with the warning status', () => {
+			const wrapper = newWrapper( {
+				property: newNumberProperty( { name: 'Foo' } ),
+				serverViolations: [
+					{ propertyName: 'Foo', code: 'max-value', args: [ '100' ], severity: 'warning', valuePartIndex: null },
+				],
+			} );
+
+			expect( wrapper.findComponent( CdxField ).props( 'status' ) ).toBe( 'warning' );
+			expect( wrapper.findComponent( CdxField ).props( 'messages' ) ).toHaveProperty( 'warning', 'neowiki-field-max-value' );
+		} );
+
 		it( 'emits clear-server-violation when the user edits the field', async () => {
 			const wrapper = newWrapper( {
 				property: newNumberProperty( { name: 'Foo' } ),
 				serverViolations: [
-					{ propertyName: 'Foo', code: 'type-mismatch', args: [ 'number', 'string' ], valuePartIndex: null },
+					{ propertyName: 'Foo', code: 'type-mismatch', args: [ 'number', 'string' ], severity: 'error', valuePartIndex: null },
 				],
 			} );
 

--- a/resources/ext.neowiki/tests/components/Value/RelationInput.spec.ts
+++ b/resources/ext.neowiki/tests/components/Value/RelationInput.spec.ts
@@ -136,7 +136,7 @@ describe( 'RelationInput', () => {
 			const withViolation = newWrapper( {
 				property: newRelationProperty( { name: 'Owner', targetSchema: 'Company' } ),
 				serverViolations: [
-					{ propertyName: 'Owner', code: 'required', args: [], valuePartIndex: null },
+					{ propertyName: 'Owner', code: 'required', args: [], severity: 'error', valuePartIndex: null },
 				],
 			} );
 			expect( withViolation.findComponent( SubjectLookup ).props( 'status' ) ).toBe( 'error' );
@@ -160,7 +160,7 @@ describe( 'RelationInput', () => {
 				// The message can only originate from the server-sourced violation.
 				property: newRelationProperty( { name: 'Owner', targetSchema: 'Company' } ),
 				serverViolations: [
-					{ propertyName: 'Owner', code: 'type-mismatch', args: [], valuePartIndex: null },
+					{ propertyName: 'Owner', code: 'type-mismatch', args: [], severity: 'error', valuePartIndex: null },
 				],
 			} );
 
@@ -173,7 +173,7 @@ describe( 'RelationInput', () => {
 			const wrapper = newWrapper( {
 				property: newRelationProperty( { name: 'Owner', targetSchema: 'Company' } ),
 				serverViolations: [
-					{ propertyName: 'Owner', code: 'type-mismatch', args: [], valuePartIndex: null },
+					{ propertyName: 'Owner', code: 'type-mismatch', args: [], severity: 'error', valuePartIndex: null },
 				],
 			} );
 
@@ -244,7 +244,7 @@ describe( 'RelationInput', () => {
 			const wrapper = newWrapper( {
 				property: newRelationProperty( { name: 'Owners', required: true, multiple: true } ),
 				serverViolations: [
-					{ propertyName: 'Owners', code: 'required', args: [], valuePartIndex: null },
+					{ propertyName: 'Owners', code: 'required', args: [], severity: 'error', valuePartIndex: null },
 				],
 			} );
 
@@ -253,11 +253,25 @@ describe( 'RelationInput', () => {
 			);
 		} );
 
+		it( 'shows a warning violation with the warning status on a single relation', () => {
+			const wrapper = newWrapper( {
+				property: newRelationProperty( { name: 'Owner', targetSchema: 'Company' } ),
+				serverViolations: [
+					{ propertyName: 'Owner', code: 'relation-target-not-found', args: [], severity: 'warning', valuePartIndex: null },
+				],
+			} );
+
+			expect( wrapper.findComponent( CdxField ).props( 'status' ) ).toBe( 'warning' );
+			expect( wrapper.findComponent( CdxField ).props( 'messages' ) ).toEqual(
+				{ warning: 'neowiki-field-relation-target-not-found' },
+			);
+		} );
+
 		it( 'keeps field status default for a multiple relation even with a violation', () => {
 			const wrapper = newWrapper( {
 				property: newRelationProperty( { name: 'Owners', required: true, multiple: true } ),
 				serverViolations: [
-					{ propertyName: 'Owners', code: 'required', args: [], valuePartIndex: null },
+					{ propertyName: 'Owners', code: 'required', args: [], severity: 'error', valuePartIndex: null },
 				],
 			} );
 
@@ -300,6 +314,7 @@ describe( 'RelationInput', () => {
 						propertyName: 'Owner',
 						code: 'relation-target-schema-mismatch',
 						args: [ 'Company', 'Person' ],
+						severity: 'error',
 						valuePartIndex: 0,
 					},
 				],
@@ -319,8 +334,8 @@ describe( 'RelationInput', () => {
 			const wrapper = newWrapper( {
 				property: newRelationProperty( { name: 'Owners', targetSchema: 'Company', multiple: true } ),
 				serverViolations: [
-					{ propertyName: 'Owners', code: 'relation-target-not-found', args: [ 'x' ], valuePartIndex: 0 },
-					{ propertyName: 'Owners', code: 'relation-target-schema-mismatch', args: [], valuePartIndex: 1 },
+					{ propertyName: 'Owners', code: 'relation-target-not-found', args: [ 'x' ], severity: 'error', valuePartIndex: 0 },
+					{ propertyName: 'Owners', code: 'relation-target-schema-mismatch', args: [], severity: 'error', valuePartIndex: 1 },
 				],
 			} );
 
@@ -339,7 +354,7 @@ describe( 'RelationInput', () => {
 			const wrapper = newWrapper( {
 				property: newRelationProperty( { name: 'Owner', targetSchema: 'Company' } ),
 				serverViolations: [
-					{ propertyName: 'Other', code: 'required', args: [], valuePartIndex: null },
+					{ propertyName: 'Other', code: 'required', args: [], severity: 'error', valuePartIndex: null },
 				],
 			} );
 
@@ -353,7 +368,7 @@ describe( 'RelationInput', () => {
 			const wrapper = newWrapper( {
 				property: newRelationProperty( { name: 'Owner', targetSchema: 'Company' } ),
 				serverViolations: [
-					{ propertyName: 'Owner', code: 'required', args: [], valuePartIndex: null },
+					{ propertyName: 'Owner', code: 'required', args: [], severity: 'error', valuePartIndex: null },
 				],
 			} );
 
@@ -371,8 +386,8 @@ describe( 'RelationInput', () => {
 			const wrapper = newWrapper( {
 				property: newRelationProperty( { name: 'Owners', targetSchema: 'Company', multiple: true } ),
 				serverViolations: [
-					{ propertyName: 'Owners', code: 'relation-target-not-found', args: [ 'x' ], valuePartIndex: 0 },
-					{ propertyName: 'Owners', code: 'relation-target-schema-mismatch', args: [], valuePartIndex: 2 },
+					{ propertyName: 'Owners', code: 'relation-target-not-found', args: [ 'x' ], severity: 'error', valuePartIndex: 0 },
+					{ propertyName: 'Owners', code: 'relation-target-schema-mismatch', args: [], severity: 'error', valuePartIndex: 2 },
 				],
 			} );
 

--- a/resources/ext.neowiki/tests/components/Value/SelectInput.spec.ts
+++ b/resources/ext.neowiki/tests/components/Value/SelectInput.spec.ts
@@ -39,7 +39,7 @@ describe( 'SelectInput', () => {
 	it( 'still surfaces a server-sourced violation on the select', () => {
 		const wrapper = newWrapper( {
 			serverViolations: [
-				{ propertyName: 'Status', code: 'required', args: [], valuePartIndex: null },
+				{ propertyName: 'Status', code: 'required', args: [], severity: 'error', valuePartIndex: null },
 			],
 		} );
 
@@ -47,11 +47,22 @@ describe( 'SelectInput', () => {
 		expect( wrapper.findComponent( CdxField ).props( 'messages' ) ).toHaveProperty( 'error', 'neowiki-field-required' );
 	} );
 
+	it( 'shows a warning violation with the warning status', () => {
+		const wrapper = newWrapper( {
+			serverViolations: [
+				{ propertyName: 'Status', code: 'invalid-option', args: [ 'bogus' ], severity: 'warning', valuePartIndex: 0 },
+			],
+		} );
+
+		expect( wrapper.findComponent( CdxField ).props( 'status' ) ).toBe( 'warning' );
+		expect( wrapper.findComponent( CdxField ).props( 'messages' ) ).toHaveProperty( 'warning', 'neowiki-field-invalid-option' );
+	} );
+
 	describe( 'clearing server violations', () => {
 		it( 'clears a part-indexed violation using its own index', async () => {
 			const wrapper = newWrapper( {
 				serverViolations: [
-					{ propertyName: 'Status', code: 'invalid-option', args: [ 'bogus' ], valuePartIndex: 0 },
+					{ propertyName: 'Status', code: 'invalid-option', args: [ 'bogus' ], severity: 'error', valuePartIndex: 0 },
 				],
 			} );
 
@@ -68,7 +79,7 @@ describe( 'SelectInput', () => {
 		it( 'does not emit when the property has no violation', async () => {
 			const wrapper = newWrapper( {
 				serverViolations: [
-					{ propertyName: 'Other', code: 'required', args: [], valuePartIndex: null },
+					{ propertyName: 'Other', code: 'required', args: [], severity: 'error', valuePartIndex: null },
 				],
 			} );
 
@@ -81,7 +92,7 @@ describe( 'SelectInput', () => {
 		it( 'clears a field-level (null-index) violation on the property', async () => {
 			const wrapper = newWrapper( {
 				serverViolations: [
-					{ propertyName: 'Status', code: 'required', args: [], valuePartIndex: null },
+					{ propertyName: 'Status', code: 'required', args: [], severity: 'error', valuePartIndex: null },
 				],
 			} );
 
@@ -107,8 +118,8 @@ describe( 'SelectInput', () => {
 					],
 				} ),
 				serverViolations: [
-					{ propertyName: 'Status', code: 'invalid-option', args: [ 'a' ], valuePartIndex: 0 },
-					{ propertyName: 'Status', code: 'invalid-option', args: [ 'b' ], valuePartIndex: 2 },
+					{ propertyName: 'Status', code: 'invalid-option', args: [ 'a' ], severity: 'error', valuePartIndex: 0 },
+					{ propertyName: 'Status', code: 'invalid-option', args: [ 'b' ], severity: 'error', valuePartIndex: 2 },
 				],
 			} );
 

--- a/resources/ext.neowiki/tests/components/Value/TextInput.spec.ts
+++ b/resources/ext.neowiki/tests/components/Value/TextInput.spec.ts
@@ -125,6 +125,17 @@ describe( 'TextInput', () => {
 			expect( field.props( 'status' ) ).toBe( 'error' );
 		} );
 
+		it( 'sets status to warning when fieldMessages carries a warning (single input)', () => {
+			mockFieldMessages.value = { warning: 'Advisory only' };
+			const wrapper = newWrapper( {
+				property: newTextProperty( { multiple: false } ),
+			} );
+			const field = wrapper.findComponent( CdxField );
+
+			expect( field.props( 'messages' ) ).toEqual( { warning: 'Advisory only' } );
+			expect( field.props( 'status' ) ).toBe( 'warning' );
+		} );
+
 		it( 'sets CdxField status to default if no fieldMessages.error (single input)', () => {
 			const wrapper = newWrapper( {
 				property: newTextProperty( { multiple: false } ),
@@ -198,7 +209,7 @@ describe( 'TextInput', () => {
 
 	describe( 'Server violations', () => {
 		it( 'passes serverViolations to useStringValueInput as the fifth argument', () => {
-			const violation = { propertyName: 'Foo', code: 'required', args: [], valuePartIndex: null };
+			const violation = { propertyName: 'Foo', code: 'required', args: [], severity: 'error' as const, valuePartIndex: null };
 			newWrapper( {
 				property: newTextProperty( { name: 'Foo', multiple: false } ),
 				serverViolations: [ violation ],
@@ -215,7 +226,7 @@ describe( 'TextInput', () => {
 			const wrapper = newWrapper( {
 				property: newTextProperty( { name: 'Foo', multiple: false } ),
 				serverViolations: [
-					{ propertyName: 'Foo', code: 'required', args: [], valuePartIndex: null },
+					{ propertyName: 'Foo', code: 'required', args: [], severity: 'error', valuePartIndex: null },
 				],
 			} );
 
@@ -224,7 +235,7 @@ describe( 'TextInput', () => {
 
 		it( 'passes server violations for a different property name through to the composable unchanged', () => {
 			// The composable is responsible for filtering by propertyName; the component passes it as-is.
-			const violation = { propertyName: 'OtherProp', code: 'required', args: [], valuePartIndex: null };
+			const violation = { propertyName: 'OtherProp', code: 'required', args: [], severity: 'error' as const, valuePartIndex: null };
 			newWrapper( {
 				property: newTextProperty( { name: 'Foo', multiple: false } ),
 				serverViolations: [ violation ],
@@ -235,7 +246,7 @@ describe( 'TextInput', () => {
 		} );
 
 		it( 'emits clear-server-violation when the composable emits it via the shared emit function', async () => {
-			const violation = { propertyName: 'Foo', code: 'required', args: [], valuePartIndex: null };
+			const violation = { propertyName: 'Foo', code: 'required', args: [], severity: 'error' as const, valuePartIndex: null };
 			const wrapper = newWrapper( {
 				property: newTextProperty( { name: 'Foo', multiple: false } ),
 				serverViolations: [ violation ],

--- a/resources/ext.neowiki/tests/components/Value/UrlInput.spec.ts
+++ b/resources/ext.neowiki/tests/components/Value/UrlInput.spec.ts
@@ -128,6 +128,17 @@ describe( 'UrlInput', () => {
 			expect( field.props( 'status' ) ).toBe( 'error' );
 		} );
 
+		it( 'sets status to warning when fieldMessages carries a warning (single input)', () => {
+			mockFieldMessages.value = { warning: 'Advisory only' };
+			const wrapper = newWrapper( {
+				property: newUrlProperty( { multiple: false } ),
+			} );
+			const field = wrapper.findComponent( CdxField );
+
+			expect( field.props( 'messages' ) ).toEqual( { warning: 'Advisory only' } );
+			expect( field.props( 'status' ) ).toBe( 'warning' );
+		} );
+
 		it( 'sets CdxField status to default if no fieldMessages.error (single input)', () => {
 			const wrapper = newWrapper( {
 				property: newUrlProperty( { multiple: false } ),
@@ -182,7 +193,7 @@ describe( 'UrlInput', () => {
 
 	describe( 'Server violations (multi-value)', () => {
 		it( 'passes serverViolations to useStringValueInput as the fifth argument', () => {
-			const violation = { propertyName: 'Website', code: 'invalid-url', args: [], valuePartIndex: 1 };
+			const violation = { propertyName: 'Website', code: 'invalid-url', args: [], severity: 'error' as const, valuePartIndex: 1 };
 			newWrapper( {
 				property: newUrlProperty( { name: 'Website', multiple: true } ),
 				serverViolations: [ violation ],
@@ -200,7 +211,7 @@ describe( 'UrlInput', () => {
 			const wrapper = newWrapper( {
 				property: newUrlProperty( { name: 'Website', multiple: true } ),
 				serverViolations: [
-					{ propertyName: 'Website', code: 'invalid-url', args: [], valuePartIndex: 1 },
+					{ propertyName: 'Website', code: 'invalid-url', args: [], severity: 'error', valuePartIndex: 1 },
 				],
 			} );
 
@@ -214,7 +225,7 @@ describe( 'UrlInput', () => {
 			const wrapper = newWrapper( {
 				property: newUrlProperty( { name: 'Website', multiple: true } ),
 				serverViolations: [
-					{ propertyName: 'Website', code: 'invalid-url', args: [], valuePartIndex: 1 },
+					{ propertyName: 'Website', code: 'invalid-url', args: [], severity: 'error', valuePartIndex: 1 },
 				],
 			} );
 
@@ -234,7 +245,7 @@ describe( 'UrlInput', () => {
 				property: newUrlProperty( { name: 'Website', multiple: true } ),
 				serverViolations: [
 					// violation only at index 1, not index 0
-					{ propertyName: 'Website', code: 'invalid-url', args: [], valuePartIndex: 1 },
+					{ propertyName: 'Website', code: 'invalid-url', args: [], severity: 'error', valuePartIndex: 1 },
 				],
 			} );
 

--- a/resources/ext.neowiki/tests/components/common/SubjectViolationBanners.spec.ts
+++ b/resources/ext.neowiki/tests/components/common/SubjectViolationBanners.spec.ts
@@ -1,0 +1,74 @@
+import { mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CdxMessage } from '@wikimedia/codex';
+import SubjectViolationBanners from '@/components/common/SubjectViolationBanners.vue';
+import type { SubjectViolation } from '@/domain/SubjectViolation';
+
+function violation( overrides: Partial<SubjectViolation> = {} ): SubjectViolation {
+	return {
+		propertyName: null,
+		code: 'schema-not-found',
+		args: [],
+		severity: 'error',
+		valuePartIndex: null,
+		...overrides,
+	};
+}
+
+function newWrapper( violations: SubjectViolation[] ): ReturnType<typeof mount> {
+	return mount( SubjectViolationBanners, {
+		props: { violations },
+	} );
+}
+
+describe( 'SubjectViolationBanners', () => {
+	beforeEach( () => {
+		vi.stubGlobal( 'mw', {
+			message: vi.fn( ( key: string, ...params: string[] ) => ( {
+				text: () => [ key, ...params ].join( '|' ),
+			} ) ),
+		} );
+	} );
+
+	it( 'renders nothing without violations', () => {
+		const wrapper = newWrapper( [] );
+
+		expect( wrapper.findAllComponents( CdxMessage ) ).toHaveLength( 0 );
+	} );
+
+	it( 'renders error violations in a single error banner', () => {
+		const wrapper = newWrapper( [
+			violation( { code: 'schema-not-found', args: [ 'Person' ] } ),
+			violation( { code: 'label-required' } ),
+		] );
+
+		const banners = wrapper.findAllComponents( CdxMessage );
+		expect( banners ).toHaveLength( 1 );
+		expect( banners[ 0 ].props( 'type' ) ).toBe( 'error' );
+		expect( banners[ 0 ].text() ).toContain( 'neowiki-field-schema-not-found|Person' );
+		expect( banners[ 0 ].text() ).toContain( 'neowiki-field-label-required' );
+	} );
+
+	it( 'renders warning violations in a warning banner', () => {
+		const wrapper = newWrapper( [ violation( { code: 'required', severity: 'warning' } ) ] );
+
+		const banners = wrapper.findAllComponents( CdxMessage );
+		expect( banners ).toHaveLength( 1 );
+		expect( banners[ 0 ].props( 'type' ) ).toBe( 'warning' );
+		expect( banners[ 0 ].text() ).toContain( 'neowiki-field-required' );
+	} );
+
+	it( 'partitions mixed severities into an error banner followed by a warning banner', () => {
+		const wrapper = newWrapper( [
+			violation( { code: 'required', severity: 'warning' } ),
+			violation( { code: 'label-required', severity: 'error' } ),
+		] );
+
+		const banners = wrapper.findAllComponents( CdxMessage );
+		expect( banners ).toHaveLength( 2 );
+		expect( banners[ 0 ].props( 'type' ) ).toBe( 'error' );
+		expect( banners[ 0 ].text() ).toContain( 'neowiki-field-label-required' );
+		expect( banners[ 1 ].props( 'type' ) ).toBe( 'warning' );
+		expect( banners[ 1 ].text() ).toContain( 'neowiki-field-required' );
+	} );
+} );

--- a/resources/ext.neowiki/tests/composables/useFieldServerViolation.spec.ts
+++ b/resources/ext.neowiki/tests/composables/useFieldServerViolation.spec.ts
@@ -31,6 +31,7 @@ function fieldViolation( overrides: Partial<SubjectViolation> = {} ): SubjectVio
 		propertyName: PROPERTY_NAME,
 		code: 'required',
 		args: [],
+		severity: 'error',
 		valuePartIndex: null,
 		...overrides,
 	};
@@ -52,65 +53,78 @@ describe( 'useFieldServerViolation', () => {
 		vi.clearAllMocks();
 	} );
 
-	describe( 'validationError', () => {
-		it( 'is null when there are no violations', () => {
-			const { validationError } = setup( [] );
+	describe( 'validationMessages and validationStatus', () => {
+		it( 'is empty with default status when there are no violations', () => {
+			const { validationMessages, validationStatus } = setup( [] );
 
-			expect( validationError.value ).toBeNull();
+			expect( validationMessages.value ).toEqual( {} );
+			expect( validationStatus.value ).toBe( 'default' );
 		} );
 
-		it( 'formats the field-level server violation', () => {
-			const { validationError } = setup( [ fieldViolation( { code: 'type-mismatch', args: [ 'url', 'number' ] } ) ] );
+		it( 'keys the field-level server violation by its severity', () => {
+			const { validationMessages, validationStatus } = setup(
+				[ fieldViolation( { code: 'type-mismatch', args: [ 'url', 'number' ] } ) ],
+			);
 
-			expect( validationError.value ).toBe( 'neowiki-field-type-mismatch|url|number' );
+			expect( validationMessages.value ).toEqual( { error: 'neowiki-field-type-mismatch|url|number' } );
+			expect( validationStatus.value ).toBe( 'error' );
+		} );
+
+		it( 'renders a warning violation with the warning status', () => {
+			const { validationMessages, validationStatus } = setup(
+				[ fieldViolation( { code: 'max-value', args: [ '100' ], severity: 'warning' } ) ],
+			);
+
+			expect( validationMessages.value ).toEqual( { warning: 'neowiki-field-max-value|100' } );
+			expect( validationStatus.value ).toBe( 'warning' );
 		} );
 
 		it( 'stops surfacing the violation when the parent removes it', () => {
-			const { validationError, serverViolations } = setup( [ fieldViolation() ] );
-			expect( validationError.value ).toBe( 'neowiki-field-required' );
+			const { validationMessages, serverViolations } = setup( [ fieldViolation() ] );
+			expect( validationMessages.value ).toEqual( { error: 'neowiki-field-required' } );
 
 			serverViolations.value = [];
 
-			expect( validationError.value ).toBeNull();
+			expect( validationMessages.value ).toEqual( {} );
 		} );
 
 		it( 'ignores violations belonging to a different property', () => {
-			const { validationError } = setup( [ fieldViolation( { propertyName: 'OtherProperty' } ) ] );
+			const { validationMessages } = setup( [ fieldViolation( { propertyName: 'OtherProperty' } ) ] );
 
-			expect( validationError.value ).toBeNull();
+			expect( validationMessages.value ).toEqual( {} );
 		} );
 
 		it( 'ignores per-index violations, since single-value inputs have no per-index slot', () => {
-			const { validationError } = setup( [ fieldViolation( { valuePartIndex: 2 } ) ] );
+			const { validationMessages } = setup( [ fieldViolation( { valuePartIndex: 2 } ) ] );
 
-			expect( validationError.value ).toBeNull();
+			expect( validationMessages.value ).toEqual( {} );
 		} );
 
 		it( 'selects the field-level violation from among per-index ones for the same property', () => {
-			const { validationError } = setup( [
+			const { validationMessages } = setup( [
 				fieldViolation( { code: 'invalid-url', valuePartIndex: 0 } ),
 				fieldViolation( { code: 'required', valuePartIndex: null } ),
 				fieldViolation( { code: 'invalid-url', valuePartIndex: 1 } ),
 			] );
 
-			expect( validationError.value ).toBe( 'neowiki-field-required' );
+			expect( validationMessages.value ).toEqual( { error: 'neowiki-field-required' } );
 		} );
 
 		it( 'passes args through unchanged when no formatter is given', () => {
-			const { validationError } = setup( [ fieldViolation( { code: 'min-value', args: [ '42' ] } ) ] );
+			const { validationMessages } = setup( [ fieldViolation( { code: 'min-value', args: [ '42' ] } ) ] );
 
-			expect( validationError.value ).toBe( 'neowiki-field-min-value|42' );
+			expect( validationMessages.value ).toEqual( { error: 'neowiki-field-min-value|42' } );
 		} );
 
 		it( 'applies the arg formatter to message args', () => {
-			const { validationError } = useFieldServerViolation(
+			const { validationMessages } = useFieldServerViolation(
 				shallowRef( newProperty() ),
 				ref<readonly SubjectViolation[] | undefined>( [ fieldViolation( { code: 'min-value', args: [ '2025-01-01' ] } ) ] ),
 				vi.fn(),
 				( arg ) => `formatted(${ arg })`,
 			);
 
-			expect( validationError.value ).toBe( 'neowiki-field-min-value|formatted(2025-01-01)' );
+			expect( validationMessages.value ).toEqual( { error: 'neowiki-field-min-value|formatted(2025-01-01)' } );
 		} );
 	} );
 

--- a/resources/ext.neowiki/tests/composables/useServerViolations.spec.ts
+++ b/resources/ext.neowiki/tests/composables/useServerViolations.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { ref, shallowRef, type Ref } from 'vue';
-import { useServerViolations } from '@/composables/useServerViolations.ts';
+import { useServerViolations, violationStatus } from '@/composables/useServerViolations.ts';
 import { SubjectViolation } from '@/domain/SubjectViolation.ts';
 import { PropertyDefinition, PropertyName } from '@/domain/PropertyDefinition.ts';
 
@@ -26,6 +26,7 @@ function violation( overrides: Partial<SubjectViolation> = {} ): SubjectViolatio
 		propertyName: PROPERTY_NAME,
 		code: 'invalid-option',
 		args: [],
+		severity: 'error',
 		valuePartIndex: null,
 		...overrides,
 	};
@@ -82,34 +83,73 @@ describe( 'useServerViolations', () => {
 		} );
 	} );
 
-	describe( 'firstMessage', () => {
-		it( 'is the first relevant violation, even when it is part-indexed', () => {
+	describe( 'firstMessages', () => {
+		it( 'keys the first relevant violation by its severity, even when part-indexed', () => {
 			const { composable } = setup( [ violation( { code: 'invalid-option', args: [ 'x' ], valuePartIndex: 1 } ) ] );
 
-			expect( composable.firstMessage.value ).toBe( 'neowiki-field-invalid-option|x' );
+			expect( composable.firstMessages.value ).toEqual( { error: 'neowiki-field-invalid-option|x' } );
 		} );
 
-		it( 'is null when there are no relevant violations', () => {
+		it( 'keys a warning violation under warning', () => {
+			const { composable } = setup( [ violation( { severity: 'warning' } ) ] );
+
+			expect( composable.firstMessages.value ).toEqual( { warning: 'neowiki-field-invalid-option' } );
+		} );
+
+		it( 'is empty when there are no relevant violations', () => {
 			const { composable } = setup( [ violation( { propertyName: 'Other' } ) ] );
 
-			expect( composable.firstMessage.value ).toBeNull();
+			expect( composable.firstMessages.value ).toEqual( {} );
+		} );
+
+		it( 'prefers an error over an earlier warning, so a blocker is never masked', () => {
+			const { composable } = setup( [
+				violation( { code: 'max-value', args: [ '100' ], severity: 'warning' } ),
+				violation( { code: 'required', severity: 'error' } ),
+			] );
+
+			expect( composable.firstMessages.value ).toEqual( { error: 'neowiki-field-required' } );
 		} );
 	} );
 
-	describe( 'fieldLevelMessage', () => {
-		it( 'is the null-index violation, ignoring part-indexed ones', () => {
+	describe( 'fieldLevelMessages', () => {
+		it( 'is the null-index violation keyed by its severity, ignoring part-indexed ones', () => {
 			const { composable } = setup( [
 				violation( { code: 'invalid-option', valuePartIndex: 0 } ),
-				violation( { code: 'required', valuePartIndex: null } ),
+				violation( { code: 'required', severity: 'warning', valuePartIndex: null } ),
 			] );
 
-			expect( composable.fieldLevelMessage.value ).toBe( 'neowiki-field-required' );
+			expect( composable.fieldLevelMessages.value ).toEqual( { warning: 'neowiki-field-required' } );
 		} );
 
-		it( 'is null when only part-indexed violations exist', () => {
+		it( 'is empty when only part-indexed violations exist', () => {
 			const { composable } = setup( [ violation( { valuePartIndex: 2 } ) ] );
 
-			expect( composable.fieldLevelMessage.value ).toBeNull();
+			expect( composable.fieldLevelMessages.value ).toEqual( {} );
+		} );
+
+		it( 'prefers a field-level error over an earlier field-level warning', () => {
+			const { composable } = setup( [
+				violation( { code: 'max-value', args: [ '100' ], severity: 'warning', valuePartIndex: null } ),
+				violation( { code: 'required', severity: 'error', valuePartIndex: null } ),
+			] );
+
+			expect( composable.fieldLevelMessages.value ).toEqual( { error: 'neowiki-field-required' } );
+		} );
+	} );
+
+	describe( 'violationStatus', () => {
+		it( 'is the key of the single message', () => {
+			expect( violationStatus( { error: 'x' } ) ).toBe( 'error' );
+			expect( violationStatus( { warning: 'x' } ) ).toBe( 'warning' );
+		} );
+
+		it( 'is default when there are no messages', () => {
+			expect( violationStatus( {} ) ).toBe( 'default' );
+		} );
+
+		it( 'prefers error when both severities carry a message', () => {
+			expect( violationStatus( { error: 'x', warning: 'y' } ) ).toBe( 'error' );
 		} );
 	} );
 
@@ -204,15 +244,15 @@ describe( 'useServerViolations', () => {
 	describe( 'reactivity', () => {
 		it( 'recomputes the display messages when serverViolations changes after creation', () => {
 			const { composable, serverViolations } = setup( [] );
-			expect( composable.firstMessage.value ).toBeNull();
-			expect( composable.fieldLevelMessage.value ).toBeNull();
+			expect( composable.firstMessages.value ).toEqual( {} );
+			expect( composable.fieldLevelMessages.value ).toEqual( {} );
 
 			// A failed save sets serverViolations on an already-mounted input; the display
 			// computeds must recompute from the live ref, not a snapshot taken at creation.
 			serverViolations.value = [ violation( { code: 'required', valuePartIndex: null } ) ];
 
-			expect( composable.firstMessage.value ).toBe( 'neowiki-field-required' );
-			expect( composable.fieldLevelMessage.value ).toBe( 'neowiki-field-required' );
+			expect( composable.firstMessages.value ).toEqual( { error: 'neowiki-field-required' } );
+			expect( composable.fieldLevelMessages.value ).toEqual( { error: 'neowiki-field-required' } );
 		} );
 	} );
 } );

--- a/resources/ext.neowiki/tests/composables/useStringValueInput.spec.ts
+++ b/resources/ext.neowiki/tests/composables/useStringValueInput.spec.ts
@@ -241,7 +241,7 @@ describe( 'useStringValueInput', () => {
 		};
 
 		function violation( overrides: Partial<SubjectViolation> = {} ): SubjectViolation {
-			return { propertyName: 'testProp', code: 'required', args: [], valuePartIndex: null, ...overrides };
+			return { propertyName: 'testProp', code: 'required', args: [], severity: 'error', valuePartIndex: null, ...overrides };
 		}
 
 		it( 'shows a field-level server violation in fieldMessages for a single-value property', async () => {
@@ -271,6 +271,44 @@ describe( 'useStringValueInput', () => {
 			await nextTick();
 
 			expect( fieldMessages.value ).toEqual( { error: 'neowiki-field-min-length' } );
+		} );
+
+		it( 'keys a warning field-level violation under warning in fieldMessages', async () => {
+			const { fieldMessages } = createComposableWithViolations(
+				[ violation( { code: 'min-length', args: [ '10' ], severity: 'warning' } ) ],
+				{ name: new PropertyName( 'testProp' ), multiple: false },
+			);
+
+			await nextTick();
+
+			expect( fieldMessages.value ).toEqual( { warning: 'neowiki-field-min-length' } );
+		} );
+
+		it( 'prefers an error over an earlier warning competing for the same input slot', async () => {
+			const { inputMessages, onInput } = createComposableWithViolations(
+				[
+					violation( { code: 'unique', severity: 'warning', valuePartIndex: 1 } ),
+					violation( { code: 'max-length', args: [ '3' ], severity: 'error', valuePartIndex: 1 } ),
+				],
+				{ name: new PropertyName( 'testProp' ), multiple: true },
+			);
+
+			onInput( [ 'a', 'a' ] );
+			await nextTick();
+
+			expect( inputMessages.value[ 1 ] ).toEqual( { error: 'neowiki-field-max-length' } );
+		} );
+
+		it( 'keys a warning per-index violation under warning in inputMessages', async () => {
+			const { inputMessages, onInput } = createComposableWithViolations(
+				[ violation( { code: 'unique', severity: 'warning', valuePartIndex: 1 } ) ],
+				{ name: new PropertyName( 'testProp' ), multiple: true },
+			);
+
+			onInput( [ 'a', 'a' ] );
+			await nextTick();
+
+			expect( inputMessages.value[ 1 ] ).toEqual( { warning: 'neowiki-field-unique' } );
 		} );
 
 		it( 'does not show a server violation belonging to a different property', async () => {

--- a/resources/ext.neowiki/tests/composables/useSubjectValidation.spec.ts
+++ b/resources/ext.neowiki/tests/composables/useSubjectValidation.spec.ts
@@ -3,7 +3,7 @@ import { useSubjectValidation } from '@/composables/useSubjectValidation.ts';
 import { SubjectViolation } from '@/domain/SubjectViolation.ts';
 
 function violation( code: string ): SubjectViolation {
-	return { propertyName: 'Title', code, args: [], valuePartIndex: null };
+	return { propertyName: 'Title', code, args: [], severity: 'error', valuePartIndex: null };
 }
 
 describe( 'useSubjectValidation', () => {

--- a/resources/ext.neowiki/tests/domain/PropertyDefinitionDeserializer.unit.spec.ts
+++ b/resources/ext.neowiki/tests/domain/PropertyDefinitionDeserializer.unit.spec.ts
@@ -4,6 +4,7 @@ import { newBooleanValue, newNumberValue, newStringValue, newUnregisteredTypeVal
 import { TextProperty, TextType } from '@/domain/propertyTypes/Text';
 import { NumberProperty, NumberType } from '@/domain/propertyTypes/Number';
 import { RelationProperty, RelationType } from '@/domain/propertyTypes/Relation';
+import { SelectProperty } from '@/domain/propertyTypes/Select';
 import { Neo } from '@/Neo';
 
 const serializer = new PropertyDefinitionDeserializer( Neo.getInstance().getPropertyTypeRegistry(), Neo.getInstance().getValueDeserializer() );
@@ -218,6 +219,79 @@ it( 'preserves default: 0 for a number property', () => {
 	);
 
 	expect( property.default ).toEqual( newNumberValue( 0 ) );
+} );
+
+it( 'unwraps object-form Constraints and records their severities', () => {
+	const json = {
+		type: 'number',
+		required: { severity: 'error' },
+		minimum: 0,
+		maximum: { value: 100, severity: 'error' },
+	};
+
+	const property = serializer.propertyDefinitionFromJson( 'test', json ) as NumberProperty;
+
+	expect( property.required ).toBe( true );
+	expect( property.minimum ).toBe( 0 );
+	expect( property.maximum ).toBe( 100 );
+	expect( property.constraintSeverities ).toEqual( { required: 'error', maximum: 'error' } );
+} );
+
+it( 'records a warning annotation so it survives a round-trip', () => {
+	const json = {
+		type: 'text',
+		uniqueItems: { severity: 'error' },
+		minLength: { value: 2, severity: 'warning' },
+	};
+
+	const property = serializer.propertyDefinitionFromJson( 'test', json ) as TextProperty;
+
+	expect( property.uniqueItems ).toBe( true );
+	expect( property.minLength ).toBe( 2 );
+	expect( property.constraintSeverities ).toEqual( { uniqueItems: 'error', minLength: 'warning' } );
+} );
+
+it( 'unwraps an object-form options Constraint to its array', () => {
+	const options = [ { id: 'a', label: 'A' }, { id: 'b', label: 'B' } ];
+	const json = {
+		type: 'select',
+		options: { value: options, severity: 'error' },
+	};
+
+	const property = serializer.propertyDefinitionFromJson( 'test', json ) as SelectProperty;
+
+	expect( property.options ).toEqual( options );
+	expect( property.constraintSeverities ).toEqual( { options: 'error' } );
+} );
+
+it( 'drops a severity on a Display Attribute but keeps its value', () => {
+	const json = {
+		type: 'number',
+		precision: { value: 2, severity: 'error' },
+	};
+
+	const property = serializer.propertyDefinitionFromJson( 'test', json ) as NumberProperty;
+
+	expect( property.precision ).toBe( 2 );
+	expect( property.constraintSeverities ).toBeUndefined();
+} );
+
+it( 'omits the severity map when no Constraint carries one', () => {
+	const property = serializer.propertyDefinitionFromJson( 'test', { type: 'number', maximum: 100 } );
+
+	expect( property.constraintSeverities ).toBeUndefined();
+} );
+
+it( 'unwraps object-form keys of an unregistered type and keeps their severities', () => {
+	const json = {
+		type: 'color',
+		palette: { value: 'warm', severity: 'error' },
+	};
+
+	const property = serializer.propertyDefinitionFromJson( 'test', json );
+
+	expect( ( property as unknown as Record<string, unknown> ).palette ).toBe( 'warm' );
+	expect( property.constraintSeverities ).toEqual( { palette: 'error' } );
 } );
 
 it( 'treats default: null as no default', () => {

--- a/resources/ext.neowiki/tests/domain/SeverityNormalizer.spec.ts
+++ b/resources/ext.neowiki/tests/domain/SeverityNormalizer.spec.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { extractSeverities, applySeverities } from '@/domain/SeverityNormalizer';
+import type { Severity } from '@/domain/Severity';
+
+describe( 'extractSeverities', () => {
+	it( 'passes a shorthand scalar through with no severity', () => {
+		const [ values, severities ] = extractSeverities( { maximum: 100 } );
+
+		expect( values ).toEqual( { maximum: 100 } );
+		expect( severities ).toEqual( {} );
+	} );
+
+	it( 'unwraps an object-form scalar', () => {
+		const [ values, severities ] = extractSeverities(
+			{ maximum: { value: 100, severity: 'error' } },
+		);
+
+		expect( values ).toEqual( { maximum: 100 } );
+		expect( severities ).toEqual( { maximum: 'error' } );
+	} );
+
+	it( 'treats the value-less object form as true', () => {
+		const [ values, severities ] = extractSeverities(
+			{ required: { severity: 'error' } },
+		);
+
+		expect( values ).toEqual( { required: true } );
+		expect( severities ).toEqual( { required: 'error' } );
+	} );
+
+	it( 'does not normalize reserved keys carrying a severity-shaped value', () => {
+		// 'high' is not a severity: normalizing this key would throw rather than pass it through.
+		const raw = { type: 'number', description: 'x', default: { severity: 'high' } };
+
+		const [ values, severities ] = extractSeverities( raw );
+
+		expect( values ).toEqual( raw );
+		expect( severities ).toEqual( {} );
+	} );
+
+	it( 'throws on an unknown severity', () => {
+		expect( () => extractSeverities( { maximum: { value: 1, severity: 'bogus' } } ) )
+			.toThrow( 'Invalid severity: "bogus"' );
+	} );
+
+	// Materially reachable only via the custom keys of unregistered types: the
+	// registered type parsers normalize null bounds to undefined downstream.
+	it( 'preserves an explicit null value rather than coalescing it to true', () => {
+		const [ values ] = extractSeverities(
+			{ maximum: { value: null, severity: 'error' } },
+		);
+
+		expect( values.maximum ).toBeNull();
+	} );
+
+	it( 'records a warning annotation so a later value edit keeps it', () => {
+		const [ values, severities ] = extractSeverities(
+			{ minimum: { value: 5, severity: 'warning' } },
+		);
+
+		expect( values ).toEqual( { minimum: 5 } );
+		expect( severities ).toEqual( { minimum: 'warning' } );
+	} );
+} );
+
+describe( 'applySeverities', () => {
+	it( 'wraps an error-annotated scalar and keeps warning as shorthand', () => {
+		const severities: Record<string, Severity> = { minimum: 'warning', maximum: 'error' };
+
+		expect( applySeverities( { minimum: 0, maximum: 100 }, severities ) ).toEqual(
+			{ minimum: 0, maximum: { value: 100, severity: 'error' } },
+		);
+	} );
+
+	it( 'wraps an error-annotated true without a value key', () => {
+		expect( applySeverities( { required: true }, { required: 'error' } ) ).toEqual(
+			{ required: { severity: 'error' } },
+		);
+	} );
+
+	it( 'keeps a false boolean value rather than implying true', () => {
+		// The value-less object form implies true, so emitting it for a `false` value
+		// would read back as `true` and silently enable a Constraint the author
+		// disabled. Core booleans are always true when annotated, but a custom
+		// Property Type's own boolean key carries no such guard.
+		expect( applySeverities( { caseSensitive: false }, { caseSensitive: 'error' } ) ).toEqual(
+			{ caseSensitive: { value: false, severity: 'error' } },
+		);
+	} );
+
+	it( 'skips severities whose key is absent or undefined in the JSON', () => {
+		expect( applySeverities(
+			{ minimum: undefined },
+			{ minimum: 'error', maximum: 'error' },
+		) ).toEqual( {} );
+	} );
+
+	it( 'drops the annotation of an unchecked core boolean Constraint instead of wrapping false', () => {
+		expect( applySeverities(
+			{ required: false, uniqueItems: false, maximum: 100 },
+			{ required: 'error', uniqueItems: 'error', maximum: 'error' },
+		) ).toEqual( { required: false, uniqueItems: false, maximum: { value: 100, severity: 'error' } } );
+	} );
+
+	it( 'round-trips an options-array annotation through extract', () => {
+		const original = { options: { value: [ 'a', 'b' ], severity: 'error' } };
+
+		const [ values, severities ] = extractSeverities( original );
+
+		expect( applySeverities( values, severities ) ).toEqual( original );
+	} );
+} );

--- a/resources/ext.neowiki/tests/domain/SubjectViolation.spec.ts
+++ b/resources/ext.neowiki/tests/domain/SubjectViolation.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { withoutMissingValueViolations, SubjectViolation } from '@/domain/SubjectViolation.ts';
 
 function violation( code: string, propertyName: string | null = 'Homepage' ): SubjectViolation {
-	return { propertyName, code, args: [], valuePartIndex: null };
+	return { propertyName, code, args: [], severity: 'error', valuePartIndex: null };
 }
 
 describe( 'withoutMissingValueViolations', () => {

--- a/resources/ext.neowiki/tests/persistence/RestSubjectRepository.neo4j.spec.ts
+++ b/resources/ext.neowiki/tests/persistence/RestSubjectRepository.neo4j.spec.ts
@@ -491,9 +491,9 @@ describe( 'RestSubjectRepository', () => {
 				status: 'error',
 				message: 'Validation failed',
 				violations: [
-					{ propertyName: 'Status', code: 'required', args: [], valuePartIndex: null },
-					{ propertyName: 'Website', code: 'invalid-url', args: [], valuePartIndex: 1 },
-					{ propertyName: null, code: 'schema-not-found', args: [ 'Person' ], valuePartIndex: null },
+					{ propertyName: 'Status', code: 'required', args: [], severity: 'error', valuePartIndex: null },
+					{ propertyName: 'Website', code: 'invalid-url', args: [], severity: 'error', valuePartIndex: 1 },
+					{ propertyName: null, code: 'schema-not-found', args: [ 'Person' ], severity: 'error', valuePartIndex: null },
 				],
 			};
 
@@ -503,9 +503,9 @@ describe( 'RestSubjectRepository', () => {
 			const error = await promise.catch( ( e ) => e );
 			expect( error ).toBeInstanceOf( ValidationFailedError );
 			expect( ( error as ValidationFailedError ).violations ).toEqual( [
-				{ propertyName: 'Status', code: 'required', args: [], valuePartIndex: null },
-				{ propertyName: 'Website', code: 'invalid-url', args: [], valuePartIndex: 1 },
-				{ propertyName: null, code: 'schema-not-found', args: [ 'Person' ], valuePartIndex: null },
+				{ propertyName: 'Status', code: 'required', args: [], severity: 'error', valuePartIndex: null },
+				{ propertyName: 'Website', code: 'invalid-url', args: [], severity: 'error', valuePartIndex: 1 },
+				{ propertyName: null, code: 'schema-not-found', args: [ 'Person' ], severity: 'error', valuePartIndex: null },
 			] );
 		} );
 
@@ -530,7 +530,7 @@ describe( 'RestSubjectRepository', () => {
 
 		it( 'throws generic Error when a violation entry has a non-string code', async () => {
 			const promise = repoWith( make422Response( {
-				violations: [ { propertyName: 'Foo', code: 123, args: [], valuePartIndex: null } ],
+				violations: [ { propertyName: 'Foo', code: 123, args: [], severity: 'error', valuePartIndex: null } ],
 			} ) ).updateSubject( new SubjectId( 's11111111111111' ), 'Label', new StatementList( [] ) );
 
 			await expect( promise ).rejects.toSatisfy(
@@ -563,7 +563,7 @@ describe( 'RestSubjectRepository', () => {
 		it( 'throws ValidationFailedError on well-formed 422', async () => {
 			const body = {
 				violations: [
-					{ propertyName: 'Status', code: 'required', args: [], valuePartIndex: null },
+					{ propertyName: 'Status', code: 'required', args: [], severity: 'error', valuePartIndex: null },
 				],
 			};
 			const inMemoryHttpClient = new InMemoryHttpClient( {
@@ -584,7 +584,7 @@ describe( 'RestSubjectRepository', () => {
 		it( 'throws ValidationFailedError on well-formed 422', async () => {
 			const body = {
 				violations: [
-					{ propertyName: 'Status', code: 'required', args: [], valuePartIndex: null },
+					{ propertyName: 'Status', code: 'required', args: [], severity: 'error', valuePartIndex: null },
 				],
 			};
 			const inMemoryHttpClient = new InMemoryHttpClient( {

--- a/resources/ext.neowiki/tests/persistence/SchemaSerializer.unit.spec.ts
+++ b/resources/ext.neowiki/tests/persistence/SchemaSerializer.unit.spec.ts
@@ -129,6 +129,100 @@ describe( 'SchemaSerializer', () => {
 		} );
 	} );
 
+	describe( 'Constraint severity round-trip', () => {
+		it( 'round-trips error-annotated Constraints back to the object form', () => {
+			const json = {
+				description: 'Schema with annotated Constraints',
+				propertyDefinitions: {
+					Score: {
+						type: 'number',
+						description: '',
+						required: { severity: 'error' },
+						minimum: 0,
+						maximum: { value: 100, severity: 'error' },
+					},
+				},
+			};
+
+			const schema = new SchemaDeserializer().deserialize( 'Test', json );
+
+			expect( JSON.parse( serializer.serializeSchema( schema ) ) ).toEqual( json );
+		} );
+
+		it( 'emits the shorthand for a warning-annotated Constraint', () => {
+			const schema = new SchemaDeserializer().deserialize( 'Test', {
+				description: '',
+				propertyDefinitions: {
+					Name: {
+						type: 'text',
+						description: '',
+						required: false,
+						multiple: false,
+						uniqueItems: false,
+						minLength: { value: 2, severity: 'warning' },
+					},
+				},
+			} );
+
+			const parsed = JSON.parse( serializer.serializeSchema( schema ) );
+
+			expect( parsed.propertyDefinitions.Name.minLength ).toBe( 2 );
+		} );
+
+		it( 'serializes an unchecked core boolean Constraint as bare false, dropping its annotation', () => {
+			// The schema editor can uncheck an annotated required/uniqueItems while its
+			// severity entry survives on the domain object. The object form cannot carry
+			// false, so serialization must emit the bare scalar the backend accepts.
+			const schema = new SchemaDeserializer().deserialize( 'Test', {
+				description: '',
+				propertyDefinitions: {
+					Name: {
+						type: 'text',
+						description: '',
+						required: { severity: 'error' },
+						multiple: true,
+						uniqueItems: { severity: 'error' },
+					},
+				},
+			} );
+
+			const unchecked = new Schema(
+				schema.getName(),
+				schema.getDescription(),
+				new PropertyDefinitionList(
+					[ ...schema.getPropertyDefinitions() ].map( ( property ) => ( {
+						...property,
+						required: false,
+						uniqueItems: false,
+					} ) ),
+				),
+			);
+
+			const parsed = JSON.parse( serializer.serializeSchema( unchecked ) );
+
+			expect( parsed.propertyDefinitions.Name.required ).toBe( false );
+			expect( parsed.propertyDefinitions.Name.uniqueItems ).toBe( false );
+		} );
+
+		it( 'round-trips an annotated key of an unregistered type', () => {
+			const json = {
+				description: '',
+				propertyDefinitions: {
+					Swatch: {
+						type: 'zzz-color',
+						description: '',
+						required: false,
+						palette: { value: 'warm', severity: 'error' },
+					},
+				},
+			};
+
+			const schema = new SchemaDeserializer().deserialize( 'Test', json );
+
+			expect( JSON.parse( serializer.serializeSchema( schema ) ) ).toEqual( json );
+		} );
+	} );
+
 	describe( 'serialization formatting', () => {
 		it( 'uses 4 spaces for indentation', () => {
 			const schema = new Schema(

--- a/resources/ext.neowiki/tests/persistence/ValidationFailedError.spec.ts
+++ b/resources/ext.neowiki/tests/persistence/ValidationFailedError.spec.ts
@@ -8,6 +8,7 @@ describe( 'ValidationFailedError', () => {
 		propertyName: 'Status',
 		code: 'required',
 		args: [],
+		severity: 'error',
 		valuePartIndex: null,
 	};
 

--- a/resources/ext.neowiki/tests/persistence/violationParsing.spec.ts
+++ b/resources/ext.neowiki/tests/persistence/violationParsing.spec.ts
@@ -4,11 +4,31 @@ import { parseViolations } from '@/persistence/violationParsing.ts';
 describe( 'parseViolations', () => {
 	it( 'parses a well-shaped violations body and defaults a missing valuePartIndex to null', () => {
 		const result = parseViolations( {
-			violations: [ { propertyName: 'Homepage', code: 'invalid-url', args: [] } ],
+			violations: [ { propertyName: 'Homepage', code: 'invalid-url', args: [], severity: 'error' } ],
 		} );
 		expect( result ).toEqual( [
-			{ propertyName: 'Homepage', code: 'invalid-url', args: [], valuePartIndex: null },
+			{ propertyName: 'Homepage', code: 'invalid-url', args: [], severity: 'error', valuePartIndex: null },
 		] );
+	} );
+
+	it( 'carries a warning severity through', () => {
+		const result = parseViolations( {
+			violations: [ { propertyName: 'Score', code: 'max-value', args: [ '100' ], severity: 'warning' } ],
+		} );
+		expect( result?.[ 0 ].severity ).toBe( 'warning' );
+	} );
+
+	it( 'defaults a missing severity to warning', () => {
+		const result = parseViolations( {
+			violations: [ { propertyName: 'Homepage', code: 'invalid-url', args: [] } ],
+		} );
+		expect( result?.[ 0 ].severity ).toBe( 'warning' );
+	} );
+
+	it( 'returns null for a body carrying an unknown severity', () => {
+		expect( parseViolations( {
+			violations: [ { propertyName: 'Homepage', code: 'invalid-url', args: [], severity: 'info' } ],
+		} ) ).toBeNull();
 	} );
 
 	it( 'returns null for a malformed body', () => {


### PR DESCRIPTION
Fixes #1148. Frontend half of per-Constraint validation severity ([ADR 26](https://github.com/ProfessionalWiki/NeoWiki/blob/master/docs/adr/026-validation-severity-levels.md)); the backend landed in #1147.

## Parsing and round-trip

* New `domain/Severity.ts` and `domain/SeverityNormalizer.ts` mirror the PHP `SeverityNormalizer`: `extractSeverities` unwraps the object Constraint form (`{ value, severity }`; value-less booleans imply `true`; explicit `value: null` preserved; reserved `type`/`description`/`default` keys skipped; invalid severities throw), `applySeverities` re-wraps only `error`-annotated keys so unannotated Schemas round-trip unchanged.
* `PropertyDefinitionDeserializer` extracts once, drops severities on registered types' Display Attributes (matching `PropertyDefinition::fromJson`), and hands the normalized values to the type parsers — so `required` no longer parses to a truthy object and numeric bounds no longer become `NaN`. The unregistered-type fallback spreads the normalized values, keeping annotated custom keys round-trippable.
* `PropertyDefinition` gains an optional `constraintSeverities` map (set only when a Constraint is annotated), which `SchemaSerializer` re-applies on output. The schema editor preserves it through attribute edits and drops it on type change, like the other Constraint fields.

## Violation severity in the UI

* `SubjectViolation` carries the always-present `severity`; `parseViolations` defaults legacy bodies to `warning` and rejects unknown values.
* `useServerViolations` returns severity-keyed Codex message objects (`firstMessages`/`fieldLevelMessages`) plus a shared `violationStatus()` helper; `useFieldServerViolation` returns `validationMessages`/`validationStatus` (rename allowed under the public-api alpha contract); `useStringValueInput` keys per-part and summary messages by severity.
* All value inputs bind a three-way field status, so warnings render with Codex `warning` styling instead of `error`. Multi-value Text/Url fields keep their pre-existing `default` field status (per-slot statuses live in `NeoMultiTextInput`).
* The duplicated dialog banner is extracted into `SubjectViolationBanners.vue`, which splits anchorless violations into an error banner and a warning banner.
* Saving was never gated client-side; new dialog tests pin that a warning-only dry-run result does not block the save in either dialog.

## Manual Browser Check

1. On a dev wiki with demo data, open a Schema page (e.g. `Schema:Person`) with `action=edit` and give a number property an annotated bound, e.g. `"maximum": { "value": 100, "severity": "error" }`, plus a plain Constraint such as `"minLength": 2` on a text property. Save.
2. Open the schema in the Schema editor (via a Subject's edit dialog → schema link), confirm the bound shows as `100` (not blank/NaN), re-save, and check the stored JSON kept the `{ "value": 100, "severity": "error" }` object form while the plain Constraints stayed scalars.
3. Edit a Subject of that schema: enter a number above the maximum and blur — the field should show red error styling with the max-value message. Violate the `minLength` Constraint — the field should show yellow warning styling instead.
4. Rename the schema page (or edit a Subject whose schema is missing) to trigger `schema-not-found`: the dialog banner should render as a warning message, and saving the Subject should still succeed.

<sub>AI-authored — Claude Code, Fable 5; implementation of #1148 mirroring the #1147 backend semantics; verified via the tsci checks run individually (vitest 1245/1245 with a capped worker pool, vue-tsc + vite build, eslint/stylelint — a single make tsci invocation OOMs in this dev sidecar) plus an adversarial review subagent whose three minor findings are addressed.</sub>