### PR TITLE
Fix the Bluesky badge and profile link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [NeoWiki](https://neowiki.ai) is a collaborative knowledge management system on top of MediaWiki and graph databases.
 
 [![Mastodon](https://img.shields.io/mastodon/follow/116122313808578574)](https://mastodon.social/@NeoWiki)
-[![Bluesky](https://img.shields.io/bluesky/followers/NeoWiki.bsky.social)](https://bsky.app/profile/neowiki.bsky.social)
+[![Bluesky](https://img.shields.io/bluesky/followers/neowiki.ai)](https://bsky.app/profile/neowiki.ai)
 [![X](https://img.shields.io/twitter/follow/NeoWikiAI)](https://x.com/NeoWikiAI)
 
 ## Installation


### PR DESCRIPTION
The README pointed at the handle `neowiki.bsky.social`, which does not resolve. The account uses the
custom-domain handle `neowiki.ai`, so the badge rendered "user not found" and the profile link led to a
page that never filled in.

Uses the handle rather than the DID (`did:plc:hu2wbg33apct3b2dazdcfnpq`). The DID would survive a future
handle change, but it is unreadable and inconsistent with the neighbouring badges.

> <sub>AI-authored — Claude Code, `Opus 5 (1M context)`; asked by @malberts to check for an existing task and then fix it, corrected once after I misread the cause as handle casing; diff not yet human-reviewed; both URLs checked against the Bluesky API and the rendered shields.io output.</sub>