### PR TITLE
Cut narration from the page-node and RDF export docs

### DIFF
--- a/docs/api/graph-model.md
+++ b/docs/api/graph-model.md
@@ -22,10 +22,8 @@ Two node types and two relationship categories:
 ## Page Nodes
 
 Every page is projected as a `:Page` node when it is saved and by
-[`RebuildGraphDatabases.php`](../operations/maintenance.md#rebuilding-the-graph), whether or not it holds Subjects. The
-exceptions are pages NeoWiki cannot read: one whose subject slot holds content it cannot read as Subjects, and one whose
-Page Properties cannot be built. Both are reported by the rebuild and left out of the graph rather than projected as
-holding nothing, which would drop data the page does hold.
+[`RebuildGraphDatabases.php`](../operations/maintenance.md#rebuilding-the-graph), whether or not it holds Subjects. A
+failed projection leaves the page with no node, or with one holding an earlier revision's data.
 
 A shared graph can hold pages from multiple wikis (a wiki farm), and MediaWiki page ids are unique only within a wiki,
 so a page is identified by the `(wiki_id, id)` pair, not `id` alone ([ADR 22](../adr/022-multi-wiki-node-identity.md)).

--- a/docs/rdf/rdf-export.md
+++ b/docs/rdf/rdf-export.md
@@ -70,15 +70,16 @@ falling back to the `Accept` header, then to TriG; a value other than `trig` or 
 Responses carry `Content-Disposition: inline` with a filename of the page or Subject ID plus the format's
 extension (`42.trig`, `42.ttl`).
 
+Both endpoints and the concept-URI negotiator answer one indistinguishable `404` when the page or Subject does
+not exist, the caller may not read it, or NeoWiki cannot describe it; a malformed Subject ID returns `400`.
+
 ### Page
 
 `GET /rest.php/neowiki/v0/page/{pageId}/rdf`
 
 Returns the page's projection: its page metadata and every Subject on it, in the page's named graph. Under the
 native projection, a page holding no Subjects projects to its page metadata alone; an ontology projection emits
-no page metadata at all, so the same page projects to an empty graph — a `200`, not a `404`. Returns `404` when
-the page does not exist, is not readable by the caller (the two are indistinguishable), its subject slot holds
-content NeoWiki cannot read as Subjects, or its Page Properties cannot be built.
+no page metadata at all, so the same page projects to an empty graph — a `200`, not a `404`.
 
 ```sh
 curl 'https://wiki.example/rest.php/neowiki/v0/page/42/rdf?format=turtle'
@@ -92,9 +93,8 @@ Returns one Subject's projection: exactly the triples the page export emits for 
 description, including the native relation reification — with none of the page-metadata triples, in the hosting page's
 named graph. Inbound relations pointing at the Subject from elsewhere are not included.
 
-Returns `404` when the Subject does not exist or is on a page the caller may not read — the two are indistinguishable.
-A malformed Subject ID returns `400`. A readable Subject whose Schema has no mapping for the requested ontology target
-projects to an empty graph — a `200`, not a `404`.
+A readable Subject whose Schema has no mapping for the requested ontology target projects to an empty graph —
+a `200`, not a `404`.
 
 ```sh
 curl 'https://wiki.example/rest.php/neowiki/v0/subject/s1demo8aaaaaab5/rdf?projection=EDM'
@@ -111,8 +111,7 @@ content-negotiates it and answers `303 See Other` with an absolute `Location`:
 | `text/turtle` | the Subject's Turtle RDF (`.../subject/{id}/rdf?format=turtle`) |
 | `text/html`, `*/*`, absent, anything else | the Subject's hosting page |
 
-TriG wins when both RDF types are acceptable; the RDF redirects use the native projection. A Subject that is absent or
-on a page the caller may not read returns one indistinguishable `404`; a malformed id `400`.
+TriG wins when both RDF types are acceptable; the RDF redirects use the native projection.
 
 The default HTML target is that page's Data tab (`/Example_Page/subjects`) opened on the Subject's row.
 When `$wgNeoWikiDereferenceSubjectsToDataTab` is set to `false`, the target is the wiki page itself (`/Example_Page`).


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1244

#1244 corrected four doc claims that had become false. Two of those corrections replaced a wrong
sentence with more than the reader needs.

**`graph-model.md` no longer explains why an unprojected page is left alone.** This page's reader
writes Cypher and decides what to assume about the graph. Naming the two failure modes does not help
them — both are invisible from inside the graph and get the same response — and the closing clause
("rather than projected as holding nothing, which would drop data the page does hold") justifies a
design choice they did not make.

The replacement states what they can act on: a failed projection leaves no node, or a node holding an
earlier revision's data. That second case was missing. On a skip the handler returns before
`savePage()` and deletes nothing, so a page projected earlier keeps a stale node rather than being
"left out of the graph".

**`rdf-export.md` states the shared `404` once instead of three times.** The same "the two are
indistinguishable" sentence appeared in the Page, Subject and dereferencing sections. It now sits once
in the `## Endpoint` preamble, alongside the malformed-Subject-ID `400`, which was also stated twice.
Each endpoint section keeps only what differs: its own cause of an empty graph.

Net: 3 lines and 86 words shorter, with no claim dropped except the one noted below.

## Considered, omitted

- **A status-code table.** Drafted, then discarded. It read shorter in words but longer in lines, moved
  the `projection` and `format` `400`s away from the parameters they constrain, and restated the
  empty-graph case that the endpoint sections already carry with its cause.
- **A per-endpoint status column in `rest-api.md`.** That page already hoists the shared contract into
  `## Permissions` for all its routes, so a column would restate it per row — inside a block whose
  drift-check test covers route coverage only, not descriptions.
- **#1244's two named `404` causes** (subject slot not holding Subject data, Page Properties that
  cannot be built), collapsed into "NeoWiki cannot describe it". A caller cannot tell them apart from
  outside. Worth restoring if that distinction was deliberate.

## Not fixed here

`docs/operations/maintenance.md` still says the rebuild runs "with no batching or resume". #1244 added
`--from-page-id` and a `waitForReplication()` every 500 pages, so that claim is stale. Left alone as
out of scope.

<sub>AI-authored — Claude Code, `Opus 5 (1M context, xhigh)`; two doc-rot concerns raised by @alistair3149, a status-code table proposed then reversed on review; diff not yet human-reviewed; claims checked against the REST handlers and the rebuild path at e9b24f44, inbound anchors and link targets verified, prose-only so no tests apply.</sub>
