### PR TITLE
Support Oxigraph as a second SPARQL store engine

### DIFF
--- a/.github/workflows/ci-php.yml
+++ b/.github/workflows/ci-php.yml
@@ -53,6 +53,9 @@ jobs:
       # reaches the QLever the "Start QLever" step publishes on the runner's localhost.
       QLEVER_TEST_URL: http://localhost:7019/
       QLEVER_TEST_ACCESS_TOKEN: neowiki_test_token
+      # Live Oxigraph store for the same system test run against a second engine, published by the
+      # "Start Oxigraph" step.
+      OXIGRAPH_TEST_BASE_URL: http://localhost:7878
 
     services:
       test_neo:
@@ -143,6 +146,19 @@ jobs:
               qlever-index -i neowiki -F nt -f data.nt
               exec qlever-server -i neowiki -p 7019 -a "$QLEVER_ACCESS_TOKEN" -m 1G --service-allowed-iri-prefixes -'
 
+      # Oxigraph, the second SPARQL engine the same system test runs against. Started explicitly next
+      # to QLever rather than as a `services:` container, so the serve flags are stated here rather than
+      # inherited from the image's default. They mirror the test_oxigraph
+      # dev-stack service (see Docker/docker-compose.dev.yml) — no --union-default-graph, so the store
+      # is spec-strict; no --location, so it is in memory, which is all a fresh-per-run CI store needs.
+      # No access-token flag: Oxigraph has no authentication (oxigraph#88). No federation flag either:
+      # Oxigraph federates unconditionally and offers no option to restrict it — see
+      # docs/operations/installation.md#restricting-federation.
+      - name: Start Oxigraph
+        run: |
+          docker run -d --name test_oxigraph -p 127.0.0.1:7878:7878 \
+            ghcr.io/oxigraph/oxigraph:latest serve --bind 0.0.0.0:7878
+
       - name: Run update.php
         run: php maintenance/update.php --quick
 
@@ -159,6 +175,16 @@ jobs:
             sleep 2
           done
           echo "QLever did not become ready in time; dumping logs:"; docker logs test_qlever; exit 1
+
+      - name: Wait for Oxigraph
+        run: |
+          for i in $(seq 1 40); do
+            if curl -fsS -o /dev/null "http://localhost:7878/query?query=SELECT%20%2A%20WHERE%20%7B%20%3Fs%20%3Fp%20%3Fo%20%7D%20LIMIT%201"; then
+              echo "Oxigraph is serving"; exit 0
+            fi
+            sleep 2
+          done
+          echo "Oxigraph did not become ready in time; dumping logs:"; docker logs test_oxigraph; exit 1
 
       - name: Run PHPUnit
         run: composer phpunit

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -27,15 +27,16 @@ are already bound on the host. The demo stack allocates nothing: it uses the val
 | `NEO_BROWSER_PORT` | (see below) | 7474    | Neo4j Browser (opt-in)     |
 | `NEO_BOLT_PORT`    | (see below) | 7687    | Neo4j Bolt endpoint (opt-in) |
 | `QLEVER_PORT`      | (see below) | 7019    | QLever SPARQL endpoint (opt-in) |
+| `OXIGRAPH_PORT`    | (see below) | 7878    | Oxigraph SPARQL endpoint (opt-in) |
 
-Neo4j and QLever ports are only exposed to the host by the `Docker/docker-compose.tools.yml`
-overlay, which works with either stack; `make dev-tools` adds it to the dev stack. They use
-conventional defaults (7474, 7687, 7019) and are not auto-allocated, so the overlay is best used
-with one stack at a time. Override `NEO_BROWSER_PORT` / `NEO_BOLT_PORT` / `QLEVER_PORT` if you
+Neo4j, QLever and Oxigraph ports are only exposed to the host by the `Docker/docker-compose.tools.yml`
+overlay, which works with either stack; `make dev-tools` adds it to the dev stack. Oxigraph also needs
+`COMPOSE_PROFILES=oxigraph`. These ports are not auto-allocated, so the overlay is best used with one
+stack at a time. Override `NEO_BROWSER_PORT` / `NEO_BOLT_PORT` / `QLEVER_PORT` / `OXIGRAPH_PORT` if you
 need to run two tools-mode stacks simultaneously.
 
-The MariaDB, (default) Neo4j and QLever ports are not exposed to the host. Reach them
-from inside the stack via `make bash` or `docker compose exec`.
+The MariaDB, (default) Neo4j, QLever and Oxigraph ports are not exposed to the host. Reach
+them from inside the stack via `make bash` or `docker compose exec`.
 
 ## QLever SPARQL store
 
@@ -86,7 +87,7 @@ Without the tools overlay, run the same query from inside the stack, e.g.
 ### `test_qlever` (SPARQL query system test)
 
 A second, dedicated QLever store — `test_qlever` — backs the SPARQL query system test
-(`QuerySparqlEndToEndTest`), isolated from the `qlever` store the way `test_neo` is
+(`QueryQLeverEndToEndTest`), isolated from the `qlever` store the way `test_neo` is
 isolated from `neo`: the test writes and deletes Subjects, so it must not touch the wiki's
 data. `phpunit.xml.dist` points the test at it via `QLEVER_TEST_URL=http://test_qlever:7019/`
 (fixed token `neowiki_test_token`); it is reached in-network only, with no host port. Unlike
@@ -96,11 +97,61 @@ up on demand via the `test` profile; in CI it is started explicitly (see
 `.github/workflows/ci-php.yml`), because its multi-step bring-up cannot be expressed as a
 GitHub Actions service container.
 
+## Oxigraph SPARQL store
+
+Both stacks also carry [Oxigraph](https://github.com/oxigraph/oxigraph), a second SPARQL engine, so
+the projection plugin can be exercised against more than one implementation. Nothing points at it by
+default, so it sits behind the `oxigraph` compose profile and neither stack starts it on its own:
+
+```sh
+COMPOSE_PROFILES=oxigraph make dev
+```
+
+`SettingsTemplate.php` points `$wgNeoWikiSparqlStores` at `QLEVER_URL`, so nothing reaches Oxigraph until
+you repoint it: `updateUrl` `http://oxigraph:7878/update`, `queryUrl` `http://oxigraph:7878/query`. On the
+dev stack put that in `Docker/LocalSettings.local.php`, which the dev overlay bind-mounts; the demo stack
+has no such file, so use the commented-out `LocalSettings.php` mount in `docker-compose.yml`. Oxigraph
+cannot refuse `SERVICE` requests, so repointing the wiki here enables federation — see
+[Restricting federation](../docs/operations/installation.md#restricting-federation).
+
+There is no index to build, unlike QLever. Data lives in the `oxigraph-data` named volume, which
+`make remove` clears along with the wiki's own data.
+
+The service runs with `--union-default-graph`, so an unscoped query sees every named graph, matching QLever.
+
+To query it from the host, add the `docker-compose.tools.yml` overlay, which maps `OXIGRAPH_PORT`
+(default 7878) — on the dev stack `COMPOSE_PROFILES=oxigraph make dev-tools` does that for you:
+
+```sh
+# <project> is this stack's compose project name, which `docker compose ls` lists.
+COMPOSE_PROFILES=oxigraph docker compose -p <project> --env-file Docker/.env \
+  -f Docker/docker-compose.yml -f Docker/docker-compose.tools.yml up -d
+
+curl http://localhost:7878/query \
+  --data-urlencode 'query=SELECT (COUNT(*) AS ?n) WHERE { GRAPH ?g { ?s ?p ?o } }' \
+  -H 'Accept: application/sparql-results+json'
+```
+
+Oxigraph has no authentication, so the overlay publishes this port on loopback only, unlike the Neo4j
+and QLever ones.
+
+### `test_oxigraph` (SPARQL query system test)
+
+The system test runs against both engines, and `test_oxigraph` is its Oxigraph store — isolated from
+the `oxigraph` service the way `test_qlever` is from `qlever`. `phpunit.xml.dist` points the test
+at it via `OXIGRAPH_TEST_BASE_URL=http://test_oxigraph:7878`; it is reached in-network only, with no
+host port. It runs with no `--location`, so the store is in memory: ephemeral scaffolding that each
+run clears, like `test_qlever` without `--persist-updates`. It runs without `--union-default-graph`;
+adding the flag breaks the test.
+
+`make phpunit` brings it up on demand via the `test` profile; in CI it is started explicitly (see
+`.github/workflows/ci-php.yml`).
+
 ## The `test` profile
 
-`test_neo` and `test_qlever` are only for the PHP test suite, so `make dev` does not start
-them. `make phpunit` and `make perf` start and seed them on demand; the first run after the
-stack comes up waits for Neo4j to boot. `make test-backends` starts them on their own.
+`test_neo`, `test_qlever` and `test_oxigraph` are only for the PHP test suite, so `make dev` does
+not start them. `make phpunit` and `make perf` start and seed them on demand; the first run after
+the stack comes up waits for Neo4j to boot. `make test-backends` starts them on their own.
 
 Run these from the host. Inside the mediawiki container there is no compose to drive, so they
 report the backends as missing instead of starting them.
@@ -113,12 +164,14 @@ report the backends as missing instead of starting them.
   `LocalSettings.php`), and `dev-mw` (the dev image with mounted NeoWiki source).
 - `docker-compose.yml` — the demo stack's services (`mediawiki`, `db`, `neo`, `qlever`
   — SPARQL store, see above) plus the profile-gated `caddy` (the `server` profile, for
-  HTTPS hosting). The dev overlay builds on this file, so these services are in both stacks.
+  HTTPS hosting) and `oxigraph` (the `oxigraph` profile, the second SPARQL store, see
+  above). The dev overlay builds on this file, so these services are in both stacks.
 - `docker-compose.dev.yml` — dev overlay; switches `mediawiki` to the dev image,
   bind-mounts the NeoWiki source, sets `MW_MODE=dev`, and adds the dev-only sidecars
-  `node` and `mailcatcher`, plus `test_neo` and `test_qlever` behind the `test` profile.
-- `docker-compose.tools.yml` — opt-in overlay that exposes Neo4j and QLever to the host,
-  usable with either stack.
+  `node` and `mailcatcher`, plus `test_neo`, `test_qlever` and `test_oxigraph` behind the
+  `test` profile.
+- `docker-compose.tools.yml` — opt-in overlay that exposes Neo4j, QLever and Oxigraph to the
+  host, usable with either stack.
 - `SettingsTemplate.php` — `LocalSettings.php` that branches on `MW_MODE`.
 - `.env.dist` — tracked defaults; auto-copied to `.env` on first `make dev`.
 - `scripts/set-port.sh` — host port allocator used by `make dev`.

--- a/Docker/docker-compose.dev.yml
+++ b/Docker/docker-compose.dev.yml
@@ -133,6 +133,27 @@ services:
       timeout: 5s
       retries: 20
 
+  # Dedicated Oxigraph store for the SPARQL query system test, isolated from the `oxigraph` service in
+  # docker-compose.yml exactly as test_qlever is from qlever: the system test writes and deletes
+  # Subjects, so it must not mutate the wiki's data. It is reached in-network as
+  # http://test_oxigraph:7878/ (see OXIGRAPH_TEST_BASE_URL in phpunit.xml.dist); no host port is
+  # exposed. Behind the `test` profile, like `test_neo` and `test_qlever`. With no healthcheck to gate
+  # on, `make test-backends` waits for its port from the mediawiki container.
+  test_oxigraph:
+    profiles:
+      - test
+    image: ghcr.io/oxigraph/oxigraph:latest
+    restart: unless-stopped
+    mem_limit: 1536m
+    # No --location, so the store is in memory. Ephemeral test scaffolding, like test_qlever running
+    # without --persist-updates: every run clears it (DROP ALL) and nothing survives a restart by
+    # design. It matches how CI starts it.
+    #
+    # Deliberately WITHOUT --union-default-graph: the spec-strict half of the engine pair (see
+    # Docker/README.md). QueryOxigraphEndToEndTest asserts it.
+    command: serve --bind 0.0.0.0:7878
+    stop_grace_period: 2s
+
   node:
     image: node:24
     restart: on-failure:3

--- a/Docker/docker-compose.tools.yml
+++ b/Docker/docker-compose.tools.yml
@@ -1,11 +1,11 @@
 services:
-  # Opt-in port exposure for graph inspection tools. Both services it touches come from
+  # Opt-in port exposure for graph inspection tools. Every service it touches comes from
   # docker-compose.yml, so this overlay works on the demo stack as well as the dev stack;
   # `make dev-tools` from the extension root adds it to the latter.
   #
-  # Default ports (7474, 7687, 7019) are the Neo4j and QLever conventions and are not
-  # auto-allocated, so run the tools overlay with one stack at a time. Override via
-  # env (NEO_BROWSER_PORT / NEO_BOLT_PORT / QLEVER_PORT) to run several simultaneously.
+  # Default ports (7474, 7687, 7019, 7878) are the Neo4j, QLever and Oxigraph conventions and are
+  # not auto-allocated, so run the tools overlay with one stack at a time. Override via env
+  # (NEO_BROWSER_PORT / NEO_BOLT_PORT / QLEVER_PORT / OXIGRAPH_PORT) to run several simultaneously.
   neo:
     ports:
       - "${NEO_BROWSER_PORT:-7474}:7474"
@@ -16,3 +16,13 @@ services:
   qlever:
     ports:
       - "${QLEVER_PORT:-7019}:7019"
+
+  # Exposes the stack's Oxigraph SPARQL endpoint on the host, once the `oxigraph` profile starts that
+  # service (see docker-compose.yml); until then there is no container to map a port for. Its
+  # query and update operations live on separate paths, unlike QLever's single one, e.g.
+  #   curl http://localhost:7878/query --data-urlencode 'query=SELECT (COUNT(*) AS ?n) WHERE { GRAPH ?g { ?s ?p ?o } }' -H 'Accept: application/sparql-results+json'
+  # Bound to the loopback interface, unlike the services above: Oxigraph has no authentication, so a
+  # published port is an open read-write SPARQL endpoint to everything that can route to this host.
+  oxigraph:
+    ports:
+      - "127.0.0.1:${OXIGRAPH_PORT:-7878}:7878"

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -134,6 +134,40 @@ services:
       timeout: 5s
       retries: 20
 
+  # A second SPARQL 1.1 graph store engine (Oxigraph), alongside the qlever service above, so the
+  # SPARQL projection plugin (#586) can be exercised against more than one implementation. Nothing
+  # points at it by default, so it sits behind its own profile and neither stack starts it: use
+  # `COMPOSE_PROFILES=oxigraph make dev`. QLEVER_URL is what the mediawiki service above is given, so
+  # even a started service holds nothing until you repoint $wgNeoWikiSparqlStores in
+  # Docker/LocalSettings.local.php at http://oxigraph:7878/update and http://oxigraph:7878/query —
+  # separate paths, unlike QLever's single one, so an entry needs both updateUrl and queryUrl. A host
+  # port for manual inspection is opt-in via docker-compose.tools.yml, which is also why this service
+  # is defined here rather than in the dev overlay: that overlay works on either stack, so a service
+  # it maps a port for has to exist in this file.
+  #
+  # No entrypoint script: unlike QLever there is no index to build, and --location below is the whole
+  # of persistence.
+  #
+  # No healthcheck either. The image is distroless, its only executable being the oxigraph binary,
+  # so a compose healthcheck — which runs inside the container — has no shell or curl to run. Wait
+  # for it from outside instead, as `make test-backends` and .github/workflows/ci-php.yml do.
+  oxigraph:
+    profiles:
+      - oxigraph
+    image: ghcr.io/oxigraph/oxigraph:latest
+    restart: unless-stopped
+    # Parity with the qlever service, so swapping which engine a stack points at does not change
+    # the stack's memory ceiling.
+    mem_limit: 1536m
+    # --union-default-graph: unscoped queries see every named graph, as QLever does (see Docker/README.md).
+    command: serve --location /data --bind 0.0.0.0:7878 --union-default-graph
+    volumes:
+      # Named volume, for the same reasons as qlever-index-data above.
+      - oxigraph-data:/data
+    # Oxigraph ignores SIGTERM as qlever does, so it gets the same short grace period to keep
+    # `make down` snappy. Safe: acknowledged updates survive a SIGKILL and reload on startup.
+    stop_grace_period: 2s
+
   # The dev-only sidecars (test_neo, node, mailcatcher) live in
   # docker-compose.dev.yml, not here, so `make up` stays minimal and `make down`
   # can clean them up as orphans on every compose backend (see that file).
@@ -161,5 +195,6 @@ volumes:
   mediawiki-images-data:
   neo4j-data:
   qlever-index-data:
+  oxigraph-data:
   caddy-data:
   caddy-config:

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -168,7 +168,7 @@ services:
     # `make down` snappy. Safe: acknowledged updates survive a SIGKILL and reload on startup.
     stop_grace_period: 2s
 
-  # The dev-only sidecars (test_neo, node, mailcatcher) live in
+  # The dev-only sidecars (test_neo, test_qlever, test_oxigraph, node, mailcatcher) live in
   # docker-compose.dev.yml, not here, so `make up` stays minimal and `make down`
   # can clean them up as orphans on every compose backend (see that file).
 

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ upgrade: _preflight ## Upgrade the demo stack: pull the latest image, restart, m
 dev: _preflight bootstrap ensure-port ## Bring up dev stack (build image, install, seed, wait for health)
 	@$(MAKE) --no-print-directory _dev-impl
 
-dev-tools: _preflight bootstrap ensure-port ## Like 'dev' but also exposes Neo4j Browser/Bolt to host
+dev-tools: _preflight bootstrap ensure-port ## Like 'dev' but also exposes the Neo4j and SPARQL store ports to host
 	@$(MAKE) --no-print-directory _dev-tools-impl
 
 _dev-tools-impl:
@@ -116,6 +116,12 @@ _dev-tools-impl:
 	@echo "Dev wiki ready at:    http://localhost:$$MW_SERVER_PORT"
 	@echo "Neo4j Browser:        http://localhost:$${NEO_BROWSER_PORT:-7474}"
 	@echo "Neo4j Bolt endpoint:  bolt://localhost:$${NEO_BOLT_PORT:-7687}"
+	@echo "QLever SPARQL:        http://localhost:$${QLEVER_PORT:-7019}/"
+	@# The tools overlay maps Oxigraph's port too, but that service only runs when its
+	@# profile is on (see Docker/docker-compose.dev.yml), so only then is there a URL.
+	@case ",$$COMPOSE_PROFILES," in \
+		*,oxigraph,*) echo "Oxigraph SPARQL:      http://localhost:$${OXIGRAPH_PORT:-7878}/query";; \
+	esac
 	@echo "Project:              $(PROJECT_NAME)"
 
 # ---- Bootstrap (one-time, idempotent) ----------------------------------------
@@ -278,7 +284,8 @@ load-neo4j-users:
 test-backends: ## Start and seed the test-only backends (the PHP test targets do this for you)
 ifeq ($(INSIDE_CONTAINER),1)
 	@if ! /wait-for-it.sh test_neo:7689 -t 1 >/dev/null 2>&1 \
-		|| ! /wait-for-it.sh test_qlever:7019 -t 1 >/dev/null 2>&1; then \
+		|| ! /wait-for-it.sh test_qlever:7019 -t 1 >/dev/null 2>&1 \
+		|| ! /wait-for-it.sh test_oxigraph:7878 -t 1 >/dev/null 2>&1; then \
 		echo "The test-only backends are not running. Start them on the host with" >&2; \
 		echo "'make test-backends', or run the PHP test targets from the host." >&2; \
 		exit 1; \
@@ -286,12 +293,12 @@ ifeq ($(INSIDE_CONTAINER),1)
 else
 	@if [ "$$(docker ps --filter label=com.docker.compose.project=$(PROJECT_NAME) \
 			--format '{{.Label "com.docker.compose.service"}}' \
-			| grep -cE '^(test_neo|test_qlever)$$')" = "2" ]; then \
+			| grep -cE '^(test_neo|test_qlever|test_oxigraph)$$')" = "3" ]; then \
 		exit 0; \
 	fi; \
 	$(DC_TEST) up -d; \
 	$(MAKE) --no-print-directory setup-test-neo; \
-	$(EXEC_MW_ROOT) bash -c '/wait-for-it.sh test_qlever:7019 -t 120'
+	$(EXEC_MW_ROOT) bash -c '/wait-for-it.sh test_qlever:7019 -t 120 && /wait-for-it.sh test_oxigraph:7878 -t 120'
 endif
 
 # Dev-only: wait for and seed the test_neo instance. Not called from prod or CI flows.

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,14 @@ PORT_RANGE_END := 8499
 DC := docker compose -p $(PROJECT_NAME) -f Docker/docker-compose.yml
 DC_DEV := $(DC) -f Docker/docker-compose.dev.yml
 DC_TOOLS := $(DC_DEV) -f Docker/docker-compose.tools.yml
-# The `test` profile holds the test-only backends: test_neo and test_qlever.
+# The `test` profile holds the test-only backends: test_neo, test_qlever and test_oxigraph.
 DC_TEST := $(DC_DEV) --profile test
+# Teardown has to see every service, including the profile-gated `oxigraph` and `caddy`. With no
+# profile active Compose leaves those out of the plan entirely, so the container survives `down`
+# and the project network then fails to go with it. They are not orphans either — they are declared
+# in the file Compose was given — so --remove-orphans does not reach them. `--profile '*'` enables
+# every profile, which for a teardown is exactly the intent.
+DC_ALL := $(DC) --profile '*'
 
 # Detect the engine from what `docker` actually is (its version string), not from
 # whether a `podman` binary happens to exist: a stray podman binary alongside real
@@ -118,8 +124,11 @@ _dev-tools-impl:
 	@echo "Neo4j Bolt endpoint:  bolt://localhost:$${NEO_BOLT_PORT:-7687}"
 	@echo "QLever SPARQL:        http://localhost:$${QLEVER_PORT:-7019}/"
 	@# The tools overlay maps Oxigraph's port too, but that service only runs when its
-	@# profile is on (see Docker/docker-compose.dev.yml), so only then is there a URL.
-	@case ",$$COMPOSE_PROFILES," in \
+	@# profile is on (see Docker/docker-compose.yml), so only then is there a URL. Compose
+	@# trims whitespace around profile names ("test, oxigraph" activates both), so strip it
+	@# here as well or the URL goes missing for a stack that did start the service.
+	@profiles=$$(printf '%s' "$$COMPOSE_PROFILES" | tr -d '[:space:]'); \
+	case ",$$profiles," in \
 		*,oxigraph,*) echo "Oxigraph SPARQL:      http://localhost:$${OXIGRAPH_PORT:-7878}/query";; \
 	esac
 	@echo "Project:              $(PROJECT_NAME)"
@@ -165,10 +174,10 @@ _dev-impl:
 	@echo "Project:           $(PROJECT_NAME)"
 
 down: ## Stop and remove containers (preserves volumes)
-	$(DC) down --remove-orphans
+	$(DC_ALL) down --remove-orphans
 
 remove: ## Stop and remove containers AND volumes (deletes all data)
-	$(DC) down --volumes --remove-orphans
+	$(DC_ALL) down --volumes --remove-orphans
 
 logs: ## Tail logs from all services
 	$(DC_DEV) logs -f

--- a/docs/authoring/lua-api.md
+++ b/docs/authoring/lua-api.md
@@ -259,6 +259,11 @@ Always throws on failure; wrap in `pcall` if you need graceful degradation.
 
 Every call counts as an expensive parser function.
 
+#### Named graphs
+
+Pages are projected into named graphs, so which of them an unscoped query reaches depends on the store — see
+[RDF Export](../rdf/rdf-export.md#iri-scheme).
+
 #### Examples
 
 ```lua

--- a/docs/authoring/parser-functions.md
+++ b/docs/authoring/parser-functions.md
@@ -187,6 +187,8 @@ document — the standard `head` / `results` structure (or `boolean` for an `ASK
 - Output is HTML-escaped, so results containing `<`, `>`, `&`, etc. display safely.
 - The output is wrapped in `<div class="mw-neowiki-sparql-result"><pre>` and the error message in
   `<div class="error">`, so you can target either with CSS.
+- Pages are projected into named graphs, so which of them an unscoped query reaches depends on the store — see
+  [RDF Export](../rdf/rdf-export.md#iri-scheme).
 
 ### Examples
 

--- a/docs/operations/installation.md
+++ b/docs/operations/installation.md
@@ -208,8 +208,8 @@ content model, validated, or read.
 ## Optional: SPARQL graph stores
 
 Alongside Neo4j, NeoWiki can keep one or more SPARQL 1.1 graph stores in sync with page changes. This
-works with QLever and any other SPARQL 1.1 store. Each configured store receives the NeoWiki data as RDF: every page
-becomes a named graph, replaced on each edit and dropped on deletion.
+works with QLever, Oxigraph and any other SPARQL 1.1 store. Each configured store receives the NeoWiki data as RDF:
+every page becomes a named graph, replaced on each edit and dropped on deletion.
 
 A SPARQL store does not yet replace Neo4j: NeoWiki's interactive features (the Subject editing UIs, views, and value
 accessors) still require a configured Neo4j backend.
@@ -236,6 +236,24 @@ $wgNeoWikiSparqlStores = [
 ```
 
 A store entry whose `updateUrl` is missing or empty is skipped with a warning rather than failing the wiki.
+
+### Oxigraph
+
+Oxigraph serves queries on `/query` and updates on `/update`, so an entry needs both:
+
+```php
+$wgNeoWikiSparqlStores = [
+	[
+		'updateUrl' => 'https://oxigraph.example/update',
+		'queryUrl' => 'https://oxigraph.example/query',
+		'projection' => 'native',
+	],
+];
+```
+
+Oxigraph has no authentication and ignores `accessToken`: it accepts every request, updates included, from anyone who
+can reach it. Put it behind network isolation or an authenticating reverse proxy, and see
+[Restricting federation](#restricting-federation).
 
 ### Several projections in one store
 
@@ -279,9 +297,12 @@ Each is read-only: the query is sent as a SPARQL 1.1 *query* operation, posted o
 
 A projection configured on a different endpoint is therefore not reachable from these surfaces.
 
-Both bundled Docker stacks, demo and dev, ship a working QLever example wired up this way — see
-[`Docker/README.md`](../../Docker/README.md#qlever-sparql-store) for the service, its `--persist-updates` requirement,
-and how to query it.
+NeoWiki writes pages into named graphs and nothing into the default graph, so whether an unscoped query finds them is
+the store's choice; see [RDF Export](../rdf/rdf-export.md#iri-scheme).
+
+Both bundled Docker stacks, demo and dev, ship working QLever and Oxigraph examples wired up this way — see
+[`Docker/README.md`](../../Docker/README.md#qlever-sparql-store) for the services, QLever's `--persist-updates`
+requirement, and how to query them.
 
 ### Restricting federation
 
@@ -300,13 +321,14 @@ qlever-server -i neowiki -p 7019 -m 1G --service-allowed-iri-prefixes -
 qlever-server -i neowiki -p 7019 -m 1G --service-allowed-iri-prefixes https://sparql.example.org/
 ```
 
-The bundled Docker stack sets the deny-all value, so federation is off unless you change it. The setting can
-also be changed at runtime through the store's endpoint by anyone holding its access token, so keep that token
-secret. Other SPARQL stores have equivalent settings — consult their documentation.
+The bundled Docker stacks set the deny-all value on their QLever services, so those do not federate unless you
+change it. The setting can also be changed at runtime through the store's endpoint by anyone holding its access
+token, so keep that token secret.
 
-Restricting the store is worth combining with restricting who may query it. The query surfaces are gated by the
-`neowiki-query` right, which by default is granted to everyone including anonymous visitors; see
-[Permissions](../api/query-api.md#permissions) for how to narrow it.
+Oxigraph has no equivalent setting and will attempt the outbound request; the stacks' Oxigraph services federate
+for that reason. Other stores vary — consult their documentation. Where the store cannot be restricted, restrict
+around it: block its outbound traffic at the network layer, and narrow the `neowiki-query` right, which by default
+is granted to everyone including anonymous visitors — see [Permissions](../api/query-api.md#permissions).
 
 ## Production hardening
 

--- a/docs/rdf/rdf-export.md
+++ b/docs/rdf/rdf-export.md
@@ -39,6 +39,11 @@ Mapping page name (e.g. `EDM`), encoded like the names below — see [Ontology M
 *resource* IRI (`neo-page:42`)
 stays projection-independent and appears inside the triples.
 
+Nothing is written to the default graph. Stores that fold their named graphs into it answer unscoped queries anyway —
+QLever always does, and Oxigraph does with `--union-default-graph` — and on a store that does not, a query reaches
+page data only through `GRAPH`. Scope each pattern by the graph holding it rather than wrapping a whole query in one
+`GRAPH` block: patterns sharing a block must match within a single page.
+
 Property, Schema, and Relation-type names, and Relation-property keys, form the local part of their IRI: spaces become
 underscores (`Has author` → `neo-prop:Has_author`), and characters illegal in an IRI (`%`, `< > " { } | ^ \`, backtick,
 control characters) are percent-encoded. Non-ASCII Unicode is kept raw. **Caveat:** the space→underscore step collides

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,5 +12,8 @@
 		     via job-level env to reach the runner-published port). -->
 		<env name="QLEVER_TEST_URL" value="http://test_qlever:7019/" />
 		<env name="QLEVER_TEST_ACCESS_TOKEN" value="neowiki_test_token" />
+		<!-- Live Oxigraph store for the same system test, run a second time against a second engine.
+		     Oxigraph has no authentication, so there is no token to set. -->
+		<env name="OXIGRAPH_TEST_BASE_URL" value="http://test_oxigraph:7878" />
 	</php>
 </phpunit>

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/Integration/QueryOxigraphEndToEndTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/Integration/QueryOxigraphEndToEndTest.php
@@ -37,7 +37,9 @@ class QueryOxigraphEndToEndTest extends QuerySparqlEndToEndTestCase {
 	}
 
 	/**
-	 * The service is started without `--union-default-graph`.
+	 * The service is started without `--union-default-graph`. Unlike QLever's counterpart this is not
+	 * an engine property but Oxigraph's spec-conforming default, which the `:latest` image tracks: an
+	 * upstream change to it would fail this suite with nothing here having changed.
 	 */
 	protected function storeUnionsNamedGraphsIntoTheDefaultGraph(): bool {
 		return false;

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/Integration/QueryOxigraphEndToEndTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/Integration/QueryOxigraphEndToEndTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\GraphDatabasePlugins\Sparql\Integration;
+
+/**
+ * {@see QuerySparqlEndToEndTestCase} against Oxigraph — the `test_oxigraph` dev-stack service, a
+ * second engine and a second endpoint shape.
+ *
+ * It runs without `--union-default-graph`, so it is strict where QLever is lenient: an unscoped query
+ * sees only the default graph, never the named graphs NeoWiki projects pages into. That is what SPARQL
+ * 1.1 specifies, so a query passing here passes on any conforming store.
+ *
+ * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryService
+ * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Persistence\HttpSparqlQueryEndpoint
+ * @covers \ProfessionalWiki\NeoWiki\Application\Rdf\OntologyMappingProjector
+ * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Persistence\SparqlProjectionStore
+ * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\SparqlPlugin
+ * @group Database
+ */
+class QueryOxigraphEndToEndTest extends QuerySparqlEndToEndTestCase {
+
+	protected function storeUpdateUrl(): string {
+		return $this->storeBaseUrl() . '/update';
+	}
+
+	protected function storeQueryUrl(): string {
+		return $this->storeBaseUrl() . '/query';
+	}
+
+	/**
+	 * Oxigraph has no authentication (oxigraph#88), so there is no token to send.
+	 */
+	protected function storeAccessToken(): ?string {
+		return null;
+	}
+
+	/**
+	 * The service is started without `--union-default-graph`.
+	 */
+	protected function storeUnionsNamedGraphsIntoTheDefaultGraph(): bool {
+		return false;
+	}
+
+	private function storeBaseUrl(): string {
+		return rtrim( $this->requireEnv( 'OXIGRAPH_TEST_BASE_URL', 'Oxigraph (the `test_oxigraph` service)' ), '/' );
+	}
+
+}

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/Integration/QueryQLeverEndToEndTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/Integration/QueryQLeverEndToEndTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\GraphDatabasePlugins\Sparql\Integration;
+
+/**
+ * {@see QuerySparqlEndToEndTestCase} against QLever — the `test_qlever` dev-stack service, and the
+ * engine the development stack points the wiki itself at.
+ *
+ * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryService
+ * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Persistence\HttpSparqlQueryEndpoint
+ * @covers \ProfessionalWiki\NeoWiki\Application\Rdf\OntologyMappingProjector
+ * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Persistence\SparqlProjectionStore
+ * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\SparqlPlugin
+ * @group Database
+ */
+class QueryQLeverEndToEndTest extends QuerySparqlEndToEndTestCase {
+
+	protected function storeUpdateUrl(): string {
+		return $this->requireEnv( 'QLEVER_TEST_URL', 'QLever (the `test_qlever` service)' );
+	}
+
+	/**
+	 * QLever serves queries and updates on one path, so this is the update endpoint's URL.
+	 */
+	protected function storeQueryUrl(): string {
+		return $this->storeUpdateUrl();
+	}
+
+	protected function storeAccessToken(): ?string {
+		return getenv( 'QLEVER_TEST_ACCESS_TOKEN' ) ?: null;
+	}
+
+	/**
+	 * QLever unions unconditionally, with no way to turn it off.
+	 */
+	protected function storeUnionsNamedGraphsIntoTheDefaultGraph(): bool {
+		return true;
+	}
+
+}

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/Integration/QueryQLeverEndToEndTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/Integration/QueryQLeverEndToEndTest.php
@@ -6,7 +6,7 @@ namespace ProfessionalWiki\NeoWiki\Tests\GraphDatabasePlugins\Sparql\Integration
 
 /**
  * {@see QuerySparqlEndToEndTestCase} against QLever — the `test_qlever` dev-stack service, and the
- * engine the development stack points the wiki itself at.
+ * engine both Docker stacks point the wiki itself at.
  *
  * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryService
  * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Persistence\HttpSparqlQueryEndpoint
@@ -28,8 +28,12 @@ class QueryQLeverEndToEndTest extends QuerySparqlEndToEndTestCase {
 		return $this->storeUpdateUrl();
 	}
 
+	/**
+	 * QLever rejects unauthorized updates, so an unset token is as fatal as an unset URL and fails
+	 * the same way rather than surfacing later as a 403 from the store.
+	 */
 	protected function storeAccessToken(): ?string {
-		return getenv( 'QLEVER_TEST_ACCESS_TOKEN' ) ?: null;
+		return $this->requireEnv( 'QLEVER_TEST_ACCESS_TOKEN', 'QLever (the `test_qlever` service)' );
 	}
 
 	/**

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/Integration/QuerySparqlEndToEndTestCase.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/Integration/QuerySparqlEndToEndTestCase.php
@@ -36,9 +36,10 @@ use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
  * sharply whether an unscoped query sees the named graphs NeoWiki writes into: SPARQL 1.1 leaves
  * that to the store — QLever always unions them in, a strict store keeps them out.
  *
- * Deliberately does NOT skip when a store is unreachable: an unset store URL fails the test through
- * {@see requireEnv}, and an unreachable store surfaces as a loud query/HTTP failure. A silently
- * skipped system test would leave the headline deliverable unverified.
+ * Deliberately does NOT skip when a store is unreachable: any unset setting the store cannot be
+ * reached without fails the test through {@see requireEnv}, and an unreachable store surfaces as a
+ * loud query/HTTP failure. A silently skipped system test would leave the headline deliverable
+ * unverified.
  *
  * Each subclass carries its own `@covers` and `@group Database`; MediaWiki reads the group off the
  * concrete class alone.
@@ -100,9 +101,10 @@ abstract class QuerySparqlEndToEndTestCase extends NeoWikiIntegrationTestCase {
 	}
 
 	/**
-	 * Reads a store URL from the environment, failing the test when it is unset rather than
-	 * skipping — see the class docblock for why. The store description goes into the failure
-	 * message, so name the dev-stack service the reader has to bring up.
+	 * Reads a setting the live store cannot be reached without — a URL, or a token the store rejects
+	 * requests lacking — failing the test when it is unset rather than skipping; see the class
+	 * docblock for why. The store description goes into the failure message, so name the dev-stack
+	 * service the reader has to bring up.
 	 */
 	protected function requireEnv( string $variable, string $store ): string {
 		$value = getenv( $variable );
@@ -127,16 +129,32 @@ abstract class QuerySparqlEndToEndTestCase extends NeoWikiIntegrationTestCase {
 		$this->overrideConfigValue(
 			'NeoWikiSparqlStores',
 			array_map(
-				fn ( string $projection ): array => [
-					'updateUrl' => $this->updateUrl,
-					'queryUrl' => $this->queryUrl,
-					'accessToken' => $this->accessToken,
-					'projection' => $projection,
-				],
+				fn ( string $projection ): array => $this->storeEntryFor( $projection ),
 				$projections
 			)
 		);
 		NeoWikiExtension::resetInstance();
+	}
+
+	/**
+	 * Omits `queryUrl` when the store serves queries and updates on one path, so a store like QLever
+	 * exercises the production default (it falls back to `updateUrl`) instead of a shape no real
+	 * deployment writes. A store that splits the two sets it explicitly, as its own entry must.
+	 *
+	 * @return array<string, string|null>
+	 */
+	private function storeEntryFor( string $projection ): array {
+		$entry = [
+			'updateUrl' => $this->updateUrl,
+			'accessToken' => $this->accessToken,
+			'projection' => $projection,
+		];
+
+		if ( $this->queryUrl !== $this->updateUrl ) {
+			$entry['queryUrl'] = $this->queryUrl;
+		}
+
+		return $entry;
 	}
 
 	public function testSubjectLabelRoundTripsThroughTheSparqlQueryService(): void {
@@ -188,7 +206,10 @@ abstract class QuerySparqlEndToEndTestCase extends NeoWikiIntegrationTestCase {
 		$this->assertSame(
 			$this->storeUnionsNamedGraphsIntoTheDefaultGraph() ? [ $label ] : [],
 			$this->queryLabelsWithoutGraphScopeOf( $subjectId ),
-			'a query without a GRAPH clause reaches the page graphs only on a unioning store'
+			'a query without a GRAPH clause reaches the page graphs only on a unioning store. If this '
+			. 'failed, check whether --union-default-graph was added to the store this subclass names '
+			. '(test_oxigraph in Docker/docker-compose.dev.yml and .github/workflows/ci-php.yml) before '
+			. 'changing the expectation — flipping it silently drops the strict-store half of the pair.'
 		);
 	}
 
@@ -327,10 +348,11 @@ abstract class QuerySparqlEndToEndTestCase extends NeoWikiIntegrationTestCase {
 		$subjectIri = NeoWikiExtension::getInstance()->getRdfNamespaces()->subject( $subjectId )->value;
 
 		// GRAPH-scoped, because NeoWiki writes each page into a named graph and never the default
-		// graph. See queryLabelsWithoutGraphScopeOf() for what dropping the clause costs. DISTINCT
-		// because a Subject saved under several projections carries its label in each of their graphs.
+		// graph. See queryLabelsWithoutGraphScopeOf() for what dropping the clause costs. No DISTINCT:
+		// its callers configure one projection, so one graph must hold the label, and scoping by GRAPH
+		// makes that cardinality observable — collapsing it would hide a page projected twice.
 		return $this->labelsFrom(
-			'SELECT DISTINCT ?label WHERE { GRAPH ?graph { <' . $subjectIri . '> <'
+			'SELECT ?label WHERE { GRAPH ?graph { <' . $subjectIri . '> <'
 			. self::LABEL_PREDICATE . '> ?label } }'
 		);
 	}

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/Integration/QuerySparqlEndToEndTestCase.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/Integration/QuerySparqlEndToEndTestCase.php
@@ -21,42 +21,68 @@ use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
 
 /**
- * The headline write+query loop, exercised against a REAL, live QLever store (the `test_qlever`
- * dev-stack service) with REAL HTTP — no mocking on either the write or the read side. A page edit that
- * stores a Subject projects into the store over the SPARQL 1.1 Update endpoint; the new SPARQL query
- * service reads it back over the SPARQL 1.1 Query endpoint. Proves the surfaces this PR adds work
- * end-to-end against a real SPARQL 1.1 store, not just against fakes.
+ * The headline write+query loop, exercised against a REAL, live SPARQL 1.1 store with REAL HTTP — no
+ * mocking on either the write or the read side. A page edit that stores a Subject projects into the
+ * store over the SPARQL 1.1 Update endpoint; the SPARQL query service reads it back over the SPARQL
+ * 1.1 Query endpoint.
  *
  * Two projections of the same wiki sharing one store (#1027) are exercised here too, for the same
  * reason: only a real store shows that their per-page named graphs (#1053) coexist rather than
  * overwrite, and that one query can join across them.
  *
- * Deliberately does NOT skip when the store is unreachable: a missing QLEVER_TEST_URL fails the test
- * with a clear message, and an unreachable store surfaces as a loud query/HTTP failure. A silently
+ * Each subclass names one live store, so the loop runs once per SPARQL engine the development stack
+ * ships — keeping NeoWiki honest about targeting SPARQL 1.1 itself rather than one implementation's
+ * dialect and defaults. Those defaults differ in ways a query can silently come to depend on, most
+ * sharply whether an unscoped query sees the named graphs NeoWiki writes into: SPARQL 1.1 leaves
+ * that to the store — QLever always unions them in, a strict store keeps them out.
+ *
+ * Deliberately does NOT skip when a store is unreachable: an unset store URL fails the test through
+ * {@see requireEnv}, and an unreachable store surfaces as a loud query/HTTP failure. A silently
  * skipped system test would leave the headline deliverable unverified.
  *
- * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryService
- * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Persistence\HttpSparqlQueryEndpoint
- * @covers \ProfessionalWiki\NeoWiki\Application\Rdf\OntologyMappingProjector
- * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Persistence\SparqlProjectionStore
- * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\SparqlPlugin
- * @group Database
+ * Each subclass carries its own `@covers` and `@group Database`; MediaWiki reads the group off the
+ * concrete class alone.
  */
-class QuerySparqlEndToEndTest extends NeoWikiIntegrationTestCase {
+abstract class QuerySparqlEndToEndTestCase extends NeoWikiIntegrationTestCase {
 
 	private const string PAGE_NAME = 'Sparql query system test page';
 	private const string LABEL_PREDICATE = 'http://www.w3.org/2000/01/rdf-schema#label';
 	private const string EDM_PROJECTION = 'EDM';
 	private const string EDM_AGENT_CLASS = 'http://www.europeana.eu/schemas/edm/Agent';
 
-	private string $storeUrl;
+	private string $updateUrl;
+	private string $queryUrl;
 	private ?string $accessToken;
+
+	/**
+	 * The store's SPARQL 1.1 Update endpoint. Read it from the environment through {@see requireEnv},
+	 * so a stack without the store fails the test rather than skipping it.
+	 */
+	abstract protected function storeUpdateUrl(): string;
+
+	/**
+	 * The store's SPARQL 1.1 Query endpoint: the same URL as the update endpoint for a store serving
+	 * both on one path, a different one for a store that splits them.
+	 */
+	abstract protected function storeQueryUrl(): string;
+
+	/**
+	 * The HTTP Bearer token both endpoints are called with, or null for a store without authentication.
+	 */
+	abstract protected function storeAccessToken(): ?string;
+
+	/**
+	 * Whether the store folds its named graphs into the default graph, so that a query without a
+	 * `GRAPH` clause still finds page data. QLever always does; SPARQL 1.1 leaves it to the store.
+	 */
+	abstract protected function storeUnionsNamedGraphsIntoTheDefaultGraph(): bool;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->storeUrl = $this->requireStoreUrl();
-		$this->accessToken = getenv( 'QLEVER_TEST_ACCESS_TOKEN' ) ?: null;
+		$this->updateUrl = $this->storeUpdateUrl();
+		$this->queryUrl = $this->storeQueryUrl();
+		$this->accessToken = $this->storeAccessToken();
 
 		// Replace the integration harness's NullHttpRequestFactory (which blocks all outbound HTTP) with a
 		// real one, so both the projection write path and the query read path reach the live store.
@@ -74,15 +100,36 @@ class QuerySparqlEndToEndTest extends NeoWikiIntegrationTestCase {
 	}
 
 	/**
+	 * Reads a store URL from the environment, failing the test when it is unset rather than
+	 * skipping — see the class docblock for why. The store description goes into the failure
+	 * message, so name the dev-stack service the reader has to bring up.
+	 */
+	protected function requireEnv( string $variable, string $store ): string {
+		$value = getenv( $variable );
+
+		if ( $value === false || trim( $value ) === '' ) {
+			$this->fail(
+				$variable . ' is not set. This SPARQL query system test requires a live ' . $store
+				. ' store. Run it via `make phpunit`, which sets the variable from phpunit.xml.dist and '
+				. 'reaches the store in the dev network. It deliberately fails rather than skips, so the '
+				. 'write+query loop is never silently left unverified.'
+			);
+		}
+
+		return $value;
+	}
+
+	/**
 	 * Points one store entry per projection at the single test store, so the projections are siblings in
-	 * one QLever index — the shape the Docker stacks ship (native + EDM).
+	 * one index — the shape the Docker stacks ship (native + EDM).
 	 */
 	private function configureStoresForProjections( string ...$projections ): void {
 		$this->overrideConfigValue(
 			'NeoWikiSparqlStores',
 			array_map(
 				fn ( string $projection ): array => [
-					'updateUrl' => $this->storeUrl,
+					'updateUrl' => $this->updateUrl,
+					'queryUrl' => $this->queryUrl,
 					'accessToken' => $this->accessToken,
 					'projection' => $projection,
 				],
@@ -119,6 +166,29 @@ class QuerySparqlEndToEndTest extends NeoWikiIntegrationTestCase {
 			[],
 			$this->queryLabelsOf( $subjectId ),
 			'the deleted Subject must no longer be queryable'
+		);
+	}
+
+	/**
+	 * Guards the semantics each subclass's store is chosen for: the pair covers both only while one
+	 * store stays strict and the other lenient. That difference lives entirely in how the services
+	 * are started, and nothing else here would notice it changing.
+	 */
+	public function testUnscopedQueryFindsPageDataOnlyWhereTheStoreUnionsNamedGraphs(): void {
+		$subjectId = TestSubject::uniqueId();
+		$label = 'System test subject ' . uniqid( '', true );
+
+		$this->savePageWithSubjectLabel( $subjectId, $label );
+
+		$this->assertSame(
+			[ $label ],
+			$this->queryLabelsOf( $subjectId ),
+			'the GRAPH-scoped query must find the Subject on any store, or this test proves nothing'
+		);
+		$this->assertSame(
+			$this->storeUnionsNamedGraphsIntoTheDefaultGraph() ? [ $label ] : [],
+			$this->queryLabelsWithoutGraphScopeOf( $subjectId ),
+			'a query without a GRAPH clause reaches the page graphs only on a unioning store'
 		);
 	}
 
@@ -251,14 +321,42 @@ class QuerySparqlEndToEndTest extends NeoWikiIntegrationTestCase {
 	}
 
 	/**
-	 * @return list<string> The rdfs:label literal values bound to the Subject, via the new query service.
+	 * @return list<string> The rdfs:label literal values bound to the Subject, via the query service.
 	 */
 	private function queryLabelsOf( SubjectId $subjectId ): array {
 		$subjectIri = NeoWikiExtension::getInstance()->getRdfNamespaces()->subject( $subjectId )->value;
 
+		// GRAPH-scoped, because NeoWiki writes each page into a named graph and never the default
+		// graph. See queryLabelsWithoutGraphScopeOf() for what dropping the clause costs. DISTINCT
+		// because a Subject saved under several projections carries its label in each of their graphs.
+		return $this->labelsFrom(
+			'SELECT DISTINCT ?label WHERE { GRAPH ?graph { <' . $subjectIri . '> <'
+			. self::LABEL_PREDICATE . '> ?label } }'
+		);
+	}
+
+	/**
+	 * The same lookup written without a `GRAPH` clause, so it matches the default graph only. Under
+	 * SPARQL 1.1 that finds nothing here; a store that unions its named graphs into the default
+	 * graph answers anyway.
+	 *
+	 * @return list<string>
+	 */
+	private function queryLabelsWithoutGraphScopeOf( SubjectId $subjectId ): array {
+		$subjectIri = NeoWikiExtension::getInstance()->getRdfNamespaces()->subject( $subjectId )->value;
+
+		return $this->labelsFrom(
+			'SELECT ?label WHERE { <' . $subjectIri . '> <' . self::LABEL_PREDICATE . '> ?label }'
+		);
+	}
+
+	/**
+	 * @return list<string>
+	 */
+	private function labelsFrom( string $sparql ): array {
 		return array_map(
 			static fn ( array $binding ): string => $binding['label']['value'],
-			$this->runQuery( 'SELECT ?label WHERE { <' . $subjectIri . '> <' . self::LABEL_PREDICATE . '> ?label }' )
+			$this->runQuery( $sparql )
 		);
 	}
 
@@ -285,7 +383,7 @@ class QuerySparqlEndToEndTest extends NeoWikiIntegrationTestCase {
 	private function clearStore(): void {
 		( new HttpSparqlUpdateEndpoint(
 			MediaWikiServices::getInstance()->getHttpRequestFactory(),
-			$this->storeUrl,
+			$this->updateUrl,
 			$this->accessToken,
 		) )->postUpdate( 'DROP ALL' );
 	}
@@ -298,21 +396,6 @@ class QuerySparqlEndToEndTest extends NeoWikiIntegrationTestCase {
 			),
 			LoggerFactory::getInstance( 'http' )
 		);
-	}
-
-	private function requireStoreUrl(): string {
-		$url = getenv( 'QLEVER_TEST_URL' );
-
-		if ( $url === false || trim( $url ) === '' ) {
-			$this->fail(
-				'QLEVER_TEST_URL is not set. This SPARQL query system test requires a live QLever store '
-				. '(the test_qlever dev-stack service). Run it via `make phpunit`, which sets QLEVER_TEST_URL '
-				. 'from phpunit.xml.dist and reaches test_qlever in the dev network. It deliberately fails '
-				. 'rather than skips, so the write+query loop is never silently left unverified.'
-			);
-		}
-
-		return $url;
 	}
 
 }


### PR DESCRIPTION
Adds Oxigraph as a second SPARQL store engine, next to QLever.

[ADR 19](https://github.com/ProfessionalWiki/NeoWiki/blob/master/docs/adr/019-graph-database-architecture.md) claims one SPARQL plugin works across stores. This PR validates that against a second engine with zero `src/` changes — for endpoint shape, auth model, and named-graph semantics. Error surfacing and result-literal serialization stay covered by fakes only, against neither live engine. The diff touches the Docker stacks, CI, docs, tests, `phpunit.xml.dist` and the Makefile.

A store entry is plain config. Oxigraph splits its endpoints, so `queryUrl` must be set explicitly, and it has no authentication (oxigraph/oxigraph#88): deployments must isolate it at the network layer, and the tools overlay and CI bind its host port to loopback only.

```php
$wgNeoWikiSparqlStores = [
	[
		'updateUrl' => 'http://oxigraph:7878/update',
		'queryUrl' => 'http://oxigraph:7878/query',
	],
];
```

What this adds:

* **Two opt-in services.** An `oxigraph` service with `--union-default-graph` (unscoped queries behave as on QLever) sits in `docker-compose.yml` next to `qlever`, behind an `oxigraph` compose profile: nothing points `$wgNeoWikiSparqlStores` at it until you repoint that setting, so neither stack starts it and `COMPOSE_PROFILES=oxigraph make dev` is what does. It lives in that file rather than the dev overlay because `docker-compose.tools.yml`, which maps its host port, works on either stack and cannot map a port for a service the base file lacks. A spec-strict `test_oxigraph` sits in the dev overlay behind the `test` profile next to `test_neo` and `test_qlever`, so violations of strict SPARQL 1.1 semantics surface in tests; `make test-backends` waits for its port the way it waits for `test_qlever`'s. The image is distroless, so neither carries a compose healthcheck. Images track `:latest` like the QLever services; behavior was verified against 0.5.9.
* **CI runs the SPARQL end-to-end tests against both engines.** An engine's test class fails rather than skips when its store is missing, so a missing store cannot silently leave the loop unverified, and a dedicated test pins each store's default-graph semantics (strict store: unscoped queries find nothing; union store: they find page data).
* **The end-to-end label query silently relied on QLever folding named graphs into the default graph**, which the spec does not guarantee, so it is now `GRAPH`-scoped and runs on either engine. The doc and demo examples are deliberately left unscoped: every configuration NeoWiki ships unions named graphs, and a blanket `GRAPH` block would constrain its patterns to a single page and so break cross-page joins — the idiom `docs/rdf/person-to-edm.md` already teaches correctly with one block per graph. [RDF Export](https://github.com/ProfessionalWiki/NeoWiki/blob/master/docs/rdf/rdf-export.md#iri-scheme) gains the named-graph query contract instead, and the Lua and parser-function pages link to it.
* Installation docs gain an Oxigraph section, and its no-authentication note matters because NeoWiki's own `accessToken` setting does nothing on this store. The federation section previously closed with "Other SPARQL stores have equivalent settings" — `oxigraph serve` has five options and none controls `SERVICE`, so that claim was false for any non-QLever store, in a security paragraph. It now states Oxigraph's gap, keeps the pointer for other stores, and names the two controls that remain.

In a live probe of 0.5.9, the write path's multi-operation update request worked as-is, and oxigraph/oxigraph#892's update-size cap did not reproduce (a 1M-triple `INSERT DATA` was accepted).

Left out deliberately: Basic auth for reverse-proxied stores (no known deployment needs it), store-choice guidance (a write-path comparison is in progress), and multi-store query addressing (the read surfaces target the first configured store, as documented).

Behavioural review findings against this branch are in a follow-up PR; the documentation findings are folded in here, since they change how the feature is documented rather than what it does.

Related: #586 (QLever support), #1053 (per-projection named graphs).

> <sub>AI-authored — Claude Code, `Fable 5 (max)` for the change and `Opus 5 (xhigh)` for the rebase onto master and a documentation revision; one-line ask from @JeroenDeDauw executing a prior decision, steered once mid-run, rebase and doc pass asked for by @alistair3149, who twice redirected the scope; diff not yet human-reviewed; both live two-engine integration suites re-run green after every rewrite, phpcs + phpstan clean, 16 compose configurations validated, teardown checked against a live stack, `oxigraph serve --help` checked before the federation claim.</sub>

<details><summary>Production notes</summary>

Original direction, implementation and description by `Fable 5 (max)` with `Opus 5 (max)` subagents; engine facts verified against a live Oxigraph 0.5.9 container.

Rebased onto master by `Opus 5 (xhigh)` after master moved the `qlever` service from the dev overlay into `docker-compose.yml` and reworked `docker-compose.tools.yml` to serve either stack. Four files conflicted. One resolution was a judgment call rather than a merge: the `oxigraph` service moved into `docker-compose.yml` too, because a ports-only entry in the tools overlay makes `docker compose -f docker-compose.yml -f docker-compose.tools.yml` fail outright with `invalid compose project` — verified before choosing, and the profile-gated `caddy` in that same file is the existing precedent.

The documentation was then revised after two blind `Opus 5` reviews, given the artifacts and `docs/AGENTS.md` but not the authoring session. That pass reverted this branch's original propagation of `GRAPH ?g { … }` into the doc and demo examples, on the finding that it narrows the queries rather than making them portable, and moved the named-graph query contract to `docs/rdf/rdf-export.md`, which already owns the graph IRI scheme.

</details>
