### PR TITLE
Explain why the QLever rebuild trails its import

### DIFF
--- a/docs/operations/performance.md
+++ b/docs/operations/performance.md
@@ -46,8 +46,10 @@ unpadded.
 | Interactive save | 40 ms | 44–54 ms | ~1.2 s |
 
 QLever's per-update cost grows as the store fills: within one such import the rate fell from 102 to
-20 Subjects/second and had not levelled off, so a fuller store is slower still. Oxigraph declined about 1.2× over
-the same growth. Both engines end up holding the identical projection, triple for triple.
+20 Subjects/second and had not levelled off, so a fuller store is slower still. That is why QLever's rebuild runs
+slower than its import — the import's mean includes the near-empty start, while the rebuild writes into the
+already-full store throughout. Oxigraph declined about 1.2× over the same growth. Both engines end up holding the
+identical projection, triple for triple.
 
 For an actively edited wiki, project into Oxigraph: at the measured size it meets
 [ADR 29](../adr/029-scalability-targets.md)'s import and interactive-save targets with room and misses its rebuild


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1271

The table shows the QLever rebuild slower than its import while the other columns run the other way; one sentence ties that to the decay the paragraph already describes.

Spec: same page reader (sysadmin comparing the table's rows); the sentence stops the 13 Subjects/second rebuild figure reading as an error; budget one sentence. Considered, omitted: that rebuild `DROP`s delete real graphs where import `DROP`s are no-ops — secondary to the store-size effect, campaign-doc detail.

> <sub>AI-authored — Claude Code, `Fable 5 (max)`; one-line ask from @JeroenDeDauw after he hit the confusion reading the merged page; not yet human-reviewed; sentence blind-judged in place and revised on the findings, line lengths checked.</sub>