### PR TITLE
Bump mediawiki-codesniffer to 52.0.0 to unblock PHPCS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 	"require-dev": {
 		"vimeo/psalm": "^5.25.0",
 		"phpstan/phpstan": "^1.12.2",
-		"mediawiki/mediawiki-codesniffer": "44.0.0",
+		"mediawiki/mediawiki-codesniffer": "52.0.0",
 		"slevomat/coding-standard": "^v8.15.0"
 	},
 	"autoload": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -27,7 +27,12 @@
 		<exclude name="Universal.WhiteSpace.CommaSpacing.SpaceBeforeInFunctionCall" />
 	</rule>
 
-	<rule ref="Generic.Formatting.NoSpaceAfterCast" />
+	<!-- Generic.Formatting.NoSpaceAfterCast is deprecated; this is its replacement. -->
+	<rule ref="Generic.Formatting.SpaceAfterCast">
+		<properties>
+			<property name="spacing" value="0" />
+		</properties>
+	</rule>
 	<rule ref="Generic.Metrics.CyclomaticComplexity">
 	</rule>
 	<rule ref="Generic.Metrics.NestingLevel" />

--- a/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jValueBuilderRegistry.php
+++ b/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jValueBuilderRegistry.php
@@ -88,7 +88,7 @@ class Neo4jValueBuilderRegistry {
 	}
 
 	/**
-	 * @phan-template T of object
+	 * @template T of object
 	 * @param callable(string): ?T $parse
 	 * @return T[]
 	 */


### PR DESCRIPTION
PHPCS is failing on every branch, and not at the PHPCS step: it fails at `composer install`, and
the "Run PHPCS" step is skipped. Composer refuses to resolve the dependency tree at all.

`squizlabs/php_codesniffer` picked up CVE-2026-67434 (OS command injection, Packagist advisory
PKSA-rdkp-vv9z-mjkg), published 2026-08-05 23:53 UTC and affecting `< 3.13.6`. Composer blocks
advisory-affected packages by default, and `mediawiki/mediawiki-codesniffer 44.0.0` requires
exactly `php_codesniffer 3.9.0`, so resolution has no candidate:

    - mediawiki/mediawiki-codesniffer v44.0.0 requires squizlabs/php_codesniffer 3.9.0 -> found
      squizlabs/php_codesniffer[3.9.0] but these were not loaded, because they are affected by
      security advisories ("PKSA-rdkp-vv9z-mjkg")

`composer.lock` is gitignored, so CI resolves from scratch on every run and broke as soon as the
advisory reached Composer's data. A local checkout with an existing lock only warns, which is why
this does not reproduce until the lock is deleted.

`mediawiki-codesniffer 52.0.0`, released today, is the first release requiring `php_codesniffer
3.13.6` — the patched version. 51.0.0 and 50.0.0 are still on 3.13.5. So the bump is 44 -> 52
rather than a smaller step; there is no closer version that resolves.

Eight majors of sniff rules turned out to cost almost nothing: the run is clean apart from one
warning, `@phan-template` on `Neo4jValueBuilderRegistry::buildParsedValues()`. Phan is not used
here — no `.phan` directory, absent from composer.json and CI — and that was the only `@phan-`
annotation in the tree, so it was inert. `@template` is what PHPStan and Psalm actually read, so
this fixes a docblock that had no effect rather than appeasing a linter.

`Generic.Formatting.NoSpaceAfterCast`, which phpcs.xml enables directly, is deprecated as of
php_codesniffer 3.4 and is removed in 4.0; it printed a deprecation notice on every run. Replaced
with the documented equivalent, `Generic.Formatting.SpaceAfterCast` with `spacing` 0. Verified it
still enforces: adding a space after a cast fails with
`Generic.Formatting.SpaceAfterCast.TooMuchSpace`.

Verified with `vendor/bin/phpcs -p -s --standard=phpcs.xml` exactly as CI invokes it (exit 0, no
deprecation notice), PHPStan, and the Domain suite.



<sub>AI-authored — Claude Opus 5 (1M context); investigation and fix; verified with `vendor/bin/phpcs -p -s --standard=phpcs.xml` as CI invokes it, a negative control on the replacement sniff, PHPStan, and the Domain suite.</sub>
