### PR TITLE
Add optional-service selection to the dev stack (services=)

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -38,14 +38,49 @@ need to run two tools-mode stacks simultaneously.
 The MariaDB, (default) Neo4j, QLever and Oxigraph ports are not exposed to the host. Reach
 them from inside the stack via `make bash` or `docker compose exec`.
 
+## Optional services
+
+The dev stack's core is `mediawiki`, `db` and `neo`; everything else is optional. `make dev` (and
+`make dev-tools`) accept a `services=` comma-list naming the optional services to run:
+
+| Service       | Needed for                                                              |
+|---------------|-------------------------------------------------------------------------|
+| `node`        | Frontend work: watches and rebuilds the TS bundle (`dist/`)             |
+| `qlever`      | SPARQL/RDF work: the wiki projects RDF into it on every save            |
+| `mailcatcher` | Testing outgoing email (web UI on `MAILCATCHER_PORT`)                   |
+| `oxigraph`    | Second SPARQL engine; needs manual wiring via `LocalSettings.local.php` |
+
+Without the flag, `node`, `qlever` and `mailcatcher` run (the default); `oxigraph` only runs when named.
+`services=none` runs core only. Examples:
+
+```sh
+make dev                        # default set
+make dev services=node          # frontend work: watcher only
+make dev services=none          # core only
+make dev services=qlever,node   # SPARQL plus frontend
+```
+
+Rerunning `make dev` with a different selection reconfigures a running stack: newly-deselected services
+are stopped (their volumes survive for reselection) and the wiki's config follows, so a deselected
+store or mail host is never configured. Details:
+
+- Without `node`, `make dev` builds the frontend bundle once in a throwaway container (`dist/` is
+  gitignored), so the UI works; the `ts-*` targets start the watcher on demand if you begin TS work.
+- The test-only backends (`test_neo`, `test_qlever`, `test_oxigraph`) are independent of this selection:
+  `make phpunit` starts them on demand, and `make test-backends-stop` stops them again.
+- Setting `COMPOSE_PROFILES` directly still works and is unioned with the selection; the profile names
+  equal the service names.
+
 ## QLever SPARQL store
 
-Both the demo stack and the dev stack bundle a [QLever](https://github.com/ad-freiburg/qlever)
-SPARQL 1.1 graph store as a working example of NeoWiki's SPARQL projection plugin (issue #586). The
-service is defined in `docker-compose.yml`, which both stacks build on, and which passes the store's
-endpoint to the wiki as `QLEVER_URL`. `SettingsTemplate.php` points `$wgNeoWikiSparqlStores` at that
-endpoint, so every page save and `RebuildGraphDatabases.php` also projects the page's RDF into
-QLever as named graphs.
+Both the demo stack and the dev stack run a [QLever](https://github.com/ad-freiburg/qlever)
+SPARQL 1.1 graph store by default as a working example of NeoWiki's SPARQL projection plugin
+(issue #586). The bundled Makefile passes the store's endpoint to the wiki as `QLEVER_URL`.
+`SettingsTemplate.php` points `$wgNeoWikiSparqlStores` at that endpoint, so every page save and
+`RebuildGraphDatabases.php` also projects the page's RDF into QLever as named graphs.
+
+On the dev stack, you can deselect QLever with `services=` (see Optional services above), which
+leaves `QLEVER_URL` empty.
 
 Two entries point at that one endpoint: the `native` projection and the `EDM` one defined
 by the demo data's `Mapping:EDM` page. Each writes its own per-page named graphs, so one

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -66,6 +66,7 @@ store or mail host is never configured. Details:
 
 - Without `node`, `make dev` builds the frontend bundle once in a throwaway container (`dist/` is
   gitignored), so the UI works; the `ts-*` targets start the watcher on demand if you begin TS work.
+  A bundle left stale by a later `git pull` is refreshed with `make ts-build`.
 - The test-only backends (`test_neo`, `test_qlever`, `test_oxigraph`) are independent of this selection:
   `make phpunit` starts them on demand, and `make test-backends-stop` stops them again.
 - Setting `COMPOSE_PROFILES` directly still works and is unioned with the selection; the profile names
@@ -141,6 +142,10 @@ default, so it sits behind the `oxigraph` compose profile and neither stack star
 ```sh
 COMPOSE_PROFILES=oxigraph make dev
 ```
+
+This only holds for that invocation: `COMPOSE_PROFILES` is not persisted, so a later plain `make dev`
+deselects Oxigraph again and stops it (its data volume survives for reselection). Pass
+`COMPOSE_PROFILES=oxigraph` again each time you want it running.
 
 `SettingsTemplate.php` points `$wgNeoWikiSparqlStores` at `QLEVER_URL`, so nothing reaches Oxigraph until
 you repoint it: `updateUrl` `http://oxigraph:7878/update`, `queryUrl` `http://oxigraph:7878/query`. On the

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -198,13 +198,15 @@ report the backends as missing instead of starting them.
   demo image published as `ghcr.io/professionalwiki/neowiki:latest`, which bakes in
   `LocalSettings.php`), and `dev-mw` (the dev image with mounted NeoWiki source).
 - `docker-compose.yml` — the demo stack's services (`mediawiki`, `db`, `neo`, `qlever`
-  — SPARQL store, see above) plus the profile-gated `caddy` (the `server` profile, for
-  HTTPS hosting) and `oxigraph` (the `oxigraph` profile, the second SPARQL store, see
-  above). The dev overlay builds on this file, so these services are in both stacks.
-- `docker-compose.dev.yml` — dev overlay; switches `mediawiki` to the dev image,
-  bind-mounts the NeoWiki source, sets `MW_MODE=dev`, and adds the dev-only sidecars
-  `node` and `mailcatcher`, plus `test_neo`, `test_qlever` and `test_oxigraph` behind the
-  `test` profile.
+  — SPARQL store, see above, unconditional so raw `docker compose` and the `--profile server`
+  deployment always get it) plus the profile-gated `caddy` (the `server` profile, for HTTPS
+  hosting) and `oxigraph` (the `oxigraph` profile, the second SPARQL store, see above). The dev
+  overlay builds on this file, so these services are in both stacks.
+- `docker-compose.dev.yml` — dev overlay; switches `mediawiki` to the dev image, bind-mounts the
+  NeoWiki source, sets `MW_MODE=dev`, and adds a `qlever` profile onto that base-file service plus
+  the dev-only sidecars `node` and `mailcatcher`, each behind its own profile so `services=` (see
+  [Optional services](#optional-services)) can select or deselect them, plus `test_neo`,
+  `test_qlever` and `test_oxigraph` behind the `test` profile.
 - `docker-compose.tools.yml` — opt-in overlay that exposes Neo4j, QLever and Oxigraph to the
   host, usable with either stack.
 - `SettingsTemplate.php` — `LocalSettings.php` that branches on `MW_MODE`.

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -50,7 +50,7 @@ The dev stack's core is `mediawiki`, `db` and `neo`; everything else is optional
 | `mailcatcher` | Testing outgoing email (web UI on `MAILCATCHER_PORT`)                   |
 | `oxigraph`    | Second SPARQL engine; needs manual wiring via `LocalSettings.local.php` |
 
-Without the flag, `node`, `qlever` and `mailcatcher` run (the default); `oxigraph` only runs when named.
+Without the flag, `node`, `qlever` and `mailcatcher` run by default; `oxigraph` runs only when named.
 `services=none` runs core only. Examples:
 
 ```sh
@@ -61,12 +61,12 @@ make dev services=qlever,node   # SPARQL plus frontend
 ```
 
 Rerunning `make dev` with a different selection reconfigures a running stack: newly-deselected services
-are stopped (their volumes survive for reselection) and the wiki's config follows, so a deselected
+stop (their volumes survive for reselection) and the wiki's config follows, so a deselected
 store or mail host is never configured. Details:
 
 - Without `node`, `make dev` builds the frontend bundle once in a throwaway container (`dist/` is
   gitignored), so the UI works; the `ts-*` targets start the watcher on demand if you begin TS work.
-  A bundle left stale by a later `git pull` is refreshed with `make ts-build`.
+  `make ts-build` refreshes a bundle left stale by a later `git pull`.
 - The test-only backends (`test_neo`, `test_qlever`, `test_oxigraph`) are independent of this selection:
   `make phpunit` starts them on demand, and `make test-backends-stop` stops them again.
 - Setting `COMPOSE_PROFILES` directly still works and is unioned with the selection; the profile names
@@ -80,7 +80,7 @@ SPARQL 1.1 graph store by default as a working example of NeoWiki's SPARQL proje
 `SettingsTemplate.php` points `$wgNeoWikiSparqlStores` at that endpoint, so every page save and
 `RebuildGraphDatabases.php` also projects the page's RDF into QLever as named graphs.
 
-On the dev stack, you can deselect QLever with `services=` (see Optional services above), which
+On the dev stack, you can deselect QLever with `services=` (see [Optional services](#optional-services)), which
 leaves `QLEVER_URL` empty.
 
 Two entries point at that one endpoint: the `native` projection and the `EDM` one defined
@@ -202,8 +202,8 @@ report the backends as missing instead of starting them.
   production `php.ini`; intermediate, no `LocalSettings.php`), `final-mw` (the prebuilt
   demo image published as `ghcr.io/professionalwiki/neowiki:latest`, which bakes in
   `LocalSettings.php`), and `dev-mw` (the dev image with mounted NeoWiki source).
-- `docker-compose.yml` — the demo stack's services (`mediawiki`, `db`, `neo`, `qlever`
-  — SPARQL store, see above, unconditional so raw `docker compose` and the `--profile server`
+- `docker-compose.yml` — the demo stack's services `mediawiki`, `db`, `neo` and `qlever` (the
+  SPARQL store, see above, unconditional so raw `docker compose` and the `--profile server`
   deployment always get it) plus the profile-gated `caddy` (the `server` profile, for HTTPS
   hosting) and `oxigraph` (the `oxigraph` profile, the second SPARQL store, see above). The dev
   overlay builds on this file, so these services are in both stacks.

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -64,9 +64,9 @@ Rerunning `make dev` with a different selection reconfigures a running stack: ne
 stop (their volumes survive for reselection) and the wiki's config follows, so a deselected
 store or mail host is never configured. Details:
 
-- Without `node`, `make dev` builds the frontend bundle once in a throwaway container (`dist/` is
-  gitignored), so the UI works; the `ts-*` targets start the watcher on demand if you begin TS work.
-  `make ts-build` refreshes a bundle left stale by a later `git pull`.
+- Without `node`, `make dev` builds the frontend bundle once in a throwaway container, so the UI
+  works; the `ts-*` targets start the watcher on demand. `make ts-build` refreshes a bundle left
+  stale by a later `git pull`.
 - The test-only backends (`test_neo`, `test_qlever`, `test_oxigraph`) are independent of this selection:
   `make phpunit` starts them on demand, and `make test-backends-stop` stops them again.
 - Setting `COMPOSE_PROFILES` directly still works and is unioned with the selection; the profile names
@@ -79,9 +79,6 @@ SPARQL 1.1 graph store by default as a working example of NeoWiki's SPARQL proje
 (issue #586). The bundled Makefile passes the store's endpoint to the wiki as `QLEVER_URL`.
 `SettingsTemplate.php` points `$wgNeoWikiSparqlStores` at that endpoint, so every page save and
 `RebuildGraphDatabases.php` also projects the page's RDF into QLever as named graphs.
-
-On the dev stack, you can deselect QLever with `services=` (see [Optional services](#optional-services)), which
-leaves `QLEVER_URL` empty.
 
 Two entries point at that one endpoint: the `native` projection and the `EDM` one defined
 by the demo data's `Mapping:EDM` page. Each writes its own per-page named graphs, so one
@@ -143,9 +140,8 @@ default, so it sits behind the `oxigraph` compose profile and neither stack star
 COMPOSE_PROFILES=oxigraph make dev
 ```
 
-This only holds for that invocation: `COMPOSE_PROFILES` is not persisted, so a later plain `make dev`
-deselects Oxigraph again and stops it (its data volume survives for reselection). Pass
-`COMPOSE_PROFILES=oxigraph` again each time you want it running.
+`COMPOSE_PROFILES` is not persisted: a later plain `make dev` deselects Oxigraph again and stops it,
+though its data volume survives.
 
 `SettingsTemplate.php` points `$wgNeoWikiSparqlStores` at `QLEVER_URL`, so nothing reaches Oxigraph until
 you repoint it: `updateUrl` `http://oxigraph:7878/update`, `queryUrl` `http://oxigraph:7878/query`. On the
@@ -202,16 +198,14 @@ report the backends as missing instead of starting them.
   production `php.ini`; intermediate, no `LocalSettings.php`), `final-mw` (the prebuilt
   demo image published as `ghcr.io/professionalwiki/neowiki:latest`, which bakes in
   `LocalSettings.php`), and `dev-mw` (the dev image with mounted NeoWiki source).
-- `docker-compose.yml` — the demo stack's services `mediawiki`, `db`, `neo` and `qlever` (the
-  SPARQL store, see above, unconditional so raw `docker compose` and the `--profile server`
-  deployment always get it) plus the profile-gated `caddy` (the `server` profile, for HTTPS
-  hosting) and `oxigraph` (the `oxigraph` profile, the second SPARQL store, see above). The dev
-  overlay builds on this file, so these services are in both stacks.
+- `docker-compose.yml` — the demo stack's services (`mediawiki`, `db`, `neo`, `qlever`
+  — SPARQL store, see above) plus the profile-gated `caddy` (the `server` profile, for
+  HTTPS hosting) and `oxigraph` (the `oxigraph` profile, the second SPARQL store, see
+  above). The dev overlay builds on this file, so these services are in both stacks.
 - `docker-compose.dev.yml` — dev overlay; switches `mediawiki` to the dev image, bind-mounts the
-  NeoWiki source, sets `MW_MODE=dev`, and adds a `qlever` profile onto that base-file service plus
-  the dev-only sidecars `node` and `mailcatcher`, each behind its own profile so `services=` (see
-  [Optional services](#optional-services)) can select or deselect them, plus `test_neo`,
-  `test_qlever` and `test_oxigraph` behind the `test` profile.
+  NeoWiki source, sets `MW_MODE=dev`, adds the dev-only sidecars `node` and `mailcatcher`, and gates
+  them plus `qlever` behind their `services=` profiles (see [Optional services](#optional-services));
+  `test_neo`, `test_qlever` and `test_oxigraph` sit behind the `test` profile.
 - `docker-compose.tools.yml` — opt-in overlay that exposes Neo4j, QLever and Oxigraph to the
   host, usable with either stack.
 - `SettingsTemplate.php` — `LocalSettings.php` that branches on `MW_MODE`.

--- a/Docker/SettingsTemplate.php
+++ b/Docker/SettingsTemplate.php
@@ -229,16 +229,15 @@ $wgNeoWikiNeo4jInternalWriteUrl = 'bolt://' . getenv( 'NEO4J_USERNAME' ) . ':' .
 $wgNeoWikiNeo4jInternalReadUrl = 'bolt://' . getenv( 'NEO4J_USERNAME_READ' ) . ':' . getenv( 'NEO4J_PASSWORD_READ' ) . '@neo:7687';
 
 // SPARQL graph store (QLever) for the SPARQL projection plugin (#586). Both the demo stack and the
-// dev stack run the qlever service defined in docker-compose.yml by default and are pointed at its
-// endpoint below via QLEVER_URL. A non-empty value is the gate: an image started outside those stacks
-// gets QLEVER_URL unset rather than a configuration pointing at a host that does not exist, and so does
-// CI, whose docker-compose.ci.yml replaces that file and sets neither variable; the dev stack's bundled
-// Makefile sets QLEVER_URL to the empty string instead when its `services=` selection deselects qlever,
-// which disables this configuration the same way being unset does. The access token is an ordinary
-// optional credential, defaulted in the compose file so a Docker/.env written before it existed still
-// yields a working store. Skipped under PHPUnit so integration tests never post updates here — they
-// configure their own stores with mocked HTTP via overrideConfigValue(), so the default must stay empty
-// during tests.
+// dev stack run the qlever service defined in docker-compose.yml by default and point the wiki at
+// its endpoint via QLEVER_URL. A non-empty value is the gate: an image started outside those stacks
+// gets QLEVER_URL unset rather than a configuration pointing at a host that does not exist, and so
+// does CI, whose docker-compose.ci.yml replaces that file and sets neither variable. The dev stack's
+// Makefile sets it to the empty string when `services=` deselects qlever, which disables the
+// configuration the same way. The access token is an ordinary optional credential, defaulted in the
+// compose file so a Docker/.env written before it existed still yields a working store. Skipped
+// under PHPUnit so integration tests never post updates here — they configure their own stores with
+// mocked HTTP via overrideConfigValue(), so the default must stay empty during tests.
 //
 // Two entries, one endpoint: the native projection and the EDM projection of the demo data's
 // Mapping:EDM page are kept in the same QLever index as sibling projections. Each lands in its own

--- a/Docker/SettingsTemplate.php
+++ b/Docker/SettingsTemplate.php
@@ -195,11 +195,14 @@ wfLoadExtension( 'SyntaxHighlight_GeSHi' );
 wfLoadExtension( 'Scribunto' );
 wfLoadExtension( 'ParserFunctions' );
 
+// Empty MW_SMTP_HOST means "no SMTP at all": the dev stack sets it when the
+// mailcatcher service is deselected. Unset means "use the mode's default".
+$mwSmtpHost = getenv( 'MW_SMTP_HOST' );
 $wgSMTP = [];
-if ( $mwIsDev && getenv( 'MW_SMTP_HOST' ) === false ) {
+if ( $mwIsDev && $mwSmtpHost === false ) {
 	// Default to the mailcatcher sidecar in dev mode.
 	$wgSMTP = [ 'host' => 'mailcatcher', 'port' => 1025 ];
-} elseif ( getenv( 'MW_SMTP_HOST' ) !== false ) {
+} elseif ( $mwSmtpHost !== false && $mwSmtpHost !== '' ) {
 	$wgSMTP = [
 		'host' => getenv( 'MW_SMTP_HOST' ),
 		'IDHost' => getenv( 'MW_SMTP_ID_HOST' ),
@@ -225,15 +228,17 @@ $wgNeoWikiEnableDevelopmentUI = true;
 $wgNeoWikiNeo4jInternalWriteUrl = 'bolt://' . getenv( 'NEO4J_USERNAME' ) . ':' . getenv( 'NEO4J_PASSWORD' ) . '@neo:7687';
 $wgNeoWikiNeo4jInternalReadUrl = 'bolt://' . getenv( 'NEO4J_USERNAME_READ' ) . ':' . getenv( 'NEO4J_PASSWORD_READ' ) . '@neo:7687';
 
-// SPARQL graph store (QLever) for the SPARQL projection plugin (#586). Configured in every mode, so
-// the demo stack has the same SPARQL surface as the dev stack — both run the qlever service defined
-// in docker-compose.yml, and that file is what supplies the endpoint below. The endpoint is therefore
-// the gate: an image started outside those stacks gets no store rather than a configuration pointing
-// at a host that does not exist, and so does CI, whose docker-compose.ci.yml replaces that file and
-// sets neither variable. The access token is an ordinary optional credential, defaulted in the compose
-// file so a Docker/.env written before it existed still yields a working store. Skipped under PHPUnit
-// so integration tests never post updates here — they configure their own stores with mocked HTTP via
-// overrideConfigValue(), so the default must stay empty during tests.
+// SPARQL graph store (QLever) for the SPARQL projection plugin (#586). Both the demo stack and the
+// dev stack run the qlever service defined in docker-compose.yml by default and are pointed at its
+// endpoint below via QLEVER_URL. A non-empty value is the gate: an image started outside those stacks
+// gets QLEVER_URL unset rather than a configuration pointing at a host that does not exist, and so does
+// CI, whose docker-compose.ci.yml replaces that file and sets neither variable; the dev stack's bundled
+// Makefile sets QLEVER_URL to the empty string instead when its `services=` selection deselects qlever,
+// which disables this configuration the same way being unset does. The access token is an ordinary
+// optional credential, defaulted in the compose file so a Docker/.env written before it existed still
+// yields a working store. Skipped under PHPUnit so integration tests never post updates here — they
+// configure their own stores with mocked HTTP via overrideConfigValue(), so the default must stay empty
+// during tests.
 //
 // Two entries, one endpoint: the native projection and the EDM projection of the demo data's
 // Mapping:EDM page are kept in the same QLever index as sibling projections. Each lands in its own
@@ -241,7 +246,7 @@ $wgNeoWikiNeo4jInternalReadUrl = 'bolt://' . getenv( 'NEO4J_USERNAME_READ' ) . '
 // target the first entry's endpoint, which both entries share, so a query reaches both projections.
 $qleverUrl = getenv( 'QLEVER_URL' );
 
-if ( $qleverUrl !== false && !defined( 'MW_PHPUNIT_TEST' ) ) {
+if ( $qleverUrl !== false && $qleverUrl !== '' && !defined( 'MW_PHPUNIT_TEST' ) ) {
 	$wgNeoWikiSparqlStores = [
 		[
 			'updateUrl' => $qleverUrl,

--- a/Docker/docker-compose.dev.yml
+++ b/Docker/docker-compose.dev.yml
@@ -50,12 +50,10 @@ services:
     command: --innodb-buffer-pool-size=128M
     mem_limit: 512m
 
-  # `qlever` itself is defined in the base file (docker-compose.yml) and runs unconditionally
-  # there, so the demo stack and raw `docker compose` invocations always get it. Only the dev
-  # stack supports deselecting optional services via `services=`, so this overlay adds the
-  # `qlever` profile here rather than in the base file — the bundled Makefile enables it by
-  # default (see the Optional services comment there), so `make dev` keeps QLever on unless
-  # `services=` deselects it.
+  # `qlever` is defined in the base file (docker-compose.yml) and runs unconditionally there, so
+  # the demo stack and raw `docker compose` invocations always get it. Only the dev stack supports
+  # `services=` selection, so the profile gating it goes in this overlay, not the base file. The
+  # Makefile selects it by default, so `make dev` keeps QLever on unless `services=` deselects it.
   qlever:
     profiles:
       - qlever

--- a/Docker/docker-compose.dev.yml
+++ b/Docker/docker-compose.dev.yml
@@ -50,6 +50,16 @@ services:
     command: --innodb-buffer-pool-size=128M
     mem_limit: 512m
 
+  # `qlever` itself is defined in the base file (docker-compose.yml) and runs unconditionally
+  # there, so the demo stack and raw `docker compose` invocations always get it. Only the dev
+  # stack supports deselecting optional services via `services=`, so this overlay adds the
+  # `qlever` profile here rather than in the base file — the bundled Makefile enables it by
+  # default (see the Optional services comment there), so `make dev` keeps QLever on unless
+  # `services=` deselects it.
+  qlever:
+    profiles:
+      - qlever
+
   # Dev-only sidecars. They live in this overlay (not the base file) so the base
   # "try-it-out" stack stays minimal and so `make down` removes them as orphans
   # regardless of the compose backend. See the Makefile `down` target.

--- a/Docker/docker-compose.dev.yml
+++ b/Docker/docker-compose.dev.yml
@@ -155,6 +155,8 @@ services:
     stop_grace_period: 2s
 
   node:
+    profiles:
+      - node
     image: node:24
     restart: on-failure:3
     mem_limit: 1536m
@@ -177,6 +179,8 @@ services:
       - HOME=/tmp
 
   mailcatcher:
+    profiles:
+      - mailcatcher
     image: sj26/mailcatcher
     restart: unless-stopped
     ports:

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -22,8 +22,9 @@ services:
       - NEO4J_USERNAME_READ
       - NEO4J_PASSWORD_READ
       # Endpoint of the qlever service below. Its presence is what makes SettingsTemplate.php
-      # configure $wgNeoWikiSparqlStores, so every stack built on this file gets the store while
-      # an image run outside one gets none.
+      # configure $wgNeoWikiSparqlStores; an image run outside this file gets none. Not itself
+      # profile-gated: deselecting qlever (see below) stops the container but leaves this pointed
+      # at an endpoint that is not running, rather than clearing it.
       - QLEVER_URL=http://qlever:7019/
       # Bearer token the wiki sends to authorize SPARQL updates. Defaulted here instead of being
       # required from Docker/.env, so a .env written before the variable existed still works; the
@@ -69,13 +70,17 @@ services:
       timeout: 1s
       retries: 10
 
-  # SPARQL 1.1 graph store (QLever) for the SPARQL projection plugin (#586). Defined in this base
-  # file rather than the dev overlay, so the demo stack gets the same RDF/SPARQL surface as the dev
-  # stack: every page save and RebuildGraphDatabases.php also projects the page's RDF here as named
-  # graphs, and the query surfaces read from it. The wiki is pointed at it by QLEVER_URL above.
-  # NeoWiki reaches it in-network as http://qlever:7019/; a host port for manual inspection is
-  # opt-in via docker-compose.tools.yml.
+  # SPARQL 1.1 graph store (QLever) for the SPARQL projection plugin (#586). Profile-gated below;
+  # the bundled Makefile enables the profile by default, so both the demo and dev stacks get the
+  # same RDF/SPARQL surface unless `services=` deselects it: every page save and
+  # RebuildGraphDatabases.php also projects the page's RDF here as named graphs, and the query
+  # surfaces read from it. The wiki is pointed at it by QLEVER_URL above; deselecting the profile
+  # stops this container but does not clear that variable (see the comment there), so a deselected
+  # wiki still tries to reach a store that is not running. NeoWiki reaches it in-network as
+  # http://qlever:7019/; a host port for manual inspection is opt-in via docker-compose.tools.yml.
   qlever:
+    profiles:
+      - qlever
     image: docker.io/adfreiburg/qlever:latest
     restart: unless-stopped
     # Above QLever's own -m 1G query budget (server command below) plus index overhead.

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -21,15 +21,20 @@ services:
       - NEO4J_PASSWORD
       - NEO4J_USERNAME_READ
       - NEO4J_PASSWORD_READ
-      # Endpoint of the qlever service below. Its presence is what makes SettingsTemplate.php
-      # configure $wgNeoWikiSparqlStores; an image run outside this file gets none. Not itself
-      # profile-gated: deselecting qlever (see below) stops the container but leaves this pointed
-      # at an endpoint that is not running, rather than clearing it.
-      - QLEVER_URL=http://qlever:7019/
+      # Endpoint of the qlever service below; a non-empty value is what makes
+      # SettingsTemplate.php configure $wgNeoWikiSparqlStores. The bundled Makefile
+      # owns the value: the qlever endpoint when the service is selected, empty
+      # ("disabled") when deselected. Running this file without the Makefile leaves
+      # it unset, which matches the qlever profile not being active: no store runs
+      # and none is configured.
+      - QLEVER_URL
       # Bearer token the wiki sends to authorize SPARQL updates. Defaulted here instead of being
       # required from Docker/.env, so a .env written before the variable existed still works; the
       # qlever service below defaults it the same way, so wiki and server always agree.
       - QLEVER_ACCESS_TOKEN=${QLEVER_ACCESS_TOKEN:-neowiki_dev_token}
+      # Empty means "no SMTP" to SettingsTemplate.php (set by the Makefile when the
+      # mailcatcher service is deselected); unset means "use the mode's default".
+      - MW_SMTP_HOST
     healthcheck:
       test: "curl -fs http://localhost:80/wiki/Special:Version | grep -q 'Jeroen De Dauw'"
       interval: 60s
@@ -74,9 +79,9 @@ services:
   # the bundled Makefile enables the profile by default, so both the demo and dev stacks get the
   # same RDF/SPARQL surface unless `services=` deselects it: every page save and
   # RebuildGraphDatabases.php also projects the page's RDF here as named graphs, and the query
-  # surfaces read from it. The wiki is pointed at it by QLEVER_URL above; deselecting the profile
-  # stops this container but does not clear that variable (see the comment there), so a deselected
-  # wiki still tries to reach a store that is not running. NeoWiki reaches it in-network as
+  # surfaces read from it. The wiki is pointed at it by QLEVER_URL above; the bundled Makefile
+  # clears that variable when the profile is deselected (see the comment there), so a deselected
+  # wiki does not try to reach a store that is not running. NeoWiki reaches it in-network as
   # http://qlever:7019/; a host port for manual inspection is opt-in via docker-compose.tools.yml.
   qlever:
     profiles:

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -24,9 +24,8 @@ services:
       # Endpoint of the qlever service below; a non-empty value is what makes
       # SettingsTemplate.php configure $wgNeoWikiSparqlStores. The bundled Makefile
       # owns the value: the qlever endpoint when the service is selected, empty
-      # ("disabled") when deselected. Running this file without the Makefile leaves
-      # it unset, which matches the qlever profile not being active: no store runs
-      # and none is configured.
+      # ("disabled") when deselected. Without the Makefile it is unset and no
+      # store is configured.
       - QLEVER_URL
       # Bearer token the wiki sends to authorize SPARQL updates. Defaulted here instead of being
       # required from Docker/.env, so a .env written before the variable existed still works; the
@@ -77,13 +76,10 @@ services:
 
   # SPARQL 1.1 graph store (QLever) for the SPARQL projection plugin (#586), as a working example
   # of NeoWiki's SPARQL projection: every page save and RebuildGraphDatabases.php also projects the
-  # page's RDF here as named graphs, and the query surfaces read from it. Unconditional here, so raw
-  # `docker compose` invocations (and the `--profile server` demo deployment) always get it. The dev
-  # overlay (docker-compose.dev.yml) adds a `qlever` profile to this same service, gating it behind
-  # `services=` there — see the comment on that override. The wiki is pointed at it by QLEVER_URL
-  # above; the bundled Makefile clears that variable when the dev-overlay profile is deselected, so a
-  # deselected wiki does not try to reach a store that is not running. NeoWiki reaches it in-network
-  # as http://qlever:7019/; a host port for manual inspection is opt-in via docker-compose.tools.yml.
+  # page's RDF here as named graphs, and the query surfaces read from it. The wiki is pointed at it
+  # by QLEVER_URL above. Unconditional in this file; the dev overlay gates it behind a `qlever`
+  # profile for `services=` selection — see the comment there. NeoWiki reaches it in-network as
+  # http://qlever:7019/; a host port for manual inspection is opt-in via docker-compose.tools.yml.
   qlever:
     image: docker.io/adfreiburg/qlever:latest
     restart: unless-stopped

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -75,17 +75,16 @@ services:
       timeout: 1s
       retries: 10
 
-  # SPARQL 1.1 graph store (QLever) for the SPARQL projection plugin (#586). Profile-gated below;
-  # the bundled Makefile enables the profile by default, so both the demo and dev stacks get the
-  # same RDF/SPARQL surface unless `services=` deselects it: every page save and
-  # RebuildGraphDatabases.php also projects the page's RDF here as named graphs, and the query
-  # surfaces read from it. The wiki is pointed at it by QLEVER_URL above; the bundled Makefile
-  # clears that variable when the profile is deselected (see the comment there), so a deselected
-  # wiki does not try to reach a store that is not running. NeoWiki reaches it in-network as
-  # http://qlever:7019/; a host port for manual inspection is opt-in via docker-compose.tools.yml.
+  # SPARQL 1.1 graph store (QLever) for the SPARQL projection plugin (#586), as a working example
+  # of NeoWiki's SPARQL projection: every page save and RebuildGraphDatabases.php also projects the
+  # page's RDF here as named graphs, and the query surfaces read from it. Unconditional here, so raw
+  # `docker compose` invocations (and the `--profile server` demo deployment) always get it. The dev
+  # overlay (docker-compose.dev.yml) adds a `qlever` profile to this same service, gating it behind
+  # `services=` there — see the comment on that override. The wiki is pointed at it by QLEVER_URL
+  # above; the bundled Makefile clears that variable when the dev-overlay profile is deselected, so a
+  # deselected wiki does not try to reach a store that is not running. NeoWiki reaches it in-network
+  # as http://qlever:7019/; a host port for manual inspection is opt-in via docker-compose.tools.yml.
   qlever:
-    profiles:
-      - qlever
     image: docker.io/adfreiburg/qlever:latest
     restart: unless-stopped
     # Above QLever's own -m 1G query budget (server command below) plus index overhead.

--- a/Docker/tests/test-services.sh
+++ b/Docker/tests/test-services.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Exercise the services= optional-service selection (Makefile), via `make print-services`.
+# Pure Makefile logic - no docker needed.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+PASSES=0
+FAILS=0
+color() { local c=$1; shift; printf '\033[%sm%s\033[0m\n' "$c" "$*"; }
+ok()   { color '32' "PASS: $*"; PASSES=$((PASSES + 1)); }
+fail() { color '31' "FAIL: $*"; FAILS=$((FAILS + 1)); }
+
+assert_eq() {
+    local got=$1 want=$2 msg=$3
+    if [ "$got" = "$want" ]; then ok "$msg"; else fail "$msg (got '$got', want '$want')"; fi
+}
+
+run_print_services() {
+    # Unset COMPOSE_PROFILES: the Makefile's global `export` means that when this script itself
+    # runs as a recipe of `make test-scripts`, the outer make's computed COMPOSE_PROFILES is
+    # already in this shell's environment and would otherwise leak into the nested make call
+    # below, unioning itself into every case regardless of services=. Case 4 sets it back
+    # explicitly for the one case that wants it.
+    ( cd "$ROOT" && unset COMPOSE_PROFILES && make -s print-services "$@" )
+}
+
+# Extracts the value after "<label>:" from print-services output, trimming leading whitespace.
+field() {
+    printf '%s\n' "$1" | grep "^$2:" | sed -E "s/^$2:[[:space:]]*//"
+}
+
+echo
+color '36' "Case 1: absent services= flag -> default set, oxigraph deselected"
+out="$(run_print_services 2>&1)"
+assert_eq "$(field "$out" selected)" "node qlever mailcatcher" "Default selection is node, qlever, mailcatcher"
+assert_eq "$(field "$out" deselected)" "oxigraph" "Default deselects only oxigraph"
+
+echo
+color '36' "Case 2: services=none -> nothing selected, all four deselected"
+out="$(run_print_services services=none 2>&1)"
+assert_eq "$(field "$out" selected)" "" "services=none selects nothing"
+assert_eq "$(field "$out" deselected)" "node qlever mailcatcher oxigraph" "services=none deselects all four"
+
+echo
+color '36' "Case 3: services=node,qlever -> only those two selected"
+out="$(run_print_services services=node,qlever 2>&1)"
+assert_eq "$(field "$out" selected)" "node qlever" "services=node,qlever selects exactly those"
+assert_eq "$(field "$out" deselected)" "mailcatcher oxigraph" "services=node,qlever deselects the rest"
+
+echo
+color '36' "Case 4: COMPOSE_PROFILES=oxigraph -> unioned in, not deselected"
+out="$( cd "$ROOT" && unset COMPOSE_PROFILES && COMPOSE_PROFILES=oxigraph make -s print-services 2>&1 )"
+assert_eq "$(field "$out" deselected)" "" "COMPOSE_PROFILES=oxigraph is not deselected"
+case ",$(field "$out" profiles)," in
+    *,oxigraph,*) ok "COMPOSE_PROFILES=oxigraph appears in the resulting profiles" ;;
+    *) fail "COMPOSE_PROFILES=oxigraph should appear in the resulting profiles (got '$(field "$out" profiles)')" ;;
+esac
+
+echo
+color '36' "Case 5: services=bogus -> non-zero exit, error names the unknown service"
+rc=0
+out="$( cd "$ROOT" && unset COMPOSE_PROFILES && make -s print-services services=bogus 2>&1 )" || rc=$?
+if [ "$rc" -ne 0 ]; then ok "services=bogus fails (exit $rc)"; else fail "services=bogus should fail (exit 0)"; fi
+if printf '%s' "$out" | grep -qF "bogus"; then ok "Error message names 'bogus'"; else fail "Error message should name 'bogus' (got: $out)"; fi
+
+echo
+if [ "$FAILS" -eq 0 ]; then color '32' "All $PASSES checks passed."; exit 0
+else color '31' "$FAILS check(s) failed ($PASSES passed)."; exit 1; fi

--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,8 @@ $(error Unknown services '$(UNKNOWN_SERVICES)'. Valid: $(subst $(space),$(comma)
 endif
 endif
 
-# The union drives every compose invocation via the global `export` above. Defined ahead of the
-# derived values below so they can all filter against this one set instead of open-coding
-# $(SELECTED_SERVICES) $(USER_PROFILES) at each site.
+# The union drives every compose invocation via the global `export` above. Defined before the
+# derived values below, which filter against it.
 ACTIVE_PROFILES := $(sort $(USER_PROFILES) $(SELECTED_SERVICES))
 COMPOSE_PROFILES := $(subst $(space),$(comma),$(strip $(ACTIVE_PROFILES)))
 

--- a/Makefile
+++ b/Makefile
@@ -20,19 +20,60 @@ PROJECT_NAME := $(shell echo "neowiki-$(notdir $(CURDIR))" | tr A-Z a-z)
 PORT_RANGE_START := 8484
 PORT_RANGE_END := 8499
 
+# ---- Optional-service selection (services=) ----------------------------------
+
+# `make dev services=node,qlever` runs only the named optional services;
+# `services=none` runs core only (mediawiki, db, neo). Absent = the default set
+# below, which is the full status quo. Values are compose service names; see
+# Docker/README.md. A COMPOSE_PROFILES value from the environment is unioned in,
+# so the documented oxigraph escape hatch keeps working.
+OPTIONAL_SERVICES := node qlever mailcatcher oxigraph
+DEFAULT_SERVICES := node qlever mailcatcher
+
+comma := ,
+empty :=
+space := $(empty) $(empty)
+
+# Captured before COMPOSE_PROFILES is overridden below.
+USER_PROFILES := $(strip $(subst $(comma),$(space),$(COMPOSE_PROFILES)))
+
+ifeq ($(origin services),undefined)
+SELECTED_SERVICES := $(DEFAULT_SERVICES)
+else ifeq ($(services),none)
+SELECTED_SERVICES :=
+else
+SELECTED_SERVICES := $(strip $(subst $(comma),$(space),$(services)))
+UNKNOWN_SERVICES := $(filter-out $(OPTIONAL_SERVICES),$(SELECTED_SERVICES))
+ifneq ($(UNKNOWN_SERVICES),)
+$(error Unknown services '$(UNKNOWN_SERVICES)'. Valid: $(subst $(space),$(comma),$(OPTIONAL_SERVICES)), or none)
+endif
+endif
+
+# Optional services outside the desired state, stopped by the dev targets so a
+# rerun with a smaller selection downgrades a running stack. Never contains
+# anything a user-supplied COMPOSE_PROFILES asked for.
+DESELECTED_SERVICES := $(filter-out $(SELECTED_SERVICES) $(USER_PROFILES),$(OPTIONAL_SERVICES))
+
+# The union drives every compose invocation via the global `export` above.
+COMPOSE_PROFILES := $(subst $(space),$(comma),$(strip $(sort $(USER_PROFILES) $(SELECTED_SERVICES))))
+
 # ---- Compose invocations -----------------------------------------------------
 
 DC := docker compose -p $(PROJECT_NAME) -f Docker/docker-compose.yml
 DC_DEV := $(DC) -f Docker/docker-compose.dev.yml
 DC_TOOLS := $(DC_DEV) -f Docker/docker-compose.tools.yml
 # The `test` profile holds the test-only backends: test_neo, test_qlever and test_oxigraph.
-DC_TEST := $(DC_DEV) --profile test
+# The selection's profiles are passed explicitly (not just via the exported COMPOSE_PROFILES
+# env var): this compose version lets a --profile CLI flag override rather than union with the
+# env var, which would otherwise drop the selected optional services from $(DC_TEST) invocations.
+DC_TEST := $(DC_DEV) --profile test $(foreach p,$(sort $(USER_PROFILES) $(SELECTED_SERVICES)),--profile $(p))
 # Teardown has to see every service, including the profile-gated `oxigraph` and `caddy`. With no
 # profile active Compose leaves those out of the plan entirely, so the container survives `down`
 # and the project network then fails to go with it. They are not orphans either — they are declared
 # in the file Compose was given — so --remove-orphans does not reach them. `--profile '*'` enables
 # every profile, which for a teardown is exactly the intent.
 DC_ALL := $(DC) --profile '*'
+DC_DEV_ALL := $(DC_DEV) --profile '*'
 
 # Detect the engine from what `docker` actually is (its version string), not from
 # whether a `podman` binary happens to exist: a stray podman binary alongside real
@@ -74,7 +115,7 @@ help:
 
 # ---- Lifecycle (host only) ---------------------------------------------------
 
-.PHONY: up pull demo upgrade dev dev-tools _dev-tools-impl down remove logs ps bash _preflight doctor
+.PHONY: up pull demo upgrade dev dev-tools _dev-tools-impl down remove logs ps print-services bash _preflight doctor
 
 # Fail fast on a broken Docker runtime (Docker or Compose missing, daemon down or
 # denied) before the lifecycle targets do expensive work. Source: Docker/scripts/preflight.sh.
@@ -115,6 +156,7 @@ dev-tools: _preflight bootstrap ensure-port ## Like 'dev' but also exposes the N
 	@$(MAKE) --no-print-directory _dev-tools-impl
 
 _dev-tools-impl:
+	@$(MAKE) --no-print-directory _stop-deselected
 	$(DC_TOOLS) up -d --build
 	@$(MAKE) --no-print-directory _wait-mw
 	@$(MAKE) --no-print-directory _first-run-seed
@@ -166,12 +208,21 @@ bootstrap: ## Clone MW core into Docker/mediawiki/ and prep gitignored files (id
 	@touch Docker/LocalSettings.local.php
 
 _dev-impl:
+	@$(MAKE) --no-print-directory _stop-deselected
 	$(DC_DEV) up -d --build
 	@$(MAKE) --no-print-directory _wait-mw
 	@$(MAKE) --no-print-directory _first-run-seed
 	@echo ""
 	@echo "Dev wiki ready at: http://localhost:$$MW_SERVER_PORT"
 	@echo "Project:           $(PROJECT_NAME)"
+
+# Downgrade a running stack to the current selection. `stop`, not `down`: the
+# containers and volumes stay for a cheap restart when reselected.
+.PHONY: _stop-deselected
+_stop-deselected:
+ifneq ($(DESELECTED_SERVICES),)
+	@$(DC_DEV_ALL) stop $(DESELECTED_SERVICES)
+endif
 
 down: ## Stop and remove containers (preserves volumes)
 	$(DC_ALL) down --remove-orphans
@@ -184,6 +235,11 @@ logs: ## Tail logs from all services
 
 ps: ## Show service status
 	$(DC_TEST) ps
+
+print-services: ## Show the optional-service selection and resulting profiles
+	@echo "selected:   $(SELECTED_SERVICES)"
+	@echo "deselected: $(DESELECTED_SERVICES)"
+	@echo "profiles:   $(COMPOSE_PROFILES)"
 
 bash: ## Shell into the mediawiki container
 	$(DC_DEV) exec mediawiki bash

--- a/Makefile
+++ b/Makefile
@@ -502,8 +502,11 @@ endif
 # The node sidecar runs `npm install && npm run build:watch` on startup. Targets
 # that depend on node_modules being populated should depend on _wait-node so the
 # first invocation after `make dev` does not race the sidecar's initial install.
+# Naming the service explicitly also starts it on stacks where the `node` profile
+# is not selected.
 .PHONY: _wait-node
 _wait-node:
+	@$(DC_DEV) up -d node
 	@for i in $$(seq 1 60); do \
 		if [ -f resources/ext.neowiki/node_modules/.package-lock.json ]; then \
 			exit 0; \

--- a/Makefile
+++ b/Makefile
@@ -308,6 +308,7 @@ endif
 test-scripts: ## Run shell-script tests (set-port.sh, preflight.sh, etc.)
 	@./Docker/tests/test-set-port.sh
 	@./Docker/tests/test-preflight.sh
+	@./Docker/tests/test-services.sh
 
 # ---- Health gate -------------------------------------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -528,10 +528,10 @@ ts-ci:
 	$(MAKE) --no-print-directory ts-build
 	$(MAKE) --no-print-directory ts-lint
 
-ts-install: ## npm install for NeoWiki frontend
+ts-install: _wait-node ## npm install for NeoWiki frontend
 	$(EXEC_NODE) sh -c 'cd /workspace/resources/ext.neowiki && npm install' < /dev/null
 
-ts-update: ## npm update for NeoWiki frontend
+ts-update: _wait-node ## npm update for NeoWiki frontend
 	$(EXEC_NODE) sh -c 'cd /workspace/resources/ext.neowiki && npm update' < /dev/null
 
 ts-build: _wait-node ## Build TS bundle (one-shot; the watcher runs as a sidecar)

--- a/Makefile
+++ b/Makefile
@@ -346,7 +346,7 @@ _first-run-seed-demo:
 
 # ---- DB and Neo4j init -------------------------------------------------------
 
-.PHONY: install-db load-neo4j-users wait-for-neo4j setup-test-neo test-backends
+.PHONY: install-db load-neo4j-users wait-for-neo4j setup-test-neo test-backends test-backends-stop
 
 install-db:
 	$(EXEC_MW_ROOT) bash -c '/wait-for-it.sh db:3306 -t 60'
@@ -403,6 +403,9 @@ setup-test-neo:
 	$(EXEC_MW_ROOT) bash -c '/wait-for-it.sh test_neo:7689 -t 60'
 	$(DC_TEST) exec -T test_neo bash -c \
 		"echo \"CREATE USER mediawiki_read IF NOT EXISTS SET PASSWORD 'mediawiki_read' CHANGE NOT REQUIRED; GRANT ROLE reader TO mediawiki_read;\" | cypher-shell -u neo4j -p password -a bolt://localhost:7689"
+
+test-backends-stop: ## Stop the test-only backends (make phpunit restarts them on demand)
+	$(DC_TEST) stop test_neo test_qlever test_oxigraph
 
 # ---- Composer ----------------------------------------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -49,20 +49,22 @@ $(error Unknown services '$(UNKNOWN_SERVICES)'. Valid: $(subst $(space),$(comma)
 endif
 endif
 
-# Optional services outside the desired state, stopped by the dev targets so a
-# rerun with a smaller selection downgrades a running stack. Never contains
-# anything a user-supplied COMPOSE_PROFILES asked for.
-DESELECTED_SERVICES := $(filter-out $(SELECTED_SERVICES) $(USER_PROFILES),$(OPTIONAL_SERVICES))
-
-# The union drives every compose invocation via the global `export` above.
+# The union drives every compose invocation via the global `export` above. Defined ahead of the
+# derived values below so they can all filter against this one set instead of open-coding
+# $(SELECTED_SERVICES) $(USER_PROFILES) at each site.
 ACTIVE_PROFILES := $(sort $(USER_PROFILES) $(SELECTED_SERVICES))
 COMPOSE_PROFILES := $(subst $(space),$(comma),$(strip $(ACTIVE_PROFILES)))
+
+# Optional services outside the desired state, stopped by the dev targets so a
+# rerun with a smaller selection downgrades a running stack. Never contains
+# anything a user-supplied COMPOSE_PROFILES asked for (ACTIVE_PROFILES includes it).
+DESELECTED_SERVICES := $(filter-out $(ACTIVE_PROFILES),$(OPTIONAL_SERVICES))
 
 # Wiki-side config follows the selection. Empty means "disabled" to
 # Docker/SettingsTemplate.php; unset means "use the default". Values already
 # present (environment or Docker/.env) always win.
 ifeq ($(origin QLEVER_URL),undefined)
-ifeq ($(filter qlever,$(SELECTED_SERVICES) $(USER_PROFILES)),)
+ifeq ($(filter qlever,$(ACTIVE_PROFILES)),)
 QLEVER_URL :=
 else
 QLEVER_URL := http://qlever:7019/
@@ -70,7 +72,7 @@ endif
 endif
 
 ifeq ($(origin MW_SMTP_HOST),undefined)
-ifeq ($(filter mailcatcher,$(SELECTED_SERVICES) $(USER_PROFILES)),)
+ifeq ($(filter mailcatcher,$(ACTIVE_PROFILES)),)
 MW_SMTP_HOST :=
 endif
 endif
@@ -249,7 +251,7 @@ endif
 # a stale bundle after git pull is refreshed via make ts-build.
 .PHONY: _ensure-frontend-bundle
 _ensure-frontend-bundle:
-ifeq ($(filter node,$(SELECTED_SERVICES) $(USER_PROFILES)),)
+ifeq ($(filter node,$(ACTIVE_PROFILES)),)
 	@if [ ! -f resources/ext.neowiki/dist/neowiki.js ]; then \
 		echo "No frontend bundle and no node watcher selected; building once..."; \
 		$(DC_DEV) run --rm node sh -c 'npm install && npm run build' < /dev/null; \

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,25 @@ endif
 DESELECTED_SERVICES := $(filter-out $(SELECTED_SERVICES) $(USER_PROFILES),$(OPTIONAL_SERVICES))
 
 # The union drives every compose invocation via the global `export` above.
-COMPOSE_PROFILES := $(subst $(space),$(comma),$(strip $(sort $(USER_PROFILES) $(SELECTED_SERVICES))))
+ACTIVE_PROFILES := $(sort $(USER_PROFILES) $(SELECTED_SERVICES))
+COMPOSE_PROFILES := $(subst $(space),$(comma),$(strip $(ACTIVE_PROFILES)))
+
+# Wiki-side config follows the selection. Empty means "disabled" to
+# Docker/SettingsTemplate.php; unset means "use the default". Values already
+# present (environment or Docker/.env) always win.
+ifeq ($(origin QLEVER_URL),undefined)
+ifeq ($(filter qlever,$(SELECTED_SERVICES) $(USER_PROFILES)),)
+QLEVER_URL :=
+else
+QLEVER_URL := http://qlever:7019/
+endif
+endif
+
+ifeq ($(origin MW_SMTP_HOST),undefined)
+ifeq ($(filter mailcatcher,$(SELECTED_SERVICES) $(USER_PROFILES)),)
+MW_SMTP_HOST :=
+endif
+endif
 
 # ---- Compose invocations -----------------------------------------------------
 
@@ -66,7 +84,7 @@ DC_TOOLS := $(DC_DEV) -f Docker/docker-compose.tools.yml
 # The selection's profiles are passed explicitly (not just via the exported COMPOSE_PROFILES
 # env var): this compose version lets a --profile CLI flag override rather than union with the
 # env var, which would otherwise drop the selected optional services from $(DC_TEST) invocations.
-DC_TEST := $(DC_DEV) --profile test $(foreach p,$(sort $(USER_PROFILES) $(SELECTED_SERVICES)),--profile $(p))
+DC_TEST := $(DC_DEV) --profile test $(foreach p,$(ACTIVE_PROFILES),--profile $(p))
 # Teardown has to see every service, including the profile-gated `oxigraph` and `caddy`. With no
 # profile active Compose leaves those out of the plan entirely, so the container survives `down`
 # and the project network then fails to go with it. They are not orphans either — they are declared

--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,7 @@ dev-tools: _preflight bootstrap ensure-port ## Like 'dev' but also exposes the N
 _dev-tools-impl:
 	@$(MAKE) --no-print-directory _stop-deselected
 	$(DC_TOOLS) up -d --build
+	@$(MAKE) --no-print-directory _ensure-frontend-bundle
 	@$(MAKE) --no-print-directory _wait-mw
 	@$(MAKE) --no-print-directory _first-run-seed
 	@echo ""
@@ -228,6 +229,7 @@ bootstrap: ## Clone MW core into Docker/mediawiki/ and prep gitignored files (id
 _dev-impl:
 	@$(MAKE) --no-print-directory _stop-deselected
 	$(DC_DEV) up -d --build
+	@$(MAKE) --no-print-directory _ensure-frontend-bundle
 	@$(MAKE) --no-print-directory _wait-mw
 	@$(MAKE) --no-print-directory _first-run-seed
 	@echo ""
@@ -240,6 +242,18 @@ _dev-impl:
 _stop-deselected:
 ifneq ($(DESELECTED_SERVICES),)
 	@$(DC_DEV_ALL) stop $(DESELECTED_SERVICES)
+endif
+
+# A stack without the node watcher still needs a built frontend: dist/ is
+# gitignored and only node builds it. One-shot build in a throwaway container;
+# a stale bundle after git pull is refreshed via make ts-build.
+.PHONY: _ensure-frontend-bundle
+_ensure-frontend-bundle:
+ifeq ($(filter node,$(SELECTED_SERVICES) $(USER_PROFILES)),)
+	@if [ ! -f resources/ext.neowiki/dist/neowiki.js ]; then \
+		echo "No frontend bundle and no node watcher selected; building once..."; \
+		$(DC_DEV) run --rm node sh -c 'npm install && npm run build' < /dev/null; \
+	fi
 endif
 
 down: ## Stop and remove containers (preserves volumes)

--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ _preflight:
 doctor: ## Diagnose dev-environment prerequisites (Docker runtime)
 	@PREFLIGHT_VERBOSE=1 ./Docker/scripts/preflight.sh
 
-up: _preflight ## Bring up try-it-out stack (no profile, prebuilt image)
+up: _preflight ## Bring up try-it-out stack (prebuilt image)
 	$(DC) up -d
 
 pull: _preflight ## Pull the latest prebuilt demo image
@@ -185,12 +185,15 @@ _dev-tools-impl:
 	@echo "Dev wiki ready at:    http://localhost:$$MW_SERVER_PORT"
 	@echo "Neo4j Browser:        http://localhost:$${NEO_BROWSER_PORT:-7474}"
 	@echo "Neo4j Bolt endpoint:  bolt://localhost:$${NEO_BOLT_PORT:-7687}"
-	@echo "QLever SPARQL:        http://localhost:$${QLEVER_PORT:-7019}/"
-	@# The tools overlay maps Oxigraph's port too, but that service only runs when its
-	@# profile is on (see Docker/docker-compose.yml), so only then is there a URL. Compose
-	@# trims whitespace around profile names ("test, oxigraph" activates both), so strip it
-	@# here as well or the URL goes missing for a stack that did start the service.
+	@# The tools overlay maps the QLever and Oxigraph ports too, but each service only runs
+	@# when its own profile is on (see Docker/docker-compose.yml and .dev.yml), so only then
+	@# is there a URL. Compose trims whitespace around profile names ("test, oxigraph"
+	@# activates both), so strip it here as well or a URL goes missing for a stack that did
+	@# start the service.
 	@profiles=$$(printf '%s' "$$COMPOSE_PROFILES" | tr -d '[:space:]'); \
+	case ",$$profiles," in \
+		*,qlever,*) echo "QLever SPARQL:        http://localhost:$${QLEVER_PORT:-7019}/";; \
+	esac; \
 	case ",$$profiles," in \
 		*,oxigraph,*) echo "Oxigraph SPARQL:      http://localhost:$${OXIGRAPH_PORT:-7878}/query";; \
 	esac

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ This builds a dev-mode image, brings up the stack (mediawiki, db, neo, qlever, n
 watcher, mailcatcher), runs first-time install and seed, and waits until the wiki is
 reachable. It prints the URL when ready (the default is `http://localhost:8484` but
 the actual port is auto-allocated; see [Reserved ports](Docker/README.md#reserved-host-ports)).
+To run a smaller or different set of these optional services, see
+[Optional services](Docker/README.md#optional-services).
 
 Mailcatcher web UI is at the port `make dev` printed (default `8025`,
 configurable via `MAILCATCHER_PORT` in `Docker/.env`).
@@ -59,6 +61,7 @@ make bash                 # shell into the mediawiki container
 make logs                 # tail logs
 make reset                # wipe DB + Neo and reseed demo data
 make import-demo-data     # load the latest demo data, overriding your changes
+make test-backends-stop   # stop the test-only backends (make phpunit restarts them on demand)
 ```
 
 The first `make phpunit` after `make dev` starts the test-only backends, so it is slower than

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This builds a dev-mode image, brings up the stack (mediawiki, db, neo, qlever, n
 watcher, mailcatcher), runs first-time install and seed, and waits until the wiki is
 reachable. It prints the URL when ready (the default is `http://localhost:8484` but
 the actual port is auto-allocated; see [Reserved ports](Docker/README.md#reserved-host-ports)).
-To run a smaller or different set of these optional services, see
+To run a different selection of these services, see
 [Optional services](Docker/README.md#optional-services).
 
 Mailcatcher web UI is at the port `make dev` printed (default `8025`,
@@ -61,7 +61,7 @@ make bash                 # shell into the mediawiki container
 make logs                 # tail logs
 make reset                # wipe DB + Neo and reseed demo data
 make import-demo-data     # load the latest demo data, overriding your changes
-make test-backends-stop   # stop the test-only backends (make phpunit restarts them on demand)
+make test-backends-stop   # stop the test-only backends (make phpunit starts them again on demand)
 ```
 
 The first `make phpunit` after `make dev` starts the test-only backends, so it is slower than


### PR DESCRIPTION
Lets a dev stack run only the optional services a task needs. `make dev services=<comma-list>` picks among `node`, `qlever`, `mailcatcher` and `oxigraph`; `services=none` runs core only (mediawiki, db, neo). Without the flag everything runs as it does today, so existing workflows are unchanged.

- Optional services sit behind compose profiles named after them; the Makefile turns the selection into `COMPOSE_PROFILES` (a user-set `COMPOSE_PROFILES` is unioned in) and stops newly-deselected services when `make dev` reruns.
- Wiki config follows the selection: `QLEVER_URL` / `MW_SMTP_HOST` are set empty when their service is off (empty means disabled), so the wiki never targets a dead endpoint.
- Stacks without the `node` watcher get a one-shot `dist/` build so the UI works; every `ts-*` target starts `node` on demand.
- New `make test-backends-stop` reclaims the test backends' ~0.5–0.7 GiB after a testing phase; `make phpunit` starts them again on demand.
- `make print-services` shows the selection; `Docker/tests/test-services.sh` (in `make test-scripts`) covers the selection logic.
- Docs: new [Optional services](https://github.com/ProfessionalWiki/NeoWiki/blob/dev-stack-service-selection/Docker/README.md#optional-services) section in Docker/README.md.

An idle full dev stack holds ~1.7 GiB; `services=none` drops ~1 GiB of that (node watcher, mailcatcher, qlever headroom) for tasks that need none of it.

Try it: `make dev services=none` then `make print-services` and `docker ps`; `make dev` restores the default set.

<details><summary>Design notes</summary>

qlever's profile tag lives in the dev overlay, not the base compose file, so the demo stack and raw `docker compose` invocations keep the store unconditionally while every dev-stack path is gated. The Makefile owns the `QLEVER_URL` value (endpoint when selected, empty when not) instead of compose interpolation defaults, keeping "no store running ⇒ none configured" true for non-make invocations.

</details>

> <sub>AI-authored — Claude Code, `Fable 5`; brainstormed from an open question by @alistair3149, design redirected several times (no presets, full default, per-repo split); diff not yet human-reviewed; per-task + whole-branch AI review, script suites green, live end-to-end matrix on a dev stack (core-only, escape-hatch union, restore, error paths).</sub>