### PR TITLE
Fix review findings in the Oxigraph SPARQL store support

### DIFF
--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -168,7 +168,7 @@ services:
     # `make down` snappy. Safe: acknowledged updates survive a SIGKILL and reload on startup.
     stop_grace_period: 2s
 
-  # The dev-only sidecars (test_neo, node, mailcatcher) live in
+  # The dev-only sidecars (test_neo, test_qlever, test_oxigraph, node, mailcatcher) live in
   # docker-compose.dev.yml, not here, so `make up` stays minimal and `make down`
   # can clean them up as orphans on every compose backend (see that file).
 

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,14 @@ PORT_RANGE_END := 8499
 DC := docker compose -p $(PROJECT_NAME) -f Docker/docker-compose.yml
 DC_DEV := $(DC) -f Docker/docker-compose.dev.yml
 DC_TOOLS := $(DC_DEV) -f Docker/docker-compose.tools.yml
-# The `test` profile holds the test-only backends: test_neo and test_qlever.
+# The `test` profile holds the test-only backends: test_neo, test_qlever and test_oxigraph.
 DC_TEST := $(DC_DEV) --profile test
+# Teardown has to see every service, including the profile-gated `oxigraph` and `caddy`. With no
+# profile active Compose leaves those out of the plan entirely, so the container survives `down`
+# and the project network then fails to go with it. They are not orphans either — they are declared
+# in the file Compose was given — so --remove-orphans does not reach them. `--profile '*'` enables
+# every profile, which for a teardown is exactly the intent.
+DC_ALL := $(DC) --profile '*'
 
 # Detect the engine from what `docker` actually is (its version string), not from
 # whether a `podman` binary happens to exist: a stray podman binary alongside real
@@ -118,8 +124,11 @@ _dev-tools-impl:
 	@echo "Neo4j Bolt endpoint:  bolt://localhost:$${NEO_BOLT_PORT:-7687}"
 	@echo "QLever SPARQL:        http://localhost:$${QLEVER_PORT:-7019}/"
 	@# The tools overlay maps Oxigraph's port too, but that service only runs when its
-	@# profile is on (see Docker/docker-compose.dev.yml), so only then is there a URL.
-	@case ",$$COMPOSE_PROFILES," in \
+	@# profile is on (see Docker/docker-compose.yml), so only then is there a URL. Compose
+	@# trims whitespace around profile names ("test, oxigraph" activates both), so strip it
+	@# here as well or the URL goes missing for a stack that did start the service.
+	@profiles=$$(printf '%s' "$$COMPOSE_PROFILES" | tr -d '[:space:]'); \
+	case ",$$profiles," in \
 		*,oxigraph,*) echo "Oxigraph SPARQL:      http://localhost:$${OXIGRAPH_PORT:-7878}/query";; \
 	esac
 	@echo "Project:              $(PROJECT_NAME)"
@@ -165,10 +174,10 @@ _dev-impl:
 	@echo "Project:           $(PROJECT_NAME)"
 
 down: ## Stop and remove containers (preserves volumes)
-	$(DC) down --remove-orphans
+	$(DC_ALL) down --remove-orphans
 
 remove: ## Stop and remove containers AND volumes (deletes all data)
-	$(DC) down --volumes --remove-orphans
+	$(DC_ALL) down --volumes --remove-orphans
 
 logs: ## Tail logs from all services
 	$(DC_DEV) logs -f

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/Integration/QueryOxigraphEndToEndTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/Integration/QueryOxigraphEndToEndTest.php
@@ -37,7 +37,9 @@ class QueryOxigraphEndToEndTest extends QuerySparqlEndToEndTestCase {
 	}
 
 	/**
-	 * The service is started without `--union-default-graph`.
+	 * The service is started without `--union-default-graph`. Unlike QLever's counterpart this is not
+	 * an engine property but Oxigraph's spec-conforming default, which the `:latest` image tracks: an
+	 * upstream change to it would fail this suite with nothing here having changed.
 	 */
 	protected function storeUnionsNamedGraphsIntoTheDefaultGraph(): bool {
 		return false;

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/Integration/QueryQLeverEndToEndTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/Integration/QueryQLeverEndToEndTest.php
@@ -6,7 +6,7 @@ namespace ProfessionalWiki\NeoWiki\Tests\GraphDatabasePlugins\Sparql\Integration
 
 /**
  * {@see QuerySparqlEndToEndTestCase} against QLever — the `test_qlever` dev-stack service, and the
- * engine the development stack points the wiki itself at.
+ * engine both Docker stacks point the wiki itself at.
  *
  * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryService
  * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Persistence\HttpSparqlQueryEndpoint
@@ -28,8 +28,12 @@ class QueryQLeverEndToEndTest extends QuerySparqlEndToEndTestCase {
 		return $this->storeUpdateUrl();
 	}
 
+	/**
+	 * QLever rejects unauthorized updates, so an unset token is as fatal as an unset URL and fails
+	 * the same way rather than surfacing later as a 403 from the store.
+	 */
 	protected function storeAccessToken(): ?string {
-		return getenv( 'QLEVER_TEST_ACCESS_TOKEN' ) ?: null;
+		return $this->requireEnv( 'QLEVER_TEST_ACCESS_TOKEN', 'QLever (the `test_qlever` service)' );
 	}
 
 	/**

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/Integration/QuerySparqlEndToEndTestCase.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/Integration/QuerySparqlEndToEndTestCase.php
@@ -36,9 +36,10 @@ use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
  * sharply whether an unscoped query sees the named graphs NeoWiki writes into: SPARQL 1.1 leaves
  * that to the store — QLever always unions them in, a strict store keeps them out.
  *
- * Deliberately does NOT skip when a store is unreachable: an unset store URL fails the test through
- * {@see requireEnv}, and an unreachable store surfaces as a loud query/HTTP failure. A silently
- * skipped system test would leave the headline deliverable unverified.
+ * Deliberately does NOT skip when a store is unreachable: any unset setting the store cannot be
+ * reached without fails the test through {@see requireEnv}, and an unreachable store surfaces as a
+ * loud query/HTTP failure. A silently skipped system test would leave the headline deliverable
+ * unverified.
  *
  * Each subclass carries its own `@covers` and `@group Database`; MediaWiki reads the group off the
  * concrete class alone.
@@ -100,9 +101,10 @@ abstract class QuerySparqlEndToEndTestCase extends NeoWikiIntegrationTestCase {
 	}
 
 	/**
-	 * Reads a store URL from the environment, failing the test when it is unset rather than
-	 * skipping — see the class docblock for why. The store description goes into the failure
-	 * message, so name the dev-stack service the reader has to bring up.
+	 * Reads a setting the live store cannot be reached without — a URL, or a token the store rejects
+	 * requests lacking — failing the test when it is unset rather than skipping; see the class
+	 * docblock for why. The store description goes into the failure message, so name the dev-stack
+	 * service the reader has to bring up.
 	 */
 	protected function requireEnv( string $variable, string $store ): string {
 		$value = getenv( $variable );
@@ -127,16 +129,32 @@ abstract class QuerySparqlEndToEndTestCase extends NeoWikiIntegrationTestCase {
 		$this->overrideConfigValue(
 			'NeoWikiSparqlStores',
 			array_map(
-				fn ( string $projection ): array => [
-					'updateUrl' => $this->updateUrl,
-					'queryUrl' => $this->queryUrl,
-					'accessToken' => $this->accessToken,
-					'projection' => $projection,
-				],
+				fn ( string $projection ): array => $this->storeEntryFor( $projection ),
 				$projections
 			)
 		);
 		NeoWikiExtension::resetInstance();
+	}
+
+	/**
+	 * Omits `queryUrl` when the store serves queries and updates on one path, so a store like QLever
+	 * exercises the production default (it falls back to `updateUrl`) instead of a shape no real
+	 * deployment writes. A store that splits the two sets it explicitly, as its own entry must.
+	 *
+	 * @return array<string, string|null>
+	 */
+	private function storeEntryFor( string $projection ): array {
+		$entry = [
+			'updateUrl' => $this->updateUrl,
+			'accessToken' => $this->accessToken,
+			'projection' => $projection,
+		];
+
+		if ( $this->queryUrl !== $this->updateUrl ) {
+			$entry['queryUrl'] = $this->queryUrl;
+		}
+
+		return $entry;
 	}
 
 	public function testSubjectLabelRoundTripsThroughTheSparqlQueryService(): void {
@@ -188,7 +206,10 @@ abstract class QuerySparqlEndToEndTestCase extends NeoWikiIntegrationTestCase {
 		$this->assertSame(
 			$this->storeUnionsNamedGraphsIntoTheDefaultGraph() ? [ $label ] : [],
 			$this->queryLabelsWithoutGraphScopeOf( $subjectId ),
-			'a query without a GRAPH clause reaches the page graphs only on a unioning store'
+			'a query without a GRAPH clause reaches the page graphs only on a unioning store. If this '
+			. 'failed, check whether --union-default-graph was added to the store this subclass names '
+			. '(test_oxigraph in Docker/docker-compose.dev.yml and .github/workflows/ci-php.yml) before '
+			. 'changing the expectation — flipping it silently drops the strict-store half of the pair.'
 		);
 	}
 
@@ -327,10 +348,11 @@ abstract class QuerySparqlEndToEndTestCase extends NeoWikiIntegrationTestCase {
 		$subjectIri = NeoWikiExtension::getInstance()->getRdfNamespaces()->subject( $subjectId )->value;
 
 		// GRAPH-scoped, because NeoWiki writes each page into a named graph and never the default
-		// graph. See queryLabelsWithoutGraphScopeOf() for what dropping the clause costs. DISTINCT
-		// because a Subject saved under several projections carries its label in each of their graphs.
+		// graph. See queryLabelsWithoutGraphScopeOf() for what dropping the clause costs. No DISTINCT:
+		// its callers configure one projection, so one graph must hold the label, and scoping by GRAPH
+		// makes that cardinality observable — collapsing it would hide a page projected twice.
 		return $this->labelsFrom(
-			'SELECT DISTINCT ?label WHERE { GRAPH ?graph { <' . $subjectIri . '> <'
+			'SELECT ?label WHERE { GRAPH ?graph { <' . $subjectIri . '> <'
 			. self::LABEL_PREDICATE . '> ?label } }'
 		);
 	}


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1235

Behavioural findings from an independent review of that branch. The documentation findings were folded into the branch itself rather than carried here, since they change how the feature is documented rather than what it does.

* **`make down` and `make remove` now run with every profile enabled.** A profile-gated service is not an orphan, so Compose left `oxigraph` out of the teardown plan entirely: the container outlived `make down`, which then could not remove the project network — enough to make `worktree-remove` fail. Checked against a live stack: before, the plan covered 9 of 10 containers and the network removal reported the resource still in use; after, all 10 go and the network with them. This closes the same latent gap for `caddy`.
* **The end-to-end test always set `queryUrl`**, so the production default — it falls back to `updateUrl` — stopped being exercised against a live store, which is the shape every real QLever deployment configures. The entry now omits the key when the two coincide.
* `QLEVER_TEST_ACCESS_TOKEN` escaped the fail-with-a-message contract the store URLs go through, surfacing an unset token as a bare 403 from QLever on the `setUp` `DROP ALL`.
* Dropped `DISTINCT` from the label query. Scoping it by `GRAPH` is what made graph cardinality observable, and collapsing the rows again would hide a page projected into two graphs; no caller of it configures more than one projection.
* The default-graph assertion now names the flag and both files that set it, so a failure cannot be repaired by flipping the expectation and quietly dropping the strict-store half of the engine pair.
* Stale comments: the `test` profile's membership, the compose file the Makefile names for the `oxigraph` service, and the dev-overlay sidecar list. The `COMPOSE_PROFILES` match in `make dev-tools` now strips whitespace, which Compose accepts (`test, oxigraph`) but the `case` statement did not.

Considered, omitted: pinning the Oxigraph image instead of tracking `:latest` (consistent with how the repo already treats QLever, Neo4j and Mailcatcher, so it is a repo-wide question rather than this branch's); a comment noting that coupling was added to the test instead.

## Manual Browser Check

None needed — no user-facing rendering changes. This PR touches the Makefile, one compose comment and three PHPUnit test files.

To exercise it locally instead:

```sh
cd mediawiki/extensions/NeoWiki
make phpunit filter=QueryQLeverEndToEndTest
make phpunit filter=QueryOxigraphEndToEndTest

# the teardown fix: the oxigraph container must not survive `make down`.
# <project> is the name `make dev` prints on the last line.
COMPOSE_PROFILES=oxigraph make dev
docker ps --filter label=com.docker.compose.project=<project> --format '{{.Names}}'

make down
docker ps -a --filter label=com.docker.compose.project=<project> --format '{{.Names}}'  # expect: empty
docker network ls --filter name=<project> --format '{{.Name}}'                          # expect: empty
```

On master's `make down` the `oxigraph` container survives both and the network removal fails.

> <sub>AI-authored — Claude Code, `Opus 5 (xhigh)`; review of the rebased #1235 asked for by @alistair3149, no revisions to this PR's own scope; diff not yet human-reviewed; every finding re-verified by the coordinator before it was applied, both live two-engine suites re-run green afterwards, phpcs + phpstan clean, teardown behaviour checked against a live stack before and after.</sub>

<details><summary>Production notes</summary>

Findings came from three independent `Opus 5` review subagents given separate lenses — rebase-induced inconsistency, infrastructure and security, test design — each read-only on the checkout. Their claims were confirmed by the coordinator against the live stack before any were acted on; the reviewers' own dry-run and probe evidence was reproduced rather than taken on trust.

A later documentation review moved this PR's original doc findings into #1235, leaving only behavioural changes here.

</details>
