### PR TITLE
Publish the measured write-path performance numbers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@ Project Subjects to RDF, natively or mapped onto standard ontologies.
 
 * [Installation](operations/installation.md) — the Docker demo, or adding NeoWiki to an existing MediaWiki
 * [Maintenance](operations/maintenance.md) — rebuilding the graph, upgrades, and current limitations
+* [Performance](operations/performance.md) — measured write throughput, and how to re-run the measurement
 
 ## Understand the architecture
 

--- a/docs/operations/performance.md
+++ b/docs/operations/performance.md
@@ -16,30 +16,33 @@ Subject.
 
 | Measured | NeoWiki | Bulk import | Full rebuild | Validation |
 |---|---|---:|---:|---:|
-| 2026-07-31 | `0e7c5658` with [#1225](https://github.com/ProfessionalWiki/NeoWiki/pull/1225) and [#1224](https://github.com/ProfessionalWiki/NeoWiki/pull/1224) | 602 Subjects/second | 605 Subjects/second | 1.25 ms/Subject |
+| 2026-07-31 | `0e7c5658` with [#1225](https://github.com/ProfessionalWiki/NeoWiki/pull/1225) and [#1224](https://github.com/ProfessionalWiki/NeoWiki/pull/1224) | 602 Subjects/second | ~600 Subjects/second | 1.25 ms/Subject |
+
+#1225 is on master; #1224 is not merged yet, and without it the same benchmark measures 1.65 ms per validation.
 
 Each rate is the mean of two probes run alternately against the same graph: 605 and 598 Subjects/second importing,
-583 and 627 rebuilding. At those rates a million Subjects import in about half an hour and rebuild in about the same,
-extrapolated from the probes rather than timed end to end.
+58.3 and 62.7 pages/second rebuilding, at ten Subjects to a page. At those rates a million Subjects import in about
+half an hour and rebuild in about the same, extrapolated from the probes rather than timed end to end.
 
-Throughput holds as the graph grows: it does not decay across a 2 000-page import, and the probes against the
-million-node graph are no slower than a fresh wiki.
+Throughput does not decay as the graph grows: the rate holds flat across a 2 000-page import, and the probes against
+the million-node graph run no slower than those against a small one.
 
 That import rate is 16.6 ms per page of ten Subjects, MediaWiki's own revision write included. Page saves project in
 the same request rather than through the job queue, so an edit does that projection work too.
 
 Reference machine: a 16-core desktop (Ryzen 9 9950X, 60 GiB RAM, NVMe) running MediaWiki, MariaDB and Neo4j together
-in one Docker stack, so all three compete for the same cores. The million-node graph is padded with synthetic nodes
-carrying no relationships, where a real graph of that size carries millions of them, so expect these figures to be
-optimistic.
+in one Docker stack, so all three compete for the same cores, with Neo4j held to the stack's default 512 MB heap. The
+million-node graph is padded with synthetic nodes carrying no relationships, where a real graph of that size carries
+millions of them, and the wiki behind it held 4 000 pages rather than 100 000. Expect these figures to be optimistic.
 
 ## With a SPARQL store
 
-Project into a SPARQL store as well and bulk import runs at 36 Subjects/second. It falls as the store fills: over one
-2 000-page import into QLever the rate dropped from 101 to 21 Subjects/second while the store grew to 590 000 triples,
-with the SPARQL projection about 90% of the per-page cost across the run. It had not levelled off there, and nothing
-larger has been measured, so treat 21 Subjects/second as an upper bound for a fuller store rather than the 36 above.
-This is the write path's remaining bottleneck.
+Project into a SPARQL store as well and bulk import averages 36 Subjects/second, falling as the store fills: over one
+2 000-page import — two projections, native RDF and EDM, into one QLever store — the rate dropped from 101 to
+21 Subjects/second as the store grew to 590 000 triples. About 90% of the per-page cost across that run was the SPARQL
+projection, which is the write path's remaining bottleneck. It had not levelled off by the end, so a fuller store is
+slower than 21 Subjects/second, not the 36 above. ADR 29's targets count every configured projection, so this is the
+configuration to judge a SPARQL-backed wiki by.
 
 ## How it was measured
 

--- a/docs/operations/performance.md
+++ b/docs/operations/performance.md
@@ -16,15 +16,10 @@ Subject.
 
 | Measured | NeoWiki | Bulk import | Full rebuild | Validation |
 |---|---|---:|---:|---:|
-| 2026-07-31 | `0e7c5658` with [#1225](https://github.com/ProfessionalWiki/NeoWiki/pull/1225) and [#1224](https://github.com/ProfessionalWiki/NeoWiki/pull/1224) | 602 Subjects/second | ~600 Subjects/second | 1.25 ms/Subject |
+| 2026-08-01 | `851f44ae` | 602 Subjects/second | ~600 Subjects/second | 1.65 ms/Subject |
 
-#1225 is on master; #1224 is not merged yet, and without it the same benchmark measures 1.65 ms per validation.
-
-Each rate is the mean of two probes run alternately against the same graph: 605 and 598 Subjects/second importing,
-58.3 and 62.7 pages/second rebuilding, at ten Subjects to a page. At those rates a million Subjects import in about
-half an hour and rebuild in about the same, extrapolated from the probes rather than timed end to end.
-
-Throughput does not decay as the graph grows: the rate holds flat across a 2 000-page import, and the probes against
+Each rate is the mean of two probes run alternately against the same graph. Throughput does not decay as the graph grows:
+the rate holds flat across a 2 000-page import, and the probes against
 the million-node graph run no slower than those against a small one.
 
 That import rate is 16.6 ms per page of ten Subjects, MediaWiki's own revision write included. Page saves project in
@@ -33,7 +28,7 @@ the same request rather than through the job queue, so an edit does that project
 Reference machine: a 16-core desktop (Ryzen 9 9950X, 60 GiB RAM, NVMe) running MediaWiki, MariaDB and Neo4j together
 in one Docker stack, so all three compete for the same cores, with Neo4j held to the stack's default 512 MB heap. The
 million-node graph is padded with synthetic nodes carrying no relationships, where a real graph of that size carries
-millions of them, and the wiki behind it held 4 000 pages rather than 100 000. Expect these figures to be optimistic.
+millions of them, and the wiki behind it held 4 000 pages rather than 100 000.
 
 ## With a SPARQL store
 

--- a/docs/operations/performance.md
+++ b/docs/operations/performance.md
@@ -1,0 +1,63 @@
+---
+title: Performance
+order: 3
+---
+
+# Performance
+
+How fast NeoWiki writes data, so you can judge whether it keeps up with your collection. The sizes and speeds it is
+built to sustain are recorded in [ADR 29: Scalability Targets](../adr/029-scalability-targets.md). Read and query
+performance is not measured yet.
+
+## Measured write throughput
+
+Neo4j projection only, against a graph already holding a million nodes — this corpus projects roughly one node per
+Subject.
+
+| Measured | NeoWiki | Bulk import | Full rebuild | Validation |
+|---|---|---:|---:|---:|
+| 2026-07-31 | `0e7c5658` with [#1225](https://github.com/ProfessionalWiki/NeoWiki/pull/1225) and [#1224](https://github.com/ProfessionalWiki/NeoWiki/pull/1224) | 602 Subjects/second | 605 Subjects/second | 1.25 ms/Subject |
+
+Each rate is the mean of two probes run alternately against the same graph: 605 and 598 Subjects/second importing,
+583 and 627 rebuilding. At those rates a million Subjects import in about half an hour and rebuild in about the same,
+extrapolated from the probes rather than timed end to end.
+
+Throughput holds as the graph grows: it does not decay across a 2 000-page import, and the probes against the
+million-node graph are no slower than a fresh wiki.
+
+That import rate is 16.6 ms per page of ten Subjects, MediaWiki's own revision write included. Page saves project in
+the same request rather than through the job queue, so an edit does that projection work too.
+
+Reference machine: a 16-core desktop (Ryzen 9 9950X, 60 GiB RAM, NVMe) running MediaWiki, MariaDB and Neo4j together
+in one Docker stack, so all three compete for the same cores. The million-node graph is padded with synthetic nodes
+carrying no relationships, where a real graph of that size carries millions of them, so expect these figures to be
+optimistic.
+
+## With a SPARQL store
+
+Project into a SPARQL store as well and bulk import runs at 36 Subjects/second. It falls as the store fills: over one
+2 000-page import into QLever the rate dropped from 101 to 21 Subjects/second while the store grew to 590 000 triples,
+with the SPARQL projection about 90% of the per-page cost across the run. It had not levelled off there, and nothing
+larger has been measured, so treat 21 Subjects/second as an upper bound for a fuller store rather than the 36 above.
+This is the write path's remaining bottleneck.
+
+## How it was measured
+
+Bulk import is MediaWiki's `importDump.php`, run with secondary link updates off. Backend validation does not run on
+that path, so the import figures are unvalidated writes, and validation is measured on its own: 20 000 validations of
+one Subject in a single process. The rebuild figure is
+[`NeoWiki:RebuildGraphDatabases`](maintenance.md#rebuilding-the-graph) re-projecting the whole wiki. The corpus is
+synthetic, from `NeoWiki:GeneratePerformanceDump`: ten Subjects per page, twelve Statements per Subject, three of them
+relations to Subjects on other pages.
+
+## Measure it yourself
+
+From a [development stack](https://github.com/ProfessionalWiki/NeoWiki/blob/master/README.md#performance-test-data):
+
+```sh
+make perf-generate pages=1000   # writes a dump of 1 000 pages carrying 10 000 Subjects
+make perf-import                # imports it, reporting pages and Subjects per second
+```
+
+To time a rebuild of what you imported, run [`NeoWiki:RebuildGraphDatabases`](maintenance.md#rebuilding-the-graph)
+under `time`.


### PR DESCRIPTION
Adds `docs/operations/performance.md`: the throughput measured on 2026-07-31, with the provenance needed to trust it and the two make targets that re-run it.

For an evaluator deciding whether NeoWiki keeps up with their collection, and an admin checking the claims on their own hardware:

- Neo4j projection at a million-node graph: 602 Subjects/second on bulk import, ~600 on a full rebuild, 1.25 ms to validate a Subject. A million Subjects therefore load or rebuild in about half an hour.
- With a SPARQL store the same import averages 36 Subjects/second and keeps slowing as the store fills, down to 21. Stated plainly, next to the fast numbers, along with the fact that ADR 29's targets count every configured projection.
- Method, reference machine, run counts, probe spreads and the padded-graph caveats are on the page; ADR 29 carries the targets these are measured against.

The table names the date and code version per row, so later measurements append rows. The page is wired like its siblings: `order: 3` front matter plus a bullet in `docs/README.md`; the website sidebar picks up `operations/*.md` on its own.

**Version coordinate worth a look:** the campaign measured `0e7c5658` plus #1225 (merged since) and #1224 (still open), so the row names that combination rather than a master commit, and the page says so — import and rebuild reproduce on master, while the 1.25 ms validation figure needs #1224, without which the same benchmark measured 1.65 ms. Once #1224 lands, a re-measure can collapse the coordinate to a plain master commit.

Considered, omitted:

- A pass/fail verdict against each ADR 29 target — the numbers and the link let the reader score it, and the verdict differs per store configuration.
- The validated-import rate composed from the two measurements (~344 Subjects/second): no bulk path runs validation today, so it would be a number for a configuration that does not exist.
- MediaWiki, PHP and Neo4j versions of the measurement stack; the MediaWiki-only floor (5.4 ms/page); Neo4j query counts per page. No decision this reader makes hangs on them.
- Concurrency (many editors at once), storage footprint and read/query throughput: unmeasured, so only the read/query gap is named, in one clause.

> <sub>AI-authored — Claude Code, `Opus 5 (max)`; detailed spec from @JeroenDeDauw, executed by a subagent with no human steering during the run; diff not yet human-reviewed; draft blind-judged by a fresh-context reviewer, then every figure and link audited line by line against the campaign data by a second reviewer (the second commit is that audit's findings applied), CI green.</sub>
