### PR TITLE
Review fixes for #1226

### DIFF
--- a/docs/api/graph-model.md
+++ b/docs/api/graph-model.md
@@ -22,8 +22,10 @@ Two node types and two relationship categories:
 ## Page Nodes
 
 Every page is projected as a `:Page` node when it is saved and by
-[`RebuildGraphDatabases.php`](../operations/maintenance.md#rebuilding-the-graph), whether or not it holds Subjects, so
-after a rebuild every page on the wiki has one.
+[`RebuildGraphDatabases.php`](../operations/maintenance.md#rebuilding-the-graph), whether or not it holds Subjects. The
+exceptions are pages NeoWiki cannot read: one whose subject slot holds content it cannot read as Subjects, and one whose
+Page Properties cannot be built. Both are reported by the rebuild and left out of the graph rather than projected as
+holding nothing, which would drop data the page does hold.
 
 A shared graph can hold pages from multiple wikis (a wiki farm), and MediaWiki page ids are unique only within a wiki,
 so a page is identified by the `(wiki_id, id)` pair, not `id` alone ([ADR 22](../adr/022-multi-wiki-node-identity.md)).

--- a/docs/rdf/rdf-export.md
+++ b/docs/rdf/rdf-export.md
@@ -74,10 +74,11 @@ extension (`42.trig`, `42.ttl`).
 
 `GET /rest.php/neowiki/v0/page/{pageId}/rdf`
 
-Returns the page's projection: its page metadata and every Subject on it, in the page's named graph. A page
-holding no Subjects projects to its page metadata alone. Returns `404` when the page does not exist, is not
-readable by the caller (the two are indistinguishable), or its subject slot holds content NeoWiki cannot read
-as Subjects.
+Returns the page's projection: its page metadata and every Subject on it, in the page's named graph. Under the
+native projection, a page holding no Subjects projects to its page metadata alone; an ontology projection emits
+no page metadata at all, so the same page projects to an empty graph — a `200`, not a `404`. Returns `404` when
+the page does not exist, is not readable by the caller (the two are indistinguishable), its subject slot holds
+content NeoWiki cannot read as Subjects, or its Page Properties cannot be built.
 
 ```sh
 curl 'https://wiki.example/rest.php/neowiki/v0/page/42/rdf?format=turtle'
@@ -137,8 +138,8 @@ the operator's own routing concern.
 ### Finding these exports
 
 These exports are surfaced in the UI. The Data tab links to each Subject's JSON and per-projection Turtle/TriG,
-and the same for the whole page. Content pages also emit `<link rel="alternate">` autodiscovery tags (Turtle and
-TriG, native projection) in the HTML head.
+and the same for the whole page. Content pages that exist also emit `<link rel="alternate">` autodiscovery tags
+(Turtle and TriG, native projection) in the HTML head, on a wiki with a graph database configured.
 
 ## Bulk dump
 

--- a/maintenance/DumpRdf.php
+++ b/maintenance/DumpRdf.php
@@ -13,6 +13,8 @@ use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfFormat;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfStreamWriter;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+use Wikimedia\Rdbms\DBError;
+use Wikimedia\RequestTimeout\TimeoutException;
 
 $basePath = getenv( 'MW_INSTALL_PATH' ) !== false ? getenv( 'MW_INSTALL_PATH' ) : __DIR__ . '/../../..';
 
@@ -68,11 +70,21 @@ class DumpRdf extends Maintenance {
 
 		$this->output( $writer->finish() );
 		$this->error( "Dumped $dumped of $total pages." );
+
+		if ( $dumped < $total ) {
+			// The document on stdout is well formed whatever happened, so a caller that only checks
+			// the exit code cannot otherwise tell a complete dump from one missing most of the wiki.
+			$this->fatalError( 'The dump is incomplete: ' . ( $total - $dumped ) . ' of ' . $total
+				. ' pages were skipped. See the messages above for why.' );
+		}
 	}
 
 	/**
-	 * A page that cannot be loaded or projected is reported to stderr and skipped, as on the rebuild
-	 * path: one unreadable page out of a wiki must not truncate the dump into an invalid document.
+	 * A page that cannot be loaded or projected is reported to stderr and skipped, so one unreadable
+	 * page out of a wiki does not truncate the dump into an invalid document. Skipping is for page
+	 * state the dump cannot describe; a failure of the infrastructure underneath is not that, so
+	 * TimeoutException and DBError propagate and end the run rather than turning every remaining page
+	 * into a skip. Which throwables are let through matches FailureIsolatingGraphDatabasePlugin.
 	 */
 	private function dumpPage(
 		int $pageId,
@@ -82,6 +94,8 @@ class DumpRdf extends Maintenance {
 	): bool {
 		try {
 			$page = $loader->loadByPageId( new PageId( $pageId ) );
+		} catch ( TimeoutException | DBError $e ) {
+			throw $e;
 		} catch ( Exception $e ) {
 			$this->error( "Skipped page $pageId: " . $e->getMessage() );
 			return false;
@@ -94,6 +108,8 @@ class DumpRdf extends Maintenance {
 
 		try {
 			$quads = $projector->projectPage( $page );
+		} catch ( TimeoutException | DBError $e ) {
+			throw $e;
 		} catch ( Exception $e ) {
 			$this->error( "Skipped page $pageId: " . $e->getMessage() );
 			return false;

--- a/maintenance/RebuildGraphDatabases.php
+++ b/maintenance/RebuildGraphDatabases.php
@@ -19,6 +19,8 @@ require_once $basePath . '/maintenance/Maintenance.php';
 
 class RebuildGraphDatabases extends Maintenance {
 
+	private const int PROGRESS_INTERVAL = 500;
+
 	public function __construct() {
 		parent::__construct();
 
@@ -28,6 +30,13 @@ class RebuildGraphDatabases extends Maintenance {
 			'revision. Useful after a graph database has been wiped or has otherwise drifted from the ' .
 			'MediaWiki source of truth.'
 		);
+		$this->addOption(
+			'from-page-id',
+			'Resume after this page id, as reported by the progress output, instead of starting at the '
+			. 'first page. Only affects the re-projection; deleted pages are always reconciled in full.',
+			false,
+			true
+		);
 	}
 
 	public function execute(): void {
@@ -36,15 +45,25 @@ class RebuildGraphDatabases extends Maintenance {
 		$this->outputChanneled( 'Rebuilding graph databases...' );
 
 		$rebuilder = NeoWikiExtension::getInstance()->newPageRebuilder();
+		$afterPageId = (int)$this->getOption( 'from-page-id', 0 );
 
 		$rebuilt = 0;
 		$total = 0;
 
-		foreach ( NeoWikiExtension::getInstance()->newPageIdsLookup()->getPageIds() as $pageId ) {
+		foreach ( NeoWikiExtension::getInstance()->newPageIdsLookup()->getPageIds( $afterPageId ) as $pageId ) {
 			$total++;
 
 			if ( $this->rebuildPage( $pageId, $rebuilder ) ) {
 				$rebuilt++;
+			}
+
+			if ( $total % self::PROGRESS_INTERVAL === 0 ) {
+				$this->outputChanneled( "... $total pages so far, last page id $pageId" );
+
+				// Projecting a page parses it and writes to every backend, so a whole-wiki rebuild runs
+				// long enough to matter to the replicas. Yielding here is also what lets the load
+				// balancer let go of a replica that has been taken out of the pool.
+				$this->waitForReplication();
 			}
 		}
 
@@ -73,6 +92,10 @@ class RebuildGraphDatabases extends Maintenance {
 	private function removeDeletedPages(): void {
 		$graphDatabasePlugin = NeoWikiExtension::getInstance()->getGraphDatabasePlugin();
 
+		// Announced before the walk rather than after it: this reads the whole archive table, which on a
+		// wiki with a long deletion history is a lot of work to spend without saying anything.
+		$this->outputChanneled( 'Removing deleted pages from the graph databases...' );
+
 		$removed = 0;
 		$total = 0;
 
@@ -82,13 +105,15 @@ class RebuildGraphDatabases extends Maintenance {
 			if ( $this->removePage( $pageId, $graphDatabasePlugin ) ) {
 				$removed++;
 			}
+
+			if ( $total % self::PROGRESS_INTERVAL === 0 ) {
+				$this->waitForReplication();
+			}
 		}
 
-		if ( $total === 0 ) {
-			return;
-		}
-
-		$this->outputChanneled( "Removed $removed of $total deleted pages from the graph databases." );
+		// A page id the archive yields more than once is counted more than once, so this counts
+		// deletions handled rather than distinct pages. Removing an already absent page is a no-op.
+		$this->outputChanneled( "Removed $removed of $total deletions from the graph databases." );
 	}
 
 	private function removePage( int $pageId, GraphDatabasePlugin $graphDatabasePlugin ): bool {

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -125,7 +125,9 @@ class NeoWikiHooks {
 	/**
 	 * Advertises the page's RDF export (native projection) via `<link rel="alternate">` autodiscovery
 	 * tags — one Turtle, one TriG — so Linked Data tooling finds the data without reading the API docs.
-	 * Every page has an export, holding its page metadata and any Subjects, so every page advertises one.
+	 * Every page that exists has an export, holding its page metadata and any Subjects, so every page
+	 * advertises one. The exception is a page NeoWiki cannot read, whose export 404s; such a page does
+	 * not render at all, so no link is advertised for it either way.
 	 * Native only; the per-projection exports are reachable from the Data tab UI.
 	 */
 	private static function addRdfAutodiscoveryLinks( OutputPage $out ): void {

--- a/src/EntryPoints/OnRevisionCreatedHandler.php
+++ b/src/EntryPoints/OnRevisionCreatedHandler.php
@@ -4,27 +4,24 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\EntryPoints;
 
-use Exception;
 use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\User\UserIdentity;
 use ProfessionalWiki\NeoWiki\Application\PageRefreshOutcome;
-use ProfessionalWiki\NeoWiki\PagePropertiesBuilder;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphDatabasePlugin;
 use ProfessionalWiki\NeoWiki\Domain\Page\Page;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
-use ProfessionalWiki\NeoWiki\Domain\Page\PageProperties;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
 use ProfessionalWiki\NeoWiki\EntryPoints\Content\SubjectContent;
+use ProfessionalWiki\NeoWiki\PagePropertiesSource;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\MediaWikiSubjectRepository;
 use Psr\Log\LoggerInterface;
-use Wikimedia\Rdbms\DBError;
-use Wikimedia\RequestTimeout\TimeoutException;
+use RuntimeException;
 
 class OnRevisionCreatedHandler {
 
 	public function __construct(
 		private readonly GraphDatabasePlugin $graphDatabasePlugin,
-		private readonly PagePropertiesBuilder $pagePropertiesBuilder,
+		private readonly PagePropertiesSource $pagePropertiesSource,
 		private readonly LoggerInterface $logger,
 	) {
 	}
@@ -35,7 +32,7 @@ class OnRevisionCreatedHandler {
 	 */
 	public function onRevisionCreated( RevisionRecord $revisionRecord, ?UserIdentity $user ): PageRefreshOutcome {
 		if ( $revisionRecord->getPageId() === 0 ) {
-			throw new \RuntimeException( 'Page ID should not be 0' );
+			throw new RuntimeException( 'Page ID should not be 0' );
 		}
 
 		$subjects = $this->getPageSubjects( $revisionRecord );
@@ -49,7 +46,10 @@ class OnRevisionCreatedHandler {
 			return PageRefreshOutcome::SkippedUnreadableSubjects;
 		}
 
-		$properties = $this->getPageProperties( $revisionRecord, $user );
+		// Null only from the isolating source the hook path is given, which has already logged the
+		// cause. The rebuild path is given the propagating one, so there the failure surfaces to the
+		// maintenance script instead, which reports it against the page.
+		$properties = $this->pagePropertiesSource->getPagePropertiesFor( $revisionRecord, $user );
 
 		if ( $properties === null ) {
 			return PageRefreshOutcome::SkippedUnreadablePageProperties;
@@ -82,24 +82,6 @@ class OnRevisionCreatedHandler {
 		$content = $revisionRecord->getSlots()->getContent( MediaWikiSubjectRepository::SLOT_NAME );
 
 		return $content instanceof SubjectContent ? $content->getPageSubjects() : null;
-	}
-
-	/**
-	 * Building the properties parses the page and runs the registered providers, which can throw for a
-	 * page MediaWiki can no longer fully handle, such as one whose content model an uninstalled extension
-	 * owned. This runs inside the user's edit, so such a page is skipped and logged rather than allowed
-	 * to abort that edit — the same trade the projection write itself makes, down to which throwables are
-	 * let through (see FailureIsolatingGraphDatabasePlugin).
-	 */
-	private function getPageProperties( RevisionRecord $revisionRecord, ?UserIdentity $user ): ?PageProperties {
-		try {
-			return $this->pagePropertiesBuilder->getPagePropertiesFor( $revisionRecord, $user );
-		} catch ( TimeoutException | DBError $e ) {
-			throw $e;
-		} catch ( Exception $e ) {
-			$this->logSkip( $revisionRecord, 'its page properties could not be built: ' . $e->getMessage() );
-			return null;
-		}
 	}
 
 	private function logSkip( RevisionRecord $revisionRecord, string $reason ): void {

--- a/src/EntryPoints/REST/ExportPageRdfApi.php
+++ b/src/EntryPoints/REST/ExportPageRdfApi.php
@@ -4,12 +4,16 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\EntryPoints\REST;
 
+use Exception;
+use MediaWiki\Logger\LoggerFactory;
 use MediaWiki\Rest\Response;
 use MediaWiki\Rest\SimpleHandler;
 use ProfessionalWiki\NeoWiki\Application\Rdf\RdfPageProjector;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use Wikimedia\ParamValidator\ParamValidator;
+use Wikimedia\Rdbms\DBError;
+use Wikimedia\RequestTimeout\TimeoutException;
 
 /**
  * Exports one page's Subjects and metadata as RDF. The `projection` query parameter selects the
@@ -53,9 +57,28 @@ class ExportPageRdfApi extends SimpleHandler {
 
 		$format = $this->resolveFormat();
 
-		$document = $extension
-			->newRdfPageExporterForProjection( $resolution->projection )
-			->exportByPageId( $page, $format );
+		// Building the page's properties parses it and runs the registered Page Property Providers,
+		// either of which can throw for a page MediaWiki can no longer fully handle — one whose content
+		// model an uninstalled extension owned, say. Every page has an export now, so such a page is
+		// reachable here, and letting the throwable out turns the documented 404 into a 500 carrying the
+		// exception message. Report it as no data, the same answer the caller gets for the other page
+		// states this export cannot describe. Which throwables are let through matches
+		// FailureIsolatingGraphDatabasePlugin: a request timeout must still abort the request, and a
+		// wiki-database error belongs to the request rather than to this page.
+		try {
+			$document = $extension
+				->newRdfPageExporterForProjection( $resolution->projection )
+				->exportByPageId( $page, $format );
+		} catch ( TimeoutException | DBError $e ) {
+			throw $e;
+		} catch ( Exception $e ) {
+			LoggerFactory::getInstance( 'NeoWiki' )->error(
+				'NeoWiki could not export page {pageId} as RDF: {message}',
+				[ 'pageId' => $pageId, 'message' => $e->getMessage(), 'exception' => $e ]
+			);
+
+			return $this->noDataResponse( $pageId );
+		}
 
 		if ( $document === null ) {
 			return $this->noDataResponse( $pageId );

--- a/src/FailureIsolatingPagePropertiesSource.php
+++ b/src/FailureIsolatingPagePropertiesSource.php
@@ -1,0 +1,51 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki;
+
+use Exception;
+use MediaWiki\Revision\RevisionRecord;
+use MediaWiki\User\UserIdentity;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageProperties;
+use Psr\Log\LoggerInterface;
+use Wikimedia\Rdbms\DBError;
+use Wikimedia\RequestTimeout\TimeoutException;
+
+/**
+ * Wraps the page-properties build so a page MediaWiki can no longer fully handle -- one whose content
+ * model an uninstalled extension owned, or one a throwing Page Property Provider cannot answer for --
+ * does not abort the edit, import or undeletion that triggered the projection.
+ *
+ * Which throwables are let through matches FailureIsolatingGraphDatabasePlugin, for the same reasons:
+ * \Error is not caught at all, and TimeoutException and DBError are re-thrown.
+ *
+ * Used only on the hook-facing write path. The RebuildGraphDatabases maintenance path deliberately
+ * runs the undecorated PagePropertiesBuilder, so a page it cannot reconcile is reported as a failure
+ * naming its cause rather than as a skip the operator cannot act on. See NeoWikiExtension.
+ */
+class FailureIsolatingPagePropertiesSource implements PagePropertiesSource {
+
+	public function __construct(
+		private readonly PagePropertiesSource $source,
+		private readonly LoggerInterface $logger,
+	) {
+	}
+
+	public function getPagePropertiesFor( RevisionRecord $revision, ?UserIdentity $user ): ?PageProperties {
+		try {
+			return $this->source->getPagePropertiesFor( $revision, $user );
+		} catch ( TimeoutException | DBError $e ) {
+			throw $e;
+		} catch ( Exception $e ) {
+			$this->logger->error(
+				'NeoWiki did not project page {pageId} because its page properties could not be built: '
+				. '{message}. The graph is out of sync for that page until the cause is resolved.',
+				[ 'pageId' => $revision->getPageId(), 'message' => $e->getMessage(), 'exception' => $e ]
+			);
+
+			return null;
+		}
+	}
+
+}

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -292,26 +292,41 @@ class NeoWikiExtension {
 	}
 
 	/**
-	 * Hook-facing write path (edit/delete/undelete). Each backend is isolated and logged, so a
-	 * projection failure never aborts the triggering user operation and one failing backend does not
-	 * starve the others. See FailureIsolatingGraphDatabasePlugin.
+	 * Hook-facing write path (edit/delete/undelete). Both halves of a projection are isolated and
+	 * logged, so a failure never aborts the triggering user operation: each backend, so one failing
+	 * backend does not starve the others, and the page-properties build, since it parses the page and
+	 * runs extension-contributed providers. See FailureIsolatingGraphDatabasePlugin and
+	 * FailureIsolatingPagePropertiesSource.
 	 */
 	public function getStoreContentUC(): OnRevisionCreatedHandler {
-		return $this->newStoreContentHandler( $this->getIsolatingGraphDatabasePlugin() );
+		return $this->newStoreContentHandler(
+			$this->getIsolatingGraphDatabasePlugin(),
+			new FailureIsolatingPagePropertiesSource(
+				$this->getPagePropertiesBuilder(),
+				LoggerFactory::getInstance( 'NeoWiki' )
+			)
+		);
 	}
 
 	/**
 	 * Maintenance rebuild path (RebuildGraphDatabases). Failures propagate so the script reports which
-	 * pages failed to reconcile, rather than the hook path's per-plugin isolation swallowing them.
+	 * pages failed to reconcile and why, rather than the hook path's isolation swallowing them and
+	 * leaving the operator a skip they cannot act on.
 	 */
 	private function newRebuildStoreContentHandler(): OnRevisionCreatedHandler {
-		return $this->newStoreContentHandler( $this->getGraphDatabasePlugin() );
+		return $this->newStoreContentHandler(
+			$this->getGraphDatabasePlugin(),
+			$this->getPagePropertiesBuilder()
+		);
 	}
 
-	private function newStoreContentHandler( GraphDatabasePlugin $graphDatabasePlugin ): OnRevisionCreatedHandler {
+	private function newStoreContentHandler(
+		GraphDatabasePlugin $graphDatabasePlugin,
+		PagePropertiesSource $pagePropertiesSource
+	): OnRevisionCreatedHandler {
 		return new OnRevisionCreatedHandler(
 			$graphDatabasePlugin,
-			$this->getPagePropertiesBuilder(),
+			$pagePropertiesSource,
 			LoggerFactory::getInstance( 'NeoWiki' ),
 		);
 	}

--- a/src/PagePropertiesBuilder.php
+++ b/src/PagePropertiesBuilder.php
@@ -16,7 +16,7 @@ use ProfessionalWiki\NeoWiki\Domain\Page\PageProperties;
 use ProfessionalWiki\NeoWiki\Domain\Page\PagePropertyProviderContext;
 use ProfessionalWiki\NeoWiki\Domain\Page\PagePropertyProviderRegistry;
 
-readonly class PagePropertiesBuilder {
+readonly class PagePropertiesBuilder implements PagePropertiesSource {
 
 	public function __construct(
 		private RevisionStore $revisionStore,

--- a/src/PagePropertiesSource.php
+++ b/src/PagePropertiesSource.php
@@ -1,0 +1,28 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki;
+
+use MediaWiki\Revision\RevisionRecord;
+use MediaWiki\User\UserIdentity;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageProperties;
+
+/**
+ * The Page Properties to project for a revision.
+ *
+ * Building them parses the page and runs the registered Page Property Providers, either of which can
+ * throw for a page MediaWiki can no longer fully handle. Whether that failure is swallowed or
+ * propagates is the caller's choice, made by which implementation it is given: the hook-facing write
+ * path isolates it so a projection failure never aborts the user's edit, and the maintenance rebuild
+ * path lets it through so the script can report which pages failed to reconcile, and why. This mirrors
+ * the same split on the graph plugins (see FailureIsolatingGraphDatabasePlugin and NeoWikiExtension).
+ *
+ * Null means the properties could not be built and the page must not be projected. Only the isolating
+ * implementation returns it; PagePropertiesBuilder always either answers or throws.
+ */
+interface PagePropertiesSource {
+
+	public function getPagePropertiesFor( RevisionRecord $revision, ?UserIdentity $user ): ?PageProperties;
+
+}

--- a/src/Persistence/MediaWiki/DatabasePageIdsLookup.php
+++ b/src/Persistence/MediaWiki/DatabasePageIdsLookup.php
@@ -23,8 +23,8 @@ class DatabasePageIdsLookup implements PageIdsLookup {
 	 *
 	 * @return iterable<int>
 	 */
-	public function getPageIds(): iterable {
-		$lastPageId = 0;
+	public function getPageIds( int $afterPageId = 0 ): iterable {
+		$lastPageId = $afterPageId;
 
 		do {
 			$pageIds = $this->db->newSelectQueryBuilder()

--- a/src/Persistence/PageIdsLookup.php
+++ b/src/Persistence/PageIdsLookup.php
@@ -10,8 +10,11 @@ interface PageIdsLookup {
 	 * The page id of every page on the wiki, in ascending order. Every page is projected, so this is the
 	 * set the graph rebuild and the RDF dump walk.
 	 *
+	 * $afterPageId starts the walk past a page id already handled, so a run interrupted partway can
+	 * resume instead of redoing the wiki from the beginning.
+	 *
 	 * @return iterable<int>
 	 */
-	public function getPageIds(): iterable;
+	public function getPageIds( int $afterPageId = 0 ): iterable;
 
 }

--- a/src/Presentation/PageToolsBuilder.php
+++ b/src/Presentation/PageToolsBuilder.php
@@ -50,8 +50,9 @@ class PageToolsBuilder {
 			];
 		}
 
-		// Every page has an RDF export, so every page links to one. A title with no page behind it has
-		// nothing to export.
+		// Every page that exists has an RDF export, so every page links to one. A title with no page
+		// behind it has nothing to export. The link 404s for the one page state the export cannot
+		// describe: a subject slot holding content that is not Subject data.
 		if ( $pageId !== 0 ) {
 			$items[] = [
 				'text' => wfMessage( 'neowiki-page-tools-rdf' )->text(),

--- a/tests/phpunit/EntryPoints/OnRevisionCreatedHandlerTest.php
+++ b/tests/phpunit/EntryPoints/OnRevisionCreatedHandlerTest.php
@@ -17,6 +17,7 @@ use ProfessionalWiki\NeoWiki\Domain\Page\PagePropertyProvider;
 use ProfessionalWiki\NeoWiki\Domain\Page\PagePropertyProviderContext;
 use ProfessionalWiki\NeoWiki\Domain\Page\PagePropertyProviderRegistry;
 use ProfessionalWiki\NeoWiki\EntryPoints\OnRevisionCreatedHandler;
+use ProfessionalWiki\NeoWiki\FailureIsolatingPagePropertiesSource;
 use ProfessionalWiki\NeoWiki\PagePropertiesBuilder;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
@@ -74,22 +75,34 @@ class OnRevisionCreatedHandlerTest extends NeoWikiIntegrationTestCase {
 
 	public function testWritesNothingWhenThePagePropertiesCannotBeBuilt(): void {
 		// Building the properties parses the page and runs every provider, which throws for a page
-		// MediaWiki can no longer handle or a provider that fails. That must not abort the triggering edit.
-		$registry = new PagePropertyProviderRegistry();
-		$registry->addProvider( new class implements PagePropertyProvider {
-			public function getProperties( PagePropertyProviderContext $context ): array {
-				throw new RuntimeException( 'unknown content model' );
-			}
-		} );
-
+		// MediaWiki can no longer handle or a provider that fails. On the hook path that must not abort
+		// the triggering edit, which is what the isolating source production wires there is for.
 		$revision = $this->newPlainPageRevision( 'Page with unbuildable properties' );
 
-		$outcome = $this->newHandlerWith( $this->graphStore, $registry )
-			->onRevisionCreated( $revision, new UserIdentityValue( 1, 'Tester' ) );
+		$outcome = $this->newHandlerWith(
+			$this->graphStore,
+			$this->newFailingProviderRegistry(),
+			isolatePageProperties: true
+		)->onRevisionCreated( $revision, new UserIdentityValue( 1, 'Tester' ) );
 
 		$this->assertSame( PageRefreshOutcome::SkippedUnreadablePageProperties, $outcome );
 		$this->assertSame( [], $this->graphStore->savedPages );
-		$this->assertTrue( $this->logger->hasWarningRecords(), 'the skipped page should be logged' );
+		$this->assertTrue( $this->logger->hasErrorRecords(), 'the skipped page should be logged' );
+	}
+
+	/**
+	 * The rebuild path is given the undecorated source, so a page whose properties cannot be built
+	 * surfaces to RebuildGraphDatabases, which reports it against the page with its cause, rather than
+	 * as a skip the operator cannot act on.
+	 */
+	public function testPagePropertyFailurePropagatesWithoutTheIsolatingSource(): void {
+		$revision = $this->newPlainPageRevision( 'Page with unbuildable properties' );
+
+		$this->expectException( RuntimeException::class );
+		$this->expectExceptionMessage( 'unknown content model' );
+
+		$this->newHandlerWith( $this->graphStore, $this->newFailingProviderRegistry() )
+			->onRevisionCreated( $revision, new UserIdentityValue( 1, 'Tester' ) );
 	}
 
 	public function testWritesNothingWhenTheSubjectSlotDoesNotHoldSubjectContent(): void {
@@ -137,6 +150,17 @@ class OnRevisionCreatedHandlerTest extends NeoWikiIntegrationTestCase {
 		);
 	}
 
+	private function newFailingProviderRegistry(): PagePropertyProviderRegistry {
+		$registry = new PagePropertyProviderRegistry();
+		$registry->addProvider( new class implements PagePropertyProvider {
+			public function getProperties( PagePropertyProviderContext $context ): array {
+				throw new RuntimeException( 'unknown content model' );
+			}
+		} );
+
+		return $registry;
+	}
+
 	private function newRevisionWithSlotContent( Content $content ): RevisionRecord {
 		$slots = $this->createStub( RevisionSlots::class );
 		$slots->method( 'getContent' )->willReturn( $content );
@@ -163,18 +187,23 @@ class OnRevisionCreatedHandlerTest extends NeoWikiIntegrationTestCase {
 
 	private function newHandlerWith(
 		GraphDatabasePlugin $graphStore,
-		?PagePropertyProviderRegistry $providerRegistry = null
+		?PagePropertyProviderRegistry $providerRegistry = null,
+		bool $isolatePageProperties = false
 	): OnRevisionCreatedHandler {
 		$services = $this->getServiceContainer();
 
+		$pageProperties = new PagePropertiesBuilder(
+			revisionStore: $services->getRevisionStore(),
+			contentHandlerFactory: $services->getContentHandlerFactory(),
+			titleFormatter: $services->getTitleFormatter(),
+			providerRegistry: $providerRegistry ?? new PagePropertyProviderRegistry(),
+		);
+
 		return new OnRevisionCreatedHandler(
 			$graphStore,
-			new PagePropertiesBuilder(
-				revisionStore: $services->getRevisionStore(),
-				contentHandlerFactory: $services->getContentHandlerFactory(),
-				titleFormatter: $services->getTitleFormatter(),
-				providerRegistry: $providerRegistry ?? new PagePropertyProviderRegistry(),
-			),
+			$isolatePageProperties
+				? new FailureIsolatingPagePropertiesSource( $pageProperties, $this->logger )
+				: $pageProperties,
 			$this->logger
 		);
 	}

--- a/tests/phpunit/EntryPoints/PageUndeleteGraphProjectionTest.php
+++ b/tests/phpunit/EntryPoints/PageUndeleteGraphProjectionTest.php
@@ -7,8 +7,10 @@ namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints;
 use MediaWiki\Deferred\DeferredUpdates;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
+use ProfessionalWiki\NeoWiki\Domain\Page\Page;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpyGraphDatabasePlugin;
 
 /**
  * Restoring a page from the archive projects the page as it stands afterwards — once, from its current
@@ -63,6 +65,31 @@ class PageUndeleteGraphProjectionTest extends NeoWikiIntegrationTestCase {
 
 		$this->assertSame( 1, $this->countPageNodes( $pageId ) );
 		$this->assertSame( 'Deleted plain page', $this->readPageNodeName( $pageId ) );
+	}
+
+	/**
+	 * Which revision is projected is asserted above; this pins how many times. Restoring a page with
+	 * several archived revisions must project it once, from the revision that ends up current — the
+	 * per-revision RevisionUndeleted hook this moved off fired once per restored revision, and a
+	 * regression back to that shape would write the page as many times as it has history without
+	 * changing the data any of the other cases assert.
+	 */
+	public function testRestoringAPageWithSeveralRevisionsProjectsItOnce(): void {
+		$this->editPage( 'Page with history', 'First revision.' );
+		$this->editPage( 'Page with history', 'Second revision.' );
+		$pageId = $this->editPage( 'Page with history', 'Third revision.' )->getNewRevision()->getPageId();
+		$this->deletePageByName( 'Page with history' );
+
+		$spy = new SpyGraphDatabasePlugin();
+		$this->registerGraphDatabasePlugins( $spy );
+
+		$this->undeletePageByName( 'Page with history' );
+
+		$this->assertSame(
+			[ $pageId ],
+			array_map( static fn ( Page $page ): int => $page->getId()->id, $spy->savedPages )
+		);
+		$this->assertSame( [], $spy->deletedPageIds );
 	}
 
 	private function countPageNodes( int $pageId ): int {

--- a/tests/phpunit/EntryPoints/REST/ExportPageRdfApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ExportPageRdfApiTest.php
@@ -18,6 +18,9 @@ use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
 use ProfessionalWiki\NeoWiki\Tests\Domain\Rdf\ParsedRdf;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiMockAuthorityTrait;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\ThrowingPagePropertyProvider;
+use RuntimeException;
+use Wikimedia\Rdbms\DBUnexpectedError;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\EntryPoints\REST\ExportPageRdfApi
@@ -206,6 +209,37 @@ JSON
 			'No NeoWiki data found for page: ' . $this->pageId,
 			$response->getBody()->getContents()
 		);
+	}
+
+	/**
+	 * A page whose properties cannot be built is one more page state this export cannot describe, so it
+	 * gets the same answer as the others rather than a 500 carrying the exception message.
+	 */
+	public function testPageWhosePropertiesCannotBeBuiltIsReportedAsNoData(): void {
+		$this->registerPagePropertyProviders( new ThrowingPagePropertyProvider(
+			Title::newFromID( $this->pageId )->getPrefixedText(),
+			new RuntimeException( 'the provider is down' )
+		) );
+
+		$response = $this->export();
+
+		$this->assertSame( 404, $response->getStatusCode() );
+		$this->assertStringNotContainsString( 'the provider is down', $response->getBody()->getContents() );
+	}
+
+	/**
+	 * A wiki-database error belongs to the request rather than to this page, so it must not be reported
+	 * as the page having no data.
+	 */
+	public function testDatabaseFailureIsNotReportedAsNoData(): void {
+		$this->registerPagePropertyProviders( new ThrowingPagePropertyProvider(
+			Title::newFromID( $this->pageId )->getPrefixedText(),
+			new DBUnexpectedError( null, 'the database went away' )
+		) );
+
+		$this->expectException( DBUnexpectedError::class );
+
+		$this->export();
 	}
 
 	public function testPageReadableByANonUltimateAuthorityIsExported(): void {

--- a/tests/phpunit/Maintenance/DumpRdfTest.php
+++ b/tests/phpunit/Maintenance/DumpRdfTest.php
@@ -4,8 +4,15 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Tests\Maintenance;
 
+use Exception;
+use MediaWiki\Maintenance\MaintenanceFatalError;
 use MediaWiki\Tests\Maintenance\MaintenanceBaseTestCase;
+use ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiRegistrar;
 use ProfessionalWiki\NeoWiki\Maintenance\DumpRdf;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\ThrowingPagePropertyProvider;
+use RuntimeException;
+use Wikimedia\Rdbms\DBUnexpectedError;
 
 // The maintenance script is not PSR-4 autoloadable (it lives outside src/), so load it explicitly.
 // Its RUN_MAINTENANCE_IF_MAIN guard is a no-op under PHPUnit, so this does not execute the script.
@@ -42,6 +49,88 @@ class DumpRdfTest extends MaintenanceBaseTestCase {
 		$this->insertPage( 'DumpRdfTest plain page', 'No subjects here.' );
 
 		$this->assertStringContainsString( 'DumpRdfTest plain page', $this->runDump() );
+	}
+
+	public function testKeepsTheDocumentWellFormedWhenAPageInTheMiddleIsSkipped(): void {
+		$this->insertPage( 'DumpRdfTest first page', 'First.' );
+		$this->insertPage( 'DumpRdfTest broken page', 'Cannot be described.' );
+		$this->insertPage( 'DumpRdfTest last page', 'Last.' );
+		$this->failPagePropertiesFor( 'DumpRdfTest broken page', new RuntimeException( 'provider is down' ) );
+
+		$output = $this->runDumpExpectingIncompleteDump();
+
+		$this->assertStringContainsString( 'DumpRdfTest first page', $output );
+		$this->assertStringContainsString( 'DumpRdfTest last page', $output );
+		$this->assertStringNotContainsString( 'DumpRdfTest broken page', $output );
+		$this->assertSame(
+			substr_count( $output, '{' ),
+			substr_count( $output, '}' ),
+			'the skipped page leaves no half-written named graph behind'
+		);
+	}
+
+	/**
+	 * A dump missing pages is still a well-formed document, so the exit code is the only signal a
+	 * caller redirecting stdout to a file has that it is incomplete.
+	 */
+	public function testFailsWhenAPageWasSkipped(): void {
+		$this->insertPage( 'DumpRdfTest broken page', 'Cannot be described.' );
+		$this->failPagePropertiesFor( 'DumpRdfTest broken page', new RuntimeException( 'provider is down' ) );
+
+		$this->expectCallToFatalError();
+
+		$this->runDump();
+	}
+
+	/**
+	 * Skipping is for page state the dump cannot describe. A database failure is not that: swallowing
+	 * it would turn every remaining page into a skip and hand back an all-but-empty document.
+	 */
+	public function testDatabaseFailureEndsTheRunInsteadOfSkippingEveryPage(): void {
+		$this->insertPage( 'DumpRdfTest plain page', 'No subjects here.' );
+		$this->failPagePropertiesFor(
+			'DumpRdfTest plain page',
+			new DBUnexpectedError( null, 'the database went away' )
+		);
+
+		$this->expectException( DBUnexpectedError::class );
+
+		$this->runDump();
+	}
+
+	private function runDumpExpectingIncompleteDump(): string {
+		ob_start();
+		$reportedIncomplete = false;
+
+		try {
+			$this->maintenance->execute();
+		} catch ( MaintenanceFatalError ) {
+			$reportedIncomplete = true;
+		} finally {
+			$output = (string)ob_get_clean();
+		}
+
+		$this->assertTrue( $reportedIncomplete, 'the run reports the dump as incomplete' );
+
+		return $output;
+	}
+
+	private function failPagePropertiesFor( string $pageTitle, Exception $failure ): void {
+		$this->setTemporaryHook(
+			'NeoWikiRegistration',
+			static function ( NeoWikiRegistrar $registrar ) use ( $pageTitle, $failure ): void {
+				$registrar->addPagePropertyProvider(
+					new ThrowingPagePropertyProvider( $pageTitle, $failure )
+				);
+			}
+		);
+
+		NeoWikiExtension::resetInstance();
+	}
+
+	protected function tearDown(): void {
+		NeoWikiExtension::resetInstance();
+		parent::tearDown();
 	}
 
 	private function runDump(): string {

--- a/tests/phpunit/Maintenance/RebuildGraphDatabasesTest.php
+++ b/tests/phpunit/Maintenance/RebuildGraphDatabasesTest.php
@@ -125,10 +125,36 @@ class RebuildGraphDatabasesTest extends NeoWikiIntegrationTestCase {
 		return array_values( array_filter( $pageIds, static fn ( int $pageId ): bool => $pageId > $firstPageId ) );
 	}
 
-	private function runRebuild(): void {
+	/**
+	 * A whole-wiki rebuild parses and re-projects every page, so an interrupted run must be able to pick
+	 * up where it stopped instead of redoing the pages it already reconciled.
+	 */
+	public function testResumesAfterTheGivenPageId(): void {
+		$firstPageId = $this->insertPage( 'Resume first page', 'One.' )['id'];
+		$secondPageId = $this->insertPage( 'Resume second page', 'Two.' )['id'];
+
+		$spy = new SpyGraphDatabasePlugin();
+		$this->registerGraphDatabasePlugins( $spy );
+
+		$this->runRebuild( fromPageId: $firstPageId );
+
+		$this->assertSame(
+			[ $secondPageId ],
+			$this->savedPageIdsAfter( $spy, $firstPageId - 1 ),
+			'the page resumed past should not be projected again'
+		);
+	}
+
+	private function runRebuild( ?int $fromPageId = null ): void {
+		$script = new RebuildGraphDatabases();
+
+		if ( $fromPageId !== null ) {
+			$script->setOption( 'from-page-id', (string)$fromPageId );
+		}
+
 		ob_start();
 		try {
-			( new RebuildGraphDatabases() )->execute();
+			$script->execute();
 		} finally {
 			ob_end_clean();
 		}

--- a/tests/phpunit/NeoWikiIntegrationTestCase.php
+++ b/tests/phpunit/NeoWikiIntegrationTestCase.php
@@ -37,6 +37,12 @@ class NeoWikiIntegrationTestCase extends MediaWikiIntegrationTestCase {
 	use HandlesNeo4jEnvOverrides;
 	use TempUserTestTrait;
 
+	/** @var GraphDatabasePlugin[] */
+	private array $registeredGraphDatabasePlugins = [];
+
+	/** @var PagePropertyProvider[] */
+	private array $registeredPagePropertyProviders = [];
+
 	/**
 	 * The singleton pins a SchemaLookup whose cache is keyed by page and revision id, and those ids
 	 * repeat across tests' temp tables, so an instance surviving a test would serve one test's Schema
@@ -220,16 +226,9 @@ class NeoWikiIntegrationTestCase extends MediaWikiIntegrationTestCase {
 	 * its choosing (a spy, or one that always throws).
 	 */
 	protected function registerGraphDatabasePlugins( GraphDatabasePlugin ...$plugins ): void {
-		$this->setTemporaryHook(
-			'NeoWikiRegistration',
-			static function ( NeoWikiRegistrar $registrar ) use ( $plugins ): void {
-				foreach ( $plugins as $plugin ) {
-					$registrar->addGraphDatabasePlugin( $plugin );
-				}
-			}
-		);
+		array_push( $this->registeredGraphDatabasePlugins, ...$plugins );
 
-		NeoWikiExtension::resetInstance();
+		$this->registerWithNeoWiki();
 	}
 
 	/**
@@ -237,9 +236,28 @@ class NeoWikiIntegrationTestCase extends MediaWikiIntegrationTestCase {
 	 * singleton, so their properties reach the page nodes the write paths project.
 	 */
 	protected function registerPagePropertyProviders( PagePropertyProvider ...$providers ): void {
+		array_push( $this->registeredPagePropertyProviders, ...$providers );
+
+		$this->registerWithNeoWiki();
+	}
+
+	/**
+	 * Everything registered so far goes through one hook handler, replacing the previous one.
+	 * setTemporaryHook clears the hook before adding its handler, so registering plugins and providers
+	 * as two handlers would silently leave only whichever was registered last — with the test still
+	 * green, since what the first helper registered simply never sees a projection.
+	 */
+	private function registerWithNeoWiki(): void {
+		$plugins = $this->registeredGraphDatabasePlugins;
+		$providers = $this->registeredPagePropertyProviders;
+
 		$this->setTemporaryHook(
 			'NeoWikiRegistration',
-			static function ( NeoWikiRegistrar $registrar ) use ( $providers ): void {
+			static function ( NeoWikiRegistrar $registrar ) use ( $plugins, $providers ): void {
+				foreach ( $plugins as $plugin ) {
+					$registrar->addGraphDatabasePlugin( $plugin );
+				}
+
 				foreach ( $providers as $provider ) {
 					$registrar->addPagePropertyProvider( $provider );
 				}

--- a/tests/phpunit/NeoWikiIntegrationTestCaseTest.php
+++ b/tests/phpunit/NeoWikiIntegrationTestCaseTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests;
+
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpyGraphDatabasePlugin;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubPagePropertyProvider;
+
+/**
+ * Guards the registration helpers themselves. Both go through the same hook, and getting that wrong
+ * loses one of them silently: the test stays green because whatever was dropped simply never sees a
+ * projection, so nothing it would have asserted on ever runs.
+ *
+ * @covers \ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase
+ * @group Database
+ */
+class NeoWikiIntegrationTestCaseTest extends NeoWikiIntegrationTestCase {
+
+	public function testPluginsAndProvidersRegisteredSeparatelyBothTakeEffect(): void {
+		$spy = new SpyGraphDatabasePlugin();
+		$this->registerGraphDatabasePlugins( $spy );
+		$this->registerPagePropertyProviders( new StubPagePropertyProvider( [ 'marker' => 'present' ] ) );
+
+		$this->insertPage( 'Page seen by both registrations', 'Plain content.' );
+
+		$this->assertCount( 1, $spy->savedPages, 'the plugin registered first still receives the page' );
+		$this->assertSame(
+			'present',
+			$spy->savedPages[0]->getProperties()->get( 'marker' ),
+			'the provider registered second still contributes its properties'
+		);
+	}
+
+}

--- a/tests/phpunit/Persistence/MediaWiki/DatabasePageIdsLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/DatabasePageIdsLookupTest.php
@@ -53,6 +53,27 @@ class DatabasePageIdsLookupTest extends NeoWikiIntegrationTestCase {
 	}
 
 	/**
+	 * A whole-wiki rebuild is long enough that being able to pick it back up matters, so the walk can
+	 * start past a page id already handled.
+	 */
+	public function testStartsPastTheGivenPageId(): void {
+		$first = $this->insertPage( 'Resume first page', 'One.' )['id'];
+		$second = $this->insertPage( 'Resume second page', 'Two.' )['id'];
+		$third = $this->insertPage( 'Resume third page', 'Three.' )['id'];
+
+		$pageIds = iterator_to_array(
+			( new DatabasePageIdsLookup( $this->getDb() ) )->getPageIds( $first ),
+			false
+		);
+
+		$this->assertNotContains( $first, $pageIds );
+		$this->assertSame( [ $second, $third ], array_values( array_filter(
+			$pageIds,
+			static fn ( int $pageId ): bool => $pageId > $first
+		) ) );
+	}
+
+	/**
 	 * The lookup yields every page on the wiki, so a test asserting a full list has to bound it: this
 	 * drops the pages that exist before the ones the test creates, such as its Schema page.
 	 *

--- a/tests/phpunit/TestDoubles/ThrowingPagePropertyProvider.php
+++ b/tests/phpunit/TestDoubles/ThrowingPagePropertyProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\TestDoubles;
+
+use Exception;
+use ProfessionalWiki\NeoWiki\Domain\Page\PagePropertyProvider;
+use ProfessionalWiki\NeoWiki\Domain\Page\PagePropertyProviderContext;
+
+/**
+ * Fails for one page and contributes nothing for the rest, as a provider owning state outside the
+ * wiki does when that state is unreachable for a particular page. Which exception it throws is the
+ * test's choice, since the paths building page properties treat an infrastructure failure
+ * (TimeoutException, DBError) differently from a provider that simply could not answer.
+ */
+class ThrowingPagePropertyProvider implements PagePropertyProvider {
+
+	public function __construct(
+		private readonly string $failingPageTitle,
+		private readonly Exception $failure,
+	) {
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function getProperties( PagePropertyProviderContext $context ): array {
+		if ( $context->pageTitle === $this->failingPageTitle ) {
+			throw $this->failure;
+		}
+
+		return [];
+	}
+
+}


### PR DESCRIPTION
Review fixes for #1226, targeting its branch so they land with it.

Seven fixes, one per commit. Two further findings are left for a decision rather than fixed; they are
at the bottom.

## What changes

**The RDF dump can no longer report success for a dump that is missing everything.**
`DumpRdf` skipped any page it could not project, so a database failure partway through was reported as
a skip for that page and every page after it. The run then exited 0 with a well-formed TriG document
holding nothing but prefixes — a scheduled `DumpRdf > dump.trig` would overwrite a good dump with an
empty one and pass its exit-code check. Database and timeout failures now end the run, matching how
`FailureIsolatingGraphDatabasePlugin` and `OnRevisionCreatedHandler` already treat them, and a run that
skipped any page exits non-zero.

**The RDF endpoint answers 404, not 500, for a page it cannot describe.**
A page whose properties cannot be built — an uninstalled content model, a `PagePropertyProvider` that
throws — produced a 500 carrying the exception message, and a stack trace when `$wgShowExceptionDetails`
is on. It now gets the same 404 as the other page states the export cannot describe, with the cause
logged, so the documented contract holds: a 404 means the page does not exist or the caller may not read
it, and those stay indistinguishable.

This defect predates #1226 — a subject-bearing page already behaved this way. What #1226 changes is that
every page can now reach it, which is the same widening that prompted the guard in
`OnRevisionCreatedHandler` and `DumpRdf`. This adds the one that was missed.

**`RebuildGraphDatabases` reports why a page failed.**
The page-properties guard was added to the handler both the hook path and the rebuild path share, so it
swallowed failures on both. The rebuild printed `Skipped <page>: its page properties could not be built`
with the cause only on the log channel — and that log line told the operator to run the rebuild, which
is what had just skipped the page.

`PagePropertiesSource` is now the seam. `PagePropertiesBuilder` implements it and either answers or
throws; `FailureIsolatingPagePropertiesSource` wraps it for the hook path only, so an edit still commits
when a provider is down. The rebuild gets the undecorated builder, so it reports
`Failed <page>: <cause>` and counts the page as a failure. This mirrors the split already in place for
the graph plugins.

**`RebuildGraphDatabases` can be resumed and does not hold replicas for hours.**
Rebuilding now walks every page, parsing each one and writing to every backend, so the run is orders of
magnitude longer than it was. Three consequences:

- `--from-page-id` resumes after a page id, pairing with the id the new progress output reports. An
  interrupted run previously restarted from the beginning of the wiki.
- `waitForReplication()` runs every 500 pages. It was never called, and it is also the call that lets
  the load balancer release a replica taken out of the pool.
- The deleted-page phase announces itself before walking the archive table instead of only afterwards,
  and always reports its result. On a wiki with a long deletion history it previously sat silent long
  enough to look hung. That result counts deletions rather than distinct pages, since the archive can
  yield a page id more than once; the message now says so.

**Tests: an undeletion is pinned to projecting the page once.**
The undelete tests asserted which revision gets projected but never how many times, and all three
restored a single-revision history. A regression back to the per-revision `RevisionUndeleted` hook — the
shape #1226 moved off — would have left them green while writing the page once per archived revision.

**Tests: the two registration helpers no longer cancel each other.**
`setTemporaryHook` clears the hook before adding its handler, so `registerGraphDatabasePlugins()`
followed by `registerPagePropertyProviders()` silently kept only the second, with the test still green
because whatever was dropped never saw a projection. A throwing provider plus a spy plugin — the natural
way to test the page-properties path — is exactly that combination.

**Docs and comments: four claims corrected.**
Three are in `docs/`, which publishes to the website. `graph-model.md` said every page has a node after a
rebuild; two of #1226's own outcomes say otherwise. `rdf-export.md` said a page holding no Subjects
projects to its page metadata alone — true of the native projection, but an ontology projection emits no
page metadata, so such a page now returns 200 with an empty graph. Its autodiscovery sentence dropped
both conditions the code enforces, and its list of what produces a 404 was missing a case.

## Left for a decision

**Every edit now runs a full uncached parse inside the page-row lock.**
`PagePropertiesBuilder::getCategories()` calls `getParserOutput()`, which bypasses the parser cache, and
the projection runs from `RevisionFromEditComplete` — inside `PageUpdater`'s atomic section, between
`startAtomic()` and `endAtomic()`. Measured on identical pages, median of 7–9 saves:

| page | before #1226 | with #1226 |
|---|---|---|
| plain subjectless wikitext | 49.3 ms | 84.3 ms |
| subjectless, 6× `{{#cypher_raw}}` | 63.9 ms | 121.9 ms |

Pages using `{{#cypher_raw}}`, `{{#view}}` or `{{#neowiki_value}}` re-run those against the graph inside
the edit lock, on pages that never had Subjects — BlueSpice's dashboard pages are that shape.

The fix is deferring the projection past the commit, which #1226 lists as explicitly out of scope
("Deferred, as in the issue: … job-queueing the projection"). Not something to reverse in a review-fix
PR, so it is flagged here instead.

**A suppressed username stays in the graph and is readable anonymously.**
After RevisionDelete suppresses the username on a page's current revision, MediaWiki hides it, but the
graph still holds `lastEditor` and an anonymous `neowiki-query` call returns it. No revision-visibility
hook is registered, so nothing re-projects. Pre-existing for subject pages; #1226 widens it to every page
on the wiki. The RDF read path is unaffected — it passes `$revision->getUser()`, whose `FOR_PUBLIC`
audience nulls the name; only the graph write path keeps the raw value.

Closing this needs a new hook, so it belongs in its own issue. #1226's description says the widened
`neowiki-query` grant "discloses nothing MediaWiki core does not already expose", which this contradicts
and which is worth correcting there.

## Note on CI

`ReplaceSubjectApiTest` fails intermittently on MW REL1_45 only, in the two cases covering a deleted
Schema page. It is not caused by this branch: #1226's own branch failed the same class in the same job
before any of these commits, and the same matrix entry passed at this exact SHA in the parallel run.
Worth a separate look at that test's isolation.

<sub>AI-authored — Claude Code, `Opus 5 (1M context)`; findings from a review of #1226, each reproduced on
a running dev wiki before and after the fix; diff not yet human-reviewed.</sub>
