### PR TITLE
Simplify the service-selection docs

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -64,9 +64,9 @@ Rerunning `make dev` with a different selection reconfigures a running stack: ne
 stop (their volumes survive for reselection) and the wiki's config follows, so a deselected
 store or mail host is never configured. Details:
 
-- Without `node`, `make dev` builds the frontend bundle once in a throwaway container (`dist/` is
-  gitignored), so the UI works; the `ts-*` targets start the watcher on demand if you begin TS work.
-  `make ts-build` refreshes a bundle left stale by a later `git pull`.
+- Without `node`, `make dev` builds the frontend bundle once in a throwaway container, so the UI
+  works; the `ts-*` targets start the watcher on demand. `make ts-build` refreshes a bundle left
+  stale by a later `git pull`.
 - The test-only backends (`test_neo`, `test_qlever`, `test_oxigraph`) are independent of this selection:
   `make phpunit` starts them on demand, and `make test-backends-stop` stops them again.
 - Setting `COMPOSE_PROFILES` directly still works and is unioned with the selection; the profile names
@@ -79,9 +79,6 @@ SPARQL 1.1 graph store by default as a working example of NeoWiki's SPARQL proje
 (issue #586). The bundled Makefile passes the store's endpoint to the wiki as `QLEVER_URL`.
 `SettingsTemplate.php` points `$wgNeoWikiSparqlStores` at that endpoint, so every page save and
 `RebuildGraphDatabases.php` also projects the page's RDF into QLever as named graphs.
-
-On the dev stack, you can deselect QLever with `services=` (see [Optional services](#optional-services)), which
-leaves `QLEVER_URL` empty.
 
 Two entries point at that one endpoint: the `native` projection and the `EDM` one defined
 by the demo data's `Mapping:EDM` page. Each writes its own per-page named graphs, so one
@@ -143,9 +140,8 @@ default, so it sits behind the `oxigraph` compose profile and neither stack star
 COMPOSE_PROFILES=oxigraph make dev
 ```
 
-This only holds for that invocation: `COMPOSE_PROFILES` is not persisted, so a later plain `make dev`
-deselects Oxigraph again and stops it (its data volume survives for reselection). Pass
-`COMPOSE_PROFILES=oxigraph` again each time you want it running.
+`COMPOSE_PROFILES` is not persisted: a later plain `make dev` deselects Oxigraph again and stops it,
+though its data volume survives.
 
 `SettingsTemplate.php` points `$wgNeoWikiSparqlStores` at `QLEVER_URL`, so nothing reaches Oxigraph until
 you repoint it: `updateUrl` `http://oxigraph:7878/update`, `queryUrl` `http://oxigraph:7878/query`. On the
@@ -202,16 +198,14 @@ report the backends as missing instead of starting them.
   production `php.ini`; intermediate, no `LocalSettings.php`), `final-mw` (the prebuilt
   demo image published as `ghcr.io/professionalwiki/neowiki:latest`, which bakes in
   `LocalSettings.php`), and `dev-mw` (the dev image with mounted NeoWiki source).
-- `docker-compose.yml` — the demo stack's services `mediawiki`, `db`, `neo` and `qlever` (the
-  SPARQL store, see above, unconditional so raw `docker compose` and the `--profile server`
-  deployment always get it) plus the profile-gated `caddy` (the `server` profile, for HTTPS
-  hosting) and `oxigraph` (the `oxigraph` profile, the second SPARQL store, see above). The dev
-  overlay builds on this file, so these services are in both stacks.
+- `docker-compose.yml` — the demo stack's services (`mediawiki`, `db`, `neo`, `qlever`
+  — SPARQL store, see above) plus the profile-gated `caddy` (the `server` profile, for
+  HTTPS hosting) and `oxigraph` (the `oxigraph` profile, the second SPARQL store, see
+  above). The dev overlay builds on this file, so these services are in both stacks.
 - `docker-compose.dev.yml` — dev overlay; switches `mediawiki` to the dev image, bind-mounts the
-  NeoWiki source, sets `MW_MODE=dev`, and adds a `qlever` profile onto that base-file service plus
-  the dev-only sidecars `node` and `mailcatcher`, each behind its own profile so `services=` (see
-  [Optional services](#optional-services)) can select or deselect them, plus `test_neo`,
-  `test_qlever` and `test_oxigraph` behind the `test` profile.
+  NeoWiki source, sets `MW_MODE=dev`, adds the dev-only sidecars `node` and `mailcatcher`, and gates
+  them plus `qlever` behind their `services=` profiles (see [Optional services](#optional-services));
+  `test_neo`, `test_qlever` and `test_oxigraph` sit behind the `test` profile.
 - `docker-compose.tools.yml` — opt-in overlay that exposes Neo4j, QLever and Oxigraph to the
   host, usable with either stack.
 - `SettingsTemplate.php` — `LocalSettings.php` that branches on `MW_MODE`.

--- a/Docker/SettingsTemplate.php
+++ b/Docker/SettingsTemplate.php
@@ -229,16 +229,15 @@ $wgNeoWikiNeo4jInternalWriteUrl = 'bolt://' . getenv( 'NEO4J_USERNAME' ) . ':' .
 $wgNeoWikiNeo4jInternalReadUrl = 'bolt://' . getenv( 'NEO4J_USERNAME_READ' ) . ':' . getenv( 'NEO4J_PASSWORD_READ' ) . '@neo:7687';
 
 // SPARQL graph store (QLever) for the SPARQL projection plugin (#586). Both the demo stack and the
-// dev stack run the qlever service defined in docker-compose.yml by default and are pointed at its
-// endpoint below via QLEVER_URL. A non-empty value is the gate: an image started outside those stacks
-// gets QLEVER_URL unset rather than a configuration pointing at a host that does not exist, and so does
-// CI, whose docker-compose.ci.yml replaces that file and sets neither variable; the dev stack's bundled
-// Makefile sets QLEVER_URL to the empty string instead when its `services=` selection deselects qlever,
-// which disables this configuration the same way being unset does. The access token is an ordinary
-// optional credential, defaulted in the compose file so a Docker/.env written before it existed still
-// yields a working store. Skipped under PHPUnit so integration tests never post updates here — they
-// configure their own stores with mocked HTTP via overrideConfigValue(), so the default must stay empty
-// during tests.
+// dev stack run the qlever service defined in docker-compose.yml by default and point the wiki at
+// its endpoint via QLEVER_URL. A non-empty value is the gate: an image started outside those stacks
+// gets QLEVER_URL unset rather than a configuration pointing at a host that does not exist, and so
+// does CI, whose docker-compose.ci.yml replaces that file and sets neither variable. The dev stack's
+// Makefile sets it to the empty string when `services=` deselects qlever, which disables the
+// configuration the same way. The access token is an ordinary optional credential, defaulted in the
+// compose file so a Docker/.env written before it existed still yields a working store. Skipped
+// under PHPUnit so integration tests never post updates here — they configure their own stores with
+// mocked HTTP via overrideConfigValue(), so the default must stay empty during tests.
 //
 // Two entries, one endpoint: the native projection and the EDM projection of the demo data's
 // Mapping:EDM page are kept in the same QLever index as sibling projections. Each lands in its own

--- a/Docker/docker-compose.dev.yml
+++ b/Docker/docker-compose.dev.yml
@@ -50,12 +50,10 @@ services:
     command: --innodb-buffer-pool-size=128M
     mem_limit: 512m
 
-  # `qlever` itself is defined in the base file (docker-compose.yml) and runs unconditionally
-  # there, so the demo stack and raw `docker compose` invocations always get it. Only the dev
-  # stack supports deselecting optional services via `services=`, so this overlay adds the
-  # `qlever` profile here rather than in the base file — the bundled Makefile enables it by
-  # default (see the Optional services comment there), so `make dev` keeps QLever on unless
-  # `services=` deselects it.
+  # `qlever` is defined in the base file (docker-compose.yml) and runs unconditionally there, so
+  # the demo stack and raw `docker compose` invocations always get it. Only the dev stack supports
+  # `services=` selection, so the profile gating it goes in this overlay, not the base file. The
+  # Makefile selects it by default, so `make dev` keeps QLever on unless `services=` deselects it.
   qlever:
     profiles:
       - qlever

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -24,9 +24,8 @@ services:
       # Endpoint of the qlever service below; a non-empty value is what makes
       # SettingsTemplate.php configure $wgNeoWikiSparqlStores. The bundled Makefile
       # owns the value: the qlever endpoint when the service is selected, empty
-      # ("disabled") when deselected. Running this file without the Makefile leaves
-      # it unset, which matches the qlever profile not being active: no store runs
-      # and none is configured.
+      # ("disabled") when deselected. Without the Makefile it is unset and no
+      # store is configured.
       - QLEVER_URL
       # Bearer token the wiki sends to authorize SPARQL updates. Defaulted here instead of being
       # required from Docker/.env, so a .env written before the variable existed still works; the
@@ -77,13 +76,10 @@ services:
 
   # SPARQL 1.1 graph store (QLever) for the SPARQL projection plugin (#586), as a working example
   # of NeoWiki's SPARQL projection: every page save and RebuildGraphDatabases.php also projects the
-  # page's RDF here as named graphs, and the query surfaces read from it. Unconditional here, so raw
-  # `docker compose` invocations (and the `--profile server` demo deployment) always get it. The dev
-  # overlay (docker-compose.dev.yml) adds a `qlever` profile to this same service, gating it behind
-  # `services=` there — see the comment on that override. The wiki is pointed at it by QLEVER_URL
-  # above; the bundled Makefile clears that variable when the dev-overlay profile is deselected, so a
-  # deselected wiki does not try to reach a store that is not running. NeoWiki reaches it in-network
-  # as http://qlever:7019/; a host port for manual inspection is opt-in via docker-compose.tools.yml.
+  # page's RDF here as named graphs, and the query surfaces read from it. The wiki is pointed at it
+  # by QLEVER_URL above. Unconditional in this file; the dev overlay gates it behind a `qlever`
+  # profile for `services=` selection — see the comment there. NeoWiki reaches it in-network as
+  # http://qlever:7019/; a host port for manual inspection is opt-in via docker-compose.tools.yml.
   qlever:
     image: docker.io/adfreiburg/qlever:latest
     restart: unless-stopped

--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,8 @@ $(error Unknown services '$(UNKNOWN_SERVICES)'. Valid: $(subst $(space),$(comma)
 endif
 endif
 
-# The union drives every compose invocation via the global `export` above. Defined ahead of the
-# derived values below so they can all filter against this one set instead of open-coding
-# $(SELECTED_SERVICES) $(USER_PROFILES) at each site.
+# The union drives every compose invocation via the global `export` above. Defined before the
+# derived values below, which filter against it.
 ACTIVE_PROFILES := $(sort $(USER_PROFILES) $(SELECTED_SERVICES))
 COMPOSE_PROFILES := $(subst $(space),$(comma),$(strip $(ACTIVE_PROFILES)))
 


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1260; merges into its branch (`dev-stack-service-selection`). Docs and comments only, no behavior change.

One change is deliberately not meaning-preserving: the `QLEVER_URL` env comment claimed "no store runs and none is configured" for non-Makefile invocations, but the base file's `qlever` has no profile, so the store does run there. The comment now claims only that no store is configured. Whether raw base-file invocations (e.g. the documented tools-overlay command) should keep a configured store is a question for the parent PR, not a blocker here.

The parent PR restated its design story — qlever unconditional in the base file, profile-gated in the dev overlay, `QLEVER_URL` owned by the Makefile — across both compose files, `SettingsTemplate.php` and the README. Each fact now has one home (placement: the dev-overlay override comment, the spot a future cleanup would edit; `QLEVER_URL` semantics: the base file's env comment) and the other sites shrink to pointers or plain inventory. Also:

- Dropped the QLever section's deselection paragraph (restates Optional services, one screen up) and two redundant clauses in Optional services.
- Collapsed Oxigraph's caveat paragraph to one sentence.
- Split `SettingsTemplate.php`'s run-on gate sentence; cut Makefile diff-narration.

Considered, omitted: restating the `COMPOSE_PROFILES`-unions-with-`services=` contract in the Oxigraph section (Optional services owns it). Considered cutting, kept: the fourth `services=` example, the "profile names equal the service names" clause, and the `DESELECTED_SERVICES` invariant comment.

> <sub>AI-authored — Claude Code, `Fable 5 (max)`; one-line ask from @JeroenDeDauw (simplify #1260's docs) after an in-session review, no redirects; diff not yet human-reviewed; fresh-context reviewer checked meaning-invariance, anchors and inbound links; selection-script tests green.</sub>