### PR TITLE
Record sub-property bridging as a mapping-layer mechanism

### DIFF
--- a/docs/planning/GlobalProperties.md
+++ b/docs/planning/GlobalProperties.md
@@ -70,6 +70,13 @@ terms during import/export. ECHOLOT T2.3 talks about "model-model mappings" betw
 system to adopt the same model. A mapping configuration like "Person.Name maps to `foaf:name`" and "City.Name
 maps to `dcterms:title`" achieves interoperability without changing the data model.
 
+**Sub-property declarations can keep local distinctions while answering ontology-term queries.** Instead of only
+renaming local properties to ontology terms, the projection can emit them as distinct terms declared
+`rdfs:subPropertyOf` the ontology term — `Person.Name` and `City.Name` stay separate in the exported RDF while both
+answer a `foaf:name` query. The unification exists only in the projection, and only for consumers that follow the
+declaration: an entailment-aware store applies it automatically, while on NeoWiki's own SPARQL endpoints (neither
+QLever nor Oxigraph does RDFS reasoning) queries must traverse it explicitly with a property path.
+
 ## Summary
 
 The main argument for global properties is direct alignment with RDF ontologies. The main argument against is

--- a/docs/planning/GlobalProperties.md
+++ b/docs/planning/GlobalProperties.md
@@ -70,12 +70,18 @@ terms during import/export. ECHOLOT T2.3 talks about "model-model mappings" betw
 system to adopt the same model. A mapping configuration like "Person.Name maps to `foaf:name`" and "City.Name
 maps to `dcterms:title`" achieves interoperability without changing the data model.
 
-**Sub-property declarations can keep local distinctions while answering ontology-term queries.** Instead of only
-renaming local properties to ontology terms, the projection can emit them as distinct terms declared
-`rdfs:subPropertyOf` the ontology term — `Person.Name` and `City.Name` stay separate in the exported RDF while both
-answer a `foaf:name` query. The unification exists only in the projection, and only for consumers that follow the
-declaration: an entailment-aware store applies it automatically, while on NeoWiki's own SPARQL endpoints (neither
-QLever nor Oxigraph does RDFS reasoning) queries must traverse it explicitly with a property path.
+**Sub-property declarations can anchor local properties to ontology terms without a global registry.** A mapping
+can declare a native predicate a sub-property of an ontology term — `neo-prop:Name rdfs:subPropertyOf foaf:name` —
+and a `foaf:name` query then finds the local data: the ontology term becomes the shared anchor across Schemas and
+NeoWiki instances that a global property registry would otherwise provide. How far this reaches depends on the
+projection's [predicate scope](NativeRdfProjection.md): with the current flat per-name predicates the declaration
+above covers every "Name" property alike — Person's and City's — while per-Schema anchoring (`Person.Name` under
+`foaf:name`, `City.Name` under `dcterms:title`) needs Schema-scoped predicates, so this mechanism is also an
+argument in that open question. The stores NeoWiki ships with (QLever, Oxigraph) apply no RDFS entailment, so a
+query follows the declarations explicitly: `?p rdfs:subPropertyOf* foaf:name . ?s ?p ?o`. Consumers needing the
+ontology's own shape — `foaf:name` as the predicate — use an ontology projection
+([OntologyMapping.md](OntologyMapping.md)); the declarations serve native-projection consumers. Not built; an
+option for the mapping design (related: [#1163](https://github.com/ProfessionalWiki/NeoWiki/issues/1163)).
 
 ## Summary
 


### PR DESCRIPTION
Adds a sub-property option to Limitations To The Upsides, written for the consortium readers weighing the local-vs-global question: a mapping can declare native predicates `rdfs:subPropertyOf` ontology terms, making the ontology term the shared anchor a global property registry would otherwise provide. States the interaction with the as-built projection honestly — predicates are flat per-name (`neo-prop:Name`), so one declaration spans all same-named properties, and per-Schema anchoring needs Schema-scoped predicates (the open predicate-scope question in NativeRdfProjection.md). Keeps the entailment caveat as a runnable property path and points ontology-shape consumers at the ontology projection.

Considered, omitted: where wiki-level declaration triples live in the per-page named-graph sync; the property path also matching co-hosted ontology projections (#1053 setups); owl:equivalentProperty for the genuinely-identical case; entailment availability on stores beyond the shipped pair (ADR 19 names more).

> <sub>AI-authored — Claude Code, `Fable 5 (max)`; Claude-proposed addition approved by @JeroenDeDauw, then rewritten for ECHOLOT-stakeholder readability on his direction (two rounds); not yet human-reviewed; predicate-shape claims verified against docs/rdf/rdf-export.md and RdfNamespaces.php, text blind-judged and blind-reviewed.</sub>