### PR TITLE
Add INSERT to the Cypher write-keyword denylist

### DIFF
--- a/src/GraphDatabasePlugins/Neo4j/Application/KeywordCypherQueryValidator.php
+++ b/src/GraphDatabasePlugins/Neo4j/Application/KeywordCypherQueryValidator.php
@@ -7,7 +7,7 @@ namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application;
 class KeywordCypherQueryValidator implements CypherQueryValidator {
 
 	private const array WRITE_KEYWORDS = [
-		'CREATE', 'SET', 'DELETE', 'REMOVE', 'MERGE', 'DROP',
+		'CREATE', 'INSERT', 'SET', 'DELETE', 'REMOVE', 'MERGE', 'DROP',
 		'CALL', 'LOAD', 'FOREACH',
 		'GRANT', 'DENY', 'REVOKE',
 		'SHOW',

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Application/ExplainCypherQueryValidatorTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Application/ExplainCypherQueryValidatorTest.php
@@ -72,6 +72,10 @@ class ExplainCypherQueryValidatorTest extends NeoWikiIntegrationTestCase {
 		$this->assertFalse( $this->validator->queryIsAllowed( 'CREATE (n:Test) RETURN n' ) );
 	}
 
+	public function testInsertIsNotAllowed(): void {
+		$this->assertFalse( $this->validator->queryIsAllowed( 'INSERT (n:Test {name: "x"}) RETURN n' ) );
+	}
+
 	public function testSetPropertyIsNotAllowed(): void {
 		$this->assertFalse( $this->validator->queryIsAllowed( 'MATCH (n) SET n.x = 1 RETURN n' ) );
 	}

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Application/KeywordCypherQueryValidatorTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Application/KeywordCypherQueryValidatorTest.php
@@ -57,6 +57,7 @@ class KeywordCypherQueryValidatorTest extends TestCase {
 	public static function writeOperationProvider(): array {
 		return [
 			[ 'CREATE' ],
+			[ 'INSERT' ],
 			[ 'SET' ],
 			[ 'DELETE' ],
 			[ 'REMOVE' ],
@@ -151,6 +152,11 @@ class KeywordCypherQueryValidatorTest extends TestCase {
 		yield 'CREATE with MATCH' => [
 			"MATCH (a:Person) CREATE (b:Person)-[:KNOWS]->(a)",
 			'Should reject CREATE after MATCH'
+		];
+
+		yield 'Simple INSERT' => [
+			"INSERT (n:Person {name: 'Alice'})",
+			'Should reject INSERT, the CREATE synonym'
 		];
 
 		yield 'Simple SET' => [


### PR DESCRIPTION
Neo4j 5.18 and later accept `INSERT` as a synonym of `CREATE`. The keyword pre-check on the read-only Cypher query
surface did not list it, so an `INSERT` write query was rejected only by the later EXPLAIN plan inspection. `INSERT`
now sits next to `CREATE` in the denylist.

Tests cover both validators; the EXPLAIN one pins behavior that was already correct but untested.

> <sub>AI-authored — Claude Code, `Opus 5 (1M context, max)` implementing a detailed spec from a `Fable 5 (max)` session at @JeroenDeDauw's request, no redirections; diff not yet human-reviewed; the two new keyword cases seen failing before the change and passing after, the EXPLAIN case seen failing under a temporary `Create` allowlist entry then reverted, full PHPUnit suite (2729 tests) and `make cs` green locally against Neo4j 2026.06.0.</sub>
