### PR TITLE
Route the NeoWiki log channel, and keep credentials out of it

### DIFF
--- a/Docker/SettingsTemplate.php
+++ b/Docker/SettingsTemplate.php
@@ -30,6 +30,13 @@ if ( $mwIsDev ) {
 	$wgDebugComments = false;
 }
 
+// MediaWiki routes no log channel anywhere by default, so every diagnostic NeoWiki emits would reach
+// nobody: a store refusing a page, a store name it will not accept, a projection failing on save.
+// Container stderr is where a Docker install's logs are read. No level floor, in either mode: a rebuild
+// records a skipped page at info, and that is a store left stale. Volume is bounded by the log driver's
+// rotation in docker-compose.yml rather than by dropping entries here.
+$wgDebugLogGroups['NeoWiki'] = 'php://stderr';
+
 ## Uncomment this to disable output compression
 # $wgDisableOutputCompression = true;
 

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -2,6 +2,13 @@ services:
   mediawiki:
     image: ghcr.io/professionalwiki/neowiki:latest
     restart: unless-stopped
+    # LocalSettings routes the NeoWiki log channel here, and a stack whose EDM projection has no Mapping
+    # page reports a failure on every save. Rotate, so a long-running stack cannot fill the host with it.
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     ports:
       - "${MW_SERVER_PORT:-8484}:80"
     volumes:

--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ wfLoadExtension( 'SomeExtension' );
 $wgDebugLogGroups['NeoWiki'] = '/tmp/neowiki-debug.log';
 ```
 
+The stack already routes the `NeoWiki` channel ([Logging](docs/operations/installation.md#logging)), so setting
+`$wgDebugLogGroups['NeoWiki']` here replaces that destination rather than adding to it.
+
 ### Try-it-out and server deployment
 
 For the prebuilt try-it-out stack or server deployment with Caddy, see

--- a/docs/extending/extending.md
+++ b/docs/extending/extending.md
@@ -157,11 +157,9 @@ class MyGraphDatabasePlugin implements GraphDatabasePlugin {
 Register with `NeoWikiRegistrar::addGraphDatabasePlugin( $name, $plugin )`. Example:
 [`src/RedHerbGraphDatabasePlugin.php`](https://github.com/ProfessionalWiki/NeoWiki/blob/master/tests/RedHerb/src/RedHerbGraphDatabasePlugin.php).
 
-The name is what [`--store`](../operations/maintenance.md#rebuilding-one-store) addresses, and what a rebuild files
-its run records under. Pick a stable one and namespace it to your extension. A name is refused with a warning on the
-`NeoWiki` channel when another backend already holds it, when it is `neo4j` in any casing — reserved for the bundled
-Neo4j backend — or when it is longer than 255 bytes, which is all a run record can hold. A refused backend receives
-no page changes and cannot be rebuilt.
+The name is what [`--store`](../operations/maintenance.md#rebuilding-one-store) addresses. Pick a stable one and
+namespace it to your extension. A refused name drops the plugin, which then projects nothing and cannot be rebuilt;
+the [`NeoWiki` log channel](../operations/installation.md#logging) says why and what to change.
 
 `savePage` hands you the page with all of its Subjects and the Page Properties contributed by every
 `PagePropertyProvider`, and runs for every revision, so subject edits, undeletions and page moves all reach you as a

--- a/docs/operations/installation.md
+++ b/docs/operations/installation.md
@@ -183,6 +183,24 @@ These are the settings you are most likely to change. For the full list with des
 | `$wgNeoWikiSparqlStores` | SPARQL 1.1 graph stores to keep in sync and query, e.g. QLever | `[]` | No |
 | `$wgNeoWikiAutoRebuildOnMappingChange` | Rebuilds every store holding a Mapping's projection when that Mapping changes | `false` | No |
 
+## Logging
+
+NeoWiki logs on the `NeoWiki` channel: a graph store failing on save, the pages a rebuild could not project, a store
+entry or name it will not accept, and RDF a projection had to drop. Below `warning` it also records rebuild decisions
+and denied page reads. MediaWiki routes no channel anywhere by default, so none of it reaches you until you route it:
+
+```php
+$wgDebugLogGroups['NeoWiki'] = '/var/log/mediawiki/neowiki.log';
+```
+
+Add a `level` to drop everything below it:
+
+```php
+$wgDebugLogGroups['NeoWiki'] = [ 'destination' => '/var/log/mediawiki/neowiki.log', 'level' => 'warning' ];
+```
+
+The [Docker install](#method-a-docker) routes the channel to container stderr. `make logs` tails it.
+
 ## User rights
 
 `neowiki-admin` allows viewing and rebuilding the wiki's graph stores, through
@@ -246,13 +264,13 @@ $wgNeoWikiSparqlStores = [
 ];
 ```
 
-A store entry whose `updateUrl` is missing or empty is skipped with a warning rather than failing the wiki.
-
 Each store's `name` identifies it when [rebuilding one store](maintenance.md#rebuilding-one-store), so no two entries
 may share one, and none may be `neo4j` in any casing — reserved for the bundled Neo4j backend. Since the name defaults
 to the projection, two entries holding the same projection — mirroring it to a second endpoint, say — collide until
-one of them sets an explicit `name`. An entry whose name cannot identify it is skipped with a warning, so its store
-receives no page changes.
+one of them sets an explicit `name`.
+
+An entry NeoWiki cannot use is skipped rather than failing the wiki; the [`NeoWiki` log channel](#logging) says which
+entry and why.
 
 ### Oxigraph
 

--- a/docs/operations/maintenance.md
+++ b/docs/operations/maintenance.md
@@ -55,12 +55,12 @@ A run that finished but left individual pages behind has nothing to continue: re
 
 Pass `--batch-size` to change how many pages are projected between recordings; it defaults to 200.
 
-A page the store rejects is counted and the rebuild carries on; the `NeoWiki` channel says which pages failed and why.
-A store that stops answering partway is another matter: when a whole batch fails the rebuild reopens the store, and
-ends the run for `--resume` to retry that batch only if it cannot. A store that still opens means its pages were at
-fault, so they are counted and the walk goes on past them. The script exits non-zero whenever a store was left out of
-sync, which covers both a failed run and one that finished having left pages behind. Only the first has anything to
-resume; rebuild the store for the second.
+A page the store rejects is counted and the rebuild carries on; the [`NeoWiki` log channel](installation.md#logging)
+says which pages failed and why. A store that stops answering partway is another matter: when a whole batch fails the
+rebuild reopens the store, and ends the run for `--resume` to retry that batch only if it cannot. A store that still
+opens means its pages were at fault, so they are counted and the walk goes on past them. The script exits non-zero
+whenever a store was left out of sync, which covers both a failed run and one that finished having left pages behind.
+Only the first has anything to resume; rebuild the store for the second.
 
 A rebuild killed outright — `kill -9`, or the machine going down — leaves its run recorded as still going, and every
 later rebuild of that store refuses to start while it is. So does a background rebuild whose first batch never
@@ -105,13 +105,10 @@ rebuild somebody started by hand is left to finish rather than restarted; the st
 ## What happens during a Neo4j outage
 
 - **Editing pages works.** Edits, deletions and undeletions all commit. NeoWiki logs the projection failure on the
-  `NeoWiki` channel.
+  [`NeoWiki` channel](installation.md#logging).
 - **Editing and displaying Subjects fails**, along with queries and anything else that reads the graph.
 
 Once Neo4j is back, [rebuild the graph](#rebuilding-the-graph): it repairs both a failed save and a failed delete.
-
-Route the `NeoWiki` log channel somewhere you read. On a default MediaWiki install it goes nowhere, and it carries
-both the outage and the pages a rebuild could not reconcile.
 
 ## Backups
 

--- a/docs/rdf/ontology-mapping.md
+++ b/docs/rdf/ontology-mapping.md
@@ -134,7 +134,8 @@ to an IRI containing an IRIREF-illegal character (`< > " { } | ^ \` backtick, sp
 
 The same checks re-run at **projection time**: a class, predicate, datatype, or prefix that does not re-expand
 safely is dropped, an unusable node takes everything below it with it, an invalid language tag falls back to a
-plain literal, and each is logged. The projection degrades rather than aborting the export.
+plain literal, and each is logged on the [`NeoWiki` channel](../operations/installation.md#logging). The projection
+degrades rather than aborting the export.
 
 ## What gets emitted
 

--- a/docs/rdf/rdf-export.md
+++ b/docs/rdf/rdf-export.md
@@ -58,7 +58,7 @@ an `xsd:anyURI` literal, so nothing is lost. The other value types map to `xsd` 
 registered mapper — including an unregistered type — is omitted from the projection.
 
 A Subject whose Schema cannot be loaded (for example, its Schema page was deleted) is omitted from the projection; a
-warning is logged for each.
+warning is logged for each on the [`NeoWiki` channel](../operations/installation.md#logging).
 
 ## Endpoint
 

--- a/src/Domain/GraphDatabase/FailureIsolatingGraphDatabasePlugin.php
+++ b/src/Domain/GraphDatabase/FailureIsolatingGraphDatabasePlugin.php
@@ -76,7 +76,7 @@ class FailureIsolatingGraphDatabasePlugin implements GraphDatabasePlugin {
 			'NeoWiki failed to ' . $operation . ' page ' . $pageId->id . ' in graph backend '
 			. $this->plugin::class . '. The triggering operation was not aborted, but this backend is '
 			. 'now out of sync for that page. Run the RebuildGraphDatabases maintenance script to '
-			. 'reconcile it. Underlying error: ' . $e->getMessage(),
+			. 'reconcile it. Underlying error: ' . BackendFailureMessage::withoutCredentials( $e->getMessage() ),
 			[ 'exception' => $e ]
 		);
 	}

--- a/src/EntryPoints/REST/ExportPageRdfApi.php
+++ b/src/EntryPoints/REST/ExportPageRdfApi.php
@@ -9,6 +9,7 @@ use MediaWiki\Logger\LoggerFactory;
 use MediaWiki\Rest\Response;
 use MediaWiki\Rest\SimpleHandler;
 use ProfessionalWiki\NeoWiki\Application\Rdf\RdfPageProjector;
+use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\BackendFailureMessage;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use Wikimedia\ParamValidator\ParamValidator;
@@ -74,7 +75,11 @@ class ExportPageRdfApi extends SimpleHandler {
 		} catch ( Exception $e ) {
 			LoggerFactory::getInstance( 'NeoWiki' )->error(
 				'NeoWiki could not export page {pageId} as RDF: {message}',
-				[ 'pageId' => $pageId, 'message' => $e->getMessage(), 'exception' => $e ]
+				[
+					'pageId' => $pageId,
+					'message' => BackendFailureMessage::withoutCredentials( $e->getMessage() ),
+					'exception' => $e,
+				]
 			);
 
 			return $this->noDataResponse( $pageId );

--- a/src/FailureIsolatingPagePropertiesSource.php
+++ b/src/FailureIsolatingPagePropertiesSource.php
@@ -7,6 +7,7 @@ namespace ProfessionalWiki\NeoWiki;
 use Exception;
 use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\User\UserIdentity;
+use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\BackendFailureMessage;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageProperties;
 use Psr\Log\LoggerInterface;
 use Wikimedia\Rdbms\DBError;
@@ -41,7 +42,11 @@ class FailureIsolatingPagePropertiesSource implements PagePropertiesSource {
 			$this->logger->error(
 				'NeoWiki did not project page {pageId} because its page properties could not be built: '
 				. '{message}. The graph is out of sync for that page until the cause is resolved.',
-				[ 'pageId' => $revision->getPageId(), 'message' => $e->getMessage(), 'exception' => $e ]
+				[
+					'pageId' => $revision->getPageId(),
+					'message' => BackendFailureMessage::withoutCredentials( $e->getMessage() ),
+					'exception' => $e,
+				]
 			);
 
 			return null;

--- a/tests/phpunit/Domain/GraphDatabase/FailureIsolatingGraphDatabasePluginTest.php
+++ b/tests/phpunit/Domain/GraphDatabase/FailureIsolatingGraphDatabasePluginTest.php
@@ -80,6 +80,24 @@ class FailureIsolatingGraphDatabasePluginTest extends TestCase {
 		$this->assertStringContainsString( 'triggering operation', $message, 'stays operation-neutral' );
 	}
 
+	/**
+	 * The Neo4j client reports what it could not reach by quoting the bolt URI it tried, userinfo and
+	 * all, so relaying its message verbatim writes the store's password to wherever the NeoWiki channel
+	 * is routed — on every save, for as long as the backend is down.
+	 */
+	public function testTheBackendPasswordIsKeptOutOfTheLoggedFailure(): void {
+		$plugin = new ThrowingGraphDatabasePlugin(
+			'Cannot connect to any server on alias: default with Uris: '
+			. "('bolt://neo4j:s3cr3t@neo.example:7687')"
+		);
+
+		$this->newDecorator( $plugin )->savePage( TestPage::build( id: 42 ) );
+
+		$message = $this->logger->records[0]['message'];
+		$this->assertStringNotContainsString( 's3cr3t', $message );
+		$this->assertStringContainsString( 'bolt://neo.example:7687', $message, 'still names the unreachable server' );
+	}
+
 	public function testFailingDeleteIsSwallowedAndLoggedForTheDeleteOperation(): void {
 		$this->newDecorator( new ThrowingGraphDatabasePlugin() )->deletePage( new PageId( 42 ) );
 


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1250

@JeroenDeDauw's review of #1250 called the graph store name paragraph in `extending.md` badly worded clutter, and said
one sentence was all it needed. The question that raised: those rules are already in the code's log messages, so does
the doc need to state them at all?

It does today, because nothing is listening. NeoWiki logs every diagnostic through
`LoggerFactory::getInstance( 'NeoWiki' )`, and MediaWiki routes no channel anywhere by default. With no destination for
the channel and no `$wgDebugLogFile`, `LegacyLogger::__construct()` sets `minimumLevel` to `LEVEL_INFINITY`, so `log()`
returns at its first guard — before the emit path, before `MW_LOG_STDERR`, and before `MWDebug::debugMsg()`, which is
what a `$wgDebugComments` page would otherwise have rendered. Measured on a fresh stack: registering a store as `neo4j`
produced no warning in `docker logs`, an empty `<!-- Debug output: -->` block in the page HTML, no store, and no clue.

An operator was not blind: `RebuildGraphDatabases.php` prints per-store status and a failed-page count and exits
non-zero, and `Special:GraphStores` shows sync state and counts. What lived on the channel alone was every *reason* —
the script says as much, reporting the failing page ids and then deferring with `'. The NeoWiki log channel says why.'`
Three categories had no other surface at all: a refused store name, an RDF projection drop, and a failed save. The last
is the worst, because `GraphStoreStatusLookup::stateOf()` derives In sync / Stale from a Mapping redefinition against
the last successful run, so a store that rotted because Neo4j was down during edits keeps reading **In sync**.

This also applies to `maintenance.md`, which twice pointed readers at this channel for rebuild diagnostics, and to
`rdf-export.md` and `ontology-mapping.md`, which each promised something "is logged" without naming where.

## Keeping credentials out of it

Routing the channel would have made a latent leak live, which is why fixing it is the earlier commit.

A graph backend reports what it could not reach by quoting the request it made, so the Neo4j client's failure carries
the bolt URI userinfo and all. Three log sites relayed `getMessage()` verbatim while eleven others already passed it
through `BackendFailureMessage::withoutCredentials()`. Reproduced against a live stack with an unreachable host:

```
Underlying error: Cannot connect to any server on alias: default with Uris:
  ('bolt://neo4j:CANARY_PW_9f3a@unreachable-host:7687')
```

On a default install this was latent, for the reason above. It was already live on any wiki that had set
`$wgDebugLogGroups['NeoWiki']`, `$wgDebugLogFile`, `$wgShowDebug` or `$wgDebugToolbar` — that is, on exactly the wikis
that had taken the advice this PR now writes down. It fires on every page save for as long as the backend is down, the
outage during which an operator is most likely to be reading the log.

After the fix the same probe yields `bolt://unreachable-host:7687`: the password is gone, the unreachable server is
still named.

## Routing

The bundled stack now sends the channel to container stderr, at every level. No level floor in either mode: `make demo`
and `make up` run production mode, so a `warning` floor would have applied to the documented install and dropped the
rebuild's skipped-page entries — which `logSkippedPage` exists to record, because a skipped page is a store left stale.
Volume is bounded by log rotation on the service instead, since a stack whose EDM projection has no Mapping page reports
a failure on every save and no compose file set a `logging:` key.

## Docs

`installation.md` gains the section documenting this and becomes the one home for it; the pages that mention the channel
link there rather than restating it. `extending.md` drops the enumeration, keeps what a refused name costs, and points
at the log for the rest.

Dropping the enumeration is also a small accuracy gain: it claimed `neo4j` was the reserved name, but
`getBundledStoreNames()` reserves every configured SPARQL store name too, which an extension developer cannot know in
advance. The reserved set is wiki configuration and was never statable in a doc.

## Considered, omitted

- **The 255-byte name cap** is now documented nowhere. It is close to impossible to hit by accident and the log names it
  and the fix when you do. Restoring it means starting to rebuild the enumeration; say the word and it goes back as four
  words in the existing sentence.
- **Surfacing refused registrations on `Special:GraphStores`**, which would make them visible with no logging config at
  all. That is a feature change, not a docs fix.
- **REST handlers returning `$e->getMessage()` in 500 responses** — the same raw-message pattern over HTTP rather than to
  a log. Untouched by this change and wants its own audit.

## Verification

`make cs` clean. `DocsPathReferencesTest` (791 assertions with the plugin suite), `OnRevisionCreatedHandlerTest` and
`ExportPageRdfApiTest` green. The credential regression test was confirmed failing against the unredacted code before
the fix. Routing and redaction were both verified end to end on a live stack, over CLI stderr and the web path into
`docker logs`, and the pre-change silence was confirmed by unsetting the routing and re-running the same request.
`make logs` was confirmed to attach to a stack brought up without the dev compose file.

<sub>AI-authored — Claude Code, `Opus 5 (1M context)`; investigation, implementation and verification in-session; reviewed by three independent agents whose findings are folded in; not yet human-reviewed.</sub>
