### PR TITLE
Add write-speed targets to the scalability ADR

### DIFF
--- a/docs/adr/029-scalability-targets.md
+++ b/docs/adr/029-scalability-targets.md
@@ -9,9 +9,18 @@ Status: Draft
 To make good design and implementation decisions, we need to know how far NeoWiki should scale, so we avoid both
 degraded performance at scale and accidental complexity via unnecessary optimization.
 
-For grounding: ~75% of surveyed GLAM institutions hold under 100 thousand objects, ~17% between 100 thousand and
-1 million, and ~7% more (ICOM, n=1,132); enterprise wikis run one to two orders smaller. Typical wikis also stay
-under 30 Schemas, 10 Subjects per page and 15 Statements per Subject.
+For grounding, informed estimates of what real deployments look like. Only collection size is surveyed (~75% of
+GLAM institutions hold under 100 thousand objects, ~17% up to 1 million, ~7% more — ICOM, n=1,132; enterprise wikis
+run one to two orders smaller); the rest extrapolates from partner soundings and modelling practice:
+
+| Metric                 | 80% of wikis stay under | 99% of wikis stay under |
+|------------------------|-------------------------|-------------------------|
+| Total Subjects         | 100 thousand            | 10 million              |
+| Total Schemas          | 30                      | 100                     |
+| Subjects per Page      | 10                      | 50                      |
+| Statements per Subject | 15                      | 50                      |
+
+The Great tier below matches the 99% column by design.
 
 ## Decision
 

--- a/docs/adr/029-scalability-targets.md
+++ b/docs/adr/029-scalability-targets.md
@@ -9,6 +9,9 @@ Status: Draft
 To make good design and implementation decisions, we need to know how far NeoWiki should scale, so we avoid both
 degraded performance at scale and accidental complexity via unnecessary optimization.
 
+The write path gets explicit speed targets because the documented scalability failures of comparable systems are
+import throughput and rebuild wall-clock rather than query latency.
+
 ## Decision
 
 NeoWiki needs to handle these sizes, counted per graph store (so for wiki farms we combine all wikis):
@@ -21,6 +24,19 @@ NeoWiki needs to handle these sizes, counted per graph store (so for wiki farms 
 | Statements per Subject | < 15                | 50                               | 100              |
 
 Great: performs well with great UX. Acceptable: usable, though some degradation of UX or performance is fine.
+Typical describes most wikis and is what defaults are designed for; Great covers essentially all real deployments;
+Acceptable keeps outliers functional.
 
 The numbers for "Great" and "Acceptable" are lower bounds. Scaling beyond them is nice, and should be done
 where it is possible cheaply.
+
+NeoWiki needs to meet these write speeds, measured through the bulk import channel (`importDump.php`) with all
+configured projections included:
+
+| Write path                            | Great                | Acceptable          |
+|---------------------------------------|----------------------|---------------------|
+| Bulk import throughput                | 100+ Subjects/second | 25 Subjects/second  |
+| Full projection rebuild               | 500+ Subjects/second | 100 Subjects/second |
+| Latency a save gains from projections | under 100 ms         | under 1 second      |
+
+These hold flat across the size targets above; at the 10 million tier, a full rebuild then takes around six hours.

--- a/docs/adr/029-scalability-targets.md
+++ b/docs/adr/029-scalability-targets.md
@@ -37,8 +37,9 @@ Definitions:
 NeoWiki needs to meet these write speeds at any size within the scalability targets above, with all configured
 projections included. The duration columns follow from the target rate:
 
-| Write path                                          | Target               | 1 million    | 10 million |
+| Write path                                          | Subjects/second      | 1 million Subjects    | 10 million Subjects |
 |-----------------------------------------------------|----------------------|--------------|------------|
 | Import throughput (`importDump.php`)                | 100+ Subjects/second | < 3 hours    | ~1 day     |
 | Projection rebuild (`RebuildGraphDatabases.php`)    | 500+ Subjects/second | ~30 minutes  | < 6 hours  |
-| Latency an interactive save gains from projections  | under 100 ms         | —            | —          |
+
+Max latency an interactive save gains from projections: 100 ms

--- a/docs/adr/029-scalability-targets.md
+++ b/docs/adr/029-scalability-targets.md
@@ -9,8 +9,9 @@ Status: Draft
 To make good design and implementation decisions, we need to know how far NeoWiki should scale, so we avoid both
 degraded performance at scale and accidental complexity via unnecessary optimization.
 
-Most real wikis sit well below the targets set here: under 100 thousand Subjects, 30 Schemas, 10 Subjects per page and
-15 Statements per Subject (per surveyed GLAM collection sizes; enterprise wikis run smaller still).
+For grounding: ~75% of surveyed GLAM institutions hold under 100 thousand objects, ~17% between 100 thousand and
+1 million, and ~7% more (ICOM, n=1,132); enterprise wikis run one to two orders smaller. Typical wikis also stay
+under 30 Schemas, 10 Subjects per page and 15 Statements per Subject.
 
 ## Decision
 

--- a/docs/adr/029-scalability-targets.md
+++ b/docs/adr/029-scalability-targets.md
@@ -35,7 +35,9 @@ NeoWiki needs to meet these write speeds, with all configured projections includ
 | Projection rebuild (`RebuildGraphDatabases.php`)    | 500+ Subjects/second | 100 Subjects/second |
 | Latency an interactive save gains from projections  | under 100 ms         | under 1 second      |
 
-These hold flat across the size targets above; at the 10 million tier, a full rebuild then takes around six hours.
+These hold flat across the size targets above. At the Great rates, importing 1 million Subjects takes under three
+hours (rebuild: about half an hour), and 10 million just over a day (rebuild: under six hours). Common Wikibase
+tooling measures 1-4 entities per second, putting a 1 million import there at days to weeks.
 
 ### Definitions
 

--- a/docs/adr/029-scalability-targets.md
+++ b/docs/adr/029-scalability-targets.md
@@ -27,17 +27,16 @@ Most real wikis sit well below these targets: under ~100 thousand Subjects, 30 S
 
 ### Writing Speed Targets
 
-NeoWiki needs to meet these write speeds, with all configured projections included:
+NeoWiki needs to meet these write speeds at any size within the scalability targets above, with all configured
+projections included. The duration columns are at the Great rate:
 
-| Write path                                          | Great                | Acceptable          |
-|-----------------------------------------------------|----------------------|---------------------|
-| Import throughput (`importDump.php`)                | 100+ Subjects/second | 25 Subjects/second  |
-| Projection rebuild (`RebuildGraphDatabases.php`)    | 500+ Subjects/second | 100 Subjects/second |
-| Latency an interactive save gains from projections  | under 100 ms         | under 1 second      |
+| Write path                                          | Great                | Acceptable          | 1 million    | 10 million |
+|-----------------------------------------------------|----------------------|---------------------|--------------|------------|
+| Import throughput (`importDump.php`)                | 100+ Subjects/second | 25 Subjects/second  | < 3 hours    | ~1 day     |
+| Projection rebuild (`RebuildGraphDatabases.php`)    | 500+ Subjects/second | 100 Subjects/second | ~30 minutes  | < 6 hours  |
+| Latency an interactive save gains from projections  | under 100 ms         | under 1 second      | —            | —          |
 
-These hold flat across the size targets above. At the Great rates, importing 1 million Subjects takes under three
-hours (rebuild: about half an hour), and 10 million just over a day (rebuild: under six hours). Common Wikibase
-tooling measures 1-4 entities per second, putting a 1 million import there at days to weeks.
+Common Wikibase tooling measures 1-4 entities per second, putting a 1 million import there at days to weeks.
 
 ### Definitions
 

--- a/docs/adr/029-scalability-targets.md
+++ b/docs/adr/029-scalability-targets.md
@@ -9,9 +9,7 @@ Status: Draft
 To make good design and implementation decisions, we need to know how far NeoWiki should scale, so we avoid both
 degraded performance at scale and accidental complexity via unnecessary optimization.
 
-For grounding, informed estimates of what real deployments look like. Only collection size is surveyed (~75% of
-GLAM institutions hold under 100 thousand objects, ~17% up to 1 million, ~7% more — ICOM, n=1,132; enterprise wikis
-run one to two orders smaller); the rest extrapolates from partner soundings and modelling practice:
+Informed estimates of what real deployments look like:
 
 | Metric                 | 80% of wikis stay under | 99% of wikis stay under |
 |------------------------|-------------------------|-------------------------|
@@ -20,7 +18,7 @@ run one to two orders smaller); the rest extrapolates from partner soundings and
 | Subjects per Page      | 10                      | 50                      |
 | Statements per Subject | 15                      | 50                      |
 
-The Great tier below matches the 99% column by design.
+The Great tier below matches the 99% column.
 
 ## Decision
 

--- a/docs/adr/029-scalability-targets.md
+++ b/docs/adr/029-scalability-targets.md
@@ -9,7 +9,7 @@ Status: Draft
 To make good design and implementation decisions, we need to know how far NeoWiki should scale, so we avoid both
 degraded performance at scale and accidental complexity via unnecessary optimization.
 
-Most real wikis sit well below these targets: under 100 thousand Subjects, 30 Schemas, 10 Subjects per page and
+Most real wikis sit well below the targets set here: under 100 thousand Subjects, 30 Schemas, 10 Subjects per page and
 15 Statements per Subject (per surveyed GLAM collection sizes; enterprise wikis run smaller still).
 
 ## Decision
@@ -35,7 +35,7 @@ Definitions:
 ### Writing Speed Targets
 
 NeoWiki needs to meet these write speeds at any size within the scalability targets above, with all configured
-projections included. The duration columns are at the Great rate:
+projections included. The duration columns follow from the target rate:
 
 | Write path                                          | Target               | 1 million    | 10 million |
 |-----------------------------------------------------|----------------------|--------------|------------|

--- a/docs/adr/029-scalability-targets.md
+++ b/docs/adr/029-scalability-targets.md
@@ -9,6 +9,10 @@ Status: Draft
 To make good design and implementation decisions, we need to know how far NeoWiki should scale, so we avoid both
 degraded performance at scale and accidental complexity via unnecessary optimization.
 
+For grounding: ~75% of surveyed GLAM institutions hold under 100 thousand objects and ~7% over 1 million (ICOM,
+n=1,132), and enterprise wikis run one to two orders smaller — so the 80th percentile of real deployments sits
+around 100 thousand Subjects and the 99th within the Great tier.
+
 ## Decision
 
 ### Scalability Targets
@@ -24,14 +28,17 @@ NeoWiki needs to handle these sizes, counted per graph store (so for wiki farms 
 
 ### Writing Speed Targets
 
-NeoWiki needs to meet these write speeds, measured through the bulk import channel (`importDump.php`) with all
-configured projections included:
+NeoWiki needs to meet these write speeds, with all configured projections included:
 
 | Write path                            | Great                | Acceptable          |
 |---------------------------------------|----------------------|---------------------|
 | Bulk import throughput                | 100+ Subjects/second | 25 Subjects/second  |
 | Full projection rebuild               | 500+ Subjects/second | 100 Subjects/second |
 | Latency a save gains from projections | under 100 ms         | under 1 second      |
+
+Bulk import is measured through `importDump.php`. A full projection rebuild is `RebuildGraphDatabases.php`
+re-projecting every page into the graph stores, without writing MediaWiki revisions. Save latency is the synchronous
+projection share of an interactive page save.
 
 These hold flat across the size targets above; at the 10 million tier, a full rebuild then takes around six hours.
 

--- a/docs/adr/029-scalability-targets.md
+++ b/docs/adr/029-scalability-targets.md
@@ -9,10 +9,9 @@ Status: Draft
 To make good design and implementation decisions, we need to know how far NeoWiki should scale, so we avoid both
 degraded performance at scale and accidental complexity via unnecessary optimization.
 
-The write path gets explicit speed targets because the documented scalability failures of comparable systems are
-import throughput and rebuild wall-clock rather than query latency.
-
 ## Decision
+
+### Scalability Targets
 
 NeoWiki needs to handle these sizes, counted per graph store (so for wiki farms we combine all wikis):
 
@@ -23,12 +22,7 @@ NeoWiki needs to handle these sizes, counted per graph store (so for wiki farms 
 | Subjects per Page      | < 10                | 50                               | 250              |
 | Statements per Subject | < 15                | 50                               | 100              |
 
-Great: performs well with great UX. Acceptable: usable, though some degradation of UX or performance is fine.
-Typical describes most wikis and is what defaults are designed for; Great covers essentially all real deployments;
-Acceptable keeps outliers functional.
-
-The numbers for "Great" and "Acceptable" are lower bounds. Scaling beyond them is nice, and should be done
-where it is possible cheaply.
+### Writing Speed Targets
 
 NeoWiki needs to meet these write speeds, measured through the bulk import channel (`importDump.php`) with all
 configured projections included:
@@ -40,3 +34,12 @@ configured projections included:
 | Latency a save gains from projections | under 100 ms         | under 1 second      |
 
 These hold flat across the size targets above; at the 10 million tier, a full rebuild then takes around six hours.
+
+### Definitions
+
+* **Typical** describes most wikis and is what defaults are designed for
+* **Great**: performs well with great UX, covers essentially all real deployments
+* **Acceptable**: usable, though some degradation of UX or performance is fine. To keep outliers functional
+
+The numbers for "Great" and "Acceptable" are lower bounds. Scaling beyond them is nice, and should be done
+where it is possible cheaply.

--- a/docs/adr/029-scalability-targets.md
+++ b/docs/adr/029-scalability-targets.md
@@ -37,9 +37,9 @@ Definitions:
 NeoWiki needs to meet these write speeds at any size within the scalability targets above, with all configured
 projections included. The duration columns follow from the target rate:
 
-| Write path                                          | Subjects/second      | 1 million Subjects    | 10 million Subjects |
-|-----------------------------------------------------|----------------------|--------------|------------|
-| Import throughput (`importDump.php`)                | 100+ Subjects/second | < 3 hours    | ~1 day     |
-| Projection rebuild (`RebuildGraphDatabases.php`)    | 500+ Subjects/second | ~30 minutes  | < 6 hours  |
+| Write path                                       | Subjects/second | 100 thousand Subjects | 1 million Subjects | 10 million Subjects |
+|--------------------------------------------------|-----------------|-----------------------|--------------------|---------------------|
+| Import throughput (`importDump.php`)             | 100+            | < 20 minutes          | < 3 hours          | ~1 day              |
+| Projection rebuild (`RebuildGraphDatabases.php`) | 500+            | ~3 minutes            | ~30 minutes        | < 6 hours           |
 
 Max latency an interactive save gains from projections: 100 ms

--- a/docs/adr/029-scalability-targets.md
+++ b/docs/adr/029-scalability-targets.md
@@ -9,42 +9,36 @@ Status: Draft
 To make good design and implementation decisions, we need to know how far NeoWiki should scale, so we avoid both
 degraded performance at scale and accidental complexity via unnecessary optimization.
 
-For grounding: ~75% of surveyed GLAM institutions hold under 100 thousand objects and ~7% over 1 million (ICOM,
-n=1,132), and enterprise wikis run one to two orders smaller — so the 80th percentile of real deployments sits
-around 100 thousand Subjects and the 99th within the Great tier.
-
 ## Decision
 
 ### Scalability Targets
 
 NeoWiki needs to handle these sizes, counted per graph store (so for wiki farms we combine all wikis):
 
-| Metric                 | Typical (90% case)  | Great up to                      | Acceptable up to |
-|------------------------|---------------------|----------------------------------|------------------|
-| Total Subjects         | << 1 million        | 10 million                       | 50 million       |
-| Total Schemas          | < 30                | 100 (UX-bound; performance: 500) | 500              |
-| Subjects per Page      | < 10                | 50                               | 250              |
-| Statements per Subject | < 15                | 50                               | 100              |
+| Metric                 | Great up to                      | Acceptable up to |
+|------------------------|----------------------------------|------------------|
+| Total Subjects         | 10 million                       | 50 million       |
+| Total Schemas          | 100 (UX-bound; performance: 500) | 500              |
+| Subjects per Page      | 50                               | 250              |
+| Statements per Subject | 50                               | 100              |
+
+Most real wikis sit well below these targets: under ~100 thousand Subjects, 30 Schemas, 10 Subjects per page and
+15 Statements per Subject (per surveyed GLAM collection sizes; enterprise wikis run smaller still).
 
 ### Writing Speed Targets
 
 NeoWiki needs to meet these write speeds, with all configured projections included:
 
-| Write path                            | Great                | Acceptable          |
-|---------------------------------------|----------------------|---------------------|
-| Bulk import throughput                | 100+ Subjects/second | 25 Subjects/second  |
-| Full projection rebuild               | 500+ Subjects/second | 100 Subjects/second |
-| Latency a save gains from projections | under 100 ms         | under 1 second      |
-
-Bulk import is measured through `importDump.php`. A full projection rebuild is `RebuildGraphDatabases.php`
-re-projecting every page into the graph stores, without writing MediaWiki revisions. Save latency is the synchronous
-projection share of an interactive page save.
+| Write path                                          | Great                | Acceptable          |
+|-----------------------------------------------------|----------------------|---------------------|
+| Import throughput (`importDump.php`)                | 100+ Subjects/second | 25 Subjects/second  |
+| Projection rebuild (`RebuildGraphDatabases.php`)    | 500+ Subjects/second | 100 Subjects/second |
+| Latency an interactive save gains from projections  | under 100 ms         | under 1 second      |
 
 These hold flat across the size targets above; at the 10 million tier, a full rebuild then takes around six hours.
 
 ### Definitions
 
-* **Typical** describes most wikis and is what defaults are designed for
 * **Great**: performs well with great UX, covers essentially all real deployments
 * **Acceptable**: usable, though some degradation of UX or performance is fine. To keep outliers functional
 

--- a/docs/adr/029-scalability-targets.md
+++ b/docs/adr/029-scalability-targets.md
@@ -9,7 +9,12 @@ Status: Draft
 To make good design and implementation decisions, we need to know how far NeoWiki should scale, so we avoid both
 degraded performance at scale and accidental complexity via unnecessary optimization.
 
+Most real wikis sit well below these targets: under 100 thousand Subjects, 30 Schemas, 10 Subjects per page and
+15 Statements per Subject (per surveyed GLAM collection sizes; enterprise wikis run smaller still).
+
 ## Decision
+
+The targets are lower bounds. Scaling beyond them is nice and should be done where it is possible and cheap.
 
 ### Scalability Targets
 
@@ -22,26 +27,18 @@ NeoWiki needs to handle these sizes, counted per graph store (so for wiki farms 
 | Subjects per Page      | 50                               | 250              |
 | Statements per Subject | 50                               | 100              |
 
-Most real wikis sit well below these targets: under ~100 thousand Subjects, 30 Schemas, 10 Subjects per page and
-15 Statements per Subject (per surveyed GLAM collection sizes; enterprise wikis run smaller still).
+Definitions:
+
+* **Great**: performs well with great UX, covers essentially all real deployments
+* **Acceptable**: usable, though some degradation of UX or performance is fine. To keep outliers functional
 
 ### Writing Speed Targets
 
 NeoWiki needs to meet these write speeds at any size within the scalability targets above, with all configured
 projections included. The duration columns are at the Great rate:
 
-| Write path                                          | Great                | Acceptable          | 1 million    | 10 million |
-|-----------------------------------------------------|----------------------|---------------------|--------------|------------|
-| Import throughput (`importDump.php`)                | 100+ Subjects/second | 25 Subjects/second  | < 3 hours    | ~1 day     |
-| Projection rebuild (`RebuildGraphDatabases.php`)    | 500+ Subjects/second | 100 Subjects/second | ~30 minutes  | < 6 hours  |
-| Latency an interactive save gains from projections  | under 100 ms         | under 1 second      | —            | —          |
-
-Common Wikibase tooling measures 1-4 entities per second, putting a 1 million import there at days to weeks.
-
-### Definitions
-
-* **Great**: performs well with great UX, covers essentially all real deployments
-* **Acceptable**: usable, though some degradation of UX or performance is fine. To keep outliers functional
-
-The numbers for "Great" and "Acceptable" are lower bounds. Scaling beyond them is nice, and should be done
-where it is possible cheaply.
+| Write path                                          | Target               | 1 million    | 10 million |
+|-----------------------------------------------------|----------------------|--------------|------------|
+| Import throughput (`importDump.php`)                | 100+ Subjects/second | < 3 hours    | ~1 day     |
+| Projection rebuild (`RebuildGraphDatabases.php`)    | 500+ Subjects/second | ~30 minutes  | < 6 hours  |
+| Latency an interactive save gains from projections  | under 100 ms         | —            | —          |


### PR DESCRIPTION
Adds write-speed targets to ADR 29, grounded in the 2026-07 measurement campaigns rather than aspiration. Three
choices worth review:

- **Rate-based throughput targets** (Subjects/second for bulk import and rebuild) instead of wall-clock at a fixed
  tier, so the targets stay coherent as the size tiers move — as they just did. One wall-clock anchor sentence
  translates the rebuild rate at the 10M tier.
- **The flatness clause** ("hold flat across the size targets") carries the real lesson of the measurements: the
  failure mode is cost growing with graph size, not a slow constant.
- **The save-latency row** is the interactive budget nothing else in the ADR captured — the bound editors feel on
  every save, and the one the SPARQL projection currently violates at large stores.

Measured today (Neo4j projection): import 602 Subjects/s and rebuild ~605 Subjects/s, both flat to a 1M-node graph;
save latency ~30 ms. With the QLever projection enabled, import is ~36 Subjects/s and decaying — the SPARQL store is
where these targets currently bind. Also adds one Context sentence on why write speed gets targets, and one sentence
defining the size table's columns in population terms.

> <sub>AI-authored — Claude Code, `Fable 5 (max)`; requested by @JeroenDeDauw with the metric choice delegated, no revisions; not yet human-reviewed; numbers cross-checked against the measurement records.</sub>
