### PR TITLE
Resolve referenced Subjects in one lookup on the read path

### DIFF
--- a/src/Application/Queries/GetPageSubjects/GetPageSubjectsQuery.php
+++ b/src/Application/Queries/GetPageSubjects/GetPageSubjectsQuery.php
@@ -14,6 +14,7 @@ use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectIdList;
 use ProfessionalWiki\NeoWiki\Presentation\SchemaPresentationSerializer;
 
 readonly class GetPageSubjectsQuery {
@@ -39,25 +40,31 @@ readonly class GetPageSubjectsQuery {
 			: PageSubjects::newEmpty();
 
 		$mainSubject = $pageSubjects->getMainSubject();
+		$subjectsOnPage = $pageSubjects->getAllSubjects();
+
+		// Each Subject takes its own entry rather than the page's: these all came out of one page's
+		// content, but an unrebuilt or stale graph can still place two of them on different pages.
+		$hostingPages = $this->pageIdentifiersLookup->getPageIdsOfSubjects( $subjectsOnPage->getIds() );
+
 		$subjectItems = [];
 
 		if ( $mainSubject !== null ) {
 			$subjectItems[$mainSubject->id->text] = GetSubjectResponseItem::fromSubject(
 				$mainSubject,
-				$this->pageIdentifiersLookup->getPageIdOfSubject( $mainSubject->id )
+				$hostingPages[$mainSubject->id->text] ?? null
 			);
 		}
 
 		foreach ( $pageSubjects->getChildSubjects()->asArray() as $childSubject ) {
 			$subjectItems[$childSubject->id->text] = GetSubjectResponseItem::fromSubject(
 				$childSubject,
-				$this->pageIdentifiersLookup->getPageIdOfSubject( $childSubject->id )
+				$hostingPages[$childSubject->id->text] ?? null
 			);
 		}
 
 		$referencedSubjectItems = null;
 		if ( $includeReferencedSubjects ) {
-			$referencedSubjectItems = $this->buildReferencedSubjectItems( $pageSubjects->getAllSubjects()->asArray(), $subjectItems );
+			$referencedSubjectItems = $this->buildReferencedSubjectItems( $subjectsOnPage->asArray(), $subjectItems );
 		}
 
 		$schemas = null;
@@ -82,35 +89,57 @@ readonly class GetPageSubjectsQuery {
 	 * @return array<string, GetSubjectResponseItem>
 	 */
 	private function buildReferencedSubjectItems( array $pageSubjects, array $alreadyIncluded ): array {
+		$referencedIds = $this->collectReferencedIds( $pageSubjects, $alreadyIncluded );
+
+		$referencedSubjects = $this->subjectLookup->getSubjects( $referencedIds );
+		$hostingPages = $this->pageIdentifiersLookup->getPageIdsOfSubjects( $referencedIds );
+
 		$referenced = [];
 
-		foreach ( $pageSubjects as $subject ) {
-			foreach ( $subject->getReferencedSubjects()->asArray() as $referencedId ) {
-				if ( array_key_exists( $referencedId->text, $alreadyIncluded ) || array_key_exists( $referencedId->text, $referenced ) ) {
-					continue;
-				}
+		// Iterated by the collected ids, not the returned map: the response keeps the order the
+		// Statements reach the targets, and SubjectMap promises no order of its own.
+		foreach ( $referencedIds->asArray() as $idText => $referencedId ) {
+			$referencedSubject = $referencedSubjects->getSubject( $referencedId );
 
-				$referencedSubject = $this->subjectLookup->getSubject( $referencedId );
-
-				if ( $referencedSubject === null ) {
-					continue;
-				}
-
-				$pageIdentifiers = $this->pageIdentifiersLookup->getPageIdOfSubject( $referencedSubject->id );
-
-				// An unresolvable page is omitted rather than served ungated. The graph-backed
-				// repository cannot reach one (it returns null first), so this only guards a
-				// future SubjectLookup that bypasses the graph.
-				if ( $pageIdentifiers === null
-					|| !$this->readAuthorizer->authorizeReadByPageId( $pageIdentifiers->getId() ) ) {
-					continue;
-				}
-
-				$referenced[$referencedId->text] = GetSubjectResponseItem::fromSubject( $referencedSubject, $pageIdentifiers );
+			if ( $referencedSubject === null ) {
+				continue;
 			}
+
+			$pageIdentifiers = $hostingPages[$idText] ?? null;
+
+			// An unresolvable page is omitted rather than served ungated. The graph-backed
+			// repository cannot reach one (it returns null first), so this only guards a
+			// future SubjectLookup that bypasses the graph.
+			if ( $pageIdentifiers === null
+				|| !$this->readAuthorizer->authorizeReadByPageId( $pageIdentifiers->getId() ) ) {
+				continue;
+			}
+
+			$referenced[$idText] = GetSubjectResponseItem::fromSubject( $referencedSubject, $pageIdentifiers );
 		}
 
 		return $referenced;
+	}
+
+	/**
+	 * The distinct Subjects the page's Statements reach that the page does not itself carry.
+	 * SubjectIdList deduplicates, so a target reached from two Statements is resolved once.
+	 *
+	 * @param array<int, Subject> $pageSubjects
+	 * @param array<string, GetSubjectResponseItem> $alreadyIncluded
+	 */
+	private function collectReferencedIds( array $pageSubjects, array $alreadyIncluded ): SubjectIdList {
+		$ids = [];
+
+		foreach ( $pageSubjects as $subject ) {
+			foreach ( $subject->getReferencedSubjects()->asArray() as $idText => $referencedId ) {
+				if ( !array_key_exists( $idText, $alreadyIncluded ) ) {
+					$ids[] = $referencedId;
+				}
+			}
+		}
+
+		return new SubjectIdList( $ids );
 	}
 
 	/**

--- a/src/Application/Queries/GetSubject/GetSubjectQuery.php
+++ b/src/Application/Queries/GetSubject/GetSubjectQuery.php
@@ -47,21 +47,27 @@ readonly class GetSubjectQuery {
 		];
 
 		if ( $includeReferencedSubjects ) {
-			foreach ( $subject->getReferencedSubjects()->asArray() as $id ) {
-				$referencedSubject = $this->subjectLookup->getSubject( $id );
+			$referencedIds = $subject->getReferencedSubjects();
+
+			$referencedSubjects = $this->subjectLookup->getSubjects( $referencedIds );
+			$hostingPages = $this->pageIdentifiersLookup->getPageIdsOfSubjects( $referencedIds );
+
+			// Iterated by the requested ids, not the returned map: the response keeps relation
+			// order, and SubjectMap promises no order of its own.
+			foreach ( $referencedIds->asArray() as $idText => $id ) {
+				$referencedSubject = $referencedSubjects->getSubject( $id );
 
 				if ( $referencedSubject === null ) {
 					continue;
 				}
 
-				$referencedPageIdentifiers = $this->pageIdentifiersLookup->getPageIdOfSubject( $referencedSubject->id );
+				$referencedPage = $hostingPages[$idText] ?? null;
 
-				if ( !$this->pageIsReadableOrUnresolved( $referencedPageIdentifiers ) ) {
+				if ( !$this->pageIsReadableOrUnresolved( $referencedPage ) ) {
 					continue;
 				}
 
-				$response[$referencedSubject->getId()->text] =
-					$this->createResponse( $referencedSubject, $includePageIdentifiers, $referencedPageIdentifiers );
+				$response[$idText] = $this->createResponse( $referencedSubject, $includePageIdentifiers, $referencedPage );
 			}
 		}
 

--- a/src/Domain/Subject/SubjectMap.php
+++ b/src/Domain/Subject/SubjectMap.php
@@ -56,6 +56,13 @@ class SubjectMap implements Countable {
 		return array_keys( $this->subjects );
 	}
 
+	public function getIds(): SubjectIdList {
+		return new SubjectIdList( array_map(
+			static fn ( Subject $subject ): SubjectId => $subject->id,
+			$this->subjects
+		) );
+	}
+
 	public function prepend( ?Subject $subject ): self {
 		$subjects = $this->subjects;
 

--- a/src/Persistence/MediaWiki/Subject/PointInTimeSubjectLookup.php
+++ b/src/Persistence/MediaWiki/Subject/PointInTimeSubjectLookup.php
@@ -32,6 +32,13 @@ class PointInTimeSubjectLookup implements SubjectLookup {
 	}
 
 	public function getSubjects( SubjectIdList $subjectIds ): SubjectMap {
+		// Not merely defensive: without it the primary revision's slot is deserialized to select
+		// nothing out of it, and SubjectContent::getPageSubjects() deserializes on every call.
+		// A Subject with no relations reaches here with an empty list, which is the common case.
+		if ( $subjectIds->asStringArray() === [] ) {
+			return new SubjectMap();
+		}
+
 		$subjects = $this->getSubjectsFromRevision( $this->primaryRevision, $subjectIds );
 		$idsByHostingPage = new SubjectIdsByHostingPage( $this->pageIdentifiersLookup );
 

--- a/tests/phpunit/Application/Queries/GetPageSubjects/GetPageSubjectsQueryTest.php
+++ b/tests/phpunit/Application/Queries/GetPageSubjects/GetPageSubjectsQueryTest.php
@@ -9,6 +9,7 @@ use ProfessionalWiki\NeoWiki\Application\Queries\GetPageSubjects\GetPageSubjects
 use ProfessionalWiki\NeoWiki\Application\Queries\GetPageSubjects\GetPageSubjectsQuery;
 use ProfessionalWiki\NeoWiki\Application\Queries\GetPageSubjects\GetPageSubjectsResponse;
 use ProfessionalWiki\NeoWiki\Application\PageIdentifiersLookup;
+use ProfessionalWiki\NeoWiki\Application\PageReadAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\Queries\GetSubject\GetSubjectResponseItem;
 use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
 use ProfessionalWiki\NeoWiki\Application\SubjectLookup;
@@ -19,6 +20,8 @@ use ProfessionalWiki\NeoWiki\Domain\PropertyType\Types\RelationType;
 use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyDefinitions;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
+use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectMap;
 use ProfessionalWiki\NeoWiki\Domain\Value\RelationValue;
@@ -27,6 +30,7 @@ use ProfessionalWiki\NeoWiki\Tests\Data\TestRelation;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSchema;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestStatement;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SelectivePageReadAuthorizer;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubPageReadAuthorizer;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemoryPageIdentifiersLookup;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySchemaLookup;
@@ -228,38 +232,6 @@ class GetPageSubjectsQueryTest extends TestCase {
 		$this->assertSame( 'target subject', $presenter->response->referencedSubjects['s11111111111tar']->label );
 	}
 
-	public function testReferencedSubjectsAlreadyOnPageAreNotDuplicated(): void {
-		$repository = new InMemorySubjectRepository();
-		$repository->savePageSubjects(
-			new PageSubjects(
-				TestSubject::build(
-					id: 's11111111111maa',
-					statements: new StatementList( [
-						TestStatement::build(
-							'partner',
-							new RelationValue( TestRelation::build( id: 'r11111111111maa', targetId: 's11111111111ca1' ) ),
-							RelationType::NAME,
-						),
-					] )
-				),
-				new SubjectMap(
-					TestSubject::build( id: 's11111111111ca1', label: new SubjectLabel( 'on-page target' ) ),
-				)
-			),
-			new PageId( 42 )
-		);
-
-		$subjectLookup = new InMemorySubjectLookup(
-			TestSubject::build( id: 's11111111111ca1', label: new SubjectLabel( 'on-page target' ) )
-		);
-
-		$presenter = $this->newSpyPresenter();
-
-		$this->newQuery( $presenter, $repository, subjectLookup: $subjectLookup )->execute( 42, includeReferencedSubjects: true );
-
-		$this->assertSame( [], $presenter->response->referencedSubjects );
-	}
-
 	public function testReferencedSubjectIsIncludedOnlyOnceWhenMultipleStatementsReferenceIt(): void {
 		$repository = new InMemorySubjectRepository();
 		$repository->savePageSubjects(
@@ -351,12 +323,231 @@ class GetPageSubjectsQueryTest extends TestCase {
 		$this->assertNull( $presenter->response->schemas );
 	}
 
+	/**
+	 * The page's own Subjects come out of one page's content, so learning where they live is one
+	 * lookup however many there are. Per-id resolution must stay at zero: doing it inside the loop
+	 * reinstates a round trip per Subject on the page with the batch call still at one.
+	 */
+	public function testResolvesHostingPagesOfPageSubjectsInOneLookup(): void {
+		$repository = new InMemorySubjectRepository();
+		$repository->savePageSubjects(
+			new PageSubjects(
+				TestSubject::build( id: 's11111111111maa' ),
+				new SubjectMap(
+					TestSubject::build( id: 's11111111111ca1' ),
+					TestSubject::build( id: 's11111111111ca2' ),
+				)
+			),
+			new PageId( 42 )
+		);
+
+		// An unrebuilt or stale graph can answer differently for two Subjects one page carries, so
+		// each item takes its own entry. Reusing one entry for all three would pass on shared values.
+		// The 'Stale' assertions pin that per-item resolution, not the disclosure they imply: this
+		// query never authorizes the page a Subject resolves to. Tracked in #1252.
+		$pageIdentifiersLookup = new InMemoryPageIdentifiersLookup( [
+			[ new SubjectId( 's11111111111maa' ), new PageIdentifiers( new PageId( 42 ), 'Current', 0 ) ],
+			[ new SubjectId( 's11111111111ca1' ), new PageIdentifiers( new PageId( 7 ), 'Stale', 12 ) ],
+		] );
+
+		$presenter = $this->newSpyPresenter();
+
+		$this->newQuery( $presenter, $repository, pageIdentifiersLookup: $pageIdentifiersLookup )->execute( 42 );
+
+		$this->assertSame( 1, $pageIdentifiersLookup->getPageIdsOfSubjectsCallCount );
+		$this->assertSame( 0, $pageIdentifiersLookup->getPageIdOfSubjectCallCount );
+
+		$this->assertSame( 42, $presenter->response->subjects['s11111111111maa']->pageId );
+		$this->assertSame( 7, $presenter->response->subjects['s11111111111ca1']->pageId );
+		$this->assertSame( 'Stale', $presenter->response->subjects['s11111111111ca1']->pageTitle );
+		// A Subject the graph does not place carries no page.
+		$this->assertNull( $presenter->response->subjects['s11111111111ca2']->pageId );
+	}
+
+	/**
+	 * Two lookups for every referenced Subject the page reaches, on top of the one the page's own
+	 * Subjects cost, rather than two apiece. The per-id counts stay at zero for both lookups.
+	 */
+	public function testResolvesEveryReferencedSubjectInTwoLookups(): void {
+		$repository = new InMemorySubjectRepository();
+		$repository->savePageSubjects(
+			new PageSubjects(
+				$this->newSubjectReferencing( 's11111111111maa', 's11111111111tt1', 's11111111111tt2' ),
+				new SubjectMap(
+					$this->newSubjectReferencing( 's11111111111ca1', 's11111111111tt3' ),
+				)
+			),
+			new PageId( 42 )
+		);
+
+		// Registered in reverse, because InMemorySubjectLookup returns its own order rather than the
+		// requested one, exactly as the graph-backed lookups do. Reading the batch out as a map
+		// instead of by the collected ids therefore fails the order assertion below.
+		$subjectLookup = new InMemorySubjectLookup(
+			TestSubject::build( id: 's11111111111tt3' ),
+			TestSubject::build( id: 's11111111111tt2' ),
+			TestSubject::build( id: 's11111111111tt1' ),
+		);
+		$pageIdentifiersLookup = new InMemoryPageIdentifiersLookup( [
+			[ new SubjectId( 's11111111111tt1' ), new PageIdentifiers( new PageId( 101 ), 'First', 0 ) ],
+			[ new SubjectId( 's11111111111tt2' ), new PageIdentifiers( new PageId( 102 ), 'Second', 0 ) ],
+			[ new SubjectId( 's11111111111tt3' ), new PageIdentifiers( new PageId( 103 ), 'Third', 0 ) ],
+		] );
+
+		$presenter = $this->newSpyPresenter();
+
+		$this->newQuery(
+			$presenter,
+			$repository,
+			subjectLookup: $subjectLookup,
+			pageIdentifiersLookup: $pageIdentifiersLookup
+		)->execute( 42, includeReferencedSubjects: true );
+
+		$this->assertSame( 1, $subjectLookup->getSubjectsCallCount );
+		$this->assertSame( 0, $subjectLookup->getSubjectCallCount );
+
+		// One for the page's own Subjects, one for the referenced ones.
+		$this->assertSame( 2, $pageIdentifiersLookup->getPageIdsOfSubjectsCallCount );
+		$this->assertSame( 0, $pageIdentifiersLookup->getPageIdOfSubjectCallCount );
+
+		// In the order the page's Statements reach the targets, not the order the lookup returned
+		// them in, and each with its own hosting page.
+		$this->assertSame(
+			[ 's11111111111tt1', 's11111111111tt2', 's11111111111tt3' ],
+			array_keys( $presenter->response->referencedSubjects )
+		);
+		$this->assertSame( 101, $presenter->response->referencedSubjects['s11111111111tt1']->pageId );
+		$this->assertSame( 102, $presenter->response->referencedSubjects['s11111111111tt2']->pageId );
+		$this->assertSame( 103, $presenter->response->referencedSubjects['s11111111111tt3']->pageId );
+	}
+
+	/**
+	 * The counterpart of GetSubjectQuery's rule, which serves such a Subject. Here it is omitted
+	 * rather than served ungated, so the `?? null` on the batch read must keep feeding the
+	 * null-page branch.
+	 */
+	public function testOmitsReferencedSubjectWhoseHostingPageDoesNotResolve(): void {
+		$repository = new InMemorySubjectRepository();
+		$repository->savePageSubjects(
+			new PageSubjects(
+				$this->newSubjectReferencing( 's11111111111maa', 's11111111111tt1', 's11111111111tt2' ),
+				new SubjectMap()
+			),
+			new PageId( 42 )
+		);
+
+		$presenter = $this->newSpyPresenter();
+
+		$this->newQuery(
+			$presenter,
+			$repository,
+			subjectLookup: new InMemorySubjectLookup(
+				TestSubject::build( id: 's11111111111tt1' ),
+				TestSubject::build( id: 's11111111111tt2' ),
+			),
+			// Places tt2 only, so tt1 resolves to a Subject the query cannot place.
+			pageIdentifiersLookup: new InMemoryPageIdentifiersLookup( [
+				[ new SubjectId( 's11111111111tt2' ), new PageIdentifiers( new PageId( 102 ), 'Second', 0 ) ],
+			] )
+		)->execute( 42, includeReferencedSubjects: true );
+
+		$this->assertSame(
+			[ 's11111111111tt2' ],
+			array_keys( $presenter->response->referencedSubjects )
+		);
+	}
+
+	/**
+	 * A referenced Subject the page already carries is left out by the collected-id filter alone.
+	 * The target is given a hosting page and a resolvable Subject here, so dropping that filter
+	 * puts it in the response rather than tripping the null-page branch on the way.
+	 */
+	public function testReferencedSubjectOnThePageIsExcludedByTheCollectedIdFilter(): void {
+		$repository = new InMemorySubjectRepository();
+		$repository->savePageSubjects(
+			new PageSubjects(
+				$this->newSubjectReferencing( 's11111111111maa', 's11111111111ca1' ),
+				new SubjectMap( TestSubject::build( id: 's11111111111ca1' ) )
+			),
+			new PageId( 42 )
+		);
+
+		$presenter = $this->newSpyPresenter();
+
+		$this->newQuery(
+			$presenter,
+			$repository,
+			subjectLookup: new InMemorySubjectLookup( TestSubject::build( id: 's11111111111ca1' ) ),
+			pageIdentifiersLookup: new InMemoryPageIdentifiersLookup( [
+				[ new SubjectId( 's11111111111maa' ), new PageIdentifiers( new PageId( 42 ), 'Page', 0 ) ],
+				[ new SubjectId( 's11111111111ca1' ), new PageIdentifiers( new PageId( 42 ), 'Page', 0 ) ],
+			] )
+		)->execute( 42, includeReferencedSubjects: true );
+
+		$this->assertSame( [], $presenter->response->referencedSubjects );
+	}
+
+	/**
+	 * The counterpart of GetSubjectQueryTest::testDeniedRequestResolvesNoReferencedSubjects. A
+	 * denied page yields no Subjects to reach targets from, so both batch calls go out empty and
+	 * cost nothing - but only because Neo4jPageIdentifiersLookup and PointInTimeSubjectLookup guard
+	 * the empty list. Asserting zero lookups here pins that rather than leaving it to those guards.
+	 */
+	public function testDeniedPageResolvesNoReferencedSubjects(): void {
+		$repository = new InMemorySubjectRepository();
+		$repository->savePageSubjects(
+			new PageSubjects(
+				$this->newSubjectReferencing( 's11111111111maa', 's11111111111tt1' ),
+				new SubjectMap()
+			),
+			new PageId( 42 )
+		);
+
+		$subjectLookup = new InMemorySubjectLookup( TestSubject::build( id: 's11111111111tt1' ) );
+		$pageIdentifiersLookup = new InMemoryPageIdentifiersLookup( [
+			[ new SubjectId( 's11111111111tt1' ), new PageIdentifiers( new PageId( 101 ), 'Target', 0 ) ],
+		] );
+
+		$presenter = $this->newSpyPresenter();
+
+		$this->newQuery(
+			$presenter,
+			$repository,
+			subjectLookup: $subjectLookup,
+			pageIdentifiersLookup: $pageIdentifiersLookup,
+			readAuthorizer: new SelectivePageReadAuthorizer( deniedPageIds: [ 42 ] )
+		)->execute( 42, includeReferencedSubjects: true );
+
+		$this->assertSame( [], $presenter->response->subjects );
+		$this->assertSame( [], $presenter->response->referencedSubjects );
+		$this->assertSame( 0, $subjectLookup->getSubjectCallCount );
+		$this->assertSame( 0, $pageIdentifiersLookup->getPageIdOfSubjectCallCount );
+	}
+
+	private function newSubjectReferencing( string $id, string ...$targetIds ): Subject {
+		$statements = [];
+
+		foreach ( $targetIds as $index => $targetId ) {
+			$statements[] = TestStatement::build(
+				'reaches ' . $index,
+				new RelationValue( TestRelation::build(
+					id: 'r1111111111' . substr( $id, -3 ) . ( $index + 1 ),
+					targetId: $targetId
+				) ),
+				RelationType::NAME,
+			);
+		}
+
+		return TestSubject::build( id: $id, statements: new StatementList( $statements ) );
+	}
+
 	private function newQuery(
 		object $presenter,
 		InMemorySubjectRepository $repository,
 		?SubjectLookup $subjectLookup = null,
 		?SchemaLookup $schemaLookup = null,
 		?PageIdentifiersLookup $pageIdentifiersLookup = null,
+		?PageReadAuthorizer $readAuthorizer = null,
 	): GetPageSubjectsQuery {
 		return new GetPageSubjectsQuery(
 			presenter: $presenter,
@@ -365,7 +556,7 @@ class GetPageSubjectsQueryTest extends TestCase {
 			schemaLookup: $schemaLookup ?? new InMemorySchemaLookup(),
 			schemaSerializer: new SchemaPresentationSerializer(),
 			pageIdentifiersLookup: $pageIdentifiersLookup ?? new InMemoryPageIdentifiersLookup(),
-			readAuthorizer: new StubPageReadAuthorizer( allowed: true ),
+			readAuthorizer: $readAuthorizer ?? new StubPageReadAuthorizer( allowed: true ),
 		);
 	}
 

--- a/tests/phpunit/Application/Queries/GetSubject/GetSubjectQueryTest.php
+++ b/tests/phpunit/Application/Queries/GetSubject/GetSubjectQueryTest.php
@@ -13,6 +13,7 @@ use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageIdentifiers;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
+use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
 use ProfessionalWiki\NeoWiki\Domain\Value\NumberValue;
@@ -21,6 +22,7 @@ use ProfessionalWiki\NeoWiki\Domain\PropertyType\Types\RelationType;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestRelation;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestStatement;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SelectivePageReadAuthorizer;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubPageReadAuthorizer;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemoryPageIdentifiersLookup;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectLookup;
@@ -219,6 +221,214 @@ class GetSubjectQueryTest extends TestCase {
 		$this->assertSame( 1337, $response->subjects[$referencedSubject->id->text]->pageId );
 		$this->assertSame( 'referenced title', $response->subjects[$referencedSubject->id->text]->pageTitle );
 		$this->assertSame( 12, $response->subjects[$referencedSubject->id->text]->pageNamespaceId );
+	}
+
+	/**
+	 * The counts, not the response, are what this pins: every referenced Subject is resolved by the
+	 * two batch calls, so adding targets does not add round trips. The per-id counts must stay at
+	 * the one the requested Subject itself costs - resolving targets one at a time inside the loop
+	 * keeps the batch calls at one apiece while reinstating the round trips they remove.
+	 */
+	public function testResolvesEveryReferencedSubjectInTwoLookups(): void {
+		$spyPresenter = $this->getSpyPresenter();
+		// Registered in reverse, because InMemorySubjectLookup returns its own order rather than the
+		// requested one, exactly as the graph-backed lookups do. Reading the batch out as a map
+		// instead of by the requested ids therefore fails the order assertion below.
+		$subjectLookup = new InMemorySubjectLookup(
+			$this->newSubjectReferencing( 's11111111111aa1', 's11111111111aa2', 's11111111111aa3' ),
+			TestSubject::build( id: 's11111111111aa3', label: new SubjectLabel( 'third target' ) ),
+			TestSubject::build( id: 's11111111111aa2', label: new SubjectLabel( 'second target' ) ),
+			TestSubject::build( id: 's11111111111aa1', label: new SubjectLabel( 'first target' ) ),
+		);
+		$pageIdentifiersLookup = new InMemoryPageIdentifiersLookup( [
+			[ new SubjectId( 's11111111111maa' ), new PageIdentifiers( new PageId( 42 ), 'Requested', 0 ) ],
+			[ new SubjectId( 's11111111111aa1' ), new PageIdentifiers( new PageId( 101 ), 'First', 0 ) ],
+			[ new SubjectId( 's11111111111aa2' ), new PageIdentifiers( new PageId( 102 ), 'Second', 0 ) ],
+			[ new SubjectId( 's11111111111aa3' ), new PageIdentifiers( new PageId( 103 ), 'Third', 0 ) ],
+		] );
+
+		$query = new GetSubjectQuery(
+			$spyPresenter,
+			$subjectLookup,
+			$pageIdentifiersLookup,
+			new StubPageReadAuthorizer( allowed: true ),
+		);
+
+		$query->execute(
+			subjectId: 's11111111111maa',
+			includePageIdentifiers: true,
+			includeReferencedSubjects: true
+		);
+
+		$this->assertSame( 1, $subjectLookup->getSubjectsCallCount );
+		$this->assertSame( 1, $pageIdentifiersLookup->getPageIdsOfSubjectsCallCount );
+
+		// One each, for the requested Subject; the three targets add none.
+		$this->assertSame( 1, $subjectLookup->getSubjectCallCount );
+		$this->assertSame( 1, $pageIdentifiersLookup->getPageIdOfSubjectCallCount );
+
+		// Requested Subject first, then the targets in the order the Statements reach them, not the
+		// order the lookup returned them in.
+		$this->assertSame(
+			[ 's11111111111maa', 's11111111111aa1', 's11111111111aa2', 's11111111111aa3' ],
+			array_keys( $spyPresenter->response->subjects )
+		);
+
+		// Each target keeps its own hosting page: one shared entry would serve the wrong page here.
+		$this->assertSame( 101, $spyPresenter->response->subjects['s11111111111aa1']->pageId );
+		$this->assertSame( 102, $spyPresenter->response->subjects['s11111111111aa2']->pageId );
+		$this->assertSame( 103, $spyPresenter->response->subjects['s11111111111aa3']->pageId );
+	}
+
+	public function testOmitsReferencedSubjectMissingFromTheBatch(): void {
+		$spyPresenter = $this->getSpyPresenter();
+		$subjectLookup = new InMemorySubjectLookup(
+			$this->newSubjectReferencing( 's11111111111aa1', 's11111111111aa2' ),
+			TestSubject::build( id: 's11111111111aa2', label: new SubjectLabel( 'second target' ) ),
+		);
+
+		$query = new GetSubjectQuery(
+			$spyPresenter,
+			$subjectLookup,
+			new InMemoryPageIdentifiersLookup( [
+				[ new SubjectId( 's11111111111aa2' ), new PageIdentifiers( new PageId( 102 ), 'Second', 0 ) ],
+			] ),
+			new StubPageReadAuthorizer( allowed: true ),
+		);
+
+		$query->execute(
+			subjectId: 's11111111111maa',
+			includePageIdentifiers: true,
+			includeReferencedSubjects: true
+		);
+
+		$this->assertSame(
+			[ 's11111111111maa', 's11111111111aa2' ],
+			array_keys( $spyPresenter->response->subjects )
+		);
+		$this->assertSame( 1, $subjectLookup->getSubjectsCallCount );
+	}
+
+	/**
+	 * A target whose page the caller may not read is omitted, and batching the resolution does not
+	 * hand it out: the check stays per Subject, against that Subject's own hosting page.
+	 */
+	public function testOmitsReferencedSubjectOnUnreadablePage(): void {
+		$spyPresenter = $this->getSpyPresenter();
+
+		$query = new GetSubjectQuery(
+			$spyPresenter,
+			new InMemorySubjectLookup(
+				$this->newSubjectReferencing( 's11111111111aa1', 's11111111111aa2' ),
+				TestSubject::build( id: 's11111111111aa1', label: new SubjectLabel( 'hidden target' ) ),
+				TestSubject::build( id: 's11111111111aa2', label: new SubjectLabel( 'visible target' ) ),
+			),
+			new InMemoryPageIdentifiersLookup( [
+				[ new SubjectId( 's11111111111maa' ), new PageIdentifiers( new PageId( 42 ), 'Requested', 0 ) ],
+				[ new SubjectId( 's11111111111aa1' ), new PageIdentifiers( new PageId( 101 ), 'Hidden', 0 ) ],
+				[ new SubjectId( 's11111111111aa2' ), new PageIdentifiers( new PageId( 102 ), 'Visible', 0 ) ],
+			] ),
+			new SelectivePageReadAuthorizer( deniedPageIds: [ 101 ] ),
+		);
+
+		$query->execute(
+			subjectId: 's11111111111maa',
+			includePageIdentifiers: true,
+			includeReferencedSubjects: true
+		);
+
+		$this->assertSame(
+			[ 's11111111111maa', 's11111111111aa2' ],
+			array_keys( $spyPresenter->response->subjects )
+		);
+	}
+
+	/**
+	 * The counterpart of GetPageSubjectsQuery's rule, and the reason the batch read takes
+	 * `?? null` rather than indexing the map directly: a referenced Subject the lookup resolved but
+	 * whose hosting page it cannot place is still served, so Subjects on a readable old revision do
+	 * not disappear once the Subject is deleted. See pageIsReadableOrUnresolved.
+	 */
+	public function testServesReferencedSubjectWhoseHostingPageDoesNotResolve(): void {
+		$spyPresenter = $this->getSpyPresenter();
+
+		$query = new GetSubjectQuery(
+			$spyPresenter,
+			new InMemorySubjectLookup(
+				$this->newSubjectReferencing( 's11111111111aa1' ),
+				TestSubject::build( id: 's11111111111aa1', label: new SubjectLabel( 'unplaced target' ) ),
+			),
+			// Places the requested Subject only, so the target's entry is absent from the batch.
+			new InMemoryPageIdentifiersLookup( [
+				[ new SubjectId( 's11111111111maa' ), new PageIdentifiers( new PageId( 42 ), 'Requested', 0 ) ],
+			] ),
+			new StubPageReadAuthorizer( allowed: true ),
+		);
+
+		$query->execute(
+			subjectId: 's11111111111maa',
+			includePageIdentifiers: true,
+			includeReferencedSubjects: true
+		);
+
+		$this->assertSame(
+			[ 's11111111111maa', 's11111111111aa1' ],
+			array_keys( $spyPresenter->response->subjects )
+		);
+		$this->assertNull( $spyPresenter->response->subjects['s11111111111aa1']->pageId );
+	}
+
+	/**
+	 * A denied request costs nothing beyond resolving the Subject it was denied: batching must not
+	 * pull the targets in before the gate, on behalf of a caller that gets a not-found (#1046).
+	 */
+	public function testDeniedRequestResolvesNoReferencedSubjects(): void {
+		$spyPresenter = $this->getSpyPresenter();
+		$subjectLookup = new InMemorySubjectLookup(
+			$this->newSubjectReferencing( 's11111111111aa1', 's11111111111aa2' ),
+			TestSubject::build( id: 's11111111111aa1' ),
+			TestSubject::build( id: 's11111111111aa2' ),
+		);
+		$pageIdentifiersLookup = new InMemoryPageIdentifiersLookup( [
+			[ new SubjectId( 's11111111111maa' ), new PageIdentifiers( new PageId( 42 ), 'Requested', 0 ) ],
+			[ new SubjectId( 's11111111111aa1' ), new PageIdentifiers( new PageId( 101 ), 'First', 0 ) ],
+			[ new SubjectId( 's11111111111aa2' ), new PageIdentifiers( new PageId( 102 ), 'Second', 0 ) ],
+		] );
+
+		$query = new GetSubjectQuery(
+			$spyPresenter,
+			$subjectLookup,
+			$pageIdentifiersLookup,
+			new SelectivePageReadAuthorizer( deniedPageIds: [ 42 ] ),
+		);
+
+		$query->execute(
+			subjectId: 's11111111111maa',
+			includePageIdentifiers: true,
+			includeReferencedSubjects: true
+		);
+
+		$this->assertTrue( $spyPresenter->notFound );
+		$this->assertSame( 0, $subjectLookup->getSubjectsCallCount );
+		$this->assertSame( 0, $pageIdentifiersLookup->getPageIdsOfSubjectsCallCount );
+	}
+
+	private function newSubjectReferencing( string ...$targetIds ): Subject {
+		$statements = [];
+
+		foreach ( $targetIds as $index => $targetId ) {
+			$statements[] = TestStatement::build(
+				'FriendOf ' . $index,
+				new RelationValue( TestRelation::build( id: 'r111111111111a' . ( $index + 1 ), targetId: $targetId ) ),
+				RelationType::NAME,
+			);
+		}
+
+		return TestSubject::build(
+			id: 's11111111111maa',
+			label: new SubjectLabel( 'requested subject' ),
+			statements: new StatementList( $statements )
+		);
 	}
 
 }

--- a/tests/phpunit/Domain/Subject/SubjectMapTest.php
+++ b/tests/phpunit/Domain/Subject/SubjectMapTest.php
@@ -126,6 +126,19 @@ class SubjectMapTest extends TestCase {
 		);
 	}
 
+	public function testGetIdsKeepsMapOrder(): void {
+		$subjectMap = new SubjectMap(
+			TestSubject::build( self::GUID_789 ),
+			TestSubject::build( self::GUID_123 ),
+			TestSubject::build( self::GUID_456 ),
+		);
+
+		$this->assertSame(
+			[ self::GUID_789, self::GUID_123, self::GUID_456 ],
+			$subjectMap->getIds()->asStringArray()
+		);
+	}
+
 	public function testOnlyWithIdsKeepsTheRequestedSubjects(): void {
 		$subject1 = TestSubject::build( self::GUID_123 );
 		$subject2 = TestSubject::build( self::GUID_456 );

--- a/tests/phpunit/Persistence/MediaWiki/Subject/PointInTimeSubjectLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/Subject/PointInTimeSubjectLookupTest.php
@@ -286,4 +286,23 @@ class PointInTimeSubjectLookupTest extends NeoWikiIntegrationTestCase {
 		);
 	}
 
+	/**
+	 * Callers resolving a Subject's relation targets pass an empty list whenever it has none, so
+	 * this is the common case rather than an edge one. Without the guard the primary revision's
+	 * slot is deserialized in order to select nothing out of it, and SubjectContent deserializes on
+	 * every getPageSubjects() call.
+	 */
+	public function testEmptyIdListReadsNothing(): void {
+		$primaryRevision = $this->createMock( RevisionRecord::class );
+		$primaryRevision->expects( $this->never() )->method( 'getContent' );
+
+		$pageIdentifiersLookup = new InMemoryPageIdentifiersLookup();
+
+		$subjects = $this->newLookup( $primaryRevision, $pageIdentifiersLookup )
+			->getSubjects( new SubjectIdList( [] ) );
+
+		$this->assertTrue( $subjects->isEmpty() );
+		$this->assertSame( 0, $pageIdentifiersLookup->getPageIdsOfSubjectsCallCount );
+	}
+
 }

--- a/tests/phpunit/TestDoubles/InMemorySubjectLookup.php
+++ b/tests/phpunit/TestDoubles/InMemorySubjectLookup.php
@@ -33,14 +33,24 @@ class InMemorySubjectLookup implements SubjectLookup {
 		return $this->subjects[$subjectId->text] ?? null;
 	}
 
+	/**
+	 * Returns the Subjects in the order the constructor was given them, deliberately not in the
+	 * order they were requested. SubjectLookup promises no ordering and neither implementation
+	 * gives one - MediaWikiSubjectRepository unions per hosting page, PointInTimeSubjectLookup puts
+	 * the primary revision's Subjects first - so a caller that reads the returned map in the map's
+	 * own order rather than indexing it by the ids it asked for reorders its output in production.
+	 * Mirroring the request here would hide exactly that, which is why tests asserting on response
+	 * order register their Subjects in an order other than the one they reference them in.
+	 */
 	public function getSubjects( SubjectIdList $subjectIds ): SubjectMap {
 		$this->getSubjectsCallCount++;
 
+		$requested = $subjectIds->asArray();
 		$found = new SubjectMap();
 
-		foreach ( $subjectIds->asStringArray() as $idText ) {
-			if ( array_key_exists( $idText, $this->subjects ) ) {
-				$found->addOrUpdateSubject( $this->subjects[$idText] );
+		foreach ( $this->subjects as $idText => $subject ) {
+			if ( array_key_exists( $idText, $requested ) ) {
+				$found->addOrUpdateSubject( $subject );
 			}
 		}
 

--- a/tests/phpunit/TestDoubles/InMemorySubjectRepository.php
+++ b/tests/phpunit/TestDoubles/InMemorySubjectRepository.php
@@ -42,12 +42,21 @@ class InMemorySubjectRepository implements SubjectRepository {
 		return $this->subjects[$subjectId->text] ?? null;
 	}
 
+	/**
+	 * Returns the Subjects in the order this repository stored them, deliberately not in the order
+	 * they were requested, for the reason {@see InMemorySubjectLookup::getSubjects} gives: the
+	 * production implementations promise no order, and a double that mirrors the request hides
+	 * callers that read the returned map in the map's own order. This class is a SubjectRepository,
+	 * which extends SubjectLookup, and production hands one object to both roles, so a test is free
+	 * to wire it as the subjectLookup.
+	 */
 	public function getSubjects( SubjectIdList $subjectIds ): SubjectMap {
+		$requested = $subjectIds->asArray();
 		$found = new SubjectMap();
 
-		foreach ( $subjectIds->asStringArray() as $idText ) {
-			if ( array_key_exists( $idText, $this->subjects ) ) {
-				$found->addOrUpdateSubject( $this->subjects[$idText] );
+		foreach ( $this->subjects as $idText => $subject ) {
+			if ( array_key_exists( $idText, $requested ) ) {
+				$found->addOrUpdateSubject( $subject );
 			}
 		}
 


### PR DESCRIPTION
Fixes #1243

#1224 batched relation-target resolution for the write path and listed read-path callers under
"Considered and omitted", on the grounds that "nothing there resolves a set today". That premise
did not hold: both read queries already held a `SubjectIdList` and looped it, and
`Subject::getReferencedSubjects()` returns exactly what the batch methods take. So this needs no
new lookup API surface.

Every `getSubject` is a graph round trip through the subject → page index plus a revision load and
a content deserialize, and every `getPageIdOfSubject` is another round trip, since
`Neo4jPageIdentifiersLookup` answers the single-id method by running the batch query.

## Change

- `GetSubjectQuery` resolves the referenced ids in one `getSubjects()` and one
  `getPageIdsOfSubjects()` ahead of the loop, and reads both out of the returned maps.
- `GetPageSubjectsQuery` does the same for the referenced ids, and additionally resolves the
  hosting pages of the page's own Subjects in one call rather than one per Subject on the page.
  Collecting the referenced ids moves into `collectReferencedIds`, where `SubjectIdList`'s
  deduplication replaces the old "already in the result" check.
- `SubjectMap::getIds()` returns the ids as the `SubjectIdList` those lookups take.
- `PointInTimeSubjectLookup::getSubjects()` returns early for an empty id list, mirroring the guard
  `Neo4jPageIdentifiersLookup::getPageIdsOfSubjects()` already has. Without it, batching *added* a
  cost the old loop did not pay: a Subject with no relations now calls `getSubjects()` once instead
  of not at all, and that call deserialized the primary revision's slot in order to select nothing
  out of it — on every `?revisionId=` read of a Subject without relations, which is the common case.

Both loops iterate the requested ids rather than the returned map, so the response keeps the order
the Statements reach the targets. The map is keyed by id and promises no order — #1224 declined to
give it one precisely because every caller indexes it.

## Behaviour

Unchanged. The per-title read authorization stays per Subject, against that Subject's own hosting
page, so batching does not widen what a caller can infer about pages it cannot read (#1046).
`GetSubjectQuery` still resolves and authorizes the requested Subject before touching its targets,
so a denied request short-circuits without paying for them. The two queries keep their differing
treatment of a target with no resolvable hosting page: `GetSubjectQuery` serves it,
`GetPageSubjectsQuery` omits it. Both rules, and the short-circuit, now have tests; none did before.

The two dedup paths cannot diverge. The old loop skipped an id already present in the accumulating
result, which only held ids that had resolved *and* passed the gate; `SubjectIdList` dedups the id
itself. A repeat of an id whose first attempt failed is therefore no longer retried — but both
lookups are deterministic within a request, so the retry produced the same failure.

Verified end to end: 24 REST requests against a 5 000-Subject wiki, both endpoints across every
`expand` combination, byte-identical on `master` and on this branch (507 693 bytes each). The
`?revisionId=` path is byte-identical with and without the new guard.

## Measurements

Dev stack. Corpus from `NeoWiki:GeneratePerformanceDump`: 500 pages × 10 Subjects, 12 Statements
each of which 3 are relations to Subjects on other pages — the shape ADR 29 calls typical. 200
consecutive pages read once each, single PHP process, warm-up excluded, `master` and this branch
alternated three times each.

`GetSubjectQuery`, one Subject with 3 relation targets on 3 pages (`expand=page|relations`):

|                        | master        | this branch   |
|------------------------|---------------|---------------|
| Per read               | 24.2–27.9 ms  | 16.3–19.3 ms  |
| Graph round trips      | 8             | 4             |

`GetPageSubjectsQuery`, 10 Subjects reaching 30 distinct targets on 3 pages (`expand=relations`):

|                        | master         | this branch   |
|------------------------|----------------|---------------|
| Per read               | 202–208 ms     | 25.7–27.4 ms  |
| Graph round trips      | 70             | 3             |

The counts follow the loops exactly. `GetSubjectQuery` paid 2 + 2M and now pays a flat 4;
`GetPageSubjectsQuery` paid N + 2M and now pays a flat 3. Both were measured, not read off the
code: the harness wraps the production `PageIdentifiersLookup` and counts.

The wall-clock gap is wider than the round-trip gap on `GetPageSubjectsQuery` because
`MediaWikiSubjectRepository::getSubjects` groups the ids by hosting page, so the 30 targets cost 3
revision loads and deserializations instead of 30. Both savings grow with the number of targets;
neither depends on corpus size.

Numbers this small are dominated by a local Neo4j, so read them as ratios, not as absolutes.

## Test doubles

`InMemorySubjectLookup::getSubjects()` returned its map in the order the ids were requested, which
no implementation does — `MediaWikiSubjectRepository` unions per hosting page and
`PointInTimeSubjectLookup` puts the primary revision's Subjects first. That made the order the two
queries must preserve untestable: reading the batch out as a map instead of by the requested ids
left every test green while reordering the REST response's keys. The double now returns its own
registration order, and the tests asserting on response order register their Subjects in an order
other than the one they reference them in.

## Considered and omitted

- **Merging the two `getPageIdsOfSubjects` calls in `GetPageSubjectsQuery`.** The page's own
  Subjects and the referenced ones could be resolved in one call, saving one constant-time query
  out of three. It costs a `SubjectIdList` union and threads a shared map through
  `buildReferencedSubjectItems`, in exchange for no change in how the cost scales.
- **Avoiding the duplicate hosting-page query for referenced ids.** `SubjectLookup::getSubjects()`
  already runs `getPageIdsOfSubjects()` on the same ids internally, and the query then runs it
  again for the identifiers it puts in the response. Removing it means either returning identifiers
  from `getSubjects()` or caching inside the lookup — both real API decisions, neither an N+1 fix.
  Note this constant factor of 2 is inherited from `master`, which paid it per referenced Subject.
- **Filtering the id list down to the ids that resolved before asking for hosting pages.** It is
  one query either way, and the entries for unresolved ids are never read.
- **The remaining read-path N+1, `SubjectResolver::resolveRelationLabel`.** The Lua and
  parser-function accessors `array_map` it over a multi-value relation, one `getSubject` apiece.
  Same shape, different surface, and that path is parser-cached; it also needs a new collection-taking
  method rather than the existing batch ones. Filed as #1253.

## Surfaced, not changed here

`GetPageSubjectsQuery` authorizes the requested page and then serves each Subject's hosting-page
identifiers without checking that page. Where a stale projection or a Subject with `HasSubject`
edges from two pages makes the two differ, another page's title and namespace reach the caller
ungated. Master does exactly the same one `getPageIdOfSubject` call at a time, so this branch does
not introduce it — but `testResolvesHostingPagesOfPageSubjectsInOneLookup` is the first test to
assert the behaviour, so its fixture says so and points at the issue. Filed as #1252.

## Verification

- `make cs` green. Psalm reports nothing new; its only complaints in the touched files are
  `git blame`d to #1224.
- Green by filter: `GetSubjectQueryTest`, `GetPageSubjectsQueryTest`, `PointInTimeSubjectLookupTest`,
  `SubjectMapTest`, `SubjectValidatorTest`, `MediaWikiSubjectRepositoryTest`, `GetSubjectApiTest`,
  `GetPageSubjectsApiTest`, plus every other consumer of the `InMemorySubjectLookup` this branch
  changes (`ProposedSubjectValidatorTest`, `CreateSubjectActionTest`, `ReplaceSubjectActionTest`).
  `Domain` passes as a whole (552 tests).
- Full PHPUnit green on CI across MW 1.43, 1.44, 1.45, 1.46 and master, plus PHPCS and PHPStan.
  (Locally an unfiltered `make phpunit` stalls at ~0 % CPU before PHPUnit prints its banner, on this
  branch and on `master` alike, so CI is the signal for the whole suite here.)
- Both batching tests fail against `master`'s implementation of the queries.
- Four mutations of the new code, each failing exactly the test written for it: re-resolving per id
  inside the loop while keeping the batch call (the failure mode #1224 added its per-id counters
  for); iterating the returned map instead of the requested ids; dropping the collected-id filter;
  and treating an unresolvable hosting page as resolvable.
- REST byte-diffs above.

<sub>AI-authored — Claude Opus 5 (1M context); implementation, tests and benchmark; verified with the full PHPUnit suite on CI, phpcs, phpstan, five mutation checks, browser smoke tests of both endpoints, and byte-for-byte REST response diffs against master on a 5 000-Subject wiki and on the demo data.</sub>
