### PR TITLE
Run the QLever SPARQL store in the demo stack

### DIFF
--- a/Docker/.env.dist
+++ b/Docker/.env.dist
@@ -19,9 +19,10 @@ NEO4J_USERNAME_READ=mediawiki_read
 # Change for production
 NEO4J_PASSWORD_READ=mediawiki_read
 
-# Access token for the dev QLever SPARQL store (docker-compose.dev.yml). The wiki sends
-# it as an HTTP Bearer token to authorize SPARQL updates; the qlever server starts with
-# the same value via -a. Dev-only credential.
+# Access token for the stack's QLever SPARQL store. The wiki sends it as an HTTP Bearer
+# token to authorize SPARQL updates; the qlever server starts with the same value via -a.
+# Anyone holding it can write to and reconfigure the store.
+# Change for production
 QLEVER_ACCESS_TOKEN=neowiki_dev_token
 
 # Change for production: https://your-domain.com

--- a/Docker/.env.dist
+++ b/Docker/.env.dist
@@ -19,7 +19,8 @@ NEO4J_USERNAME_READ=mediawiki_read
 # Change for production
 NEO4J_PASSWORD_READ=mediawiki_read
 
-# Access token for the stack's QLever SPARQL store. The wiki sends it as an HTTP Bearer
+# Access token for the stack's QLever SPARQL store, overriding the default that
+# docker-compose.yml gives both the wiki and the server. The wiki sends it as an HTTP Bearer
 # token to authorize SPARQL updates; the qlever server starts with the same value via -a.
 # Anyone holding it can write to and reconfigure the store.
 # Change for production

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -29,7 +29,7 @@ are already bound on the host. The demo stack allocates nothing: it uses the val
 | `QLEVER_PORT`      | (see below) | 7019    | QLever SPARQL endpoint (opt-in) |
 
 Neo4j and QLever ports are only exposed to the host by the `Docker/docker-compose.tools.yml`
-overlay, which works with either stack and which `make dev-tools` adds to the dev stack. They use
+overlay, which works with either stack; `make dev-tools` adds it to the dev stack. They use
 conventional defaults (7474, 7687, 7019) and are not auto-allocated, so the overlay is best used
 with one stack at a time. Override `NEO_BROWSER_PORT` / `NEO_BOLT_PORT` / `QLEVER_PORT` if you
 need to run two tools-mode stacks simultaneously.
@@ -41,8 +41,8 @@ from inside the stack via `make bash` or `docker compose exec`.
 
 Both the demo stack and the dev stack bundle a [QLever](https://github.com/ad-freiburg/qlever)
 SPARQL 1.1 graph store as a working example of NeoWiki's SPARQL projection plugin (issue #586). The
-service is defined in `docker-compose.yml`, which both stacks build on, and which passes the wiki
-the store's endpoint as `QLEVER_URL`. `SettingsTemplate.php` points `$wgNeoWikiSparqlStores` at that
+service is defined in `docker-compose.yml`, which both stacks build on, and which passes the store's
+endpoint to the wiki as `QLEVER_URL`. `SettingsTemplate.php` points `$wgNeoWikiSparqlStores` at that
 endpoint, so every page save and `RebuildGraphDatabases.php` also projects the page's RDF into
 QLever as named graphs.
 
@@ -113,7 +113,7 @@ report the backends as missing instead of starting them.
   `LocalSettings.php`), and `dev-mw` (the dev image with mounted NeoWiki source).
 - `docker-compose.yml` — the demo stack's services (`mediawiki`, `db`, `neo`, `qlever`
   — SPARQL store, see above) plus the profile-gated `caddy` (the `server` profile, for
-  HTTPS hosting). The dev overlay builds on this file, so its services are in both stacks.
+  HTTPS hosting). The dev overlay builds on this file, so these services are in both stacks.
 - `docker-compose.dev.yml` — dev overlay; switches `mediawiki` to the dev image,
   bind-mounts the NeoWiki source, sets `MW_MODE=dev`, and adds the dev-only sidecars
   `node` and `mailcatcher`, plus `test_neo` and `test_qlever` behind the `test` profile.

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -36,14 +36,14 @@ need to run two tools-mode worktrees simultaneously.
 The MariaDB, (default) Neo4j and QLever ports are not exposed to the host. Reach them
 from inside the stack via `make bash` or `docker compose exec`.
 
-## QLever SPARQL store (dev)
+## QLever SPARQL store
 
-The dev stack bundles a [QLever](https://github.com/ad-freiburg/qlever) SPARQL 1.1 graph
-store as a working example of NeoWiki's SPARQL projection plugin (issue #586). It is a
-dev-only sidecar (in `docker-compose.dev.yml`); the base "try-it-out" / demo stack does not
-run it. `SettingsTemplate.php` points `$wgNeoWikiSparqlStores` at it (`http://qlever:7019/`)
-only in dev mode, so every page save and `RebuildGraphDatabases.php` also projects the page's
-RDF into QLever as named graphs.
+The stack bundles a [QLever](https://github.com/ad-freiburg/qlever) SPARQL 1.1 graph store as a
+working example of NeoWiki's SPARQL projection plugin (issue #586). It is a base-stack service (in
+`docker-compose.yml`), so both the "try-it-out" / demo stack and the dev stack run it.
+`SettingsTemplate.php` points `$wgNeoWikiSparqlStores` at it (`http://qlever:7019/`) whenever
+`QLEVER_ACCESS_TOKEN` is set — which is what running inside these stacks means — so every page save
+and `RebuildGraphDatabases.php` also projects the page's RDF into QLever as named graphs.
 
 Two entries point at that one endpoint: the `native` projection and the `EDM` one defined
 by the demo data's `Mapping:EDM` page. Each writes its own per-page named graphs, so one
@@ -80,11 +80,11 @@ Without the tools overlay, run the same query from inside the stack, e.g.
 ### `test_qlever` (SPARQL query system test)
 
 A second, dedicated QLever store — `test_qlever` — backs the SPARQL query system test
-(`QuerySparqlEndToEndTest`), isolated from the demo `qlever` store the way `test_neo` is
-isolated from `neo`: the test writes and deletes Subjects, so it must not touch the demo
+(`QuerySparqlEndToEndTest`), isolated from the `qlever` store the way `test_neo` is
+isolated from `neo`: the test writes and deletes Subjects, so it must not touch the wiki's
 data. `phpunit.xml.dist` points the test at it via `QLEVER_TEST_URL=http://test_qlever:7019/`
 (fixed token `neowiki_test_token`); it is reached in-network only, with no host port. Unlike
-the demo store it runs **without** `--persist-updates`: it is ephemeral test scaffolding that
+the `qlever` store it runs **without** `--persist-updates`: it is ephemeral test scaffolding that
 each run clears (`DROP ALL`), so keeping updates in memory is enough. `make phpunit` brings it
 up on demand via the `test` profile; in CI it is started explicitly (see
 `.github/workflows/ci-php.yml`), because its multi-step bring-up cannot be expressed as a
@@ -105,12 +105,12 @@ report the backends as missing instead of starting them.
   production `php.ini`; intermediate, no `LocalSettings.php`), `final-mw` (the prebuilt
   demo image published as `ghcr.io/professionalwiki/neowiki:latest`, which bakes in
   `LocalSettings.php`), and `dev-mw` (the dev image with mounted NeoWiki source).
-- `docker-compose.yml` — base "try-it-out" services (`mediawiki`, `db`, `neo`) plus
-  the profile-gated `caddy` (the `server` profile, for HTTPS hosting).
+- `docker-compose.yml` — base "try-it-out" services (`mediawiki`, `db`, `neo`, `qlever`
+  — SPARQL store, see above) plus the profile-gated `caddy` (the `server` profile, for
+  HTTPS hosting).
 - `docker-compose.dev.yml` — dev overlay; switches `mediawiki` to the dev image,
   bind-mounts the NeoWiki source, sets `MW_MODE=dev`, and adds the dev-only sidecars
-  `qlever` (SPARQL store, see above), `node`, and `mailcatcher`, plus `test_neo` and
-  `test_qlever` behind the `test` profile.
+  `node` and `mailcatcher`, plus `test_neo` and `test_qlever` behind the `test` profile.
 - `docker-compose.tools.yml` — opt-in overlay that exposes Neo4j and QLever to the host.
 - `SettingsTemplate.php` — `LocalSettings.php` that branches on `MW_MODE`.
 - `.env.dist` — tracked defaults; auto-copied to `.env` on first `make dev`.

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -17,7 +17,8 @@ This file is a reference for the `Docker/` directory itself. For instructions:
 ## Reserved host ports
 
 `make dev` allocates host ports from these ranges. Auto-allocation skips ports that
-are already bound on the host.
+are already bound on the host. The demo stack allocates nothing: it uses the values in
+`Docker/.env` as they stand.
 
 | Variable           | Range       | Default | Service                    |
 |--------------------|-------------|---------|----------------------------|
@@ -27,23 +28,23 @@ are already bound on the host.
 | `NEO_BOLT_PORT`    | (see below) | 7687    | Neo4j Bolt endpoint (opt-in) |
 | `QLEVER_PORT`      | (see below) | 7019    | QLever SPARQL endpoint (opt-in) |
 
-Neo4j and QLever ports are only exposed to the host when you run `make dev-tools` (which
-adds the `Docker/docker-compose.tools.yml` overlay). They use conventional defaults
-(7474, 7687, 7019) and are not auto-allocated, so `make dev-tools` is best used with one
-worktree at a time. Override `NEO_BROWSER_PORT` / `NEO_BOLT_PORT` / `QLEVER_PORT` if you
-need to run two tools-mode worktrees simultaneously.
+Neo4j and QLever ports are only exposed to the host by the `Docker/docker-compose.tools.yml`
+overlay, which works with either stack and which `make dev-tools` adds to the dev stack. They use
+conventional defaults (7474, 7687, 7019) and are not auto-allocated, so the overlay is best used
+with one stack at a time. Override `NEO_BROWSER_PORT` / `NEO_BOLT_PORT` / `QLEVER_PORT` if you
+need to run two tools-mode stacks simultaneously.
 
 The MariaDB, (default) Neo4j and QLever ports are not exposed to the host. Reach them
 from inside the stack via `make bash` or `docker compose exec`.
 
 ## QLever SPARQL store
 
-The stack bundles a [QLever](https://github.com/ad-freiburg/qlever) SPARQL 1.1 graph store as a
-working example of NeoWiki's SPARQL projection plugin (issue #586). It is a base-stack service (in
-`docker-compose.yml`), so both the "try-it-out" / demo stack and the dev stack run it.
-`SettingsTemplate.php` points `$wgNeoWikiSparqlStores` at it (`http://qlever:7019/`) whenever
-`QLEVER_ACCESS_TOKEN` is set — which is what running inside these stacks means — so every page save
-and `RebuildGraphDatabases.php` also projects the page's RDF into QLever as named graphs.
+Both the demo stack and the dev stack bundle a [QLever](https://github.com/ad-freiburg/qlever)
+SPARQL 1.1 graph store as a working example of NeoWiki's SPARQL projection plugin (issue #586). The
+service is defined in `docker-compose.yml`, which both stacks build on, and which passes the wiki
+the store's endpoint as `QLEVER_URL`. `SettingsTemplate.php` points `$wgNeoWikiSparqlStores` at that
+endpoint, so every page save and `RebuildGraphDatabases.php` also projects the page's RDF into
+QLever as named graphs.
 
 Two entries point at that one endpoint: the `native` projection and the `EDM` one defined
 by the demo data's `Mapping:EDM` page. Each writes its own per-page named graphs, so one
@@ -64,10 +65,14 @@ and wipes the updates); NeoWiki fills it at runtime over the SPARQL endpoint, no
 source file. A named volume (not a bind mount) keeps the index clear of host SELinux
 labeling and ownership issues under rootless Podman.
 
-To query it from the host, expose the endpoint with `make dev-tools` (or add the
-`docker-compose.tools.yml` overlay), which maps `QLEVER_PORT` (default 7019):
+To query it from the host, add the `docker-compose.tools.yml` overlay, which maps `QLEVER_PORT`
+(default 7019) — on the dev stack `make dev-tools` does that for you:
 
 ```sh
+# <project> is this stack's compose project name, which `docker compose ls` lists.
+docker compose -p <project> --env-file Docker/.env \
+  -f Docker/docker-compose.yml -f Docker/docker-compose.tools.yml up -d
+
 curl http://localhost:7019/ \
   --data-urlencode 'query=SELECT (COUNT(*) AS ?n) WHERE { GRAPH ?g { ?s ?p ?o } }' \
   -H 'Accept: application/sparql-results+json'
@@ -75,7 +80,8 @@ curl http://localhost:7019/ \
 
 Without the tools overlay, run the same query from inside the stack, e.g.
 `docker compose exec qlever curl ...` or from the `mediawiki` container against
-`http://qlever:7019/`. Writes require the `QLEVER_ACCESS_TOKEN` Bearer token; reads do not.
+`http://qlever:7019/`. The wiki's own query surfaces reach it either way. Writes require the
+`QLEVER_ACCESS_TOKEN` Bearer token; reads do not.
 
 ### `test_qlever` (SPARQL query system test)
 
@@ -105,13 +111,14 @@ report the backends as missing instead of starting them.
   production `php.ini`; intermediate, no `LocalSettings.php`), `final-mw` (the prebuilt
   demo image published as `ghcr.io/professionalwiki/neowiki:latest`, which bakes in
   `LocalSettings.php`), and `dev-mw` (the dev image with mounted NeoWiki source).
-- `docker-compose.yml` — base "try-it-out" services (`mediawiki`, `db`, `neo`, `qlever`
+- `docker-compose.yml` — the demo stack's services (`mediawiki`, `db`, `neo`, `qlever`
   — SPARQL store, see above) plus the profile-gated `caddy` (the `server` profile, for
-  HTTPS hosting).
+  HTTPS hosting). The dev overlay builds on this file, so its services are in both stacks.
 - `docker-compose.dev.yml` — dev overlay; switches `mediawiki` to the dev image,
   bind-mounts the NeoWiki source, sets `MW_MODE=dev`, and adds the dev-only sidecars
   `node` and `mailcatcher`, plus `test_neo` and `test_qlever` behind the `test` profile.
-- `docker-compose.tools.yml` — opt-in overlay that exposes Neo4j and QLever to the host.
+- `docker-compose.tools.yml` — opt-in overlay that exposes Neo4j and QLever to the host,
+  usable with either stack.
 - `SettingsTemplate.php` — `LocalSettings.php` that branches on `MW_MODE`.
 - `.env.dist` — tracked defaults; auto-copied to `.env` on first `make dev`.
 - `scripts/set-port.sh` — host port allocator used by `make dev`.

--- a/Docker/SettingsTemplate.php
+++ b/Docker/SettingsTemplate.php
@@ -225,17 +225,19 @@ $wgNeoWikiEnableDevelopmentUI = true;
 $wgNeoWikiNeo4jInternalWriteUrl = 'bolt://' . getenv( 'NEO4J_USERNAME' ) . ':' . getenv( 'NEO4J_PASSWORD' ) . '@neo:7687';
 $wgNeoWikiNeo4jInternalReadUrl = 'bolt://' . getenv( 'NEO4J_USERNAME_READ' ) . ':' . getenv( 'NEO4J_PASSWORD_READ' ) . '@neo:7687';
 
-// SPARQL graph store (QLever) for the SPARQL projection plugin (#586). Configured only in the dev
-// stack: the qlever service lives in docker-compose.dev.yml, so the production/demo image (which runs
-// this same file in production mode) never references a non-existent service. Skipped under PHPUnit so
-// integration tests never post updates to the dev QLever — they configure their own store with mocked
-// HTTP via overrideConfigValue(), so the default here must stay empty during tests.
+// SPARQL graph store (QLever) for the SPARQL projection plugin (#586). Configured in every mode, so
+// the demo stack has the same SPARQL surface as the dev stack — both run the qlever service from
+// docker-compose.yml. The gate is the QLever access token rather than the mode: it is set by the
+// compose stacks that run a qlever service, so an image started outside them gets no store instead of
+// a configuration pointing at a host that does not exist. Skipped under PHPUnit so integration tests
+// never post updates to this store — they configure their own with mocked HTTP via
+// overrideConfigValue(), so the default here must stay empty during tests.
 //
 // Two entries, one endpoint: the native projection and the EDM projection of the demo data's
 // Mapping:EDM page are kept in the same QLever index as sibling projections. Each lands in its own
 // family of per-page named graphs (#1053), so neither overwrites the other. The query surfaces
 // target the first entry's endpoint, which both entries share, so a query reaches both projections.
-if ( $mwIsDev && !defined( 'MW_PHPUNIT_TEST' ) ) {
+if ( getenv( 'QLEVER_ACCESS_TOKEN' ) !== false && !defined( 'MW_PHPUNIT_TEST' ) ) {
 	$wgNeoWikiSparqlStores = [
 		[
 			'updateUrl' => 'http://qlever:7019/',

--- a/Docker/SettingsTemplate.php
+++ b/Docker/SettingsTemplate.php
@@ -226,26 +226,30 @@ $wgNeoWikiNeo4jInternalWriteUrl = 'bolt://' . getenv( 'NEO4J_USERNAME' ) . ':' .
 $wgNeoWikiNeo4jInternalReadUrl = 'bolt://' . getenv( 'NEO4J_USERNAME_READ' ) . ':' . getenv( 'NEO4J_PASSWORD_READ' ) . '@neo:7687';
 
 // SPARQL graph store (QLever) for the SPARQL projection plugin (#586). Configured in every mode, so
-// the demo stack has the same SPARQL surface as the dev stack — both run the qlever service from
-// docker-compose.yml. The gate is the QLever access token rather than the mode: it is set by the
-// compose stacks that run a qlever service, so an image started outside them gets no store instead of
-// a configuration pointing at a host that does not exist. Skipped under PHPUnit so integration tests
-// never post updates to this store — they configure their own with mocked HTTP via
-// overrideConfigValue(), so the default here must stay empty during tests.
+// the demo stack has the same SPARQL surface as the dev stack — both run the qlever service defined
+// in docker-compose.yml, and that file is what supplies the endpoint below. The endpoint is therefore
+// the gate: an image started outside those stacks gets no store rather than a configuration pointing
+// at a host that does not exist, and so does CI, whose docker-compose.ci.yml replaces that file and
+// sets neither variable. The access token is an ordinary optional credential, defaulted in the compose
+// file so a Docker/.env written before it existed still yields a working store. Skipped under PHPUnit
+// so integration tests never post updates here — they configure their own stores with mocked HTTP via
+// overrideConfigValue(), so the default must stay empty during tests.
 //
 // Two entries, one endpoint: the native projection and the EDM projection of the demo data's
 // Mapping:EDM page are kept in the same QLever index as sibling projections. Each lands in its own
 // family of per-page named graphs (#1053), so neither overwrites the other. The query surfaces
 // target the first entry's endpoint, which both entries share, so a query reaches both projections.
-if ( getenv( 'QLEVER_ACCESS_TOKEN' ) !== false && !defined( 'MW_PHPUNIT_TEST' ) ) {
+$qleverUrl = getenv( 'QLEVER_URL' );
+
+if ( $qleverUrl !== false && !defined( 'MW_PHPUNIT_TEST' ) ) {
 	$wgNeoWikiSparqlStores = [
 		[
-			'updateUrl' => 'http://qlever:7019/',
+			'updateUrl' => $qleverUrl,
 			'accessToken' => getenv( 'QLEVER_ACCESS_TOKEN' ) ?: null,
 			'projection' => 'native',
 		],
 		[
-			'updateUrl' => 'http://qlever:7019/',
+			'updateUrl' => $qleverUrl,
 			'accessToken' => getenv( 'QLEVER_ACCESS_TOKEN' ) ?: null,
 			'projection' => 'EDM',
 		],

--- a/Docker/docker-compose.dev.yml
+++ b/Docker/docker-compose.dev.yml
@@ -9,10 +9,6 @@ services:
     mem_limit: 2g
     environment:
       - MW_MODE=dev
-      # Bearer token the wiki sends to authorize writes to the dev QLever SPARQL store
-      # (see the qlever service below and SettingsTemplate.php's $wgNeoWikiSparqlStores).
-      # Sourced from Docker/.env.
-      - QLEVER_ACCESS_TOKEN
     volumes:
       - mediawiki-images-data:/var/www/html/w/images
       # NeoWiki source bind-mount (the worktree).
@@ -88,70 +84,9 @@ services:
       timeout: 1s
       retries: 10
 
-  # SPARQL 1.1 graph store (QLever) for the SPARQL projection plugin (#586). Dev-only: the
-  # base "try-it-out"/demo stack does not use it — that stack runs the prebuilt image in
-  # production mode, where SettingsTemplate.php configures no SPARQL store. NeoWiki reaches this in-network as http://qlever:7019/; a host port for manual
-  # inspection is opt-in via docker-compose.tools.yml.
-  qlever:
-    image: docker.io/adfreiburg/qlever:latest
-    restart: unless-stopped
-    # Above QLever's own -m 1G query budget (server command below) plus index overhead.
-    mem_limit: 1536m
-    # The image's default entrypoint is an interactive CLI wrapper; bypass it and drive
-    # the engine binaries (qlever-index / qlever-server) directly.
-    entrypoint:
-      - /bin/bash
-      - -lc
-      - |
-        set -e
-        # The image runs as the non-root "qlever" user, but on rootful Docker the qlever-index-data
-        # volume mounts empty and root-owned (the image ships no /index for Docker to copy ownership
-        # from), so qlever cannot write the index or persisted updates. Take ownership via the image's
-        # sudo grant. Rootless Podman already makes the fresh volume qlever-owned, so this is a no-op.
-        sudo chown qlever:qlever /index
-        cd /index
-        # Build an empty index once. The sentinel keeps a container restart from
-        # re-indexing, which would wipe the persisted SPARQL updates. NeoWiki fills the
-        # store at runtime over the SPARQL 1.1 Update endpoint (page edits and
-        # RebuildGraphDatabases.php), not from a source file.
-        if [ ! -f .neowiki-indexed ]; then
-          : > data.nt
-          qlever-index -i neowiki -F nt -f data.nt
-          touch .neowiki-indexed
-        fi
-        # --persist-updates is mandatory: without it every SPARQL update is lost on
-        # restart. With it, updates persist to neowiki.update-triples on the named volume
-        # and are reloaded on startup.
-        # --service-allowed-iri-prefixes disables SPARQL federation. NeoWiki's query surfaces
-        # let wiki users send arbitrary SPARQL, and SERVICE makes the store issue outbound
-        # requests from its own network position — here, inside the compose network. QLever
-        # allows every IRI when the option is omitted, so this sets the documented deny-all
-        # value: an invalid prefix ("-") that no IRI can match. Drop or narrow it only if you
-        # actually want federation, and then list real prefixes rather than removing the flag.
-        # Keep it last: it takes an arbitrary number of prefixes, so a bare value placed
-        # after it would be read as another prefix.
-        exec qlever-server -i neowiki -p 7019 -a "$$QLEVER_ACCESS_TOKEN" -m 1G --persist-updates --service-allowed-iri-prefixes -
-    environment:
-      - QLEVER_ACCESS_TOKEN
-    volumes:
-      # Named volume (not a bind mount) so the index directory avoids host SELinux
-      # labeling / ownership issues under rootless Podman, and so the index plus its
-      # persisted updates survive container restarts.
-      - qlever-index-data:/index
-    # qlever-server ignores SIGTERM/SIGINT, so a short grace period keeps `make down`
-    # snappy. Safe: updates are persisted at acknowledgement time, so the kill loses none.
-    stop_grace_period: 2s
-    healthcheck:
-      # Minimal SPARQL query over the endpoint via GET (URL-encoded, so no shell quoting):
-      # SELECT * WHERE { ?s ?p ?o } LIMIT 1. Returns 200 once the server is serving.
-      test: ["CMD", "curl", "-fsS", "-o", "/dev/null", "http://localhost:7019/?query=SELECT%20%2A%20WHERE%20%7B%20%3Fs%20%3Fp%20%3Fo%20%7D%20LIMIT%201"]
-      interval: 5s
-      timeout: 5s
-      retries: 20
-
-  # Dedicated QLever store for the SPARQL query system test, isolated from the demo `qlever` service
-  # above the way `test_neo` is isolated from `neo`: the system test writes and deletes Subjects, so it
-  # must not mutate the demo data. It reaches this in-network as http://test_qlever:7019/ (see
+  # Dedicated QLever store for the SPARQL query system test, isolated from the `qlever` service in
+  # docker-compose.yml the way `test_neo` is isolated from `neo`: the system test writes and deletes
+  # Subjects, so it must not mutate the wiki's data. It reaches this in-network as http://test_qlever:7019/ (see
   # QLEVER_TEST_URL in phpunit.xml.dist); no host port is exposed. Behind the `test` profile,
   # like `test_neo`.
   test_qlever:
@@ -159,7 +94,7 @@ services:
       - test
     image: docker.io/adfreiburg/qlever:latest
     restart: unless-stopped
-    # Same ceiling as qlever.
+    # Same ceiling as the `qlever` service in docker-compose.yml.
     mem_limit: 1536m
     # Fixed access token (intentional, like test_neo's fixed password): the test suite uses this exact
     # value to authorize its updates. Do not parameterize without updating phpunit.xml.dist.
@@ -170,14 +105,14 @@ services:
       - -lc
       - |
         set -e
-        # Same rootful-Docker ownership fix as the demo `qlever` service above: the image runs as
+        # Same rootful-Docker ownership fix as the `qlever` service in docker-compose.yml: the image runs as
         # non-root "qlever" and Docker mounts test-qlever-index-data root-owned, so take ownership via
         # the image's sudo grant. A no-op under rootless Podman.
         sudo chown qlever:qlever /index
         cd /index
         # Build an empty index once; the sentinel keeps a container restart from re-indexing (which
         # would error on the existing index). NeoWiki fills the store at runtime over the SPARQL 1.1
-        # Update endpoint. Unlike the demo `qlever` service, --persist-updates is deliberately omitted:
+        # Update endpoint. Unlike the `qlever` service, --persist-updates is deliberately omitted:
         # this store is ephemeral test scaffolding — each test run clears it (DROP ALL) and never relies
         # on updates surviving a restart — so keeping updates in memory is simpler and lighter.
         if [ ! -f .neowiki-indexed ]; then
@@ -185,8 +120,8 @@ services:
           qlever-index -i neowiki -F nt -f data.nt
           touch .neowiki-indexed
         fi
-        # --service-allowed-iri-prefixes disables SPARQL federation, as on the demo `qlever`
-        # service above; see the comment there. No test federates, so deny-all is also what
+        # --service-allowed-iri-prefixes disables SPARQL federation, as on the `qlever` service
+        # in docker-compose.yml; see the comment there. No test federates, so deny-all is also what
         # the system test should run against.
         exec qlever-server -i neowiki -p 7019 -a "$$QLEVER_ACCESS_TOKEN" -m 1G --service-allowed-iri-prefixes -
     volumes:
@@ -229,5 +164,4 @@ services:
 
 volumes:
   test-neo4j-data:
-  qlever-index-data:
   test-qlever-index-data:

--- a/Docker/docker-compose.tools.yml
+++ b/Docker/docker-compose.tools.yml
@@ -1,17 +1,17 @@
 services:
-  # Opt-in port exposure for graph inspection tools. Activate by including this
-  # overlay alongside the dev overlay, or by running `make dev-tools` from the
-  # extension root.
+  # Opt-in port exposure for graph inspection tools. Both services it touches come from
+  # docker-compose.yml, so this overlay works on the demo stack as well as the dev stack;
+  # `make dev-tools` from the extension root adds it to the latter.
   #
   # Default ports (7474, 7687, 7019) are the Neo4j and QLever conventions and are not
-  # auto-allocated, so run the tools overlay with one worktree at a time. Override via
+  # auto-allocated, so run the tools overlay with one stack at a time. Override via
   # env (NEO_BROWSER_PORT / NEO_BOLT_PORT / QLEVER_PORT) to run several simultaneously.
   neo:
     ports:
       - "${NEO_BROWSER_PORT:-7474}:7474"
       - "${NEO_BOLT_PORT:-7687}:7687"
 
-  # Exposes the dev QLever SPARQL endpoint on the host for manual querying, e.g.
+  # Exposes the stack's QLever SPARQL endpoint on the host for manual querying, e.g.
   #   curl http://localhost:7019/ --data-urlencode 'query=SELECT (COUNT(*) AS ?n) WHERE { GRAPH ?g { ?s ?p ?o } }' -H 'Accept: application/sparql-results+json'
   qlever:
     ports:

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -21,6 +21,10 @@ services:
       - NEO4J_PASSWORD
       - NEO4J_USERNAME_READ
       - NEO4J_PASSWORD_READ
+      # Bearer token the wiki sends to authorize writes to the QLever SPARQL store
+      # (see the qlever service below and SettingsTemplate.php's $wgNeoWikiSparqlStores).
+      # Sourced from Docker/.env.
+      - QLEVER_ACCESS_TOKEN
     healthcheck:
       test: "curl -fs http://localhost:80/wiki/Special:Version | grep -q 'Jeroen De Dauw'"
       interval: 60s
@@ -61,6 +65,70 @@ services:
       timeout: 1s
       retries: 10
 
+  # SPARQL 1.1 graph store (QLever) for the SPARQL projection plugin (#586). Part of the base
+  # stack, so the demo wiki gets the same RDF/SPARQL surface as the dev stack: every page save
+  # and RebuildGraphDatabases.php also projects the page's RDF here as named graphs, and the
+  # query surfaces read from it. SettingsTemplate.php configures $wgNeoWikiSparqlStores when
+  # QLEVER_ACCESS_TOKEN is set, which is what running inside this stack signals. NeoWiki reaches
+  # it in-network as http://qlever:7019/; a host port for manual inspection is opt-in via
+  # docker-compose.tools.yml.
+  qlever:
+    image: docker.io/adfreiburg/qlever:latest
+    restart: unless-stopped
+    # Above QLever's own -m 1G query budget (server command below) plus index overhead.
+    mem_limit: 1536m
+    # The image's default entrypoint is an interactive CLI wrapper; bypass it and drive
+    # the engine binaries (qlever-index / qlever-server) directly.
+    entrypoint:
+      - /bin/bash
+      - -lc
+      - |
+        set -e
+        # The image runs as the non-root "qlever" user, but on rootful Docker the qlever-index-data
+        # volume mounts empty and root-owned (the image ships no /index for Docker to copy ownership
+        # from), so qlever cannot write the index or persisted updates. Take ownership via the image's
+        # sudo grant. Rootless Podman already makes the fresh volume qlever-owned, so this is a no-op.
+        sudo chown qlever:qlever /index
+        cd /index
+        # Build an empty index once. The sentinel keeps a container restart from
+        # re-indexing, which would wipe the persisted SPARQL updates. NeoWiki fills the
+        # store at runtime over the SPARQL 1.1 Update endpoint (page edits and
+        # RebuildGraphDatabases.php), not from a source file.
+        if [ ! -f .neowiki-indexed ]; then
+          : > data.nt
+          qlever-index -i neowiki -F nt -f data.nt
+          touch .neowiki-indexed
+        fi
+        # --persist-updates is mandatory: without it every SPARQL update is lost on
+        # restart. With it, updates persist to neowiki.update-triples on the named volume
+        # and are reloaded on startup.
+        # --service-allowed-iri-prefixes disables SPARQL federation. NeoWiki's query surfaces
+        # let wiki users send arbitrary SPARQL, and SERVICE makes the store issue outbound
+        # requests from its own network position — here, inside the compose network. QLever
+        # allows every IRI when the option is omitted, so this sets the documented deny-all
+        # value: an invalid prefix ("-") that no IRI can match. Drop or narrow it only if you
+        # actually want federation, and then list real prefixes rather than removing the flag.
+        # Keep it last: it takes an arbitrary number of prefixes, so a bare value placed
+        # after it would be read as another prefix.
+        exec qlever-server -i neowiki -p 7019 -a "$$QLEVER_ACCESS_TOKEN" -m 1G --persist-updates --service-allowed-iri-prefixes -
+    environment:
+      - QLEVER_ACCESS_TOKEN
+    volumes:
+      # Named volume (not a bind mount) so the index directory avoids host SELinux
+      # labeling / ownership issues under rootless Podman, and so the index plus its
+      # persisted updates survive container restarts.
+      - qlever-index-data:/index
+    # qlever-server ignores SIGTERM/SIGINT, so a short grace period keeps `make down`
+    # snappy. Safe: updates are persisted at acknowledgement time, so the kill loses none.
+    stop_grace_period: 2s
+    healthcheck:
+      # Minimal SPARQL query over the endpoint via GET (URL-encoded, so no shell quoting):
+      # SELECT * WHERE { ?s ?p ?o } LIMIT 1. Returns 200 once the server is serving.
+      test: ["CMD", "curl", "-fsS", "-o", "/dev/null", "http://localhost:7019/?query=SELECT%20%2A%20WHERE%20%7B%20%3Fs%20%3Fp%20%3Fo%20%7D%20LIMIT%201"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
   # The dev-only sidecars (test_neo, node, mailcatcher) live in
   # docker-compose.dev.yml, not here, so `make up` stays minimal and `make down`
   # can clean them up as orphans on every compose backend (see that file).
@@ -87,5 +155,6 @@ volumes:
   mediawiki-db-data:
   mediawiki-images-data:
   neo4j-data:
+  qlever-index-data:
   caddy-data:
   caddy-config:

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -21,10 +21,14 @@ services:
       - NEO4J_PASSWORD
       - NEO4J_USERNAME_READ
       - NEO4J_PASSWORD_READ
-      # Bearer token the wiki sends to authorize writes to the QLever SPARQL store
-      # (see the qlever service below and SettingsTemplate.php's $wgNeoWikiSparqlStores).
-      # Sourced from Docker/.env.
-      - QLEVER_ACCESS_TOKEN
+      # Endpoint of the qlever service below. Its presence is what makes SettingsTemplate.php
+      # configure $wgNeoWikiSparqlStores, so every stack built on this file gets the store while
+      # an image run outside one gets none.
+      - QLEVER_URL=http://qlever:7019/
+      # Bearer token the wiki sends to authorize SPARQL updates. Defaulted here instead of being
+      # required from Docker/.env, so a .env written before the variable existed still works; the
+      # qlever service below defaults it the same way, so wiki and server always agree.
+      - QLEVER_ACCESS_TOKEN=${QLEVER_ACCESS_TOKEN:-neowiki_dev_token}
     healthcheck:
       test: "curl -fs http://localhost:80/wiki/Special:Version | grep -q 'Jeroen De Dauw'"
       interval: 60s
@@ -65,13 +69,12 @@ services:
       timeout: 1s
       retries: 10
 
-  # SPARQL 1.1 graph store (QLever) for the SPARQL projection plugin (#586). Part of the base
-  # stack, so the demo wiki gets the same RDF/SPARQL surface as the dev stack: every page save
-  # and RebuildGraphDatabases.php also projects the page's RDF here as named graphs, and the
-  # query surfaces read from it. SettingsTemplate.php configures $wgNeoWikiSparqlStores when
-  # QLEVER_ACCESS_TOKEN is set, which is what running inside this stack signals. NeoWiki reaches
-  # it in-network as http://qlever:7019/; a host port for manual inspection is opt-in via
-  # docker-compose.tools.yml.
+  # SPARQL 1.1 graph store (QLever) for the SPARQL projection plugin (#586). Defined in this base
+  # file rather than the dev overlay, so the demo stack gets the same RDF/SPARQL surface as the dev
+  # stack: every page save and RebuildGraphDatabases.php also projects the page's RDF here as named
+  # graphs, and the query surfaces read from it. The wiki is pointed at it by QLEVER_URL above.
+  # NeoWiki reaches it in-network as http://qlever:7019/; a host port for manual inspection is
+  # opt-in via docker-compose.tools.yml.
   qlever:
     image: docker.io/adfreiburg/qlever:latest
     restart: unless-stopped
@@ -112,7 +115,9 @@ services:
         # after it would be read as another prefix.
         exec qlever-server -i neowiki -p 7019 -a "$$QLEVER_ACCESS_TOKEN" -m 1G --persist-updates --service-allowed-iri-prefixes -
     environment:
-      - QLEVER_ACCESS_TOKEN
+      # Same default as the mediawiki service above, so the server and the wiki agree on the token
+      # even when Docker/.env predates the variable or leaves it empty.
+      - QLEVER_ACCESS_TOKEN=${QLEVER_ACCESS_TOKEN:-neowiki_dev_token}
     volumes:
       # Named volume (not a bind mount) so the index directory avoids host SELinux
       # labeling / ownership issues under rootless Podman, and so the index plus its

--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ name. After `perf-restore`:
 
 - Run `make update-dot-php`: the MediaWiki schema is the snapshot's, not this checkout's.
 - QLever is not part of the snapshot, and `make rebuild-graph-databases` only adds to it, so a
-  SPARQL store that has to match the restored wiki must start empty. No target empties it:
+  SPARQL store that has to match the restored wiki must start empty. `make remove` clears it
+  along with the wiki's own data; to empty only QLever, drop its volume while the stack is down:
 
   ```bash
   make down                                     # also removes the qlever container
@@ -128,7 +129,7 @@ Example:
 ```php
 <?php
 wfLoadExtension( 'SomeExtension' );
-$wgDebugLogGroups['neowiki'] = '/tmp/neowiki-debug.log';
+$wgDebugLogGroups['NeoWiki'] = '/tmp/neowiki-debug.log';
 ```
 
 ### Try-it-out and server deployment

--- a/docs/operations/installation.md
+++ b/docs/operations/installation.md
@@ -279,9 +279,9 @@ Each is read-only: the query is sent as a SPARQL 1.1 *query* operation, posted o
 
 A projection configured on a different endpoint is therefore not reachable from these surfaces.
 
-The bundled Docker stack ships a working QLever example wired up this way — the demo stack and the dev stack both
-run it — see [`Docker/README.md`](../../Docker/README.md#qlever-sparql-store) for the service, its
-`--persist-updates` requirement, and how to query it.
+Both bundled Docker stacks, demo and dev, ship a working QLever example wired up this way — see
+[`Docker/README.md`](../../Docker/README.md#qlever-sparql-store) for the service, its `--persist-updates` requirement,
+and how to query it.
 
 ### Restricting federation
 

--- a/docs/operations/installation.md
+++ b/docs/operations/installation.md
@@ -277,9 +277,9 @@ Each is read-only: the query is sent as a SPARQL 1.1 *query* operation, posted o
 
 A projection configured on a different endpoint is therefore not reachable from these surfaces.
 
-The bundled development stack ships a working QLever example wired up this way — see
-[`Docker/README.md`](../../Docker/README.md#qlever-sparql-store-dev) for the service, its `--persist-updates`
-requirement, and how to query it.
+The bundled Docker stack ships a working QLever example wired up this way, in both the demo and the development
+variant — see [`Docker/README.md`](../../Docker/README.md#qlever-sparql-store) for the service, its
+`--persist-updates` requirement, and how to query it.
 
 ### Restricting federation
 
@@ -298,7 +298,7 @@ qlever-server -i neowiki -p 7019 -m 1G --service-allowed-iri-prefixes -
 qlever-server -i neowiki -p 7019 -m 1G --service-allowed-iri-prefixes https://sparql.example.org/
 ```
 
-The bundled development stack sets the deny-all value, so federation is off unless you change it. The setting can
+The bundled Docker stack sets the deny-all value, so federation is off unless you change it. The setting can
 also be changed at runtime through the store's endpoint by anyone holding its access token, so keep that token
 secret. Other SPARQL stores have equivalent settings — consult their documentation.
 

--- a/docs/operations/installation.md
+++ b/docs/operations/installation.md
@@ -33,7 +33,9 @@ This pulls the latest demo image, starts the stack, installs the wiki, and loads
 data. Later, `make pull` refreshes the image, `make down` stops and removes the containers, and
 `make remove` also deletes the data volumes.
 
-For an empty wiki without the sample data, run `make up && make install-db && make load-neo4j-users` instead.
+For an empty wiki without the sample data, run `make up && make install-db && make load-neo4j-users` instead. That
+wiki has no `Mapping:EDM` page, so the stack's preconfigured EDM projection reports a failure on every save until you
+create that Mapping or remove its entry from `$wgNeoWikiSparqlStores`.
 
 Open `http://localhost:8484` and log in as `AdminName` with the password `AdminPassword`.
 
@@ -277,8 +279,8 @@ Each is read-only: the query is sent as a SPARQL 1.1 *query* operation, posted o
 
 A projection configured on a different endpoint is therefore not reachable from these surfaces.
 
-The bundled Docker stack ships a working QLever example wired up this way, in both the demo and the development
-variant — see [`Docker/README.md`](../../Docker/README.md#qlever-sparql-store) for the service, its
+The bundled Docker stack ships a working QLever example wired up this way — the demo stack and the dev stack both
+run it — see [`Docker/README.md`](../../Docker/README.md#qlever-sparql-store) for the service, its
 `--persist-updates` requirement, and how to query it.
 
 ### Restricting federation

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/Integration/QuerySparqlEndToEndTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/Integration/QuerySparqlEndToEndTest.php
@@ -75,7 +75,7 @@ class QuerySparqlEndToEndTest extends NeoWikiIntegrationTestCase {
 
 	/**
 	 * Points one store entry per projection at the single test store, so the projections are siblings in
-	 * one QLever index — the shape the development stack ships (native + EDM).
+	 * one QLever index — the shape the Docker stacks ship (native + EDM).
 	 */
 	private function configureStoresForProjections( string ...$projections ): void {
 		$this->overrideConfigValue(


### PR DESCRIPTION
`make demo` now ships the QLever SPARQL store, so a fresh demo install has the same RDF and SPARQL
surface as the public demo wiki. Page saves project into the store, `{{#sparql_raw}}`,
`nw.sparqlQuery` and `POST /neowiki/v0/query/sparql` return live results, and the `SPARQL queries`
and `EDM queries` example pages appear — `ImportDemoData` already gated those on a configured store,
so it now seeds them without a code change.

The `qlever` service and its volume move verbatim from `docker-compose.dev.yml` to
`docker-compose.yml`; `docker compose config` renders the dev stack byte-identically to master.
`test_qlever` stays in the dev overlay. The tools overlay now also renders against the base stack
alone, which errored on master because `qlever` was not there. Outside the compose and docs files the
only change is a comment.

## The gate

`SettingsTemplate.php` configured `$wgNeoWikiSparqlStores` only under `MW_MODE=dev`, which would
leave the demo without the feature. It now keys on `QLEVER_URL`, which `docker-compose.yml` supplies:
endpoint required, access token an ordinary optional credential defaulted via
`${QLEVER_ACCESS_TOKEN:-...}` on both the wiki and the server side.

Deliberately not the token. `Docker/.env` is gitignored and copied once, so a token gate would
silently withhold the store from every checkout whose `.env` predates 2026-07-16 — this repo's own
main checkout among them — and a blanked token would open the gate while sending no auth. An endpoint
in a tracked file has neither failure mode, still yields no store for an image run outside these
stacks (CI included: `docker-compose.ci.yml` replaces the base file and sets neither variable), and
matches the store contract the docs already state — `updateUrl` required, `accessToken` optional.

## Blast radius

`build-docker.yml` republishes the image on merge. Until it does, a new compose against the old image
just runs an idle `qlever` container. Existing demo stacks gain the store on re-pull; the example
pages and the back-projection of already-saved pages then come from the demo-content refresh and
rebuild that the upgrading guide in https://github.com/ProfessionalWiki/NeoWiki/pull/1237 documents.

One more service: ~500 MB image pull, idle RSS ~8 MB against the service's existing 1536 MB
`mem_limit`. It publishes no host port — exposure stays opt-in through `docker-compose.tools.yml` —
and keeps its deny-all federation setting; `.env.dist` now marks its token "Change for production".

New documented caveat: the empty-wiki path (`make up && make install-db && make load-neo4j-users`)
has no `Mapping:EDM`, so the preconfigured EDM projection logs a failure per save until that Mapping
exists or its entry is removed. Saves still succeed — `FailureIsolatingGraphDatabasePlugin` keeps a
projection failure from aborting the edit.

## Merge order

Overlaps with https://github.com/ProfessionalWiki/NeoWiki/pull/1235 (Oxigraph). The doc conflicts are
visible, but two comments there merge cleanly and become wrong once `qlever` is no longer in the dev
overlay ("alongside the QLever pair above... dev-only like them"; "the demo `oxigraph` service
above"). Both merge orders are simulated in the coordination comment on that PR; whichever lands
second sweeps the other's terminology.

## Verified

Compose render matrix across base/dev/tools/test/server combinations, `qlever` exactly once in each;
gate matrix over a stock, a `QLEVER_URL`-less, and a deleted-or-blanked-token `.env`, giving two
entries, `[]`, and a working store on the compose default; an end-to-end demo seed reaching 1611
triples across 116 named graphs, with both example pages rendering live bindings and the counts
surviving a `qlever` restart. Worth eyeballing once the image republishes: those two pages on a fresh
`make demo` — local runs only simulated that image, by bind-mounting the changed settings file over
it.

Considered, omitted: renaming the `neowiki_dev_token` default value; dropping the targeted
`docker volume rm` recipe step now that `make remove` is named as the blunt option; a pre-existing
import-vs-rebuild delta (1611 triples after import, a stable 1601 after a rebuild — identical on
master).

> <sub>AI-authored — Claude Code, `Opus 5 (max)`; delegated by @JeroenDeDauw, spec and review direction from the session lead; one adversarial review round, fixes applied; diff not yet human-reviewed; compose render and gate matrices, an end-to-end demo seed and a restart check run locally, docs links and anchors checked, CI green.</sub>

<details><summary>Production notes</summary>

Design, review orchestration and final judgment by `Fable 5 (max)`; implementation, adversarial pr-review and this description by separate `Opus 5 (max)` subagents.

</details>
