### PR TITLE
Verify Fuseki as a third SPARQL store engine

### DIFF
--- a/.github/workflows/ci-php.yml
+++ b/.github/workflows/ci-php.yml
@@ -167,15 +167,34 @@ jobs:
       # conformance target, not as an engine NeoWiki ships: Jena is the most complete SPARQL 1.1
       # implementation to check the emitted queries and updates against. The version is pinned for that
       # reason — the reference to test against should change deliberately, not with upstream releases.
-      # Apache publishes no image of its own, so this is a third-party build of its distribution.
-      # `--mem /ds` serves an in-memory dataset unauthenticated on /ds/query and /ds/update, which is all
-      # a fresh-per-run CI store needs, and keeps named graphs out of the default graph the way Oxigraph
-      # above does — the spec-strict behaviour the suite asserts. JAVA_OPTIONS caps a JVM that would
-      # otherwise size its heap from total runner memory.
+      # Apache publishes no container image, so instead of trusting a third-party build this runs the
+      # release Apache itself publishes: the tarball comes from the ASF archive (cached, so the archive
+      # is only hit when the pin changes) and is checked against the checksum recorded here before
+      # anything in it runs. `--mem /ds` serves an in-memory dataset unauthenticated on /ds/query and
+      # /ds/update, which is all a fresh-per-run CI store needs, and keeps named graphs out of the
+      # default graph the way Oxigraph above does — the spec-strict behaviour the suite asserts.
+      # JVM_ARGS caps a heap the launcher otherwise defaults to -Xmx4G.
+      - name: Cache Fuseki
+        uses: actions/cache@v5
+        with:
+          path: ~/fuseki-dist
+          key: fuseki-6.2.0
+
       - name: Start Fuseki
+        env:
+          FUSEKI_VERSION: 6.2.0
+          FUSEKI_SHA512: ba65f5867d2d4741b2ed9e2af5a0d4fbb447909894ab2a0c6bc4dac8997f4fe339c87b13c48d45d054977769f0f8bf763ea346b1f7792d5cdc458041bd43a132
         run: |
-          docker run -d --name test_fuseki -p 127.0.0.1:3030:3030 \
-            -e JAVA_OPTIONS=-Xmx512m docker.io/atomgraph/fuseki:6.1.0 --mem /ds
+          mkdir -p ~/fuseki-dist && cd ~/fuseki-dist
+          if [ ! -f "apache-jena-fuseki-$FUSEKI_VERSION.tar.gz" ]; then
+            curl -fsSL -o "apache-jena-fuseki-$FUSEKI_VERSION.tar.gz" \
+              "https://archive.apache.org/dist/jena/binaries/apache-jena-fuseki-$FUSEKI_VERSION.tar.gz"
+          fi
+          echo "$FUSEKI_SHA512  apache-jena-fuseki-$FUSEKI_VERSION.tar.gz" | sha512sum -c -
+          tar -xzf "apache-jena-fuseki-$FUSEKI_VERSION.tar.gz"
+          cd "apache-jena-fuseki-$FUSEKI_VERSION"
+          JAVA_HOME="$JAVA_HOME_21_X64" JVM_ARGS=-Xmx512m \
+            nohup ./fuseki-server --mem /ds > "$RUNNER_TEMP/fuseki.log" 2>&1 &
 
       - name: Run update.php
         run: php maintenance/update.php --quick
@@ -212,7 +231,7 @@ jobs:
             fi
             sleep 2
           done
-          echo "Fuseki did not become ready in time; dumping logs:"; docker logs test_fuseki; exit 1
+          echo "Fuseki did not become ready in time; dumping logs:"; cat "$RUNNER_TEMP/fuseki.log"; exit 1
 
       - name: Run PHPUnit
         run: composer phpunit

--- a/.github/workflows/ci-php.yml
+++ b/.github/workflows/ci-php.yml
@@ -56,6 +56,10 @@ jobs:
       # Live Oxigraph store for the same system test run against a second engine, published by the
       # "Start Oxigraph" step.
       OXIGRAPH_TEST_BASE_URL: http://localhost:7878
+      # Live Fuseki store for a third run of the same system test, published by the "Start Fuseki" step.
+      # Nothing outside CI sets this, and QueryFusekiEndToEndTest skips without it, so this line is what
+      # makes that suite run at all.
+      FUSEKI_TEST_BASE_URL: http://localhost:3030/ds
 
     services:
       test_neo:
@@ -159,6 +163,20 @@ jobs:
           docker run -d --name test_oxigraph -p 127.0.0.1:7878:7878 \
             ghcr.io/oxigraph/oxigraph:latest serve --bind 0.0.0.0:7878
 
+      # Apache Jena Fuseki, which the same system test runs against a third time. It is here as a
+      # conformance target, not as an engine NeoWiki ships: Jena is the most complete SPARQL 1.1
+      # implementation to check the emitted queries and updates against. The version is pinned for that
+      # reason — the reference to test against should change deliberately, not with upstream releases.
+      # Apache publishes no image of its own, so this is a third-party build of its distribution.
+      # `--mem /ds` serves an in-memory dataset unauthenticated on /ds/query and /ds/update, which is all
+      # a fresh-per-run CI store needs, and keeps named graphs out of the default graph the way Oxigraph
+      # above does — the spec-strict behaviour the suite asserts. JAVA_OPTIONS caps a JVM that would
+      # otherwise size its heap from total runner memory.
+      - name: Start Fuseki
+        run: |
+          docker run -d --name test_fuseki -p 127.0.0.1:3030:3030 \
+            -e JAVA_OPTIONS=-Xmx512m docker.io/atomgraph/fuseki:6.1.0 --mem /ds
+
       - name: Run update.php
         run: php maintenance/update.php --quick
 
@@ -185,6 +203,16 @@ jobs:
             sleep 2
           done
           echo "Oxigraph did not become ready in time; dumping logs:"; docker logs test_oxigraph; exit 1
+
+      - name: Wait for Fuseki
+        run: |
+          for i in $(seq 1 40); do
+            if curl -fsS -o /dev/null "http://localhost:3030/ds/query?query=SELECT%20%2A%20WHERE%20%7B%20%3Fs%20%3Fp%20%3Fo%20%7D%20LIMIT%201"; then
+              echo "Fuseki is serving"; exit 0
+            fi
+            sleep 2
+          done
+          echo "Fuseki did not become ready in time; dumping logs:"; docker logs test_fuseki; exit 1
 
       - name: Run PHPUnit
         run: composer phpunit

--- a/docs/operations/installation.md
+++ b/docs/operations/installation.md
@@ -218,8 +218,8 @@ content model, validated, or read.
 
 ## Optional: SPARQL graph stores
 
-Alongside Neo4j, NeoWiki can keep one or more SPARQL 1.1 graph stores in sync with page changes. This
-works with QLever, Oxigraph and any other SPARQL 1.1 store. Each configured store receives the NeoWiki data as RDF:
+Alongside Neo4j, NeoWiki can keep one or more SPARQL 1.1 graph stores in sync with page changes. This works with
+QLever, Oxigraph, Fuseki and any other SPARQL 1.1 store. Each configured store receives the NeoWiki data as RDF:
 every page becomes a named graph, replaced on each edit and dropped on deletion.
 
 A SPARQL store does not yet replace Neo4j: NeoWiki's interactive features (the Subject editing UIs, views, and value
@@ -271,6 +271,24 @@ $wgNeoWikiSparqlStores = [
 Oxigraph has no authentication and ignores `accessToken`: it accepts every request, updates included, from anyone who
 can reach it. Put it behind network isolation or an authenticating reverse proxy, and see
 [Restricting federation](#restricting-federation).
+
+### Fuseki
+
+Fuseki serves each dataset under its own path, queries on `/query` and updates on `/update` below it:
+
+```php
+$wgNeoWikiSparqlStores = [
+	[
+		'updateUrl' => 'https://fuseki.example/ds/update',
+		'queryUrl' => 'https://fuseki.example/ds/query',
+		'projection' => 'native',
+	],
+];
+```
+
+A dataset's endpoints accept every request, updates included, from anyone who can reach them: Fuseki's shipped
+configuration protects its admin interface, not its data. Put it behind network isolation or an authenticating
+reverse proxy, and see [Restricting federation](#restricting-federation).
 
 ### Several projections in one store
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,5 +15,8 @@
 		<!-- Live Oxigraph store for the same system test, run a second time against a second engine.
 		     Oxigraph has no authentication, so there is no token to set. -->
 		<env name="OXIGRAPH_TEST_BASE_URL" value="http://test_oxigraph:7878" />
+		<!-- FUSEKI_TEST_BASE_URL is deliberately absent. The stacks bring up the two stores above, so a
+		     test without one is a broken stack; Fuseki is a conformance target only CI starts, so the
+		     suite naming it skips here instead. QueryFusekiEndToEndTest's docblock has the opt-in. -->
 	</php>
 </phpunit>

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/Integration/QueryFusekiEndToEndTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/Integration/QueryFusekiEndToEndTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\GraphDatabasePlugins\Sparql\Integration;
+
+/**
+ * {@see QuerySparqlEndToEndTestCase} against Apache Jena Fuseki — a conformance target, not an engine
+ * NeoWiki ships or recommends. Jena is the most complete SPARQL 1.1 implementation available to point
+ * the same loop at, so what passing here establishes is about the SPARQL NeoWiki emits rather than
+ * about one store's tolerance of it.
+ *
+ * The only one of these suites that skips rather than fails when its store is unset, because it is the
+ * only one no stack ships: nothing sets `FUSEKI_TEST_BASE_URL` except the CI workflow that starts the
+ * server, so `make phpunit` skips it and CI runs it. Its siblings guard stores the Docker stacks bring
+ * up, where an unreachable store is a broken stack rather than an absent extra.
+ *
+ * To run it here, put a Fuseki on the dev stack's network — `<stack project>_default`, so
+ * `neowiki-neowiki_default` for the main checkout:
+ *
+ *     docker run --rm --name test_fuseki --network neowiki-neowiki_default \
+ *         -e JAVA_OPTIONS=-Xmx512m docker.io/atomgraph/fuseki:6.1.0 --mem /ds
+ *
+ * then, from a shell in the mediawiki container (`make bash`):
+ *
+ *     FUSEKI_TEST_BASE_URL=http://test_fuseki:3030/ds make phpunit filter=QueryFusekiEndToEndTest
+ *
+ * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryService
+ * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Persistence\HttpSparqlQueryEndpoint
+ * @covers \ProfessionalWiki\NeoWiki\Application\Rdf\OntologyMappingProjector
+ * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Persistence\SparqlProjectionStore
+ * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\SparqlPlugin
+ * @group Database
+ */
+class QueryFusekiEndToEndTest extends QuerySparqlEndToEndTestCase {
+
+	private const string BASE_URL_VARIABLE = 'FUSEKI_TEST_BASE_URL';
+
+	protected function storeUpdateUrl(): string {
+		return $this->storeBaseUrl() . '/update';
+	}
+
+	protected function storeQueryUrl(): string {
+		return $this->storeBaseUrl() . '/query';
+	}
+
+	/**
+	 * The CI server runs without authentication, and Fuseki ignores a Bearer token where none is
+	 * configured, so sending one would prove nothing the QLever suite does not already.
+	 */
+	protected function storeAccessToken(): ?string {
+		return null;
+	}
+
+	/**
+	 * Fuseki keeps its named graphs out of the default graph, as SPARQL 1.1 specifies. A dataset
+	 * assembled with `tdb2:unionDefaultGraph` would not, which is why the server is started from the
+	 * command line with a plain in-memory dataset.
+	 */
+	protected function storeUnionsNamedGraphsIntoTheDefaultGraph(): bool {
+		return false;
+	}
+
+	/**
+	 * The base URL of the Fuseki dataset, both endpoints hang off it. Skips instead of failing through
+	 * {@see requireEnv}: see the class docblock for why this suite alone is opt-in.
+	 */
+	private function storeBaseUrl(): string {
+		$baseUrl = trim( (string)getenv( self::BASE_URL_VARIABLE ) );
+
+		if ( $baseUrl === '' ) {
+			$this->markTestSkipped(
+				self::BASE_URL_VARIABLE . ' is not set, so there is no Fuseki to run against. CI sets it; '
+				. 'this class\'s docblock has the command to run one here.'
+			);
+		}
+
+		return rtrim( $baseUrl, '/' );
+	}
+
+}

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/Integration/QueryFusekiEndToEndTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/Integration/QueryFusekiEndToEndTest.php
@@ -15,11 +15,11 @@ namespace ProfessionalWiki\NeoWiki\Tests\GraphDatabasePlugins\Sparql\Integration
  * server, so `make phpunit` skips it and CI runs it. Its siblings guard stores the Docker stacks bring
  * up, where an unreachable store is a broken stack rather than an absent extra.
  *
- * To run it here, put a Fuseki on the dev stack's network — `<stack project>_default`, so
- * `neowiki-neowiki_default` for the main checkout:
+ * To run it here, build Fuseki's container image — Apache publishes none, only a build kit
+ * (https://jena.apache.org/documentation/fuseki2/fuseki-docker.html) — and put it on the dev stack's
+ * network (`<stack project>_default`, so `neowiki-neowiki_default` for the main checkout):
  *
- *     docker run --rm --name test_fuseki --network neowiki-neowiki_default \
- *         -e JAVA_OPTIONS=-Xmx512m docker.io/atomgraph/fuseki:6.1.0 --mem /ds
+ *     docker run --rm --name test_fuseki --network neowiki-neowiki_default <your-image> --mem /ds
  *
  * then, from a shell in the mediawiki container (`make bash`):
  *


### PR DESCRIPTION
Runs the existing SPARQL write+query system test against Apache Jena Fuseki in CI: a
conformance check on the SPARQL NeoWiki emits, not a new engine to ship. It passes the
shared test case unchanged — no source change and no accommodation, so the subclass
differs only in its endpoint URLs, its absent token, and the strict default-graph
semantics it shares with Oxigraph.

Fuseki stays CI-only: no dev-stack service and no phpunit.xml.dist entry, so
`make phpunit` skips this suite while CI, which starts the server and sets
FUSEKI_TEST_BASE_URL, runs it. The two shipped stores still fail rather than skip when
unset, because an unreachable store there means a broken stack. Apache publishes no
container image, so CI runs the release tarball Apache itself publishes, fetched from
the ASF archive (cached) and verified against a checksum recorded in the workflow; the
version is pinned because the reference to test against should change deliberately.

Considered, omitted: a dev-stack service for it (nothing local needs Fuseki, and the
mandatory test backends stay at three); Basic-auth support for a dataset secured with
Fuseki's own authentication (untested — the docs point at a reverse proxy, as they do
for Oxigraph).

> <sub>AI-authored — Claude Code, `Opus 5 1M (max)`; detailed spec, run unattended as a background job, no corrections; diff not yet human-reviewed; suite run locally against a live Fuseki (6 tests, 13 assertions) and with the variable unset (6 skipped, no errors), all three engine suites green together (18 tests, 39 assertions), phpcs and phpstan clean. Image-sourcing hardening (ASF tarball + checksum pin instead of a third-party image) by `Fable 5 (max)`, verified via this PR's CI.</sub>
