### PR TITLE
Clear the error and the deprecations the CI test run reports

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -55,12 +55,6 @@ jobs:
       - name: Start containers
         run: make up
 
-      - name: Wait for Neo4j
-        uses: iFaxity/wait-on-action@v1.1.0
-        with:
-          resource: http-get://localhost:7687
-          timeout: 60000
-
       - name: Install MediaWiki
         run: make install-db
 

--- a/.github/workflows/ci-php.yml
+++ b/.github/workflows/ci-php.yml
@@ -124,11 +124,12 @@ jobs:
 
       - run: composer update
 
+      # Asks Neo4j to answer a query rather than to open its port, which is what the next step needs of it.
+      # Not a `--health-cmd` on the service: that gates every step on it, measured at some 26 seconds a leg.
       - name: Wait for Neo4j
-        uses: iFaxity/wait-on-action@v1
-        with:
-          resource: http-get://localhost:7689
-          timeout: 60000
+        run: |
+          timeout 90 bash -c 'until docker exec test_neo cypher-shell -u neo4j -p password -a bolt://localhost:7689 "RETURN 1" >/dev/null 2>&1; do sleep 2; done' \
+            || { echo "Neo4j did not become ready in time; dumping logs:"; docker logs test_neo; exit 1; }
 
       # QLever for the SPARQL query system test. It cannot be a `services:` container: its bring-up needs
       # a multi-step entrypoint (build an empty index, then serve) that a service container cannot express

--- a/.github/workflows/ci-php.yml
+++ b/.github/workflows/ci-php.yml
@@ -205,33 +205,18 @@ jobs:
 
       - name: Wait for QLever
         run: |
-          for i in $(seq 1 40); do
-            if curl -fsS -o /dev/null "http://localhost:7019/?query=SELECT%20%2A%20WHERE%20%7B%20%3Fs%20%3Fp%20%3Fo%20%7D%20LIMIT%201"; then
-              echo "QLever is serving"; exit 0
-            fi
-            sleep 2
-          done
-          echo "QLever did not become ready in time; dumping logs:"; docker logs test_qlever; exit 1
+          timeout 90 bash -c 'until curl -fsS -o /dev/null "http://localhost:7019/?query=SELECT%20%2A%20WHERE%20%7B%20%3Fs%20%3Fp%20%3Fo%20%7D%20LIMIT%201"; do sleep 2; done' \
+            || { echo "QLever did not become ready in time; dumping logs:"; docker logs test_qlever; exit 1; }
 
       - name: Wait for Oxigraph
         run: |
-          for i in $(seq 1 40); do
-            if curl -fsS -o /dev/null "http://localhost:7878/query?query=SELECT%20%2A%20WHERE%20%7B%20%3Fs%20%3Fp%20%3Fo%20%7D%20LIMIT%201"; then
-              echo "Oxigraph is serving"; exit 0
-            fi
-            sleep 2
-          done
-          echo "Oxigraph did not become ready in time; dumping logs:"; docker logs test_oxigraph; exit 1
+          timeout 90 bash -c 'until curl -fsS -o /dev/null "http://localhost:7878/query?query=SELECT%20%2A%20WHERE%20%7B%20%3Fs%20%3Fp%20%3Fo%20%7D%20LIMIT%201"; do sleep 2; done' \
+            || { echo "Oxigraph did not become ready in time; dumping logs:"; docker logs test_oxigraph; exit 1; }
 
       - name: Wait for Fuseki
         run: |
-          for i in $(seq 1 40); do
-            if curl -fsS -o /dev/null "http://localhost:3030/ds/query?query=SELECT%20%2A%20WHERE%20%7B%20%3Fs%20%3Fp%20%3Fo%20%7D%20LIMIT%201"; then
-              echo "Fuseki is serving"; exit 0
-            fi
-            sleep 2
-          done
-          echo "Fuseki did not become ready in time; dumping logs:"; cat "$RUNNER_TEMP/fuseki.log"; exit 1
+          timeout 90 bash -c 'until curl -fsS -o /dev/null "http://localhost:3030/ds/query?query=SELECT%20%2A%20WHERE%20%7B%20%3Fs%20%3Fp%20%3Fo%20%7D%20LIMIT%201"; do sleep 2; done' \
+            || { echo "Fuseki did not become ready in time; dumping logs:"; cat "$RUNNER_TEMP/fuseki.log"; exit 1; }
 
       - name: Run PHPUnit
         run: composer phpunit

--- a/Makefile
+++ b/Makefile
@@ -351,10 +351,9 @@ _first-run-seed-demo:
 
 # ---- DB and Neo4j init -------------------------------------------------------
 
-.PHONY: install-db load-neo4j-users wait-for-neo4j setup-test-neo test-backends test-backends-stop
+.PHONY: install-db load-neo4j-users setup-test-neo test-backends test-backends-stop
 
 install-db:
-	$(EXEC_MW_ROOT) bash -c '/wait-for-it.sh db:3306 -t 60'
 	$(EXEC_MW_ROOT) mv LocalSettings.php __LocalSettings.php
 	$(EXEC_MW_ROOT) \
 		php maintenance/install.php --dbuser $(MARIADB_USER) --dbpass $(MARIADB_PASSWORD) \
@@ -364,14 +363,9 @@ install-db:
 			SiteName AdminName
 	$(EXEC_MW_ROOT) rm LocalSettings.php
 	$(EXEC_MW_ROOT) mv __LocalSettings.php LocalSettings.php
-	$(MAKE) --no-print-directory wait-for-neo4j
 	$(EXEC_MW_ROOT) php maintenance/run.php update --quick
 
-wait-for-neo4j:
-	$(EXEC_MW_ROOT) bash -c '/wait-for-it.sh neo:7687 -t 60'
-
 load-neo4j-users:
-	$(MAKE) --no-print-directory wait-for-neo4j
 	$(DC) exec -T neo bash -c \
 		"echo \"CREATE USER $(NEO4J_USERNAME_READ) SET PASSWORD '$(NEO4J_PASSWORD_READ)' CHANGE NOT REQUIRED; GRANT ROLE reader TO $(NEO4J_USERNAME_READ);\" | cypher-shell -u neo4j -p $(NEO4J_PASSWORD) -a bolt://localhost:7687"
 

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
 		}
 	},
 	"scripts": {
-		"phpunit": "cd ${MW_INSTALL_PATH:-../..} && (composer phpunit:config 2>/dev/null || true) && vendor/bin/phpunit -c extensions/NeoWiki/phpunit.xml.dist --bootstrap tests/phpunit/bootstrap.php",
+		"phpunit": "cd ${MW_INSTALL_PATH:-../..} && if [ -f phpunit.xml.template ]; then composer phpunit:config; fi && vendor/bin/phpunit -c extensions/NeoWiki/phpunit.xml.dist --bootstrap tests/phpunit/bootstrap.php",
 		"dbschema": [
 			"php ../../maintenance/generateSchemaSql.php --json sql/neowiki_rebuild_runs.json --sql sql/mysql/neowiki_rebuild_runs.sql --type mysql",
 			"php ../../maintenance/generateSchemaSql.php --json sql/neowiki_rebuild_runs.json --sql sql/sqlite/neowiki_rebuild_runs.sql --type sqlite",
@@ -52,6 +52,9 @@
 			"php ../../maintenance/generateSchemaChangeSql.php --json sql/abstractSchemaChanges/patch-neowiki_rebuild_runs-nwrr_phase.json --sql sql/sqlite/patch-neowiki_rebuild_runs-nwrr_phase.sql --type sqlite",
 			"php ../../maintenance/generateSchemaChangeSql.php --json sql/abstractSchemaChanges/patch-neowiki_rebuild_runs-nwrr_phase.json --sql sql/postgres/patch-neowiki_rebuild_runs-nwrr_phase.sql --type postgres"
 		]
+	},
+	"scripts-descriptions": {
+		"phpunit": "Runs the test suite against the surrounding MediaWiki. Generates core's phpunit.xml first where core ships the generator, because from MediaWiki 1.46 core's bootstrap refuses to run without it."
 	},
 	"config": {
 		"allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,10 @@
 		}
 	},
 	"scripts": {
-		"phpunit": "cd ${MW_INSTALL_PATH:-../..} && if [ -f phpunit.xml.template ]; then composer phpunit:config; fi && vendor/bin/phpunit -c extensions/NeoWiki/phpunit.xml.dist --bootstrap tests/phpunit/bootstrap.php",
+		"phpunit": [
+			"Composer\\Config::disableProcessTimeout",
+			"cd ${MW_INSTALL_PATH:-../..} && if [ -f phpunit.xml.template ]; then composer phpunit:config; fi && vendor/bin/phpunit -c extensions/NeoWiki/phpunit.xml.dist --bootstrap tests/phpunit/bootstrap.php"
+		],
 		"dbschema": [
 			"php ../../maintenance/generateSchemaSql.php --json sql/neowiki_rebuild_runs.json --sql sql/mysql/neowiki_rebuild_runs.sql --type mysql",
 			"php ../../maintenance/generateSchemaSql.php --json sql/neowiki_rebuild_runs.json --sql sql/sqlite/neowiki_rebuild_runs.sql --type sqlite",

--- a/src/EntryPoints/SpecialPages/SpecialGraphStores.php
+++ b/src/EntryPoints/SpecialPages/SpecialGraphStores.php
@@ -6,9 +6,12 @@ namespace ProfessionalWiki\NeoWiki\EntryPoints\SpecialPages;
 
 use MediaWiki\Html\Html;
 use MediaWiki\Logger\LoggerFactory;
+use MediaWiki\MediaWikiServices;
 use MediaWiki\Message\Message;
 use MediaWiki\Session\CsrfTokenSet;
 use MediaWiki\SpecialPage\SpecialPage;
+use MediaWiki\User\User;
+use PermissionsError;
 use ProfessionalWiki\NeoWiki\Application\GraphRebuild\GraphRebuildCoordinator;
 use ProfessionalWiki\NeoWiki\Application\GraphRebuild\GraphStoreStatus;
 use ProfessionalWiki\NeoWiki\Application\GraphRebuild\NothingToCancelException;
@@ -55,10 +58,33 @@ class SpecialGraphStores extends SpecialPage {
 	private const array SUCCESSFUL_OUTCOMES = [ 'queued', 'cancelled' ];
 
 	public function __construct() {
-		// MediaWiki 1.46 deprecates passing the restriction here, but on 1.43 — the version this extension
-		// supports — the permission check reads the property this sets and not getRestriction(), so
-		// overriding that instead would leave the page open to everyone there.
-		parent::__construct( 'GraphStores', NeoWikiExtension::ADMIN_RIGHT );
+		parent::__construct( 'GraphStores' );
+	}
+
+	public function getRestriction(): string {
+		return NeoWikiExtension::ADMIN_RIGHT;
+	}
+
+	/**
+	 * MediaWiki 1.46 made getRestriction() the one place a special page names the right it needs, and
+	 * pointed enforcement, listing and the denial page at it. Up to 1.45 those three instead read the
+	 * property the deprecated constructor parameter set, so each is restated here against
+	 * getRestriction(), leaving every supported version taking the right from one place.
+	 */
+	public function userCanExecute( User $user ): bool {
+		return MediaWikiServices::getInstance()
+			->getPermissionManager()
+			->userHasRight( $user, $this->getRestriction() );
+	}
+
+	public function isRestricted(): bool {
+		return !MediaWikiServices::getInstance()
+			->getGroupPermissionsLookup()
+			->groupHasPermission( '*', $this->getRestriction() );
+	}
+
+	protected function displayRestrictionError(): never {
+		throw new PermissionsError( $this->getRestriction() );
 	}
 
 	/**

--- a/tests/phpunit/EntryPoints/SpecialPages/SpecialGraphStoresTest.php
+++ b/tests/phpunit/EntryPoints/SpecialPages/SpecialGraphStoresTest.php
@@ -5,9 +5,11 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\SpecialPages;
 
 use MediaWiki\CommentStore\CommentStoreComment;
+use MediaWiki\Context\RequestContext;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Request\FauxRequest;
 use MediaWiki\Session\CsrfTokenSet;
+use MediaWiki\SpecialPage\SpecialPage;
 use MediaWiki\User\User;
 use PermissionsError;
 use ProfessionalWiki\NeoWiki\Domain\GraphRebuild\RebuildStatus;
@@ -64,6 +66,19 @@ class SpecialGraphStoresTest extends SpecialPageTestBase {
 		$this->expectException( PermissionsError::class );
 
 		$this->executeSpecialPage( '', null, null, $this->getTestUser()->getUser() );
+	}
+
+	public function testThePageNamesTheAdminRightAsItsRestriction(): void {
+		$this->assertSame( NeoWikiExtension::ADMIN_RIGHT, $this->newSpecialPage()->getRestriction() );
+	}
+
+	/**
+	 * Whether a page is listed is decided from isRestricted() and userCanExecute() together, so it is
+	 * asserted through the factory that combines them rather than through either one.
+	 */
+	public function testThePageIsListedOnlyForUsersWithTheAdminRight(): void {
+		$this->assertArrayNotHasKey( 'GraphStores', $this->usablePages( $this->getTestUser()->getUser() ) );
+		$this->assertArrayHasKey( 'GraphStores', $this->usablePages( $this->newAdmin() ) );
 	}
 
 	public function testEachStoreIsListedWithHowFarItIsFromTheWiki(): void {
@@ -292,6 +307,16 @@ class SpecialGraphStoresTest extends SpecialPageTestBase {
 
 	private function newAdmin(): User {
 		return $this->getTestUser( [ 'sysop' ] )->getUser();
+	}
+
+	/**
+	 * The context argument is mandatory from MediaWiki 1.47 and ignored before 1.45, so it is always passed.
+	 *
+	 * @return SpecialPage[]
+	 */
+	private function usablePages( User $user ): array {
+		return $this->getServiceContainer()->getSpecialPageFactory()
+			->getUsablePages( $user, RequestContext::getMain() );
 	}
 
 	private function newRunRepository(): RebuildRunRepository {

--- a/tests/phpunit/Maintenance/GeneratePerformanceDumpTest.php
+++ b/tests/phpunit/Maintenance/GeneratePerformanceDumpTest.php
@@ -283,8 +283,6 @@ class GeneratePerformanceDumpTest extends MaintenanceBaseTestCase {
 	 * Imports the way importDump.php does: bare, with no reporter wrapping the importer.
 	 */
 	private function importDump( string $dump ): void {
-		$this->tablesUsed[] = 'page';
-
 		$this->getServiceContainer()->getWikiImporterFactory()->getWikiImporter(
 			new ImportStringSource( $dump ),
 			$this->getTestSysop()->getAuthority()


### PR DESCRIPTION
Clears what the CI test run reports: one error, 96 PHP deprecation lines and 10 Node 20 warnings. Seven commits, one concern each.

**`composer phpunit:config`** was called unconditionally, but MediaWiki ships that script only from 1.46. Under `GITHUB_ACTIONS` Composer writes the resulting error as a `::error ::` annotation on **stdout**, which the `2>/dev/null` guarding stderr never caught. It now runs where core ships the generator.

**`$tablesUsed`** in `GeneratePerformanceDumpTest` fed nothing — core has detected changed tables by itself since 1.41 and dropped the property in 1.44 — while raising a dynamic-property deprecation from 1.44 on.

**`SpecialGraphStores`** named its right through the `SpecialPage` constructor, deprecated in 1.46 and logged 88 times per run. From 1.46 enforcement, listing and the denial page read `getRestriction()`; up to 1.45 they read the property that parameter set. All three are restated against `getRestriction()`, which holds on every supported version without a version check.

**The Neo4j waits** drop `iFaxity/wait-on-action`, which has no release that is not Node 20. The PHPUnit one becomes a bounded retry matching the QLever, Oxigraph and Fuseki waits beside it. The image build's is deleted outright: since #1284, `make up` cannot return while db or neo is still starting, which also retires the `/wait-for-it.sh` calls in `install-db` and `load-neo4j-users`. The test backends keep theirs, as nothing `depends_on` them.

The test script also disables Composer's process timeout, as core does for its own, so a full local run is no longer killed at 300 seconds.

## Why it looks like this

* **`phpunit:config` is guarded, not deleted.** NeoWiki passes its own `-c`, so the generated config looks unused — but core's bootstrap, which this script passes via `--bootstrap`, throws without it from 1.46.
* **Three overrides, not a version check.** `version_compare( MW_VERSION, '1.46', '<' )` works but exercises only one of its branches per run. Overriding `getRestriction()` alone is not enough: reduced to that, `testAUserWithoutTheAdminRightIsRefused` fails on 1.43.
* **`isRestricted()` is load-bearing.** `getUsablePages()` lists a page when `isListed() && ( !isRestricted() || userCanExecute( $user ) )`, so a page reporting itself unrestricted is listed for everyone.
* **`MediaWikiServices` rather than constructor injection.** Injecting `GroupPermissionsLookup` would make this the only special page with a constructor dependency and the only ObjectFactory `SpecialPages` entry, while the class keeps locating its other three collaborators at point of use. `SpecialPage` exposes no accessor for it on any supported version.
* **No `--health-cmd` on the Neo4j service.** It works, but the runner gates every step on service health and polls with exponential backoff — about 2, 6, 14, 30 then 62 seconds — while Neo4j answers at around 35. Measured at 26 seconds a matrix leg.
* **`actions/delete-package-versions` stays on Node 20.** No release of it is otherwise, and replacing it means a destructive loop over the packages API that only ever runs on master, so its first execution would be its first test.

## Verification

CI green on all seven jobs. Against the previous master run: `phpunit:config` errors 3 → 0, PHP deprecation lines 96 → 0, Node 20 warnings 10 → 0. Test count is baseline +2 on every version with skips unchanged; assertion totals vary between runs of the same commit, so they are not compared.

The restriction is checked on a live 1.43.8 wiki rather than only through PHPUnit: an anonymous request to Special:GraphStores is refused with *"limited to users in the group: Administrators"* — message key `badaccess-groups`, so the right reached the denial page rather than an empty string — and the page appears zero times on Special:SpecialPages for that user, while the unrestricted `Special:Schemas` appears twice.

Both new tests were mutation-checked on 1.43: overriding only `getRestriction()` fails the refusal test, and delegating `isRestricted()` to the parent fails the listing test with the page leaking into a non-admin's list.

The Makefile change was checked on a cold start with the volumes destroyed: `install-db` and `load-neo4j-users` both succeed unguarded, and `mediawiki_read` connects afterwards.

Locally, `make cs` is clean. The Scribunto/Lua subtree stalls on this stack independently of this change, so the full local suite was not run to completion.

<sub>AI-authored — Claude Code, `Opus 5 (1M context)`; root-cause analysis, fix and verification in-session; not yet human-reviewed.</sub>
