### PR TITLE
Publish the SPARQL-engine write-path comparison and interactive-save latency

### DIFF
--- a/docs/operations/performance.md
+++ b/docs/operations/performance.md
@@ -18,35 +18,54 @@ Subject.
 |---|---|---:|---:|---:|
 | 2026-08-01 | `851f44ae` | 602 Subjects/second | ~600 Subjects/second | 1.65 ms/Subject |
 
-Each rate is the mean of two probes run alternately against the same graph. Throughput does not decay as the graph grows:
-the rate holds flat across a 2 000-page import, and the probes against
-the million-node graph run no slower than those against a small one.
+Each rate is the mean of two probes run alternately against the same graph. Import throughput does not decay as the
+graph grows: the rate holds flat across a 2 000-page import, and the probes against the million-node graph run no
+slower than those against a small one.
 
 That import rate is 16.6 ms per page of ten Subjects, MediaWiki's own revision write included. Page saves project in
 the same request rather than through the job queue, so an edit does that projection work too.
 
-Reference machine: a 16-core desktop (Ryzen 9 9950X, 60 GiB RAM, NVMe) running MediaWiki, MariaDB and Neo4j together
-in one Docker stack, so all three compete for the same cores, with Neo4j held to the stack's default 512 MB heap. The
-million-node graph is padded with synthetic nodes carrying no relationships, where a real graph of that size carries
-millions of them, and the wiki behind it held 4 000 pages rather than 100 000.
+Reference machine: a 16-core desktop (Ryzen 9 9950X, 60 GiB RAM, NVMe) running MediaWiki, MariaDB and Neo4j in one
+Docker stack, with Neo4j held to the stack's default 512 MB heap and each SPARQL engine, when configured, to 1.5 GB.
+The million-node graph is padded with synthetic nodes carrying no relationships, where a real graph of that size
+carries millions of them, and the wiki behind it held 4 000 pages rather than 100 000.
 
 ## With a SPARQL store
 
-Project into a SPARQL store as well and bulk import averages 36 Subjects/second, falling as the store fills: over one
-2 000-page import — two projections, native RDF and EDM, into one QLever store — the rate dropped from 101 to
-21 Subjects/second as the store grew to 590 000 triples. About 90% of the per-page cost across that run was the SPARQL
-projection, which is the write path's remaining bottleneck. It had not levelled off by the end, so a fuller store is
-slower than 21 Subjects/second, not the 36 above. ADR 29's targets count every configured projection, so this is the
-configuration to judge a SPARQL-backed wiki by.
+A [SPARQL store](installation.md#optional-sparql-graph-stores) adds the
+[RDF projection and its SPARQL query surface](../rdf/rdf-export.md) alongside Neo4j, and every write then pays for
+it — how much depends on the engine. Measured 2026-08-09 on `adbdd656`: a fresh wiki grown to 20 000 Subjects /
+590 000 triples (~30 triples per Subject), two projections per page into one store, whole-run means of two imports
+per engine. These rates are not comparable to the million-node table above; this corpus is fifty times smaller and
+unpadded.
+
+| Write path | No SPARQL store | With Oxigraph | With QLever |
+|---|---:|---:|---:|
+| Bulk import | 402 Subjects/second | 282 Subjects/second | 34 Subjects/second |
+| Full rebuild | 1 035 Subjects/second | 415 Subjects/second | 13 Subjects/second |
+| Interactive save | 40 ms | 44–54 ms | ~1.2 s |
+
+QLever's per-update cost grows as the store fills: within one such import the rate fell from 102 to
+20 Subjects/second and had not levelled off, so a fuller store is slower still. Oxigraph declined about 1.2× over
+the same growth. Both engines end up holding the identical projection, triple for triple.
+
+For an actively edited wiki, project into Oxigraph: at the measured size it meets
+[ADR 29](../adr/029-scalability-targets.md)'s import and interactive-save targets with room and misses its rebuild
+target by about a fifth. QLever misses all three — the cost of an engine built for query speed over large corpora,
+which this page does not measure — and configuring it alongside Oxigraph still puts its latency on every save, so
+it fits wikis whose writes come as imports and rebuilds that can run unattended. Beyond the measured size both
+engine columns are extrapolation: Oxigraph's curve has stayed near-flat, QLever's rises.
 
 ## How it was measured
 
-Bulk import is MediaWiki's `importDump.php`, run with secondary link updates off. Backend validation does not run on
-that path, so the import figures are unvalidated writes, and validation is measured on its own: 20 000 validations of
-one Subject in a single process. The rebuild figure is
-[`NeoWiki:RebuildGraphDatabases`](maintenance.md#rebuilding-the-graph) re-projecting the whole wiki. The corpus is
-synthetic, from `NeoWiki:GeneratePerformanceDump`: ten Subjects per page, twelve Statements per Subject, three of them
-relations to Subjects on other pages.
+Bulk import is MediaWiki's `importDump.php`, run with secondary link updates off (a real import still runs those
+afterwards); loading over the REST API instead pays interactive-save latency per Subject. Backend validation does
+not run on the import path, so the import figures are unvalidated writes — the REST saves are validated — and
+validation is also measured on its own: 20 000 validations of one Subject in a single process. The rebuild figure is
+[`NeoWiki:RebuildGraphDatabases`](maintenance.md#rebuilding-the-graph) re-projecting the whole wiki. Interactive
+save is the median of 60 REST subject creates and replaces, with the store at the size above. The corpus is
+synthetic, from `NeoWiki:GeneratePerformanceDump`: ten Subjects per page, twelve Statements per Subject, three of
+them relations to Subjects on other pages.
 
 ## Measure it yourself
 
@@ -59,3 +78,7 @@ make perf-import                # imports it, reporting pages and Subjects per s
 
 To time a rebuild of what you imported, run [`NeoWiki:RebuildGraphDatabases`](maintenance.md#rebuilding-the-graph)
 under `time`.
+
+A stock development stack projects into QLever, so this measures the slowest column above. Point
+`$wgNeoWikiSparqlStores` in `Docker/LocalSettings.local.php` at the configuration you are evaluating — `[]` for
+none.


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1234

The SPARQL-store section named only QLever and predates Oxigraph support (#1235). It now compares the two engines on the same corpus — import, full rebuild, and the first interactive-save numbers — and gives the store choice that follows: Oxigraph for actively edited wikis, QLever where large-corpus query speed is worth its write costs. Also states how to measure a chosen configuration rather than the dev default.

Spec: reader = a sysadmin choosing the SPARQL store configuration; decision = which stores to run and whether writes keep up with their collection; budget ~75 lines — landed at 84, the overrun being the engine table and the scale-bound caveat, which are new facts rather than elaboration.

Considered, omitted:

* the per-store rebuild split (`neo4j` / `native` / `EDM`) and the dev stack's `redherb` store — campaign-doc detail
* QLever's union-default-graph COUNT dedupe and the import-time script-error category triples (measurement artifacts, recorded in the NeoWiki-Docker performance ledger)
* Oxigraph's between-run import spread (263–301 Subjects/second behind the 282 mean)
* that the EDM projection writes zero triples on the synthetic corpus
* the first-configured-store query-surface constraint (installation.md's fact) and background-rebuild remedies (maintenance.md's)
* upstream engine query benchmarks

Numbers: 2026-08-09 campaign, `write-path-remeasure-2026-08-09.md` + `perf-data/remeasure-2026-08-09/` in NeoWiki-Docker (untracked, measurement machine); ledger PR https://github.com/ProfessionalWiki/NeoWiki-Docker/pull/167.

> <sub>AI-authored — Claude Code, `Fable 5 (max)`; detailed ask from @JeroenDeDauw, no revisions; not yet human-reviewed; numbers cross-checked against the campaign CSVs, links and anchors verified, draft blind-judged by a fresh-context agent and revised on its findings.</sub>

<details><summary>Production notes</summary>

The measurement passes behind the numbers were executed by a `Claude Opus 5` subagent on a fresh master worktree; the two count-offset anomalies were root-caused live before publication (both measurement artifacts, neither an engine nor rebuild defect). The blind judge flagged the prior draft's two-table inconsistency, the missing scale bound, and that `make perf-import` on a stock stack measures the QLever column — all addressed in this version.

</details>