### PR TITLE
Add structural ontology mapping: node synthesis and contributions

### DIFF
--- a/DemoData/EdmSparqlPage/EDM_queries.wikitext
+++ b/DemoData/EdmSparqlPage/EDM_queries.wikitext
@@ -4,15 +4,15 @@ Every example below uses the <code><nowiki>{{#sparql_raw}}</nowiki></code> parse
 
 == Query in EDM terms ==
 
-The Person and Artist Schemas both map to <code>edm:Agent</code>, so a query in EDM terms spans them without knowing either Schema:
+The Person and Artist Schemas both map to <code>edm:Agent</code>, so a query in EDM terms spans them without knowing either Schema. The birth date sits in its own <code>GRAPH</code> block because it does not always live with the agent: where a birth is modelled as its own Subject, [[Mapping:EDM]] contributes <code>rdaGr2:dateOfBirth</code> from the Birth page's graph instead.
 
 <syntaxhighlight lang="mediawiki">
-{{#sparql_raw:PREFIX edm: <http://www.europeana.eu/schemas/edm/> PREFIX rdaGr2: <http://rdvocab.info/ElementsGr2/> PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> SELECT ?agent ?dateOfBirth WHERE { GRAPH ?graph { ?a a edm:Agent ; rdfs:label ?agent ; rdaGr2:dateOfBirth ?dateOfBirth } } ORDER BY ?agent}}
+{{#sparql_raw:PREFIX edm: <http://www.europeana.eu/schemas/edm/> PREFIX rdaGr2: <http://rdvocab.info/ElementsGr2/> PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> SELECT ?agent ?dateOfBirth WHERE { GRAPH ?agentGraph { ?a a edm:Agent ; rdfs:label ?agent } GRAPH ?birthGraph { ?a rdaGr2:dateOfBirth ?dateOfBirth } } ORDER BY ?agent}}
 </syntaxhighlight>
 
 Result:
 
-{{#sparql_raw:PREFIX edm: <http://www.europeana.eu/schemas/edm/> PREFIX rdaGr2: <http://rdvocab.info/ElementsGr2/> PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> SELECT ?agent ?dateOfBirth WHERE { GRAPH ?graph { ?a a edm:Agent ; rdfs:label ?agent ; rdaGr2:dateOfBirth ?dateOfBirth } } ORDER BY ?agent}}
+{{#sparql_raw:PREFIX edm: <http://www.europeana.eu/schemas/edm/> PREFIX rdaGr2: <http://rdvocab.info/ElementsGr2/> PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> SELECT ?agent ?dateOfBirth WHERE { GRAPH ?agentGraph { ?a a edm:Agent ; rdfs:label ?agent } GRAPH ?birthGraph { ?a rdaGr2:dateOfBirth ?dateOfBirth } } ORDER BY ?agent}}
 
 A relation projects as a direct triple between two entity IRIs, so a query follows it the way it would in any EDM dataset. The artwork and its creator live on separate wiki pages, hence in separate named graphs:
 

--- a/DemoData/Mapping/CIDOC-CRM.json
+++ b/DemoData/Mapping/CIDOC-CRM.json
@@ -1,0 +1,56 @@
+{
+	"version": 1,
+	"prefixes": {
+		"crm": "http://www.cidoc-crm.org/cidoc-crm/"
+	},
+	"schemas": {
+		"Person": {
+			"subject": { "class": "crm:E21_Person" },
+			"nodes": {
+				"birth": { "class": "crm:E67_Birth", "linkPredicate": "crm:P98i_was_born" },
+				"birthTimespan": { "class": "crm:E52_Time-Span", "linkPredicate": "crm:P4_has_time-span", "parent": "birth" },
+				"appellation": { "class": "crm:E41_Appellation", "linkPredicate": "crm:P1_is_identified_by", "per": "value" }
+			},
+			"properties": {
+				"Description": { "predicate": "crm:P3_has_note" },
+				"Also known as": { "predicate": "crm:P190_has_symbolic_content", "node": "appellation" },
+				"Birth date": { "predicate": "crm:P82_at_some_time_within", "node": "birthTimespan" },
+				"Birth place": { "predicate": "crm:P7_took_place_at", "node": "birth" }
+			}
+		},
+		"Birth": {
+			"subject": { "class": "crm:E67_Birth" },
+			"nodes": {
+				"timespan": { "class": "crm:E52_Time-Span", "linkPredicate": "crm:P4_has_time-span" }
+			},
+			"properties": {
+				"Brought into life": { "predicate": "crm:P98_brought_into_life" },
+				"By mother": { "predicate": "crm:P96_by_mother" },
+				"From father": { "predicate": "crm:P97_from_father" },
+				"Took place at": { "predicate": "crm:P7_took_place_at" },
+				"Date": { "predicate": "crm:P82_at_some_time_within", "node": "timespan" }
+			}
+		},
+		"Place": {
+			"subject": { "class": "crm:E53_Place" },
+			"properties": {
+				"Description": { "predicate": "crm:P3_has_note" }
+			}
+		},
+		"City": {
+			"subject": { "class": "crm:E53_Place" }
+		},
+		"Artwork": {
+			"subject": { "class": "crm:E22_Human-Made_Object" },
+			"nodes": {
+				"production": { "class": "crm:E12_Production", "linkPredicate": "crm:P108i_was_produced_by", "per": "value" }
+			},
+			"properties": {
+				"Creator": { "predicate": "crm:P14_carried_out_by", "node": "production" }
+			}
+		},
+		"Artist": {
+			"subject": { "class": "crm:E21_Person" }
+		}
+	}
+}

--- a/DemoData/Mapping/EDM.json
+++ b/DemoData/Mapping/EDM.json
@@ -11,7 +11,7 @@
 	},
 	"schemas": {
 		"Person": {
-			"subject": { "class": "edm:Agent" },
+			"subject": { "class": "edm:Agent", "labelPredicate": "foaf:name" },
 			"properties": {
 				"Gender": { "predicate": "rdaGr2:gender" },
 				"Birth date": { "predicate": "rdaGr2:dateOfBirth" },
@@ -19,8 +19,16 @@
 				"Description": { "predicate": "skos:note", "lang": "en" }
 			}
 		},
+		"Birth": {
+			"contributions": {
+				"Brought into life": {
+					"Date": { "predicate": "rdaGr2:dateOfBirth" },
+					"Took place at": { "predicate": "rdaGr2:placeOfBirth" }
+				}
+			}
+		},
 		"Artist": {
-			"subject": { "class": "edm:Agent" },
+			"subject": { "class": "edm:Agent", "labelPredicate": "foaf:name" },
 			"properties": {
 				"Born": { "predicate": "rdaGr2:dateOfBirth", "datatype": "xsd:gYear" },
 				"Died": { "predicate": "rdaGr2:dateOfDeath", "datatype": "xsd:gYear" },
@@ -39,8 +47,10 @@
 			}
 		},
 		"City": {
-			"subject": { "class": "edm:Place" },
-			"properties": {}
+			"subject": { "class": "edm:Place" }
+		},
+		"Place": {
+			"subject": { "class": "edm:Place" }
 		}
 	}
 }

--- a/DemoData/Page/Main_Page.wikitext
+++ b/DemoData/Page/Main_Page.wikitext
@@ -12,7 +12,7 @@ This is a public demo of [https://neowiki.ai NeoWiki]. Explore the examples belo
 * Structured data, queried in a page: [[Museum collection]] runs live graph queries over linked museums, artworks, and exhibitions.
 * Several Subjects on one page: open the Data tab on [{{fullurl:Rijksmuseum|action=subjects}} Rijksmuseum] to see the museum and its yearly visitor records as separate Subjects.
 * Every Subject is shaped by a [[Special:Schemas|Schema]], and [[Special:Layouts|Layouts]] control how Subjects are displayed.
-* Every Subject's data as RDF: [[RDF and ontology mappings]] shows native and EDM projections of the demo content, the latter defined by [[Special:Mappings|Mappings]].
+* Every Subject's data as RDF: [[RDF and ontology mappings]] shows native, EDM and CIDOC-CRM projections of the demo content, the ontology ones defined by [[Special:Mappings|Mappings]].
 
 '''Trying it hands-on'''
 

--- a/DemoData/Page/People_and_life_events.wikitext
+++ b/DemoData/Page/People_and_life_events.wikitext
@@ -16,7 +16,9 @@ Each birth is its own Subject linking a child, mother, father, place, and date. 
 
 == Mapping to CIDOC CRM ==
 
-This dataset partially maps to [http://www.cidoc-crm.org/ CIDOC CRM]. The canonical statements run from the event to the person (E67 Birth, P98 brought into life, E21 Person); the reverse "was born" (P98i) is not stored as a separate edge but derived by [[Module:NeoWikiDemo]] reverse-querying the graph, which is how CIDOC inverse properties work.
+This dataset partially maps to [http://www.cidoc-crm.org/ CIDOC CRM], via [[Mapping:CIDOC-CRM]]. The canonical statements run from the event to the person (E67 Birth, P98 brought into life, E21 Person); the reverse "was born" (P98i) is not stored as a separate edge but derived by [[Module:NeoWikiDemo]] reverse-querying the graph, which is how CIDOC inverse properties work.
+
+A person who carries the flat Birth date and Birth place fields instead of a Birth Subject still gets a birth event in the projection: the Mapping synthesizes the E67 Birth and the E52 Time-Span the CIDOC path runs through.
 
 {| class="wikitable"
 ! NeoWiki !! CIDOC CRM !! URI
@@ -37,13 +39,17 @@ This dataset partially maps to [http://www.cidoc-crm.org/ CIDOC CRM]. The canoni
 |-
 | Birth: Date || P4 has time-span (E52 Time-Span; the date is the time-span's P82 value, collapsed to one date) || http://www.cidoc-crm.org/cidoc-crm/P4_has_time-span
 |-
-| Person: Also known as || P1 is identified by (E41 Appellation) || http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by
+| Person: Also known as || P1 is identified by, to one synthesized E41 Appellation per name, carrying P190 has symbolic content || http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by
+|-
+| Person: Birth date || P98i was born, to a synthesized E67 Birth, then P4 has time-span (E52 Time-Span) and P82 at some time within || http://www.cidoc-crm.org/cidoc-crm/P82_at_some_time_within
+|-
+| Person: Birth place || P98i was born, to that same synthesized E67 Birth, then P7 took place at || http://www.cidoc-crm.org/cidoc-crm/P7_took_place_at
 |-
 | Person / Place: Description || P3 has note (E62 String) || http://www.cidoc-crm.org/cidoc-crm/P3_has_note
 |-
-| Place: Coordinates || P168 place is defined by (E94 Space Primitive); stored as a lat/long display label, not a WKT/GML geometry literal || http://www.cidoc-crm.org/cidoc-crm/P168_place_is_defined_by
+| Place: Coordinates || P168 place is defined by (E94 Space Primitive). Not projected: the stored value is a lat/long display label, not the WKT/GML geometry literal P168 expects || http://www.cidoc-crm.org/cidoc-crm/P168_place_is_defined_by
 |-
-| Place: Country || No direct CIDOC property: denormalised country-name label (a faithful model would use P89 falls within a containing E53 Place) || http://www.cidoc-crm.org/cidoc-crm/P89_falls_within
+| Place: Country || Not projected: no direct CIDOC property for a denormalised country-name label (a faithful model would use P89 falls within a containing E53 Place) || http://www.cidoc-crm.org/cidoc-crm/P89_falls_within
 |}
 
 == How this is built ==

--- a/DemoData/Page/RDF_and_ontology_mappings.wikitext
+++ b/DemoData/Page/RDF_and_ontology_mappings.wikitext
@@ -7,9 +7,10 @@ Each export is produced on demand from the page's current data and downloads as 
 
 == The Mapping page ==
 
-Each Mapping page targets one ontology, named by the page title, and holds an entry for every mapped Schema. [[Special:Mappings]] lists them all; this wiki ships one:
+Each Mapping page targets one ontology, named by the page title, and holds an entry for every mapped Schema. [[Special:Mappings]] lists them all; this wiki ships two:
 
-* [[Mapping:EDM]]: the Person, City, Artwork and Artist Schemas, all mapped to EDM
+* [[Mapping:EDM]]: the Person, City, Place, Artwork and Artist Schemas mapped to EDM; the Birth Schema, deliberately given no EDM class, instead contributes flat triples to the people it points at
+* [[Mapping:CIDOC-CRM]]: the same Schemas mapped to [http://www.cidoc-crm.org/ CIDOC CRM], which routes birth and production through event nodes that NeoWiki's data does not hold and the Mapping synthesizes
 
 == Explore the projections ==
 
@@ -20,7 +21,8 @@ You don't need these links to reach an export: on any subject page, the Data tab
 # '''Pablo Picasso''', [{{SERVER}}{{SCRIPTPATH}}/rest.php/neowiki/v0/page/{{PAGEID:Pablo Picasso}}/rdf native] vs [{{SERVER}}{{SCRIPTPATH}}/rest.php/neowiki/v0/page/{{PAGEID:Pablo Picasso}}/rdf?projection=EDM EDM]: the native file has everything, including the two-layer "Born in" relation and the page metadata; the EDM file is an <code>edm:Agent</code> carrying only the mapped vocabulary, with the unmapped <code>Source</code> absent.
 # '''Málaga''', [{{SERVER}}{{SCRIPTPATH}}/rest.php/neowiki/v0/page/{{PAGEID:Málaga}}/rdf?projection=EDM EDM]: an <code>edm:Place</code> with the very same entity IRI that Picasso's <code>rdaGr2:placeOfBirth</code> points at, because sibling projections share entity IRIs.
 # '''The Milkmaid''', [{{SERVER}}{{SCRIPTPATH}}/rest.php/neowiki/v0/page/{{PAGEID:The Milkmaid}}/rdf?projection=EDM EDM]: an <code>edm:ProvidedCHO</code> whose <code>dc:creator</code> is the IRI of [{{SERVER}}{{SCRIPTPATH}}/rest.php/neowiki/v0/page/{{PAGEID:Johannes Vermeer}}/rdf?projection=EDM Vermeer] (an <code>edm:Agent</code>) and whose <code>edm:currentLocation</code> is the Rijksmuseum.
-# '''Johann Sebastian Bach''', [{{SERVER}}{{SCRIPTPATH}}/rest.php/neowiki/v0/page/{{PAGEID:Johann Sebastian Bach}}/rdf?projection=EDM EDM]: Bach's birth is modelled as its own [[Birth of Johann Sebastian Bach|Birth Subject]] instead of flat fields, so his <code>edm:Agent</code> projects sparse. Same Person Schema as Picasso, a different modelling style.
+# '''Johann Sebastian Bach''', [{{SERVER}}{{SCRIPTPATH}}/rest.php/neowiki/v0/page/{{PAGEID:Johann Sebastian Bach}}/rdf?projection=EDM EDM]: Bach's birth is modelled as its own [[Birth of Johann Sebastian Bach|Birth Subject]] instead of flat fields. The EDM Mapping collapses it back to flat <code>rdaGr2:dateOfBirth</code> and <code>rdaGr2:placeOfBirth</code>, but the [{{SERVER}}{{SCRIPTPATH}}/rest.php/neowiki/v0/page/{{PAGEID:Birth of Johann Sebastian Bach}}/rdf?projection=EDM Birth page] emits those triples, so this page's export does not show them — a store or bulk dump holding both graphs does.
+# '''Pablo Picasso''', [{{SERVER}}{{SCRIPTPATH}}/rest.php/neowiki/v0/page/{{PAGEID:Pablo Picasso}}/rdf?projection=CIDOC-CRM CIDOC CRM]: the same flat birth fields go the other way. CIDOC routes birth through an <code>E67_Birth</code> event and an <code>E52_Time-Span</code>, neither of which exists in the data, so the Mapping synthesizes both and hangs the date and the place off them.
 # '''ACME Inc''', [{{SERVER}}{{SCRIPTPATH}}/rest.php/neowiki/v0/page/{{PAGEID:ACME Inc}}/rdf?projection=EDM EDM]: its Company Schema has no EDM Mapping, so the EDM projection comes back empty. An unmapped Schema is simply left out, so the projection stays conformant.
 
 == Learn more ==

--- a/DemoData/Schema/Person.json
+++ b/DemoData/Schema/Person.json
@@ -1,5 +1,5 @@
 {
-	"description": "A human being. Maps to CIDOC CRM E21 Person (http://www.cidoc-crm.org/cidoc-crm/E21_Person) and, via the EDM Mapping, to EDM edm:Agent. Life events such as birth can be modelled richly as their own event Subjects (see the Birth schema), or flatly via the Birth date and Birth place fields here — the flat form is what the near-1:1 EDM projection consumes.",
+	"description": "A human being. Maps to CIDOC CRM E21 Person (http://www.cidoc-crm.org/cidoc-crm/E21_Person) and, via the EDM Mapping, to EDM edm:Agent. Life events such as birth can be modelled richly as their own event Subjects (see the Birth schema), or flatly via the Birth date and Birth place fields here — the EDM Mapping reaches both, projecting the flat fields directly and letting a Birth Subject contribute its own.",
 	"propertyDefinitions": {
 		"Description": {
 			"type": "text",
@@ -12,7 +12,7 @@
 		},
 		"Gender": {
 			"type": "text",
-			"description": "Gender, as a literal (EDM rdaGr2:gender). Kept as text rather than select on purpose: the v1 ontology projection emits a select value's stored option id, not its label, so a controlled-vocabulary select would project an opaque id."
+			"description": "Gender, as a literal (EDM rdaGr2:gender). Kept as text rather than select on purpose: the ontology projection emits a select value's stored option id, not its label, so a controlled-vocabulary select would project an opaque id."
 		},
 		"Birth date": {
 			"type": "date",

--- a/DemoData/Subject/Pablo_Picasso.wikitext
+++ b/DemoData/Subject/Pablo_Picasso.wikitext
@@ -1,3 +1,3 @@
 '''Pablo Picasso''' (1881–1973) was a Spanish painter, sculptor, and printmaker who co-founded the Cubist movement. He was born in [[Málaga]] and spent most of his working life in France.
 
-This page's Person Subject carries the flat toy-model fields (gender, birth date, birth place, description, source) used by the [[Mapping:EDM]] ontology mapping to project the page into EDM. See the person→EDM walkthrough in the NeoWiki docs.
+This page's Person Subject carries the flat toy-model fields (gender, birth date, birth place, description, source) that the ontology mappings project. [[Mapping:EDM]] takes them across near-1:1; [[Mapping:CIDOC-CRM]] expands the birth fields into the E67 Birth and E52 Time-Span nodes CIDOC routes them through. See the person→EDM walkthrough in the NeoWiki docs.

--- a/docs/planning/OntologyMapping.md
+++ b/docs/planning/OntologyMapping.md
@@ -9,15 +9,16 @@ Status: Draft strawman, for discussion with ECHOLOT partners (T2.3 and T3.x).
 
 Discussion: [#996](https://github.com/ProfessionalWiki/NeoWiki/discussions/996).
 
-> **As-built (v1, 2026-07).** The near-1:1 term-substitution tier of this design has shipped: Mappings as
-> pages in a `Mapping:` namespace — one page per target ontology, the page title being the target name
-> ([#1065](https://github.com/ProfessionalWiki/NeoWiki/discussions/1065)) — and an ontology projection
-> selectable alongside the native one on the RDF export endpoint and `DumpRdf`. See the
-> [Ontology Mapping reference](../rdf/ontology-mapping.md) and the worked
-> [Person → EDM example](../rdf/person-to-edm.md). The structural / node-synthesis
-> tier and the mapping-formalism question (Q1, [#995](https://github.com/ProfessionalWiki/NeoWiki/issues/995))
-> remain open; the stored `"version": 1` format is provisional. Provisional answers v1 gives to some open
-> questions below are noted inline.
+> **As-built (2026-08).** Mappings are pages in a `Mapping:` namespace — one page per target ontology, the
+> page title being the target name ([#1065](https://github.com/ProfessionalWiki/NeoWiki/discussions/1065)) —
+> and an ontology projection is selectable alongside the native one on the RDF export endpoint and `DumpRdf`.
+> The near-1:1 term-substitution tier shipped first (2026-07); the **structural tier** followed as an optional
+> addition to the same format: node synthesis with deterministic IRIs, and contraction as source-side
+> contributions. See the [Ontology Mapping reference](../rdf/ontology-mapping.md) and the worked
+> [Person → EDM example](../rdf/person-to-edm.md). The rule format is NeoWiki-native, so the
+> mapping-formalism question (Q1, [#995](https://github.com/ProfessionalWiki/NeoWiki/issues/995)) stays open
+> at the authoring level; the stored format is provisional. Where the as-built provisionally answers an open
+> question below, that is noted inline.
 
 ## Summary
 
@@ -118,7 +119,10 @@ a target does not want, the mapping must walk it and collapse it — a Birth eve
 to `rdaGr2:dateOfBirth` on the flat EDM agent. Both directions are needed because a wiki serves several targets at once
 ([sibling projections](#projections-not-layers)) that disagree about shape, so at least one target mismatches whichever
 style the data is modelled in. Live on the demo wiki ([neowiki.dev](https://neowiki.dev)): flat-modelled Picasso
-projects fully to EDM; Bach, whose birth is an explicit Subject, projects sparse because contraction is unimplemented.
+projects fully to EDM and expands into `E67_Birth` for CIDOC-CRM; Bach, whose birth is an explicit Subject, has that
+Subject contribute the flat `rdaGr2:dateOfBirth` and `rdaGr2:placeOfBirth` back onto him. Contraction is source-side —
+the contributing page emits the triples into its own graph — so a store or bulk dump sees the complete flat agent
+while a per-page export of Bach alone does not.
 
 ### Flat vs nested native modelling (open fork)
 
@@ -324,6 +328,10 @@ collapsing it for a flatter target? Both directions are recorded as an evaluatio
 (SPARQL-based `sh:rule`) or `CONSTRUCT` the right executable substrate? Do partners already have CIDOC-CRM expansion
 patterns in an executable form we can target?
 
+*As built: the native format expresses both directions — synthesized nodes for expansion, contributions for
+contraction ([reference](../rdf/ontology-mapping.md)). Whether a higher-level formalism should author or compile to
+it stays open on Q1.*
+
 **Q3: Platka boundary.** Our understanding (to confirm): the T2.3 pattern library *creates* ontologies and derivatives
 (e.g. SHACL for validation) but does **not** perform ontology-to-ontology mapping. If so, NeoWiki owns Schema→ontology
 mappings, and the library supplies (a) the target patterns we project to and possibly (b) SHACL we validate against.
@@ -345,15 +353,16 @@ above, since the store has no sync-back to the wiki.
 mapping per Schema? Per-target is more modular and independently installable; combined may reduce duplication for shared
 sub-patterns.
 
-*v1: one Mapping page per target ontology, holding an entry for every mapped Schema — the page title is the target name,
-so uniqueness needs no save-time check ([#1065](https://github.com/ProfessionalWiki/NeoWiki/discussions/1065)). Combined
-multi-target pages stay open for a later format version.*
+*As built: one Mapping page per target ontology, holding an entry for every mapped Schema — the page title is the
+target name, so uniqueness needs no save-time check
+([#1065](https://github.com/ProfessionalWiki/NeoWiki/discussions/1065)). Combined multi-target pages stay open for a
+later format version.*
 
 **Q7: Authoring and distribution.** Where do Mappings live (a dedicated namespace? API-only?), who authors them (data
 modellers) vs installs them (wiki admins), and how are bundles (e.g. "CIDOC-CRM for Person / Place / Object") packaged
 and shared across wikis and a farm?
 
-*v1: Mappings live as pages in a dedicated `Mapping:` namespace (one page per target ontology, named after it —
+*As built: Mappings live as pages in a dedicated `Mapping:` namespace (one page per target ontology, named after it —
 [ADR 17](../adr/017-names-as-identifiers.md)-style), authored like Schemas/Layouts and gated by the
 `neowiki-mapping-edit` right, and seedable as demo/bundle data (the Person→EDM example ships this way). Packaging and
 farm-wide sharing of bundles is not yet addressed.*
@@ -366,11 +375,11 @@ the native projection vs Views?
 native + one or more ontologies), and is a native projection always available as a baseline? This makes "which
 vocabulary is in the store" a per-store configuration rather than a single global choice.
 
-*v1: yes for export — a wiki serves several projections at once, selected per request via the `projection` parameter,
-with `native` always the baseline and each Mapping page adding its target to the known set. Named graphs are qualified
-by projection ([#1053](https://github.com/ProfessionalWiki/NeoWiki/issues/1053)), so a single store can likewise hold
-several projections at once — see [Projections, not layers](#projections-not-layers). The projector/serializer seam
-#586 consumes is `newRdfProjection(name)`.*
+*As built: yes for export — a wiki serves several projections at once, selected per request via the `projection`
+parameter, with `native` always the baseline and each Mapping page adding its target to the known set. Named graphs
+are qualified by projection ([#1053](https://github.com/ProfessionalWiki/NeoWiki/issues/1053)), so a single store can
+likewise hold several projections at once — see [Projections, not layers](#projections-not-layers). The
+projector/serializer seam #586 consumes is `newRdfProjection(name)`.*
 
 **Q10: Flat vs nested native modelling.** The [fork above](#flat-vs-nested-native-modelling-open-fork): should
 case-study data live in flat Schemas with the mapping synthesizing intermediate nodes, or in nested Schemas with the

--- a/docs/rdf/ontology-mapping.md
+++ b/docs/rdf/ontology-mapping.md
@@ -5,20 +5,22 @@ order: 2
 # Ontology Mapping
 
 Alongside the built-in [native projection](rdf-export.md), which needs no mapping, you can project to an
-established ontology such as EDM by defining an **ontology mapping**.
+established ontology such as EDM or CIDOC-CRM by defining an **ontology mapping**.
 
 The native projection and each ontology mapping are sibling projections of the same source data. Several can
 run at once: an export request selects one by name, and a SPARQL store can hold
 [several side by side](../operations/installation.md#several-projections-in-one-store).
 
 The design and its open questions live in [planning/OntologyMapping.md](../planning/OntologyMapping.md); this
-page is the as-built reference for the shipped v1. The
-[Person-to-EDM worked example](person-to-edm.md) walks through a Person Schema projected to EDM,
-with native and mapped output side by side and the current gaps.
+page is the as-built reference for the shipped format. The
+[Person-to-EDM worked example](person-to-edm.md) walks through a Person Schema projected to EDM, with native
+and mapped output side by side.
 
-> **v1 scope.** It covers only *near-1:1* term substitution — a target class per Subject and one target
-> predicate per mapped property — and does **not** synthesize the intermediate event nodes that
-> CIDOC-CRM-style ontologies need. The stored `"version": 1` format may change; see the
+> **Scope.** A mapping reshapes the data as well as the vocabulary: it can **synthesize** the intermediate
+> event nodes a target like CIDOC-CRM routes its paths through, and it can **contract** structure a flat
+> target does not want by contributing a Subject's values to the Subject it points at. Out of scope: RDF
+> **import** (a mapping drives export only), contributions across more than one relation hop, and link
+> predicates running from a node back to its anchor. The stored `"version": 1` format may change; see the
 > [open questions](../planning/OntologyMapping.md#open-questions).
 
 ## Ontology Mappings are wiki pages
@@ -41,22 +43,32 @@ page is rejected on save.
 {
     "version": 1,
     "prefixes": {
-        "edm": "http://www.europeana.eu/schemas/edm/",
-        "rdaGr2": "http://rdvocab.info/ElementsGr2/",
-        "skos": "http://www.w3.org/2004/02/skos/core#"
+        "crm": "http://www.cidoc-crm.org/cidoc-crm/",
+        "rdaGr2": "http://rdvocab.info/ElementsGr2/"
     },
     "schemas": {
         "Person": {
-            "subject": { "class": "edm:Agent" },
+            "subject": { "class": "crm:E21_Person", "labelPredicate": "rdaGr2:nameOfThePerson" },
+            "nodes": {
+                "birth": { "class": "crm:E67_Birth", "linkPredicate": "crm:P98i_was_born" },
+                "birthTimespan": {
+                    "class": "crm:E52_Time-Span",
+                    "linkPredicate": "crm:P4_has_time-span",
+                    "parent": "birth"
+                }
+            },
             "properties": {
-                "Description": { "predicate": "skos:note", "lang": "en" },
-                "Birth date":  { "predicate": "rdaGr2:dateOfBirth" },
-                "Birth place": { "predicate": "rdaGr2:placeOfBirth" }
+                "Birth date":  { "predicate": "crm:P82_at_some_time_within", "node": "birthTimespan" },
+                "Birth place": { "predicate": "crm:P7_took_place_at", "node": "birth" }
             }
         },
-        "City": {
-            "subject": { "class": "edm:Place" },
-            "properties": {}
+        "Birth": {
+            "contributions": {
+                "Brought into life": {
+                    "Date":          { "predicate": "rdaGr2:dateOfBirth" },
+                    "Took place at": { "predicate": "rdaGr2:placeOfBirth" }
+                }
+            }
         }
     }
 }
@@ -70,26 +82,50 @@ Top level:
 | `prefixes` | no | Prefix label → namespace IRI, shared by every entry, used to expand the CURIEs below. |
 | `schemas` | yes | Native Schema name → the entry that projects its Subjects (see below). May be empty. A Schema's existence is not checked at save time; the page's read view shows a missing Schema as a red link. |
 
-Each **schema** entry (a value in `schemas`):
+Each **schema** entry (a value in `schemas`) needs at least one of `subject` and `contributions`:
 
 | Field | Required | Meaning |
 |---|---|---|
-| `subject.class` | yes | The `rdf:type` given to each Subject of the Schema. A CURIE or an absolute IRI. |
-| `properties` | yes | NeoWiki property name → how to project it (see below). May be empty. |
+| `subject` | with `properties`/`nodes` | How the Subject itself projects (see below). Leave it out for an entry that only contributes to other Subjects. |
+| `nodes` | no | Node key → an intermediate node the projection synthesizes (see below). Keys match `^[A-Za-z_][A-Za-z0-9_-]*$` and appear in the node's IRI. At most 64. |
+| `properties` | no | NeoWiki property name → how to project it (see below). At most 500. |
+| `contributions` | no | Relation name → values this Schema sends to the Subjects that relation points at (see below). At most 32. |
+
+Each **subject** entry:
+
+| Field | Required | Meaning |
+|---|---|---|
+| `class` | yes | The `rdf:type` given to each Subject of the Schema. A CURIE or an absolute IRI. |
+| `labelPredicate` | no | An **additional** predicate carrying the Subject's label, for a target ontology with a label term of its own (`foaf:name`, …). `rdfs:label` is emitted either way. |
+
+Each **node** entry (a value in `nodes`):
+
+| Field | Required | Meaning |
+|---|---|---|
+| `class` | yes | The `rdf:type` given to each instance of the node. |
+| `linkPredicate` | yes | Predicate of the triple from the anchor — the parent node's instance, or the Subject — to the node instance. |
+| `parent` | no | Another node key, making this node hang off that node instead of off the Subject. |
+| `per` | no | `subject` (default) for one instance shared by every property attached to it, or `value` for one instance per value. A `per: "value"` node takes at most one property and cannot be a `parent`. |
 
 Each **property** entry:
 
 | Key | Required | Meaning |
 |---|---|---|
 | `predicate` | yes | Target predicate for the property's values. A CURIE or an absolute IRI. |
+| `node` | no | A node key. The property's values then attach to that node's instance instead of to the Subject. |
 | `lang` | no | BCP-47-shaped language tag (`^[A-Za-z]{1,8}(-[A-Za-z0-9]{1,8})*$`, e.g. `en`, `pt-BR`) applied to the produced literal **when it is a plain string** (text/select values). Ignored for typed literals (numbers, dates, …). Mutually exclusive with `datatype`. |
 | `datatype` | no | Absolute IRI or CURIE that overrides the literal's datatype. For a `url` value, which otherwise projects as an IRI object, setting `datatype` forces a literal with that datatype. Mutually exclusive with `lang`. |
 
+Each **contribution** (an entry in `contributions`) is keyed by the name of a relation-typed property on
+*this* Schema, and every Subject that property points at receives the contributed values. The value is a
+non-empty map (at most 100 entries) of *this* Schema's property names to `predicate`, plus optional `lang` /
+`datatype` as above. `node` is not allowed: the triples are about the target Subject.
+
 ### CURIEs, IRIs, and safety
 
-A `class`, `predicate`, or `datatype` is either a **CURIE** `prefix:local` whose prefix is declared in
-`prefixes`, or an **absolute IRI** containing `://`. A CURIE with an undeclared prefix is rejected;
-non-authority schemes (`urn:`, `mailto:`, …) are out of scope for v1.
+A `class`, `linkPredicate`, `predicate`, `labelPredicate`, or `datatype` is either a **CURIE** `prefix:local` whose
+prefix is declared in `prefixes`, or an **absolute IRI** containing `://`. A CURIE with an undeclared prefix is
+rejected; non-authority schemes (`urn:`, `mailto:`, …) are out of scope.
 
 Terms are reproduced verbatim, never percent-encoded. A term or a declared prefix namespace that would expand
 to an IRI containing an IRIREF-illegal character (`< > " { } | ^ \` backtick, space, control characters) is
@@ -97,29 +133,51 @@ to an IRI containing an IRIREF-illegal character (`< > " { } | ^ \` backtick, sp
 `lang` and `datatype`.
 
 The same checks re-run at **projection time**: a class, predicate, datatype, or prefix that does not re-expand
-safely is dropped, an invalid language tag falls back to a plain literal, and each is logged. The projection
-degrades rather than aborting the export.
+safely is dropped, an unusable node takes everything below it with it, an invalid language tag falls back to a
+plain literal, and each is logged. The projection degrades rather than aborting the export.
 
 ## What gets emitted
 
 For each Subject on a page whose Schema has an entry on the requested projection's Mapping page:
 
-- `rdf:type <subject.class>`.
+- `rdf:type <subject.class>`, and the `labelPredicate` triple when one is set.
 - `rdfs:label "<label>"` — the Subject's label, always.
-- One triple per mapped property **value**; multi-valued properties repeat the predicate. Unmapped properties
-  are absent.
+- One triple per mapped property **value**, on the Subject or on the node the entry attaches it to;
+  multi-valued properties repeat the predicate. Unmapped properties are absent.
 - A **relation** value becomes a direct triple to the target Subject's IRI. No `neo:Relation` reification node
   and no relation qualifiers are projected.
+- A node instance, with its `rdf:type` and its link triple, **only where a value reached it** — pulling in
+  every node on the way down to it, so the output carries no empty event nodes.
+- One triple per contributed value, **about each target** of the contribution's relation.
 
-v1 boundaries:
+Boundaries:
 
 - **Subject IRIs stay native** (`neo-subj:`): only the vocabulary comes from the target ontology. Cross-linking
   to external entities (`owl:sameAs`, reconciliation) is later work.
 - A **Subject whose Schema has no entry** on the Mapping page is absent, but its IRI can still appear as a
   bare IRI — no type, no label — as the target of a relation from a mapped Subject.
+- **Contributed triples live in the contributing page's graph**, not the target's, so a per-page export of the
+  target does not carry them; a SPARQL store or a bulk dump holding both graphs does. Same rule as a relation
+  target's own type and label — see [Per-page vs bulk](person-to-edm.md#per-page-vs-bulk-the-relation-targets-type).
 - **No page-metadata triples** are emitted (no page node, `neo:hasSubject`, etc.).
 - Quads go in the per-page named graph for this target (`$base/graph/{target}/page/{id}`), where `{target}` is
   the projection name.
+
+### Synthesized-node IRIs
+
+A node instance's IRI is derived from the data, so re-projecting a page produces the same document and the
+per-page store sync stays correct:
+
+| Node | IRI |
+|---|---|
+| `per: "subject"` | `$base/node/{subjectId}/{key}`, each nesting level appending its own key: `$base/node/{subjectId}/{parentKey}/{key}` |
+| `per: "value"`, on a relation property | `$base/node/{relationId}` — keyed on the Relation's persistent ID, so the node is the same in every projection |
+| `per: "value"`, on a literal property | `$base/node/{subjectId}/{key}/{position}` — the node's own key only, not its parent chain |
+
+They are emitted in full rather than abbreviated: they have no `neo-` prefix of their own.
+
+The position-based case is stable only for unchanged data: reordering or removing a property's values
+renumbers the instances after the change.
 
 ## Selecting a projection
 
@@ -134,6 +192,9 @@ prefix (`EDM`), or `native` for the built-in projection. See
    existing one.
 2. Declare the page-level `prefixes` you will use.
 3. Add an entry under `schemas` for each Schema to project: give the Subject a `subject.class` and map the
-   properties to publish.
-4. Save. Structural errors and unresolvable or unsafe terms are reported on save.
+   properties to publish. Where the target routes a property through an intermediate node, declare the node
+   and point the property at it. Where the target wants a related Subject's structure flattened onto it, add a
+   contribution to the Schema that holds the structure.
+4. Save. Structural errors, unresolvable or unsafe terms, and node references that do not resolve are reported
+   on save.
 5. Export a page of a mapped Schema with `?projection=EDM` (the page title without the `Mapping:` prefix).

--- a/docs/rdf/person-to-edm.md
+++ b/docs/rdf/person-to-edm.md
@@ -4,7 +4,7 @@ order: 3
 ---
 # Worked example: projecting a Person to EDM
 
-End-to-end walkthrough of the [Ontology Mapping](ontology-mapping.md) v1 projection: a NeoWiki-native `Person`
+End-to-end walkthrough of an [Ontology Mapping](ontology-mapping.md) projection: a NeoWiki-native `Person`
 Schema, an EDM Mapping, and a demo page projected into
 [Europeana Data Model](https://pro.europeana.eu/page/edm-documentation) (EDM) RDF, shown against the native projection.
 
@@ -12,14 +12,14 @@ It projects the EDM column of a small "person to many standards" toy model. Ever
 [demo data](../../DemoData/), so a wiki with the demo data imported (`php maintenance/run.php NeoWiki:ImportDemoData`)
 reproduces it — up to instance-specific page IDs and base URI (and, in the page metadata, timestamps and last editor).
 
-> **Scope: the near-1:1 tier only.** Event-based ontologies like CIDOC-CRM need the intermediate-node synthesis that v1
-> does not do — see [Known next tier: CIDOC-CRM](#known-next-tier-cidoc-crm).
+> **Scope: the near-1:1 tier.** EDM is flat, so this walkthrough is term substitution. For the structural tier, the
+> same demo data ships a `Mapping:CIDOC-CRM` — see [the same data in CIDOC-CRM](#the-same-data-in-cidoc-crm) below.
 
 ## The toy model
 
 | Neutral Person field | Example value | EDM target |
 |---|---|---|
-| Name | "Pablo Picasso" | `foaf:name` *(not in v1 — see [Findings](#findings))* |
+| Name | "Pablo Picasso" | `foaf:name`, alongside the always-emitted `rdfs:label` |
 | Gender | "Male" | `rdaGr2:gender` literal |
 | Birth date | 1881-10-25 | `rdaGr2:dateOfBirth` (`xsd:date`) |
 | Birth place | Málaga | `rdaGr2:placeOfBirth` → an `edm:Place` |
@@ -27,7 +27,7 @@ reproduces it — up to instance-specific page IDs and base URI (and, in the pag
 | Source | "A Life of Picasso I…" (ISBN) | **n/a in EDM** — unmapped |
 
 Prefixes: `edm: http://www.europeana.eu/schemas/edm/`, `rdaGr2: http://rdvocab.info/ElementsGr2/`,
-`skos: http://www.w3.org/2004/02/skos/core#`.
+`skos: http://www.w3.org/2004/02/skos/core#`, `foaf: http://xmlns.com/foaf/0.1/`.
 
 ## 1. The Schemas
 
@@ -52,8 +52,8 @@ The demo `City` Schema ([`DemoData/Schema/City.json`](../../DemoData/Schema/City
 
 One Mapping page, **[`Mapping:EDM`](../../DemoData/Mapping/EDM.json)**, holds an entry per mapped Schema; its title
 (`EDM`) is the projection name (see [Ontology Mapping](ontology-mapping.md) for the format). Abbreviated to the
-two entries this walkthrough uses — the shipped file also maps `Artwork` and `Artist` and declares the
-`dc`/`dcterms`/`foaf`/`xsd` prefixes those need:
+two entries this walkthrough uses — the shipped file also maps `Birth`, `Place`, `Artwork` and `Artist` and declares
+the `dc`/`dcterms`/`xsd` prefixes those need:
 
 ```json
 {
@@ -61,11 +61,12 @@ two entries this walkthrough uses — the shipped file also maps `Artwork` and `
     "prefixes": {
         "edm": "http://www.europeana.eu/schemas/edm/",
         "rdaGr2": "http://rdvocab.info/ElementsGr2/",
-        "skos": "http://www.w3.org/2004/02/skos/core#"
+        "skos": "http://www.w3.org/2004/02/skos/core#",
+        "foaf": "http://xmlns.com/foaf/0.1/"
     },
     "schemas": {
         "Person": {
-            "subject": { "class": "edm:Agent" },
+            "subject": { "class": "edm:Agent", "labelPredicate": "foaf:name" },
             "properties": {
                 "Gender":      { "predicate": "rdaGr2:gender" },
                 "Birth date":  { "predicate": "rdaGr2:dateOfBirth" },
@@ -74,8 +75,7 @@ two entries this walkthrough uses — the shipped file also maps `Artwork` and `
             }
         },
         "City": {
-            "subject": { "class": "edm:Place" },
-            "properties": {}
+            "subject": { "class": "edm:Place" }
         }
     }
 }
@@ -138,6 +138,7 @@ The **EDM** projection of the same page — target vocabulary only, no page meta
 ```turtle
 neo-subj:s2picasso2aaaa2 a edm:Agent;
     rdfs:label "Pablo Picasso";
+    foaf:name "Pablo Picasso";
     skos:note "Spanish painter, sculptor, and printmaker who co-founded the Cubist movement…"@en;
     rdaGr2:gender "Male";
     rdaGr2:dateOfBirth "1881-10-25"^^xsd:date;
@@ -155,7 +156,8 @@ What changed, native → EDM:
 
 - The Subject IRI is unchanged (`neo-subj:s2picasso2aaaa2`): the entity stays the wiki's own, only the vocabulary is
   EDM.
-- `rdf:type` and each mapped predicate are substituted; `rdfs:label` is a shared term, kept verbatim.
+- `rdf:type` and each mapped predicate are substituted; `rdfs:label` is a shared term, kept verbatim, and the entry's
+  `labelPredicate` repeats it as EDM's own `foaf:name`.
 - The datatype comes from the value mapper, not the Mapping: `"1881-10-25"^^xsd:date` is identical in both. A Mapping
   property may override it with `datatype`.
 - The birth-place relation becomes one direct triple. Its EDM predicate keys on the **property name** `Birth place`
@@ -180,13 +182,9 @@ share one triple store. A consumer that needs a relation target's type or label 
 
 ## Findings
 
-1. **The name projects only as `rdfs:label`; `foaf:name` is unreachable in v1.** A Subject's name is its built-in label,
-   not a property; the projector always emits it as `rdfs:label`, and v1 has no facility to also map the label to
-   another predicate. The toy model's `Name → foaf:name` therefore cannot be produced. Tracked at
-   [#996](https://github.com/ProfessionalWiki/NeoWiki/discussions/996).
-2. **A `select` value projects its stored option id, not its label.** The v1 value mapper emits the stored id, so a
-   `select` `Gender` would carry an opaque `o1…` id instead of `"Male"`. The demo uses a `text` property to get a
-   meaningful literal; a select→label (or select→`skos:Concept` IRI) projection is later work.
+**A `select` value projects its stored option id, not its label.** The value mapper emits the stored id, so a `select`
+`Gender` would carry an opaque `o1…` id instead of `"Male"`. The demo uses a `text` property to get a meaningful
+literal; a select→label (or select→`skos:Concept` IRI) projection is later work.
 
 ## Querying via SPARQL
 
@@ -226,9 +224,12 @@ The two graph variables bind to `.../graph/EDM/page/115` and `.../graph/native/p
 
 For an ad-hoc load instead, feed the `DumpRdf --projection=EDM` output into any SPARQL engine (e.g. a local QLever).
 
-## Known next tier: CIDOC-CRM
+## The same data in CIDOC-CRM
 
-The toy model's CIDOC-CRM column is out of scope for v1. CIDOC-CRM mediates birth through a synthesized `E67_Birth`
-event node with no counterpart in NeoWiki's flat data, which v1's term substitution cannot mint. Choosing a formalism
-that can is the open mapping-formalism question ([OntologyMapping.md Q1](../planning/OntologyMapping.md#open-questions),
+The toy model's CIDOC-CRM column mediates birth through an `E67_Birth` event node and an `E52_Time-Span`, neither of
+which exists in NeoWiki's flat data. `Mapping:CIDOC-CRM`, also shipped as demo data, declares both as
+[synthesized nodes](ontology-mapping.md#synthesized-node-iris) and attaches `Birth place` and `Birth date` to them, so
+the same `Pablo_Picasso` page exports as an `E21_Person` whose birth hangs off minted event nodes. Which formalism
+authors should ultimately write such mappings in stays open
+([OntologyMapping.md Q1](../planning/OntologyMapping.md#open-questions),
 [#995](https://github.com/ProfessionalWiki/NeoWiki/issues/995)).

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -285,6 +285,7 @@
 	"neowiki-mapping-page-prefixes-heading": "Prefixes",
 	"neowiki-mapping-page-prefix-column": "Prefix",
 	"neowiki-mapping-page-namespace-column": "Namespace IRI",
+	"neowiki-mapping-unsupported-version": "This Mapping page uses format version $1. Only format version 1 is supported; the page defines no projection.",
 
 	"neowiki-layout-creator-title": "Create layout",
 	"neowiki-layout-creator-button": "Create",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -183,6 +183,7 @@
 	"neowiki-mapping-page-prefixes-heading": "Heading for the table on the read view of a Mapping page that lists the namespace prefixes the mapping declares.",
 	"neowiki-mapping-page-prefix-column": "Column header for the prefix in the prefixes table on a Mapping page.",
 	"neowiki-mapping-page-namespace-column": "Column header for the namespace IRI in the prefixes table on a Mapping page.",
+	"neowiki-mapping-unsupported-version": "Warning shown above the JSON of a Mapping page written in a format version this NeoWiki cannot read. Parameters:\n* $1 - the format version found on the page",
 
 	"neowiki-layout-creator-title": "Title of the dialog for creating a new layout.",
 	"neowiki-layout-creator-button": "Label for the button that opens the layout creation dialog on [[Special:Layouts]].",

--- a/src/Application/Rdf/OntologyMappingProjector.php
+++ b/src/Application/Rdf/OntologyMappingProjector.php
@@ -7,8 +7,12 @@ namespace ProfessionalWiki\NeoWiki\Application\Rdf;
 use LogicException;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\CurieExpander;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\Mapping;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\NodeMapping;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\NodeScope;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\PropertyMapping;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\PropertyMappings;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\SchemaMapping;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\SubjectMapping;
 use ProfessionalWiki\NeoWiki\Domain\Page\Page;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\Types\RelationType;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\Iri;
@@ -19,6 +23,8 @@ use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfLiteralFactory;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfNamespaces;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfTerm;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfValueMapperRegistry;
+use ProfessionalWiki\NeoWiki\Domain\Relation\Relation;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyName;
 use ProfessionalWiki\NeoWiki\Domain\Statement;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
@@ -26,14 +32,25 @@ use ProfessionalWiki\NeoWiki\Domain\Value\RelationValue;
 use Psr\Log\LoggerInterface;
 
 /**
- * Projects a {@see Page} into a target ontology using one page-level {@see Mapping} (OntologyMapping.md,
- * v1 near-1:1 term-substitution tier). The Mapping page's name is the projection target; it holds one
- * entry per mapped Schema. Per Subject whose Schema has an entry it emits `rdf:type <mapped class>`,
- * `rdfs:label` (always), and one triple per mapped property value — mapping only the vocabulary, because
- * the Subject IRI stays native (`neo-subj:`), the entity being the wiki's own. Unmapped properties are
- * absent, so the output is conformant to the target ontology. There is no intermediate-node synthesis and
- * no `neo:Relation` reification in v1; relation values become a direct triple to the target Subject's
- * native IRI, which may be untyped when that Subject has no entry of its own.
+ * Projects a {@see Page} into a target ontology using one page-level {@see Mapping} (OntologyMapping.md).
+ * The Mapping page's name is the projection target; it holds one entry per mapped Schema. Per Subject
+ * whose Schema has an entry it emits `rdf:type <mapped class>`, `rdfs:label` (always), and one triple per
+ * mapped property value — mapping only the vocabulary, because the Subject IRI stays native
+ * (`neo-subj:`), the entity being the wiki's own. Unmapped properties are absent, so the output is
+ * conformant to the target ontology.
+ *
+ * On top of that term substitution it performs both structural transformations
+ * (OntologyMapping.md § What makes this hard):
+ *
+ *  - **Expansion.** A property entry may attach its values to a synthesized intermediate node instead of
+ *    to the Subject, so an event-centric target gets the `E67_Birth` / `E12_Production` node its paths
+ *    run through. {@see SynthesizedNodes} mints those nodes, and only where a value reached them.
+ *  - **Contraction.** A Schema entry may contribute its own values to the Subjects it points at, so a
+ *    Subject that models an event explicitly still lands as flat properties on a flat target. This is
+ *    source-side: the contributing page emits the triples into its own graph, and no other page is read.
+ *
+ * There is no `neo:Relation` reification; a relation value becomes a direct triple to the target
+ * Subject's native IRI, which may be untyped when that Subject has no entry of its own.
  *
  * Every quad is placed in the page's named graph for this projection's target (`{$base}/graph/{target}/page/{id}`,
  * #1053), so the per-page sync used by the native projection (NativeRdfProjection.md) works for an ontology
@@ -44,6 +61,9 @@ class OntologyMappingProjector implements PageProjector {
 
 	private readonly string $target;
 	private readonly CurieExpander $expander;
+
+	/** @var array<string, array<string, SynthesizedNode>> The resolved nodes of each Schema entry reached. */
+	private array $resolvedNodes = [];
 
 	public function __construct(
 		private readonly Mapping $mapping,
@@ -72,9 +92,10 @@ class OntologyMappingProjector implements PageProjector {
 
 	/**
 	 * Projects a single Subject on the page into the target ontology — its per-Subject block from
-	 * {@see projectPage()} (mapped type, label, mapped property values, relations as direct triples)
-	 * placed in the target's named graph. A Subject that is not on the page, or whose Schema has no
-	 * entry in this Mapping, yields an empty list.
+	 * {@see projectPage()} (mapped type, label, mapped property values with the nodes they are attached
+	 * to, relations as direct triples, and what it contributes to other Subjects) placed in the target's
+	 * named graph. A Subject that is not on the page, or whose Schema has no entry in this Mapping,
+	 * yields an empty list.
 	 */
 	public function projectSubject( Page $page, SubjectId $subjectId ): QuadList {
 		$subject = $page->getSubjects()->getAllSubjects()->getSubject( $subjectId );
@@ -98,13 +119,69 @@ class OntologyMappingProjector implements PageProjector {
 	 * @return Quad[]
 	 */
 	private function subjectQuads( Subject $subject, SchemaMapping $schemaMapping, Iri $graph ): array {
+		$schemaName = $subject->getSchemaName()->getText();
+
+		$quads = $schemaMapping->subject === null
+			? []
+			: $this->ownQuads( $subject, $schemaName, $schemaMapping, $schemaMapping->subject, $graph );
+
+		foreach ( $schemaMapping->contributions as $relationName => $properties ) {
+			// A numeric relation name becomes an int array key, so it is cast where it is consumed.
+			$quads = array_merge( $quads, $this->contributionQuads( $subject, (string)$relationName, $properties, $graph ) );
+		}
+
+		return $quads;
+	}
+
+	/**
+	 * What the Subject says about itself: its type and label, plus its mapped property values, on the
+	 * Subject or on the synthesized node each is attached to.
+	 *
+	 * @return Quad[]
+	 */
+	private function ownQuads(
+		Subject $subject,
+		string $schemaName,
+		SchemaMapping $schemaMapping,
+		SubjectMapping $subjectMapping,
+		Iri $graph
+	): array {
 		$subjectIri = $this->namespaces->subject( $subject->id );
+		$nodes = new SynthesizedNodes(
+			$this->resolveNodes( $schemaName, $schemaMapping ),
+			$subject->id,
+			$subjectIri,
+			$graph,
+			$this->namespaces
+		);
 
-		$quads = [
-			new Quad( $subjectIri, $this->namespaces->rdfsLabel(), RdfLiteralFactory::typed( $subject->label->text, 'string' ), $graph ),
-		];
+		$quads = $this->headQuads( $subject, $subjectMapping, $subjectIri, $graph );
 
-		$class = $this->expander->expand( $schemaMapping->subjectClass );
+		foreach ( $subject->getStatements()->asArray() as $statement ) {
+			$propertyMapping = $schemaMapping->properties->get( $statement->getPropertyName()->text );
+
+			if ( $propertyMapping !== null ) {
+				$quads = array_merge(
+					$quads,
+					$this->statementQuads( $statement, $propertyMapping, $nodes, $subjectIri, $graph )
+				);
+			}
+		}
+
+		// Last, because a node is scaffolded by the statements that reached it.
+		return array_merge( $quads, $nodes->scaffoldQuads() );
+	}
+
+	/**
+	 * The type and label triples. `rdfs:label` is always emitted; a `labelPredicate` adds the target
+	 * ontology's own label term for the same text rather than replacing it.
+	 *
+	 * @return Quad[]
+	 */
+	private function headQuads( Subject $subject, SubjectMapping $subjectMapping, Iri $subjectIri, Iri $graph ): array {
+		$quads = [];
+		$class = $this->expander->expand( $subjectMapping->class );
+
 		if ( $class === null ) {
 			// Cannot happen for a Mapping that passed save-time validation; guard the projection anyway.
 			$this->logger->warning(
@@ -113,17 +190,23 @@ class OntologyMappingProjector implements PageProjector {
 			);
 		}
 		else {
-			array_unshift( $quads, new Quad( $subjectIri, $this->namespaces->rdfType(), $class, $graph ) );
+			$quads[] = new Quad( $subjectIri, $this->namespaces->rdfType(), $class, $graph );
 		}
 
-		foreach ( $subject->getStatements()->asArray() as $statement ) {
-			$propertyMapping = $schemaMapping->properties->get( $statement->getPropertyName()->text );
+		$label = RdfLiteralFactory::typed( $subject->label->text, 'string' );
+		$quads[] = new Quad( $subjectIri, $this->namespaces->rdfsLabel(), $label, $graph );
 
-			if ( $propertyMapping !== null ) {
-				$quads = array_merge(
-					$quads,
-					$this->projectStatement( $statement, $propertyMapping, $subjectIri, $graph )
+		if ( $subjectMapping->labelPredicate !== null ) {
+			$predicate = $this->expander->expand( $subjectMapping->labelPredicate );
+
+			if ( $predicate === null ) {
+				$this->logger->warning(
+					'Mapping "' . $this->target . '" has an unresolvable label predicate for Schema "'
+					. $subject->getSchemaName()->getText() . '"; skipping the extra label triple.'
 				);
+			}
+			else {
+				$quads[] = new Quad( $subjectIri, $predicate, $label, $graph );
 			}
 		}
 
@@ -133,12 +216,162 @@ class OntologyMappingProjector implements PageProjector {
 	/**
 	 * @return Quad[]
 	 */
-	private function projectStatement(
+	private function statementQuads(
 		Statement $statement,
 		PropertyMapping $propertyMapping,
+		SynthesizedNodes $nodes,
 		Iri $subjectIri,
 		Iri $graph
 	): array {
+		$predicate = $this->expandPredicate( $propertyMapping, $statement );
+
+		if ( $predicate === null ) {
+			return [];
+		}
+
+		if ( $propertyMapping->node === null ) {
+			return $this->quadsOn( $subjectIri, $predicate, $this->objectTerms( $statement, $propertyMapping ), $graph );
+		}
+
+		$node = $nodes->get( $propertyMapping->node );
+
+		if ( $node === null ) {
+			$this->logger->warning(
+				'Mapping "' . $this->target . '" attaches property "' . $statement->getPropertyName()->text
+				. '" to node "' . $propertyMapping->node . '", which is not usable; skipping the property.'
+			);
+			return [];
+		}
+
+		if ( $node->scope === NodeScope::Value ) {
+			return $this->perValueNodeQuads( $statement, $propertyMapping, $predicate, $node, $nodes, $graph );
+		}
+
+		$objects = $this->objectTerms( $statement, $propertyMapping );
+
+		// The instance is minted only once there is something to hang off it, so a Subject with no value
+		// for any of a node's properties gets no empty node.
+		return $objects === [] ? [] : $this->quadsOn( $nodes->instance( $node ), $predicate, $objects, $graph );
+	}
+
+	/**
+	 * A value-scoped node gets one instance per value of the property attached to it: the CIDOC-CRM
+	 * `E12_Production` each Creator of an Artwork carries out. A relation value's instance is identified
+	 * by the Relation's persistent ID, a literal value's by its position among the property's values.
+	 *
+	 * @return Quad[]
+	 */
+	private function perValueNodeQuads(
+		Statement $statement,
+		PropertyMapping $propertyMapping,
+		Iri $predicate,
+		SynthesizedNode $node,
+		SynthesizedNodes $nodes,
+		Iri $graph
+	): array {
+		$quads = [];
+
+		if ( $statement->getPropertyType() === RelationType::NAME ) {
+			foreach ( $this->relationsOf( $statement ) as $relation ) {
+				$quads[] = new Quad(
+					$nodes->relationInstance( $node, $relation->id ),
+					$predicate,
+					$this->namespaces->subject( $relation->targetId ),
+					$graph
+				);
+			}
+
+			return $quads;
+		}
+
+		foreach ( $this->objectTerms( $statement, $propertyMapping ) as $position => $object ) {
+			$quads[] = new Quad( $nodes->valueInstance( $node, $position ), $predicate, $object, $graph );
+		}
+
+		return $quads;
+	}
+
+	/**
+	 * Contraction: this Subject's own values, emitted about each Subject its named relation points at,
+	 * into this page's named graph. Every target of a multi-valued relation receives them — twins sharing
+	 * one Birth each get its date. A Subject with no value for the relation contributes nothing, which is
+	 * the normal shape of optional data; a property that is not relation-typed at all is a mismatch
+	 * between the Mapping and the Schema and is logged.
+	 *
+	 * @return Quad[]
+	 */
+	private function contributionQuads(
+		Subject $subject,
+		string $relationName,
+		PropertyMappings $properties,
+		Iri $graph
+	): array {
+		$relationStatement = $subject->getStatements()->getStatement( new PropertyName( $relationName ) );
+
+		if ( $relationStatement === null ) {
+			return [];
+		}
+
+		if ( $relationStatement->getPropertyType() !== RelationType::NAME ) {
+			$this->logger->warning(
+				'Mapping "' . $this->target . '" contributes through relation "' . $relationName
+				. '", which Subject "' . $subject->id->text . '" does not hold as a relation; skipping the contribution.'
+			);
+			return [];
+		}
+
+		$contributed = $this->contributedTerms( $subject, $properties );
+		$quads = [];
+
+		foreach ( $this->relationsOf( $relationStatement ) as $relation ) {
+			$target = $this->namespaces->subject( $relation->targetId );
+
+			foreach ( $contributed as [ $predicate, $objects ] ) {
+				$quads = array_merge( $quads, $this->quadsOn( $target, $predicate, $objects, $graph ) );
+			}
+		}
+
+		return $quads;
+	}
+
+	/**
+	 * The predicate and objects each contributed property produces. Neither depends on which Subject
+	 * receives them, so they are computed once and reused for every target of the relation.
+	 *
+	 * @return list<array{Iri, list<RdfTerm>}>
+	 */
+	private function contributedTerms( Subject $subject, PropertyMappings $properties ): array {
+		$contributed = [];
+
+		foreach ( $subject->getStatements()->asArray() as $statement ) {
+			$propertyMapping = $properties->get( $statement->getPropertyName()->text );
+
+			if ( $propertyMapping === null ) {
+				continue;
+			}
+
+			$predicate = $this->expandPredicate( $propertyMapping, $statement );
+
+			if ( $predicate !== null ) {
+				$contributed[] = [ $predicate, $this->objectTerms( $statement, $propertyMapping ) ];
+			}
+		}
+
+		return $contributed;
+	}
+
+	/**
+	 * @param list<RdfTerm> $objects
+	 * @return Quad[]
+	 */
+	private function quadsOn( Iri $anchor, Iri $predicate, array $objects, Iri $graph ): array {
+		return array_map(
+			static fn ( RdfTerm $object ): Quad => new Quad( $anchor, $predicate, $object, $graph ),
+			$objects
+		);
+	}
+
+	private function expandPredicate( PropertyMapping $propertyMapping, Statement $statement ): ?Iri {
 		$predicate = $this->expander->expand( $propertyMapping->predicate );
 
 		if ( $predicate === null ) {
@@ -146,63 +379,144 @@ class OntologyMappingProjector implements PageProjector {
 				'Mapping "' . $this->target . '" has an unresolvable predicate for property "'
 				. $statement->getPropertyName()->text . '"; skipping it.'
 			);
-			return [];
 		}
 
-		if ( $statement->getPropertyType() === RelationType::NAME ) {
-			return $this->projectRelationStatement( $statement, $predicate, $subjectIri, $graph );
-		}
-
-		return $this->projectValueStatement( $statement, $propertyMapping, $predicate, $subjectIri, $graph );
+		return $predicate;
 	}
 
 	/**
-	 * A relation value becomes a direct triple to each target Subject's native IRI. No `neo:Relation`
-	 * node and no relation properties are projected: those are native-vocabulary constructs with no v1
-	 * ontology mapping.
+	 * The objects a statement's values become: each relation target's native Subject IRI, or the mapped
+	 * literal (or IRI, for a url value) each value produces.
 	 *
-	 * @return Quad[]
+	 * @return list<RdfTerm>
 	 */
-	private function projectRelationStatement( Statement $statement, Iri $predicate, Iri $subjectIri, Iri $graph ): array {
-		$value = $statement->getValue();
-
-		if ( !$value instanceof RelationValue ) {
-			return [];
+	private function objectTerms( Statement $statement, PropertyMapping $propertyMapping ): array {
+		if ( $statement->getPropertyType() === RelationType::NAME ) {
+			return array_map(
+				fn ( Relation $relation ): Iri => $this->namespaces->subject( $relation->targetId ),
+				$this->relationsOf( $statement )
+			);
 		}
 
-		$quads = [];
-
-		foreach ( $value->relations as $relation ) {
-			$quads[] = new Quad( $subjectIri, $predicate, $this->namespaces->subject( $relation->targetId ), $graph );
-		}
-
-		return $quads;
-	}
-
-	/**
-	 * @return Quad[]
-	 */
-	private function projectValueStatement(
-		Statement $statement,
-		PropertyMapping $propertyMapping,
-		Iri $predicate,
-		Iri $subjectIri,
-		Iri $graph
-	): array {
 		$terms = $this->valueMappers->mapValue( $statement->getPropertyType(), $statement->getValue() );
 
 		if ( $terms === null ) {
 			return [];
 		}
 
-		$quads = [];
+		return array_values( array_map(
+			fn ( RdfTerm $term ): RdfTerm => $this->applyOverrides( $term, $propertyMapping, $statement->getPropertyName()->text ),
+			$terms
+		) );
+	}
 
-		foreach ( $terms as $term ) {
-			$object = $this->applyOverrides( $term, $propertyMapping, $statement->getPropertyName()->text );
-			$quads[] = new Quad( $subjectIri, $predicate, $object, $graph );
+	/**
+	 * @return list<Relation>
+	 */
+	private function relationsOf( Statement $statement ): array {
+		$value = $statement->getValue();
+
+		return $value instanceof RelationValue ? array_values( $value->relations ) : [];
+	}
+
+	/**
+	 * The Schema entry's usable nodes. Resolution is per Schema entry rather than per Subject, so a page
+	 * holding fifty Subjects of one Schema expands its nodes once and logs each problem once.
+	 *
+	 * @return array<string, SynthesizedNode> Keyed by node key.
+	 */
+	private function resolveNodes( string $schemaName, SchemaMapping $schemaMapping ): array {
+		$this->resolvedNodes[$schemaName] ??= $this->newResolvedNodes( $schemaName, $schemaMapping );
+
+		return $this->resolvedNodes[$schemaName];
+	}
+
+	/**
+	 * Expands each declared node's terms and places it in the node tree, dropping the ones the projection
+	 * cannot use. A node whose class or link predicate does not expand safely is dropped, and so is
+	 * everything below it: without its anchor there is nowhere for its descendants' triples to hang. A
+	 * parent chain that is broken, cyclic, or runs through a per-value node — impossible for a Mapping
+	 * that passed save-time validation, reachable through import — drops the node the same way.
+	 *
+	 * @return array<string, SynthesizedNode> Keyed by node key.
+	 */
+	private function newResolvedNodes( string $schemaName, SchemaMapping $schemaMapping ): array {
+		/** @var array<string, array{class: Iri, linkPredicate: Iri, mapping: NodeMapping}> $expanded */
+		$expanded = [];
+
+		foreach ( $schemaMapping->nodes as $key => $node ) {
+			// An all-digit node key is an int array key by the time json_decode is done with it, so the
+			// cast has to happen where the key is consumed rather than where it was stored.
+			$key = (string)$key;
+			$class = $this->expander->expand( $node->class );
+			$linkPredicate = $this->expander->expand( $node->linkPredicate );
+
+			if ( $class === null || $linkPredicate === null ) {
+				$this->logger->warning(
+					'Mapping "' . $this->target . '" has an unresolvable class or link predicate for node "'
+					. $key . '" of Schema "' . $schemaName . '"; skipping the node.'
+				);
+				continue;
+			}
+
+			$expanded[$key] = [ 'class' => $class, 'linkPredicate' => $linkPredicate, 'mapping' => $node ];
 		}
 
-		return $quads;
+		$resolved = [];
+
+		foreach ( $expanded as $key => $node ) {
+			$key = (string)$key;
+			$keyPath = self::keyPath( $key, $expanded );
+
+			if ( $keyPath === null ) {
+				$this->logger->warning(
+					'Mapping "' . $this->target . '" has an unusable parent chain for node "' . $key
+					. '" of Schema "' . $schemaName . '"; skipping the node.'
+				);
+				continue;
+			}
+
+			$resolved[$key] = new SynthesizedNode(
+				class: $node['class'],
+				linkPredicate: $node['linkPredicate'],
+				scope: $node['mapping']->scope,
+				keyPath: $keyPath,
+			);
+		}
+
+		return $resolved;
+	}
+
+	/**
+	 * The node keys from the Subject down to this node, or null when the chain cannot anchor it: a parent
+	 * that is undeclared or was itself dropped, a parent that is per value and so has no single instance
+	 * to hang a child off, or a loop.
+	 *
+	 * @param array<string, array{class: Iri, linkPredicate: Iri, mapping: NodeMapping}> $expanded
+	 * @return non-empty-list<string>|null The node's own key is always the last element.
+	 */
+	private static function keyPath( string $key, array $expanded ): ?array {
+		$path = [];
+		$seen = [];
+		$current = $key;
+
+		while ( $current !== null ) {
+			if ( isset( $seen[$current] ) || !array_key_exists( $current, $expanded ) ) {
+				return null;
+			}
+
+			$node = $expanded[$current]['mapping'];
+
+			if ( $path !== [] && $node->scope === NodeScope::Value ) {
+				return null;
+			}
+
+			$seen[$current] = true;
+			array_unshift( $path, $current );
+			$current = $node->parent;
+		}
+
+		return $path;
 	}
 
 	/**

--- a/src/Application/Rdf/SynthesizedNode.php
+++ b/src/Application/Rdf/SynthesizedNode.php
@@ -1,0 +1,40 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application\Rdf;
+
+use ProfessionalWiki\NeoWiki\Domain\Mapping\NodeMapping;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\NodeScope;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\Iri;
+
+/**
+ * A {@see NodeMapping} whose terms have been expanded and whose place in the node tree is known, ready
+ * for {@see SynthesizedNodes} to mint instances of. A node that cannot be resolved — an unusable class or
+ * link predicate, a parent that is missing, unusable, per value, or forms a cycle — has no
+ * {@see SynthesizedNode} at all, which is what drops its whole subtree from the projection.
+ */
+readonly class SynthesizedNode {
+
+	/**
+	 * @param non-empty-list<string> $keyPath The node keys from the Subject down to this node, its own
+	 *   key last. Subject-anchored instance IRIs are built from it, so nesting is visible in the IRI, and
+	 *   it is where the node's own key and its parent's come from.
+	 */
+	public function __construct(
+		public Iri $class,
+		public Iri $linkPredicate,
+		public NodeScope $scope,
+		public array $keyPath,
+	) {
+	}
+
+	public function key(): string {
+		return $this->keyPath[count( $this->keyPath ) - 1];
+	}
+
+	public function parentKey(): ?string {
+		return count( $this->keyPath ) > 1 ? $this->keyPath[count( $this->keyPath ) - 2] : null;
+	}
+
+}

--- a/src/Application/Rdf/SynthesizedNodes.php
+++ b/src/Application/Rdf/SynthesizedNodes.php
@@ -1,0 +1,116 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application\Rdf;
+
+use ProfessionalWiki\NeoWiki\Domain\Rdf\Iri;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\Quad;
+use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfNamespaces;
+use ProfessionalWiki\NeoWiki\Domain\Relation\RelationId;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
+
+/**
+ * The synthesized intermediate-node instances of one Subject's projection: it mints their IRIs and, for
+ * the instances that ended up carrying something, the triples that put them in the graph.
+ *
+ * Instances are minted on demand and their scaffolding — the `rdf:type` triple and the link triple from
+ * the anchor (the parent node's instance, or the Subject) — is recorded at the same moment, so a node is
+ * in the output only when a value attached to it or to something below it. Asking for an instance also
+ * pulls in its parent chain, which is how a nested node brings its ancestors along. Nothing is emitted
+ * for a node no value reached, so an event ontology's projection carries no empty event nodes.
+ */
+class SynthesizedNodes {
+
+	/**
+	 * @var array<string, true> Keyed by the IRI of every instance already scaffolded, so a node shared by
+	 *   several properties is scaffolded once.
+	 */
+	private array $scaffolded = [];
+
+	/** @var list<Quad> */
+	private array $scaffold = [];
+
+	/**
+	 * @param array<string, SynthesizedNode> $nodes The resolvable nodes of the Subject's Schema entry,
+	 *   keyed by node key.
+	 */
+	public function __construct(
+		private readonly array $nodes,
+		private readonly SubjectId $subjectId,
+		private readonly Iri $subjectIri,
+		private readonly Iri $graph,
+		private readonly RdfNamespaces $namespaces,
+	) {
+	}
+
+	/**
+	 * The node a property entry's key names, or null when it was not declared or could not be resolved.
+	 */
+	public function get( string $key ): ?SynthesizedNode {
+		return $this->nodes[$key] ?? null;
+	}
+
+	/**
+	 * The single instance a subject-scoped node has on this Subject.
+	 */
+	public function instance( SynthesizedNode $node ): Iri {
+		return $this->record( $node, $this->namespaces->synthesizedNode( $this->subjectId, ...$node->keyPath ) );
+	}
+
+	/**
+	 * The instance a value-scoped node has for one relation value. Anchoring it on the Relation's
+	 * persistent ID keeps the node the same across projections and re-projections.
+	 */
+	public function relationInstance( SynthesizedNode $node, RelationId $relationId ): Iri {
+		return $this->record( $node, $this->namespaces->synthesizedRelationNode( $relationId ) );
+	}
+
+	/**
+	 * The instance a value-scoped node has for one literal value, which has no persistent ID of its own
+	 * and is therefore identified by its position among the property's values.
+	 */
+	public function valueInstance( SynthesizedNode $node, int $position ): Iri {
+		return $this->record(
+			$node,
+			$this->namespaces->synthesizedNode( $this->subjectId, $node->key(), (string)$position )
+		);
+	}
+
+	private function record( SynthesizedNode $node, Iri $instance ): Iri {
+		if ( isset( $this->scaffolded[$instance->value] ) ) {
+			return $instance;
+		}
+
+		// Recorded before resolving the anchor, so a parent cycle that survived node resolution
+		// terminates here instead of recursing forever.
+		$this->scaffolded[$instance->value] = true;
+
+		$anchor = $this->anchor( $node );
+
+		$this->scaffold[] = new Quad( $instance, $this->namespaces->rdfType(), $node->class, $this->graph );
+		$this->scaffold[] = new Quad( $anchor, $node->linkPredicate, $instance, $this->graph );
+
+		return $instance;
+	}
+
+	/**
+	 * What the node's link triple runs from: its parent's instance, or the Subject when it has no parent.
+	 * A parent is always subject-scoped, so it has exactly one instance. Reaching for it records it, which
+	 * is what makes a whole ancestor chain appear when only its deepest node carries a value. Node
+	 * resolution drops a node whose parent is missing or unusable, so a resolved node's parent is here.
+	 */
+	private function anchor( SynthesizedNode $node ): Iri {
+		$parentKey = $node->parentKey();
+
+		return $parentKey === null ? $this->subjectIri : $this->instance( $this->nodes[$parentKey] );
+	}
+
+	/**
+	 * @return list<Quad>
+	 */
+	public function scaffoldQuads(): array {
+		return $this->scaffold;
+	}
+
+}

--- a/src/Domain/Mapping/CurieExpander.php
+++ b/src/Domain/Mapping/CurieExpander.php
@@ -43,7 +43,7 @@ readonly class CurieExpander {
 
 		// Not a declared CURIE. Accept only an explicit absolute IRI with an authority (`scheme://…`);
 		// a bare `prefix:local` with an undeclared prefix is a typo'd CURIE and is rejected, not
-		// silently treated as an IRI. Non-authority schemes (urn:, mailto:) are out of scope for v1.
+		// silently treated as an IRI. Non-authority schemes (urn:, mailto:) are out of scope.
 		if ( str_contains( $term, '://' ) ) {
 			return self::newSafeIri( $term );
 		}

--- a/src/Domain/Mapping/Mapping.php
+++ b/src/Domain/Mapping/Mapping.php
@@ -13,11 +13,20 @@ use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
  * page holds an entry for every mapped Schema, so a Schema is mapped by adding an entry rather than by
  * creating a page — and a page cannot list the same Schema twice, so uniqueness needs no save-time check.
  *
- * This is the deliberately minimal v1 shape: term substitution only (a target class for each Subject and
- * one predicate per mapped property), no intermediate-node synthesis. The stored format is versioned and
- * provisional; the mapping-formalism question (OntologyMapping.md Q1, #995) stays open.
+ * On top of term substitution — a target class per Subject, one predicate per mapped property — the
+ * format expresses both structural transformations of OntologyMapping.md: synthesizing the intermediate
+ * nodes an event-centric target needs, and contributing a Subject's values to the Subjects it points at
+ * for a target that wants them flat. The stored format is versioned and provisional; the
+ * mapping-formalism question (OntologyMapping.md Q1, #995) stays open at the authoring level.
  */
 readonly class Mapping {
+
+	/**
+	 * The one format version that can be read. The format so far grows by optional additions, which leave
+	 * existing documents valid and unchanged in meaning, so this bumps only once a change breaks them. A
+	 * page in any other version is unreadable and its projection is simply unknown.
+	 */
+	public const int FORMAT_VERSION = 1;
 
 	/**
 	 * @param array<string, string> $prefixes Prefix label to namespace IRI, shared by every entry, for

--- a/src/Domain/Mapping/NodeMapping.php
+++ b/src/Domain/Mapping/NodeMapping.php
@@ -1,0 +1,32 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\Mapping;
+
+/**
+ * One intermediate node a {@see SchemaMapping} synthesizes: the event-style node that event-centric
+ * ontologies mediate a relationship through and that has no counterpart in NeoWiki's data
+ * (OntologyMapping.md § What makes this hard). The node key it is declared under names it from the
+ * property entries that attach to it and from another node's `$parent`, so it is not repeated here.
+ *
+ * The CURIEs are expanded against the Mapping's page-level prefixes by a {@see CurieExpander} at
+ * validation and projection time.
+ */
+readonly class NodeMapping {
+
+	/**
+	 * @param string $class The `rdf:type` given to each instance of the node.
+	 * @param string $linkPredicate The predicate of the triple from the anchor — the parent node's
+	 *   instance, or the Subject when there is no parent — to the node instance.
+	 * @param string|null $parent The key of the node this one hangs off, instead of the Subject.
+	 */
+	public function __construct(
+		public string $class,
+		public string $linkPredicate,
+		public ?string $parent = null,
+		public NodeScope $scope = NodeScope::Subject,
+	) {
+	}
+
+}

--- a/src/Domain/Mapping/NodeScope.php
+++ b/src/Domain/Mapping/NodeScope.php
@@ -1,0 +1,24 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\Mapping;
+
+/**
+ * How many instances of a {@see NodeMapping} a Subject gets.
+ */
+enum NodeScope: string {
+
+	/**
+	 * One instance per Subject, shared by every property that attaches to the node — the CIDOC-CRM
+	 * `E67_Birth` that a birth date and a birth place both hang off.
+	 */
+	case Subject = 'subject';
+
+	/**
+	 * One instance per value of the single property that attaches to the node — the `E12_Production`
+	 * that each Creator of an Artwork gets.
+	 */
+	case Value = 'value';
+
+}

--- a/src/Domain/Mapping/PropertyMapping.php
+++ b/src/Domain/Mapping/PropertyMapping.php
@@ -11,10 +11,15 @@ namespace ProfessionalWiki\NeoWiki\Domain\Mapping;
  */
 readonly class PropertyMapping {
 
+	/**
+	 * @param string|null $node The key of a {@see NodeMapping} on the same Schema entry. The property's
+	 *   values then attach to that synthesized node's instance instead of to the Subject.
+	 */
 	public function __construct(
 		public string $predicate,
 		public ?string $language = null,
 		public ?string $datatype = null,
+		public ?string $node = null,
 	) {
 	}
 

--- a/src/Domain/Mapping/SchemaMapping.php
+++ b/src/Domain/Mapping/SchemaMapping.php
@@ -5,16 +5,36 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Domain\Mapping;
 
 /**
- * One Schema's entry within a page-level {@see Mapping}: the target class given to each Subject of the
- * Schema and the per-property predicates. The Schema it applies to is its key in {@see Mapping::$schemas},
- * so it is not repeated here. The CURIEs used here are expanded against the Mapping's page-level prefixes
- * by a {@see CurieExpander} at validation and projection time.
+ * One Schema's entry within a page-level {@see Mapping}. The Schema it applies to is its key in
+ * {@see Mapping::$schemas}, so it is not repeated here. The CURIEs used here are expanded against the
+ * Mapping's page-level prefixes by a {@see CurieExpander} at validation and projection time.
+ *
+ * It covers both structural directions of OntologyMapping.md § What makes this hard:
+ *
+ *  - **Expansion**, for a target that mediates relationships through event nodes NeoWiki's data does not
+ *    have: {@see $nodes} declares those nodes, and a {@see PropertyMapping::$node} attaches a property's
+ *    values to one of them instead of to the Subject.
+ *  - **Contraction**, for a flat target that does not want structure the data does carry:
+ *    {@see $contributions} sends this Schema's own values to the Subjects it points at.
+ *
+ * An entry with neither is the near-1:1 term substitution the format started out as.
  */
 readonly class SchemaMapping {
 
+	/**
+	 * @param SubjectMapping|null $subject How the Subject itself projects. Null for an entry that only
+	 *   contributes to other Subjects, which then emits no type or label of its own.
+	 * @param array<string, NodeMapping> $nodes Keyed by node key.
+	 * @param array<string, PropertyMappings> $contributions Keyed by the name of a relation-typed
+	 *   property on this Schema; every Subject that relation points at receives the mapped values. A
+	 *   {@see PropertyMapping::$node} there has no meaning: contributed triples attach to the target
+	 *   Subject, not to a synthesized node.
+	 */
 	public function __construct(
-		public string $subjectClass,
-		public PropertyMappings $properties,
+		public ?SubjectMapping $subject,
+		public PropertyMappings $properties = new PropertyMappings(),
+		public array $nodes = [],
+		public array $contributions = [],
 	) {
 	}
 

--- a/src/Domain/Mapping/SubjectMapping.php
+++ b/src/Domain/Mapping/SubjectMapping.php
@@ -1,0 +1,22 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\Mapping;
+
+/**
+ * How a {@see SchemaMapping} projects the Subject itself: its target class and, optionally, a second
+ * predicate for its label. `rdfs:label` is emitted regardless, so `$labelPredicate` adds a target-ontology
+ * label term (`foaf:name`, `crm:P1_is_identified_by`, …) rather than replacing it.
+ *
+ * Absent from a Schema entry that only {@see SchemaMapping::$contributions contributes} to other Subjects.
+ */
+readonly class SubjectMapping {
+
+	public function __construct(
+		public string $class,
+		public ?string $labelPredicate = null,
+	) {
+	}
+
+}

--- a/src/Domain/Rdf/RdfNamespaces.php
+++ b/src/Domain/Rdf/RdfNamespaces.php
@@ -67,6 +67,31 @@ readonly class RdfNamespaces {
 		return new Iri( $this->baseUri . '/relation/' . $id->asString() );
 	}
 
+	/**
+	 * A synthesized intermediate node of an ontology projection, anchored on the Subject it expands
+	 * (OntologyMapping.md § Synthesized-node IRIs). For a subject-scoped node the keys are its chain of
+	 * Mapping node keys from the Subject down, so nesting reads off the IRI. For a value-scoped node they
+	 * are its own key and the value's position — its parent chain is left out.
+	 *
+	 * These IRIs are deliberately not in {@see prefixMap()}: like a graph IRI, their local part can start
+	 * with a digit, so a prefix would not abbreviate them anyway.
+	 */
+	public function synthesizedNode( SubjectId $subjectId, string ...$keys ): Iri {
+		return new Iri(
+			$this->baseUri . '/node/' . $subjectId->text . '/'
+				. implode( '/', array_map( self::localName( ... ), $keys ) )
+		);
+	}
+
+	/**
+	 * A synthesized intermediate node anchored on the Relation whose value it mediates. Relations carry a
+	 * persistent ID ([ADR 10](../../../docs/adr/010-add-guids-to-relations.md)), so the node for a given
+	 * relation value is the same node in every projection and across re-projections.
+	 */
+	public function synthesizedRelationNode( RelationId $relationId ): Iri {
+		return new Iri( $this->baseUri . '/node/' . $relationId->asString() );
+	}
+
 	public function page( PageId $id ): Iri {
 		return new Iri( $this->baseUri . '/page/' . $id->id );
 	}

--- a/src/EntryPoints/Content/MappingContentHandler.php
+++ b/src/EntryPoints/Content/MappingContentHandler.php
@@ -9,11 +9,13 @@ use MediaWiki\Content\Content;
 use MediaWiki\Content\JsonContentHandler;
 use MediaWiki\Content\Renderer\ContentParseParams;
 use MediaWiki\Content\ValidationParams;
+use MediaWiki\Html\Html;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Page\PageReference;
 use MediaWiki\Parser\ParserOutput;
 use MediaWiki\Title\Title;
 use MediaWiki\Title\TitleValue;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\Mapping;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\MappingName;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\MappingContentValidator;
@@ -60,8 +62,8 @@ class MappingContentHandler extends JsonContentHandler {
 	/**
 	 * Renders the Mapping as a header (mapped-schemas overview, prefixes, format version) plus one section
 	 * per schema whose body stays the default mw-json table. Falls back to the inherited JSON rendering when
-	 * the content does not parse or is not the expected v1 shape (XML import and future versions bypass save
-	 * validation), so display never fatals.
+	 * the content does not parse or is not the expected shape (XML import and other format versions bypass
+	 * save validation), so display never fatals.
 	 */
 	protected function fillParserOutput(
 		Content $content,
@@ -75,9 +77,36 @@ class MappingContentHandler extends JsonContentHandler {
 				$this->renderMapping( $content, $mapping, $cpoParams->getPage(), $parserOutput );
 				return;
 			}
+
+			parent::fillParserOutput( $content, $cpoParams, $parserOutput );
+			$this->addUnsupportedVersionNotice( $mapping, $parserOutput );
+			return;
 		}
 
 		parent::fillParserOutput( $content, $cpoParams, $parserOutput );
+	}
+
+	/**
+	 * A page written in another format version renders as plain JSON, which on its own looks like an
+	 * ordinary Mapping page even though it defines no projection and every export of it fails. Saying so
+	 * is the only signal the reader gets.
+	 */
+	private function addUnsupportedVersionNotice( mixed $mapping, ParserOutput $parserOutput ): void {
+		$version = $mapping instanceof stdClass ? ( $mapping->version ?? null ) : null;
+
+		if ( !is_scalar( $version ) || $version === Mapping::FORMAT_VERSION ) {
+			return;
+		}
+
+		$parserOutput->setContentHolderText(
+			Html::warningBox(
+				wfMessage( 'neowiki-mapping-unsupported-version' )
+					->params( (string)$version )
+					->inContentLanguage()
+					->escaped()
+			) . $parserOutput->getContentHolderText()
+		);
+		$parserOutput->addModuleStyles( [ 'mediawiki.codex.messagebox.styles' ] );
 	}
 
 	private function renderMapping(
@@ -118,15 +147,17 @@ class MappingContentHandler extends JsonContentHandler {
 	 */
 	private function isRenderableMapping( mixed $mapping ): bool {
 		return $mapping instanceof stdClass
-			&& ( $mapping->version ?? null ) === 1
+			&& ( $mapping->version ?? null ) === Mapping::FORMAT_VERSION
 			&& isset( $mapping->schemas )
 			&& $mapping->schemas instanceof stdClass;
 	}
 
 	public function makeEmptyContent(): MappingContent {
+		$version = Mapping::FORMAT_VERSION;
+
 		return new MappingContent( <<<JSON
 {
-	"version": 1,
+	"version": {$version},
 	"prefixes": {},
 	"schemas": {}
 }

--- a/src/Persistence/MediaWiki/MappingContentValidator.php
+++ b/src/Persistence/MediaWiki/MappingContentValidator.php
@@ -16,19 +16,25 @@ use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use RuntimeException;
 
 /**
- * Validates the JSON of a Mapping page against the v1 format, in three stages:
+ * Validates the JSON of a Mapping page against the Mapping format, in three stages:
  *
  *  1. Structural validation against mappingContentSchema.json (versioned, deliberately minimal).
- *  2. Semantic IRI-safety validation: every declared prefix namespace, and every class, predicate and
- *     datatype term across all Schema entries, must expand to a valid, safe absolute IRI (the #1029
- *     lesson). A term that cannot be resolved against the declared prefixes, or that would break out of
- *     its IRI, is rejected here rather than percent-encoded — a Mapping must reproduce the ontology's
- *     exact terms.
+ *  2. Semantic IRI-safety validation: every declared prefix namespace, and every class, label predicate,
+ *     node class, node link predicate, predicate and datatype term across all Schema entries, must expand
+ *     to a valid, safe absolute IRI (the #1029 lesson). A term that cannot be resolved against the declared
+ *     prefixes, or that would break out of its IRI, is rejected here rather than percent-encoded — a
+ *     Mapping must reproduce the ontology's exact terms. The node graph is checked in the same stage:
+ *     every node reference names a declared node, and the shapes the projector supports are enforced
+ *     (see {@see nodeGraphErrors()}).
  *  3. Schema-name validation: each key under `schemas` must be a usable Schema name written exactly as
  *     its Schema page title. The projector matches keys against a Subject's Schema name byte for byte,
  *     while a page lookup normalizes, so "Person_X" would resolve to the Schema page yet never project.
  *     Requiring the canonical form keeps those two agreeing, and makes the read view's red or blue link
  *     an honest signal of whether the Schema is there.
+ *
+ * Property, node-attached property, and contribution relation names are **not** checked against the
+ * actual Schema, for the same reason Schema names are not checked for existence: a Mapping may be
+ * authored or installed before the Schema it maps.
  */
 class MappingContentValidator {
 
@@ -90,25 +96,28 @@ class MappingContentValidator {
 	}
 
 	/**
-	 * The structure has already passed JSON-Schema validation, so the fields are present and well-typed;
-	 * the guards here keep the analyser happy and make a hand-called validator robust to raw input.
+	 * Runs only after the structural stage passed, so every field that is present has the type the JSON
+	 * Schema declares; only optional fields need an absent case.
 	 *
 	 * @param array<string, mixed> $data
 	 * @return array<string, string>
 	 */
 	private function semanticErrors( array $data ): array {
-		$prefixes = $this->stringMap( $data['prefixes'] ?? [] );
+		/** @var array<string, string> $prefixes */
+		$prefixes = $data['prefixes'] ?? [];
 		$expander = new CurieExpander( $prefixes );
 
 		$errors = $this->prefixErrors( $prefixes );
 
-		$schemas = is_array( $data['schemas'] ?? null ) ? $data['schemas'] : [];
-		foreach ( $schemas as $schemaName => $entry ) {
-			$errors = array_merge( $errors, $this->schemaNameErrors( (string)$schemaName ) );
+		/** @var array<string, array<string, mixed>> $schemas */
+		$schemas = $data['schemas'];
 
-			if ( is_array( $entry ) ) {
-				$errors = array_merge( $errors, $this->schemaErrors( (string)$schemaName, $entry, $expander ) );
-			}
+		foreach ( $schemas as $schemaName => $entry ) {
+			$errors = array_merge(
+				$errors,
+				$this->schemaNameErrors( (string)$schemaName ),
+				$this->schemaErrors( (string)$schemaName, $entry, $expander )
+			);
 		}
 
 		return $errors;
@@ -165,65 +174,227 @@ class MappingContentValidator {
 	 */
 	private function schemaErrors( string $schemaName, array $entry, CurieExpander $expander ): array {
 		$base = '/schemas/' . $schemaName;
+
+		return array_merge(
+			$this->subjectErrors( $base, $this->arrayValue( $entry, 'subject' ), $expander ),
+			$this->nodeTermErrors( $base, $this->arrayValue( $entry, 'nodes' ), $expander ),
+			$this->nodeGraphErrors( $base, $entry ),
+			$this->propertiesErrors( $base . '/properties', $this->arrayValue( $entry, 'properties' ), $expander ),
+			$this->contributionsErrors( $base, $entry, $expander ),
+		);
+	}
+
+	/**
+	 * @param array<mixed> $subject
+	 * @return array<string, string>
+	 */
+	private function subjectErrors( string $base, array $subject, CurieExpander $expander ): array {
+		return array_merge(
+			$this->termErrors( $base . '/subject/class', $subject['class'] ?? null, $expander ),
+			$this->termErrors( $base . '/subject/labelPredicate', $subject['labelPredicate'] ?? null, $expander ),
+		);
+	}
+
+	/**
+	 * @param array<mixed> $nodes
+	 * @return array<string, string>
+	 */
+	private function nodeTermErrors( string $base, array $nodes, CurieExpander $expander ): array {
 		$errors = [];
 
-		$subject = $entry['subject'] ?? null;
-		$class = is_array( $subject ) ? $this->stringOrNull( $subject['class'] ?? null ) : null;
-		if ( $class !== null && $expander->expand( $class ) === null ) {
-			$errors[$base . '/subject/class'] = $this->unresolvedTermMessage( $class );
-		}
-
-		$properties = is_array( $entry['properties'] ?? null ) ? $entry['properties'] : [];
-		foreach ( $properties as $name => $propertyEntry ) {
-			if ( is_array( $propertyEntry ) ) {
-				$errors = array_merge( $errors, $this->propertyErrors( $base, (string)$name, $propertyEntry, $expander ) );
+		foreach ( $nodes as $key => $node ) {
+			if ( is_array( $node ) ) {
+				$errors = array_merge(
+					$errors,
+					$this->termErrors( $base . '/nodes/' . $key . '/class', $node['class'] ?? null, $expander ),
+					$this->termErrors(
+						$base . '/nodes/' . $key . '/linkPredicate',
+						$node['linkPredicate'] ?? null,
+						$expander
+					),
+				);
 			}
 		}
 
 		return $errors;
+	}
+
+	/**
+	 * The shape rules the projector's node handling relies on: every `node` and `parent` names a declared
+	 * node, the parent chain reaches the Subject rather than looping, and a per-value node stays a leaf
+	 * carrying one property — the projector mints one instance of it per value of that property, so a
+	 * second referrer or a child hanging off it would have no single instance to attach to.
+	 *
+	 * @param array<mixed> $entry
+	 * @return array<string, string>
+	 */
+	private function nodeGraphErrors( string $base, array $entry ): array {
+		$nodes = $this->arrayValue( $entry, 'nodes' );
+		$errors = $this->numericNodeKeyErrors( $base, $nodes );
+
+		foreach ( $nodes as $key => $node ) {
+			$parent = is_array( $node ) ? $this->stringOrNull( $node['parent'] ?? null ) : null;
+
+			if ( $parent === null ) {
+				continue;
+			}
+
+			$pointer = $base . '/nodes/' . $key;
+
+			if ( !array_key_exists( $parent, $nodes ) ) {
+				$errors[$pointer . '/parent'] = 'The node "' . $parent . '" is not declared.';
+			}
+			elseif ( $this->isPerValue( $nodes[$parent] ) ) {
+				$errors[$pointer . '/parent'] = 'The node "' . $parent . '" is per value, so it cannot be a parent.';
+			}
+			elseif ( self::chainLoops( (string)$key, $nodes ) ) {
+				$errors[$pointer . '/parent'] = 'The node "' . $key . '" is its own ancestor.';
+			}
+		}
+
+		return array_merge( $errors, $this->perValueReferrerErrors( $base, $nodes, $this->arrayValue( $entry, 'properties' ) ) );
+	}
+
+	/**
+	 * An all-digit node key survives JSON parsing as an integer key, which the JSON Schema's
+	 * `propertyNames` pattern cannot see because a pattern only constrains strings. Rejecting it here
+	 * keeps every stored node key identifier-shaped — and such a node is unreachable anyway, since the
+	 * `parent` and `node` references that would name it are pattern-checked.
+	 *
+	 * @param array<mixed> $nodes
+	 * @return array<string, string>
+	 */
+	private function numericNodeKeyErrors( string $base, array $nodes ): array {
+		$errors = [];
+
+		foreach ( array_keys( $nodes ) as $key ) {
+			if ( !is_string( $key ) ) {
+				$errors[$base . '/nodes/' . $key] =
+					'The node key "' . $key . '" must start with a letter or an underscore.';
+			}
+		}
+
+		return $errors;
+	}
+
+	/**
+	 * @param array<mixed> $nodes
+	 * @param array<mixed> $properties
+	 * @return array<string, string>
+	 */
+	private function perValueReferrerErrors( string $base, array $nodes, array $properties ): array {
+		$errors = [];
+		$referrers = [];
+
+		foreach ( $properties as $name => $property ) {
+			$node = is_array( $property ) ? $this->stringOrNull( $property['node'] ?? null ) : null;
+
+			if ( $node === null ) {
+				continue;
+			}
+
+			if ( !array_key_exists( $node, $nodes ) ) {
+				$errors[$base . '/properties/' . $name . '/node'] = 'The node "' . $node . '" is not declared.';
+				continue;
+			}
+
+			$referrers[$node] ??= 0;
+			$referrers[$node]++;
+
+			if ( $referrers[$node] > 1 && $this->isPerValue( $nodes[$node] ) ) {
+				$errors[$base . '/properties/' . $name . '/node'] =
+					'The node "' . $node . '" is per value, so only one property can attach to it.';
+			}
+		}
+
+		return $errors;
+	}
+
+	private function isPerValue( mixed $node ): bool {
+		return is_array( $node ) && ( $node['per'] ?? null ) === 'value';
+	}
+
+	/**
+	 * @param array<mixed> $nodes
+	 */
+	private static function chainLoops( string $key, array $nodes ): bool {
+		$seen = [];
+		$current = $key;
+
+		while ( is_string( $current ) && is_array( $nodes[$current] ?? null ) ) {
+			if ( array_key_exists( $current, $seen ) ) {
+				return true;
+			}
+
+			$seen[$current] = true;
+			$current = $nodes[$current]['parent'] ?? null;
+		}
+
+		return false;
 	}
 
 	/**
 	 * @param array<mixed> $entry
 	 * @return array<string, string>
 	 */
-	private function propertyErrors( string $base, string $name, array $entry, CurieExpander $expander ): array {
+	private function contributionsErrors( string $base, array $entry, CurieExpander $expander ): array {
 		$errors = [];
 
-		$predicate = $this->stringOrNull( $entry['predicate'] ?? null );
-		if ( $predicate !== null && $expander->expand( $predicate ) === null ) {
-			$errors[$base . '/properties/' . $name . '/predicate'] = $this->unresolvedTermMessage( $predicate );
-		}
-
-		$datatype = $this->stringOrNull( $entry['datatype'] ?? null );
-		if ( $datatype !== null && $expander->expand( $datatype ) === null ) {
-			$errors[$base . '/properties/' . $name . '/datatype'] = $this->unresolvedTermMessage( $datatype );
+		foreach ( $this->arrayValue( $entry, 'contributions' ) as $relation => $properties ) {
+			if ( is_array( $properties ) ) {
+				$errors = array_merge(
+					$errors,
+					$this->propertiesErrors( $base . '/contributions/' . $relation, $properties, $expander )
+				);
+			}
 		}
 
 		return $errors;
 	}
 
-	private function stringOrNull( mixed $value ): ?string {
-		return is_string( $value ) ? $value : null;
+	/**
+	 * @param array<mixed> $properties
+	 * @return array<string, string>
+	 */
+	private function propertiesErrors( string $base, array $properties, CurieExpander $expander ): array {
+		$errors = [];
+
+		foreach ( $properties as $name => $property ) {
+			if ( is_array( $property ) ) {
+				$errors = array_merge(
+					$errors,
+					$this->termErrors( $base . '/' . $name . '/predicate', $property['predicate'] ?? null, $expander ),
+					$this->termErrors( $base . '/' . $name . '/datatype', $property['datatype'] ?? null, $expander ),
+				);
+			}
+		}
+
+		return $errors;
 	}
 
 	/**
 	 * @return array<string, string>
 	 */
-	private function stringMap( mixed $value ): array {
-		if ( !is_array( $value ) ) {
+	private function termErrors( string $pointer, mixed $term, CurieExpander $expander ): array {
+		$term = $this->stringOrNull( $term );
+
+		if ( $term === null || $expander->expand( $term ) !== null ) {
 			return [];
 		}
 
-		$map = [];
+		return [ $pointer => $this->unresolvedTermMessage( $term ) ];
+	}
 
-		foreach ( $value as $key => $entry ) {
-			if ( is_string( $key ) && is_string( $entry ) ) {
-				$map[$key] = $entry;
-			}
-		}
+	/**
+	 * @param array<mixed> $data
+	 * @return array<mixed>
+	 */
+	private function arrayValue( array $data, string $key ): array {
+		return is_array( $data[$key] ?? null ) ? $data[$key] : [];
+	}
 
-		return $map;
+	private function stringOrNull( mixed $value ): ?string {
+		return is_string( $value ) ? $value : null;
 	}
 
 	private function unresolvedTermMessage( string $term ): string {

--- a/src/Persistence/MediaWiki/MappingPersistenceDeserializer.php
+++ b/src/Persistence/MediaWiki/MappingPersistenceDeserializer.php
@@ -7,24 +7,33 @@ namespace ProfessionalWiki\NeoWiki\Persistence\MediaWiki;
 use InvalidArgumentException;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\Mapping;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\MappingName;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\NodeMapping;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\NodeScope;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\PropertyMapping;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\PropertyMappings;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\SchemaMapping;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\SubjectMapping;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 
 class MappingPersistenceDeserializer {
 
 	/**
-	 * @throws InvalidArgumentException When the JSON is not a Mapping document (invalid JSON, or no
-	 *   `schemas` object). The lookups catch this and treat the page as having no valid Mapping, so a
-	 *   malformed page never breaks a projection. A single malformed Schema entry is skipped rather than
-	 *   failing the whole page, mirroring how a malformed property entry is skipped.
+	 * @throws InvalidArgumentException When the JSON is not a Mapping document of the supported format
+	 *   version (invalid JSON, a `version` other than the current one, or no `schemas` object). The
+	 *   lookups catch this and treat the page as having no valid Mapping, so an unreadable page degrades
+	 *   to an unknown projection instead of breaking a projection or a page save. A single malformed
+	 *   Schema entry is skipped rather than failing the whole page, mirroring how a malformed property
+	 *   entry is skipped.
 	 */
 	public function deserialize( MappingName $name, string $json ): Mapping {
 		$data = json_decode( $json, true );
 
 		if ( !is_array( $data ) ) {
 			throw new InvalidArgumentException( 'Invalid JSON' );
+		}
+
+		if ( ( $data['version'] ?? null ) !== Mapping::FORMAT_VERSION ) {
+			throw new InvalidArgumentException( 'Unsupported mapping format version' );
 		}
 
 		if ( !is_array( $data['schemas'] ?? null ) ) {
@@ -77,45 +86,117 @@ class MappingPersistenceDeserializer {
 			return null;
 		}
 
-		$subject = $entry['subject'] ?? null;
-		$class = is_array( $subject ) ? ( $subject['class'] ?? null ) : null;
-
-		if ( !is_string( $class ) ) {
-			return null;
-		}
-
 		try {
 			// The key is the Schema name; constructing it validates the key — an empty or reserved name
-			// throws — so a malformed key skips the entry, like a missing subject.class does. The result
-			// is not stored: the entry's Schema is its key in Mapping::$schemas.
+			// throws — so a malformed key skips the entry. The result is not stored: the entry's Schema is
+			// its key in Mapping::$schemas.
 			new SchemaName( $schemaName );
 		} catch ( InvalidArgumentException ) {
 			return null;
 		}
 
+		$subject = $this->subjectMappingFromJson( $entry );
+		$contributions = $this->contributionsFromJson( $entry );
+
+		// An entry that neither projects its own Subject nor contributes to another has nothing to say.
+		if ( $subject === null && $contributions === [] ) {
+			return null;
+		}
+
 		return new SchemaMapping(
-			subjectClass: $class,
-			properties: $this->propertyMappingsFromJson( $entry ),
+			subject: $subject,
+			properties: $this->propertyMappingsFromJson( $this->arrayValue( $entry, 'properties' ) ),
+			nodes: $this->nodeMappingsFromJson( $entry ),
+			contributions: $contributions,
 		);
 	}
 
 	/**
 	 * @param array<string, mixed> $entry
 	 */
-	private function propertyMappingsFromJson( array $entry ): PropertyMappings {
+	private function subjectMappingFromJson( array $entry ): ?SubjectMapping {
+		$subject = $this->arrayValue( $entry, 'subject' );
+		$class = $subject['class'] ?? null;
+
+		if ( !is_string( $class ) ) {
+			return null;
+		}
+
+		return new SubjectMapping(
+			class: $class,
+			labelPredicate: $this->stringOrNull( $subject['labelPredicate'] ?? null ),
+		);
+	}
+
+	/**
+	 * @param array<string, mixed> $entry
+	 * @return array<string, NodeMapping>
+	 */
+	private function nodeMappingsFromJson( array $entry ): array {
+		$nodes = [];
+
+		foreach ( $this->arrayValue( $entry, 'nodes' ) as $key => $node ) {
+			if ( !is_array( $node ) || !is_string( $node['class'] ?? null ) || !is_string( $node['linkPredicate'] ?? null ) ) {
+				continue;
+			}
+
+			$nodes[(string)$key] = new NodeMapping(
+				class: $node['class'],
+				linkPredicate: $node['linkPredicate'],
+				parent: $this->stringOrNull( $node['parent'] ?? null ),
+				scope: NodeScope::tryFrom( (string)( $node['per'] ?? '' ) ) ?? NodeScope::Subject,
+			);
+		}
+
+		return $nodes;
+	}
+
+	/**
+	 * @param array<string, mixed> $entry
+	 * @return array<string, PropertyMappings> Keyed by relation name.
+	 */
+	private function contributionsFromJson( array $entry ): array {
+		$contributions = [];
+
+		foreach ( $this->arrayValue( $entry, 'contributions' ) as $relation => $properties ) {
+			$relation = trim( (string)$relation );
+
+			if ( $relation === '' || !is_array( $properties ) ) {
+				continue;
+			}
+
+			$propertyMappings = $this->propertyMappingsFromJson( $properties );
+
+			if ( $propertyMappings->asArray() !== [] ) {
+				$contributions[$relation] = $propertyMappings;
+			}
+		}
+
+		return $contributions;
+	}
+
+	/**
+	 * @param array<mixed> $properties
+	 */
+	private function propertyMappingsFromJson( array $properties ): PropertyMappings {
 		$mappings = [];
 
-		foreach ( $this->arrayValue( $entry, 'properties' ) as $name => $property ) {
-			if ( is_string( $name ) && is_array( $property ) && is_string( $property['predicate'] ?? null ) ) {
-				$mappings[$name] = new PropertyMapping(
+		foreach ( $properties as $name => $property ) {
+			if ( is_array( $property ) && is_string( $property['predicate'] ?? null ) ) {
+				$mappings[(string)$name] = new PropertyMapping(
 					predicate: $property['predicate'],
-					language: is_string( $property['lang'] ?? null ) ? $property['lang'] : null,
-					datatype: is_string( $property['datatype'] ?? null ) ? $property['datatype'] : null,
+					language: $this->stringOrNull( $property['lang'] ?? null ),
+					datatype: $this->stringOrNull( $property['datatype'] ?? null ),
+					node: $this->stringOrNull( $property['node'] ?? null ),
 				);
 			}
 		}
 
 		return new PropertyMappings( $mappings );
+	}
+
+	private function stringOrNull( mixed $value ): ?string {
+		return is_string( $value ) ? $value : null;
 	}
 
 	/**

--- a/src/Persistence/MediaWiki/mappingContentSchema.json
+++ b/src/Persistence/MediaWiki/mappingContentSchema.json
@@ -12,25 +12,29 @@
 		},
 		"prefixes": {
 			"type": "object",
+			"maxProperties": 200,
 			"propertyNames": {
 				"pattern": "^[A-Za-z][A-Za-z0-9_-]*$"
 			},
 			"additionalProperties": {
 				"type": "string",
 				"minLength": 1
+			},
+			"$error": {
+				"maxProperties": "A mapping may declare at most 200 prefixes."
 			}
 		},
 		"schemas": {
 			"type": "object",
+			"maxProperties": 1000,
 			"propertyNames": {
 				"minLength": 1
 			},
+			"$error": {
+				"maxProperties": "A mapping may hold at most 1000 schema entries."
+			},
 			"additionalProperties": {
 				"type": "object",
-				"required": [
-					"subject",
-					"properties"
-				],
 				"properties": {
 					"subject": {
 						"type": "object",
@@ -41,46 +45,178 @@
 							"class": {
 								"type": "string",
 								"minLength": 1
+							},
+							"labelPredicate": {
+								"type": "string",
+								"minLength": 1
 							}
 						},
 						"additionalProperties": false
 					},
-					"properties": {
+					"nodes": {
 						"type": "object",
+						"maxProperties": 64,
+						"propertyNames": {
+							"pattern": "^[A-Za-z_][A-Za-z0-9_-]*$",
+							"$error": "A node key must start with a letter or an underscore, and may only contain letters, digits, underscores and hyphens."
+						},
+						"$error": {
+							"maxProperties": "A schema entry may declare at most 64 nodes."
+						},
 						"additionalProperties": {
 							"type": "object",
 							"required": [
-								"predicate"
+								"class",
+								"linkPredicate"
 							],
 							"properties": {
-								"predicate": {
+								"class": {
 									"type": "string",
 									"minLength": 1
 								},
-								"lang": {
-									"type": "string",
-									"pattern": "^[A-Za-z]{1,8}(-[A-Za-z0-9]{1,8})*$",
-									"$error": "The language tag must be BCP-47-shaped (e.g. \"en\" or \"pt-BR\")."
-								},
-								"datatype": {
+								"linkPredicate": {
 									"type": "string",
 									"minLength": 1
+								},
+								"parent": {
+									"type": "string",
+									"pattern": "^[A-Za-z_][A-Za-z0-9_-]*$"
+								},
+								"per": {
+									"enum": [
+										"subject",
+										"value"
+									],
+									"$error": "A node is either per \"subject\" or per \"value\"."
 								}
 							},
-							"additionalProperties": false,
-							"not": {
-								"required": [
-									"lang",
-									"datatype"
-								],
-								"$error": "A property mapping cannot set both a language tag and a datatype."
+							"additionalProperties": false
+						}
+					},
+					"properties": {
+						"type": "object",
+						"maxProperties": 500,
+						"additionalProperties": {
+							"$ref": "#/$defs/propertyMapping"
+						},
+						"$error": {
+							"maxProperties": "A schema entry may map at most 500 properties."
+						}
+					},
+					"contributions": {
+						"type": "object",
+						"minProperties": 1,
+						"maxProperties": 32,
+						"propertyNames": {
+							"minLength": 1
+						},
+						"additionalProperties": {
+							"type": "object",
+							"minProperties": 1,
+							"maxProperties": 100,
+							"additionalProperties": {
+								"$ref": "#/$defs/valueMapping"
+							},
+							"$error": {
+								"maxProperties": "A contribution may map at most 100 properties."
 							}
+						},
+						"$error": {
+							"maxProperties": "A schema entry may contribute through at most 32 relations."
 						}
 					}
 				},
-				"additionalProperties": false
+				"additionalProperties": false,
+				"anyOf": [
+					{
+						"required": [
+							"subject"
+						]
+					},
+					{
+						"required": [
+							"contributions"
+						]
+					}
+				],
+				"dependentRequired": {
+					"properties": [
+						"subject"
+					],
+					"nodes": [
+						"subject"
+					]
+				},
+				"$error": {
+					"anyOf": "A schema entry must project the Subject itself, contribute to other Subjects, or both.",
+					"dependentRequired": "\"properties\" and \"nodes\" project the Subject, so they need a \"subject\"."
+				}
 			}
 		}
 	},
-	"additionalProperties": false
+	"additionalProperties": false,
+	"$defs": {
+		"valueMapping": {
+			"type": "object",
+			"required": [
+				"predicate"
+			],
+			"properties": {
+				"predicate": {
+					"type": "string",
+					"minLength": 1
+				},
+				"lang": {
+					"type": "string",
+					"pattern": "^[A-Za-z]{1,8}(-[A-Za-z0-9]{1,8})*$",
+					"$error": "The language tag must be BCP-47-shaped (e.g. \"en\" or \"pt-BR\")."
+				},
+				"datatype": {
+					"type": "string",
+					"minLength": 1
+				}
+			},
+			"additionalProperties": false,
+			"not": {
+				"required": [
+					"lang",
+					"datatype"
+				],
+				"$error": "A property mapping cannot set both a language tag and a datatype."
+			}
+		},
+		"propertyMapping": {
+			"type": "object",
+			"required": [
+				"predicate"
+			],
+			"properties": {
+				"predicate": {
+					"type": "string",
+					"minLength": 1
+				},
+				"lang": {
+					"type": "string",
+					"pattern": "^[A-Za-z]{1,8}(-[A-Za-z0-9]{1,8})*$",
+					"$error": "The language tag must be BCP-47-shaped (e.g. \"en\" or \"pt-BR\")."
+				},
+				"datatype": {
+					"type": "string",
+					"minLength": 1
+				},
+				"node": {
+					"type": "string",
+					"pattern": "^[A-Za-z_][A-Za-z0-9_-]*$"
+				}
+			},
+			"additionalProperties": false,
+			"not": {
+				"required": [
+					"lang",
+					"datatype"
+				],
+				"$error": "A property mapping cannot set both a language tag and a datatype."
+			}
+		}
+	}
 }

--- a/src/Presentation/MappingPageHtmlBuilder.php
+++ b/src/Presentation/MappingPageHtmlBuilder.php
@@ -166,9 +166,26 @@ class MappingPageHtmlBuilder {
 		return '';
 	}
 
+	/**
+	 * Every property the entry maps, whether onto the Subject itself or, through a contribution, onto the
+	 * Subjects it points at — so a contributes-only entry does not read as mapping nothing.
+	 */
 	private function propertyCount( mixed $schema ): int {
-		$properties = $schema instanceof stdClass ? ( $schema->properties ?? null ) : null;
+		if ( !$schema instanceof stdClass ) {
+			return 0;
+		}
 
+		$count = $this->countOf( $schema->properties ?? null );
+		$contributions = $schema->contributions ?? null;
+
+		foreach ( $contributions instanceof stdClass ? get_object_vars( $contributions ) : [] as $properties ) {
+			$count += $this->countOf( $properties );
+		}
+
+		return $count;
+	}
+
+	private function countOf( mixed $properties ): int {
 		return $properties instanceof stdClass ? count( get_object_vars( $properties ) ) : 0;
 	}
 

--- a/tests/phpunit/Application/Rdf/OntologyMappingProjectorTest.php
+++ b/tests/phpunit/Application/Rdf/OntologyMappingProjectorTest.php
@@ -8,9 +8,12 @@ use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Application\Rdf\OntologyMappingProjector;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\Mapping;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\MappingName;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\NodeMapping;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\NodeScope;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\PropertyMapping;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\PropertyMappings;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\SchemaMapping;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\SubjectMapping;
 use ProfessionalWiki\NeoWiki\Domain\Page\Page;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\Iri;
@@ -29,6 +32,7 @@ use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectMap;
 use ProfessionalWiki\NeoWiki\Domain\Value\NumberValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
 use ProfessionalWiki\NeoWiki\Infrastructure\Rdf\HardfRdfSerializer;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\MappingPersistenceDeserializer;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestPage;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestRelation;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestStatement;
@@ -44,9 +48,14 @@ class OntologyMappingProjectorTest extends TestCase {
 	private const string PERSON_ID = 's1janeaaaaaaaa2';
 	private const string CITY_ID = 's1cityaaaaaaaa3';
 	private const string GHOST_ID = 's1ghostaaaaaaa9';
+	private const string ARTWORK_ID = 's1artworkaaaaa4';
+	private const string TWIN_ID = 's1twinaaaaaaaa5';
+	private const string BIRTH_ID = 's1birthaaaaaaa6';
 
 	private const string EDM = 'http://www.europeana.eu/schemas/edm/';
 	private const string DC = 'http://purl.org/dc/elements/1.1/';
+	private const string CRM = 'http://www.cidoc-crm.org/cidoc-crm/';
+	private const string RDA_GR2 = 'http://rdvocab.info/ElementsGr2/';
 
 	private RdfNamespaces $ns;
 	private LegacyLoggerSpy $logger;
@@ -224,7 +233,7 @@ class OntologyMappingProjectorTest extends TestCase {
 
 	private function personMapping(): SchemaMapping {
 		return new SchemaMapping(
-			subjectClass: 'edm:ProvidedCHO',
+			subject: new SubjectMapping( 'edm:ProvidedCHO' ),
 			properties: new PropertyMappings( [
 				'Name' => new PropertyMapping( 'dc:title', 'en', null ),
 				'Homepage' => new PropertyMapping( 'edm:isShownAt' ),
@@ -236,7 +245,7 @@ class OntologyMappingProjectorTest extends TestCase {
 
 	private function cityMapping(): SchemaMapping {
 		return new SchemaMapping(
-			subjectClass: 'edm:Place',
+			subject: new SubjectMapping( 'edm:Place' ),
 			properties: new PropertyMappings( [
 				'Name' => new PropertyMapping( 'dc:title' ),
 			] )
@@ -338,7 +347,7 @@ class OntologyMappingProjectorTest extends TestCase {
 
 	private function personMappingWithNameLang( string $lang ): SchemaMapping {
 		return new SchemaMapping(
-			subjectClass: 'http://example.org/CHO',
+			subject: new SubjectMapping( 'http://example.org/CHO' ),
 			properties: new PropertyMappings( [
 				'Name' => new PropertyMapping( 'dc:title', $lang, null ),
 			] )
@@ -378,6 +387,11 @@ class OntologyMappingProjectorTest extends TestCase {
 		$output = ( new HardfRdfSerializer( $this->serializerPrefixes() ) )->serialize( $quads, RdfFormat::TriG );
 
 		$this->assertStringNotContainsString( 'evil', $output, 'No injection term survives to the document.' );
+		$this->assertStringNotContainsString(
+			'/a> <b>',
+			$output,
+			'A node key that is IRI syntax is percent-encoded into the node IRI, not obeyed as syntax.'
+		);
 		$this->assertSame(
 			ParsedRdf::canonicalQuads( $this->expectedSafeAdversarialTriG() ),
 			ParsedRdf::canonicalQuads( $output ),
@@ -389,8 +403,12 @@ class OntologyMappingProjectorTest extends TestCase {
 
 	private function adversarialMapping(): SchemaMapping {
 		return new SchemaMapping(
-			// A subject class that would break out of its IRI: it must not produce an rdf:type triple.
-			subjectClass: 'http://x/> <http://evil.example/s> <http://evil.example/p> <http://evil.example/o',
+			subject: new SubjectMapping(
+				// A subject class that would break out of its IRI: it must not produce an rdf:type triple.
+				class: 'http://x/> <http://evil.example/s> <http://evil.example/p> <http://evil.example/o',
+				// A CURIE against the unsafe prefix: the extra label triple is dropped, rdfs:label stays.
+				labelPredicate: 'evil:name'
+			),
 			properties: new PropertyMappings( [
 				'Name' => new PropertyMapping( 'dc:title' ),
 				// A safe predicate with an injection datatype override: the value keeps its native datatype.
@@ -399,7 +417,12 @@ class OntologyMappingProjectorTest extends TestCase {
 				'Bio' => new PropertyMapping( 'http://x/> <http://evil.example/p2> <http://evil.example/o2' ),
 				// A CURIE against the unsafe prefix: dropped.
 				'Homepage' => new PropertyMapping( 'evil:foo' ),
-			] )
+				// Attached to a node whose key is IRI syntax: the key is encoded, not obeyed.
+				'Alias' => new PropertyMapping( predicate: 'dc:alternative', node: 'a> <b> <c' ),
+			] ),
+			nodes: [
+				'a> <b> <c' => new NodeMapping( class: 'http://example.org/Appellation', linkPredicate: 'dc:relation' ),
+			],
 		);
 	}
 
@@ -413,6 +436,7 @@ class OntologyMappingProjectorTest extends TestCase {
 				TestStatement::build( 'BirthYear', new NumberValue( 1990 ), 'number' ),
 				TestStatement::build( 'Bio', new StringValue( 'Hi' ), 'text' ),
 				TestStatement::build( 'Homepage', new StringValue( 'http://jane.example' ), 'text' ),
+				TestStatement::build( 'Alias', new StringValue( 'Janey' ), 'text' ),
 			] )
 		);
 	}
@@ -427,7 +451,11 @@ class OntologyMappingProjectorTest extends TestCase {
 			<https://wiki.example/graph/edm/page/42> {
 				neo-subj:s1janeaaaaaaaa2 rdfs:label "Jane" ;
 					dc:title "Jane" ;
-					dc:date "1990"^^xsd:integer .
+					dc:date "1990"^^xsd:integer ;
+					dc:relation <https://wiki.example/node/s1janeaaaaaaaa2/a%3E_%3Cb%3E_%3Cc> .
+
+				<https://wiki.example/node/s1janeaaaaaaaa2/a%3E_%3Cb%3E_%3Cc> a <http://example.org/Appellation> ;
+					dc:alternative "Janey" .
 			}
 			TRIG;
 	}
@@ -453,7 +481,7 @@ class OntologyMappingProjectorTest extends TestCase {
 		// A url value projects as an IRI object by default, but an explicit `datatype` on the property
 		// mapping is deliberate configuration and wins: the value is emitted as a literal with that datatype.
 		$mapping = new SchemaMapping(
-			subjectClass: 'edm:ProvidedCHO',
+			subject: new SubjectMapping( 'edm:ProvidedCHO' ),
 			properties: new PropertyMappings( [
 				'Homepage' => new PropertyMapping( 'edm:isShownAt', null, 'http://www.w3.org/2001/XMLSchema#anyURI' ),
 			] )
@@ -491,7 +519,7 @@ class OntologyMappingProjectorTest extends TestCase {
 		// Constructed directly, bypassing the save-time lang/datatype mutual-exclusion check, to prove
 		// the projector ignores literal overrides on a relation (its object is an IRI, not a literal).
 		$mapping = new SchemaMapping(
-			subjectClass: 'http://example.org/CHO',
+			subject: new SubjectMapping( 'http://example.org/CHO' ),
 			properties: new PropertyMappings( [
 				'BornIn' => new PropertyMapping( 'dc:spatial', 'en', 'edm:year' ),
 			] )
@@ -532,7 +560,7 @@ class OntologyMappingProjectorTest extends TestCase {
 
 	private function personBirthYearMappingWithLang( string $lang ): SchemaMapping {
 		return new SchemaMapping(
-			subjectClass: 'http://example.org/CHO',
+			subject: new SubjectMapping( 'http://example.org/CHO' ),
 			properties: new PropertyMappings( [
 				'BirthYear' => new PropertyMapping( 'dc:date', $lang, null ),
 			] )
@@ -586,10 +614,640 @@ class OntologyMappingProjectorTest extends TestCase {
 	}
 
 	/**
+	 * @param array<string, string> $extra
 	 * @return array<string, string>
 	 */
-	private function serializerPrefixes(): array {
-		return array_merge( $this->ns->prefixMap(), [ 'edm' => self::EDM, 'dc' => self::DC ] );
+	private function serializerPrefixes( array $extra = [] ): array {
+		return array_merge( $this->ns->prefixMap(), [ 'edm' => self::EDM, 'dc' => self::DC ], $extra );
+	}
+
+	// Structural transformation: synthesized nodes (expansion) and contributions (contraction).
+
+	private function newCrmProjector( string $schemaName, SchemaMapping $mapping ): OntologyMappingProjector {
+		return $this->newProjector( [ $schemaName => $mapping ], [ 'crm' => self::CRM, 'rdaGr2' => self::RDA_GR2 ] );
+	}
+
+	private function crmTriG( string $body ): string {
+		return <<<TRIG
+			@prefix neo-subj: <https://wiki.example/entity/> .
+			@prefix neo-graph: <https://wiki.example/graph/edm/page/> .
+			@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+			@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+			@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+			@prefix crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+			@prefix rdaGr2: <http://rdvocab.info/ElementsGr2/> .
+
+			neo-graph:42 {
+			$body
+			}
+			TRIG;
+	}
+
+	private function assertProjectsTo( string $expectedTriG, QuadList $quads ): void {
+		$this->assertSame(
+			ParsedRdf::canonicalQuads( $expectedTriG ),
+			ParsedRdf::canonicalQuads(
+				( new HardfRdfSerializer( $this->serializerPrefixes( [ 'crm' => self::CRM, 'rdaGr2' => self::RDA_GR2 ] ) ) )
+					->serialize( $quads, RdfFormat::TriG )
+			)
+		);
+	}
+
+	/**
+	 * A Person with the flat birth fields the near-1:1 tier consumes, which CIDOC-CRM mediates through an
+	 * E67_Birth event node.
+	 */
+	private function personWithFlatBirthFields(): Page {
+		return TestPage::build( id: 42, mainSubject: TestSubject::build(
+			id: self::PERSON_ID,
+			label: 'Jane',
+			schemaName: new SchemaName( 'Person' ),
+			statements: new StatementList( [
+				TestStatement::build( 'Birth date', new StringValue( '1990-01-31' ), 'date' ),
+				TestStatement::buildRelation( 'Birth place', [ TestRelation::build( targetId: self::CITY_ID ) ] ),
+			] )
+		) );
+	}
+
+	public function testEveryPropertyAttachedToASubjectScopedNodeSharesOneInstance(): void {
+		$quads = $this->newCrmProjector( 'Person', new SchemaMapping(
+			subject: new SubjectMapping( 'crm:E21_Person' ),
+			properties: new PropertyMappings( [
+				'Birth date' => new PropertyMapping( predicate: 'crm:P4_has_time-span', node: 'birth' ),
+				'Birth place' => new PropertyMapping( predicate: 'crm:P7_took_place_at', node: 'birth' ),
+			] ),
+			nodes: [
+				'birth' => new NodeMapping( class: 'crm:E67_Birth', linkPredicate: 'crm:P98i_was_born' ),
+			],
+		) )->projectPage( $this->personWithFlatBirthFields() );
+
+		// One E67_Birth, reached by one P98i_was_born, carrying both properties: the two flat fields are
+		// coordinated onto the same synthesized node.
+		$this->assertProjectsTo( $this->crmTriG( <<<'TRIG'
+			neo-subj:s1janeaaaaaaaa2 a crm:E21_Person ;
+				rdfs:label "Jane" ;
+				crm:P98i_was_born <https://wiki.example/node/s1janeaaaaaaaa2/birth> .
+
+			<https://wiki.example/node/s1janeaaaaaaaa2/birth> a crm:E67_Birth ;
+				crm:P4_has_time-span "1990-01-31"^^xsd:date ;
+				crm:P7_took_place_at neo-subj:s1cityaaaaaaaa3 .
+			TRIG ), $quads );
+		$this->logger->assertNoLoggingCallsWhereMade();
+	}
+
+	public function testNestedNodeHangsOffItsParentInstanceAndBringsTheChainAlong(): void {
+		$quads = $this->newCrmProjector( 'Person', new SchemaMapping(
+			subject: new SubjectMapping( 'crm:E21_Person' ),
+			properties: new PropertyMappings( [
+				// Only the deepest node carries a value: the E67_Birth between it and the Person is
+				// emitted because its descendant needs it.
+				'Birth date' => new PropertyMapping( predicate: 'crm:P82_at_some_time_within', node: 'birthTimespan' ),
+			] ),
+			nodes: [
+				'birth' => new NodeMapping( class: 'crm:E67_Birth', linkPredicate: 'crm:P98i_was_born' ),
+				'birthTimespan' => new NodeMapping(
+					class: 'crm:E52_Time-Span',
+					linkPredicate: 'crm:P4_has_time-span',
+					parent: 'birth'
+				),
+			],
+		) )->projectPage( $this->personWithFlatBirthFields() );
+
+		$this->assertProjectsTo( $this->crmTriG( <<<'TRIG'
+			neo-subj:s1janeaaaaaaaa2 a crm:E21_Person ;
+				rdfs:label "Jane" ;
+				crm:P98i_was_born <https://wiki.example/node/s1janeaaaaaaaa2/birth> .
+
+			<https://wiki.example/node/s1janeaaaaaaaa2/birth> a crm:E67_Birth ;
+				crm:P4_has_time-span <https://wiki.example/node/s1janeaaaaaaaa2/birth/birthTimespan> .
+
+			<https://wiki.example/node/s1janeaaaaaaaa2/birth/birthTimespan> a crm:E52_Time-Span ;
+				crm:P82_at_some_time_within "1990-01-31"^^xsd:date .
+			TRIG ), $quads );
+		$this->logger->assertNoLoggingCallsWhereMade();
+	}
+
+	public function testANodeIsNotEmittedForAPropertyTheSubjectDoesNotHave(): void {
+		// The mapping declares the birth node, but the Person carries no value for the property that
+		// attaches to it, so there must be no empty E67_Birth in the output.
+		$quads = $this->newCrmProjector( 'Person', new SchemaMapping(
+			subject: new SubjectMapping( 'crm:E21_Person' ),
+			properties: new PropertyMappings( [
+				'Death date' => new PropertyMapping( predicate: 'crm:P4_has_time-span', node: 'birth' ),
+			] ),
+			nodes: [
+				'birth' => new NodeMapping( class: 'crm:E67_Birth', linkPredicate: 'crm:P98i_was_born' ),
+			],
+		) )->projectPage( $this->personWithFlatBirthFields() );
+
+		$this->assertProjectsTo( $this->crmTriG( <<<'TRIG'
+			neo-subj:s1janeaaaaaaaa2 a crm:E21_Person ;
+				rdfs:label "Jane" .
+			TRIG ), $quads );
+		$this->logger->assertNoLoggingCallsWhereMade();
+	}
+
+	public function testANodeIsNotEmittedWhenItsPropertyProducesNoValueTriple(): void {
+		// The Subject does hold the attached property, but its Property Type has no RDF value mapper, so
+		// it produces nothing to hang off the node — and an event node with no content is worse than none.
+		$page = TestPage::build( id: 42, mainSubject: TestSubject::build(
+			id: self::PERSON_ID,
+			label: 'Jane',
+			schemaName: new SchemaName( 'Person' ),
+			statements: new StatementList( [
+				TestStatement::build( 'Birth date', new StringValue( '1990-01-31' ), 'typewithoutanrdfmapper' ),
+			] )
+		) );
+
+		$quads = $this->newCrmProjector( 'Person', new SchemaMapping(
+			subject: new SubjectMapping( 'crm:E21_Person' ),
+			properties: new PropertyMappings( [
+				'Birth date' => new PropertyMapping( predicate: 'crm:P4_has_time-span', node: 'birth' ),
+			] ),
+			nodes: [
+				'birth' => new NodeMapping( class: 'crm:E67_Birth', linkPredicate: 'crm:P98i_was_born' ),
+			],
+		) )->projectPage( $page );
+
+		$this->assertProjectsTo( $this->crmTriG( <<<'TRIG'
+			neo-subj:s1janeaaaaaaaa2 a crm:E21_Person ;
+				rdfs:label "Jane" .
+			TRIG ), $quads );
+		$this->logger->assertNoLoggingCallsWhereMade();
+	}
+
+	public function testValueScopedNodeGetsOneRelationIdAnchoredInstancePerRelationValue(): void {
+		$artwork = TestPage::build( id: 42, mainSubject: TestSubject::build(
+			id: self::ARTWORK_ID,
+			label: 'The Milkmaid',
+			schemaName: new SchemaName( 'Artwork' ),
+			statements: new StatementList( [
+				TestStatement::buildRelation( 'Creator', [
+					TestRelation::build( id: 'r1firstaaaaaaa2', targetId: self::PERSON_ID ),
+					TestRelation::build( id: 'r1secondaaaaaa3', targetId: self::CITY_ID ),
+				] ),
+			] )
+		) );
+
+		$quads = $this->newProjector(
+			[ 'Artwork' => new SchemaMapping(
+				subject: new SubjectMapping( 'crm:E22_Human-Made_Object' ),
+				properties: new PropertyMappings( [
+					'Creator' => new PropertyMapping( predicate: 'crm:P14_carried_out_by', node: 'production' ),
+				] ),
+				nodes: [
+					'production' => new NodeMapping(
+						class: 'crm:E12_Production',
+						linkPredicate: 'crm:P108i_was_produced_by',
+						scope: NodeScope::Value
+					),
+				],
+			) ],
+			[ 'crm' => self::CRM ]
+		)->projectPage( $artwork );
+
+		// Two creators, two production events, each IRI derived from its Relation's persistent ID.
+		$this->assertProjectsTo( $this->crmTriG( <<<'TRIG'
+			neo-subj:s1artworkaaaaa4 a crm:E22_Human-Made_Object ;
+				rdfs:label "The Milkmaid" ;
+				crm:P108i_was_produced_by <https://wiki.example/node/r1firstaaaaaaa2>, <https://wiki.example/node/r1secondaaaaaa3> .
+
+			<https://wiki.example/node/r1firstaaaaaaa2> a crm:E12_Production ;
+				crm:P14_carried_out_by neo-subj:s1janeaaaaaaaa2 .
+
+			<https://wiki.example/node/r1secondaaaaaa3> a crm:E12_Production ;
+				crm:P14_carried_out_by neo-subj:s1cityaaaaaaaa3 .
+			TRIG ), $quads );
+		$this->logger->assertNoLoggingCallsWhereMade();
+	}
+
+	public function testValueScopedNodeGetsOnePositionAnchoredInstancePerLiteralValue(): void {
+		$page = TestPage::build( id: 42, mainSubject: TestSubject::build(
+			id: self::PERSON_ID,
+			label: 'Jane',
+			schemaName: new SchemaName( 'Person' ),
+			statements: new StatementList( [
+				TestStatement::build( 'Also known as', new StringValue( 'Janey', 'J. Doe' ), 'text' ),
+			] )
+		) );
+
+		$quads = $this->newCrmProjector( 'Person', new SchemaMapping(
+			subject: new SubjectMapping( 'crm:E21_Person' ),
+			properties: new PropertyMappings( [
+				'Also known as' => new PropertyMapping( predicate: 'crm:P190_has_symbolic_content', node: 'appellation' ),
+			] ),
+			nodes: [
+				'appellation' => new NodeMapping(
+					class: 'crm:E41_Appellation',
+					linkPredicate: 'crm:P1_is_identified_by',
+					scope: NodeScope::Value
+				),
+			],
+		) )->projectPage( $page );
+
+		$this->assertProjectsTo( $this->crmTriG( <<<'TRIG'
+			neo-subj:s1janeaaaaaaaa2 a crm:E21_Person ;
+				rdfs:label "Jane" ;
+				crm:P1_is_identified_by <https://wiki.example/node/s1janeaaaaaaaa2/appellation/0>, <https://wiki.example/node/s1janeaaaaaaaa2/appellation/1> .
+
+			<https://wiki.example/node/s1janeaaaaaaaa2/appellation/0> a crm:E41_Appellation ;
+				crm:P190_has_symbolic_content "Janey" .
+
+			<https://wiki.example/node/s1janeaaaaaaaa2/appellation/1> a crm:E41_Appellation ;
+				crm:P190_has_symbolic_content "J. Doe" .
+			TRIG ), $quads );
+		$this->logger->assertNoLoggingCallsWhereMade();
+	}
+
+	public function testAnUnusableNodeDropsItsWholeSubtreeButLeavesTheRestOfTheSubject(): void {
+		$quads = $this->newCrmProjector( 'Person', new SchemaMapping(
+			subject: new SubjectMapping( 'crm:E21_Person' ),
+			properties: new PropertyMappings( [
+				'Birth date' => new PropertyMapping( predicate: 'crm:P82_at_some_time_within', node: 'birthTimespan' ),
+				'Birth place' => new PropertyMapping( predicate: 'rdaGr2:placeOfBirth' ),
+			] ),
+			nodes: [
+				// An unresolvable class: the node and everything under it must be dropped.
+				'birth' => new NodeMapping( class: 'nosuchprefix:E67_Birth', linkPredicate: 'crm:P98i_was_born' ),
+				'birthTimespan' => new NodeMapping(
+					class: 'crm:E52_Time-Span',
+					linkPredicate: 'crm:P4_has_time-span',
+					parent: 'birth'
+				),
+			],
+		) )->projectPage( $this->personWithFlatBirthFields() );
+
+		$this->assertProjectsTo( $this->crmTriG( <<<'TRIG'
+			neo-subj:s1janeaaaaaaaa2 a crm:E21_Person ;
+				rdfs:label "Jane" ;
+				rdaGr2:placeOfBirth neo-subj:s1cityaaaaaaaa3 .
+			TRIG ), $quads );
+		// One warning for the unusable node, one for the child it orphaned, one for the property that
+		// pointed at the child.
+		$this->assertCount( 3, $this->logger->getLogCalls()->getMessages() );
+	}
+
+	public function testLabelPredicateAddsATargetLabelTermWithoutReplacingRdfsLabel(): void {
+		$quads = $this->newCrmProjector( 'Person', new SchemaMapping(
+			subject: new SubjectMapping( class: 'crm:E21_Person', labelPredicate: 'rdaGr2:nameOfThePerson' ),
+		) )->projectPage( TestPage::build( id: 42, mainSubject: $this->examplePersonWithoutRelations() ) );
+
+		$this->assertProjectsTo( $this->crmTriG( <<<'TRIG'
+			neo-subj:s1janeaaaaaaaa2 a crm:E21_Person ;
+				rdfs:label "Jane" ;
+				rdaGr2:nameOfThePerson "Jane" .
+			TRIG ), $quads );
+		$this->logger->assertNoLoggingCallsWhereMade();
+	}
+
+	/**
+	 * Contraction. The Birth Subject holds the structure a flat target does not want, so it emits its own
+	 * date and place as flat properties **of the people it brought into life** — twins share one Birth, so
+	 * both receive them — and the place, a relation-valued contribution property, arrives as the Place
+	 * Subject's IRI. All of it lands in the Birth page's graph, since that is the page being projected.
+	 */
+	public function testContributionEmitsThisSubjectsValuesAboutEveryTargetOfItsRelation(): void {
+		$birth = TestPage::build( id: 42, mainSubject: TestSubject::build(
+			id: self::BIRTH_ID,
+			label: 'Birth of the twins',
+			schemaName: new SchemaName( 'Birth' ),
+			statements: new StatementList( [
+				TestStatement::buildRelation( 'Brought into life', [
+					TestRelation::build( targetId: self::PERSON_ID ),
+					TestRelation::build( targetId: self::TWIN_ID ),
+				] ),
+				TestStatement::buildRelation( 'Took place at', [ TestRelation::build( targetId: self::CITY_ID ) ] ),
+				TestStatement::build( 'Date', new StringValue( '1990-01-31' ), 'date' ),
+				TestStatement::build( 'Weather', new StringValue( 'Rainy' ), 'text' ),
+			] )
+		) );
+
+		$quads = $this->newProjector(
+			[ 'Birth' => new SchemaMapping(
+				subject: null,
+				contributions: [ 'Brought into life' => new PropertyMappings( [
+					'Date' => new PropertyMapping( 'rdaGr2:dateOfBirth' ),
+					'Took place at' => new PropertyMapping( 'rdaGr2:placeOfBirth' ),
+				] ) ],
+			) ],
+			[ 'rdaGr2' => self::RDA_GR2 ]
+		)->projectPage( $birth );
+
+		// No type or label for the Birth itself: the entry only contributes. The unmapped Weather is
+		// absent, as unmapped properties always are.
+		$this->assertProjectsTo( $this->crmTriG( <<<'TRIG'
+			neo-subj:s1janeaaaaaaaa2 rdaGr2:dateOfBirth "1990-01-31"^^xsd:date ;
+				rdaGr2:placeOfBirth neo-subj:s1cityaaaaaaaa3 .
+
+			neo-subj:s1twinaaaaaaaa5 rdaGr2:dateOfBirth "1990-01-31"^^xsd:date ;
+				rdaGr2:placeOfBirth neo-subj:s1cityaaaaaaaa3 .
+			TRIG ), $quads );
+		$this->logger->assertNoLoggingCallsWhereMade();
+	}
+
+	public function testContributionThroughARelationTheSubjectHasNoValueForIsSilentlySkipped(): void {
+		// An optional relation left empty produces no Statement at all, which is ordinary sparse data
+		// rather than a misconfigured Mapping, so it must not fill the log on every page it touches.
+		$page = TestPage::build( id: 42, mainSubject: TestSubject::build(
+			id: self::BIRTH_ID,
+			label: 'A birth with no child',
+			schemaName: new SchemaName( 'Birth' ),
+			statements: new StatementList( [ TestStatement::build( 'Date', new StringValue( '1990-01-31' ), 'date' ) ] )
+		) );
+
+		$quads = $this->newProjector(
+			[ 'Birth' => $this->birthContributingItsDate() ],
+			[ 'rdaGr2' => self::RDA_GR2 ]
+		)->projectPage( $page );
+
+		$this->assertTrue( $quads->isEmpty() );
+		$this->logger->assertNoLoggingCallsWhereMade();
+	}
+
+	public function testContributionThroughAPropertyThatIsNotARelationIsLogged(): void {
+		// The Subject does hold the named property, but as text: the Mapping and the Schema disagree
+		// about what it is, which is worth telling the wiki about.
+		$page = TestPage::build( id: 42, mainSubject: TestSubject::build(
+			id: self::BIRTH_ID,
+			label: 'A birth naming its child in prose',
+			schemaName: new SchemaName( 'Birth' ),
+			statements: new StatementList( [
+				TestStatement::build( 'Brought into life', new StringValue( 'Jane' ), 'text' ),
+				TestStatement::build( 'Date', new StringValue( '1990-01-31' ), 'date' ),
+			] )
+		) );
+
+		$quads = $this->newProjector(
+			[ 'Birth' => $this->birthContributingItsDate() ],
+			[ 'rdaGr2' => self::RDA_GR2 ]
+		)->projectPage( $page );
+
+		$this->assertTrue( $quads->isEmpty() );
+		$this->assertCount( 1, $this->logger->getLogCalls()->getMessages() );
+	}
+
+	private function birthContributingItsDate(): SchemaMapping {
+		return new SchemaMapping(
+			subject: null,
+			contributions: [ 'Brought into life' => new PropertyMappings( [
+				'Date' => new PropertyMapping( 'rdaGr2:dateOfBirth' ),
+			] ) ],
+		);
+	}
+
+	/**
+	 * An entry may project its own Subject and contribute at the same time, through more than one
+	 * relation: the Birth is an event in its own right for a target that has a class for it, and still
+	 * flattens its date onto both the child and the place it happened at.
+	 */
+	public function testAnEntryProjectsItsOwnSubjectAndContributesThroughSeveralRelations(): void {
+		$birth = TestPage::build( id: 42, mainSubject: TestSubject::build(
+			id: self::BIRTH_ID,
+			label: 'Birth of Jane',
+			schemaName: new SchemaName( 'Birth' ),
+			statements: new StatementList( [
+				TestStatement::buildRelation( 'Brought into life', [ TestRelation::build( targetId: self::PERSON_ID ) ] ),
+				TestStatement::buildRelation( 'Took place at', [ TestRelation::build( targetId: self::CITY_ID ) ] ),
+				TestStatement::build( 'Date', new StringValue( '1990-01-31' ), 'date' ),
+			] )
+		) );
+
+		$quads = $this->newProjector(
+			[ 'Birth' => new SchemaMapping(
+				subject: new SubjectMapping( 'crm:E67_Birth' ),
+				properties: new PropertyMappings( [
+					'Brought into life' => new PropertyMapping( 'crm:P98_brought_into_life' ),
+				] ),
+				contributions: [
+					'Brought into life' => new PropertyMappings( [
+						'Date' => new PropertyMapping( 'rdaGr2:dateOfBirth' ),
+					] ),
+					'Took place at' => new PropertyMappings( [
+						'Date' => new PropertyMapping( 'rdaGr2:dateOfEstablishment' ),
+					] ),
+				],
+			) ],
+			[ 'crm' => self::CRM, 'rdaGr2' => self::RDA_GR2 ]
+		)->projectPage( $birth );
+
+		$this->assertProjectsTo( $this->crmTriG( <<<'TRIG'
+			neo-subj:s1birthaaaaaaa6 a crm:E67_Birth ;
+				rdfs:label "Birth of Jane" ;
+				crm:P98_brought_into_life neo-subj:s1janeaaaaaaaa2 .
+
+			neo-subj:s1janeaaaaaaaa2 rdaGr2:dateOfBirth "1990-01-31"^^xsd:date .
+
+			neo-subj:s1cityaaaaaaaa3 rdaGr2:dateOfEstablishment "1990-01-31"^^xsd:date .
+			TRIG ), $quads );
+		$this->logger->assertNoLoggingCallsWhereMade();
+	}
+
+	// Shapes save-time validation rejects, which XML import can still put on a wiki. They reach the
+	// projector through the persistence deserializer, so these go in the same way rather than being
+	// hand-built, and must degrade the projection instead of aborting it.
+
+	private function newImportedProjector( string $json ): OntologyMappingProjector {
+		return new OntologyMappingProjector(
+			( new MappingPersistenceDeserializer() )->deserialize( new MappingName( 'edm' ), $json ),
+			$this->ns,
+			RdfValueMapperRegistry::withCoreMappers(),
+			$this->logger,
+		);
+	}
+
+	public function testAnAllDigitNodeKeyProjects(): void {
+		// json_decode turns an all-digit object key into an int array key, which every consumer of the
+		// key has to survive.
+		$quads = $this->newImportedProjector( <<<'JSON'
+			{
+				"version": 1,
+				"prefixes": { "crm": "http://www.cidoc-crm.org/cidoc-crm/" },
+				"schemas": {
+					"Person": {
+						"subject": { "class": "crm:E21_Person" },
+						"nodes": { "2024": { "class": "crm:E67_Birth", "linkPredicate": "crm:P98i_was_born" } },
+						"properties": { "Birth date": { "predicate": "crm:P82_at_some_time_within", "node": "2024" } }
+					}
+				}
+			}
+			JSON )->projectPage( $this->personWithFlatBirthFields() );
+
+		$this->assertProjectsTo( $this->crmTriG( <<<'TRIG'
+			neo-subj:s1janeaaaaaaaa2 a crm:E21_Person ;
+				rdfs:label "Jane" ;
+				crm:P98i_was_born <https://wiki.example/node/s1janeaaaaaaaa2/2024> .
+
+			<https://wiki.example/node/s1janeaaaaaaaa2/2024> a crm:E67_Birth ;
+				crm:P82_at_some_time_within "1990-01-31"^^xsd:date .
+			TRIG ), $quads );
+		$this->logger->assertNoLoggingCallsWhereMade();
+	}
+
+	public function testAnAllDigitPropertyNameProjects(): void {
+		// A year is a realistic property name, and is an int array key by the time json_decode is done.
+		$page = TestPage::build( id: 42, mainSubject: TestSubject::build(
+			id: self::PERSON_ID,
+			label: 'Jane',
+			schemaName: new SchemaName( 'Person' ),
+			statements: new StatementList( [ TestStatement::build( '2020', new StringValue( 'Sabbatical' ), 'text' ) ] )
+		) );
+
+		$quads = $this->newImportedProjector( <<<'JSON'
+			{
+				"version": 1,
+				"prefixes": { "crm": "http://www.cidoc-crm.org/cidoc-crm/" },
+				"schemas": {
+					"Person": {
+						"subject": { "class": "crm:E21_Person" },
+						"properties": { "2020": { "predicate": "crm:P3_has_note" } }
+					}
+				}
+			}
+			JSON )->projectPage( $page );
+
+		$this->assertProjectsTo( $this->crmTriG( <<<'TRIG'
+			neo-subj:s1janeaaaaaaaa2 a crm:E21_Person ;
+				rdfs:label "Jane" ;
+				crm:P3_has_note "Sabbatical" .
+			TRIG ), $quads );
+		$this->logger->assertNoLoggingCallsWhereMade();
+	}
+
+	public function testANodeHangingOffAPerValueNodeIsDroppedWithWhatItCarries(): void {
+		// A per-value parent has one instance per value, so a child would have no single instance to hang
+		// off. The parent itself still projects.
+		$artwork = TestPage::build( id: 42, mainSubject: TestSubject::build(
+			id: self::ARTWORK_ID,
+			label: 'The Milkmaid',
+			schemaName: new SchemaName( 'Artwork' ),
+			statements: new StatementList( [
+				TestStatement::buildRelation( 'Creator', [
+					TestRelation::build( id: 'r1firstaaaaaaa2', targetId: self::PERSON_ID ),
+				] ),
+				TestStatement::build( 'Year', new StringValue( '1658' ), 'text' ),
+			] )
+		) );
+
+		$quads = $this->newImportedProjector( <<<'JSON'
+			{
+				"version": 1,
+				"prefixes": { "crm": "http://www.cidoc-crm.org/cidoc-crm/" },
+				"schemas": {
+					"Artwork": {
+						"subject": { "class": "crm:E22_Human-Made_Object" },
+						"nodes": {
+							"production": {
+								"class": "crm:E12_Production",
+								"linkPredicate": "crm:P108i_was_produced_by",
+								"per": "value"
+							},
+							"timespan": {
+								"class": "crm:E52_Time-Span",
+								"linkPredicate": "crm:P4_has_time-span",
+								"parent": "production"
+							}
+						},
+						"properties": {
+							"Creator": { "predicate": "crm:P14_carried_out_by", "node": "production" },
+							"Year": { "predicate": "crm:P82_at_some_time_within", "node": "timespan" }
+						}
+					}
+				}
+			}
+			JSON )->projectPage( $artwork );
+
+		$this->assertProjectsTo( $this->crmTriG( <<<'TRIG'
+			neo-subj:s1artworkaaaaa4 a crm:E22_Human-Made_Object ;
+				rdfs:label "The Milkmaid" ;
+				crm:P108i_was_produced_by <https://wiki.example/node/r1firstaaaaaaa2> .
+
+			<https://wiki.example/node/r1firstaaaaaaa2> a crm:E12_Production ;
+				crm:P14_carried_out_by neo-subj:s1janeaaaaaaaa2 .
+			TRIG ), $quads );
+		// One for the child of the per-value node, one for the property that pointed at that child.
+		$this->assertCount( 2, $this->logger->getLogCalls()->getMessages() );
+	}
+
+	public function testAParentCycleDropsOnlyTheNodesInTheCycle(): void {
+		$page = TestPage::build( id: 42, mainSubject: TestSubject::build(
+			id: self::PERSON_ID,
+			label: 'Jane',
+			schemaName: new SchemaName( 'Person' ),
+			statements: new StatementList( [
+				TestStatement::build( 'Birth date', new StringValue( '1990-01-31' ), 'date' ),
+				TestStatement::build( 'Also known as', new StringValue( 'Janey' ), 'text' ),
+			] )
+		) );
+
+		$quads = $this->newImportedProjector( <<<'JSON'
+			{
+				"version": 1,
+				"prefixes": { "crm": "http://www.cidoc-crm.org/cidoc-crm/" },
+				"schemas": {
+					"Person": {
+						"subject": { "class": "crm:E21_Person" },
+						"nodes": {
+							"birth": {
+								"class": "crm:E67_Birth",
+								"linkPredicate": "crm:P98i_was_born",
+								"parent": "birthTimespan"
+							},
+							"birthTimespan": {
+								"class": "crm:E52_Time-Span",
+								"linkPredicate": "crm:P4_has_time-span",
+								"parent": "birth"
+							},
+							"naming": { "class": "crm:E41_Appellation", "linkPredicate": "crm:P1_is_identified_by" }
+						},
+						"properties": {
+							"Birth date": { "predicate": "crm:P82_at_some_time_within", "node": "birthTimespan" },
+							"Also known as": { "predicate": "crm:P190_has_symbolic_content", "node": "naming" }
+						}
+					}
+				}
+			}
+			JSON )->projectPage( $page );
+
+		$this->assertProjectsTo( $this->crmTriG( <<<'TRIG'
+			neo-subj:s1janeaaaaaaaa2 a crm:E21_Person ;
+				rdfs:label "Jane" ;
+				crm:P1_is_identified_by <https://wiki.example/node/s1janeaaaaaaaa2/naming> .
+
+			<https://wiki.example/node/s1janeaaaaaaaa2/naming> a crm:E41_Appellation ;
+				crm:P190_has_symbolic_content "Janey" .
+			TRIG ), $quads );
+		// One for each node in the cycle, one for the property that pointed into it.
+		$this->assertCount( 3, $this->logger->getLogCalls()->getMessages() );
+	}
+
+	public function testSynthesizedNodeIrisAreIdenticalAcrossProjectionsOfTheSamePage(): void {
+		// Re-projection must be byte-identical, because the per-page store sync replaces a graph with
+		// DROP + INSERT DATA: a node IRI that moved would leave the store inconsistent.
+		$mapping = new SchemaMapping(
+			subject: new SubjectMapping( 'crm:E21_Person' ),
+			properties: new PropertyMappings( [
+				'Birth date' => new PropertyMapping( predicate: 'crm:P82_at_some_time_within', node: 'birthTimespan' ),
+				'Birth place' => new PropertyMapping( predicate: 'crm:P7_took_place_at', node: 'birth' ),
+			] ),
+			nodes: [
+				'birth' => new NodeMapping( class: 'crm:E67_Birth', linkPredicate: 'crm:P98i_was_born' ),
+				'birthTimespan' => new NodeMapping(
+					class: 'crm:E52_Time-Span',
+					linkPredicate: 'crm:P4_has_time-span',
+					parent: 'birth'
+				),
+			],
+		);
+		$page = $this->personWithFlatBirthFields();
+
+		$first = $this->newCrmProjector( 'Person', $mapping )->projectPage( $page );
+		$second = $this->newCrmProjector( 'Person', $mapping )->projectPage( $page );
+
+		$serializer = new HardfRdfSerializer( $this->serializerPrefixes( [ 'crm' => self::CRM ] ) );
+		$this->assertSame(
+			$serializer->serialize( $first, RdfFormat::TriG ),
+			$serializer->serialize( $second, RdfFormat::TriG )
+		);
 	}
 
 }

--- a/tests/phpunit/Application/Rdf/ProjectionNamedGraphTest.php
+++ b/tests/phpunit/Application/Rdf/ProjectionNamedGraphTest.php
@@ -9,8 +9,8 @@ use ProfessionalWiki\NeoWiki\Application\Rdf\OntologyMappingProjector;
 use ProfessionalWiki\NeoWiki\Application\Rdf\RdfPageProjector;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\Mapping;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\MappingName;
-use ProfessionalWiki\NeoWiki\Domain\Mapping\PropertyMappings;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\SchemaMapping;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\SubjectMapping;
 use ProfessionalWiki\NeoWiki\Domain\Page\Page;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\Quad;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\QuadList;
@@ -108,10 +108,7 @@ class ProjectionNamedGraphTest extends TestCase {
 			name: new MappingName( 'edm' ),
 			prefixes: [ 'edm' => 'http://www.europeana.eu/schemas/edm/' ],
 			schemas: [
-				'Person' => new SchemaMapping(
-					subjectClass: 'edm:Agent',
-					properties: new PropertyMappings( [] )
-				),
+				'Person' => new SchemaMapping( subject: new SubjectMapping( 'edm:Agent' ) ),
 			],
 		);
 	}

--- a/tests/phpunit/Domain/GraphDatabase/FailureIsolatingGraphDatabasePluginTest.php
+++ b/tests/phpunit/Domain/GraphDatabase/FailureIsolatingGraphDatabasePluginTest.php
@@ -9,6 +9,7 @@ use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\FailureIsolatingGraphDatabaseP
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphDatabasePlugin;
 use ProfessionalWiki\NeoWiki\Domain\Page\Page;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\UnknownProjectionException;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestPage;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpyGraphDatabasePlugin;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\ThrowingGraphDatabasePlugin;
@@ -88,6 +89,21 @@ class FailureIsolatingGraphDatabasePluginTest extends TestCase {
 		$this->assertStringContainsString( 'delete', $message, 'reflects the actual operation, not a hardcoded edit/save' );
 		$this->assertStringContainsString( '42', $message );
 		$this->assertStringContainsString( 'RebuildGraphDatabases', $message );
+	}
+
+	/**
+	 * A Mapping page the deserializer cannot read makes its projection unknown, and a SPARQL store
+	 * configured for that projection throws when the page is saved. Saving a page must still succeed:
+	 * an unreadable Mapping degrades the store's sync, it does not break editing.
+	 */
+	public function testUnknownProjectionOnSaveIsSwallowedAndLogged(): void {
+		$decorator = $this->newDecorator( $this->pluginThrowing(
+			new UnknownProjectionException( 'https://qlever.example/api/neowiki', 'EDM', [ 'native' ] )
+		) );
+
+		$decorator->savePage( TestPage::build( id: 42 ) );
+
+		$this->assertTrue( $this->logger->hasErrorRecords() );
 	}
 
 	public function testRequestTimeoutIsReThrownRatherThanSwallowed(): void {

--- a/tests/phpunit/Domain/Rdf/RdfNamespacesTest.php
+++ b/tests/phpunit/Domain/Rdf/RdfNamespacesTest.php
@@ -118,6 +118,42 @@ class RdfNamespacesTest extends TestCase {
 		);
 	}
 
+	public function testSubjectAnchoredSynthesizedNodeIriUsesNodePathUnderTheSubjectId(): void {
+		$this->assertSame(
+			'https://wiki.example/node/s1demo8aaaaaab5/birth',
+			$this->namespaces()->synthesizedNode( new SubjectId( 's1demo8aaaaaab5' ), 'birth' )->value
+		);
+	}
+
+	public function testNestedSynthesizedNodeIriExtendsItsParentsPath(): void {
+		$this->assertSame(
+			'https://wiki.example/node/s1demo8aaaaaab5/birth/timespan',
+			$this->namespaces()->synthesizedNode( new SubjectId( 's1demo8aaaaaab5' ), 'birth', 'timespan' )->value
+		);
+	}
+
+	public function testPerValueSynthesizedNodeIriEndsInTheValuePosition(): void {
+		$this->assertSame(
+			'https://wiki.example/node/s1demo8aaaaaab5/dimension/2',
+			$this->namespaces()->synthesizedNode( new SubjectId( 's1demo8aaaaaab5' ), 'dimension', '2' )->value
+		);
+	}
+
+	public function testSynthesizedNodeIriPercentEncodesIriIllegalCharactersInAKey(): void {
+		// Node keys are restricted at save time, but an imported Mapping bypasses that.
+		$this->assertSame(
+			'https://wiki.example/node/s1demo8aaaaaab5/a%3Eb',
+			$this->namespaces()->synthesizedNode( new SubjectId( 's1demo8aaaaaab5' ), 'a>b' )->value
+		);
+	}
+
+	public function testRelationAnchoredSynthesizedNodeIriUsesTheRelationId(): void {
+		$this->assertSame(
+			'https://wiki.example/node/r1demo8aaaaaaD6',
+			$this->namespaces()->synthesizedRelationNode( new RelationId( 'r1demo8aaaaaaD6' ) )->value
+		);
+	}
+
 	public function testVocabularyTermUsesOntologyPath(): void {
 		$this->assertSame(
 			'https://wiki.example/ontology/hasSubject',

--- a/tests/phpunit/EntryPoints/Content/MappingContentHandlerParserOutputTest.php
+++ b/tests/phpunit/EntryPoints/Content/MappingContentHandlerParserOutputTest.php
@@ -79,6 +79,45 @@ class MappingContentHandlerParserOutputTest extends MediaWikiIntegrationTestCase
 		$this->assertStringContainsString( '>City</a></td><td>edm:Place</td><td>0</td>', $html );
 	}
 
+	public function testOverviewCountsContributedPropertiesOfAContributesOnlyEntry(): void {
+		// No target class of its own, but it does map two properties — onto the Subjects it points at.
+		$this->assertStringContainsString(
+			'>Birth</a></td><td></td><td>2</td>',
+			$this->render( $this->structural() )
+		);
+	}
+
+	private function structural(): string {
+		return <<<JSON
+			{
+				"version": 1,
+				"prefixes": {
+					"crm": "http://www.cidoc-crm.org/cidoc-crm/",
+					"rdaGr2": "http://rdvocab.info/ElementsGr2/"
+				},
+				"schemas": {
+					"Person": {
+						"subject": { "class": "crm:E21_Person" },
+						"nodes": {
+							"birth": { "class": "crm:E67_Birth", "linkPredicate": "crm:P98i_was_born" }
+						},
+						"properties": {
+							"Birth place": { "predicate": "crm:P7_took_place_at", "node": "birth" }
+						}
+					},
+					"Birth": {
+						"contributions": {
+							"Brought into life": {
+								"Date": { "predicate": "rdaGr2:dateOfBirth" },
+								"Took place at": { "predicate": "rdaGr2:placeOfBirth" }
+							}
+						}
+					}
+				}
+			}
+			JSON;
+	}
+
 	public function testFormatVersionIsRenderedAsASubtleLine(): void {
 		$this->assertStringContainsString(
 			'ext-neowiki-mapping-page__version',
@@ -187,11 +226,26 @@ class MappingContentHandlerParserOutputTest extends MediaWikiIntegrationTestCase
 		$this->assertStringNotContainsString( 'mw-json', $html );
 	}
 
-	public function testNonV1ShapeFallsBackToTheDefaultJsonTable(): void {
+	public function testAnUnsupportedFormatVersionFallsBackToTheDefaultJsonTable(): void {
 		$html = $this->render( '{ "version": 2, "schemas": {} }' );
 
 		$this->assertStringContainsString( 'mw-json', $html );
 		$this->assertStringNotContainsString( 'ext-neowiki-mapping-page', $html );
+	}
+
+	/**
+	 * Raw JSON on its own looks like an ordinary Mapping page, so the version it is written in — the
+	 * reason it defines no projection and fails every export — has to be said out loud.
+	 */
+	public function testAnUnsupportedFormatVersionIsNamedAboveTheRawJson(): void {
+		$html = $this->render( '{ "version": 2, "schemas": {} }' );
+
+		$this->assertStringContainsString( 'format version 2', $html );
+		$this->assertLessThan( strpos( $html, 'mw-json' ), strpos( $html, 'format version 2' ) );
+	}
+
+	public function testContentThatIsNotAMappingDocumentGetsNoVersionNotice(): void {
+		$this->assertStringNotContainsString( 'format version', $this->render( '[ 1, 2, 3 ]' ) );
 	}
 
 	public function testInvalidJsonFallsBackToTheDefaultRendering(): void {

--- a/tests/phpunit/EntryPoints/Content/MappingContentHandlerValidateSaveTest.php
+++ b/tests/phpunit/EntryPoints/Content/MappingContentHandlerValidateSaveTest.php
@@ -35,7 +35,7 @@ class MappingContentHandlerValidateSaveTest extends NeoWikiIntegrationTestCase {
 	}
 
 	public function testStructurallyInvalidMappingFailsValidation(): void {
-		$this->assertFalse( $this->validate( '{ "version": 2, "schemas": {} }' )->isOK() );
+		$this->assertFalse( $this->validate( '{ "version": 1, "schemas": { "Person": {} } }' )->isOK() );
 	}
 
 	public function testUnresolvableCuriePredicateFailsValidation(): void {

--- a/tests/phpunit/EntryPoints/REST/ExportPageRdfApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ExportPageRdfApiTest.php
@@ -362,6 +362,57 @@ JSON
 		);
 	}
 
+	/**
+	 * End to end for the structural tier: a Mapping page whose entry sends a property's values to a
+	 * synthesized node produces that node, typed and linked from the Subject, in the exported document.
+	 */
+	public function testAMappingWithASynthesizedNodeExportsTheNodeItMints(): void {
+		$this->createMapping( 'CIDOC', <<<JSON
+			{
+				"version": 1,
+				"prefixes": { "crm": "http://www.cidoc-crm.org/cidoc-crm/" },
+				"schemas": {
+					"{$this->schemaName()}": {
+						"subject": { "class": "crm:E53_Place" },
+						"nodes": {
+							"naming": { "class": "crm:E41_Appellation", "linkPredicate": "crm:P1_is_identified_by" }
+						},
+						"properties": {
+							"population": { "predicate": "crm:P190_has_symbolic_content", "node": "naming" }
+						}
+					}
+				}
+			}
+			JSON );
+
+		$response = $this->export( query: [ 'projection' => 'CIDOC', 'format' => 'turtle' ] );
+		$body = $response->getBody()->getContents();
+
+		$this->assertSame( 200, $response->getStatusCode() );
+		$this->assertStringContainsString( '/node/' . self::SUBJECT_ID . '/naming', $body, 'The node IRI is minted from the Subject and the node key.' );
+		$this->assertStringContainsString( 'E41_Appellation', $body, 'The node carries its target class.' );
+		$this->assertStringContainsString( 'P1_is_identified_by', $body, 'The Subject links to the node.' );
+		$this->assertStringContainsString( 'P190_has_symbolic_content', $body, 'The value hangs off the node, not the Subject.' );
+	}
+
+	/**
+	 * A Mapping page the deserializer cannot read — here an unknown format version, which import can
+	 * still put on a wiki — must behave exactly like a name no Mapping page has: an unknown projection.
+	 */
+	public function testAMappingPageInAnUnreadableFormatIsAnUnknownProjection(): void {
+		$this->createMapping( 'Unreadableseed', '{ "version": 1, "schemas": {} }' );
+		$this->importXml( str_replace(
+			[ 'Mapping:Unreadableseed', '"version": 1' ],
+			[ 'Mapping:Unreadablemapping', '"version": 2' ],
+			$this->exportPageToXml( 'Mapping:Unreadableseed' )
+		) );
+
+		$response = $this->export( query: [ 'projection' => 'Unreadablemapping' ] );
+
+		$this->assertSame( 400, $response->getStatusCode() );
+		$this->assertStringContainsString( 'native', $response->getBody()->getContents(), 'The known-projection list is still reported.' );
+	}
+
 	private function createEdmMapping(): void {
 		$this->createMapping( 'EDM', <<<JSON
 			{

--- a/tests/phpunit/Persistence/MediaWiki/MappingContentValidatorTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/MappingContentValidatorTest.php
@@ -67,7 +67,7 @@ class MappingContentValidatorTest extends MediaWikiIntegrationTestCase {
 		);
 	}
 
-	public function testRejectsAWrongFormatVersion(): void {
+	public function testRejectsAnUnknownFormatVersion(): void {
 		$this->assertInvalidAt(
 			<<<JSON
 			{ "version": 2, "schemas": { "Person": { "subject": { "class": "edm:X" }, "properties": {} } }, "prefixes": { "edm": "http://europeana.eu/edm/" } }
@@ -311,6 +311,396 @@ class MappingContentValidatorTest extends MediaWikiIntegrationTestCase {
 			JSON,
 			'/schemas/Person/properties/Name'
 		);
+	}
+
+	// Structural tier: synthesized nodes and contributions.
+
+	public function testAcceptsAMappingWithANestedNodeChainAndAContribution(): void {
+		$this->assertValid( $this->structuralMapping() );
+	}
+
+	/**
+	 * A Schema entry may project its Subject, contribute to others, or both — but an empty entry says
+	 * nothing and is a mistake worth catching.
+	 */
+	public function testRejectsAnEntryThatNeitherProjectsNorContributes(): void {
+		$this->assertInvalidAt( '{ "version": 1, "schemas": { "Person": {} } }', '/schemas/Person' );
+	}
+
+	public function testRejectsPropertiesWithoutASubjectToHangThemOn(): void {
+		$this->assertInvalidAt(
+			<<<JSON
+			{
+				"version": 1,
+				"prefixes": { "dc": "http://purl.org/dc/elements/1.1/" },
+				"schemas": {
+					"Person": { "properties": { "Name": { "predicate": "dc:title" } } }
+				}
+			}
+			JSON,
+			'/schemas/Person'
+		);
+	}
+
+	public function testRejectsALabelPredicateThatWouldBreakOutOfItsIri(): void {
+		$this->assertInvalidAt(
+			<<<JSON
+			{
+				"version": 1,
+				"prefixes": { "foaf": "http://xmlns.com/foaf/0.1/" },
+				"schemas": {
+					"Person": {
+						"subject": {
+							"class": "http://example.org/Person",
+							"labelPredicate": "foaf:name> <http://evil.example/s> <http://evil/p> <http://evil/o"
+						}
+					}
+				}
+			}
+			JSON,
+			'/schemas/Person/subject/labelPredicate'
+		);
+	}
+
+	public function testRejectsANodeClassWhoseCurieDoesNotResolve(): void {
+		$this->assertInvalidAt(
+			<<<JSON
+			{
+				"version": 1,
+				"prefixes": { "crm": "http://www.cidoc-crm.org/cidoc-crm/" },
+				"schemas": {
+					"Person": {
+						"subject": { "class": "crm:E21_Person" },
+						"nodes": { "birth": { "class": "nosuch:E67_Birth", "linkPredicate": "crm:P98i_was_born" } }
+					}
+				}
+			}
+			JSON,
+			'/schemas/Person/nodes/birth/class'
+		);
+	}
+
+	public function testRejectsANodeLinkPredicateThatWouldBreakOutOfItsIri(): void {
+		$this->assertInvalidAt(
+			<<<JSON
+			{
+				"version": 1,
+				"prefixes": { "crm": "http://www.cidoc-crm.org/cidoc-crm/" },
+				"schemas": {
+					"Person": {
+						"subject": { "class": "crm:E21_Person" },
+						"nodes": {
+							"birth": {
+								"class": "crm:E67_Birth",
+								"linkPredicate": "crm:P98i> <http://evil.example/s> <http://evil/p> <http://evil/o"
+							}
+						}
+					}
+				}
+			}
+			JSON,
+			'/schemas/Person/nodes/birth/linkPredicate'
+		);
+	}
+
+	public function testRejectsANodeKeyThatIsNotIdentifierShaped(): void {
+		foreach ( [ '-birth', 'birth place', '' ] as $nodeKey ) {
+			$this->assertInvalidAt( $this->mappingWithNodeKey( $nodeKey ), '/schemas/Person/nodes' );
+		}
+	}
+
+	/**
+	 * An all-digit node key survives JSON parsing as an integer key, which every consumer of the key
+	 * would then have to handle — and nothing can reference it, since a `node` or `parent` naming it is
+	 * pattern-checked as a string. Rejecting it removes the class of bug.
+	 */
+	public function testRejectsAnAllDigitNodeKey(): void {
+		$this->assertInvalidAt( $this->mappingWithNodeKey( '2024' ), '/schemas/Person/nodes/2024' );
+	}
+
+	private function mappingWithNodeKey( string $nodeKey ): string {
+		return (string)json_encode( [
+			'version' => 1,
+			'schemas' => [
+				'Person' => [
+					'subject' => [ 'class' => 'http://example.org/Person' ],
+					'nodes' => [
+						$nodeKey => [
+							'class' => 'http://example.org/Birth',
+							'linkPredicate' => 'http://example.org/wasBorn',
+						],
+					],
+				],
+			],
+		] );
+	}
+
+	public function testRejectsANodeScopeThatIsNeitherSubjectNorValue(): void {
+		$this->assertInvalidAt(
+			<<<JSON
+			{
+				"version": 1,
+				"schemas": {
+					"Person": {
+						"subject": { "class": "http://example.org/Person" },
+						"nodes": {
+							"birth": {
+								"class": "http://example.org/Birth",
+								"linkPredicate": "http://example.org/wasBorn",
+								"per": "page"
+							}
+						}
+					}
+				}
+			}
+			JSON,
+			'/schemas/Person/nodes/birth/per'
+		);
+	}
+
+	public function testRejectsAPropertyAttachedToAnUndeclaredNode(): void {
+		$this->assertInvalidAt(
+			<<<JSON
+			{
+				"version": 1,
+				"prefixes": { "crm": "http://www.cidoc-crm.org/cidoc-crm/" },
+				"schemas": {
+					"Person": {
+						"subject": { "class": "crm:E21_Person" },
+						"nodes": { "birth": { "class": "crm:E67_Birth", "linkPredicate": "crm:P98i_was_born" } },
+						"properties": { "Birth date": { "predicate": "crm:P82_at_some_time_within", "node": "death" } }
+					}
+				}
+			}
+			JSON,
+			'/schemas/Person/properties/Birth date/node'
+		);
+	}
+
+	public function testRejectsANodeWhoseParentIsNotDeclared(): void {
+		$this->assertInvalidAt(
+			<<<JSON
+			{
+				"version": 1,
+				"prefixes": { "crm": "http://www.cidoc-crm.org/cidoc-crm/" },
+				"schemas": {
+					"Person": {
+						"subject": { "class": "crm:E21_Person" },
+						"nodes": {
+							"timespan": {
+								"class": "crm:E52_Time-Span",
+								"linkPredicate": "crm:P4_has_time-span",
+								"parent": "birth"
+							}
+						}
+					}
+				}
+			}
+			JSON,
+			'/schemas/Person/nodes/timespan/parent'
+		);
+	}
+
+	public function testRejectsAParentCycle(): void {
+		// A cycle never reaches the Subject, so nothing the nodes carry could be anchored.
+		$this->assertInvalidAt(
+			<<<JSON
+			{
+				"version": 1,
+				"prefixes": { "crm": "http://www.cidoc-crm.org/cidoc-crm/" },
+				"schemas": {
+					"Person": {
+						"subject": { "class": "crm:E21_Person" },
+						"nodes": {
+							"birth": { "class": "crm:E67_Birth", "linkPredicate": "crm:P98i_was_born", "parent": "timespan" },
+							"timespan": {
+								"class": "crm:E52_Time-Span",
+								"linkPredicate": "crm:P4_has_time-span",
+								"parent": "birth"
+							}
+						}
+					}
+				}
+			}
+			JSON,
+			'/schemas/Person/nodes/birth/parent'
+		);
+	}
+
+	public function testRejectsASecondPropertyAttachedToAPerValueNode(): void {
+		// A per-value node has one instance per value of the property that attaches to it, so a second
+		// property would have no single instance to attach to.
+		$this->assertInvalidAt(
+			<<<JSON
+			{
+				"version": 1,
+				"prefixes": { "crm": "http://www.cidoc-crm.org/cidoc-crm/" },
+				"schemas": {
+					"Artwork": {
+						"subject": { "class": "crm:E22_Human-Made_Object" },
+						"nodes": {
+							"production": {
+								"class": "crm:E12_Production",
+								"linkPredicate": "crm:P108i_was_produced_by",
+								"per": "value"
+							}
+						},
+						"properties": {
+							"Creator": { "predicate": "crm:P14_carried_out_by", "node": "production" },
+							"Technique": { "predicate": "crm:P32_used_general_technique", "node": "production" }
+						}
+					}
+				}
+			}
+			JSON,
+			'/schemas/Artwork/properties/Technique/node'
+		);
+	}
+
+	public function testRejectsAPerValueNodeUsedAsAParent(): void {
+		$this->assertInvalidAt(
+			<<<JSON
+			{
+				"version": 1,
+				"prefixes": { "crm": "http://www.cidoc-crm.org/cidoc-crm/" },
+				"schemas": {
+					"Artwork": {
+						"subject": { "class": "crm:E22_Human-Made_Object" },
+						"nodes": {
+							"production": {
+								"class": "crm:E12_Production",
+								"linkPredicate": "crm:P108i_was_produced_by",
+								"per": "value"
+							},
+							"timespan": {
+								"class": "crm:E52_Time-Span",
+								"linkPredicate": "crm:P4_has_time-span",
+								"parent": "production"
+							}
+						}
+					}
+				}
+			}
+			JSON,
+			'/schemas/Artwork/nodes/timespan/parent'
+		);
+	}
+
+	public function testRejectsAContributionWithNoProperties(): void {
+		$this->assertInvalidAt(
+			<<<JSON
+			{
+				"version": 1,
+				"schemas": {
+					"Birth": { "contributions": { "Brought into life": {} } }
+				}
+			}
+			JSON,
+			'/schemas/Birth/contributions/Brought%20into%20life'
+		);
+	}
+
+	public function testRejectsAContributionThroughANamelessRelation(): void {
+		$this->assertInvalidAt(
+			<<<JSON
+			{
+				"version": 1,
+				"schemas": {
+					"Birth": { "contributions": { "": { "Date": { "predicate": "http://example.org/born" } } } }
+				}
+			}
+			JSON,
+			'/schemas/Birth/contributions'
+		);
+	}
+
+	public function testRejectsAContributionPredicateWhoseCurieDoesNotResolve(): void {
+		$this->assertInvalidAt(
+			<<<JSON
+			{
+				"version": 1,
+				"schemas": {
+					"Birth": {
+						"contributions": {
+							"Brought into life": { "Date": { "predicate": "rdaGr2:dateOfBirth" } }
+						}
+					}
+				}
+			}
+			JSON,
+			'/schemas/Birth/contributions/Brought into life/Date/predicate'
+		);
+	}
+
+	/**
+	 * A contribution names properties of the contributing Schema, which attach to the target Subject, so
+	 * there is no node of the contributing entry for them to hang off.
+	 */
+	public function testRejectsANodeReferenceInsideAContribution(): void {
+		$this->assertInvalidAt(
+			<<<JSON
+			{
+				"version": 1,
+				"prefixes": { "crm": "http://www.cidoc-crm.org/cidoc-crm/" },
+				"schemas": {
+					"Birth": {
+						"subject": { "class": "crm:E67_Birth" },
+						"nodes": { "timespan": { "class": "crm:E52_Time-Span", "linkPredicate": "crm:P4_has_time-span" } },
+						"contributions": {
+							"Brought into life": {
+								"Date": { "predicate": "crm:P82_at_some_time_within", "node": "timespan" }
+							}
+						}
+					}
+				}
+			}
+			JSON,
+			'/schemas/Birth/contributions/Brought%20into%20life/Date'
+		);
+	}
+
+	private function structuralMapping(): string {
+		return <<<JSON
+			{
+				"version": 1,
+				"prefixes": {
+					"crm": "http://www.cidoc-crm.org/cidoc-crm/",
+					"rdaGr2": "http://rdvocab.info/ElementsGr2/",
+					"foaf": "http://xmlns.com/foaf/0.1/"
+				},
+				"schemas": {
+					"Person": {
+						"subject": { "class": "crm:E21_Person", "labelPredicate": "foaf:name" },
+						"nodes": {
+							"birth": { "class": "crm:E67_Birth", "linkPredicate": "crm:P98i_was_born" },
+							"birthTimespan": {
+								"class": "crm:E52_Time-Span",
+								"linkPredicate": "crm:P4_has_time-span",
+								"parent": "birth"
+							},
+							"appellation": {
+								"class": "crm:E41_Appellation",
+								"linkPredicate": "crm:P1_is_identified_by",
+								"per": "value"
+							}
+						},
+						"properties": {
+							"Birth date": { "predicate": "crm:P82_at_some_time_within", "node": "birthTimespan" },
+							"Birth place": { "predicate": "crm:P7_took_place_at", "node": "birth" },
+							"Also known as": { "predicate": "crm:P190_has_symbolic_content", "node": "appellation" }
+						}
+					},
+					"Birth": {
+						"contributions": {
+							"Brought into life": {
+								"Date": { "predicate": "rdaGr2:dateOfBirth" },
+								"Took place at": { "predicate": "rdaGr2:placeOfBirth" }
+							}
+						}
+					}
+				}
+			}
+			JSON;
 	}
 
 	private function validMapping(): string {

--- a/tests/phpunit/Persistence/MediaWiki/MappingPersistenceDeserializerTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/MappingPersistenceDeserializerTest.php
@@ -8,6 +8,8 @@ use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\Mapping;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\MappingName;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\NodeMapping;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\NodeScope;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\MappingPersistenceDeserializer;
 
@@ -36,8 +38,8 @@ class MappingPersistenceDeserializerTest extends TestCase {
 	public function testDeserializesEverySchemaEntrySubjectClass(): void {
 		$mapping = $this->deserialize( $this->validJson() );
 
-		$this->assertSame( 'edm:ProvidedCHO', $mapping->forSchema( new SchemaName( 'Person' ) )?->subjectClass );
-		$this->assertSame( 'edm:Place', $mapping->forSchema( new SchemaName( 'City' ) )?->subjectClass );
+		$this->assertSame( 'edm:ProvidedCHO', $mapping->forSchema( new SchemaName( 'Person' ) )?->subject?->class );
+		$this->assertSame( 'edm:Place', $mapping->forSchema( new SchemaName( 'City' ) )?->subject?->class );
 	}
 
 	public function testUnmappedSchemaHasNoEntry(): void {
@@ -60,8 +62,8 @@ class MappingPersistenceDeserializerTest extends TestCase {
 			}
 			JSON );
 
-		$this->assertSame( 'edm:Agent', $mapping->forSchema( new SchemaName( 'Person' ) )?->subjectClass );
-		$this->assertSame( 'edm:Place', $mapping->forSchema( new SchemaName( 'City' ) )?->subjectClass );
+		$this->assertSame( 'edm:Agent', $mapping->forSchema( new SchemaName( 'Person' ) )?->subject?->class );
+		$this->assertSame( 'edm:Place', $mapping->forSchema( new SchemaName( 'City' ) )?->subject?->class );
 		$this->assertNull(
 			$mapping->forSchema( new SchemaName( 'Broken' ) ),
 			'the entry missing subject.class is skipped, not included'
@@ -85,8 +87,8 @@ class MappingPersistenceDeserializerTest extends TestCase {
 			}
 			JSON );
 
-		$this->assertSame( 'edm:Agent', $mapping->forSchema( new SchemaName( 'Person' ) )?->subjectClass );
-		$this->assertSame( 'edm:Place', $mapping->forSchema( new SchemaName( 'City' ) )?->subjectClass );
+		$this->assertSame( 'edm:Agent', $mapping->forSchema( new SchemaName( 'Person' ) )?->subject?->class );
+		$this->assertSame( 'edm:Place', $mapping->forSchema( new SchemaName( 'City' ) )?->subject?->class );
 	}
 
 	public function testDeserializesAPropertyWithALanguageTag(): void {
@@ -115,6 +117,188 @@ class MappingPersistenceDeserializerTest extends TestCase {
 	public function testThrowsOnInvalidJson(): void {
 		$this->expectException( InvalidArgumentException::class );
 		$this->deserialize( 'not json' );
+	}
+
+	/**
+	 * Only the one known format version is read: a page in any other reads as no Mapping at all, which
+	 * degrades to an unknown projection rather than a half-understood one.
+	 */
+	public function testThrowsOnAnUnknownFormatVersion(): void {
+		$this->expectException( InvalidArgumentException::class );
+		$this->deserialize( '{ "version": 2, "schemas": { "Person": { "subject": { "class": "edm:Agent" } } } }' );
+	}
+
+	// Structural tier: synthesized nodes and contributions.
+
+	public function testDeserializesTheSubjectsExtraLabelPredicate(): void {
+		$subject = $this->deserialize( $this->structuralJson() )->forSchema( new SchemaName( 'Person' ) )?->subject;
+
+		$this->assertSame( 'crm:E21_Person', $subject?->class );
+		$this->assertSame( 'foaf:name', $subject->labelPredicate );
+	}
+
+	public function testDeserializesASubjectScopedNode(): void {
+		$birth = $this->personNodes()['birth'] ?? null;
+
+		$this->assertSame( 'crm:E67_Birth', $birth?->class );
+		$this->assertSame( 'crm:P98i_was_born', $birth->linkPredicate );
+		$this->assertNull( $birth->parent );
+		$this->assertSame( NodeScope::Subject, $birth->scope );
+	}
+
+	public function testDeserializesANestedNodesParent(): void {
+		$this->assertSame( 'birth', $this->personNodes()['birthTimespan']?->parent );
+	}
+
+	public function testDeserializesAPerValueNodesScope(): void {
+		$this->assertSame( NodeScope::Value, $this->personNodes()['appellation']?->scope );
+	}
+
+	public function testSkipsANodeWithoutTheTermsItNeeds(): void {
+		// Shapes save validation rejects: a node with no class, and one with no link predicate. Neither
+		// can be placed in the graph, so both are dropped while their valid sibling survives.
+		$nodes = $this->deserialize( <<<'JSON'
+			{
+				"version": 1,
+				"prefixes": { "crm": "http://www.cidoc-crm.org/cidoc-crm/" },
+				"schemas": {
+					"Person": {
+						"subject": { "class": "crm:E21_Person" },
+						"nodes": {
+							"classless": { "linkPredicate": "crm:P98i_was_born" },
+							"birth": { "class": "crm:E67_Birth", "linkPredicate": "crm:P98i_was_born" },
+							"unlinked": { "class": "crm:E52_Time-Span" }
+						}
+					}
+				}
+			}
+			JSON )->forSchema( new SchemaName( 'Person' ) )?->nodes ?? [];
+
+		$this->assertSame( [ 'birth' ], array_keys( $nodes ) );
+	}
+
+	/**
+	 * @return array<string, NodeMapping>
+	 */
+	private function personNodes(): array {
+		return $this->deserialize( $this->structuralJson() )->forSchema( new SchemaName( 'Person' ) )?->nodes ?? [];
+	}
+
+	public function testDeserializesThePropertysNodeAttachment(): void {
+		$properties = $this->deserialize( $this->structuralJson() )->forSchema( new SchemaName( 'Person' ) )?->properties;
+
+		$this->assertSame( 'birthTimespan', $properties?->get( 'Birth date' )?->node );
+		$this->assertNull( $properties->get( 'Description' )?->node );
+	}
+
+	public function testDeserializesAContributionKeyedByItsRelation(): void {
+		$contributions = $this->deserialize( $this->structuralJson() )->forSchema( new SchemaName( 'Birth' ) )?->contributions;
+
+		$this->assertSame( [ 'Brought into life' ], array_keys( $contributions ?? [] ) );
+		$this->assertSame(
+			'rdaGr2:dateOfBirth',
+			$contributions['Brought into life']->get( 'Date' )?->predicate
+		);
+	}
+
+	public function testSkipsAContributionWithNoUsableProperties(): void {
+		// Save validation requires at least one property; an import can store an entry whose only
+		// property lacks a predicate, which would contribute nothing.
+		$birth = $this->deserialize( <<<'JSON'
+			{
+				"version": 1,
+				"schemas": {
+					"Birth": {
+						"contributions": {
+							"Brought into life": { "Date": { "lang": "en" } }
+						}
+					}
+				}
+			}
+			JSON )->forSchema( new SchemaName( 'Birth' ) );
+
+		$this->assertNull( $birth, 'An entry left with neither a subject nor a contribution is skipped whole.' );
+	}
+
+	public function testDeserializesAPropertyWhoseNameIsAllDigits(): void {
+		// A year column is a realistic property name, and json_decode makes it an int array key.
+		$properties = $this->deserialize( <<<'JSON'
+			{
+				"version": 1,
+				"schemas": {
+					"Person": {
+						"subject": { "class": "http://example.org/Person" },
+						"properties": { "2020": { "predicate": "http://example.org/note" } }
+					}
+				}
+			}
+			JSON )->forSchema( new SchemaName( 'Person' ) )?->properties;
+
+		$this->assertSame( 'http://example.org/note', $properties?->get( '2020' )?->predicate );
+	}
+
+	public function testAContributesOnlyEntryHasNoSubject(): void {
+		$this->assertNull( $this->deserialize( $this->structuralJson() )->forSchema( new SchemaName( 'Birth' ) )?->subject );
+	}
+
+	public function testSkipsAnEntryThatNeitherProjectsNorContributes(): void {
+		// A shape only an import can store, since save validation rejects it.
+		$mapping = $this->deserialize( <<<JSON
+			{
+				"version": 1,
+				"schemas": {
+					"Person": { "subject": { "class": "http://example.org/Person" } },
+					"Empty": {}
+				}
+			}
+			JSON );
+
+		$this->assertNotNull( $mapping->forSchema( new SchemaName( 'Person' ) ) );
+		$this->assertNull( $mapping->forSchema( new SchemaName( 'Empty' ) ) );
+	}
+
+	private function structuralJson(): string {
+		return <<<JSON
+			{
+				"version": 1,
+				"prefixes": {
+					"crm": "http://www.cidoc-crm.org/cidoc-crm/",
+					"rdaGr2": "http://rdvocab.info/ElementsGr2/",
+					"foaf": "http://xmlns.com/foaf/0.1/"
+				},
+				"schemas": {
+					"Person": {
+						"subject": { "class": "crm:E21_Person", "labelPredicate": "foaf:name" },
+						"nodes": {
+							"birth": { "class": "crm:E67_Birth", "linkPredicate": "crm:P98i_was_born" },
+							"birthTimespan": {
+								"class": "crm:E52_Time-Span",
+								"linkPredicate": "crm:P4_has_time-span",
+								"parent": "birth"
+							},
+							"appellation": {
+								"class": "crm:E41_Appellation",
+								"linkPredicate": "crm:P1_is_identified_by",
+								"per": "value"
+							}
+						},
+						"properties": {
+							"Description": { "predicate": "crm:P3_has_note" },
+							"Birth date": { "predicate": "crm:P82_at_some_time_within", "node": "birthTimespan" },
+							"Also known as": { "predicate": "crm:P190_has_symbolic_content", "node": "appellation" }
+						}
+					},
+					"Birth": {
+						"contributions": {
+							"Brought into life": {
+								"Date": { "predicate": "rdaGr2:dateOfBirth" },
+								"Took place at": { "predicate": "rdaGr2:placeOfBirth" }
+							}
+						}
+					}
+				}
+			}
+			JSON;
 	}
 
 	private function validJson(): string {


### PR DESCRIPTION
Adds the structural tier of [ontology mapping](https://github.com/ProfessionalWiki/NeoWiki/blob/master/docs/planning/OntologyMapping.md). The version-1 Mapping format grows in place — every new key is optional, so every existing document stays valid (that doc's as-built notes are updated in this diff). Term substitution works as before; two structural transformations join it:

- **Expansion.** A Schema entry declares synthesized intermediate nodes and attaches property values to them, so flat Person fields project the CIDOC-CRM chain `E21_Person → P98i_was_born → E67_Birth → P4_has_time-span → E52_Time-Span`, birth date and birth place meeting on the same `E67_Birth`. A node is subject-scoped (one per Subject; `parent` names another node, forming a tree) or value-scoped (`per: "value"`: one instance per value of the property attached to it — one `E12_Production` per Creator relation).
- **Contraction.** A Schema entry contributes its own values to the Subjects its outbound relation points at: a Birth event Subject emits `rdaGr2:dateOfBirth`/`placeOfBirth` about the person it brought into life, so explicitly modelled events still land flat in EDM.

A Schema entry can also set `labelPredicate` to emit the Subject's label under a target term such as `foaf:name`, alongside the always-emitted `rdfs:label`.

Semantics:

- Synthesized-node IRIs are deterministic — `$base/node/{subjectId}/{keyPath}` for subject-scoped instances, `$base/node/{relationId}` for relation-anchored ones — so re-projection is idempotent.
- A node no value reaches is not emitted.
- Contraction is source-side: the contributing page emits into its own named graph and nothing reads other pages. A flat entity's per-page export therefore does not contain triples contributed by other pages; the SPARQL store and the bulk dump, holding all graphs, do.
- The format version stays 1: `subject` became optional (a contributes-only entry has no class), and all other changes are new optional keys, so previously valid documents keep their meaning. A page with an unknown version renders an explanatory notice and defines no projection.
- Save-time validation covers the new surface (node references, parent cycles, value-scope rules, size caps). Import bypasses save validation, so projection re-checks everything and degrades: an unusable construct is dropped and logged, an export never aborts.
- Output for pre-existing mappings is unchanged apart from the optional `labelPredicate` triple; the native projection and the REST surfaces are untouched.

Demo data exercises both directions in both modelling styles: `Mapping:CIDOC-CRM` is new, and `Mapping:EDM` gains the Birth contributions, `foaf:name`, and typed Places. Coverage: whole-output projector tests (expected TriG including node IRIs), validator and deserializer tests for every new rule, and REST integration tests.

Deliberately out of scope: RDF import, multi-hop contributions, inverse-direction node links, and mapping-authoring UI beyond the JSON page.

Decisions taken here, revisable:

1. **The rule language is NeoWiki's own JSON format.** The open formalism question ([#995](https://github.com/ProfessionalWiki/NeoWiki/issues/995)) is whether a standard formalism (LinkML, X3ML) should author or compile to it; adopting one now would block on consortium input.
2. **Source-side contraction.** The alternative — folding contributed data into the flat entity's own graph — needs inverse-relation lookups plus a way to re-sync that graph when the event page changes.
3. **No format-version bump.** The additions are backward-compatible and nothing runs this in production; the first real bump waits for a change that breaks existing documents.
4. **Synthesized-node IRIs carry no projection segment**, so a wiki's sibling projections of the same data mint the same node IRI and can be joined on it; qualifying per projection would isolate them instead.

Related: [#995](https://github.com/ProfessionalWiki/NeoWiki/issues/995), [discussion #996](https://github.com/ProfessionalWiki/NeoWiki/discussions/996), [discussion #999](https://github.com/ProfessionalWiki/NeoWiki/discussions/999). Follow-up: [#1230](https://github.com/ProfessionalWiki/NeoWiki/issues/1230) (Mapping edits leave configured SPARQL stores stale — pre-existing).

> <sub>AI-authored — Claude Code, `Fable 5 (max)`; directive from @JeroenDeDauw to implement the committed structural-mapping design, spec settled in-session, one redirect during wrap-up (format-version bump reverted); diff not yet human-reviewed; adversarial review pass applied, verified live on the dev stack, CI green.</sub>

<details><summary>Production notes</summary>

Design and supervision by `Fable 5 (max)`; implementation, review fixes, and text pass by `Opus 5 (max)` subagents. A separate review pass (correctness, security, tests, design) ran before the fix round; its blocking finding — numeric node keys fataling every projection — and most should-fixes are incorporated. Live verification: Picasso projects the full birth chain, The Milkmaid one `E12_Production` per Creator anchored on the Relation ID, Birth of Johann Sebastian Bach contributes the flat birth triples about Bach; two consecutive exports byte-identical.

</details>
