### PR TITLE
Address the review findings on the scoped graph rebuild

### DIFF
--- a/docs/extending/extending.md
+++ b/docs/extending/extending.md
@@ -163,15 +163,16 @@ refused backend receives no page changes.
 `PagePropertyProvider`, and runs for every revision, so subject edits, undeletions and page moves all reach you as a
 save. `deletePage` gets only the page id.
 
-`initialize` runs on `update.php`, and at the start of a `RebuildGraphDatabases` run of your store before any page is
-projected — create the store-level structures a fresh store needs there. Make it idempotent, since both paths call it
-every time; it never runs on an individual edit.
+`initialize` runs on `update.php`, at the start of a `RebuildGraphDatabases` run of your store before any page is
+projected, and once per batch of a rebuild started from the wiki — create the store-level structures a fresh store
+needs there. Make it idempotent and cheap, since every path calls it every time; it never runs on an individual edit.
+A rebuild also calls it to ask whether your store is still there when a whole batch of pages has failed.
 
 **Signal failure by throwing.** On an edit, delete or undelete, NeoWiki logs the failure and lets the user's
 operation commit, so a backend being down never blocks the wiki or starves the other backends — your projection is
-simply out of sync until someone runs `RebuildGraphDatabases`. During a rebuild, failures reach the rebuild instead: a
-page you refuse is logged and counted and the rebuild carries on, while an `initialize` throw ends the run before a
-page is read. On `update.php` a failing `initialize` is reported and the update carries on, though the backends
+simply out of sync until the store is rebuilt. During a rebuild, failures reach the rebuild instead: a page you refuse
+is logged and counted and the rebuild carries on, while an `initialize` throw ends the run — before a page is read
+when it opens the store for the run, and at whichever batch it happens on otherwise. On `update.php` a failing `initialize` is reported and the update carries on, though the backends
 registered after yours do not initialize on that run.
 
 Make `deletePage` idempotent: the rebuild re-issues a delete for every page MediaWiki no longer has, so it will ask

--- a/docs/extending/extending.md
+++ b/docs/extending/extending.md
@@ -155,9 +155,11 @@ class MyGraphDatabasePlugin implements GraphDatabasePlugin {
 Register with `NeoWikiRegistrar::addGraphDatabasePlugin( $name, $plugin )`. Example:
 [`src/RedHerbGraphDatabasePlugin.php`](https://github.com/ProfessionalWiki/NeoWiki/blob/master/tests/RedHerb/src/RedHerbGraphDatabasePlugin.php).
 
-The name is what [`--store`](../operations/maintenance.md#rebuilding-one-store) addresses. Pick a stable one and
-namespace it to your extension: a name already taken is refused with a warning on the `NeoWiki` channel, and a
-refused backend receives no page changes.
+The name is what [`--store`](../operations/maintenance.md#rebuilding-one-store) addresses, and what a rebuild files
+its run records under. Pick a stable one and namespace it to your extension. A name is refused with a warning on the
+`NeoWiki` channel when another backend already holds it, when it is `neo4j` in any casing — reserved for the bundled
+Neo4j backend — or when it is longer than 255 bytes, which is all a run record can hold. A refused backend receives
+no page changes and cannot be rebuilt.
 
 `savePage` hands you the page with all of its Subjects and the Page Properties contributed by every
 `PagePropertyProvider`, and runs for every revision, so subject edits, undeletions and page moves all reach you as a

--- a/docs/operations/maintenance.md
+++ b/docs/operations/maintenance.md
@@ -92,12 +92,13 @@ A rebuild started this way runs on MediaWiki's job queue, a batch of pages per j
 
 ### Stale stores
 
-A store is reported as stale when the Mapping page defining its projection was edited or deleted after that store's
-last successful rebuild started: the store still describes every page projected before that change in the old
-vocabulary. Rebuilding it is the fix.
+A store is reported as stale when the Mapping page defining its projection was edited, deleted or restored after that
+store's last successful rebuild started: the store still describes every page projected before that change in the old
+vocabulary. Rebuilding it is the fix. Restoring counts because a store rebuilt while the page was gone was built with
+no projection for it at all.
 
-Set `$wgNeoWikiAutoRebuildOnMappingChange = true;` to have saving or deleting a Mapping page rebuild every store
-holding that projection in the background. It is off by default: such a rebuild reprojects every page carrying a
+Set `$wgNeoWikiAutoRebuildOnMappingChange = true;` to have saving, deleting or restoring a Mapping page rebuild every
+store holding that projection in the background. It is off by default: such a rebuild reprojects every page carrying a
 Subject, and it lets anyone who may edit Mapping pages set that going — work `neowiki-admin` otherwise gates. A
 rebuild somebody started by hand is left to finish rather than restarted; the store shows up stale once it ends.
 

--- a/docs/operations/maintenance.md
+++ b/docs/operations/maintenance.md
@@ -63,12 +63,15 @@ sync, which covers both a failed run and one that finished having left pages beh
 resume; rebuild the store for the second.
 
 A rebuild killed outright — `kill -9`, or the machine going down — leaves its run recorded as still going, and every
-later rebuild of that store refuses to start while it is. Release it by cancelling it on
+later rebuild of that store refuses to start while it is. So does a background rebuild whose first batch never
+reached the job queue, or whose job the queue lost: that one is left queued rather than running, and blocks the store
+just as hard. Release it by cancelling it on
 [Special:GraphStores](#background-rebuilds), which keeps the cursor `--resume` continues from. When the wiki is out of
 reach, record the run as cancelled directly:
 
 ```sql
-UPDATE neowiki_rebuild_runs SET nwrr_status = 'cancelled' WHERE nwrr_store = '<name>' AND nwrr_status = 'running';
+UPDATE neowiki_rebuild_runs SET nwrr_status = 'cancelled'
+WHERE nwrr_store = '<name>' AND nwrr_status IN ( 'running', 'queued' );
 ```
 
 ## Background rebuilds

--- a/docs/operations/maintenance.md
+++ b/docs/operations/maintenance.md
@@ -56,8 +56,11 @@ A run that finished but left individual pages behind has nothing to continue: re
 Pass `--batch-size` to change how many pages are projected between recordings; it defaults to 200.
 
 A page the store rejects is counted and the rebuild carries on; the `NeoWiki` channel says which pages failed and why.
-A store that stops answering partway is another matter: a whole batch failing ends the run, and `--resume` retries
-that batch. The script exits non-zero whenever a store was left out of sync.
+A store that stops answering partway is another matter: when a whole batch fails the rebuild reopens the store, and
+ends the run for `--resume` to retry that batch only if it cannot. A store that still opens means its pages were at
+fault, so they are counted and the walk goes on past them. The script exits non-zero whenever a store was left out of
+sync, which covers both a failed run and one that finished having left pages behind. Only the first has anything to
+resume; rebuild the store for the second.
 
 A rebuild killed outright — `kill -9`, or the machine going down — leaves its run recorded as still going, and every
 later rebuild of that store refuses to start while it is. Release it by cancelling it on

--- a/extension.json
+++ b/extension.json
@@ -45,6 +45,7 @@
 		"RevisionFromEditComplete": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onRevisionFromEditComplete",
 		"PageDeleteComplete": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onPageDeleteComplete",
 		"RevisionUndeleted": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onRevisionUndeleted",
+		"PageUndeleteComplete": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onPageUndeleteComplete",
 		"AfterImportPage": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onAfterImportPage",
 
 		"CodeEditorGetPageLanguage": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onCodeEditorGetPageLanguage",

--- a/maintenance/RebuildGraphDatabases.php
+++ b/maintenance/RebuildGraphDatabases.php
@@ -150,7 +150,7 @@ class RebuildGraphDatabases extends Maintenance implements RebuildBatchObserver 
 
 		try {
 			$run = $this->hasOption( 'resume' )
-				? $coordinator->resume( $storeName, $batchSize, $this )
+				? $coordinator->resume( $storeName, RebuildTrigger::Cli, $batchSize, $this )
 				: $coordinator->rebuild( $storeName, RebuildTrigger::Cli, $batchSize, $this );
 		} catch ( NothingToResumeException $e ) {
 			return $this->reportNothingToResume( $storeName, $e );

--- a/src/Application/GraphRebuild/GraphRebuildCoordinator.php
+++ b/src/Application/GraphRebuild/GraphRebuildCoordinator.php
@@ -195,6 +195,21 @@ class GraphRebuildCoordinator {
 			return;
 		}
 
+		if ( $run->trigger === RebuildTrigger::Cli ) {
+			// A shell is driving this run. Terminal used to be enough to tell a stale job to stop, because
+			// nothing reopened a run id — until --resume did: cancel a background rebuild, resume it from a
+			// shell, and a batch still queued for it finds it going again and advances it alongside the
+			// script, each writing over the other's phase, cursor and counters. Only the maintenance script
+			// resumes, and it is also the only caller that never queues, so a queued batch that finds its
+			// run being driven from a shell has nothing left to do.
+			$this->logger->info(
+				'NeoWiki background graph rebuild left run ' . $runId . ' of graph store "' . $run->store
+				. '" to the shell that is driving it.',
+				[ 'runId' => $runId, 'store' => $run->store ]
+			);
+			return;
+		}
+
 		try {
 			$store = $this->getStore( $run->store );
 

--- a/src/Application/GraphRebuild/GraphRebuildCoordinator.php
+++ b/src/Application/GraphRebuild/GraphRebuildCoordinator.php
@@ -256,12 +256,17 @@ class GraphRebuildCoordinator {
 	 *
 	 * @param int<1, max> $batchSize
 	 */
-	public function resume( string $storeName, int $batchSize, RebuildBatchObserver $observer ): RebuildRun {
+	public function resume(
+		string $storeName,
+		RebuildTrigger $trigger,
+		int $batchSize,
+		RebuildBatchObserver $observer
+	): RebuildRun {
 		self::refuseAnEmptyBatch( $batchSize );
 		$store = $this->getStore( $storeName );
 		$pageRebuilder = ( $this->newPageRebuilder )( $store );
 
-		$reopenedRun = $this->startLock->whileHeld( $storeName, function () use ( $storeName ): RebuildRun {
+		$reopenedRun = $this->startLock->whileHeld( $storeName, function () use ( $storeName, $trigger ): RebuildRun {
 			$this->refuseWhenAlreadyActive( $storeName );
 
 			$latestRun = $this->runs->getLatestRun( $storeName );
@@ -270,7 +275,7 @@ class GraphRebuildCoordinator {
 				throw new NothingToResumeException( $storeName, $latestRun );
 			}
 
-			$reopenedRun = $latestRun->started();
+			$reopenedRun = $latestRun->resumedBy( $trigger );
 			$this->runs->updateRun( $reopenedRun );
 
 			return $reopenedRun;

--- a/src/Application/GraphRebuild/GraphRebuildExecutor.php
+++ b/src/Application/GraphRebuild/GraphRebuildExecutor.php
@@ -166,7 +166,7 @@ class GraphRebuildExecutor {
 		}
 
 		return match ( $current->phase ) {
-			RebuildPhase::Pages => $this->projectPageBatch( $current, $pageRebuilder, $batchSize, $observer ),
+			RebuildPhase::Pages => $this->projectPageBatch( $current, $store, $pageRebuilder, $batchSize, $observer ),
 			RebuildPhase::Deletions => $this->removePageBatch( $current, $store, $batchSize, $observer ),
 		};
 	}
@@ -202,6 +202,7 @@ class GraphRebuildExecutor {
 	 */
 	private function projectPageBatch(
 		RebuildRun $run,
+		GraphDatabasePlugin $store,
 		SubjectPageRebuilder $pageRebuilder,
 		int $batchSize,
 		RebuildBatchObserver $observer
@@ -228,8 +229,12 @@ class GraphRebuildExecutor {
 			}
 		}
 
-		if ( self::storeLooksGone( count( $pageIds ), $batchSize, $offered, count( $failures ) ) ) {
-			return $this->failWholeBatch( $run, $failures );
+		if ( self::everyOfferedPageFailed( count( $pageIds ), $batchSize, $offered, count( $failures ) ) ) {
+			$storeFailure = $this->whyTheStoreCannotBeReached( $store );
+
+			if ( $storeFailure !== null ) {
+				return $this->failWholeBatch( $run, $storeFailure );
+			}
 		}
 
 		$this->reportFailedPages( 'project', $failures, $observer );
@@ -241,19 +246,21 @@ class GraphRebuildExecutor {
 	}
 
 	/**
-	 * Whether a batch failing says something about the store rather than about its pages. Three things
-	 * have to hold at once, and each of them rules out a way of being wrong:
+	 * Whether a batch failed in a way worth asking the store about. Three things have to hold at once,
+	 * and each of them rules out a way of being wrong:
 	 *
 	 * - The batch was a full one. A short batch is the tail of the walk, where a handful of permanently
-	 *   unprojectable pages is enough to fail every page there is — and reading that as the store having
-	 *   gone would leave `--resume` retrying those same pages for ever.
+	 *   unprojectable pages is enough to fail every page there is.
 	 * - The store was offered enough of it for a wholly failed batch to mean anything. One page failing is
 	 *   one page failing, whether the batch held only it or the rest of the batch never reached the store.
 	 * - Every page the store was offered failed. Counted over those rather than over the batch, because a
 	 *   page the walk found and the wiki has since dropped never reached the store: letting one of those
-	 *   stand for a page the store took would walk the whole wiki one failure at a time.
+	 *   stand for a page the store took would ask about the store once per page.
+	 *
+	 * A batch that fails this way still says nothing on its own about whose fault it is — that is what
+	 * whyTheStoreCannotBeReached() settles.
 	 */
-	private static function storeLooksGone(
+	private static function everyOfferedPageFailed(
 		int $batchPageCount,
 		int $batchSize,
 		int $offeredPageCount,
@@ -265,19 +272,42 @@ class GraphRebuildExecutor {
 	}
 
 	/**
-	 * @param array<int, Throwable> $failures Keys are page ids
+	 * Asks a store that has just refused a whole batch whether it is still there, because the batch alone
+	 * cannot say: a store that has gone refuses everything sent to it, and so does a store that is up and
+	 * holding a run of pages it will not take — a family of bulk-imported pages too large for it, say.
+	 *
+	 * Counting the failures cannot tell those apart, and reading the run of pages as the store having gone
+	 * is the worse way to be wrong: the cursor is rewound to the batch, so every later attempt walks back
+	 * into the same pages and stops there, and a store rebuilt only from the wiki never gets past them.
+	 *
+	 * Opening the store is what the plugin contract already offers for this. It is idempotent, callers are
+	 * asked to be free to repeat it, and a rebuild already reads a store whose initialize() throws as one
+	 * it cannot reach. This costs one round trip per wholly failed batch, which is a batch that has just
+	 * cost as many failed round trips as it held pages.
+	 *
+	 * @return ?Throwable Why the store could not be reached, or null when it answered.
 	 */
-	private function failWholeBatch( RebuildRun $run, array $failures ): RebuildRun {
-		$failure = $failures[array_key_last( $failures )];
+	private function whyTheStoreCannotBeReached( GraphDatabasePlugin $store ): ?Throwable {
+		try {
+			$store->initialize();
+		} catch ( TimeoutException | DBError $e ) {
+			throw $e;
+		} catch ( Exception $e ) {
+			return $e;
+		}
 
+		return null;
+	}
+
+	private function failWholeBatch( RebuildRun $run, Throwable $storeFailure ): RebuildRun {
 		// The run rather than its progress, so the cursor stays where this batch began and a resumed run
 		// retries it rather than walking past pages nothing is known to be wrong with.
 		return $this->failRun(
 			$run,
-			'Every page of a batch failed, so the store is treated as gone rather than its pages as '
-				. 'unprojectable. Underlying error: '
-				. BackendFailureMessage::withoutCredentials( $failure->getMessage() ),
-			$failure
+			'Every page of a batch failed and the store could not be opened, so it is treated as gone '
+				. 'rather than its pages as unprojectable. Underlying error: '
+				. BackendFailureMessage::withoutCredentials( $storeFailure->getMessage() ),
+			$storeFailure
 		);
 	}
 
@@ -371,8 +401,12 @@ class GraphRebuildExecutor {
 
 		// Every page of a deletion batch is offered to the store: there is nothing to read off the wiki
 		// first, so none of them can be skipped the way a page the wiki has dropped is while projecting.
-		if ( self::storeLooksGone( count( $pageIds ), $batchSize, count( $pageIds ), count( $failures ) ) ) {
-			return $this->failWholeBatch( $run, $failures );
+		if ( self::everyOfferedPageFailed( count( $pageIds ), $batchSize, count( $pageIds ), count( $failures ) ) ) {
+			$storeFailure = $this->whyTheStoreCannotBeReached( $store );
+
+			if ( $storeFailure !== null ) {
+				return $this->failWholeBatch( $run, $storeFailure );
+			}
 		}
 
 		$this->reportFailedPages( 'remove', $failures, $observer );

--- a/src/Application/GraphRebuild/MappingChangeRebuilder.php
+++ b/src/Application/GraphRebuild/MappingChangeRebuilder.php
@@ -36,14 +36,28 @@ class MappingChangeRebuilder {
 	}
 
 	/**
+	 * The stores whose projection this Mapping page defines. Each of them has to be started in a
+	 * transaction round of its own: starting one takes a database lock that flushes the connection's
+	 * snapshot, which a connection still holding the previous store's writes may not do.
+	 *
 	 * @param string $mappingName The name of the Mapping page that was saved or deleted, normalised.
+	 *
+	 * @return string[] Store names
 	 */
-	public function onMappingChanged( string $mappingName ): void {
+	public function storesHoldingProjection( string $mappingName ): array {
+		$stores = [];
+
 		foreach ( $this->projectionsByStore as $storeName => $projection ) {
 			if ( $projection === $mappingName ) {
-				$this->restartRebuildOf( (string)$storeName );
+				$stores[] = (string)$storeName;
 			}
 		}
+
+		return $stores;
+	}
+
+	public function onMappingChanged( string $storeName ): void {
+		$this->restartRebuildOf( $storeName );
 	}
 
 	/**

--- a/src/Domain/GraphDatabase/GraphDatabasePluginRegistry.php
+++ b/src/Domain/GraphDatabase/GraphDatabasePluginRegistry.php
@@ -41,16 +41,40 @@ class GraphDatabasePluginRegistry {
 	}
 
 	public function addPlugin( string $name, GraphDatabasePlugin $plugin ): void {
-		if ( isset( $this->reservedNames[$name] ) || isset( $this->plugins[$name] ) ) {
+		$rejection = $this->rejectionReason( $name );
+
+		if ( $rejection !== null ) {
 			$this->logger->warning(
-				'Ignoring the graph database plugin registered as "{name}": that name is already taken. '
-				. 'Namespace it to the extension registering it.',
+				'Ignoring the graph database plugin registered as "{name}": ' . $rejection,
 				[ 'name' => $name ]
 			);
 			return;
 		}
 
 		$this->plugins[$name] = $plugin;
+	}
+
+	/**
+	 * Why this name cannot identify a store, as a message to log, or null when it can. The same rules a
+	 * configured store's name is held to, because both end up as the key a rebuild is addressed by and
+	 * as the value its run records are filed under.
+	 */
+	private function rejectionReason( string $name ): ?string {
+		if ( GraphStoreName::isReserved( $name, $this->reservedNames ) ) {
+			return 'that name is held by a bundled backend, in any casing. Namespace it to the '
+				. 'extension registering it.';
+		}
+
+		if ( isset( $this->plugins[$name] ) ) {
+			return 'that name is already taken. Namespace it to the extension registering it.';
+		}
+
+		if ( GraphStoreName::isTooLong( $name ) ) {
+			return 'that name is longer than ' . GraphStoreName::MAX_LENGTH . ' bytes, which is all a '
+				. 'rebuild can file its run records under. Register it under a shorter name.';
+		}
+
+		return null;
 	}
 
 	/**

--- a/src/Domain/GraphDatabase/GraphStoreName.php
+++ b/src/Domain/GraphDatabase/GraphStoreName.php
@@ -1,0 +1,43 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\GraphDatabase;
+
+/**
+ * What a graph store may be called, wherever the name comes from.
+ *
+ * A store name is how a scoped rebuild is addressed and what its run records are filed under, so the
+ * same two rules have to hold for a name out of `NeoWikiSparqlStores` and for one an extension
+ * registers. They were only applied to the first, and a plugin taking a name the records cannot hold
+ * got a store whose runs it could never find again.
+ */
+class GraphStoreName {
+
+	/**
+	 * As many bytes as a rebuild can file its run records under. The run records' own column is this
+	 * wide, and a name cut to fit no longer matches the one every lookup passes.
+	 */
+	public const int MAX_LENGTH = 255;
+
+	public static function isTooLong( string $name ): bool {
+		return strlen( $name ) > self::MAX_LENGTH;
+	}
+
+	/**
+	 * Whatever its casing: a store called "Neo4j" reads as the bundled backend wherever a name is
+	 * written or reported, whether or not the two collide as array keys.
+	 *
+	 * @param array<string, true> $reservedNames Keys are the names the bundled backends hold
+	 */
+	public static function isReserved( string $name, array $reservedNames ): bool {
+		foreach ( array_keys( $reservedNames ) as $reserved ) {
+			if ( strcasecmp( $name, (string)$reserved ) === 0 ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+}

--- a/src/Domain/GraphRebuild/RebuildRun.php
+++ b/src/Domain/GraphRebuild/RebuildRun.php
@@ -75,6 +75,16 @@ readonly class RebuildRun {
 		return $this->with( status: RebuildStatus::Cancelled );
 	}
 
+	/**
+	 * The run is being picked back up by hand, so it is now driven by whoever asked for that rather than
+	 * by whatever filed it. The trigger is what decides whether an automatic rebuild may take a run away
+	 * from someone and how a failure tells them to continue, and both of those are about who is driving
+	 * it now, not about how it started.
+	 */
+	public function resumedBy( RebuildTrigger $trigger ): self {
+		return $this->with( status: RebuildStatus::Running, trigger: $trigger );
+	}
+
 	private function with(
 		RebuildStatus $status,
 		?RebuildPhase $phase = null,
@@ -82,6 +92,7 @@ readonly class RebuildRun {
 		?int $processed = null,
 		?int $failed = null,
 		?string $error = null,
+		?RebuildTrigger $trigger = null,
 	): self {
 		return new self(
 			id: $this->id,
@@ -91,7 +102,7 @@ readonly class RebuildRun {
 			cursor: $cursor ?? $this->cursor,
 			processed: $processed ?? $this->processed,
 			failed: $failed ?? $this->failed,
-			trigger: $this->trigger,
+			trigger: $trigger ?? $this->trigger,
 			error: $error,
 			started: $this->started,
 			finished: $this->finished,

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -327,9 +327,16 @@ class NeoWikiHooks {
 
 		$mappingName = $title->getText();
 
-		DeferredUpdates::addCallableUpdate( static function () use ( $mappingName ): void {
-			self::rebuildStoresHoldingMapping( $mappingName );
-		} );
+		// One update per store, so each takes its start lock on a connection with nothing pending. Sharing
+		// a round, the second store's lock would find the first store's writes still there and throw.
+		foreach (
+			NeoWikiExtension::getInstance()->newMappingChangeRebuilder()->storesHoldingProjection( $mappingName )
+			as $storeName
+		) {
+			DeferredUpdates::addCallableUpdate( static function () use ( $storeName, $mappingName ): void {
+				self::rebuildStoreHoldingMapping( $storeName, $mappingName );
+			} );
+		}
 	}
 
 	/**
@@ -338,14 +345,14 @@ class NeoWikiHooks {
 	 * reported rather than allowed to take the rest of the deferred work down with it, and
 	 * Special:GraphStores still shows the store as stale.
 	 */
-	private static function rebuildStoresHoldingMapping( string $mappingName ): void {
+	private static function rebuildStoreHoldingMapping( string $storeName, string $mappingName ): void {
 		try {
-			NeoWikiExtension::getInstance()->newMappingChangeRebuilder()->onMappingChanged( $mappingName );
+			NeoWikiExtension::getInstance()->newMappingChangeRebuilder()->onMappingChanged( $storeName );
 		} catch ( Throwable $e ) {
 			LoggerFactory::getInstance( 'NeoWiki' )->error(
-				'NeoWiki could not rebuild the graph stores holding the projection Mapping page "'
-				. $mappingName . '" defines, so they still hold the old vocabulary. Rebuild them from '
-				. 'Special:GraphStores. Underlying error: '
+				'NeoWiki could not rebuild graph store "' . $storeName . '", which holds the projection '
+				. 'Mapping page "' . $mappingName . '" defines, so it still holds the old vocabulary. '
+				. 'Rebuild it from Special:GraphStores. Underlying error: '
 				. BackendFailureMessage::withoutCredentials( $e->getMessage() ),
 				[ 'exception' => $e, 'mapping' => $mappingName ]
 			);

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -283,7 +283,29 @@ class NeoWikiHooks {
 	): void {
 		NeoWikiExtension::getInstance()->getStoreContentUC()->onRevisionCreated( $revision, $user );
 		$wikiPage->doPurge(); // clear cache
-		self::rebuildStoresHoldingChangedMapping( $wikiPage->getTitle() );
+
+		if ( self::changedTheContent( $revision ) ) {
+			self::rebuildStoresHoldingChangedMapping( $wikiPage->getTitle() );
+		}
+	}
+
+	/**
+	 * Whether this revision says anything new. Protecting or unprotecting a page, or changing when that
+	 * expires, inserts a revision carrying the content of the one before it, and this hook fires for
+	 * those as for any other. A Mapping page is what a projection is defined by, so reading one of them
+	 * as a definition change throws away an in-flight rebuild and reprojects the wiki to reach the same
+	 * graph it already had.
+	 */
+	private static function changedTheContent( RevisionRecord $revision ): bool {
+		$parentId = $revision->getParentId();
+
+		if ( $parentId === null || $parentId === 0 ) {
+			return true;
+		}
+
+		$parent = MediaWikiServices::getInstance()->getRevisionLookup()->getRevisionById( $parentId );
+
+		return $parent === null || $parent->getSha1() !== $revision->getSha1();
 	}
 
 	/**

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -9,6 +9,7 @@ use MediaWiki\Deferred\DeferredUpdates;
 use MediaWiki\EditPage\EditPage;
 use MediaWiki\Html\Html;
 use MediaWiki\Installer\DatabaseUpdater;
+use ManualLogEntry;
 use MediaWiki\Logger\LoggerFactory;
 use MediaWiki\MainConfigNames;
 use MediaWiki\MediaWikiServices;
@@ -388,6 +389,28 @@ class NeoWikiHooks {
 
 	public static function onRevisionUndeleted( RevisionRecord $restoredRevision, ?int $oldPageId ): void {
 		NeoWikiExtension::getInstance()->getStoreContentUC()->onPageUndelete( $restoredRevision );
+	}
+
+	/**
+	 * Restoring a Mapping page puts a projection back that the stores holding it were rebuilt without,
+	 * so it changes what their graphs should contain exactly as deleting it did. Handled here rather
+	 * than in onRevisionUndeleted, which fires once per restored revision.
+	 *
+	 * @see PageUndeleteCompleteHook
+	 *
+	 * @param int[] $restoredPageIds
+	 */
+	public static function onPageUndeleteComplete(
+		ProperPageIdentity $page,
+		Authority $restorer,
+		string $reason,
+		RevisionRecord $restoredRev,
+		ManualLogEntry $logEntry,
+		int $restoredRevisionCount,
+		bool $created,
+		array $restoredPageIds
+	): void {
+		self::rebuildStoresHoldingChangedMapping( Title::newFromPageIdentity( $page ) );
 	}
 
 	public static function onSpecialPageInitList( array &$specialPages ): void {

--- a/src/NeoWikiConfig.php
+++ b/src/NeoWikiConfig.php
@@ -4,6 +4,10 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki;
 
+use ProfessionalWiki\NeoWiki\Application\Rdf\RdfPageProjector;
+use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphStoreName;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Neo4jPlugin;
+
 readonly class NeoWikiConfig {
 
 	/**
@@ -59,9 +63,10 @@ readonly class NeoWikiConfig {
 	/**
 	 * Whether at least one usable SPARQL store is present in the raw `NeoWikiSparqlStores` config. Used
 	 * at registration time (before the config is parsed into {@see SparqlStoreConfig} objects) to gate
-	 * the SPARQL query surfaces. The acceptance rule — an array entry with a non-empty-string
-	 * `updateUrl` — mirrors {@see NeoWikiConfigFactory::buildSparqlStore}, so the route is present
-	 * exactly when a plugin will be built.
+	 * the SPARQL query surfaces. The acceptance rule mirrors {@see NeoWikiConfigFactory::buildSparqlStore}
+	 * and the name rules applied after it, so the route is present exactly when a plugin will be built:
+	 * a route registered over a config every entry of which was dropped answers a query with a 500 where
+	 * it should not answer at all.
 	 */
 	public static function hasConfiguredSparqlStore( mixed $rawStores ): bool {
 		if ( !is_array( $rawStores ) ) {
@@ -69,12 +74,41 @@ readonly class NeoWikiConfig {
 		}
 
 		foreach ( $rawStores as $entry ) {
-			if ( is_array( $entry ) && is_string( $entry['updateUrl'] ?? null ) && trim( $entry['updateUrl'] ) !== '' ) {
-				return true;
+			if ( !is_array( $entry ) || !is_string( $entry['updateUrl'] ?? null ) || trim( $entry['updateUrl'] ) === '' ) {
+				continue;
 			}
+
+			// A duplicate name is not among the rules checked here: the first entry claiming a name keeps
+			// it, so a later duplicate being dropped can never leave the stores empty.
+			$name = self::rawStoreName( $entry );
+
+			if ( GraphStoreName::isTooLong( $name )
+				|| GraphStoreName::isReserved( $name, [ Neo4jPlugin::STORE_NAME => true ] ) ) {
+				continue;
+			}
+
+			return true;
 		}
 
 		return false;
+	}
+
+	/**
+	 * The name an entry would be filed under, derived exactly as {@see NeoWikiConfigFactory::buildSparqlStore}
+	 * derives it: an explicit "name", or the projection it holds, or the native projection.
+	 *
+	 * @param array<string, mixed> $entry
+	 */
+	private static function rawStoreName( array $entry ): string {
+		foreach ( [ 'name', 'projection' ] as $key ) {
+			$value = $entry[$key] ?? null;
+
+			if ( is_string( $value ) && trim( $value ) !== '' ) {
+				return trim( $value );
+			}
+		}
+
+		return RdfPageProjector::PROJECTION;
 	}
 
 }

--- a/src/NeoWikiConfigFactory.php
+++ b/src/NeoWikiConfigFactory.php
@@ -7,6 +7,7 @@ namespace ProfessionalWiki\NeoWiki;
 use MediaWiki\Config\Config;
 use MediaWiki\WikiMap\WikiMap;
 use ProfessionalWiki\NeoWiki\Application\Rdf\RdfPageProjector;
+use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphStoreName;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Neo4jPlugin;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -18,8 +19,6 @@ class NeoWikiConfigFactory {
 	 * without a word, so two stores could end up sharing one row — and with it the check that stops two
 	 * rebuilds of one store running at once.
 	 */
-	private const MAX_NAME_LENGTH = 255;
-
 	public function __construct(
 		private readonly LoggerInterface $logger = new NullLogger(),
 	) {
@@ -95,8 +94,8 @@ class NeoWikiConfigFactory {
 				. 'Give this store another "name".';
 		}
 
-		if ( strlen( $name ) > self::MAX_NAME_LENGTH ) {
-			return 'the name "{name}" is longer than ' . self::MAX_NAME_LENGTH . ' bytes, which is all a '
+		if ( GraphStoreName::isTooLong( $name ) ) {
+			return 'the name "{name}" is longer than ' . GraphStoreName::MAX_LENGTH . ' bytes, which is all a '
 				. 'rebuild can file its run records under. Give this store a shorter "name".';
 		}
 

--- a/src/Persistence/MediaWiki/DatabaseRebuildRunRepository.php
+++ b/src/Persistence/MediaWiki/DatabaseRebuildRunRepository.php
@@ -114,6 +114,7 @@ class DatabaseRebuildRunRepository implements RebuildRunRepository {
 				'nwrr_cursor' => $run->cursor,
 				'nwrr_processed' => $run->processed,
 				'nwrr_failed' => $run->failed,
+				'nwrr_trigger' => $run->trigger->value,
 				'nwrr_finished' => $run->status->isTerminal() ? $db->timestamp() : null,
 				'nwrr_error' => $run->error === null ? null : mb_strcut( $run->error, 0, self::MAX_ERROR_LENGTH ),
 			] )

--- a/src/Persistence/MediaWiki/MappingPageChangeTimeLookup.php
+++ b/src/Persistence/MediaWiki/MappingPageChangeTimeLookup.php
@@ -39,21 +39,32 @@ class MappingPageChangeTimeLookup implements ProjectionChangeTimeLookup {
 			return null;
 		}
 
-		return $this->revisionLookup->getRevisionByTitle( $title )?->getTimestamp()
-			?? $this->getDeletionTime( $title );
+		$revisionTime = $this->revisionLookup->getRevisionByTitle( $title )?->getTimestamp();
+		$logTime = $this->getLastDeletionOrRestorationTime( $title );
+
+		if ( $revisionTime === null || $logTime === null ) {
+			return $revisionTime ?? $logTime;
+		}
+
+		// Both are TS_MW, which sorts as it reads.
+		return max( $revisionTime, $logTime );
 	}
 
 	/**
-	 * The most recent time the page was deleted. Most recent, because a page can be deleted, restored and
-	 * deleted again, and only a page that is gone now gets this far.
+	 * The most recent time the page was deleted or put back. Most recent, because a page can be deleted,
+	 * restored and deleted again.
+	 *
+	 * Restoring counts because a restored revision keeps its original timestamp: read off the page alone,
+	 * a projection put back after its stores were rebuilt without it looks untouched since before the
+	 * deletion, and the stores that no longer describe it report as in sync.
 	 */
-	private function getDeletionTime( Title $title ): ?string {
+	private function getLastDeletionOrRestorationTime( Title $title ): ?string {
 		$timestamp = $this->connectionProvider->getReplicaDatabase()->newSelectQueryBuilder()
 			->select( 'MAX(log_timestamp)' )
 			->from( 'logging' )
 			->where( [
 				'log_type' => 'delete',
-				'log_action' => 'delete',
+				'log_action' => [ 'delete', 'restore' ],
 				'log_namespace' => $title->getNamespace(),
 				'log_title' => $title->getDBkey(),
 			] )

--- a/tests/phpunit/Application/GraphRebuild/BackgroundGraphRebuildTest.php
+++ b/tests/phpunit/Application/GraphRebuild/BackgroundGraphRebuildTest.php
@@ -302,6 +302,46 @@ class BackgroundGraphRebuildTest extends NeoWikiIntegrationTestCase {
 	}
 
 	/**
+	 * Cancelling does not reach into the queue, because a job for an ended run does nothing — which held
+	 * until --resume reopened a run under its old id. A batch still queued from before the cancel then
+	 * found the run going again and advanced it alongside the script, each writing over the other's
+	 * phase, cursor and counters, so the wiki was walked twice and the totals came out short.
+	 */
+	public function testABatchQueuedBeforeACancelDoesNotDriveTheRunAShellResumed(): void {
+		$pageIds = $this->createSubjectPages( 'One', 'Two', 'Three', 'Four' );
+		$this->registerStore( new SpyGraphDatabasePlugin() );
+		$coordinator = $this->newCoordinator( batchSize: 2 );
+		$run = $coordinator->startBackground( self::STORE, RebuildTrigger::Api );
+		$coordinator->cancel( self::STORE );
+
+		// The job runner pops the batch queued before the cancel while the script is mid-walk, which is
+		// the window the run id being reopened creates.
+		$stragglerRan = false;
+		$store = new SpyGraphDatabasePlugin(
+			whileSavingEachPage: function () use ( $run, &$stragglerRan ): void {
+				if ( $stragglerRan ) {
+					return;
+				}
+
+				$stragglerRan = true;
+				$this->newCoordinator( batchSize: 2 )->continueInBackground( $run->id );
+			}
+		);
+		$this->registerStore( $store );
+
+		$resumedRun = $this->newCoordinator( batchSize: 2 )
+			->resume( self::STORE, RebuildTrigger::Cli, 2, new NullRebuildBatchObserver() );
+
+		$this->assertTrue( $stragglerRan, 'the queued batch has to have been run for this to test anything' );
+		$this->assertSame( RebuildStatus::Succeeded, $resumedRun->status );
+		$this->assertSame(
+			$pageIds,
+			self::savedPageIds( $store ),
+			'the queued batch must not have projected pages the script is already walking'
+		);
+	}
+
+	/**
 	 * A batch that could not run at all leaves no way for the queue to carry the run forward, so it has
 	 * to end the run rather than leave it recorded as going with nothing going.
 	 */

--- a/tests/phpunit/Application/GraphRebuild/BackgroundGraphRebuildTest.php
+++ b/tests/phpunit/Application/GraphRebuild/BackgroundGraphRebuildTest.php
@@ -296,7 +296,7 @@ class BackgroundGraphRebuildTest extends NeoWikiIntegrationTestCase {
 		$run = $coordinator->startBackground( self::STORE, RebuildTrigger::Api );
 		$coordinator->continueInBackground( $run->id );
 		$coordinator->cancel( self::STORE );
-		$coordinator->resume( self::STORE, 200, new NullRebuildBatchObserver() );
+		$coordinator->resume( self::STORE, RebuildTrigger::Cli, 200, new NullRebuildBatchObserver() );
 
 		$this->assertSame( $pageIds, self::savedPageIds( $store ) );
 	}

--- a/tests/phpunit/Application/GraphRebuild/GraphRebuildTest.php
+++ b/tests/phpunit/Application/GraphRebuild/GraphRebuildTest.php
@@ -56,6 +56,7 @@ class GraphRebuildTest extends NeoWikiIntegrationTestCase {
 	private const STORE = 'scoped-store';
 	private const OTHER_STORE = 'other-store';
 	private const WIKI_DATABASE_FAILURE_MESSAGE = 'the wiki database is gone';
+	private const STORE_IS_GONE_MESSAGE = 'the store is not answering';
 	private const PAGE_ID_THE_WIKI_NO_LONGER_HAS = 987654;
 	private const OTHER_PAGE_ID_THE_WIKI_NO_LONGER_HAS = 987655;
 	private const PASSWORD = 'sekrit';
@@ -475,17 +476,53 @@ class GraphRebuildTest extends NeoWikiIntegrationTestCase {
 	}
 
 	/**
-	 * Nothing about a store that is answering makes a whole batch of unrelated pages fail at once, so
-	 * that is read as the store having gone rather than as a wiki full of unprojectable pages.
+	 * A whole batch failing is read as the store having gone only once the store has been asked and could
+	 * not be opened either.
 	 */
-	public function testAStoreThatFailsEveryPageOfABatchFailsTheRun(): void {
+	public function testAStoreThatFailsEveryPageOfABatchAndCannotBeOpenedFailsTheRun(): void {
 		$pageIds = $this->createSubjectPages( 'One', 'Two', 'Three', 'Four' );
-		$this->registerStore( new SpyGraphDatabasePlugin( refusedPageIds: $pageIds ) );
+		$this->registerStore( self::newStoreThatHasGone( refusedPageIds: $pageIds ) );
 
 		$run = $this->rebuild( batchSize: 2 );
 
 		$this->assertSame( RebuildStatus::Failed, $run->status );
-		$this->assertStringContainsString( SpyGraphDatabasePlugin::FAILURE_MESSAGE, (string)$run->error );
+		$this->assertStringContainsString( self::STORE_IS_GONE_MESSAGE, (string)$run->error );
+	}
+
+	/**
+	 * A store that is up and holding a run of pages it will not take refuses a whole batch exactly as a
+	 * store that has gone does, and reading that as the store having gone rewinds the cursor to the batch,
+	 * so every later attempt walks back into the same pages and stops there. The pages are counted and
+	 * reported instead, and the walk goes on past them.
+	 */
+	public function testAStoreThatStillOpensWalksPastAWholeBatchItRefused(): void {
+		$pageIds = $this->createSubjectPages( 'One', 'Two', 'Three', 'Four' );
+		$store = new SpyGraphDatabasePlugin( refusedPageIds: [ $pageIds[0], $pageIds[1] ] );
+		$this->registerStore( $store );
+
+		$run = $this->rebuild( batchSize: 2 );
+
+		$this->assertSame( RebuildStatus::Succeeded, $run->status );
+		$this->assertSame( 2, $run->failed, 'the refused pages are counted against the wiki, not the store' );
+		$this->assertSame(
+			[ $pageIds[2], $pageIds[3] ],
+			self::savedPageIds( $store ),
+			'the pages behind the refused batch are still projected'
+		);
+	}
+
+	public function testAWholeBatchAStoreRefusedWhileStillOpeningIsReportedPageByPage(): void {
+		$pageIds = $this->createSubjectPages( 'One', 'Two', 'Three', 'Four' );
+		$this->registerStore( new SpyGraphDatabasePlugin( refusedPageIds: [ $pageIds[0], $pageIds[1] ] ) );
+		$observer = new SpyRebuildBatchObserver();
+
+		$this->rebuild( batchSize: 2, observer: $observer );
+
+		$this->assertSame(
+			[ $pageIds[0], $pageIds[1] ],
+			$observer->failedPageIds,
+			'the operator is told which pages the store would not take'
+		);
 	}
 
 	/**
@@ -494,7 +531,7 @@ class GraphRebuildTest extends NeoWikiIntegrationTestCase {
 	 */
 	public function testARunEndedByAWholeBatchFailingIsRewoundToThatBatch(): void {
 		$pageIds = $this->createSubjectPages( 'One', 'Two', 'Three', 'Four' );
-		$this->registerStore( new SpyGraphDatabasePlugin( refusedPageIds: [ $pageIds[2], $pageIds[3] ] ) );
+		$this->registerStore( self::newStoreThatHasGone( refusedPageIds: [ $pageIds[2], $pageIds[3] ] ) );
 
 		$run = $this->rebuild( batchSize: 2 );
 
@@ -505,7 +542,7 @@ class GraphRebuildTest extends NeoWikiIntegrationTestCase {
 
 	public function testAStoreThatFailsEveryPageOfABatchIsRetriedFromThereOnResume(): void {
 		$pageIds = $this->createSubjectPages( 'One', 'Two', 'Three', 'Four' );
-		$this->registerStore( new SpyGraphDatabasePlugin( refusedPageIds: [ $pageIds[2], $pageIds[3] ] ) );
+		$this->registerStore( self::newStoreThatHasGone( refusedPageIds: [ $pageIds[2], $pageIds[3] ] ) );
 		$this->rebuild( batchSize: 2 );
 
 		$recoveredStore = new SpyGraphDatabasePlugin();
@@ -537,7 +574,7 @@ class GraphRebuildTest extends NeoWikiIntegrationTestCase {
 	 */
 	public function testAPageTheWikiDroppedDoesNotSpareAStoreThatFailedEveryPageItWasOffered(): void {
 		$pageIds = $this->createSubjectPages( 'One', 'Two' );
-		$store = new SpyGraphDatabasePlugin( refusedPageIds: $pageIds );
+		$store = self::newStoreThatHasGone( refusedPageIds: $pageIds );
 
 		$run = $this->executeOver(
 			new InMemorySubjectPageIdsLookup( self::PAGE_ID_THE_WIKI_NO_LONGER_HAS, ...$pageIds ),
@@ -547,7 +584,7 @@ class GraphRebuildTest extends NeoWikiIntegrationTestCase {
 		);
 
 		$this->assertSame( RebuildStatus::Failed, $run->status );
-		$this->assertStringContainsString( SpyGraphDatabasePlugin::FAILURE_MESSAGE, (string)$run->error );
+		$this->assertStringContainsString( self::STORE_IS_GONE_MESSAGE, (string)$run->error );
 	}
 
 	/**
@@ -576,7 +613,7 @@ class GraphRebuildTest extends NeoWikiIntegrationTestCase {
 	 */
 	public function testAStoreThatRefusesAWholeBatchOfRemovalsFailsTheRun(): void {
 		$this->createDeletedSubjectPages( 'First deleted', 'Second deleted' );
-		$this->registerStore( new SpyGraphDatabasePlugin( refusesDeletions: true ) );
+		$this->registerStore( self::newStoreThatHasGone( refusesDeletions: true ) );
 
 		$run = $this->rebuild( batchSize: 2 );
 
@@ -588,7 +625,7 @@ class GraphRebuildTest extends NeoWikiIntegrationTestCase {
 
 	public function testAStoreThatRefusedAWholeBatchOfRemovalsRetriesItOnResume(): void {
 		$this->createDeletedSubjectPages( 'First deleted', 'Second deleted' );
-		$this->registerStore( new SpyGraphDatabasePlugin( refusesDeletions: true ) );
+		$this->registerStore( self::newStoreThatHasGone( refusesDeletions: true ) );
 		$this->rebuild( batchSize: 2 );
 
 		$recoveredStore = new SpyGraphDatabasePlugin();
@@ -606,7 +643,7 @@ class GraphRebuildTest extends NeoWikiIntegrationTestCase {
 	 */
 	public function testThePagesOfARewoundBatchAreNotReportedAsFailed(): void {
 		$pageIds = $this->createSubjectPages( 'One', 'Two' );
-		$this->registerStore( new SpyGraphDatabasePlugin( refusedPageIds: $pageIds ) );
+		$this->registerStore( self::newStoreThatHasGone( refusedPageIds: $pageIds ) );
 		$observer = new SpyRebuildBatchObserver();
 
 		$this->rebuild( batchSize: 2, observer: $observer );
@@ -804,6 +841,24 @@ class GraphRebuildTest extends NeoWikiIntegrationTestCase {
 		RebuildBatchObserver $observer = new NullRebuildBatchObserver()
 	): RebuildRun {
 		return $this->newCoordinator()->rebuild( self::STORE, RebuildTrigger::Cli, $batchSize, $observer );
+	}
+
+	/**
+	 * A store that goes during the walk: it opens for the run, then refuses what it is sent and will not
+	 * open again. Both halves matter, because refusing a batch is what a store holding pages it will not
+	 * take does too, and reopening it is what tells the two apart.
+	 *
+	 * @param int[] $refusedPageIds
+	 */
+	private static function newStoreThatHasGone(
+		array $refusedPageIds = [],
+		bool $refusesDeletions = false
+	): SpyGraphDatabasePlugin {
+		return new SpyGraphDatabasePlugin(
+			refusedPageIds: $refusedPageIds,
+			refusesDeletions: $refusesDeletions,
+			whenReopened: new RuntimeException( self::STORE_IS_GONE_MESSAGE )
+		);
 	}
 
 	/**

--- a/tests/phpunit/Application/GraphRebuild/GraphRebuildTest.php
+++ b/tests/phpunit/Application/GraphRebuild/GraphRebuildTest.php
@@ -44,6 +44,7 @@ use Psr\Log\NullLogger;
 use RuntimeException;
 use TestLogger;
 use Wikimedia\Rdbms\DBUnexpectedError;
+use Wikimedia\RequestTimeout\TimeoutException;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\Application\GraphRebuild\GraphRebuildCoordinator
@@ -56,6 +57,7 @@ class GraphRebuildTest extends NeoWikiIntegrationTestCase {
 	private const STORE = 'scoped-store';
 	private const OTHER_STORE = 'other-store';
 	private const WIKI_DATABASE_FAILURE_MESSAGE = 'the wiki database is gone';
+	private const REQUEST_TIMEOUT_MESSAGE = 'the request ran out of time';
 	private const STORE_IS_GONE_MESSAGE = 'the store is not answering';
 	private const PAGE_ID_THE_WIKI_NO_LONGER_HAS = 987654;
 	private const OTHER_PAGE_ID_THE_WIKI_NO_LONGER_HAS = 987655;
@@ -220,6 +222,25 @@ class GraphRebuildTest extends NeoWikiIntegrationTestCase {
 
 		$this->assertSame( RebuildStatus::Failed, $run->status, 'the pages after it would fail identically' );
 		$this->assertSame( self::WIKI_DATABASE_FAILURE_MESSAGE, $run->error );
+		$this->assertSame( 0, $run->failed, 'the run ended rather than counting a page against the store' );
+	}
+
+	/**
+	 * A request that has run out of time does not get more of it by moving to the next page, so the run
+	 * ends where a wiki-database error would. The twin of the case above: both types are re-thrown by the
+	 * same clause, and without this only one of them holds it in place.
+	 */
+	public function testARequestTimeoutEndsTheRunRatherThanCountingOnePage(): void {
+		$pageIds = $this->createSubjectPages( 'One', 'Two', 'Three' );
+		$this->registerStore( new SpyGraphDatabasePlugin(
+			refusedPageIds: $pageIds,
+			failure: new TimeoutException( self::REQUEST_TIMEOUT_MESSAGE, 30.0 )
+		) );
+
+		$run = $this->rebuild();
+
+		$this->assertSame( RebuildStatus::Failed, $run->status, 'the pages after it would fail identically' );
+		$this->assertStringContainsString( self::REQUEST_TIMEOUT_MESSAGE, (string)$run->error );
 		$this->assertSame( 0, $run->failed, 'the run ended rather than counting a page against the store' );
 	}
 
@@ -736,6 +757,21 @@ class GraphRebuildTest extends NeoWikiIntegrationTestCase {
 
 		$this->assertSame( RebuildStatus::Failed, $run->status, 'the removals after it would fail identically' );
 		$this->assertSame( self::WIKI_DATABASE_FAILURE_MESSAGE, $run->error );
+		$this->assertSame( 0, $run->failed, 'the run ended rather than counting a page against the store' );
+	}
+
+	public function testARequestTimeoutWhileRemovingEndsTheRunRatherThanCountingOnePage(): void {
+		$this->createSubjectPages( 'Page deleted during the outage' );
+		$this->deletePageByName( 'Page deleted during the outage' );
+		$this->registerStore( new SpyGraphDatabasePlugin(
+			refusesDeletions: true,
+			failure: new TimeoutException( self::REQUEST_TIMEOUT_MESSAGE, 30.0 )
+		) );
+
+		$run = $this->rebuild();
+
+		$this->assertSame( RebuildStatus::Failed, $run->status, 'the removals after it would fail identically' );
+		$this->assertStringContainsString( self::REQUEST_TIMEOUT_MESSAGE, (string)$run->error );
 		$this->assertSame( 0, $run->failed, 'the run ended rather than counting a page against the store' );
 	}
 

--- a/tests/phpunit/Application/GraphRebuild/GraphRebuildTest.php
+++ b/tests/phpunit/Application/GraphRebuild/GraphRebuildTest.php
@@ -271,7 +271,7 @@ class GraphRebuildTest extends NeoWikiIntegrationTestCase {
 		$coordinator = $this->newCoordinatorThatCannotBuildARebuilder();
 
 		try {
-			$coordinator->resume( self::STORE, 200, new NullRebuildBatchObserver() );
+			$coordinator->resume( self::STORE, RebuildTrigger::Cli, 200, new NullRebuildBatchObserver() );
 			$this->fail( 'a rebuilder that cannot be built has to say so' );
 		} catch ( LogicException ) {
 		}
@@ -304,7 +304,7 @@ class GraphRebuildTest extends NeoWikiIntegrationTestCase {
 		$this->registerStore( $store );
 		$this->recordFailedRunStoppedAt( $pageIds[1], processed: 2 );
 
-		$run = $this->newCoordinator()->resume( self::STORE, 200, new NullRebuildBatchObserver() );
+		$run = $this->newCoordinator()->resume( self::STORE, RebuildTrigger::Cli, 200, new NullRebuildBatchObserver() );
 
 		$this->assertSame(
 			[ $pageIds[2], $pageIds[3] ],
@@ -327,7 +327,7 @@ class GraphRebuildTest extends NeoWikiIntegrationTestCase {
 		$this->registerStore( $store );
 		$this->recordFailedRunInTheDeletionPhase( cursor: 0 );
 
-		$run = $this->newCoordinator()->resume( self::STORE, 200, new NullRebuildBatchObserver() );
+		$run = $this->newCoordinator()->resume( self::STORE, RebuildTrigger::Cli, 200, new NullRebuildBatchObserver() );
 
 		$this->assertSame( RebuildStatus::Succeeded, $run->status );
 		$this->assertSame( [], $store->savedPages, 'the pages the run already projected are left alone' );
@@ -344,7 +344,7 @@ class GraphRebuildTest extends NeoWikiIntegrationTestCase {
 		$this->registerStore( $store );
 		$this->recordFailedRunInTheDeletionPhase( cursor: $deletedPageIds[0] );
 
-		$run = $this->newCoordinator()->resume( self::STORE, 200, new NullRebuildBatchObserver() );
+		$run = $this->newCoordinator()->resume( self::STORE, RebuildTrigger::Cli, 200, new NullRebuildBatchObserver() );
 
 		$this->assertSame( RebuildStatus::Succeeded, $run->status );
 		$this->assertSame(
@@ -359,7 +359,7 @@ class GraphRebuildTest extends NeoWikiIntegrationTestCase {
 		$this->registerStore( new SpyGraphDatabasePlugin() );
 		$failedRun = $this->recordFailedRunStoppedAt( $pageIds[0], processed: 1 );
 
-		$resumedRun = $this->newCoordinator()->resume( self::STORE, 200, new NullRebuildBatchObserver() );
+		$resumedRun = $this->newCoordinator()->resume( self::STORE, RebuildTrigger::Cli, 200, new NullRebuildBatchObserver() );
 
 		$this->assertSame( $failedRun->id, $resumedRun->id );
 	}
@@ -371,7 +371,7 @@ class GraphRebuildTest extends NeoWikiIntegrationTestCase {
 
 		$this->expectException( NothingToResumeException::class );
 
-		$this->newCoordinator()->resume( self::STORE, 200, new NullRebuildBatchObserver() );
+		$this->newCoordinator()->resume( self::STORE, RebuildTrigger::Cli, 200, new NullRebuildBatchObserver() );
 	}
 
 	public function testResumingAStoreThatWasNeverRebuiltIsRefused(): void {
@@ -379,7 +379,7 @@ class GraphRebuildTest extends NeoWikiIntegrationTestCase {
 
 		$this->expectException( NothingToResumeException::class );
 
-		$this->newCoordinator()->resume( self::STORE, 200, new NullRebuildBatchObserver() );
+		$this->newCoordinator()->resume( self::STORE, RebuildTrigger::Cli, 200, new NullRebuildBatchObserver() );
 	}
 
 	/**
@@ -547,7 +547,7 @@ class GraphRebuildTest extends NeoWikiIntegrationTestCase {
 
 		$recoveredStore = new SpyGraphDatabasePlugin();
 		$this->registerStore( $recoveredStore );
-		$run = $this->newCoordinator()->resume( self::STORE, 2, new NullRebuildBatchObserver() );
+		$run = $this->newCoordinator()->resume( self::STORE, RebuildTrigger::Cli, 2, new NullRebuildBatchObserver() );
 
 		$this->assertSame( RebuildStatus::Succeeded, $run->status );
 		$this->assertSame( [ $pageIds[2], $pageIds[3] ], self::savedPageIds( $recoveredStore ) );
@@ -630,7 +630,7 @@ class GraphRebuildTest extends NeoWikiIntegrationTestCase {
 
 		$recoveredStore = new SpyGraphDatabasePlugin();
 		$this->registerStore( $recoveredStore );
-		$run = $this->newCoordinator()->resume( self::STORE, 2, new NullRebuildBatchObserver() );
+		$run = $this->newCoordinator()->resume( self::STORE, RebuildTrigger::Cli, 2, new NullRebuildBatchObserver() );
 
 		$this->assertSame( RebuildStatus::Succeeded, $run->status );
 		$this->assertCount( 2, $recoveredStore->deletedPageIds );
@@ -699,7 +699,7 @@ class GraphRebuildTest extends NeoWikiIntegrationTestCase {
 		$coordinator = $this->newCoordinatorThatCannotTakeTheStartLock();
 
 		try {
-			$coordinator->resume( self::STORE, 200, new NullRebuildBatchObserver() );
+			$coordinator->resume( self::STORE, RebuildTrigger::Cli, 200, new NullRebuildBatchObserver() );
 			$this->fail( 'a resume that cannot take the start lock has to say so' );
 		} catch ( RebuildStartLockUnavailableException ) {
 		}
@@ -712,7 +712,7 @@ class GraphRebuildTest extends NeoWikiIntegrationTestCase {
 
 		$this->expectException( UnknownGraphStoreException::class );
 
-		$this->newCoordinator()->resume( 'no-such-store', 200, new NullRebuildBatchObserver() );
+		$this->newCoordinator()->resume( 'no-such-store', RebuildTrigger::Cli, 200, new NullRebuildBatchObserver() );
 	}
 
 	public function testResumingAStoreAlreadyRebuildingIsRefused(): void {
@@ -721,7 +721,7 @@ class GraphRebuildTest extends NeoWikiIntegrationTestCase {
 
 		$this->expectException( RebuildAlreadyRunningException::class );
 
-		$this->newCoordinator()->resume( self::STORE, 200, new NullRebuildBatchObserver() );
+		$this->newCoordinator()->resume( self::STORE, RebuildTrigger::Cli, 200, new NullRebuildBatchObserver() );
 	}
 
 	public function testAWikiDatabaseFailureWhileRemovingEndsTheRunRatherThanCountingOnePage(): void {
@@ -841,6 +841,34 @@ class GraphRebuildTest extends NeoWikiIntegrationTestCase {
 		RebuildBatchObserver $observer = new NullRebuildBatchObserver()
 	): RebuildRun {
 		return $this->newCoordinator()->rebuild( self::STORE, RebuildTrigger::Cli, $batchSize, $observer );
+	}
+
+	/**
+	 * Resuming from a shell is someone driving the rebuild by hand, whatever filed the run being picked
+	 * up. Left recorded as the automatic rebuild it started life as, an operator's resumed run is one an
+	 * automatic restart reads as unattended and takes away from them mid-walk.
+	 */
+	public function testResumingARunRecordsWhoeverIsDrivingItNow(): void {
+		$this->createSubjectPages( 'One' );
+		$this->registerStore( new SpyGraphDatabasePlugin() );
+		$this->newRunRepository()->startRun( self::STORE, RebuildTrigger::Auto, RebuildStatus::Failed );
+
+		$run = $this->newCoordinator()->resume( self::STORE, RebuildTrigger::Cli, 200, new NullRebuildBatchObserver() );
+
+		$this->assertSame( RebuildTrigger::Cli, $run->trigger );
+	}
+
+	public function testAnAutoStartedRunResumedFromAShellIsLeftAloneByAnAutomaticRestart(): void {
+		$this->createSubjectPages( 'One' );
+		$this->registerStore( new SpyGraphDatabasePlugin() );
+		$repository = $this->newRunRepository();
+		$repository->startRun( self::STORE, RebuildTrigger::Auto, RebuildStatus::Failed );
+		$resumedRun = $this->newCoordinator()->resume( self::STORE, RebuildTrigger::Cli, 200, new NullRebuildBatchObserver() );
+		$repository->updateRun( $resumedRun->started() );
+
+		$this->expectException( RebuildAlreadyRunningException::class );
+
+		$this->newCoordinator()->restartBackground( self::STORE, RebuildTrigger::Auto );
 	}
 
 	/**

--- a/tests/phpunit/Application/GraphRebuild/MappingChangeRebuildTest.php
+++ b/tests/phpunit/Application/GraphRebuild/MappingChangeRebuildTest.php
@@ -110,6 +110,24 @@ class MappingChangeRebuildTest extends NeoWikiIntegrationTestCase {
 		$this->assertNotSame( $firstRun->id, $this->activeRunOf( self::MAPPED_STORE )?->id );
 	}
 
+	/**
+	 * Starting a rebuild takes a database lock that flushes the connection's snapshot, which a connection
+	 * still holding the previous store's writes may not do. Started in one transaction round, every store
+	 * after the first threw, so a mirrored projection left all but one store on the old vocabulary.
+	 */
+	public function testEveryStoreSharingAProjectionIsQueued(): void {
+		$this->overrideConfigValue( 'NeoWikiSparqlStores', [
+			[ 'updateUrl' => 'http://sparql.invalid/edm-a', 'projection' => self::PROJECTION, 'name' => 'edm-a' ],
+			[ 'updateUrl' => 'http://sparql.invalid/edm-b', 'projection' => self::PROJECTION, 'name' => 'edm-b' ],
+		] );
+		NeoWikiExtension::resetInstance();
+
+		$this->createMapping( self::PROJECTION, self::MAPPING_JSON );
+
+		$this->assertNotNull( $this->activeRunOf( 'edm-a' ), 'the first store sharing the projection' );
+		$this->assertNotNull( $this->activeRunOf( 'edm-b' ), 'the second store sharing the projection' );
+	}
+
 	public function testRestoringAMappingQueuesARebuildOfTheStoreHoldingItsProjection(): void {
 		$this->createMapping( self::PROJECTION, self::MAPPING_JSON );
 		$this->deleteMapping( self::PROJECTION );
@@ -234,7 +252,7 @@ class MappingChangeRebuildTest extends NeoWikiIntegrationTestCase {
 			logger: $logger,
 		);
 
-		$rebuilder->onMappingChanged( self::PROJECTION );
+		$rebuilder->onMappingChanged( self::MAPPED_STORE );
 
 		$this->assertStringContainsString(
 			'could not rebuild graph store "' . self::MAPPED_STORE . '"',

--- a/tests/phpunit/Application/GraphRebuild/MappingChangeRebuildTest.php
+++ b/tests/phpunit/Application/GraphRebuild/MappingChangeRebuildTest.php
@@ -111,6 +111,20 @@ class MappingChangeRebuildTest extends NeoWikiIntegrationTestCase {
 	}
 
 	/**
+	 * Protecting a page inserts a revision carrying the content of the one before it. Read as a
+	 * definition change, that throws away whatever rebuild the store had going and starts the wiki over
+	 * from the first page to reach the graph it already had.
+	 */
+	public function testProtectingAMappingLeavesTheRebuildItsStoreAlreadyHadGoing(): void {
+		$this->createMapping( self::PROJECTION, self::MAPPING_JSON );
+		$firstRun = $this->activeRunOf( self::MAPPED_STORE );
+
+		$this->protectMapping( self::PROJECTION );
+
+		$this->assertSame( $firstRun?->id, $this->activeRunOf( self::MAPPED_STORE )?->id );
+	}
+
+	/**
 	 * NeoWiki's own code defines the native projection, so creating a page that happens to be called
 	 * Mapping:Native changes nothing about what a store holding it should contain.
 	 */
@@ -230,6 +244,21 @@ class MappingChangeRebuildTest extends NeoWikiIntegrationTestCase {
 
 	private function newRunRepository(): RebuildRunRepository {
 		return NeoWikiExtension::getInstance()->newRebuildRunRepository();
+	}
+
+	private function protectMapping( string $name ): void {
+		$page = MediaWikiServices::getInstance()->getWikiPageFactory()->newFromTitle(
+			Title::newFromText( $name, NeoWikiExtension::NS_MAPPING )
+		);
+		$status = $page->doUpdateRestrictions(
+			[ 'edit' => 'sysop' ],
+			[],
+			$cascade,
+			'test protection',
+			$this->getTestSysop()->getUser()
+		);
+
+		$this->assertStatusGood( $status );
 	}
 
 	private function deleteMapping( string $name ): void {

--- a/tests/phpunit/Application/GraphRebuild/MappingChangeRebuildTest.php
+++ b/tests/phpunit/Application/GraphRebuild/MappingChangeRebuildTest.php
@@ -110,6 +110,16 @@ class MappingChangeRebuildTest extends NeoWikiIntegrationTestCase {
 		$this->assertNotSame( $firstRun->id, $this->activeRunOf( self::MAPPED_STORE )?->id );
 	}
 
+	public function testRestoringAMappingQueuesARebuildOfTheStoreHoldingItsProjection(): void {
+		$this->createMapping( self::PROJECTION, self::MAPPING_JSON );
+		$this->deleteMapping( self::PROJECTION );
+		$this->newRunRepository()->cancelActiveRun( self::MAPPED_STORE );
+
+		$this->restoreMapping( self::PROJECTION );
+
+		$this->assertNotNull( $this->activeRunOf( self::MAPPED_STORE ) );
+	}
+
 	/**
 	 * Protecting a page inserts a revision carrying the content of the one before it. Read as a
 	 * definition change, that throws away whatever rebuild the store had going and starts the wiki over
@@ -244,6 +254,17 @@ class MappingChangeRebuildTest extends NeoWikiIntegrationTestCase {
 
 	private function newRunRepository(): RebuildRunRepository {
 		return NeoWikiExtension::getInstance()->newRebuildRunRepository();
+	}
+
+	private function restoreMapping( string $name ): void {
+		$status = MediaWikiServices::getInstance()->getUndeletePageFactory()->newUndeletePage(
+			MediaWikiServices::getInstance()->getWikiPageFactory()->newFromTitle(
+				Title::newFromText( $name, NeoWikiExtension::NS_MAPPING )
+			),
+			$this->getTestSysop()->getAuthority()
+		)->undeleteUnsafe( 'test restoration' );
+
+		$this->assertStatusGood( $status );
 	}
 
 	private function protectMapping( string $name ): void {

--- a/tests/phpunit/Domain/GraphDatabase/GraphDatabasePluginRegistryTest.php
+++ b/tests/phpunit/Domain/GraphDatabase/GraphDatabasePluginRegistryTest.php
@@ -6,6 +6,7 @@ namespace ProfessionalWiki\NeoWiki\Tests\Domain\GraphDatabase;
 
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphDatabasePluginRegistry;
+use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphStoreName;
 use Psr\Log\Test\TestLogger;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpyGraphDatabasePlugin;
 
@@ -71,7 +72,7 @@ class GraphDatabasePluginRegistryTest extends TestCase {
 
 		$registry->addPlugin( 'neo4j', new SpyGraphDatabasePlugin() );
 
-		$this->assertTrue( $logger->hasWarningThatContains( 'already taken' ) );
+		$this->assertTrue( $logger->hasWarningThatContains( 'held by a bundled backend' ) );
 	}
 
 	public function testReservingANameLeavesTheOtherNamesFree(): void {
@@ -82,6 +83,41 @@ class GraphDatabasePluginRegistryTest extends TestCase {
 		$registry->addPlugin( 'redherb', $plugin );
 
 		$this->assertSame( [ 'redherb' => $plugin ], $registry->getPlugins() );
+	}
+
+	/**
+	 * A name the run records cannot hold whole is cut to fit when a run is filed, and every lookup then
+	 * passes the uncut name and matches nothing — so the store's rebuilds never find their own records.
+	 */
+	public function testAPluginWhoseNameTheRunRecordsCannotHoldIsIgnored(): void {
+		$registry = new GraphDatabasePluginRegistry();
+
+		$registry->addPlugin( str_repeat( 'a', GraphStoreName::MAX_LENGTH + 1 ), new SpyGraphDatabasePlugin() );
+
+		$this->assertSame( [], $registry->getPlugins() );
+	}
+
+	public function testAPluginNamedExactlyAsLongAsTheRunRecordsAllowIsRegistered(): void {
+		$registry = new GraphDatabasePluginRegistry();
+		$name = str_repeat( 'a', GraphStoreName::MAX_LENGTH );
+
+		$registry->addPlugin( $name, new SpyGraphDatabasePlugin() );
+
+		$this->assertSame( [ $name ], array_keys( $registry->getPlugins() ) );
+	}
+
+	/**
+	 * The bundled backends' names are reserved whatever the casing, as they are for a configured store:
+	 * a plugin registered as "Neo4j" would otherwise stand beside the bundled one and read as it
+	 * wherever a store name is written or reported.
+	 */
+	public function testAPluginTakingAReservedNameInAnotherCasingIsIgnored(): void {
+		$registry = new GraphDatabasePluginRegistry();
+		$registry->reserveNames( 'neo4j' );
+
+		$registry->addPlugin( 'Neo4j', new SpyGraphDatabasePlugin() );
+
+		$this->assertSame( [], $registry->getPlugins() );
 	}
 
 	public function testEmptyRegistryHasNoPlugins(): void {

--- a/tests/phpunit/NamedGraphDatabasePluginsTest.php
+++ b/tests/phpunit/NamedGraphDatabasePluginsTest.php
@@ -68,7 +68,7 @@ class NamedGraphDatabasePluginsTest extends NeoWikiIntegrationTestCase {
 
 		$this->assertNotSame( $spy, $plugins[Neo4jPlugin::STORE_NAME] );
 		$this->assertCount( 1, $warnings, 'the plugin is dropped with a warning rather than in silence' );
-		$this->assertStringContainsString( 'already taken', $warnings[0][1] );
+		$this->assertStringContainsString( 'held by a bundled backend', $warnings[0][1] );
 		$this->assertSame(
 			[ 'name' => Neo4jPlugin::STORE_NAME ],
 			$warnings[0][2],

--- a/tests/phpunit/NeoWikiConfigTest.php
+++ b/tests/phpunit/NeoWikiConfigTest.php
@@ -145,4 +145,39 @@ class NeoWikiConfigTest extends TestCase {
 		);
 	}
 
+	/**
+	 * The gate decides whether the SPARQL query route is registered, and the factory decides whether a
+	 * plugin is built for it to reach. A config whose only usable entry the factory drops for its name
+	 * would otherwise register a route with nothing behind it, which answers a query with a 500 rather
+	 * than the 404 the gate exists to produce.
+	 */
+	public function testAStoreWhoseNameIsReservedDoesNotRegisterTheQueryRoute(): void {
+		$this->assertFalse( NeoWikiConfig::hasConfiguredSparqlStore( [
+			[ 'updateUrl' => 'http://sparql.invalid/', 'name' => 'Neo4j' ],
+		] ) );
+	}
+
+	public function testAStoreWhoseNameTheRunRecordsCannotHoldDoesNotRegisterTheQueryRoute(): void {
+		$this->assertFalse( NeoWikiConfig::hasConfiguredSparqlStore( [
+			[ 'updateUrl' => 'http://sparql.invalid/', 'name' => str_repeat( 'a', 256 ) ],
+		] ) );
+	}
+
+	public function testAStoreSurvivingTheNameRulesRegistersTheQueryRoute(): void {
+		$this->assertTrue( NeoWikiConfig::hasConfiguredSparqlStore( [
+			[ 'updateUrl' => 'http://sparql.invalid/', 'name' => 'Neo4j' ],
+			[ 'updateUrl' => 'http://sparql.invalid/edm', 'projection' => 'EDM' ],
+		] ) );
+	}
+
+	/**
+	 * A duplicate never empties the stores on its own: the first entry claiming the name keeps it.
+	 */
+	public function testADuplicateNameStillRegistersTheQueryRoute(): void {
+		$this->assertTrue( NeoWikiConfig::hasConfiguredSparqlStore( [
+			[ 'updateUrl' => 'http://sparql.invalid/a', 'projection' => 'EDM' ],
+			[ 'updateUrl' => 'http://sparql.invalid/b', 'projection' => 'EDM' ],
+		] ) );
+	}
+
 }

--- a/tests/phpunit/Persistence/MediaWiki/MappingPageChangeTimeLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/MappingPageChangeTimeLookupTest.php
@@ -6,6 +6,7 @@ namespace ProfessionalWiki\NeoWiki\Tests\Persistence\MediaWiki;
 
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
+use Wikimedia\Timestamp\ConvertibleTimestamp;
 use ProfessionalWiki\NeoWiki\Application\GraphRebuild\ProjectionChangeTimeLookup;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\MappingPageChangeTimeLookup;
@@ -49,12 +50,21 @@ class MappingPageChangeTimeLookupTest extends NeoWikiIntegrationTestCase {
 		);
 	}
 
-	public function testAProjectionWhoseMappingPageWasRestoredChangedWhenItWasLastEdited(): void {
-		$latestRevision = $this->createMapping( 'EDM', '{"version":1,"schemas":{}}' );
+	/**
+	 * A restored revision keeps its original timestamp, so reading the page alone puts the projection's
+	 * last change before the deletion. A store rebuilt while the page was gone was built without the
+	 * projection and is exactly as far from the wiki as one rebuilt before an edit, so the restoration
+	 * is what it has to be measured against.
+	 */
+	public function testAProjectionWhoseMappingPageWasRestoredChangedWhenItWasPutBack(): void {
+		ConvertibleTimestamp::setFakeTime( '20260101000000' );
+		$this->createMapping( 'EDM', '{"version":1,"schemas":{}}' );
 		$this->deleteMapping( 'EDM' );
+
+		ConvertibleTimestamp::setFakeTime( '20260202000000' );
 		$this->undeleteMapping( 'EDM' );
 
-		$this->assertSame( $latestRevision?->getTimestamp(), $this->newLookup()->getLastChangeTime( 'EDM' ) );
+		$this->assertSame( '20260202000000', $this->newLookup()->getLastChangeTime( 'EDM' ) );
 	}
 
 	private function deleteMapping( string $name ): void {

--- a/tests/phpunit/Persistence/RebuildRunsSchemaTest.php
+++ b/tests/phpunit/Persistence/RebuildRunsSchemaTest.php
@@ -7,6 +7,7 @@ namespace ProfessionalWiki\NeoWiki\Tests\Persistence;
 use GenerateSchemaChangeSql;
 use GenerateSchemaSql;
 use MediaWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphStoreName;
 
 /**
  * The per-DBMS SQL that update.php applies is generated from the abstract schema and committed
@@ -16,6 +17,28 @@ use MediaWikiIntegrationTestCase;
  * @coversNothing
  */
 class RebuildRunsSchemaTest extends MediaWikiIntegrationTestCase {
+
+	/**
+	 * The longest name a store may be called and the width of the column its runs are filed under are
+	 * declared in two places that know nothing about each other. Narrowing the column alone would leave
+	 * accepted names the records cannot hold whole, and every lookup for such a store would then match
+	 * nothing. Read off the abstract schema rather than off a per-DBMS file, so this holds wherever the
+	 * suite runs — only MySQL materialises the width at all.
+	 */
+	public function testTheStoreNameLimitIsTheWidthOfTheColumnItIsFiledUnder(): void {
+		$schema = json_decode(
+			(string)file_get_contents( dirname( __DIR__, 3 ) . '/sql/neowiki_rebuild_runs.json' ),
+			true
+		);
+
+		$columns = array_column( $schema[0]['columns'], null, 'name' );
+
+		$this->assertSame(
+			GraphStoreName::MAX_LENGTH,
+			$columns['nwrr_store']['type'] === 'binary' ? $columns['nwrr_store']['options']['length'] : null,
+			'GraphStoreName::MAX_LENGTH and the nwrr_store column width have to agree'
+		);
+	}
 
 	/**
 	 * @dataProvider databaseTypeProvider

--- a/tests/phpunit/TestDoubles/SpyGraphDatabasePlugin.php
+++ b/tests/phpunit/TestDoubles/SpyGraphDatabasePlugin.php
@@ -42,17 +42,26 @@ class SpyGraphDatabasePlugin implements GraphDatabasePlugin {
 	 *        store raises about a page it cannot accept.
 	 * @param Closure(): void|null $whileSavingEachPage Run as each page is saved, standing in for whatever
 	 *        else the wiki does during the seconds a real store spends on a batch.
+	 * @param Throwable|null $whenReopened What opening it throws every time after the first, standing in
+	 *        for a store that was there when the rebuild started and has gone since. A rebuild that has
+	 *        just watched a whole batch fail reopens the store to tell one that has gone from one refusing
+	 *        the pages it was sent, so this is what tells the two apart in a test.
 	 */
 	public function __construct(
 		private readonly array $refusedPageIds = [],
 		private readonly bool $refusesDeletions = false,
 		private readonly ?Throwable $failure = null,
 		private readonly ?Closure $whileSavingEachPage = null,
+		private readonly ?Throwable $whenReopened = null,
 	) {
 	}
 
 	public function initialize(): void {
 		$this->initializeCount++;
+
+		if ( $this->whenReopened !== null && $this->initializeCount > 1 ) {
+			throw $this->whenReopened;
+		}
 	}
 
 	public function savePage( Page $page ): void {


### PR DESCRIPTION
Addresses the findings from a review of #1233, one commit per finding. Targets `graph-rebuild-scoped` so it can be merged into that PR before it goes to master.

The review found 15 issues; one was refuted on validation and one is deferred. What is fixed here:

**Behaviour**

- **A run of page-specific failures is no longer an absorbing stop.** `storeLooksGone()` inferred store death from counts alone and rewound the cursor, so a contiguous window of pages a healthy store refuses stopped every attempt at the same place — `--resume` and a fresh run both walked back into it, and nothing behind it was ever projected. The store is now asked whether it is still there, via the `initialize()` the plugin contract already offers for exactly that. A store that answers means the pages are at fault, so they are counted, reported and walked past. This also fixes the failed page ids never reaching the log, since a rewound batch reports nothing.
- **A resumed run records who is driving it.** `resume()` copied the trigger, so `refuseWhenStartedByHand()` read an operator's resumed run as unattended and a Mapping edit cancelled it mid-walk — via the recovery route the docs endorse (cancel on the page, then `--resume`).
- **A stale queued job no longer drives a run the shell resumed.** Cancelling deliberately does not reach into the queue because a job for an ended run does nothing — which held until `--resume` reopened a run id. Only the script resumes, and it never queues, so a queued batch that finds its run being driven from a shell stops.
- **Each store sharing a projection starts in its own transaction round.** Started in one deferred update, every store after the first threw `Cannot flush pre-lock snapshot` and was left on the old vocabulary.
- **Protecting a Mapping page no longer restarts its rebuild.** Protect, unprotect and expiry changes insert a content-identical null revision; a revision now has to say something new to count as a definition change.
- **Restoring a Mapping page counts as a change.** It queued no rebuild and flipped the store straight back to In sync, so a store rebuilt while the page was gone reported as reconciled.
- **An extension's store name is held to the rules a configured one meets.** `addPlugin()` applied neither the 255-byte limit nor the case-insensitive `neo4j` reservation, so a plugin could take a name whose run records it could never find again (truncated silently on production MySQL), or stand as `Neo4j` beside the bundled backend.
- **The SPARQL query route registers only when a store will back it.** A config whose usable entries are all dropped for their names registered the route with no plugin behind it, answering a query with a 500 instead of a 404.

**Tests**

- The request-timeout half of the executor's `catch ( TimeoutException | DBError )` was untested in both phases; dropping the type left the suite green.
- Nothing linked `GraphStoreName::MAX_LENGTH` to the `nwrr_store` column width. The new check reads the width off the abstract schema, because only MySQL materialises it and CI installs SQLite.

**Docs**

- `maintenance.md` over-generalised a whole batch failing, and its offline-recovery SQL matched nothing for a run stranded `queued` — the state the trigger it names actually leaves.
- `extending.md` named two of the three paths that call `initialize()`, and its throw-timing sentence was false for every background batch after the first.

Two further doc updates follow behaviour changed here, and are folded into the commits that caused them rather than standing alone: staleness and auto-rebuild now name restoring a Mapping page alongside editing and deleting it, and the plugin-facing name rules in `extending.md` now match the ones `installation.md` states for configured stores.

## Worth a look

1. **The store probe is the one design decision here.** Classifying the failures or bounding the rewind were the alternatives; probing needs no schema change, no new state, and no guesses about what a backend throws.
2. **One commit reverses a deliberate, tested decision.** `MappingPageChangeTimeLookupTest` pinned that a restored Mapping page reads as changed when it was last edited. That holds only for a store rebuilt before the deletion; one rebuilt during it is as far from the wiki as a store rebuilt before an edit.
3. **#2 is fenced by trigger rather than by an epoch column.** Only the CLI reopens a run id and only the CLI never queues, so the trigger already distinguishes the attempts. An epoch column would be the general fix if background resumption is ever added.

## Not addressed

- **`Special:GraphStores` emits `cdx-button` but loads no Codex styles**, so the buttons render as plain submit inputs. Left out at @alistair3149's request for a separate pass.
- **A Mapping page rename** was reported and refuted: `NS_NEOWIKI_MAPPING` is declared `"movable": false`, so no core move path can rename one.
- **#1233's own description is stale** — it lists the #1236 work as deferred and names three "known gaps" that no longer match the code.

## Verification

`make cs` clean, CI green across MW 1.43–master on PHP 8.3–8.5. Every behavioural fix has a test that was confirmed to fail without it; the two test-only commits were confirmed against the mutation they exist to catch. Local full-suite runs hang on this box for environmental reasons (the unmodified branch hangs identically), so per-file runs were used locally and CI covers the whole suite.

<sub>AI-authored — Claude Code, `Opus 5 (1M context)`; review, validation and implementation in-session; each fix verified against its negative case; not yet human-reviewed.</sub>
