### PR TITLE
Add an upgrading guide and a make upgrade target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ help:
 
 # ---- Lifecycle (host only) ---------------------------------------------------
 
-.PHONY: up pull demo dev dev-tools _dev-tools-impl down remove logs ps bash _preflight doctor
+.PHONY: up pull demo upgrade dev dev-tools _dev-tools-impl down remove logs ps bash _preflight doctor
 
 # Fail fast on a broken Docker runtime (Docker or Compose missing, daemon down or
 # denied) before the lifecycle targets do expensive work. Source: Docker/scripts/preflight.sh.
@@ -92,6 +92,15 @@ demo: _preflight ## One-command demo: pull image, start stack, install + seed (i
 	@echo ""
 	@echo "Demo wiki ready at: http://localhost:$$MW_SERVER_PORT"
 	@echo "Log in as AdminName (password: $$MW_ADMIN_PASSWORD)."
+
+upgrade: _preflight ## Upgrade the demo stack: pull the latest image, restart, migrate, rebuild the graph
+	$(DC) pull
+	$(DC) up -d
+	@$(MAKE) --no-print-directory _wait-mw
+	@$(MAKE) --no-print-directory update-dot-php
+	@$(MAKE) --no-print-directory rebuild-graph-databases
+	@echo ""
+	@echo "Upgrade complete: http://localhost:$$MW_SERVER_PORT"
 
 dev: _preflight bootstrap ensure-port ## Bring up dev stack (build image, install, seed, wait for health)
 	@$(MAKE) --no-print-directory _dev-impl

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,7 +44,8 @@ Project Subjects to RDF, natively or mapped onto standard ontologies.
 ## Run NeoWiki
 
 * [Installation](operations/installation.md) — the Docker demo, or adding NeoWiki to an existing MediaWiki
-* [Maintenance](operations/maintenance.md) — rebuilding the graph, upgrades, and current limitations
+* [Upgrading](operations/upgrading.md) — moving either install to the latest NeoWiki
+* [Maintenance](operations/maintenance.md) — rebuilding the graph, Neo4j outage behavior, and backups
 * [Performance](operations/performance.md) — measured write throughput, and how to re-run the measurement
 
 ## Understand the architecture

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,7 +44,7 @@ Project Subjects to RDF, natively or mapped onto standard ontologies.
 ## Run NeoWiki
 
 * [Installation](operations/installation.md) — the Docker demo, or adding NeoWiki to an existing MediaWiki
-* [Upgrading](operations/upgrading.md) — moving either install to the latest NeoWiki
+* [Upgrading](operations/upgrading.md) — moving your wiki to the latest NeoWiki
 * [Maintenance](operations/maintenance.md) — rebuilding the graph, Neo4j outage behavior, and backups
 * [Performance](operations/performance.md) — measured write throughput, and how to re-run the measurement
 

--- a/docs/operations/installation.md
+++ b/docs/operations/installation.md
@@ -3,7 +3,7 @@ title: Installation
 order: 1
 ---
 
-# Installing the NeoWiki Demo
+# Installing NeoWiki
 
 NeoWiki is pre-release software. It is not production ready, and breaking changes can land at any time without a
 migration path. Treat any install as an evaluation or pilot and run it on disposable data.
@@ -29,9 +29,9 @@ Download the `ProfessionalWiki/NeoWiki` repository and run this from its root:
 make demo
 ```
 
-This pulls the latest demo image, starts the stack, installs the wiki, and loads the demo
-data. Later, `make pull` refreshes the image, `make down` stops and removes the containers, and
-`make remove` also deletes the data volumes.
+This pulls the latest demo image, starts the stack, installs the wiki, and loads the demo data. Later, `make down`
+stops and removes the containers, and `make remove` also deletes the data volumes. To move a running stack to the
+latest NeoWiki, see [Upgrading](upgrading.md).
 
 For an empty wiki without the sample data, run `make up && make install-db && make load-neo4j-users` instead.
 

--- a/docs/operations/maintenance.md
+++ b/docs/operations/maintenance.md
@@ -1,11 +1,12 @@
 ---
 title: Maintenance
-order: 2
+order: 3
 ---
 
 # Maintaining NeoWiki
 
-Upkeep tasks for an evaluation NeoWiki instance. For first-time setup, see [installation](installation.md).
+Upkeep tasks for an evaluation NeoWiki instance. For first-time setup, see [installation](installation.md); for
+moving to a newer version, see [upgrading](upgrading.md).
 
 ## Rebuilding the graph
 
@@ -30,20 +31,6 @@ Two things to plan around:
   result, empty the backend before rebuilding: wipe Neo4j's data volume, or drop the wiki's named graphs from the store.
 - It runs as a single sequential process with no batching or resume, so the time scales with the number of pages. Plan
   downtime on large wikis.
-
-## Upgrades
-
-Update the NeoWiki code, then run MediaWiki's standard updater from the root:
-
-```sh
-php maintenance/run.php update --quick
-```
-
-If the new version changes how data is stored in the graph, [rebuild the projection](#rebuilding-the-graph) afterwards.
-
-NeoWiki is pre-release, so a new version can change the canonical revision-slot format with no migration path. Your
-evaluation data may not survive an upgrade, so be ready to recreate it from scratch — a projection rebuild does not
-recover data the new version can no longer read.
 
 ## What happens during a Neo4j outage
 

--- a/docs/operations/performance.md
+++ b/docs/operations/performance.md
@@ -1,6 +1,6 @@
 ---
 title: Performance
-order: 3
+order: 4
 ---
 
 # Performance

--- a/docs/operations/upgrading.md
+++ b/docs/operations/upgrading.md
@@ -5,10 +5,7 @@ order: 2
 
 # Upgrading NeoWiki
 
-NeoWiki has no releases or version numbers yet, so upgrading means moving to the latest development state. For
-first-time setup, see [installation](installation.md). A new version can change the canonical revision-slot format
-with no migration path. Your evaluation data may not survive an upgrade, so be ready to recreate it; a projection
-rebuild does not recover data the new version can no longer read.
+NeoWiki has no releases or version numbers yet, so upgrading means moving to the latest development state.
 
 ## Method A: Docker
 

--- a/docs/operations/upgrading.md
+++ b/docs/operations/upgrading.md
@@ -1,0 +1,55 @@
+---
+title: Upgrading
+order: 2
+---
+
+# Upgrading NeoWiki
+
+NeoWiki has no releases or version numbers yet, so upgrading means moving to the latest development state. For
+first-time setup, see [installation](installation.md). A new version can change the canonical revision-slot format
+with no migration path. Your evaluation data may not survive an upgrade, so be ready to recreate it; a projection
+rebuild does not recover data the new version can no longer read.
+
+## Method A: Docker
+
+Update the copy of the repository the stack runs from: `git pull` in it, or re-download it if you took an archive.
+Keep it at the same path, or `make` targets a different, empty stack and your `Docker/.env` settings are lost. Then,
+from the repository root:
+
+```sh
+make upgrade
+```
+
+This pulls the latest demo image, restarts the stack on it, runs MediaWiki's updater, and
+[rebuilds](maintenance.md#rebuilding-the-graph) every configured backend's projection.
+
+For a stack started with the `server` profile, run `COMPOSE_PROFILES=server make upgrade` instead.
+
+If the new version can no longer read your evaluation data, start fresh with `make remove && make demo`.
+
+### Optional: refresh the demo content
+
+`make import-demo-data` updates the demo pages to the current demo set, the same content as the public demo wiki. It
+overwrites your edits to those pages, which the page history keeps, and leaves pages you created alone.
+
+## Method B: An existing MediaWiki
+
+From the MediaWiki root, update the code, its dependencies, and the frontend bundle:
+
+```sh
+git -C extensions/NeoWiki pull
+composer update
+
+cd extensions/NeoWiki/resources/ext.neowiki
+npm ci && npm run build
+```
+
+Then, back at the MediaWiki root:
+
+```sh
+php maintenance/run.php update --quick
+php maintenance/run.php NeoWiki:RebuildGraphDatabases
+```
+
+[Rebuild](maintenance.md#rebuilding-the-graph) after every upgrade: with no release notes there is no way to tell
+whether the new version changed the projected shape, and rebuilds are quick at evaluation scale.

--- a/docs/operations/upgrading.md
+++ b/docs/operations/upgrading.md
@@ -10,8 +10,8 @@ NeoWiki has no releases or version numbers yet, so upgrading means moving to the
 ## Method A: Docker
 
 Update the copy of the repository the stack runs from: `git pull` in it, or re-download it if you took an archive.
-Keep it at the same path, or `make` targets a different, empty stack and your `Docker/.env` settings are lost. Then,
-from the repository root:
+
+Then, from the repository root:
 
 ```sh
 make upgrade
@@ -27,7 +27,7 @@ If the new version can no longer read your evaluation data, start fresh with `ma
 ### Optional: refresh the demo content
 
 `make import-demo-data` updates the demo pages to the current demo set, the same content as the public demo wiki. It
-overwrites your edits to those pages, which the page history keeps, and leaves pages you created alone.
+overwrites your edits to those pages (still accessible via page history) and leaves pages you created alone.
 
 ## Method B: An existing MediaWiki
 

--- a/docs/operations/upgrading.md
+++ b/docs/operations/upgrading.md
@@ -27,7 +27,8 @@ If the new version can no longer read your evaluation data, start fresh with `ma
 ### Optional: refresh the demo content
 
 `make import-demo-data` updates the demo pages to the current demo set, the same content as the public demo wiki. It
-overwrites your edits to those pages (still accessible via page history) and leaves pages you created alone.
+overwrites your edits to those pages (still accessible via page history) and leaves pages you created alone. Then run
+`make rebuild-graph-databases` so pages that predate the refresh reach every configured store.
 
 ## Upgrading a manual install
 

--- a/docs/operations/upgrading.md
+++ b/docs/operations/upgrading.md
@@ -7,7 +7,7 @@ order: 2
 
 NeoWiki has no releases or version numbers yet, so upgrading means moving to the latest development state.
 
-## Method A: Docker
+## Upgrading a Docker install
 
 Update the copy of the repository the stack runs from: `git pull` in it, or re-download it if you took an archive.
 
@@ -29,7 +29,7 @@ If the new version can no longer read your evaluation data, start fresh with `ma
 `make import-demo-data` updates the demo pages to the current demo set, the same content as the public demo wiki. It
 overwrites your edits to those pages (still accessible via page history) and leaves pages you created alone.
 
-## Method B: An existing MediaWiki
+## Upgrading a manual install
 
 From the MediaWiki root, update the code, its dependencies, and the frontend bundle:
 


### PR DESCRIPTION
Nothing documented moving an install to a newer NeoWiki: the demo stack had no update path at all, and the Upgrades
section under Maintenance covered neither the Docker stack nor the Composer and frontend-bundle steps of a manual
install.

* New docs/operations/upgrading.md, covering the Docker stack and the manual install; replaces the Upgrades
  section of maintenance.md.
* New `make upgrade` for the demo stack: pull the latest image, restart, run the updater, rebuild every configured
  backend's projection. Exercised end to end (make demo, then make upgrade: updater and rebuild clean, all 77 demo
  pages reprojected, graph queryable), including COMPOSE_PROFILES=server passthrough for server-profile stacks.
* Installation: H1 "Installing the NeoWiki Demo" becomes "Installing NeoWiki" (Method B adds NeoWiki to an existing
  wiki, not the demo), and the demo section now points at the upgrading guide.
* docs README: Upgrading entry added; the Maintenance blurb now names that page's actual sections.

Considered, omitted: Docker/.env.dist drift on upgrade; dev-environment and worktree upgrades (the GitHub README's
audience); why the demo stack lacks a SPARQL store and the SPARQL demo-page import gating; base-image bumps that
docker compose pull may bring; decomposing make upgrade into its underlying targets; a post-upgrade verify link;
naming that the demo-content refresh deletes demo pages dropped from the set.

> <sub>AI-authored — Claude Code, `Fable 5 (max)`; chat directive from @JeroenDeDauw (dedicated upgrade page suspected, holistic operations-docs review requested), no revisions; diff not yet human-reviewed; make demo then make upgrade run end to end on the demo stack, links and anchors of every changed file checked.</sub>

<details><summary>Production notes</summary>

Guide prose drafted by an `Opus 5 (max)` subagent via the writing skill (fresh-context blind judge included) and
reviewed by a second `Opus 5 (max)` subagent via the text-review skill; the make target, the sibling-page edits, and
final judgment by `Fable 5 (max)`. The end-to-end run used a scratch clone under rootless Podman.

</details>

