### PR TITLE
Scope the tools-overlay recipe to the demo stack

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -66,13 +66,20 @@ source file. A named volume (not a bind mount) keeps the index clear of host SEL
 labeling and ownership issues under rootless Podman.
 
 To query it from the host, add the `docker-compose.tools.yml` overlay, which maps `QLEVER_PORT`
-(default 7019) — on the dev stack `make dev-tools` does that for you:
+(default 7019). On the dev stack, `make dev-tools` does that for you. The demo stack has no make
+target for it, so drive compose directly, passing the demo stack's project name (`docker compose ls`
+lists it):
 
 ```sh
-# <project> is this stack's compose project name, which `docker compose ls` lists.
-docker compose -p <project> --env-file Docker/.env \
+docker compose -p <demo-project> --env-file Docker/.env \
   -f Docker/docker-compose.yml -f Docker/docker-compose.tools.yml up -d
+```
 
+That `-f` list is the demo stack's. Pointed at a dev stack's project name it would recreate
+`mediawiki` from the base image and drop the dev overlay's source bind-mount, so reach for
+`make dev-tools` there instead.
+
+```sh
 curl http://localhost:7019/ \
   --data-urlencode 'query=SELECT (COUNT(*) AS ?n) WHERE { GRAPH ?g { ?s ?p ?o } }' \
   -H 'Accept: application/sparql-results+json'


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1238

The recipe's `-f` list is the demo stack's, but the placeholder was introduced as "this stack's
compose project name" and shared one block with the curl example. Aimed at a dev stack's project
name, that file set reconciles `mediawiki` to the published image, without `MW_MODE=dev` and without
the source bind-mount, so the dev stack serves the released extension instead of the worktree until
`make dev` runs again.

Name the demo stack in the placeholder, split the compose-up and the query into separate blocks so
the surrounding prose attaches to the right one, and state the failure mode.

Rendering both file sets shows the difference the recipe hides:

```
$ docker compose -f Docker/docker-compose.yml -f Docker/docker-compose.tools.yml config
    image: ghcr.io/professionalwiki/neowiki:latest

$ docker compose -f Docker/docker-compose.yml -f Docker/docker-compose.dev.yml \
    -f Docker/docker-compose.tools.yml config
    build:
      MW_MODE: dev
    - ../:/var/www/html/w/extensions/NeoWiki:z
```

> <sub>AI-authored — Claude Code, `Opus 5 (1M context)`; one finding from an AI review of #1238, raised as a PR at @malberts' request after the diff was shown in chat; diff not yet human-reviewed; the compose render above is the whole verification, the recipe was not run against a live dev stack.</sub>
