### PR TITLE
Answer 400 instead of 500-ing or deleting on a misshapen Statement write

### DIFF
--- a/docs/api/subject-format.md
+++ b/docs/api/subject-format.md
@@ -195,7 +195,7 @@ Subject's label and its other Statements as they are:
 
 | Field | Required | Notes |
 |-------|----------|-------|
-| `statement` | Yes | A [Statement object](#statement-object). `propertyType` may be omitted, and then takes the type the Subject's Schema currently gives the property; a property the Schema does not define is rejected with `400`. A value that is empty for its type removes the Statement. |
+| `statement` | Yes | A [Statement object](#statement-object) carrying a `value`. `propertyType` may be omitted, and then takes the type the Subject's Schema currently gives the property; a property the Schema does not define is rejected with `400`. A value that is empty for its type removes the Statement. |
 | `comment` | No | Edit summary. |
 
 `DELETE` on the same path removes the Statement and takes only `comment`. Removing a Statement the Subject does

--- a/src/Application/Actions/UpdateStatement/UpdateStatementAction.php
+++ b/src/Application/Actions/UpdateStatement/UpdateStatementAction.php
@@ -46,18 +46,20 @@ readonly class UpdateStatementAction {
 	}
 
 	/**
-	 * @param string|null $propertyType The writer's type for the value. Falls back to the type the
-	 *  Subject's Schema currently gives the property.
+	 * @param mixed $propertyType The writer's type for the value, as the caller supplied it. Falls
+	 *  back to the type the Subject's Schema currently gives the property when null. Taken raw
+	 *  rather than as a string because the request body it comes from is unvalidated below its top
+	 *  level; the builder rejects anything that is not a string.
 	 *
-	 * @throws InvalidArgumentException When no property type is given and none can be derived,
-	 *  or when a select value cannot be resolved.
+	 * @throws InvalidArgumentException When the property type is not a string, when none is given
+	 *  and none can be derived, or when a select value cannot be resolved.
 	 * @throws SubjectNotFoundException
 	 * @throws SubjectEditNotAuthorizedException
 	 */
 	public function setStatement(
 		SubjectId $subjectId,
 		PropertyName $propertyName,
-		?string $propertyType,
+		mixed $propertyType,
 		mixed $value,
 		?string $comment
 	): void {
@@ -135,7 +137,7 @@ readonly class UpdateStatementAction {
 	private function buildStatement(
 		?Schema $schema,
 		PropertyName $propertyName,
-		?string $propertyType,
+		mixed $propertyType,
 		mixed $value
 	): ?Statement {
 		$statements = [

--- a/src/Application/SelectStatementResolver.php
+++ b/src/Application/SelectStatementResolver.php
@@ -62,11 +62,11 @@ readonly class SelectStatementResolver {
 				continue;
 			}
 
-			if ( !$schema->hasProperty( $propertyName ) ) {
+			if ( !$schema->hasProperty( (string)$propertyName ) ) {
 				continue;
 			}
 
-			$property = $schema->getProperty( $propertyName );
+			$property = $schema->getProperty( (string)$propertyName );
 
 			if ( !$property instanceof SelectProperty ) {
 				continue;
@@ -137,11 +137,11 @@ readonly class SelectStatementResolver {
 				continue;
 			}
 
-			if ( !$schema->hasProperty( $propertyName ) ) {
+			if ( !$schema->hasProperty( (string)$propertyName ) ) {
 				continue;
 			}
 
-			$property = $schema->getProperty( $propertyName );
+			$property = $schema->getProperty( (string)$propertyName );
 
 			if ( !$property instanceof SelectProperty ) {
 				continue;

--- a/src/Application/StatementListBuilder.php
+++ b/src/Application/StatementListBuilder.php
@@ -110,6 +110,8 @@ readonly class StatementListBuilder {
 		foreach ( $json as $relation ) {
 			// Skipping an entry that is not a relation object would turn a list of bare target
 			// ids into an empty value, which the write paths read as the Statement being absent.
+			// Raised as a TypeError so it reaches the caller as the same bad-value report the
+			// constructors below produce for every other misshapen relation.
 			if ( !is_array( $relation ) ) {
 				throw new TypeError( 'Relation entry must be an object' );
 			}

--- a/src/Application/StatementListBuilder.php
+++ b/src/Application/StatementListBuilder.php
@@ -57,7 +57,7 @@ readonly class StatementListBuilder {
 			}
 
 			$built[$propertyName] = new Statement(
-				property: new PropertyName( $propertyName ),
+				property: new PropertyName( (string)$propertyName ),
 				propertyType: $propertyType,
 				value: $value
 			);
@@ -72,6 +72,17 @@ readonly class StatementListBuilder {
 	private function deserializeValue( string $propertyName, string $propertyType, mixed $value ): NeoValue {
 		$valueType = $this->propertyTypeLookup->getType( $propertyType )?->getValueType()
 			?? ValueType::UnregisteredType;
+
+		// A JSON object reaches the list-shaped types as named arguments rather than as a type
+		// error: it would be stored as an object where every reader expects a list, and the graph
+		// projection cannot hold one. The value types cannot tell it apart from a list, so it is
+		// rejected before they see it.
+		if ( in_array( $valueType, [ ValueType::String, ValueType::Relation ], true )
+			&& is_array( $value ) && !array_is_list( $value ) ) {
+			throw new InvalidArgumentException(
+				"Value of \"{$propertyName}\" must be a list, not an object"
+			);
+		}
 
 		// The value types below declare what each shape accepts, so a value of the wrong shape
 		// arrives here as a TypeError. Every one of them comes from the caller's value, never from
@@ -97,13 +108,17 @@ readonly class StatementListBuilder {
 		$relations = [];
 
 		foreach ( $json as $relation ) {
-			if ( is_array( $relation ) ) {
-				$relations[] = new Relation(
-					id: $this->buildRelationId( $relation ),
-					targetId: new SubjectId( $relation['target'] ?? null ),
-					properties: new RelationProperties( $relation['properties'] ?? [] )
-				);
+			// Skipping an entry that is not a relation object would turn a list of bare target
+			// ids into an empty value, which the write paths read as the Statement being absent.
+			if ( !is_array( $relation ) ) {
+				throw new TypeError( 'Relation entry must be an object' );
 			}
+
+			$relations[] = new Relation(
+				id: $this->buildRelationId( $relation ),
+				targetId: new SubjectId( $relation['target'] ?? null ),
+				properties: new RelationProperties( $relation['properties'] ?? [] )
+			);
 		}
 
 		return new RelationValue( ...$relations );

--- a/src/Application/StatementListBuilder.php
+++ b/src/Application/StatementListBuilder.php
@@ -45,6 +45,11 @@ readonly class StatementListBuilder {
 			}
 
 			$propertyType = $entry['propertyType'];
+
+			if ( !is_string( $propertyType ) ) {
+				throw new InvalidArgumentException( "Property type of \"{$propertyName}\" must be a string" );
+			}
+
 			$value = $this->deserializeValue( (string)$propertyName, $propertyType, $entry['value'] ?? null );
 
 			if ( $value->isEmpty() ) {

--- a/src/EntryPoints/REST/SetStatementApi.php
+++ b/src/EntryPoints/REST/SetStatementApi.php
@@ -33,6 +33,16 @@ class SetStatementApi extends SimpleHandler {
 		$body = $this->getValidatedBody();
 		$statement = $body['statement'];
 
+		// The body validator types `statement` but nothing inside it, so the value has to be
+		// required here. Without this, an absent value reads as an empty one and removes the
+		// Statement, so a client that drops the key is told its write succeeded.
+		if ( !array_key_exists( 'value', $statement ) ) {
+			return $this->getResponseFactory()->createHttpError( 400, [
+				'status' => 'error',
+				'message' => 'The "statement" parameter must have a "value".',
+			] );
+		}
+
 		$presenter = new RestUpdateStatementPresenter();
 
 		try {

--- a/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectUpdater.php
+++ b/src/GraphDatabasePlugins/Neo4j/Persistence/Neo4jSubjectUpdater.php
@@ -112,14 +112,16 @@ class Neo4jSubjectUpdater {
 	 * @return array<string, mixed>
 	 */
 	private function nodeProperties( Subject $subject ): array {
-		return array_merge(
-			$this->statementsToNodeProperties( $subject->getStatements() ),
-			[
-				'name' => $subject->label->text,
-				'id' => $subject->id->text,
-				'wiki_id' => $this->wikiId,
-			]
-		);
+		$properties = $this->statementsToNodeProperties( $subject->getStatements() );
+
+		// Assigned rather than array_merge()d: a property named like a decimal integer is an int
+		// key by then, and array_merge() renumbers those, which would file its value under a
+		// different property name.
+		$properties['name'] = $subject->label->text;
+		$properties['id'] = $subject->id->text;
+		$properties['wiki_id'] = $this->wikiId;
+
+		return $properties;
 	}
 
 	/**

--- a/src/Persistence/MediaWiki/Subject/SubjectContentDataDeserializer.php
+++ b/src/Persistence/MediaWiki/Subject/SubjectContentDataDeserializer.php
@@ -67,7 +67,8 @@ class SubjectContentDataDeserializer {
 
 		foreach ( $jsonArray['statements'] ?? [] as $propertyName => $value ) {
 			if ( $value !== null ) {
-				$statements[] = $this->statementDeserializer->deserialize( $propertyName, $value );
+				// A property named like a decimal integer comes back from json_decode as an int key.
+				$statements[] = $this->statementDeserializer->deserialize( (string)$propertyName, $value );
 			}
 		}
 

--- a/tests/phpunit/Application/SelectStatementResolverTest.php
+++ b/tests/phpunit/Application/SelectStatementResolverTest.php
@@ -26,11 +26,15 @@ class SelectStatementResolverTest extends TestCase {
 	}
 
 	private function newSchemaWithSelect( bool $multiple = false ): Schema {
+		return $this->newSchemaWithSelectNamed( 'Status', $multiple );
+	}
+
+	private function newSchemaWithSelectNamed( string $propertyName, bool $multiple ): Schema {
 		return new Schema(
 			name: new SchemaName( 'SomeSchema' ),
 			description: '',
 			properties: new PropertyDefinitions( [
-				'Status' => new SelectProperty(
+				$propertyName => new SelectProperty(
 					core: new PropertyCore( description: '', required: false, default: null ),
 					options: [
 						new SelectOption( id: 'opt1', label: 'Draft' ),
@@ -134,6 +138,30 @@ class SelectStatementResolverTest extends TestCase {
 		$resolved = $this->newResolver()->resolve( $this->newSchemaWithSelect(), $patch );
 
 		$this->assertSame( $patch, $resolved );
+	}
+
+	/**
+	 * PHP turns a decimal-integer array key into an int, so a select property named like a year
+	 * reaches the Schema lookups as one.
+	 */
+	public function testResolvesValueOfPropertyNamedLikeAnInteger(): void {
+		$patch = [
+			'2024' => [ 'propertyType' => 'select', 'value' => 'Draft' ],
+		];
+
+		$resolved = $this->newResolver()->resolve( $this->newSchemaWithSelectNamed( '2024', false ), $patch );
+
+		$this->assertSame( 'opt1', $resolved['2024']['value'] );
+	}
+
+	public function testResolveOrLeaveResolvesValueOfPropertyNamedLikeAnInteger(): void {
+		$patch = [
+			'2024' => [ 'propertyType' => 'select', 'value' => 'Draft' ],
+		];
+
+		$resolved = $this->newResolver()->resolveOrLeave( $this->newSchemaWithSelectNamed( '2024', false ), $patch );
+
+		$this->assertSame( 'opt1', $resolved['2024']['value'] );
 	}
 
 	public function testResolveOrLeaveResolvesKnownLabelToId(): void {

--- a/tests/phpunit/Application/StatementListBuilderTest.php
+++ b/tests/phpunit/Application/StatementListBuilderTest.php
@@ -113,6 +113,25 @@ class StatementListBuilderTest extends TestCase {
 	}
 
 	/**
+	 * @dataProvider nonStringPropertyTypeProvider
+	 */
+	public function testNonStringPropertyTypeIsRejected( mixed $propertyType ): void {
+		$builder = $this->newBuilder();
+
+		$this->expectException( InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'Mistyped' );
+
+		$builder->build( [ 'Mistyped' => [ 'propertyType' => $propertyType, 'value' => 'yes' ] ] );
+	}
+
+	public static function nonStringPropertyTypeProvider(): iterable {
+		yield 'number' => [ 2019 ];
+		yield 'boolean' => [ true ];
+		yield 'array' => [ [ 'text' ] ];
+		yield 'object' => [ [ 'name' => 'text' ] ];
+	}
+
+	/**
 	 * The legacy `type` key is tolerated when reading stored revisions, never on API input:
 	 * accepting both here would restore the ambiguity the rename removed.
 	 */

--- a/tests/phpunit/Application/StatementListBuilderTest.php
+++ b/tests/phpunit/Application/StatementListBuilderTest.php
@@ -110,6 +110,7 @@ class StatementListBuilderTest extends TestCase {
 		yield 'boolean given a string' => [ 'boolean', 'yes' ];
 		yield 'relation given a scalar' => [ 'relation', 'sTargetIdWanted' ];
 		yield 'relation target missing' => [ 'relation', [ [ 'properties' => [] ] ] ];
+		yield 'relation given a list of bare target ids' => [ 'relation', [ 'sTargetIdWanted' ] ];
 	}
 
 	/**
@@ -129,6 +130,40 @@ class StatementListBuilderTest extends TestCase {
 		yield 'boolean' => [ true ];
 		yield 'array' => [ [ 'text' ] ];
 		yield 'object' => [ [ 'name' => 'text' ] ];
+	}
+
+	/**
+	 * PHP turns a decimal-integer array key into an int, so a property named like a year
+	 * reaches the value objects as one.
+	 */
+	public function testPropertyNameThatLooksLikeAnIntegerIsBuilt(): void {
+		$list = $this->newBuilder()->build( [ '2024' => [ 'propertyType' => 'text', 'value' => 'yes' ] ] );
+
+		$this->assertSame(
+			[ 'yes' ],
+			$list->getStatement( new PropertyName( '2024' ) )?->getValue()->toScalars()
+		);
+	}
+
+	/**
+	 * @dataProvider objectWhereAListIsExpectedProvider
+	 */
+	public function testObjectValueWhereAListIsExpectedIsRejected( string $propertyType, mixed $value ): void {
+		$builder = $this->newBuilder();
+
+		$this->expectException( InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'Objected' );
+
+		$builder->build( [ 'Objected' => [ 'propertyType' => $propertyType, 'value' => $value ] ] );
+	}
+
+	public static function objectWhereAListIsExpectedProvider(): iterable {
+		yield 'text given an object' => [ 'text', [ 'a' => 'yes' ] ];
+		yield 'url given an object' => [ 'url', [ 'a' => 'https://pro.wiki' ] ];
+		yield 'relation given one relation rather than a list' => [
+			'relation',
+			[ 'target' => 'sTargetIdWanted' ],
+		];
 	}
 
 	/**

--- a/tests/phpunit/EntryPoints/REST/RemoveStatementApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/RemoveStatementApiTest.php
@@ -4,8 +4,10 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\REST;
 
+use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Rest\RequestData;
 use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
+use MediaWiki\Title\Title;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
@@ -201,6 +203,48 @@ class RemoveStatementApiTest extends NeoWikiIntegrationTestCase {
 		);
 
 		$this->assertSame( 200, $response->getStatusCode() );
+	}
+
+	public function testCommentBecomesTheEditSummary(): void {
+		$this->createSubjectPage();
+
+		$this->executeHandler(
+			$this->newRemoveStatementApi(),
+			$this->newRequest( 'Website', [ 'comment' => 'My edit summary' ] )
+		);
+
+		$this->assertSame(
+			'My edit summary',
+			$this->latestRevisionOfSubjectPage()->getComment()?->text
+		);
+	}
+
+	private function latestRevisionOfSubjectPage(): RevisionRecord {
+		$revision = $this->getServiceContainer()->getRevisionLookup()->getRevisionByTitle(
+			Title::newFromText( 'RemoveStatementApiTest' )
+		);
+
+		$this->assertNotNull( $revision );
+		return $revision;
+	}
+
+	public function testUpdatedResponseOmitsTheSchemaWhenTheSchemaIsMissing(): void {
+		$this->createSubjectPage();
+		$this->deletePage(
+			$this->getServiceContainer()->getWikiPageFactory()->newFromTitle(
+				Title::newFromText( 'RemoveStatementSchema', NeoWikiExtension::NS_SCHEMA )
+			)
+		);
+
+		$response = $this->executeHandler(
+			$this->newRemoveStatementApi(),
+			$this->newRequest( 'Website' )
+		);
+
+		$responseData = json_decode( $response->getBody()->getContents(), true );
+
+		$this->assertArrayHasKey( 'subject', $responseData );
+		$this->assertArrayNotHasKey( 'schema', $responseData );
 	}
 
 	public function testEnforcementBlocksRemovingARequiredStatement(): void {

--- a/tests/phpunit/EntryPoints/REST/RemoveStatementApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/RemoveStatementApiTest.php
@@ -236,6 +236,8 @@ class RemoveStatementApiTest extends NeoWikiIntegrationTestCase {
 			)
 		);
 
+		$this->startFreshRequest();
+
 		$response = $this->executeHandler(
 			$this->newRemoveStatementApi(),
 			$this->newRequest( 'Website' )

--- a/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
@@ -456,6 +456,21 @@ class ReplaceSubjectApiTest extends NeoWikiIntegrationTestCase {
 		$this->assertSame( [], $this->getSubjectFromRepository( 'sTestSA11111111' )->getStatements()->asArray() );
 	}
 
+	public function testNonStringPropertyTypeReturns400(): void {
+		$this->createPages();
+
+		$body = $this->validBody();
+		$body['statements'] = [ 'Founded at' => [ 'propertyType' => [ 'number' ], 'value' => 2019 ] ];
+
+		$response = $this->executeHandler(
+			$this->newReplaceSubjectApi(),
+			$this->createRequestData( $body )
+		);
+
+		$this->assertSame( 400, $response->getStatusCode() );
+		$this->assertSame( [], $this->getSubjectFromRepository( 'sTestSA11111111' )->getStatements()->asArray() );
+	}
+
 	public function testReadableButNotEditablePageReturns403(): void {
 		$this->createPages();
 

--- a/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
@@ -129,6 +129,7 @@ class ReplaceSubjectApiTest extends NeoWikiIntegrationTestCase {
 				Title::newFromText( 'GoneSchema', NeoWikiExtension::NS_SCHEMA )
 			)
 		);
+		$this->startFreshRequest();
 
 		$response = $this->executeHandler(
 			$this->newReplaceSubjectApi(),
@@ -356,6 +357,7 @@ class ReplaceSubjectApiTest extends NeoWikiIntegrationTestCase {
 				Title::newFromText( 'OrphanSchema', NeoWikiExtension::NS_SCHEMA )
 			)
 		);
+		$this->startFreshRequest();
 
 		$response = $this->executeHandler(
 			$this->newReplaceSubjectApi(),

--- a/tests/phpunit/EntryPoints/REST/SetStatementApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/SetStatementApiTest.php
@@ -260,6 +260,30 @@ class SetStatementApiTest extends NeoWikiIntegrationTestCase {
 		$this->assertNull( $this->getStoredValue( 'Founded at' ) );
 	}
 
+	/**
+	 * The body validator types `statement` but not the keys inside it, so a non-string
+	 * `propertyType` reaches the action unchecked.
+	 *
+	 * @dataProvider nonStringPropertyTypeProvider
+	 */
+	public function testNonStringPropertyTypeReturns400( mixed $propertyType ): void {
+		$this->createSubjectPage();
+
+		$response = $this->executeHandler(
+			$this->newSetStatementApi(),
+			$this->newRequest( 'Website', [ 'statement' => [ 'propertyType' => $propertyType, 'value' => [ 'https://pro.wiki' ] ] ] )
+		);
+
+		$this->assertSame( 400, $response->getStatusCode() );
+		$this->assertNull( $this->getStoredValue( 'Website' ) );
+	}
+
+	public static function nonStringPropertyTypeProvider(): iterable {
+		yield 'number' => [ 2019 ];
+		yield 'boolean' => [ true ];
+		yield 'array' => [ [ 'url' ] ];
+	}
+
 	public function testStatementWithoutAValueReturns400(): void {
 		$this->createSubjectPage();
 

--- a/tests/phpunit/EntryPoints/REST/SetStatementApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/SetStatementApiTest.php
@@ -284,6 +284,58 @@ class SetStatementApiTest extends NeoWikiIntegrationTestCase {
 		yield 'array' => [ [ 'url' ] ];
 	}
 
+	/**
+	 * A property named like a year is ordinary, and the name reaches the write path as an array
+	 * key, which PHP hands on as an int.
+	 */
+	public function testPropertyNameThatLooksLikeAnIntegerIsStored(): void {
+		$this->createSubjectPage();
+
+		$response = $this->executeHandler(
+			$this->newSetStatementApi(),
+			$this->newRequest( '2024', [ 'statement' => [ 'propertyType' => 'url', 'value' => [ 'https://pro.wiki' ] ] ] )
+		);
+
+		$this->assertSame( 200, $response->getStatusCode() );
+		$this->assertSame( [ 'https://pro.wiki' ], $this->getStoredValue( '2024' ) );
+	}
+
+	/**
+	 * A JSON object unpacks into the value objects as named arguments, so it used to be stored as
+	 * an object where every reader expects a list.
+	 */
+	public function testObjectValueWhereAListIsExpectedReturns400(): void {
+		$this->createSubjectPage( new StatementList( [
+			TestStatement::build( property: 'Website', value: 'https://pro.wiki', propertyType: 'url' ),
+		] ) );
+
+		$response = $this->executeHandler(
+			$this->newSetStatementApi(),
+			$this->newRequest( 'Website', [ 'statement' => [ 'propertyType' => 'url', 'value' => [ 'a' => 'https://evil.example' ] ] ] )
+		);
+
+		$this->assertSame( 400, $response->getStatusCode() );
+		$this->assertSame( [ 'https://pro.wiki' ], $this->getStoredValue( 'Website' ) );
+	}
+
+	/**
+	 * Without a value there is nothing to set. Treating the absent key as an empty value would
+	 * delete the Statement and answer 200, so a client that drops the key loses data silently.
+	 */
+	public function testStatementWithoutAValueKeyLeavesTheStatementAlone(): void {
+		$this->createSubjectPage( new StatementList( [
+			TestStatement::build( property: 'Website', value: 'https://pro.wiki', propertyType: 'url' ),
+		] ) );
+
+		$response = $this->executeHandler(
+			$this->newSetStatementApi(),
+			$this->newRequest( 'Website', [ 'statement' => [ 'propertyType' => 'url' ] ] )
+		);
+
+		$this->assertSame( 400, $response->getStatusCode() );
+		$this->assertSame( [ 'https://pro.wiki' ], $this->getStoredValue( 'Website' ) );
+	}
+
 	public function testStatementWithoutAValueReturns400(): void {
 		$this->createSubjectPage();
 

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/NumericPropertyNameProjectionTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Persistence/NumericPropertyNameProjectionTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\GraphDatabasePlugins\Neo4j\Persistence;
+
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestStatement;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+
+/**
+ * A property named like a decimal integer is an int array key by the time the node property map is
+ * assembled, so combining it with the map's fixed entries must not renumber it onto another name.
+ *
+ * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jSubjectUpdater
+ * @group Database
+ */
+class NumericPropertyNameProjectionTest extends NeoWikiIntegrationTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->setUpNeo4j();
+		$this->createSchema( 'NumericPropertyNameSchema' );
+	}
+
+	public function testPropertyNamedLikeAnIntegerKeepsItsNameInTheGraph(): void {
+		$this->createPageWithSubjectNamedProperty();
+
+		$this->assertSame(
+			[ 'yes' ],
+			$this->readSubjectProperty( '2024' )
+		);
+	}
+
+	public function testPropertyNamedLikeAnIntegerDoesNotDisplaceTheFixedNodeProperties(): void {
+		$this->createPageWithSubjectNamedProperty();
+
+		$this->assertSame( 'Numbered subject', $this->readSubjectProperty( 'name' ) );
+	}
+
+	private function createPageWithSubjectNamedProperty(): void {
+		$this->createPageWithSubjects(
+			'NumericPropertyNameTest',
+			mainSubject: TestSubject::build(
+				id: 'sTestNP11111111',
+				label: new SubjectLabel( 'Numbered subject' ),
+				schemaName: new SchemaName( 'NumericPropertyNameSchema' ),
+				statements: new StatementList( [
+					TestStatement::build( property: '2024', value: 'yes', propertyType: 'text' ),
+				] ),
+			)
+		);
+	}
+
+	private function readSubjectProperty( string $propertyName ): mixed {
+		$result = $this->readGraph(
+			'MATCH (subject:Subject {id: $id}) RETURN subject[$property] AS value',
+			[ 'id' => 'sTestNP11111111', 'property' => $propertyName ]
+		);
+
+		return $result->first()->toRecursiveArray()['value'];
+	}
+
+}

--- a/tests/phpunit/NeoWikiIntegrationTestCase.php
+++ b/tests/phpunit/NeoWikiIntegrationTestCase.php
@@ -358,6 +358,16 @@ class NeoWikiIntegrationTestCase extends MediaWikiIntegrationTestCase {
 		);
 	}
 
+	/**
+	 * Drops the state a real request would not inherit: MediaWiki's services, and the extension
+	 * singleton that pins the Schema lookup and its caches. A test that changes a page and then
+	 * reads it back otherwise depends on every cache in this process having noticed the change.
+	 */
+	protected function startFreshRequest(): void {
+		$this->resetServices();
+		NeoWikiExtension::resetInstance();
+	}
+
 	protected function readGraph( string $cypher, array $parameters = [] ): SummarizedResult {
 		return NeoWikiExtension::getInstance()->requireNeo4jPlugin()->getReadQueryEngine()->runReadQuery( $cypher, $parameters );
 	}


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1216

Review fixes for #1216. Each is a request shape the new endpoints answer wrongly today, found by review and
reproduced over HTTP against a dev stack before and after the fix.

<img width="1366" height="272" alt="image" src="https://github.com/user-attachments/assets/14128935-4907-4d90-baf0-2c1291a695e5" />


## Answered 500

* **A property type that is not a string.** `{"statement": {"propertyType": 123, …}}`. MediaWiki's body validator
  types the declared fields but nothing inside them, so it reached `?string` parameters. Also reachable through
  `PUT /subject/{subjectId}`.
* **A property name PHP reads as a decimal integer**, e.g. `.../statements/2024`. Property names travel as array
  keys, which PHP casts to `int`, and `PropertyName`, `Schema` and `StatementDeserializer` are typed. The last of
  those sits on the read-back path, so the write would have persisted a revision that could no longer be
  deserialized.

## Answered 200 after removing the Statement

Each of these reached the write path as an empty value, which the write paths read as the Statement being absent,
so a request meaning *set this* removed it and reported success:

* a JSON object where a list belongs — it unpacks into the value objects as named arguments instead of raising a
  type error, and was stored as an object no reader and no graph store can hold;
* a relation value given as bare target ids rather than relation objects, whose entries were skipped one by one;
* a statement carrying no `value` at all, which only number and boolean properties rejected.

`{"value": []}` still removes the Statement, as documented.

## Wrote to the wrong property

The Neo4j node property map is assembled with `array_merge`, which renumbers integer keys. A property named `2024`
projected its value onto a property named `0`, so the graph disagreed with the revision slot.

## Notes

* `UpdateStatementAction::setStatement` now takes `propertyType` as `mixed`. It comes from the unvalidated part of
  the body, and `StatementListBuilder` is where the other input-shape checks live, so the type reaches that check
  rather than failing at the action's own signature.
* Requiring `value` is the one judgement call here: the request shape is ambiguous between *set* and *remove*, and
  this reads it as neither. `testStatementWithoutAValueReturns400` in #1216 already asserts that reading for number
  properties; this makes it hold for the rest. Easy to drop if you meant the other reading.
* Everything except the `value` requirement is equally reachable through `PUT /subject/{subjectId}`, so the fixes
  are in the shared classes and that endpoint improves with them.

Full suite and `make cs` green.

---
🤖 Written by [Claude Code](https://claude.com/claude-code) using `claude-opus-5[1m]` (max)