### PR TITLE
Pin what the batching review found unpinned

### DIFF
--- a/src/Application/Validation/SubjectValidator.php
+++ b/src/Application/Validation/SubjectValidator.php
@@ -40,8 +40,10 @@ readonly class SubjectValidator {
 
 		// Resolved in one lookup ahead of the per-Statement pass: resolving each target where it is
 		// checked costs a round trip apiece, paid serially. Ids absent from the map resolved to no
-		// Subject. Where the Schema has drifted this reaches targets the pass below never checks,
-		// which costs a longer id list and no violations.
+		// Subject. Where the Schema has drifted this reaches targets the pass below never checks:
+		// they cannot produce a violation, but they are not free either - the graph query stays one
+		// query however long the id list, while a target on a page no other target shares still
+		// costs that page's revision load and slot deserialization.
 		$relationTargets = $this->subjectLookup->getSubjects( $statements->getReferencedSubjects() );
 
 		foreach ( $statements->asArray() as $statement ) {

--- a/tests/phpunit/Application/Validation/SubjectValidatorTest.php
+++ b/tests/phpunit/Application/Validation/SubjectValidatorTest.php
@@ -20,6 +20,7 @@ use ProfessionalWiki\NeoWiki\Domain\Statement;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
 use ProfessionalWiki\NeoWiki\Domain\Validation\Severity;
+use ProfessionalWiki\NeoWiki\Domain\Validation\Violation;
 use ProfessionalWiki\NeoWiki\Domain\Value\NumberValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\RelationValue;
 use ProfessionalWiki\NeoWiki\Domain\Value\UnregisteredTypeValue;
@@ -552,7 +553,7 @@ class SubjectValidatorTest extends TestCase {
 			subjectLookup: $subjectLookup,
 		);
 
-		$validator->validate(
+		$violations = $validator->validate(
 			new SubjectLabel( 'X' ),
 			new StatementList( [
 				$this->newRelationStatement( self::MATCHING_TARGET_ID, self::MISMATCHING_TARGET_ID ),
@@ -576,6 +577,39 @@ class SubjectValidatorTest extends TestCase {
 		// Batching the resolution buys nothing if the targets are then fetched again where they are
 		// checked, which is what the per-target round trips this replaces looked like.
 		$this->assertSame( 0, $subjectLookup->getSubjectCallCount );
+
+		// Reading targets out of one map rather than resolving each where it is checked must leave
+		// the composed result alone. This is the only Subject here carrying relations under more
+		// than one property, so an id list that stops short of the later Statements' targets shows
+		// up here: those targets fall out of the map and report as not-found, turning a blocking
+		// mismatch into a non-blocking warning. Filtering the collected ids by the Schema is a
+		// different matter - it cannot reach a violation, so this assertion does not constrain it.
+		$this->assertEquals(
+			[
+				new Violation(
+					propertyName: new PropertyName( 'Links' ),
+					code: 'relation-target-schema-mismatch',
+					args: [ self::TARGET_SCHEMA, 'Company' ],
+					valuePartIndex: 1,
+					severity: Severity::Error,
+				),
+				new Violation(
+					propertyName: new PropertyName( 'Employers' ),
+					code: 'relation-target-not-found',
+					args: [ self::NONEXISTENT_TARGET_ID ],
+					valuePartIndex: 0,
+					severity: Severity::Warning,
+				),
+				new Violation(
+					propertyName: new PropertyName( 'Employers' ),
+					code: 'relation-target-schema-mismatch',
+					args: [ self::TARGET_SCHEMA, 'DecoySchema' ],
+					valuePartIndex: 1,
+					severity: Severity::Error,
+				),
+			],
+			$violations
+		);
 	}
 
 	// --- Helpers ---

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jPageIdentifiersLookupTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/Neo4jPageIdentifiersLookupTest.php
@@ -14,10 +14,8 @@ use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jPageIdentifiersLookup;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestPage;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestPageProperties;
-use ProfessionalWiki\NeoWiki\Tests\Data\TestSchema;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
-use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySchemaLookup;
 use RuntimeException;
 
 /**
@@ -107,19 +105,39 @@ class Neo4jPageIdentifiersLookupTest extends NeoWikiIntegrationTestCase {
 		);
 	}
 
-	public function testRepeatedIdYieldsOneEntry(): void {
+	/**
+	 * Subject nodes are merged on id alone and detached per page, so an id can carry a HasSubject
+	 * edge from more than one page. Which of them it resolves to is unspecified, but the map is
+	 * keyed by Subject id, so the second edge must not add a second entry or disturb the other ids.
+	 */
+	public function testSubjectHostedByTwoPagesYieldsOneEntry(): void {
 		$this->savePages();
+		$this->savePageHostingSubject( 77, self::GUID_4, 'Qux' );
 
-		$this->assertCount(
-			1,
-			$this->newLookup()->getPageIdsOfSubjects(
-				new SubjectIdList( [
-					new SubjectId( self::GUID_2 ),
-					new SubjectId( self::GUID_2 ),
-					new SubjectId( self::GUID_2 ),
-				] )
-			)
+		$this->assertSame(
+			2,
+			$this->countHostingEdges( self::GUID_4 ),
+			'the fixture must leave two pages hosting the Subject, or this test asserts nothing'
 		);
+
+		$identifiers = $this->newLookup()->getPageIdsOfSubjects(
+			new SubjectIdList( [ new SubjectId( self::GUID_4 ), new SubjectId( self::GUID_2 ) ] )
+		);
+
+		$this->assertCount( 2, $identifiers );
+		$this->assertArrayHasKey( self::GUID_4, $identifiers );
+		$this->assertContains( $identifiers[self::GUID_4]->getId()->id, [ 1, 77 ] );
+		$this->assertEquals(
+			new PageIdentifiers( new PageId( 42 ), 'Bar', 12 ),
+			$identifiers[self::GUID_2] ?? null
+		);
+	}
+
+	private function countHostingEdges( string $subjectId ): int {
+		return $this->readGraph(
+			'MATCH (:Page)-[:HasSubject]->(subject:Subject { id: $subjectId }) RETURN count(*) AS count',
+			[ 'subjectId' => $subjectId ]
+		)->first()->toRecursiveArray()['count'];
 	}
 
 	/**
@@ -133,12 +151,24 @@ class Neo4jPageIdentifiersLookupTest extends NeoWikiIntegrationTestCase {
 		$this->assertSame( [], $this->newLookup( $client )->getPageIdsOfSubjects( new SubjectIdList( [] ) ) );
 	}
 
-	private function savePages(): void {
-		$projectionStore = NeoWikiExtension::getInstance()->newNeo4jProjectionStore(
-			new InMemorySchemaLookup(
-				TestSchema::build( name: TestSubject::DEFAULT_SCHEMA_ID )
+	/**
+	 * Only sound for a page the graph does not hold yet: nothing is removed or detached, so the
+	 * edge an earlier page already holds to the same Subject stays. Re-saving an existing page is
+	 * not equivalent - dropping a Subject from a page that used to host it removes that Subject
+	 * graph-wide, every other page's edge to it included.
+	 */
+	private function savePageHostingSubject( int $pageId, string $subjectId, string $title ): void {
+		$this->newProjectionStore()->savePage( TestPage::build(
+			id: $pageId,
+			properties: TestPageProperties::build( title: $title ),
+			childSubjects: new SubjectMap(
+				TestSubject::build( id: $subjectId ),
 			)
-		);
+		) );
+	}
+
+	private function savePages(): void {
+		$projectionStore = $this->newProjectionStore();
 
 		$projectionStore->savePage( TestPage::build(
 			id: 1,

--- a/tests/phpunit/Persistence/MediaWiki/Subject/MediaWikiSubjectRepositoryTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/Subject/MediaWikiSubjectRepositoryTest.php
@@ -247,6 +247,11 @@ class MediaWikiSubjectRepositoryTest extends NeoWikiIntegrationTestCase {
 
 		$this->assertCount( 3, $subjects );
 		$this->assertSame( 1, $pageIdentifiersLookup->getPageIdsOfSubjectsCallCount );
+
+		// Keeping the batch call and resolving the ids again one at a time would leave the count
+		// above at one while costing a graph round trip per id, since the production lookup answers
+		// getPageIdOfSubject by running the batch query.
+		$this->assertSame( 0, $pageIdentifiersLookup->getPageIdOfSubjectCallCount );
 	}
 
 	private function getPageId( string $pageName ): PageId {

--- a/tests/phpunit/Persistence/MediaWiki/Subject/PointInTimeSubjectLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/Subject/PointInTimeSubjectLookupTest.php
@@ -213,6 +213,11 @@ class PointInTimeSubjectLookupTest extends NeoWikiIntegrationTestCase {
 		);
 
 		$this->assertSame( 1, $pageIdentifiersLookup->getPageIdsOfSubjectsCallCount );
+
+		// Keeping the batch call and resolving the ids again one at a time would leave the count
+		// above at one while costing a graph round trip per id, since the production lookup answers
+		// getPageIdOfSubject by running the batch query.
+		$this->assertSame( 0, $pageIdentifiersLookup->getPageIdOfSubjectCallCount );
 	}
 
 	public function testGetSubjectsOmitsSubjectsSharingAPageWithARequestedOne(): void {

--- a/tests/phpunit/TestDoubles/InMemoryPageIdentifiersLookup.php
+++ b/tests/phpunit/TestDoubles/InMemoryPageIdentifiersLookup.php
@@ -15,6 +15,8 @@ class InMemoryPageIdentifiersLookup implements PageIdentifiersLookup {
 
 	public int $getPageIdsOfSubjectsCallCount = 0;
 
+	public int $getPageIdOfSubjectCallCount = 0;
+
 	/**
 	 * @param array<int, array{0: SubjectId, 1: PageIdentifiers}> $subjectIdsAndPageIdentifiers
 	 */
@@ -28,7 +30,14 @@ class InMemoryPageIdentifiersLookup implements PageIdentifiersLookup {
 		$this->pageIdentifiers[$subjectId->text] = $pageIdentifiers;
 	}
 
+	/**
+	 * Counted separately from getPageIdsOfSubjects because the production lookup answers this one
+	 * by running the batch query, so a caller that resolves ids one at a time here is one graph
+	 * round trip per id there. Tests that pin batching assert this count is zero.
+	 */
 	public function getPageIdOfSubject( SubjectId $subjectId ): ?PageIdentifiers {
+		$this->getPageIdOfSubjectCallCount++;
+
 		return $this->pageIdentifiers[$subjectId->text] ?? null;
 	}
 


### PR DESCRIPTION
Four findings from a review of #1224, targeted at its branch so they land with it rather than after.
All are minor, and the only production change is a comment.

## The comment on the widened id set understates the cost

`e7de4e3e` moved the collection to `StatementList::getReferencedSubjects()`, and the comment left
behind says the ids it reaches beyond what the per-Statement pass checks cost "a longer id list and
no violations".

That holds for the graph, where the lookup is one query however long the list. It does not hold
after it. The ids go on to `MediaWikiSubjectRepository::getSubjects`, which reads one page's content
per *distinct hosting page*, so a target the Schema no longer defines as a relation, on a page no
other target shares, costs that page's `getRevisionByPageId` plus a `SubjectContent::getPageSubjects()`
deserialization, which re-runs on every call. It is reachable where `ReplaceSubjectAction` validates
the stored Subject, which carries whatever drifted Statements it holds.

The comment now says that. I have not narrowed the collected set: `e7de4e3e` dropped the
Schema-filtered collector on purpose, so that is your call rather than a review fix. If the cost is
worth removing, intersecting the collected ids with the Statements whose Schema property is a
`RelationProperty` keeps both the single query and the terminology.

## `testResolvesEveryRelationTargetInOneLookup` did not look at the result

It builds the only Subject in the class carrying relations under two properties, then discarded
`validate()`'s return and asserted call counts alone. An id list that stops short of the later
Statements' targets leaves them out of the map, where they report as `relation-target-not-found`
rather than `relation-target-schema-mismatch` — a blocking violation downgraded to a non-blocking
one, with the suite still green. The three violations are now asserted whole: codes, args,
severities, `valuePartIndex` and order.

## `testRepeatedIdYieldsOneEntry` could not fail

`SubjectIdList` keys by id text, so the repeats collapse before the lookup sees them, and that dedup
is already pinned by `SubjectIdListTest`. Even without it, `newPageIdentifiersMap` keys by
`subject.id`, so duplicate rows collapse anyway. The assertion held at both layers regardless of what
the lookup did.

It is replaced by the case the new docblock describes and nothing covered: two pages holding a
`HasSubject` edge to one Subject. The fixture asserts its own precondition, two hosting edges in the
graph, so it cannot quietly go vacuous.

## The double hid per-id resolution from the batching assertions

`Neo4jPageIdentifiersLookup::getPageIdOfSubject` answers by running the batch query, so one single-id
call is one graph round trip. `InMemoryPageIdentifiersLookup` counted only `getPageIdsOfSubjects`,
so the "one lookup" assertions caught an edit that *replaces* the batch call but not one that keeps
it and resolves the ids again per item inside the grouping loop — reinstating the round trips this PR
removes. It now carries its own counter, asserted zero in both batching tests, matching the shape
`InMemorySubjectLookup` already uses for the same guard.

## Why these assertions rather than none

Each was confirmed to kill a mutation the branch's existing tests miss: slicing the batched id list
(only the new violation assertion fails), resolving each id again inside the grouping loop with the
batch call retained (only the new zero-count assertion fails), and `newPageIdentifiersMap` appending
on a duplicate Subject id (only the new two-hosting-page test fails). The last is the case for
replacing `testRepeatedIdYieldsOneEntry` rather than deleting it: no other test builds a Subject with
two hosting edges.

`phpcs`, `phpstan` and every affected suite are green.

<sub>AI-authored — Claude Code, `Opus 5 (1M context)`; reviewing #1224 on request and fixing what the
review found, no human-authored lines; findings came from a multi-lens review with per-finding
adversarial verification, and this commit was reviewed the same way, which caught an over-broad
docblock about `savePage`'s scoping that is fixed here; each new assertion confirmed to kill a
mutation the existing tests miss.</sub>
