### PR TITLE
Support node→anchor link direction in ontology Mappings

### DIFF
--- a/DemoData/Mapping/EDM.json
+++ b/DemoData/Mapping/EDM.json
@@ -2,6 +2,7 @@
 	"version": 1,
 	"prefixes": {
 		"edm": "http://www.europeana.eu/schemas/edm/",
+		"ore": "http://www.openarchives.org/ore/terms/",
 		"rdaGr2": "http://rdvocab.info/ElementsGr2/",
 		"skos": "http://www.w3.org/2004/02/skos/core#",
 		"dc": "http://purl.org/dc/elements/1.1/",
@@ -38,12 +39,19 @@
 		},
 		"Artwork": {
 			"subject": { "class": "edm:ProvidedCHO" },
+			"nodes": {
+				"aggregation": {
+					"class": "ore:Aggregation",
+					"linkPredicate": "edm:aggregatedCHO",
+					"linkDirection": "fromNode"
+				}
+			},
 			"properties": {
 				"Creator": { "predicate": "dc:creator" },
 				"Year": { "predicate": "dcterms:created", "datatype": "xsd:gYear" },
 				"Medium": { "predicate": "dcterms:medium" },
 				"Located at": { "predicate": "edm:currentLocation" },
-				"Image": { "predicate": "edm:isShownBy" }
+				"Image": { "predicate": "edm:isShownBy", "node": "aggregation" }
 			}
 		},
 		"City": {

--- a/docs/planning/OntologyMapping.md
+++ b/docs/planning/OntologyMapping.md
@@ -226,7 +226,7 @@ WHERE {
 
 Here `crm:` is CIDOC-CRM and `crm-prod:` is an illustrative namespace for synthesized event nodes; the `BIND` anchors
 that node's IRI on the Relation ID so it is stable across re-projections. The same Artwork Schema mapped to EDM would be
-mostly flat rules (`?object a edm:ProvidedCHO`, `?object dc:creator ?actor`) with no synthesized nodes — illustrating
+mostly flat rules (`?object a edm:ProvidedCHO`, `?object dc:creator ?actor`) — illustrating
 that one formalism must span both ends of the spectrum.
 
 `CONSTRUCT` is one candidate form. Whether authors write templates directly, or write something higher-level (LinkML,

--- a/docs/rdf/ontology-mapping.md
+++ b/docs/rdf/ontology-mapping.md
@@ -19,9 +19,8 @@ and mapped output side by side.
 > **Scope.** A mapping reshapes the data as well as the vocabulary: it can **synthesize** the intermediate
 > event nodes a target like CIDOC-CRM routes its paths through, and it can **contract** structure a flat
 > target does not want by contributing a Subject's values to the Subject it points at. Out of scope: RDF
-> **import** (a mapping drives export only), contributions across more than one relation hop, and link
-> predicates running from a node back to its anchor. The stored `"version": 1` format may change; see the
-> [open questions](../planning/OntologyMapping.md#open-questions).
+> **import** (a mapping drives export only) and contributions across more than one relation hop. The stored
+> `"version": 1` format may change; see the [open questions](../planning/OntologyMapping.md#open-questions).
 
 ## Ontology Mappings are wiki pages
 
@@ -103,7 +102,8 @@ Each **node** entry (a value in `nodes`):
 | Field | Required | Meaning |
 |---|---|---|
 | `class` | yes | The `rdf:type` given to each instance of the node. |
-| `linkPredicate` | yes | Predicate of the triple from the anchor — the parent node's instance, or the Subject — to the node instance. |
+| `linkPredicate` | yes | Predicate of the triple between the node instance and its anchor — the parent node's instance, or the Subject. |
+| `linkDirection` | no | `toNode` (default) emits `<anchor> <linkPredicate> <node>`; `fromNode` emits `<node> <linkPredicate> <anchor>`. |
 | `parent` | no | Another node key, making this node hang off that node instead of off the Subject. |
 | `per` | no | `subject` (default) for one instance shared by every property attached to it, or `value` for one instance per value. A `per: "value"` node takes at most one property and cannot be a `parent`. |
 

--- a/docs/rdf/ontology-mapping.md
+++ b/docs/rdf/ontology-mapping.md
@@ -17,7 +17,7 @@ page is the as-built reference for the shipped format. The
 and mapped output side by side.
 
 > **Scope.** A mapping reshapes the data as well as the vocabulary: it can **synthesize** the intermediate
-> event nodes a target like CIDOC-CRM routes its paths through, and it can **contract** structure a flat
+> nodes a target like CIDOC-CRM routes its paths through, and it can **contract** structure a flat
 > target does not want by contributing a Subject's values to the Subject it points at. Out of scope: RDF
 > **import** (a mapping drives export only) and contributions across more than one relation hop. The stored
 > `"version": 1` format may change; see the [open questions](../planning/OntologyMapping.md#open-questions).

--- a/docs/rdf/person-to-edm.md
+++ b/docs/rdf/person-to-edm.md
@@ -12,8 +12,9 @@ It projects the EDM column of a small "person to many standards" toy model. Ever
 [demo data](../../DemoData/), so a wiki with the demo data imported (`php maintenance/run.php NeoWiki:ImportDemoData`)
 reproduces it — up to instance-specific page IDs and base URI (and, in the page metadata, timestamps and last editor).
 
-> **Scope: the near-1:1 tier.** EDM is flat, so this walkthrough is term substitution. For the structural tier, the
-> same demo data ships a `Mapping:CIDOC-CRM` — see [the same data in CIDOC-CRM](#the-same-data-in-cidoc-crm) below.
+> **Scope: the near-1:1 tier.** This Person mapping is flat, so the walkthrough is term substitution. For the
+> structural tier, the same demo data ships a `Mapping:CIDOC-CRM` — see
+> [the same data in CIDOC-CRM](#the-same-data-in-cidoc-crm) below.
 
 ## The toy model
 

--- a/docs/rdf/person-to-edm.md
+++ b/docs/rdf/person-to-edm.md
@@ -53,7 +53,7 @@ The demo `City` Schema ([`DemoData/Schema/City.json`](../../DemoData/Schema/City
 One Mapping page, **[`Mapping:EDM`](../../DemoData/Mapping/EDM.json)**, holds an entry per mapped Schema; its title
 (`EDM`) is the projection name (see [Ontology Mapping](ontology-mapping.md) for the format). Abbreviated to the
 two entries this walkthrough uses — the shipped file also maps `Birth`, `Place`, `Artwork` and `Artist` and declares
-the `dc`/`dcterms`/`xsd` prefixes those need:
+the `dc`/`dcterms`/`xsd`/`ore` prefixes those need:
 
 ```json
 {

--- a/docs/rdf/rdf-export.md
+++ b/docs/rdf/rdf-export.md
@@ -94,8 +94,8 @@ curl 'https://wiki.example/rest.php/neowiki/v0/page/42/rdf?format=turtle'
 
 `GET /rest.php/neowiki/v0/subject/{subjectId}/rdf`
 
-Returns one Subject's projection: exactly the triples the page export emits for that Subject — its outbound
-description, including the native relation reification — with none of the page-metadata triples, in the hosting page's
+Returns one Subject's projection: exactly the triples the page export emits for that Subject — its description,
+including the native relation reification — with none of the page-metadata triples, in the hosting page's
 named graph. Inbound relations pointing at the Subject from elsewhere are not included.
 
 A readable Subject whose Schema has no mapping for the requested ontology target projects to an empty graph —

--- a/src/Application/Rdf/OntologyMappingProjector.php
+++ b/src/Application/Rdf/OntologyMappingProjector.php
@@ -480,6 +480,7 @@ class OntologyMappingProjector implements PageProjector {
 				class: $node['class'],
 				linkPredicate: $node['linkPredicate'],
 				scope: $node['mapping']->scope,
+				linkDirection: $node['mapping']->linkDirection,
 				keyPath: $keyPath,
 			);
 		}

--- a/src/Application/Rdf/SynthesizedNode.php
+++ b/src/Application/Rdf/SynthesizedNode.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Application\Rdf;
 
+use ProfessionalWiki\NeoWiki\Domain\Mapping\LinkDirection;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\NodeMapping;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\NodeScope;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\Iri;
@@ -25,6 +26,7 @@ readonly class SynthesizedNode {
 		public Iri $class,
 		public Iri $linkPredicate,
 		public NodeScope $scope,
+		public LinkDirection $linkDirection,
 		public array $keyPath,
 	) {
 	}

--- a/src/Application/Rdf/SynthesizedNodes.php
+++ b/src/Application/Rdf/SynthesizedNodes.php
@@ -19,8 +19,7 @@ use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
  * the instance and its anchor (the parent node's instance, or the Subject) — is recorded at the same
  * moment, so a node is in the output only when a value attached to it or to something below it. Asking
  * for an instance also pulls in its parent chain, which is how a nested node brings its ancestors along.
- * Nothing is emitted for a node no value reached, so an event ontology's projection carries no empty
- * event nodes.
+ * Nothing is emitted for a node no value reached, so an event ontology's projection carries no empty nodes.
  */
 class SynthesizedNodes {
 
@@ -96,11 +95,6 @@ class SynthesizedNodes {
 		return $instance;
 	}
 
-	/**
-	 * The triple that puts the node in the graph, pointing whichever way the node declares: at the node
-	 * for the CIDOC-CRM `person crm:P98i_was_born birth`, or at the anchor for the EDM
-	 * `aggregation edm:aggregatedCHO cho`, whose wrapper is the subject of its own link.
-	 */
 	private function linkQuad( SynthesizedNode $node, Iri $instance, Iri $anchor ): Quad {
 		return match ( $node->linkDirection ) {
 			LinkDirection::ToNode => new Quad( $anchor, $node->linkPredicate, $instance, $this->graph ),

--- a/src/Application/Rdf/SynthesizedNodes.php
+++ b/src/Application/Rdf/SynthesizedNodes.php
@@ -102,11 +102,10 @@ class SynthesizedNodes {
 	 * `aggregation edm:aggregatedCHO cho`, whose wrapper is the subject of its own link.
 	 */
 	private function linkQuad( SynthesizedNode $node, Iri $instance, Iri $anchor ): Quad {
-		if ( $node->linkDirection === LinkDirection::FromNode ) {
-			return new Quad( $instance, $node->linkPredicate, $anchor, $this->graph );
-		}
-
-		return new Quad( $anchor, $node->linkPredicate, $instance, $this->graph );
+		return match ( $node->linkDirection ) {
+			LinkDirection::ToNode => new Quad( $anchor, $node->linkPredicate, $instance, $this->graph ),
+			LinkDirection::FromNode => new Quad( $instance, $node->linkPredicate, $anchor, $this->graph ),
+		};
 	}
 
 	/**

--- a/src/Application/Rdf/SynthesizedNodes.php
+++ b/src/Application/Rdf/SynthesizedNodes.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Application\Rdf;
 
+use ProfessionalWiki\NeoWiki\Domain\Mapping\LinkDirection;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\Iri;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\Quad;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfNamespaces;
@@ -14,11 +15,12 @@ use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
  * The synthesized intermediate-node instances of one Subject's projection: it mints their IRIs and, for
  * the instances that ended up carrying something, the triples that put them in the graph.
  *
- * Instances are minted on demand and their scaffolding — the `rdf:type` triple and the link triple from
- * the anchor (the parent node's instance, or the Subject) — is recorded at the same moment, so a node is
- * in the output only when a value attached to it or to something below it. Asking for an instance also
- * pulls in its parent chain, which is how a nested node brings its ancestors along. Nothing is emitted
- * for a node no value reached, so an event ontology's projection carries no empty event nodes.
+ * Instances are minted on demand and their scaffolding — the `rdf:type` triple and the link triple between
+ * the instance and its anchor (the parent node's instance, or the Subject) — is recorded at the same
+ * moment, so a node is in the output only when a value attached to it or to something below it. Asking
+ * for an instance also pulls in its parent chain, which is how a nested node brings its ancestors along.
+ * Nothing is emitted for a node no value reached, so an event ontology's projection carries no empty
+ * event nodes.
  */
 class SynthesizedNodes {
 
@@ -89,16 +91,29 @@ class SynthesizedNodes {
 		$anchor = $this->anchor( $node );
 
 		$this->scaffold[] = new Quad( $instance, $this->namespaces->rdfType(), $node->class, $this->graph );
-		$this->scaffold[] = new Quad( $anchor, $node->linkPredicate, $instance, $this->graph );
+		$this->scaffold[] = $this->linkQuad( $node, $instance, $anchor );
 
 		return $instance;
 	}
 
 	/**
-	 * What the node's link triple runs from: its parent's instance, or the Subject when it has no parent.
-	 * A parent is always subject-scoped, so it has exactly one instance. Reaching for it records it, which
-	 * is what makes a whole ancestor chain appear when only its deepest node carries a value. Node
-	 * resolution drops a node whose parent is missing or unusable, so a resolved node's parent is here.
+	 * The triple that puts the node in the graph, pointing whichever way the node declares: at the node
+	 * for the CIDOC-CRM `person crm:P98i_was_born birth`, or at the anchor for the EDM
+	 * `aggregation edm:aggregatedCHO cho`, whose wrapper is the subject of its own link.
+	 */
+	private function linkQuad( SynthesizedNode $node, Iri $instance, Iri $anchor ): Quad {
+		if ( $node->linkDirection === LinkDirection::FromNode ) {
+			return new Quad( $instance, $node->linkPredicate, $anchor, $this->graph );
+		}
+
+		return new Quad( $anchor, $node->linkPredicate, $instance, $this->graph );
+	}
+
+	/**
+	 * The node's other end: its parent's instance, or the Subject when it has no parent. A parent is
+	 * always subject-scoped, so it has exactly one instance. Reaching for it records it, which is what
+	 * makes a whole ancestor chain appear when only its deepest node carries a value. Node resolution
+	 * drops a node whose parent is missing or unusable, so a resolved node's parent is here.
 	 */
 	private function anchor( SynthesizedNode $node ): Iri {
 		$parentKey = $node->parentKey();

--- a/src/Domain/Mapping/LinkDirection.php
+++ b/src/Domain/Mapping/LinkDirection.php
@@ -16,8 +16,7 @@ enum LinkDirection: string {
 	case ToNode = 'toNode';
 
 	/**
-	 * `<node> <linkPredicate> <anchor>` — the EDM `aggregation edm:aggregatedCHO cho`, where the node
-	 * wraps the entity it points at.
+	 * `<node> <linkPredicate> <anchor>` — the EDM `aggregation edm:aggregatedCHO cho`.
 	 */
 	case FromNode = 'fromNode';
 

--- a/src/Domain/Mapping/LinkDirection.php
+++ b/src/Domain/Mapping/LinkDirection.php
@@ -1,0 +1,24 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\Mapping;
+
+/**
+ * Which way a {@see NodeMapping}'s link triple runs between the node and its anchor — the parent node's
+ * instance, or the Subject when there is no parent.
+ */
+enum LinkDirection: string {
+
+	/**
+	 * `<anchor> <linkPredicate> <node>` — the CIDOC-CRM `person crm:P98i_was_born birth`.
+	 */
+	case ToNode = 'toNode';
+
+	/**
+	 * `<node> <linkPredicate> <anchor>` — the EDM `aggregation edm:aggregatedCHO cho`, where the node
+	 * wraps the entity it points at.
+	 */
+	case FromNode = 'fromNode';
+
+}

--- a/src/Domain/Mapping/NodeMapping.php
+++ b/src/Domain/Mapping/NodeMapping.php
@@ -17,8 +17,8 @@ readonly class NodeMapping {
 
 	/**
 	 * @param string $class The `rdf:type` given to each instance of the node.
-	 * @param string $linkPredicate The predicate of the triple from the anchor — the parent node's
-	 *   instance, or the Subject when there is no parent — to the node instance.
+	 * @param string $linkPredicate The predicate of the triple between the node instance and its anchor —
+	 *   the parent node's instance, or the Subject when there is no parent.
 	 * @param string|null $parent The key of the node this one hangs off, instead of the Subject.
 	 */
 	public function __construct(
@@ -26,6 +26,7 @@ readonly class NodeMapping {
 		public string $linkPredicate,
 		public ?string $parent = null,
 		public NodeScope $scope = NodeScope::Subject,
+		public LinkDirection $linkDirection = LinkDirection::ToNode,
 	) {
 	}
 

--- a/src/Persistence/MediaWiki/MappingPersistenceDeserializer.php
+++ b/src/Persistence/MediaWiki/MappingPersistenceDeserializer.php
@@ -161,10 +161,8 @@ class MappingPersistenceDeserializer {
 
 	/**
 	 * A stored direction the projector does not know — reachable through import, since save validation
-	 * rejects it — drops the node, the way a node missing its terms is dropped. Deliberately not the
-	 * fallback-to-default an unknown `per` gets: a guessed direction puts the link triple the wrong way
-	 * round in output that is meant to be conformant, and the wrong direction is harder to notice than a
-	 * missing node.
+	 * rejects it — drops the node. Not the fallback-to-default an unknown `per` gets: a guessed direction
+	 * puts the link triple the wrong way round in output that is meant to be conformant.
 	 */
 	private function linkDirection( mixed $value ): ?LinkDirection {
 		if ( $value === null ) {

--- a/src/Persistence/MediaWiki/MappingPersistenceDeserializer.php
+++ b/src/Persistence/MediaWiki/MappingPersistenceDeserializer.php
@@ -160,10 +160,11 @@ class MappingPersistenceDeserializer {
 	}
 
 	/**
-	 * A stored direction the projector does not know drops the node, rather than falling back to the
-	 * default the way an unknown `per` does: guessing here would put the node's link triple the wrong way
-	 * round, asserting something the Mapping never said, while dropping it only leaves the node's values
-	 * out — and the properties pointing at it are logged.
+	 * A stored direction the projector does not know — reachable through import, since save validation
+	 * rejects it — drops the node, the way a node missing its terms is dropped. Deliberately not the
+	 * fallback-to-default an unknown `per` gets: a guessed direction puts the link triple the wrong way
+	 * round in output that is meant to be conformant, and the wrong direction is harder to notice than a
+	 * missing node.
 	 */
 	private function linkDirection( mixed $value ): ?LinkDirection {
 		if ( $value === null ) {

--- a/src/Persistence/MediaWiki/MappingPersistenceDeserializer.php
+++ b/src/Persistence/MediaWiki/MappingPersistenceDeserializer.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Persistence\MediaWiki;
 
 use InvalidArgumentException;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\LinkDirection;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\Mapping;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\MappingName;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\NodeMapping;
@@ -140,15 +141,36 @@ class MappingPersistenceDeserializer {
 				continue;
 			}
 
+			$linkDirection = $this->linkDirection( $node['linkDirection'] ?? null );
+
+			if ( $linkDirection === null ) {
+				continue;
+			}
+
 			$nodes[(string)$key] = new NodeMapping(
 				class: $node['class'],
 				linkPredicate: $node['linkPredicate'],
 				parent: $this->stringOrNull( $node['parent'] ?? null ),
 				scope: NodeScope::tryFrom( (string)( $node['per'] ?? '' ) ) ?? NodeScope::Subject,
+				linkDirection: $linkDirection,
 			);
 		}
 
 		return $nodes;
+	}
+
+	/**
+	 * A stored direction the projector does not know drops the node, rather than falling back to the
+	 * default the way an unknown `per` does: guessing here would put the node's link triple the wrong way
+	 * round, asserting something the Mapping never said, while dropping it only leaves the node's values
+	 * out — and the properties pointing at it are logged.
+	 */
+	private function linkDirection( mixed $value ): ?LinkDirection {
+		if ( $value === null ) {
+			return LinkDirection::ToNode;
+		}
+
+		return is_string( $value ) ? LinkDirection::tryFrom( $value ) : null;
 	}
 
 	/**

--- a/src/Persistence/MediaWiki/mappingContentSchema.json
+++ b/src/Persistence/MediaWiki/mappingContentSchema.json
@@ -94,7 +94,7 @@
 										"toNode",
 										"fromNode"
 									],
-									"$error": "A node's link triple runs either \"toNode\" or \"fromNode\"."
+									"$error": "A node's link direction is either \"toNode\" or \"fromNode\"."
 								}
 							},
 							"additionalProperties": false

--- a/src/Persistence/MediaWiki/mappingContentSchema.json
+++ b/src/Persistence/MediaWiki/mappingContentSchema.json
@@ -88,6 +88,13 @@
 										"value"
 									],
 									"$error": "A node is either per \"subject\" or per \"value\"."
+								},
+								"linkDirection": {
+									"enum": [
+										"toNode",
+										"fromNode"
+									],
+									"$error": "A node's link triple runs either \"toNode\" or \"fromNode\"."
 								}
 							},
 							"additionalProperties": false

--- a/tests/phpunit/Application/Rdf/OntologyMappingProjectorTest.php
+++ b/tests/phpunit/Application/Rdf/OntologyMappingProjectorTest.php
@@ -1274,7 +1274,7 @@ class OntologyMappingProjectorTest extends TestCase {
 			TRIG;
 	}
 
-	private function artworkWithWebResourceFields(): Page {
+	private function artworkWithImageAndRights(): Page {
 		return TestPage::build( id: 42, mainSubject: TestSubject::build(
 			id: self::ARTWORK_ID,
 			label: 'The Milkmaid',
@@ -1299,7 +1299,7 @@ class OntologyMappingProjectorTest extends TestCase {
 					linkDirection: LinkDirection::FromNode
 				),
 			],
-		) )->projectPage( $this->artworkWithWebResourceFields() );
+		) )->projectPage( $this->artworkWithImageAndRights() );
 
 		// The aggregation, not the CHO, is the subject of the link triple, so the record has the shape
 		// Europeana ingests; the CHO itself carries only what is mapped onto it.
@@ -1332,7 +1332,7 @@ class OntologyMappingProjectorTest extends TestCase {
 					parent: 'aggregation'
 				),
 			],
-		) )->projectPage( $this->artworkWithWebResourceFields() );
+		) )->projectPage( $this->artworkWithImageAndRights() );
 
 		// Only the web resource carries a value, so it pulls the aggregation above it into the output.
 		// Each node's own direction applies: the aggregation points back at the CHO, the web resource is

--- a/tests/phpunit/Application/Rdf/OntologyMappingProjectorTest.php
+++ b/tests/phpunit/Application/Rdf/OntologyMappingProjectorTest.php
@@ -6,6 +6,7 @@ namespace ProfessionalWiki\NeoWiki\Tests\Application\Rdf;
 
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Application\Rdf\OntologyMappingProjector;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\LinkDirection;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\Mapping;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\MappingName;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\NodeMapping;
@@ -53,6 +54,7 @@ class OntologyMappingProjectorTest extends TestCase {
 	private const string BIRTH_ID = 's1birthaaaaaaa6';
 
 	private const string EDM = 'http://www.europeana.eu/schemas/edm/';
+	private const string ORE = 'http://www.openarchives.org/ore/terms/';
 	private const string DC = 'http://purl.org/dc/elements/1.1/';
 	private const string CRM = 'http://www.cidoc-crm.org/cidoc-crm/';
 	private const string RDA_GR2 = 'http://rdvocab.info/ElementsGr2/';
@@ -1248,6 +1250,149 @@ class OntologyMappingProjectorTest extends TestCase {
 			$serializer->serialize( $first, RdfFormat::TriG ),
 			$serializer->serialize( $second, RdfFormat::TriG )
 		);
+	}
+
+	// A node whose link triple runs the other way: the ore:Aggregation an EDM record wraps its CHO in.
+
+	private function newOreProjector( SchemaMapping $mapping ): OntologyMappingProjector {
+		return $this->newProjector( [ 'Artwork' => $mapping ], [ 'edm' => self::EDM, 'ore' => self::ORE ] );
+	}
+
+	private function oreTriG( string $body ): string {
+		return <<<TRIG
+			@prefix neo-subj: <https://wiki.example/entity/> .
+			@prefix neo-graph: <https://wiki.example/graph/edm/page/> .
+			@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+			@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+			@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+			@prefix edm: <http://www.europeana.eu/schemas/edm/> .
+			@prefix ore: <http://www.openarchives.org/ore/terms/> .
+
+			neo-graph:42 {
+			$body
+			}
+			TRIG;
+	}
+
+	private function artworkWithWebResourceFields(): Page {
+		return TestPage::build( id: 42, mainSubject: TestSubject::build(
+			id: self::ARTWORK_ID,
+			label: 'The Milkmaid',
+			schemaName: new SchemaName( 'Artwork' ),
+			statements: new StatementList( [
+				TestStatement::build( 'Image', new StringValue( 'https://example.org/milkmaid.jpg' ), 'url' ),
+				TestStatement::build( 'Rights', new StringValue( 'https://example.org/rights/publicdomain' ), 'url' ),
+			] )
+		) );
+	}
+
+	public function testAReversedNodeIsLinkedFromItselfToTheSubject(): void {
+		$quads = $this->newOreProjector( new SchemaMapping(
+			subject: new SubjectMapping( 'edm:ProvidedCHO' ),
+			properties: new PropertyMappings( [
+				'Image' => new PropertyMapping( predicate: 'edm:isShownBy', node: 'aggregation' ),
+			] ),
+			nodes: [
+				'aggregation' => new NodeMapping(
+					class: 'ore:Aggregation',
+					linkPredicate: 'edm:aggregatedCHO',
+					linkDirection: LinkDirection::FromNode
+				),
+			],
+		) )->projectPage( $this->artworkWithWebResourceFields() );
+
+		// The aggregation, not the CHO, is the subject of the link triple, so the record has the shape
+		// Europeana ingests; the CHO itself carries only what is mapped onto it.
+		$this->assertProjectsTo( $this->oreTriG( <<<'TRIG'
+			neo-subj:s1artworkaaaaa4 a edm:ProvidedCHO ;
+				rdfs:label "The Milkmaid" .
+
+			<https://wiki.example/node/s1artworkaaaaa4/aggregation> a ore:Aggregation ;
+				edm:aggregatedCHO neo-subj:s1artworkaaaaa4 ;
+				edm:isShownBy <https://example.org/milkmaid.jpg> .
+			TRIG ), $quads );
+		$this->logger->assertNoLoggingCallsWhereMade();
+	}
+
+	public function testANodeUnderAReversedParentIsLinkedToTheParentsInstance(): void {
+		$quads = $this->newOreProjector( new SchemaMapping(
+			subject: new SubjectMapping( 'edm:ProvidedCHO' ),
+			properties: new PropertyMappings( [
+				'Rights' => new PropertyMapping( predicate: 'edm:rights', node: 'webResource' ),
+			] ),
+			nodes: [
+				'aggregation' => new NodeMapping(
+					class: 'ore:Aggregation',
+					linkPredicate: 'edm:aggregatedCHO',
+					linkDirection: LinkDirection::FromNode
+				),
+				'webResource' => new NodeMapping(
+					class: 'edm:WebResource',
+					linkPredicate: 'edm:isShownBy',
+					parent: 'aggregation'
+				),
+			],
+		) )->projectPage( $this->artworkWithWebResourceFields() );
+
+		// Only the web resource carries a value, so it pulls the aggregation above it into the output.
+		// Each node's own direction applies: the aggregation points back at the CHO, the web resource is
+		// pointed at by the aggregation.
+		$this->assertProjectsTo( $this->oreTriG( <<<'TRIG'
+			neo-subj:s1artworkaaaaa4 a edm:ProvidedCHO ;
+				rdfs:label "The Milkmaid" .
+
+			<https://wiki.example/node/s1artworkaaaaa4/aggregation> a ore:Aggregation ;
+				edm:aggregatedCHO neo-subj:s1artworkaaaaa4 ;
+				edm:isShownBy <https://wiki.example/node/s1artworkaaaaa4/aggregation/webResource> .
+
+			<https://wiki.example/node/s1artworkaaaaa4/aggregation/webResource> a edm:WebResource ;
+				edm:rights <https://example.org/rights/publicdomain> .
+			TRIG ), $quads );
+		$this->logger->assertNoLoggingCallsWhereMade();
+	}
+
+	public function testEveryInstanceOfAReversedPerValueNodeIsLinkedToTheSubject(): void {
+		$artwork = TestPage::build( id: 42, mainSubject: TestSubject::build(
+			id: self::ARTWORK_ID,
+			label: 'The Milkmaid',
+			schemaName: new SchemaName( 'Artwork' ),
+			statements: new StatementList( [
+				TestStatement::buildRelation( 'Provider', [
+					TestRelation::build( id: 'r1firstaaaaaaa2', targetId: self::PERSON_ID ),
+					TestRelation::build( id: 'r1secondaaaaaa3', targetId: self::CITY_ID ),
+				] ),
+			] )
+		) );
+
+		$quads = $this->newOreProjector( new SchemaMapping(
+			subject: new SubjectMapping( 'edm:ProvidedCHO' ),
+			properties: new PropertyMappings( [
+				'Provider' => new PropertyMapping( predicate: 'edm:provider', node: 'aggregation' ),
+			] ),
+			nodes: [
+				'aggregation' => new NodeMapping(
+					class: 'ore:Aggregation',
+					linkPredicate: 'edm:aggregatedCHO',
+					scope: NodeScope::Value,
+					linkDirection: LinkDirection::FromNode
+				),
+			],
+		) )->projectPage( $artwork );
+
+		// One aggregation per provider, each pointing back at the same CHO.
+		$this->assertProjectsTo( $this->oreTriG( <<<'TRIG'
+			neo-subj:s1artworkaaaaa4 a edm:ProvidedCHO ;
+				rdfs:label "The Milkmaid" .
+
+			<https://wiki.example/node/r1firstaaaaaaa2> a ore:Aggregation ;
+				edm:aggregatedCHO neo-subj:s1artworkaaaaa4 ;
+				edm:provider neo-subj:s1janeaaaaaaaa2 .
+
+			<https://wiki.example/node/r1secondaaaaaa3> a ore:Aggregation ;
+				edm:aggregatedCHO neo-subj:s1artworkaaaaa4 ;
+				edm:provider neo-subj:s1cityaaaaaaaa3 .
+			TRIG ), $quads );
+		$this->logger->assertNoLoggingCallsWhereMade();
 	}
 
 }

--- a/tests/phpunit/Application/Rdf/OntologyMappingProjectorTest.php
+++ b/tests/phpunit/Application/Rdf/OntologyMappingProjectorTest.php
@@ -629,7 +629,7 @@ class OntologyMappingProjectorTest extends TestCase {
 		return $this->newProjector( [ $schemaName => $mapping ], [ 'crm' => self::CRM, 'rdaGr2' => self::RDA_GR2 ] );
 	}
 
-	private function crmTriG( string $body ): string {
+	private function triG( string $body ): string {
 		return <<<TRIG
 			@prefix neo-subj: <https://wiki.example/entity/> .
 			@prefix neo-graph: <https://wiki.example/graph/edm/page/> .
@@ -638,6 +638,8 @@ class OntologyMappingProjectorTest extends TestCase {
 			@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 			@prefix crm: <http://www.cidoc-crm.org/cidoc-crm/> .
 			@prefix rdaGr2: <http://rdvocab.info/ElementsGr2/> .
+			@prefix edm: <http://www.europeana.eu/schemas/edm/> .
+			@prefix ore: <http://www.openarchives.org/ore/terms/> .
 
 			neo-graph:42 {
 			$body
@@ -685,7 +687,7 @@ class OntologyMappingProjectorTest extends TestCase {
 
 		// One E67_Birth, reached by one P98i_was_born, carrying both properties: the two flat fields are
 		// coordinated onto the same synthesized node.
-		$this->assertProjectsTo( $this->crmTriG( <<<'TRIG'
+		$this->assertProjectsTo( $this->triG( <<<'TRIG'
 			neo-subj:s1janeaaaaaaaa2 a crm:E21_Person ;
 				rdfs:label "Jane" ;
 				crm:P98i_was_born <https://wiki.example/node/s1janeaaaaaaaa2/birth> .
@@ -715,7 +717,7 @@ class OntologyMappingProjectorTest extends TestCase {
 			],
 		) )->projectPage( $this->personWithFlatBirthFields() );
 
-		$this->assertProjectsTo( $this->crmTriG( <<<'TRIG'
+		$this->assertProjectsTo( $this->triG( <<<'TRIG'
 			neo-subj:s1janeaaaaaaaa2 a crm:E21_Person ;
 				rdfs:label "Jane" ;
 				crm:P98i_was_born <https://wiki.example/node/s1janeaaaaaaaa2/birth> .
@@ -742,7 +744,7 @@ class OntologyMappingProjectorTest extends TestCase {
 			],
 		) )->projectPage( $this->personWithFlatBirthFields() );
 
-		$this->assertProjectsTo( $this->crmTriG( <<<'TRIG'
+		$this->assertProjectsTo( $this->triG( <<<'TRIG'
 			neo-subj:s1janeaaaaaaaa2 a crm:E21_Person ;
 				rdfs:label "Jane" .
 			TRIG ), $quads );
@@ -771,7 +773,7 @@ class OntologyMappingProjectorTest extends TestCase {
 			],
 		) )->projectPage( $page );
 
-		$this->assertProjectsTo( $this->crmTriG( <<<'TRIG'
+		$this->assertProjectsTo( $this->triG( <<<'TRIG'
 			neo-subj:s1janeaaaaaaaa2 a crm:E21_Person ;
 				rdfs:label "Jane" .
 			TRIG ), $quads );
@@ -809,7 +811,7 @@ class OntologyMappingProjectorTest extends TestCase {
 		)->projectPage( $artwork );
 
 		// Two creators, two production events, each IRI derived from its Relation's persistent ID.
-		$this->assertProjectsTo( $this->crmTriG( <<<'TRIG'
+		$this->assertProjectsTo( $this->triG( <<<'TRIG'
 			neo-subj:s1artworkaaaaa4 a crm:E22_Human-Made_Object ;
 				rdfs:label "The Milkmaid" ;
 				crm:P108i_was_produced_by <https://wiki.example/node/r1firstaaaaaaa2>, <https://wiki.example/node/r1secondaaaaaa3> .
@@ -847,7 +849,7 @@ class OntologyMappingProjectorTest extends TestCase {
 			],
 		) )->projectPage( $page );
 
-		$this->assertProjectsTo( $this->crmTriG( <<<'TRIG'
+		$this->assertProjectsTo( $this->triG( <<<'TRIG'
 			neo-subj:s1janeaaaaaaaa2 a crm:E21_Person ;
 				rdfs:label "Jane" ;
 				crm:P1_is_identified_by <https://wiki.example/node/s1janeaaaaaaaa2/appellation/0>, <https://wiki.example/node/s1janeaaaaaaaa2/appellation/1> .
@@ -879,7 +881,7 @@ class OntologyMappingProjectorTest extends TestCase {
 			],
 		) )->projectPage( $this->personWithFlatBirthFields() );
 
-		$this->assertProjectsTo( $this->crmTriG( <<<'TRIG'
+		$this->assertProjectsTo( $this->triG( <<<'TRIG'
 			neo-subj:s1janeaaaaaaaa2 a crm:E21_Person ;
 				rdfs:label "Jane" ;
 				rdaGr2:placeOfBirth neo-subj:s1cityaaaaaaaa3 .
@@ -894,7 +896,7 @@ class OntologyMappingProjectorTest extends TestCase {
 			subject: new SubjectMapping( class: 'crm:E21_Person', labelPredicate: 'rdaGr2:nameOfThePerson' ),
 		) )->projectPage( TestPage::build( id: 42, mainSubject: $this->examplePersonWithoutRelations() ) );
 
-		$this->assertProjectsTo( $this->crmTriG( <<<'TRIG'
+		$this->assertProjectsTo( $this->triG( <<<'TRIG'
 			neo-subj:s1janeaaaaaaaa2 a crm:E21_Person ;
 				rdfs:label "Jane" ;
 				rdaGr2:nameOfThePerson "Jane" .
@@ -937,7 +939,7 @@ class OntologyMappingProjectorTest extends TestCase {
 
 		// No type or label for the Birth itself: the entry only contributes. The unmapped Weather is
 		// absent, as unmapped properties always are.
-		$this->assertProjectsTo( $this->crmTriG( <<<'TRIG'
+		$this->assertProjectsTo( $this->triG( <<<'TRIG'
 			neo-subj:s1janeaaaaaaaa2 rdaGr2:dateOfBirth "1990-01-31"^^xsd:date ;
 				rdaGr2:placeOfBirth neo-subj:s1cityaaaaaaaa3 .
 
@@ -1032,7 +1034,7 @@ class OntologyMappingProjectorTest extends TestCase {
 			[ 'crm' => self::CRM, 'rdaGr2' => self::RDA_GR2 ]
 		)->projectPage( $birth );
 
-		$this->assertProjectsTo( $this->crmTriG( <<<'TRIG'
+		$this->assertProjectsTo( $this->triG( <<<'TRIG'
 			neo-subj:s1birthaaaaaaa6 a crm:E67_Birth ;
 				rdfs:label "Birth of Jane" ;
 				crm:P98_brought_into_life neo-subj:s1janeaaaaaaaa2 .
@@ -1074,7 +1076,7 @@ class OntologyMappingProjectorTest extends TestCase {
 			}
 			JSON )->projectPage( $this->personWithFlatBirthFields() );
 
-		$this->assertProjectsTo( $this->crmTriG( <<<'TRIG'
+		$this->assertProjectsTo( $this->triG( <<<'TRIG'
 			neo-subj:s1janeaaaaaaaa2 a crm:E21_Person ;
 				rdfs:label "Jane" ;
 				crm:P98i_was_born <https://wiki.example/node/s1janeaaaaaaaa2/2024> .
@@ -1107,7 +1109,7 @@ class OntologyMappingProjectorTest extends TestCase {
 			}
 			JSON )->projectPage( $page );
 
-		$this->assertProjectsTo( $this->crmTriG( <<<'TRIG'
+		$this->assertProjectsTo( $this->triG( <<<'TRIG'
 			neo-subj:s1janeaaaaaaaa2 a crm:E21_Person ;
 				rdfs:label "Jane" ;
 				crm:P3_has_note "Sabbatical" .
@@ -1158,7 +1160,7 @@ class OntologyMappingProjectorTest extends TestCase {
 			}
 			JSON )->projectPage( $artwork );
 
-		$this->assertProjectsTo( $this->crmTriG( <<<'TRIG'
+		$this->assertProjectsTo( $this->triG( <<<'TRIG'
 			neo-subj:s1artworkaaaaa4 a crm:E22_Human-Made_Object ;
 				rdfs:label "The Milkmaid" ;
 				crm:P108i_was_produced_by <https://wiki.example/node/r1firstaaaaaaa2> .
@@ -1210,7 +1212,7 @@ class OntologyMappingProjectorTest extends TestCase {
 			}
 			JSON )->projectPage( $page );
 
-		$this->assertProjectsTo( $this->crmTriG( <<<'TRIG'
+		$this->assertProjectsTo( $this->triG( <<<'TRIG'
 			neo-subj:s1janeaaaaaaaa2 a crm:E21_Person ;
 				rdfs:label "Jane" ;
 				crm:P1_is_identified_by <https://wiki.example/node/s1janeaaaaaaaa2/naming> .
@@ -1258,31 +1260,20 @@ class OntologyMappingProjectorTest extends TestCase {
 		return $this->newProjector( [ 'Artwork' => $mapping ], [ 'edm' => self::EDM, 'ore' => self::ORE ] );
 	}
 
-	private function oreTriG( string $body ): string {
-		return <<<TRIG
-			@prefix neo-subj: <https://wiki.example/entity/> .
-			@prefix neo-graph: <https://wiki.example/graph/edm/page/> .
-			@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-			@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-			@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-			@prefix edm: <http://www.europeana.eu/schemas/edm/> .
-			@prefix ore: <http://www.openarchives.org/ore/terms/> .
-
-			neo-graph:42 {
-			$body
-			}
-			TRIG;
+	private function artworkWithImage(): Page {
+		return $this->artworkWith( 'Image', 'https://example.org/milkmaid.jpg' );
 	}
 
-	private function artworkWithImageAndRights(): Page {
+	private function artworkWithRights(): Page {
+		return $this->artworkWith( 'Rights', 'https://example.org/rights/publicdomain' );
+	}
+
+	private function artworkWith( string $property, string $url ): Page {
 		return TestPage::build( id: 42, mainSubject: TestSubject::build(
 			id: self::ARTWORK_ID,
 			label: 'The Milkmaid',
 			schemaName: new SchemaName( 'Artwork' ),
-			statements: new StatementList( [
-				TestStatement::build( 'Image', new StringValue( 'https://example.org/milkmaid.jpg' ), 'url' ),
-				TestStatement::build( 'Rights', new StringValue( 'https://example.org/rights/publicdomain' ), 'url' ),
-			] )
+			statements: new StatementList( [ TestStatement::build( $property, new StringValue( $url ), 'url' ) ] )
 		) );
 	}
 
@@ -1299,11 +1290,11 @@ class OntologyMappingProjectorTest extends TestCase {
 					linkDirection: LinkDirection::FromNode
 				),
 			],
-		) )->projectPage( $this->artworkWithImageAndRights() );
+		) )->projectPage( $this->artworkWithImage() );
 
 		// The aggregation, not the CHO, is the subject of the link triple, so the record has the shape
 		// Europeana ingests; the CHO itself carries only what is mapped onto it.
-		$this->assertProjectsTo( $this->oreTriG( <<<'TRIG'
+		$this->assertProjectsTo( $this->triG( <<<'TRIG'
 			neo-subj:s1artworkaaaaa4 a edm:ProvidedCHO ;
 				rdfs:label "The Milkmaid" .
 
@@ -1314,7 +1305,7 @@ class OntologyMappingProjectorTest extends TestCase {
 		$this->logger->assertNoLoggingCallsWhereMade();
 	}
 
-	public function testANodeUnderAReversedParentIsLinkedToTheParentsInstance(): void {
+	public function testEachNodeUsesItsOwnLinkDirection(): void {
 		$quads = $this->newOreProjector( new SchemaMapping(
 			subject: new SubjectMapping( 'edm:ProvidedCHO' ),
 			properties: new PropertyMappings( [
@@ -1332,12 +1323,12 @@ class OntologyMappingProjectorTest extends TestCase {
 					parent: 'aggregation'
 				),
 			],
-		) )->projectPage( $this->artworkWithImageAndRights() );
+		) )->projectPage( $this->artworkWithRights() );
 
 		// Only the web resource carries a value, so it pulls the aggregation above it into the output.
 		// Each node's own direction applies: the aggregation points back at the CHO, the web resource is
 		// pointed at by the aggregation.
-		$this->assertProjectsTo( $this->oreTriG( <<<'TRIG'
+		$this->assertProjectsTo( $this->triG( <<<'TRIG'
 			neo-subj:s1artworkaaaaa4 a edm:ProvidedCHO ;
 				rdfs:label "The Milkmaid" .
 
@@ -1346,6 +1337,43 @@ class OntologyMappingProjectorTest extends TestCase {
 				edm:isShownBy <https://wiki.example/node/s1artworkaaaaa4/aggregation/webResource> .
 
 			<https://wiki.example/node/s1artworkaaaaa4/aggregation/webResource> a edm:WebResource ;
+				edm:rights <https://example.org/rights/publicdomain> .
+			TRIG ), $quads );
+		$this->logger->assertNoLoggingCallsWhereMade();
+	}
+
+	public function testAReversedNodeUnderAParentPointsAtTheParentsInstance(): void {
+		$quads = $this->newOreProjector( new SchemaMapping(
+			subject: new SubjectMapping( 'edm:ProvidedCHO' ),
+			properties: new PropertyMappings( [
+				'Rights' => new PropertyMapping( predicate: 'edm:rights', node: 'proxy' ),
+			] ),
+			nodes: [
+				'aggregation' => new NodeMapping(
+					class: 'ore:Aggregation',
+					linkPredicate: 'edm:aggregatedCHO',
+					linkDirection: LinkDirection::FromNode
+				),
+				'proxy' => new NodeMapping(
+					class: 'ore:Proxy',
+					linkPredicate: 'ore:proxyIn',
+					parent: 'aggregation',
+					linkDirection: LinkDirection::FromNode
+				),
+			],
+		) )->projectPage( $this->artworkWithRights() );
+
+		// A reversed node points at its own anchor, which here is the aggregation above it rather than the
+		// Subject: the proxy sits in the aggregation, not in the CHO.
+		$this->assertProjectsTo( $this->triG( <<<'TRIG'
+			neo-subj:s1artworkaaaaa4 a edm:ProvidedCHO ;
+				rdfs:label "The Milkmaid" .
+
+			<https://wiki.example/node/s1artworkaaaaa4/aggregation> a ore:Aggregation ;
+				edm:aggregatedCHO neo-subj:s1artworkaaaaa4 .
+
+			<https://wiki.example/node/s1artworkaaaaa4/aggregation/proxy> a ore:Proxy ;
+				ore:proxyIn <https://wiki.example/node/s1artworkaaaaa4/aggregation> ;
 				edm:rights <https://example.org/rights/publicdomain> .
 			TRIG ), $quads );
 		$this->logger->assertNoLoggingCallsWhereMade();
@@ -1380,7 +1408,7 @@ class OntologyMappingProjectorTest extends TestCase {
 		) )->projectPage( $artwork );
 
 		// One aggregation per provider, each pointing back at the same CHO.
-		$this->assertProjectsTo( $this->oreTriG( <<<'TRIG'
+		$this->assertProjectsTo( $this->triG( <<<'TRIG'
 			neo-subj:s1artworkaaaaa4 a edm:ProvidedCHO ;
 				rdfs:label "The Milkmaid" .
 

--- a/tests/phpunit/Persistence/MediaWiki/MappingContentValidatorTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/MappingContentValidatorTest.php
@@ -458,6 +458,29 @@ class MappingContentValidatorTest extends MediaWikiIntegrationTestCase {
 		);
 	}
 
+	public function testRejectsALinkDirectionThatIsNeitherToNodeNorFromNode(): void {
+		$this->assertInvalidAt(
+			<<<JSON
+			{
+				"version": 1,
+				"schemas": {
+					"Person": {
+						"subject": { "class": "http://example.org/Person" },
+						"nodes": {
+							"birth": {
+								"class": "http://example.org/Birth",
+								"linkPredicate": "http://example.org/wasBorn",
+								"linkDirection": "eitherWay"
+							}
+						}
+					}
+				}
+			}
+			JSON,
+			'/schemas/Person/nodes/birth/linkDirection'
+		);
+	}
+
 	public function testRejectsAPropertyAttachedToAnUndeclaredNode(): void {
 		$this->assertInvalidAt(
 			<<<JSON

--- a/tests/phpunit/Persistence/MediaWiki/MappingContentValidatorTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/MappingContentValidatorTest.php
@@ -699,7 +699,8 @@ class MappingContentValidatorTest extends MediaWikiIntegrationTestCase {
 							"birthTimespan": {
 								"class": "crm:E52_Time-Span",
 								"linkPredicate": "crm:P4_has_time-span",
-								"parent": "birth"
+								"parent": "birth",
+								"linkDirection": "toNode"
 							},
 							"appellation": {
 								"class": "crm:E41_Appellation",

--- a/tests/phpunit/Persistence/MediaWiki/MappingPersistenceDeserializerTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/MappingPersistenceDeserializerTest.php
@@ -6,6 +6,7 @@ namespace ProfessionalWiki\NeoWiki\Tests\Persistence\MediaWiki;
 
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\Mapping\LinkDirection;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\Mapping;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\MappingName;
 use ProfessionalWiki\NeoWiki\Domain\Mapping\NodeMapping;
@@ -152,6 +153,75 @@ class MappingPersistenceDeserializerTest extends TestCase {
 
 	public function testDeserializesAPerValueNodesScope(): void {
 		$this->assertSame( NodeScope::Value, $this->personNodes()['appellation']?->scope );
+	}
+
+	public function testANodeWithoutALinkDirectionIsLinkedTowardsItself(): void {
+		$this->assertSame( LinkDirection::ToNode, $this->personNodes()['birth']?->linkDirection );
+	}
+
+	public function testDeserializesAReversedNodesLinkDirection(): void {
+		$this->assertSame( LinkDirection::FromNode, $this->aggregationNodes()['aggregation']?->linkDirection );
+	}
+
+	public function testSkipsANodeWithAnUnknownLinkDirection(): void {
+		// Save validation rejects any other value, but an import can store one. Defaulting it would emit
+		// the node's link triple the wrong way round, so the node goes instead — as it does when its terms
+		// are missing.
+		$nodes = $this->deserialize( <<<'JSON'
+			{
+				"version": 1,
+				"prefixes": { "ore": "http://www.openarchives.org/ore/terms/" },
+				"schemas": {
+					"Artwork": {
+						"subject": { "class": "http://www.europeana.eu/schemas/edm/ProvidedCHO" },
+						"nodes": {
+							"sideways": {
+								"class": "ore:Aggregation",
+								"linkPredicate": "http://www.europeana.eu/schemas/edm/aggregatedCHO",
+								"linkDirection": "eitherWay"
+							},
+							"aggregation": {
+								"class": "ore:Aggregation",
+								"linkPredicate": "http://www.europeana.eu/schemas/edm/aggregatedCHO",
+								"linkDirection": "fromNode"
+							}
+						}
+					}
+				}
+			}
+			JSON )->forSchema( new SchemaName( 'Artwork' ) )?->nodes ?? [];
+
+		$this->assertSame( [ 'aggregation' ], array_keys( $nodes ) );
+	}
+
+	/**
+	 * @return array<string, NodeMapping>
+	 */
+	private function aggregationNodes(): array {
+		return $this->deserialize( <<<'JSON'
+			{
+				"version": 1,
+				"prefixes": {
+					"edm": "http://www.europeana.eu/schemas/edm/",
+					"ore": "http://www.openarchives.org/ore/terms/"
+				},
+				"schemas": {
+					"Artwork": {
+						"subject": { "class": "edm:ProvidedCHO" },
+						"nodes": {
+							"aggregation": {
+								"class": "ore:Aggregation",
+								"linkPredicate": "edm:aggregatedCHO",
+								"linkDirection": "fromNode"
+							}
+						},
+						"properties": {
+							"Image": { "predicate": "edm:isShownBy", "node": "aggregation" }
+						}
+					}
+				}
+			}
+			JSON )->forSchema( new SchemaName( 'Artwork' ) )?->nodes ?? [];
 	}
 
 	public function testSkipsANodeWithoutTheTermsItNeeds(): void {

--- a/tests/phpunit/Persistence/MediaWiki/MappingPersistenceDeserializerTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/MappingPersistenceDeserializerTest.php
@@ -155,39 +155,16 @@ class MappingPersistenceDeserializerTest extends TestCase {
 		$this->assertSame( NodeScope::Value, $this->personNodes()['appellation']?->scope );
 	}
 
-	public function testANodeWithoutALinkDirectionIsLinkedTowardsItself(): void {
+	public function testANodeWithoutALinkDirectionDefaultsToToNode(): void {
 		$this->assertSame( LinkDirection::ToNode, $this->personNodes()['birth']?->linkDirection );
 	}
 
-	public function testDeserializesAReversedNodesLinkDirection(): void {
-		$this->assertSame( LinkDirection::FromNode, $this->aggregationNodes()['aggregation']?->linkDirection );
+	public function testDeserializesAnExplicitToNodeLinkDirection(): void {
+		$this->assertSame( LinkDirection::ToNode, $this->personNodes()['birthTimespan']?->linkDirection );
 	}
 
-	/**
-	 * @return array<string, NodeMapping>
-	 */
-	private function aggregationNodes(): array {
-		return $this->deserialize( <<<'JSON'
-			{
-				"version": 1,
-				"prefixes": {
-					"edm": "http://www.europeana.eu/schemas/edm/",
-					"ore": "http://www.openarchives.org/ore/terms/"
-				},
-				"schemas": {
-					"Artwork": {
-						"subject": { "class": "edm:ProvidedCHO" },
-						"nodes": {
-							"aggregation": {
-								"class": "ore:Aggregation",
-								"linkPredicate": "edm:aggregatedCHO",
-								"linkDirection": "fromNode"
-							}
-						}
-					}
-				}
-			}
-			JSON )->forSchema( new SchemaName( 'Artwork' ) )?->nodes ?? [];
+	public function testDeserializesAReversedNodesLinkDirection(): void {
+		$this->assertSame( LinkDirection::FromNode, $this->personNodes()['death']?->linkDirection );
 	}
 
 	public function testSkipsANodeWithAnUnknownLinkDirection(): void {
@@ -345,12 +322,18 @@ class MappingPersistenceDeserializerTest extends TestCase {
 							"birthTimespan": {
 								"class": "crm:E52_Time-Span",
 								"linkPredicate": "crm:P4_has_time-span",
-								"parent": "birth"
+								"parent": "birth",
+								"linkDirection": "toNode"
 							},
 							"appellation": {
 								"class": "crm:E41_Appellation",
 								"linkPredicate": "crm:P1_is_identified_by",
 								"per": "value"
+							},
+							"death": {
+								"class": "crm:E69_Death",
+								"linkPredicate": "crm:P100_was_death_of",
+								"linkDirection": "fromNode"
 							}
 						},
 						"properties": {

--- a/tests/phpunit/Persistence/MediaWiki/MappingPersistenceDeserializerTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/MappingPersistenceDeserializerTest.php
@@ -163,37 +163,6 @@ class MappingPersistenceDeserializerTest extends TestCase {
 		$this->assertSame( LinkDirection::FromNode, $this->aggregationNodes()['aggregation']?->linkDirection );
 	}
 
-	public function testSkipsANodeWithAnUnknownLinkDirection(): void {
-		// Save validation rejects any other value, but an import can store one. Defaulting it would emit
-		// the node's link triple the wrong way round, so the node goes instead — as it does when its terms
-		// are missing.
-		$nodes = $this->deserialize( <<<'JSON'
-			{
-				"version": 1,
-				"prefixes": { "ore": "http://www.openarchives.org/ore/terms/" },
-				"schemas": {
-					"Artwork": {
-						"subject": { "class": "http://www.europeana.eu/schemas/edm/ProvidedCHO" },
-						"nodes": {
-							"sideways": {
-								"class": "ore:Aggregation",
-								"linkPredicate": "http://www.europeana.eu/schemas/edm/aggregatedCHO",
-								"linkDirection": "eitherWay"
-							},
-							"aggregation": {
-								"class": "ore:Aggregation",
-								"linkPredicate": "http://www.europeana.eu/schemas/edm/aggregatedCHO",
-								"linkDirection": "fromNode"
-							}
-						}
-					}
-				}
-			}
-			JSON )->forSchema( new SchemaName( 'Artwork' ) )?->nodes ?? [];
-
-		$this->assertSame( [ 'aggregation' ], array_keys( $nodes ) );
-	}
-
 	/**
 	 * @return array<string, NodeMapping>
 	 */
@@ -214,14 +183,46 @@ class MappingPersistenceDeserializerTest extends TestCase {
 								"linkPredicate": "edm:aggregatedCHO",
 								"linkDirection": "fromNode"
 							}
-						},
-						"properties": {
-							"Image": { "predicate": "edm:isShownBy", "node": "aggregation" }
 						}
 					}
 				}
 			}
 			JSON )->forSchema( new SchemaName( 'Artwork' ) )?->nodes ?? [];
+	}
+
+	public function testSkipsANodeWithAnUnknownLinkDirection(): void {
+		// Save validation rejects any other value, but an import can store one. Defaulting it would emit
+		// the node's link triple the wrong way round, so the node goes instead — as it does when its terms
+		// are missing.
+		$nodes = $this->deserialize( <<<'JSON'
+			{
+				"version": 1,
+				"prefixes": { "ore": "http://www.openarchives.org/ore/terms/" },
+				"schemas": {
+					"Artwork": {
+						"subject": { "class": "http://www.europeana.eu/schemas/edm/ProvidedCHO" },
+						"nodes": {
+							"forwards": {
+								"class": "ore:Aggregation",
+								"linkPredicate": "http://www.europeana.eu/schemas/edm/aggregatedCHO"
+							},
+							"sideways": {
+								"class": "ore:Aggregation",
+								"linkPredicate": "http://www.europeana.eu/schemas/edm/aggregatedCHO",
+								"linkDirection": "eitherWay"
+							},
+							"backwards": {
+								"class": "ore:Aggregation",
+								"linkPredicate": "http://www.europeana.eu/schemas/edm/aggregatedCHO",
+								"linkDirection": "fromNode"
+							}
+						}
+					}
+				}
+			}
+			JSON )->forSchema( new SchemaName( 'Artwork' ) )?->nodes ?? [];
+
+		$this->assertSame( [ 'forwards', 'backwards' ], array_keys( $nodes ) );
 	}
 
 	public function testSkipsANodeWithoutTheTermsItNeeds(): void {


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/1232

A node in an ontology Mapping takes an optional `linkDirection`. `toNode` — the default, and what omitting the key means — keeps today's `<anchor> <linkPredicate> <node>`; `fromNode` emits `<node> <linkPredicate> <anchor>`. Everything else about a node is unchanged: class triple, lazy emission, parent chains, per-value scoping and IRIs.

The demo `Mapping:EDM` now routes an Artwork's `edm:isShownBy` through an `ore:Aggregation` that points at the CHO — where EDM puts it. The previous placement was a modelling error: `edm:isShownBy` on the CHO formally typed the CHO as an Aggregation.

Boundary: the direction governs the link triple only. A property's own values still run from the node they attach to.

A second commit applies findings from an AI review pass: an exhaustive `match` on the direction, a corrected comment about what the projector actually logs when a node is dropped, and test naming and ordering.

> <sub>AI-authored — Claude Code, `Opus 5 (max)`; detailed spec from @JeroenDeDauw, no redirections; diff not yet human-reviewed; PHPUnit and phpcs/phpstan run locally and green on CI, the new tests seen failing before the change, and the EDM export of the demo Milkmaid page checked against the expected `ore:Aggregation` shape.</sub>
