### PR TITLE
Bring the RDF planning docs in line with the shipped implementation

### DIFF
--- a/docs/planning/NativeRdfProjection.md
+++ b/docs/planning/NativeRdfProjection.md
@@ -2,7 +2,7 @@
 
 Written 2026-02-23 by Jeroen De Dauw with help from Claude Opus 4.6
 
-Status: Draft, incorporating feedback from ECHOLOT partners (Bilbao meeting March 2026 and async discussion)
+Status: Implemented; open questions still under discussion with ECHOLOT partners.
 
 Discussion: [#999](https://github.com/ProfessionalWiki/NeoWiki/discussions/999).
 

--- a/docs/planning/NativeRdfProjection.md
+++ b/docs/planning/NativeRdfProjection.md
@@ -102,12 +102,8 @@ neo-subj:s0gje3k4m8n2p1q  neo-prop:Website  <https://example.com> ;
 
 #### Value type mapping
 
-| NeoWiki Value Type | RDF Datatype | Notes |
-|--------------------|-------------|-------|
-| `text` | `xsd:string` | Each part is a separate triple |
-| `number` | `xsd:decimal` | Or `xsd:integer` when the value has no fractional part |
-| `boolean` | `xsd:boolean` | |
-| `url` | IRI object (`<…>`), or `xsd:anyURI` when the value is not a valid absolute IRI | Each part is a separate triple |
+How each Value Type is represented in RDF — and how extensions map their own property types — is specified in the
+[RDF Export reference](../rdf/rdf-export.md).
 
 ### Relations
 
@@ -231,6 +227,9 @@ DROP SILENT GRAPH <neo-graph:42>
 
 `DROP SILENT` avoids errors when the graph does not exist (e.g., first save of a new page).
 
+The measured cost of this write path, and the targets it is held to, are in the
+[performance reference](../operations/performance.md) and [ADR 29](../adr/029-scalability-targets.md).
+
 ## What This Does Not Cover
 
 - **Ontology mapping.** The [Global Properties](GlobalProperties.md) document concluded that ontology alignment
@@ -238,7 +237,9 @@ DROP SILENT GRAPH <neo-graph:42>
   model. That mapping is designed in [Ontology Mapping](OntologyMapping.md). The projection described here emits
   NeoWiki-native predicates; an ontology mapping instead projects the data into standard-ontology terms. Ontology
   mappings need to be quite expressive: CIDOC-CRM alignment isn't just predicate renaming — it requires generating
-  intermediate nodes that don't exist in NeoWiki's data (worked example under Q4 below).
+  intermediate nodes that don't exist in NeoWiki's data (worked example under Q4 below). That node synthesis has
+  shipped ([#1229](https://github.com/ProfessionalWiki/NeoWiki/pull/1229),
+  [#1263](https://github.com/ProfessionalWiki/NeoWiki/pull/1263)).
   At the ECHOLOT meeting in Bilbao (March 2026), the consortium agreed that wiki admins should be able to define
   mappings between ontologies they care about and the NeoWiki Schemas of their wiki. This confirms the
   separate-mapping approach and means several open questions below (Q1, Q2, Q4) are less critical for the native
@@ -251,9 +252,10 @@ DROP SILENT GRAPH <neo-graph:42>
   NeoWiki Subjects is a T3.2/T4.1 concern and has its own challenges (mapping external ontologies to NeoWiki
   Schemas).
 - **RDF-star / RDF 1.2.** The grant (T3.2) and the D2.1 system spec refer to "native RDF/RDF*" import/export. The
-  native projection deliberately targets standard RDF 1.1 (Relation reification, see Design Principle 3), and common
-  target stores such as QLever do not support RDF-star. RDF-star is out of scope for now; it would only be
-  revisited given a concrete need, and then at the import/export serialization layer rather than the triple store.
+  native projection deliberately targets standard RDF 1.1 (Relation reification, see Design Principle 3), and QLever,
+  the primary target store, does not support RDF-star (Oxigraph has preliminary RDF 1.2 support). RDF-star is out of
+  scope for now; it would only be revisited given a concrete need, and then at the import/export serialization layer
+  rather than the triple store.
 
 ## Open Questions
 
@@ -331,6 +333,9 @@ there a convention in the ECHOLOT/ECCCH context for how services should mint URI
 *Feedback: There is a URI policy being discussed within ECCCH. Aligning with it would be beneficial. To be
 followed up on.*
 
+*As built: the base URI is configurable — `$wgNeoWikiRdfBaseUri`, defaulting to the wiki's canonical URL
+(`$wgCanonicalServer`); see the [RDF Export reference](../rdf/rdf-export.md).*
+
 **Q7: URI design for Properties.** Property Names can contain spaces and special characters (e.g., "Founded at",
 "Has author"). What's the convention — URL-encode them (`Has%20author`), replace spaces with underscores
 (`Has_author`), or something else?
@@ -364,5 +369,6 @@ ordering is real data, model it explicitly so it stays recoverable in the export
 Property Definition (as a property with domain/range)? This would make the RDF self-describing. Tentative answer:
 yes, but as a separate enhancement, not blocking the initial projection. Partner demand recorded (takin, 2026-07-03):
 an RDFS export of local Schemas is wanted as an input for authoring ontology mappings — a wiki's Schemas are
-effectively its own ontology, and the native projection should be able to say so in RDF. See also the generated shape
-exports in [ShapeLanguages.md](ShapeLanguages.md).
+effectively its own ontology, and the native projection should be able to say so in RDF. Tracked in
+[#1163](https://github.com/ProfessionalWiki/NeoWiki/issues/1163). See also the generated shape exports in
+[ShapeLanguages.md](ShapeLanguages.md).

--- a/docs/planning/NativeRdfProjection.md
+++ b/docs/planning/NativeRdfProjection.md
@@ -12,33 +12,30 @@ Discussion: [#999](https://github.com/ProfessionalWiki/NeoWiki/discussions/999).
 > ([#1053](https://github.com/ProfessionalWiki/NeoWiki/issues/1053)) so sibling projections can share one store. See
 > the [RDF Export reference](../rdf/rdf-export.md). Ontology (sibling) projections build on this shared
 > infrastructure — see [OntologyMapping.md](OntologyMapping.md) and the worked
-> [Person → EDM example](../rdf/person-to-edm.md). The [Sync Mechanism](#sync-mechanism) has shipped too: the
-> SPARQL graph-store plugin (#586) projects each save and delete into a configured SPARQL 1.1 store (e.g. QLever) as
-> the per-page DROP/INSERT it defines.
+> [Person → EDM example](../rdf/person-to-edm.md). The sync into a configured SPARQL 1.1 store (e.g. QLever) has
+> shipped too, as the per-page graph replacement this document specifies.
+
+## Still open (2026-08)
+
+- [Q6 — Base URI conventions](#q6-base-uri-conventions): which base URI an ECCCH-integrated deployment mints under.
+- [Q8 — Writer's schema in RDF](#q8-writers-schema-in-rdf): whether a full-export mode carries it. Untracked.
+- [Q10 — Schema namespace page](#q10-schema-namespace-page): RDFS/OWL self-description of Schemas
+  ([#1163](https://github.com/ProfessionalWiki/NeoWiki/issues/1163)).
+
+Everything else this document asked has been answered — see [Decided](#decided).
 
 ## Purpose
 
-This document specifies how NeoWiki's data model projects to RDF triples for the SPARQL plugin described in
-[ADR 19](../adr/019-graph-database-architecture.md). The projection determines what RDF a triple store contains
-and therefore what SPARQL queries users can write. It also defines the shape of RDF exports.
+Why NeoWiki has a projection of its own, and in the shape it has. The projection determines what RDF a triple store
+holds and therefore what SPARQL queries users can write, so it is a design decision rather than a serialization
+detail; [ADR 19](../adr/019-graph-database-architecture.md) puts it behind the SPARQL plugin.
 
-It has two jobs:
-
-1. **Specify the native projection** — RDF in NeoWiki's own vocabulary: lossless, self-sufficient, and the default
-   when no ontology mapping is configured.
-2. **Specify the projection infrastructure shared by all projections** — the IRI and namespace regime, per-page
-   named graphs, and the sync mechanism. An ontology store reuses all of this; only the triples inside each page's
-   graph and the projection segment of that graph's IRI differ.
-
-Everything specific to non-native targets — projecting into CIDOC-CRM, EDM, and other standard ontologies — lives in
-[OntologyMapping.md](OntologyMapping.md), which builds on this document. Native and ontology projections are
-siblings: a store holds one or more projections, each in its own family of per-page named graphs, and is queried in
-the vocabulary of whichever projection a query targets, so the SPARQL plugin is parameterized by projection rather
-than hardwired to the native one. Read this document first.
-
-This is a strawman proposal. Many decisions here need input from partners with RDF and Linked Open Data expertise,
-particularly regarding ontology alignment and cultural heritage conventions. [Open questions](#open-questions) are
-collected at the end.
+The native projection is RDF in NeoWiki's own vocabulary: lossless, self-sufficient, and the default when no ontology
+mapping is configured. It also settles the infrastructure every projection shares — the IRI and namespace regime,
+per-page named graphs, and the store sync. Native and ontology projections are siblings: a store holds one or more,
+each in its own family of per-page named graphs, and is queried in the vocabulary of whichever projection a query
+targets. Everything specific to non-native targets lives in [OntologyMapping.md](OntologyMapping.md), which builds on
+this document.
 
 ## Design Principles
 
@@ -53,181 +50,14 @@ collected at the end.
 5. **Per-wiki namespaces.** Each wiki instance mints its own entity and property URIs. Cross-wiki linking is a
    separate concern (via `owl:sameAs` or similar).
 
-## Namespaces
+## What it emits
 
-Each NeoWiki instance uses a configurable base URI (`$base`), defaulting to the wiki's canonical URL. All NeoWiki
-URIs live under this base.
-
-| Prefix | URI pattern | Purpose | Example |
-|--------|------------|---------|---------|
-| `neo:` | `$base/ontology/` | NeoWiki vocabulary terms | `neo:Relation`, `neo:source` |
-| `neo-subj:` | `$base/entity/` | Subject IRIs | `neo-subj:s0gje3k4m8n2p1q` |
-| `neo-prop:` | `$base/prop/` | Property predicates (direct) | `neo-prop:Website` |
-| `neo-schema:` | `$base/schema/` | Schema classes | `neo-schema:Person` |
-| `neo-rel:` | `$base/relation/` | Relation node IRIs | `neo-rel:r0gje3k4m8n2p1s` |
-| `neo-page:` | `$base/page/` | Page resource IRIs | `neo-page:12345` |
-| `neo-graph:` | `$base/graph/{projection}/page/` | Named graph IRIs (projection-qualified) | `$base/graph/native/page/12345` |
-
-Standard prefixes used alongside:
-
-| Prefix | URI |
-|--------|-----|
-| `rdf:` | `http://www.w3.org/1999/02/22-rdf-syntax-ns#` |
-| `rdfs:` | `http://www.w3.org/2000/01/rdf-schema#` |
-| `xsd:` | `http://www.w3.org/2001/XMLSchema#` |
-| `dcterms:` | `http://purl.org/dc/terms/` |
-
-## Projection
-
-### Subjects
-
-Each Subject becomes an RDF resource. Its Schema determines its `rdf:type`. Its label becomes `rdfs:label`.
-
-```turtle
-neo-subj:s0gje3k4m8n2p1q  a           neo-schema:Person ;
-                           rdfs:label  "John Doe" .
-```
-
-### Statements (non-Relation)
-
-Each Statement becomes one or more triples using the Property Name as predicate. Multi-valued properties
-(e.g., a text property with multiple parts) produce multiple triples with the same predicate.
-
-```turtle
-neo-subj:s0gje3k4m8n2p1q  neo-prop:Website  <https://example.com> ;
-                           neo-prop:Website  <https://johndoe.dev> ;
-                           neo-prop:Age      42 ;
-                           neo-prop:Active   true .
-```
-
-#### Value type mapping
-
-How each Value Type is represented in RDF — and how extensions map their own property types — is specified in the
-[RDF Export reference](../rdf/rdf-export.md).
-
-### Relations
-
-Relations are the most complex part of the projection because they carry their own ID and optional properties,
-similar to Wikibase qualifiers.
-
-The projection uses a **two-layer approach** inspired by [Wikibase's RDF model](https://www.mediawiki.org/wiki/Wikibase/Indexing/RDF_Dump_Format):
-
-**Layer 1 — Direct triples** for simple queries:
-
-```turtle
-neo-subj:s0gje3k4m8n2p1q  neo-prop:Has_author  neo-subj:s0gje3k4m8n2p1r .
-```
-
-**Layer 2 — Relation nodes** preserving the Relation ID and properties:
-
-```turtle
-neo-rel:r0gje3k4m8n2p1s  a                neo:Relation ;
-                          neo:source        neo-subj:s0gje3k4m8n2p1q ;
-                          neo:target        neo-subj:s0gje3k4m8n2p1r ;
-                          neo:relationType  neo-prop:Has_author ;
-                          neo-prop:Role     "Editor" ;
-                          neo-prop:Since    2019 .
-```
-
-The direct triple (Layer 1) is always emitted, even when the Relation has no properties, so that simple queries
-like `?person neo-prop:Has_author ?author` always work without navigating Relation nodes.
-
-The Relation node (Layer 2) is always emitted too, because every Relation has an ID that must be preserved for
-round-tripping. Queries that need Relation properties join through the Relation node.
-
-### Pages
-
-Page metadata is emitted as triples about the page resource (`neo-page:`). The page's named graph is a separate,
-projection-qualified IRI — see [Named Graphs](#named-graphs) below.
-
-```turtle
-neo-page:12345  a                 neo:Page ;
-                neo:pageName      "John Doe" ;
-                dcterms:created   "2024-01-15T10:30:00Z"^^xsd:dateTime ;
-                dcterms:modified  "2024-06-20T14:22:00Z"^^xsd:dateTime ;
-                neo:lastEditor    "JaneDoe" ;
-                neo:category      "People" ;
-                neo:category      "Scientists" ;
-                neo:mainSubject   neo-subj:s0gje3k4m8n2p1q ;
-                neo:hasSubject    neo-subj:s0gje3k4m8n2p1q ;
-                neo:hasSubject    neo-subj:s0gje3k4m8n2p2r .
-```
-
-### Named Graphs
-
-All triples a projection emits for a single wiki page are placed in a named graph qualified by projection:
-`$base/graph/{projection}/page/{pageId}` — for the native projection `$base/graph/native/page/12345`, abbreviated
-`neo-graph:12345` below. Sibling projections of a page thus write disjoint graphs and can share one triple store.
-This enables:
-
-- **Efficient sync:** On page save, `DROP GRAPH <neo-graph:12345>` then `INSERT DATA { GRAPH <neo-graph:12345> { ... } }`
-  replaces all triples for that page's projection atomically.
-- **Provenance:** The graph IRI tells you which wiki page — and which projection — the data came from.
-- **Page deletion:** `DROP GRAPH <neo-graph:12345>` removes all associated triples for that projection.
-
-The page metadata triples themselves also live in the page's named graph.
-
-### Complete Example
-
-A page (ID 42) with a main Subject "ACME Corp" (Company) and a child Subject "Jane Smith" (Person),
-where Jane is the CEO of ACME:
-
-```trig
-GRAPH neo-graph:42 {
-    # Page metadata
-    neo-page:42  a                 neo:Page ;
-                 neo:pageName      "ACME Corp" ;
-                 dcterms:created   "2024-03-01T09:00:00Z"^^xsd:dateTime ;
-                 dcterms:modified  "2025-11-15T16:45:00Z"^^xsd:dateTime ;
-                 neo:lastEditor    "Admin" ;
-                 neo:mainSubject   neo-subj:s0gje3k4m8n2p1q ;
-                 neo:hasSubject    neo-subj:s0gje3k4m8n2p1q ;
-                 neo:hasSubject    neo-subj:s0abc1def2ghi3j .
-
-    # Main Subject: ACME Corp (Company)
-    neo-subj:s0gje3k4m8n2p1q  a                neo-schema:Company ;
-                               rdfs:label       "ACME Corp" ;
-                               neo-prop:Website  <https://acme.example> ;
-                               neo-prop:Founded  2019 ;
-                               neo-prop:CEO      neo-subj:s0abc1def2ghi3j .
-
-    # Relation node for CEO relation
-    neo-rel:r0rel1ation2id3  a                neo:Relation ;
-                             neo:source        neo-subj:s0gje3k4m8n2p1q ;
-                             neo:target        neo-subj:s0abc1def2ghi3j ;
-                             neo:relationType  neo-prop:CEO ;
-                             neo-prop:Since    2022 .
-
-    # Child Subject: Jane Smith (Person)
-    neo-subj:s0abc1def2ghi3j  a           neo-schema:Person ;
-                               rdfs:label  "Jane Smith" ;
-                               neo-prop:Age  45 .
-}
-```
-
-## Sync Mechanism
-
-On each page save, the SPARQL plugin:
-
-1. Maps the `Page` domain object to RDF triples (using the projection above).
-2. Issues a SPARQL Update to the configured endpoint, targeting the projection's graph for that page:
-   ```sparql
-   DROP SILENT GRAPH <neo-graph:42> ;
-   INSERT DATA {
-       GRAPH <neo-graph:42> {
-           # ... all triples ...
-       }
-   }
-   ```
-
-On page deletion:
-```sparql
-DROP SILENT GRAPH <neo-graph:42>
-```
-
-`DROP SILENT` avoids errors when the graph does not exist (e.g., first save of a new page).
-
-The measured cost of this write path, and the targets it is held to, are in the
+This design has shipped. What NeoWiki actually emits — the IRI and namespace regime, the triples
+for Subjects, Statements, Relations and page metadata, the per-page named graphs, and the export endpoints — is
+the [RDF Export reference](../rdf/rdf-export.md); the [Person → EDM example](../rdf/person-to-edm.md) shows a real
+page projected. A configured SPARQL store receives each save as a replace of that page's graph and each deletion as
+a drop ([store configuration](../operations/installation.md#optional-sparql-graph-stores)); the measured cost of
+that write path, and the targets it is held to, are in the
 [performance reference](../operations/performance.md) and [ADR 29](../adr/029-scalability-targets.md).
 
 ## What This Does Not Cover
@@ -237,17 +67,19 @@ The measured cost of this write path, and the targets it is held to, are in the
   model. That mapping is designed in [Ontology Mapping](OntologyMapping.md). The projection described here emits
   NeoWiki-native predicates; an ontology mapping instead projects the data into standard-ontology terms. Ontology
   mappings need to be quite expressive: CIDOC-CRM alignment isn't just predicate renaming — it requires generating
-  intermediate nodes that don't exist in NeoWiki's data (worked example under Q4 below). That node synthesis has
-  shipped ([#1229](https://github.com/ProfessionalWiki/NeoWiki/pull/1229),
-  [#1263](https://github.com/ProfessionalWiki/NeoWiki/pull/1263)).
+  intermediate nodes that don't exist in NeoWiki's data. That node synthesis has shipped
+  ([#1229](https://github.com/ProfessionalWiki/NeoWiki/pull/1229),
+  [#1263](https://github.com/ProfessionalWiki/NeoWiki/pull/1263)); the
+  [Person → EDM example](../rdf/person-to-edm.md) walks a worked case.
   At the ECHOLOT meeting in Bilbao (March 2026), the consortium agreed that wiki admins should be able to define
-  mappings between ontologies they care about and the NeoWiki Schemas of their wiki. This confirms the
-  separate-mapping approach and means several open questions below (Q1, Q2, Q4) are less critical for the native
-  projection, since ontology alignment is handled separately. The plan is that NeoWiki provides the mapping
+  mappings between ontologies they care about and the NeoWiki Schemas of their wiki. This confirmed the
+  separate-mapping approach, and is why Q1, Q2 and Q4 resolved toward keeping the native projection minimal (see
+  [Decided](#decided)). The plan is that NeoWiki provides the mapping
   mechanism, data modellers in the project create standard mapping + Schema bundles (e.g., for CIDOC-CRM), and users
   can optionally install those bundles where relevant.
 - **Schema definitions as RDF.** Schemas could be expressed as RDFS/OWL classes with property constraints (similar
-  to SHACL shapes). This is potentially valuable for validation and documentation, but is a separate concern.
+  to SHACL shapes). Valuable for validation and documentation, but a separate concern — see
+  [Q10](#q10-schema-namespace-page).
 - **RDF import.** This document covers the outbound direction (NeoWiki data to RDF). Importing RDF data into
   NeoWiki Subjects is a T3.2/T4.1 concern and has its own challenges (mapping external ontologies to NeoWiki
   Schemas).
@@ -259,116 +91,60 @@ The measured cost of this write path, and the targets it is held to, are in the
 
 ## Open Questions
 
-### For ECHOLOT partners with RDF/LOD expertise
+Questions the implementation answered are listed under [Decided](#decided), keeping their original numbers so a
+thread that cites "Q7" still resolves.
 
-These questions need input from people experienced with RDF in cultural heritage contexts. TIB, KMA, TAKIN, and
-OEAW are likely the right people.
+### Q6: Base URI conventions
 
-**Q1: Property predicate scope.** NeoWiki properties are local to Schemas: "Name" in Person and "Name" in Company
-are independent definitions. Should the RDF predicates reflect this (`$base/prop/Person/Name` vs
-`$base/prop/Company/Name`) or use a flat namespace (`$base/prop/Name`) where same-named properties share a
-predicate? The flat approach is more natural for RDF and enables cross-schema queries, but implies a semantic
-equivalence that NeoWiki does not enforce. The scoped approach is faithful to the data model but unusual in RDF.
-
-*Feedback: The scoped approach would not be objectionable but makes ontology mapping harder — it duplicates
-properties and requires inference for mappings to function at a more general level. With the separate ontology
-mapping confirmed (see above), this question is less critical for the native projection: NeoWiki-native predicates
-are emitted regardless, and the ontology mapping translates to standard ontology terms. Tentative resolution: flat
-namespace (`$base/prop/Name`), since it is more natural for RDF and the ontology mapping handles ontology
-alignment.*
-
-*Additional input (2026-07-03): when authoring ontology mappings, same-named properties across Schemas must be
-disambiguated as (Schema, property) pairs regardless of predicate scope, and with a flat namespace any mapping rule
-that reads the native projection needs an `rdf:type` constraint to select the right Schema's property. Recorded as a
-cost of the flat resolution, not a reversal.*
-
-**Q2: Standard vocabulary in the native projection.** The strawman uses `rdf:type`, `rdfs:label`, and `dcterms:created`
-/ `dcterms:modified`. Should more standard predicates be used in the native projection (e.g., `foaf:name` for labels,
-`dcterms:title` for page names)? Or should all standard vocabulary alignment happen in the ontology mapping?
-
-*Less critical given the confirmed ontology mapping. Tentative resolution: keep the native projection minimal
-with the current standard predicates (`rdf:type`, `rdfs:label`, `dcterms:created/modified`). Further standard
-vocabulary alignment happens in the ontology mapping.*
-
-**Q3: Relation representation.** The strawman uses Wikibase-style reification (a dedicated Relation node with
-`source`, `target`, `relationType`, and properties). Is this the right approach for the CH/LOD community? Are
-there conventions we should follow? Should we plan the data model with future RDF-star migration in mind?
-
-*Feedback and as-built (2026-07): shipped as specified — Relations emit both the direct triple and the reified
-Relation node; see [Relations](#relations) and the [RDF Export reference](../rdf/rdf-export.md). George Bruseker
-(takin): having both the direct and the indirect representation is handy; the Wikibase-style reification is
-essentially a named graph. RDF-star migration stays out of scope here (see
-[What This Does Not Cover](#what-this-does-not-cover)). Still moving: the `relationType` term was flagged as
-confusing ([#999](https://github.com/ProfessionalWiki/NeoWiki/discussions/999)), and renaming it is committed as
-part of the cohesive relations design pass ([#630](https://github.com/ProfessionalWiki/NeoWiki/issues/630)), which
-may also reshape the Relation node.*
-
-**Q4: CIDOC-CRM alignment.** CIDOC-CRM is the dominant ontology in cultural heritage. It uses an event-centric
-model (relationships mediated through events) which is quite different from NeoWiki's entity-property model. For
-example, a simple "Creator" relation in NeoWiki would correspond to the CIDOC-CRM path
-`E22_Human-Made_Object → P108i_was_produced_by → E12_Production → P14_carried_out_by → E39_Actor`, where the
-Production event is an intermediate entity that doesn't exist in NeoWiki's data. Does this affect the native
-projection, or is it purely an ontology-mapping concern?
-
-*Feedback (TIB, Kolja, from Wikibase experience): Three approaches exist: (1) basic entity-property — simplest,
-(2) event-centric — more performant for queries but data not visible on the subject's page, (3) qualifier-based
-— familiar from Wikidata, all data on one page. The event-centric UX downside could be mitigated by displaying
-related pages on a subject's page (like transclusion of the named graph up to a defined depth). For SPARQL, the
-query limitations that SMW had with qualifiers do not occur. Tentative resolution: confirmed as an ontology-mapping
-concern, not a native-projection concern. The native projection represents NeoWiki's native data model; CIDOC-CRM
-event expansion happens in the ontology mapping.*
-
-**Q5: Named graph conventions.** Per-page named graphs are proposed for operational reasons (efficient sync). Are
-there CH/LOD conventions for named graph usage (e.g., per-source, per-dataset) that we should align with? Does
-ECHOLOT's provenance model (T2.4) have implications for named graph design?
-
-*Resolved: No CH conventions exist for named graph usage. Per-page named graphs are fine for operational
-purposes. Note: per-page named graphs record only data origin (which page), not chain-of-production provenance;
-the latter is handled by the provenance model (T2.4) and a dedicated provenance plug-in (T3.4) on top of NeoWiki's
-extension points and MediaWiki versioning, not by the native projection. See [ECHOLOT.md](ECHOLOT.md).*
-
-**Q6: Base URI conventions.** Should the base URI be the wiki's URL (e.g., `https://mywiki.example.org/`)? Is
-there a convention in the ECHOLOT/ECCCH context for how services should mint URIs?
+Should the base URI be the wiki's URL, and is there a convention in the ECHOLOT/ECCCH context for how services
+should mint URIs?
 
 *Feedback: There is a URI policy being discussed within ECCCH. Aligning with it would be beneficial. To be
 followed up on.*
 
 *As built: the base URI is configurable — `$wgNeoWikiRdfBaseUri`, defaulting to the wiki's canonical URL
-(`$wgCanonicalServer`); see the [RDF Export reference](../rdf/rdf-export.md).*
+(`$wgCanonicalServer`); see the [RDF Export reference](../rdf/rdf-export.md). What stays open is which value an
+ECCCH-integrated deployment should be given.*
 
-**Q7: URI design for Properties.** Property Names can contain spaces and special characters (e.g., "Founded at",
-"Has author"). What's the convention — URL-encode them (`Has%20author`), replace spaces with underscores
-(`Has_author`), or something else?
+### Q8: Writer's schema in RDF
 
-*Feedback: Two suggestions received. (1) CamelCase — upper-case for classes (`BeautifulClass`), lower-case for
-properties (`hasSomeFeature`). This is the most common RDF convention. (2) Underscores (`Has_author`) — more
-practical for cultural heritage users less familiar with URL encoding. Both are viable; this is a convention
-choice, not an architectural one.*
+NeoWiki Statements record the "writer's schema", the property type at write time
+([ADR 11](../adr/011-include-writers-schema.md)). The projection omits it, as proposed: it is metadata about the
+Statement rather than about the entity, and useful mainly for debugging and round-tripping. Open: whether a
+"full export" mode should carry it. No issue tracks this.
 
-*Resolved by shipping: underscores — spaces in Property Names become underscores in the IRI local name
-(`Has_author`); see the [RDF Export reference](../rdf/rdf-export.md). Partner concurrence that either convention
-works (George Bruseker, takin, 2026-07-06).*
+### Q10: Schema namespace page
 
-### Implementation decisions (can resolve ourselves)
-
-**Q8: Property type in RDF.** NeoWiki Statements include the "writer's schema" (the property type at write time).
-Should this be emitted as a triple on the Subject or Relation node? It's metadata about the statement, not about
-the entity. Probably only useful for debugging / round-tripping. Tentative answer: omit from native projection, include
-in a "full export" mode.
-
-**Q9: Ordering of multi-valued properties.** NeoWiki stores multi-valued properties as ordered arrays. RDF triple
-sets are unordered. Accept the ordering loss for the native projection? Or emit ordering information (adds complexity)?
-Tentative answer: accept the loss; ordering is a display concern handled by Views.
-
-*Feedback: Question raised whether ordering truly matters for some use cases (e.g., pages in a book). Tentative
-answer unchanged: accept ordering loss in the native projection. If specific use cases require ordering, it can be
-added later (e.g., via `rdf:List` or index properties). Concurrence (George Bruseker, takin, 2026-07-06): where
-ordering is real data, model it explicitly so it stays recoverable in the export.*
-
-**Q10: Schema namespace page.** Should NeoWiki emit an RDFS/OWL definition for each Schema (as a class) and each
-Property Definition (as a property with domain/range)? This would make the RDF self-describing. Tentative answer:
-yes, but as a separate enhancement, not blocking the initial projection. Partner demand recorded (takin, 2026-07-03):
-an RDFS export of local Schemas is wanted as an input for authoring ontology mappings — a wiki's Schemas are
-effectively its own ontology, and the native projection should be able to say so in RDF. Tracked in
+Should NeoWiki emit an RDFS/OWL definition for each Schema (as a class) and each Property Definition (as a property
+with domain/range)? This would make the RDF self-describing. Tentative answer: yes, but as a separate enhancement,
+not blocking the initial projection. Partner demand recorded (takin, 2026-07-03): an RDFS export of local Schemas is
+wanted as an input for authoring ontology mappings — a wiki's Schemas are effectively its own ontology, and the
+native projection should be able to say so in RDF. Tracked in
 [#1163](https://github.com/ProfessionalWiki/NeoWiki/issues/1163). See also the generated shape exports in
 [ShapeLanguages.md](ShapeLanguages.md).
+
+## Decided
+
+Answered by shipping or by partner feedback. Numbers are the original question numbers.
+
+- **Q1 — property predicate scope.** Flat (`$base/prop/Name`), not scoped per Schema: more natural for RDF, and
+  ontology alignment happens in the mapping either way. Recorded cost: a mapping rule reading the native projection
+  needs an `rdf:type` constraint to select the right Schema's property (2026-07-03).
+- **Q2 — standard vocabulary.** The native projection stays minimal — `rdf:type`, `rdfs:label`, and
+  `dcterms:created`/`dcterms:modified`. Further standard-vocabulary alignment belongs to an ontology mapping.
+- **Q3 — relation representation.** Wikibase-style reification alongside the direct triple, as specified
+  ([reference](../rdf/rdf-export.md#projected-triples)); George Bruseker (takin) confirmed having both
+  representations is handy. Residue: `relationType` was flagged as a confusing term
+  ([#999](https://github.com/ProfessionalWiki/NeoWiki/discussions/999)) and renaming it rides with the relations
+  design pass ([#630](https://github.com/ProfessionalWiki/NeoWiki/issues/630)), which may reshape the Relation node.
+- **Q4 — CIDOC-CRM alignment.** An ontology-mapping concern, not a native-projection one (TIB, Kolja). The node
+  synthesis it needs has since shipped ([#1229](https://github.com/ProfessionalWiki/NeoWiki/pull/1229),
+  [#1263](https://github.com/ProfessionalWiki/NeoWiki/pull/1263)).
+- **Q5 — named graph conventions.** No CH convention exists; per-page named graphs are fine for operational purposes.
+  They record data origin only — chain-of-production provenance is the T2.4 model and a T3.4 plug-in, not the
+  projection (see [ECHOLOT.md](ECHOLOT.md)).
+- **Q7 — URI design for Properties.** Underscores: spaces in a name become underscores in the IRI local name
+  (`Has_author`), with partner concurrence that either convention works (George Bruseker, takin, 2026-07-06).
+- **Q9 — ordering of multi-valued properties.** Ordering loss is accepted; ordering is a display concern for Views.
+  Where ordering is real data, model it explicitly so it stays recoverable in the export (George Bruseker, takin,
+  2026-07-06).

--- a/docs/planning/OntologyMapping.md
+++ b/docs/planning/OntologyMapping.md
@@ -1,11 +1,11 @@
 # Ontology Mapping
 
-This is an early design document for stakeholder feedback before we start implementation and record decisions via a
-new ADR.
+A design document whose implementation has since shipped (see the as-built note below). The open questions at the end
+still stand, and the decisions still need consolidating into an ADR.
 
 Started 2026-06-24 by Jeroen De Dauw with help from Claude Opus 4.8.
 
-Status: Draft strawman, for discussion with ECHOLOT partners (T2.3 and T3.x).
+Status: Implemented; open questions still under discussion with ECHOLOT partners (T2.3 and T3.x).
 
 Discussion: [#996](https://github.com/ProfessionalWiki/NeoWiki/discussions/996).
 
@@ -179,8 +179,8 @@ back to the wiki (both below).
 
 ## Strawman model
 
-A concrete proposal to react to. Details are deliberately tentative; the open questions below are where partner input is
-needed.
+*Superseded by the shipped format ([reference](../rdf/ontology-mapping.md)), and kept because the open questions
+below still refer to it.*
 
 ### The Mapping object
 
@@ -252,7 +252,8 @@ export projection does not have:
 
 - **Reconciliation / entity linking** of incoming IRIs to existing Subjects — a WP4 concern (T4.2), not the mapping
   itself.
-- **Batch ID-minting** for many interlinked incoming Subjects (the current API mints one Subject at a time).
+- **Batch ID-minting** for many interlinked incoming Subjects — shipped
+  ([#1100](https://github.com/ProfessionalWiki/NeoWiki/issues/1100)).
 - **Target-Schema selection** for incoming data.
 
 So a Mapping should aim to be a bidirectional *definition*, while import and export are separate *executors* and the

--- a/docs/planning/OntologyMapping.md
+++ b/docs/planning/OntologyMapping.md
@@ -17,8 +17,22 @@ Discussion: [#996](https://github.com/ProfessionalWiki/NeoWiki/discussions/996).
 > contributions. See the [Ontology Mapping reference](../rdf/ontology-mapping.md) and the worked
 > [Person → EDM example](../rdf/person-to-edm.md). The rule format is NeoWiki-native, so the
 > mapping-formalism question (Q1, [#995](https://github.com/ProfessionalWiki/NeoWiki/issues/995)) stays open
-> at the authoring level; the stored format is provisional. Where the as-built provisionally answers an open
-> question below, that is noted inline.
+> at the authoring level; the stored format is provisional. The questions it answered are listed under
+> [Decided](#decided).
+
+## Still open (2026-08)
+
+- [Q1 — Authoring formalism](#q1-authoring-formalism): should LinkML or a Platka export sit in front of the shipped
+  JSON?
+- [Q3 — Platka boundary](#q3-platka-boundary): division of labour, format, and interface with takin's library.
+- [Q4 — Import](#q4-import): how far to shape the format for the import direction.
+- [Q5 — Validation via SHACL](#q5-validation-via-shacl): which shapes, and where findings surface for curators.
+- [Q7 — Packaging and distribution](#q7-packaging-and-distribution): bundles across wikis and a farm.
+- [Q8 — Multilinguality](#q8-multilinguality): the cohesive pass across NeoWiki's surfaces.
+- [Q10 — Flat vs nested native modelling](#q10-flat-vs-nested-native-modelling): the modelling fork, settled outside
+  this document.
+
+Everything else the document asked has been answered by the implementation — see [Decided](#decided).
 
 ## Summary
 
@@ -27,13 +41,9 @@ RDF; the native projection uses NeoWiki-native predicates ([NativeRdfProjection.
 interoperability — the core of ECHOLOT (SO2, T3.1, T3.2) — the data must instead be available in established
 cultural-heritage ontologies such as CIDOC-CRM, EDM, HDTO, and BIBFRAME.
 
-An **ontology mapping** projects native NeoWiki data **directly into a target ontology**. That ontology RDF is what a
-configured triple store holds and what SPARQL queries run against. The NeoWiki-native projection
-([NativeRdfProjection.md](NativeRdfProjection.md)) and each target ontology are **sibling projections** of the same
-source data, selected per store rather than stacked: a store can hold one or more projections, each in its own family
-of named graphs, and different stores can hold different projection sets of the same wiki. The native
-projection is the default (used when no ontology mapping is configured) and the lossless-export target; ontology
-mappings define the other targets.
+An **ontology mapping** projects native NeoWiki data **directly into a target ontology**: that ontology RDF is what a
+configured triple store holds and what SPARQL queries run against. The native projection stays the default — used
+when no mapping is configured — and the lossless-export target; ontology mappings define the others.
 
 Mappings are first-class, authorable, installable objects, kept separate from Schemas so the native data model is not
 deformed to fit an ontology. A mapping defines the **correspondence** between NeoWiki's model and an ontology, and is
@@ -41,13 +51,11 @@ intended to drive both export (native → ontology) and, later, import (ontology
 
 The central difficulty is that good ontology mapping is **not predicate renaming**: CIDOC-CRM and similar ontologies
 are event-centric and require *synthesizing intermediate nodes that do not exist in NeoWiki's data*. The mapping is a
-graph-to-graph transformation governed by reusable patterns. Most of this document is about expressing those patterns,
-where they come from, how the open flat-vs-nested modelling fork affects them, the import direction, and validating
-what the projections produce.
+graph-to-graph transformation governed by reusable patterns.
 
 > Terminology note: ECHOLOT partners often say "RDF mapping" for ontology alignment — that is *this* document. The
-> native vocabulary and the projection infrastructure shared by all projections (IRIs, named graphs, sync) live in
-> [NativeRdfProjection.md](NativeRdfProjection.md).
+> native vocabulary and the infrastructure shared by all projections (IRIs, named graphs, sync) are specified in the
+> [RDF Export reference](../rdf/rdf-export.md).
 
 ## Projections, not layers
 
@@ -96,33 +104,16 @@ Settled across our planning:
 
 ## What makes this hard: structural transformation
 
-Target ontologies sit on a spectrum of difficulty.
+Targets sit on a spectrum. Flat, property-centric ones (Dublin Core, much of EDM) mostly need term substitution:
+`Person.Name` → `foaf:name`. Event-centric ones do not: CIDOC-CRM mediates relationships through events, so a native
+`Creator` relation expands to a path through an `E12_Production` node that has **no counterpart in NeoWiki's data**
+and must be minted. The mirror case is contraction — where the data carries structure a target does not want, the
+mapping collapses it, as a Birth event Subject collapses to `rdaGr2:dateOfBirth` on a flat EDM agent. Both directions
+are needed because a wiki serves several targets at once ([sibling projections](#projections-not-layers)) that
+disagree about shape, so at least one mismatches whichever style the data is modelled in.
 
-**The easy tier — near 1:1 alignment.** Flat, property-centric targets (Dublin Core, much of EDM) mostly need term
-substitution: `Person.Name` → `foaf:name`, `Artwork.Creator` → `dc:creator`.
-
-**The hard tier — structural / event-centric alignment.** CIDOC-CRM, the dominant CH ontology, mediates relationships
-through events. A single native `Creator` relation from an object to a person does not map to one predicate; it expands
-to a path with an intermediate event node:
-
-```
-E22_Human-Made_Object  →  P108i_was_produced_by  →  E12_Production  →  P14_carried_out_by  →  E39_Actor
-```
-
-The `E12_Production` node has **no counterpart in NeoWiki's data**. The mapping must mint it. This is the crux: any
-mapping formalism we adopt has to express **path expansion and node synthesis**, not just renaming. A formalism that
-only substitutes terms covers flat data going to EDM but fails CIDOC-CRM — and CIDOC-CRM is the one that matters most
-for the case studies.
-
-**The mirror requirement — contraction.** The transformation also runs the other way: where the data carries structure
-a target does not want, the mapping must walk it and collapse it — a Birth event Subject linked from a Person collapses
-to `rdaGr2:dateOfBirth` on the flat EDM agent. Both directions are needed because a wiki serves several targets at once
-([sibling projections](#projections-not-layers)) that disagree about shape, so at least one target mismatches whichever
-style the data is modelled in. Live on the demo wiki ([neowiki.dev](https://neowiki.dev)): flat-modelled Picasso
-projects fully to EDM and expands into `E67_Birth` for CIDOC-CRM; Bach, whose birth is an explicit Subject, has that
-Subject contribute the flat `rdaGr2:dateOfBirth` and `rdaGr2:placeOfBirth` back onto him. Contraction is source-side —
-the contributing page emits the triples into its own graph — so a store or bulk dump sees the complete flat agent
-while a per-page export of Bach alone does not.
+Expressing both in one declarative form is what the mapping format had to solve, and does. The
+[Person → EDM example](../rdf/person-to-edm.md) walks a real projection, including the `E67_Birth` synthesis.
 
 ### Flat vs nested native modelling (open fork)
 
@@ -147,20 +138,7 @@ WP2/3/4 call). What matters here is that the formalism needs both directions und
 will model maximally nested (a mapping must handle whatever the native model is), and sibling targets decompose
 differently — EDM stays flat where CIDOC-CRM wants events — so no single nesting depth spares all projections.
 Route (b) reduces how often synthesis fires and makes contraction fire for the flat targets instead; it does not
-remove the requirement (Q2, Q10).
-
-### Identity for synthesized nodes
-
-Synthesized nodes need stable, deterministic IRIs so that re-projecting a page is idempotent and the per-page
-named-graph sync in [NativeRdfProjection.md](NativeRdfProjection.md#named-graphs) (`DROP GRAPH` + `INSERT DATA`)
-stays correct for an ontology store too.
-
-NeoWiki gives a natural anchor: **Relations carry a persistent ID** ([ADR 10](../adr/010-add-guids-to-relations.md)).
-The mediating CIDOC-CRM event node can derive its IRI from that Relation ID, so the `E12_Production` for a given Creator
-relation is the same node on every projection. Where no native ID exists (e.g. a literal-valued statement that expands
-structurally), the IRI is derived deterministically from the source Subject IRI plus the rule and a stable position key.
-Stable synthesized-node identity is also what makes the import direction tractable and validation reports traceable
-back to the wiki (both below).
+remove the requirement (Q10).
 
 ## Design principles
 
@@ -177,67 +155,11 @@ back to the wiki (both below).
 5. **Bidirectional correspondence.** A mapping describes how NeoWiki's model and an ontology correspond, for both export
    and import. Export ships first; import (below) reuses the correspondence but needs additional machinery.
 
-## Strawman model
+## The shipped format
 
-*Superseded by the shipped format ([reference](../rdf/ontology-mapping.md)), and kept because the open questions
-below still refer to it.*
-
-### The Mapping object
-
-A **Mapping** binds one source Schema to one target ontology and is a set of **rules**. It is a first-class object,
-separate from the Schema it references ([ADR 17](../adr/017-names-as-identifiers.md): Schemas are referenced by name),
-so the Schema stays clean and can carry several mappings (one per target ontology), installed independently.
-
-```
-Mapping {
-  schema:  "Artwork"            # source Schema (by name)
-  target:  "cidoc-crm"          # target ontology / profile
-  rules:   [ Rule, Rule, ... ]
-}
-```
-
-### Rules and the transformation
-
-Each **rule** matches a native construct — a Subject of the Schema, a Statement on a given property, or a Relation of a
-given type — and emits a **pattern**: target triples that may mint intermediate nodes.
-
-A natural way to express a rule is a **`CONSTRUCT`-style template**: standard, store-agnostic, minting nodes via
-deterministic IRI templates. The native projection serves as the transformation's input representation, and the
-target-ontology triples it produces are what the store holds. A rule for the Creator example:
-
-```sparql
-# rule: Artwork.Creator → CIDOC-CRM production event
-CONSTRUCT {
-  ?object      a crm:E22_Human-Made_Object ;
-               crm:P108i_was_produced_by ?production .
-  ?production  a crm:E12_Production ;
-               crm:P14_carried_out_by ?actor .
-  ?actor       a crm:E39_Actor .
-}
-WHERE {
-  ?rel  a neo:Relation ;
-        neo:relationType neo-prop:Creator ;
-        neo:source ?object ;
-        neo:target ?actor .
-  # deterministic IRI for the synthesized event, anchored on the Relation ID
-  BIND( IRI(CONCAT(STR(crm-prod:), STRAFTER(STR(?rel), STR(neo-rel:)))) AS ?production )
-}
-```
-
-Here `crm:` is CIDOC-CRM and `crm-prod:` is an illustrative namespace for synthesized event nodes; the `BIND` anchors
-that node's IRI on the Relation ID so it is stable across re-projections. The same Artwork Schema mapped to EDM would be
-mostly flat rules (`?object a edm:ProvidedCHO`, `?object dc:creator ?actor`) — illustrating
-that one formalism must span both ends of the spectrum.
-
-`CONSTRUCT` is one candidate form. Whether authors write templates directly, or write something higher-level (LinkML,
-SHACL rules, or patterns sourced from the T2.3 library) that compiles to them, is the central open question below.
-
-### Where patterns come from
-
-We should not hand-encode CIDOC-CRM paths from scratch if a curated source exists. T2.3 (takin) is building a pattern
-library (Platka) that stores ontology patterns as machine-readable paths. The ideal division of labour: the library
-owns the *recipe* (the exact RDF a given alignment must produce); NeoWiki owns the *binding* of local Schemas and data
-onto those recipes and the *execution* against actual Subjects. The exact interface and format are open (below).
+A Mapping is a JSON page in the `Mapping:` namespace, one per target ontology, declaring per Schema how the Subject,
+its properties, its synthesized nodes, and its contributions project. It is specified in the
+[Ontology Mapping reference](../rdf/ontology-mapping.md).
 
 ## Import
 
@@ -276,8 +198,8 @@ Proposed division of labour: shape engines run in external quality tooling (T4.5
 NeoWiki's job is to keep projections checkable and findings traceable:
 
 - Export of projected RDF for a given mapping (per page and in bulk), so external validators have input.
-- Per-page named graphs ([NativeRdfProjection.md](NativeRdfProjection.md#named-graphs)) make re-validation
-  incremental: only pages whose graphs changed since the last run need re-checking.
+- Per-page named graphs ([RDF Export reference](../rdf/rdf-export.md#iri-scheme)) make re-validation incremental:
+  only pages whose graphs changed since the last run need re-checking.
 - **Traceability requirement.** A validation report references ontology-projection nodes, but the people acting on it
   work in the wiki. Reports must be translatable back to the originating page, Subject, and property. The anchors
   exist by construction — focus node → named graph → page; synthesized-node IRI → Relation ID → Statement; violated
@@ -296,7 +218,8 @@ native projection as the default target; the Mapping as a bidirectional definiti
 **Out of scope (separate concerns, cross-referenced):**
 
 - The native projection and the shared projection infrastructure (IRIs, named graphs, sync) —
-  [NativeRdfProjection.md](NativeRdfProjection.md).
+  [NativeRdfProjection.md](NativeRdfProjection.md) for the rationale, the
+  [RDF Export reference](../rdf/rdf-export.md) for what it emits.
 - The import *pipeline* mechanics and orchestration — T4.1.
 - Reconciliation / entity linking / `owl:sameAs` minting — WP4 (T4.2); mapped IRIs are its input.
 - Rich chain-of-production provenance and rights — T2.4 model and a T3.4 plug-in (see [ECHOLOT.md](ECHOLOT.md)).
@@ -305,87 +228,62 @@ native projection as the default target; the Mapping as a bidirectional definiti
 ## Open questions
 
 These need ECHOLOT partner input, especially from T2.3 (semantic interoperability / ontology patterns) and partners
-with deep CIDOC-CRM / EDM / RDF experience.
+with deep CIDOC-CRM / EDM / RDF experience. Questions the implementation answered are listed under
+[Decided](#decided), keeping their original numbers so a thread that cites "Q6" still resolves.
 
-**Q1: Mapping formalism.** The central fork. Candidates:
-  1. **A NeoWiki-native mapping object** (rules compiling to `CONSTRUCT`-style templates as sketched above). Full
-     control, fitted to our model; but a formalism we own and maintain.
-  2. **LinkML.** An established, tooling-rich modelling language with class/slot mappings to external vocabularies. Open
-     whether its mapping facilities are expressive enough for CIDOC-CRM-style structural expansion, or only the near-1:1
-     tier.
-  3. **Patterns sourced from the T2.3 library (Platka).** Bind local constructs to externally-curated patterns,
-     minimizing ontology knowledge in NeoWiki. Depends on what the library can emit and how stable that interface is.
+### Q1: Authoring formalism
 
-  These are not mutually exclusive: e.g. consume patterns from (3), expressed in a formalism like (2), executed via (1).
-  What combination do partners recommend? Independent of the combination: survey existing CH mapping tooling before
-  building — mature ontology-mapping frameworks exist in this space, and reusing or aligning with one may beat
-  rebuilding (George, 2026-07-03).
+The shipped format is a NeoWiki-native declarative JSON, and it is the executable substrate. What stays open is
+whether a higher-level formalism should sit in front of it: **LinkML**, whose class/slot mappings to external
+vocabularies are established and tooling-rich but of unproven expressiveness for CIDOC-CRM-style structural expansion
+([#995](https://github.com/ProfessionalWiki/NeoWiki/issues/995)), or an export from the T2.3 pattern library that
+compiles down to it. Independent of the answer: survey existing CH mapping tooling before building more — mature
+ontology-mapping frameworks exist in this space, and reusing or aligning with one may beat rebuilding (George,
+2026-07-03).
 
-**Q2: Expressiveness for node synthesis.** Whatever formalism is chosen, can it express path expansion and
-intermediate-node minting (the `E12_Production` case) — not just term substitution? Can it equally express the
-[mirror direction](#what-makes-this-hard-structural-transformation) — recognizing explicitly modelled structure and
-collapsing it for a flatter target? Both directions are recorded as an evaluation constraint on
-[#995](https://github.com/ProfessionalWiki/NeoWiki/issues/995). Are SHACL Advanced Features
-(SPARQL-based `sh:rule`) or `CONSTRUCT` the right executable substrate? Do partners already have CIDOC-CRM expansion
-patterns in an executable form we can target?
+### Q3: Platka boundary
 
-*As built: the native format expresses both directions — synthesized nodes for expansion, contributions for
-contraction ([reference](../rdf/ontology-mapping.md)). Whether a higher-level formalism should author or compile to
-it stays open on Q1.*
+Platka is the T2.3 pattern library (takin). Open: the division of labour between it and NeoWiki, what NeoWiki would
+consume from it, in what format, and over what interface. The division we have assumed is that the library owns the
+*recipe* — the exact RDF a given alignment must produce — while NeoWiki owns the *binding* of local Schemas onto it
+and the *execution* against actual Subjects; to be confirmed with takin
+([#996](https://github.com/ProfessionalWiki/NeoWiki/discussions/996)).
 
-**Q3: Platka boundary.** Our understanding (to confirm): the T2.3 pattern library *creates* ontologies and derivatives
-(e.g. SHACL for validation) but does **not** perform ontology-to-ontology mapping. If so, NeoWiki owns Schema→ontology
-mappings, and the library supplies (a) the target patterns we project to and possibly (b) SHACL we validate against.
-What exactly does NeoWiki consume from the library, in what format, over what interface?
+### Q4: Import
 
-**Q4: Import.** How far should the export formalism be shaped now so the same Mapping can drive import later? Where is
-the boundary between the Mapping (correspondence), the import executor (pattern recognition), and T4.1/T4.2 (pipeline,
+How far should the export format be shaped now so the same Mapping can drive import later? Where is the boundary
+between the Mapping (correspondence), the import executor (pattern recognition), and T4.1/T4.2 (pipeline,
 reconciliation)?
 
-**Q5: Validation via SHACL.** [Validating projections](#validating-projections) proposes consuming shapes emitted by
-the T2.3 library to check ontology projections, with the engines in the T4.5 tooling rather than in NeoWiki. Open:
-which shapes the library actually emits and their coverage per ontology; and where findings surface for curators
-(report pages, a dashboard, an API the quality component writes back to) — in NeoWiki core or a plug-in. Candidate
-engine (suggested 2026-07-03): [rudof](https://github.com/rudof-project/rudof) — Rust, SHACL + ShEx, has an MCP
-interface, and can validate a QLever endpoint directly; endpoint-side validation still needs the traceability path
-above, since the store has no sync-back to the wiki.
+### Q5: Validation via SHACL
 
-**Q6: One mapping per target vs combined.** A separate Mapping per (Schema, target ontology), or a single multi-target
-mapping per Schema? Per-target is more modular and independently installable; combined may reduce duplication for shared
-sub-patterns.
+[Validating projections](#validating-projections) proposes consuming shapes emitted by the T2.3 library to check
+ontology projections, with the engines in the T4.5 tooling rather than in NeoWiki. Open: which shapes the library
+actually emits and their coverage per ontology; and where findings surface for curators (report pages, a dashboard,
+an API the quality component writes back to) — in NeoWiki core or a plug-in. Candidate engine (suggested 2026-07-03):
+[rudof](https://github.com/rudof-project/rudof) — Rust, SHACL + ShEx, has an MCP interface, and can validate a QLever
+endpoint directly; endpoint-side validation still needs the traceability path above, since the store has no sync-back
+to the wiki.
 
-*As built: one Mapping page per target ontology, holding an entry for every mapped Schema — the page title is the
-target name, so uniqueness needs no save-time check
-([#1065](https://github.com/ProfessionalWiki/NeoWiki/discussions/1065)). Combined multi-target pages stay open for a
-later format version.*
+### Q7: Packaging and distribution
 
-**Q7: Authoring and distribution.** Where do Mappings live (a dedicated namespace? API-only?), who authors them (data
-modellers) vs installs them (wiki admins), and how are bundles (e.g. "CIDOC-CRM for Person / Place / Object") packaged
-and shared across wikis and a farm?
+Mappings are wiki pages, but bundles are not addressed: how a set such as "CIDOC-CRM for Person / Place / Object" is
+packaged, versioned, installed, and shared across wikis and a farm.
 
-*As built: Mappings live as pages in a dedicated `Mapping:` namespace (one page per target ontology, named after it —
-[ADR 17](../adr/017-names-as-identifiers.md)-style), authored like Schemas/Layouts and gated by the
-`neowiki-mapping-edit` right, and seedable as demo/bundle data (the Person→EDM example ships this way). Packaging and
-farm-wide sharing of bundles is not yet addressed.*
+### Q8: Multilinguality
 
-**Q8: Multilinguality.** Mapped labels should carry language tags (`@lang`); canonical values used in queries stay
-language-neutral. CH data is heavily multilingual (Basque, the ELB languages, etc.). How much belongs in the mapping vs
-the native projection vs Views?
+A mapping can language-tag the literals it projects, which leaves the harder half open: where multilinguality lives
+across NeoWiki as a whole — property labels ([#710](https://github.com/ProfessionalWiki/NeoWiki/issues/710)), select
+options ([#726](https://github.com/ProfessionalWiki/NeoWiki/issues/726)), the native projection, and Views. CH data is
+heavily multilingual (Basque, the ELB languages), while canonical values used in queries stay language-neutral. A
+cohesive pass across surfaces is wanted rather than per-surface answers.
 
-**Q9: Multiple projections per wiki.** Should a wiki be able to serve several projections at once (several stores:
-native + one or more ontologies), and is a native projection always available as a baseline? This makes "which
-vocabulary is in the store" a per-store configuration rather than a single global choice.
+### Q10: Flat vs nested native modelling
 
-*As built: yes for export — a wiki serves several projections at once, selected per request via the `projection`
-parameter, with `native` always the baseline and each Mapping page adding its target to the known set. Named graphs
-are qualified by projection ([#1053](https://github.com/ProfessionalWiki/NeoWiki/issues/1053)), so a single store can
-likewise hold several projections at once — see [Projections, not layers](#projections-not-layers). The
-projector/serializer seam #586 consumes is `newRdfProjection(name)`.*
-
-**Q10: Flat vs nested native modelling.** The [fork above](#flat-vs-nested-native-modelling-open-fork): should
-case-study data live in flat Schemas with the mapping synthesizing intermediate nodes, or in nested Schemas with the
-editing UI projecting the nesting down? Settled through the toy model, outside this document. If (b) wins: what does
-nesting look like in the schema format, and how much of the synthesis machinery here stops being exercised in practice?
+The [fork above](#flat-vs-nested-native-modelling-open-fork): should case-study data live in flat Schemas with the
+mapping synthesizing intermediate nodes, or in nested Schemas with the editing UI projecting the nesting down?
+Settled through the toy model, outside this document. If (b) wins: what does nesting look like in the schema format,
+and how much of the synthesis machinery stops being exercised in practice?
 
 *Update (2026-07): the fork no longer gates the transformation machinery — both directions are needed however it
 resolves, since sibling targets disagree about shape and at least one mismatches whichever style the data is
@@ -393,9 +291,32 @@ modelled in ("one would need to expand (or contract) on export/import" — Georg
 [#999](https://github.com/ProfessionalWiki/NeoWiki/discussions/999), 2026-07-06). What the fork still steers: build
 order, editing-UI investment, and what standard Schema bundles default to.*
 
+## Decided
+
+Answered by the shipped implementation. Numbers are the original question numbers.
+
+- **Q2 — expressiveness for node synthesis.** The format expresses both directions natively: synthesized nodes for
+  expansion, contributions for contraction. Neither SHACL Advanced Features nor `CONSTRUCT` became the substrate
+  ([reference](../rdf/ontology-mapping.md)).
+- **Q6 — one mapping per target vs combined.** One Mapping page per target ontology, holding an entry for every mapped
+  Schema ([#1086](https://github.com/ProfessionalWiki/NeoWiki/pull/1086),
+  [discussion #1065](https://github.com/ProfessionalWiki/NeoWiki/discussions/1065)).
+- **Q7 — where Mappings live.** Pages in the `Mapping:` namespace, listed on `Special:Mappings` and gated by the
+  `neowiki-mapping-edit` right ([reference](../rdf/ontology-mapping.md#ontology-mappings-are-wiki-pages)).
+- **Q8 — language tags in a mapping.** A mapped property or contribution takes a `lang` tag, applied to the plain-string
+  literals it produces ([reference](../rdf/ontology-mapping.md#format-version-1)); the native projection mints none.
+- **Q9 — multiple projections per wiki.** A wiki serves several sibling projections at once, selected per request, with
+  `native` always the baseline; named graphs are qualified by projection so one store can hold several
+  ([#1055](https://github.com/ProfessionalWiki/NeoWiki/pull/1055),
+  [config](../operations/installation.md#several-projections-in-one-store)).
+- **Identity for synthesized nodes.** Node IRIs are derived deterministically from the data — from the Relation's
+  persistent ID where one exists ([ADR 10](../adr/010-add-guids-to-relations.md)), otherwise from the Subject IRI and
+  the node key — so re-projecting a page is idempotent
+  ([reference](../rdf/ontology-mapping.md#synthesized-node-iris)).
+
 ## Related
 
-- Planning: [NativeRdfProjection](NativeRdfProjection.md) (the native projection and shared per-store infrastructure),
+- Planning: [NativeRdfProjection](NativeRdfProjection.md) (why the native projection is shaped as it is),
   [GlobalProperties](GlobalProperties.md) (why mapping is separate from the data model),
   [SubjectSources](SubjectSources.md) (the `source → base-URI` registry that is also the RDF prefix/URI map),
   [ECHOLOT](ECHOLOT.md).

--- a/docs/planning/OntologyMapping.md
+++ b/docs/planning/OntologyMapping.md
@@ -29,8 +29,8 @@ Discussion: [#996](https://github.com/ProfessionalWiki/NeoWiki/discussions/996).
 - [Q5 — Validation via SHACL](#q5-validation-via-shacl): which shapes, and where findings surface for curators.
 - [Q7 — Packaging and distribution](#q7-packaging-and-distribution): bundles across wikis and a farm.
 - [Q8 — Multilinguality](#q8-multilinguality): the cohesive pass across NeoWiki's surfaces.
-- [Q10 — Flat vs nested native modelling](#q10-flat-vs-nested-native-modelling): the modelling fork, settled outside
-  this document.
+- [Q10 — Flat vs nested native modelling](#q10-flat-vs-nested-native-modelling): the modelling fork, to be settled
+  outside this document.
 
 Everything else the document asked has been answered by the implementation — see [Decided](#decided).
 
@@ -129,7 +129,7 @@ should be and where the burden sits:
   editing UI, which must project the nesting down into an accessible form — what Arches and ResearchSpace do. George
   Bruseker leans (b) if the UI can project down.
 
-The fork is settled outside this document — it is a schema-model and editing-UX decision, exercised through the shared
+The fork is to be settled outside this document — it is a schema-model and editing-UX decision, exercised through the shared
 toy model ([Neutral Person to Many Standards](https://docs.google.com/spreadsheets/d/1j2_7j8RCUJrrMsfZaXtqHQOwp9cN9F8HIBtd3pfsToU/edit))
 that expresses one person model across several ontologies. The same toy model doubles as the first end-to-end
 exercise of this document's approach: implement its neutral person schema in NeoWiki, define a Mapping for it, and
@@ -282,8 +282,8 @@ cohesive pass across surfaces is wanted rather than per-surface answers.
 
 The [fork above](#flat-vs-nested-native-modelling-open-fork): should case-study data live in flat Schemas with the
 mapping synthesizing intermediate nodes, or in nested Schemas with the editing UI projecting the nesting down?
-Settled through the toy model, outside this document. If (b) wins: what does nesting look like in the schema format,
-and how much of the synthesis machinery stops being exercised in practice?
+To be settled through the toy model, outside this document. If (b) wins: what does nesting look like in the schema
+format, and how much of the synthesis machinery stops being exercised in practice?
 
 *Update (2026-07): the fork no longer gates the transformation machinery — both directions are needed however it
 resolves, since sibling targets disagree about shape and at least one mismatches whichever style the data is

--- a/docs/planning/ShapeLanguages.md
+++ b/docs/planning/ShapeLanguages.md
@@ -42,7 +42,7 @@ and the editing UI renders what the server returns. For RDF, the wiki's data is 
 ## Why not as the internal format or engine
 
 [ADR 9](../adr/009-move-away-from-json-schema.md) already records the short form of this decision. Since the project
-has changed around it — validation moved to the backend, RDF projections and ontology mappings are being designed —
+has changed around it — validation moved to the backend, RDF projections and ontology mappings were being designed —
 we revisited it. The conclusion stands, for these reasons:
 
 1. **Our data model is not an RDF graph.** Shape engines validate RDF. Using one internally would put a

--- a/docs/planning/ShapeLanguages.md
+++ b/docs/planning/ShapeLanguages.md
@@ -33,12 +33,11 @@ small subset of what shape languages express. The reverse direction is lossy, wh
 For NeoWiki terminology, see the [glossary](../glossary.md). The short version: Subjects hold Statements
 whose Values can have multiple ordered parts; Relations between Subjects carry persistent IDs and their own
 properties. Schemas define Subject types via Property Definitions. Subject validation is backend-only: a single PHP
-validator behind REST endpoints returns structured violations
-([ADR 21](../adr/021-add-backend-validation.md), amended by ADR 25 in
-[#973](https://github.com/ProfessionalWiki/NeoWiki/pull/973); [codes reference](../api/validation-codes.md)),
+validator behind REST endpoints returns structured violations ([ADR 21](../adr/021-add-backend-validation.md),
+amended by [ADR 25](../adr/025-backend-driven-frontend-validation.md); [codes reference](../api/validation-codes.md)),
 and the editing UI renders what the server returns. For RDF, the wiki's data is *projected*: a native projection
 ([NativeRdfProjection](NativeRdfProjection.md)) and per-store ontology projections
-([OntologyMapping](OntologyMapping.md), in review in [#920](https://github.com/ProfessionalWiki/NeoWiki/pull/920)).
+([OntologyMapping](OntologyMapping.md); shipped, see the [reference](../rdf/ontology-mapping.md)).
 
 ## Why not as the internal format or engine
 
@@ -142,8 +141,8 @@ something the boundary approach above cannot serve?
   [ECHOLOT](ECHOLOT.md).
 - ADRs: [006 schemas](../adr/006-schemas.md), [009 move away from JSON Schema](../adr/009-move-away-from-json-schema.md)
   (records ShEx/SHACL as considered alternatives), [011 writer's schema](../adr/011-include-writers-schema.md),
-  [021 backend validation](../adr/021-add-backend-validation.md) and its amendment in
-  [#973](https://github.com/ProfessionalWiki/NeoWiki/pull/973).
+  [021 backend validation](../adr/021-add-backend-validation.md) and its amendment
+  [025 backend-driven frontend validation](../adr/025-backend-driven-frontend-validation.md).
 - Reference: [schema format](../api/schema-format.md), [validation codes](../api/validation-codes.md).
 - ECHOLOT tasks: T3.1 (structured data, constraints and validation), T3.2 (RDF import/export), T2.3 (semantic
   interoperability / ontology patterns), T4.1 (import pipelines), T4.5 (quality checks, names SHACL).

--- a/docs/rdf/rdf-export.md
+++ b/docs/rdf/rdf-export.md
@@ -7,8 +7,8 @@ order: 1
 NeoWiki projects its data to RDF in its own vocabulary — the **native projection**. Each wiki page becomes a named
 graph holding its page metadata and its Subjects (one RDF resource each) with their Statements and Relations.
 
-The model is specified in [NativeRdfProjection.md](../planning/NativeRdfProjection.md); this page is the as-built
-reference for the export surface.
+This page is the reference for what NeoWiki emits. Why the projection is shaped this way, and what is still open
+about it, is in [NativeRdfProjection.md](../planning/NativeRdfProjection.md).
 
 For an end-to-end example comparing the native and ontology-mapped output, see the
 [Person-to-EDM worked example](person-to-edm.md).
@@ -59,6 +59,39 @@ registered mapper — including an unregistered type — is omitted from the pro
 
 A Subject whose Schema cannot be loaded (for example, its Schema page was deleted) is omitted from the projection; a
 warning is logged for each.
+
+## Projected triples
+
+A Subject becomes one RDF resource: its `rdf:type` is its Schema's `neo-schema:` class, and its label is always
+emitted as `rdfs:label`. Each Statement adds triples whose predicate is the property's `neo-prop:` IRI, one per part
+of a multi-part Value.
+
+A Relation is emitted twice, so that a simple query never has to navigate reification:
+
+| Layer | Triples |
+|---|---|
+| Direct | `neo-subj:<source> neo-prop:<RelationType> neo-subj:<target>` |
+| Reified | `neo-rel:<relationId> a neo:Relation`, carrying `neo:source`, `neo:target`, `neo:relationType`, and each scalar Relation property as `neo-prop:<key>` |
+
+Both are always present, including for a Relation carrying no properties: the reified node is what preserves the
+Relation ID. The direct predicate is the **Relation type** declared in the Schema, which need not match the property
+name, and `neo:relationType`'s object is that same predicate IRI. Non-scalar Relation property values are dropped.
+
+Page metadata describes the `neo-page:` resource, in the same named graph as the page's Subjects:
+
+| Predicate | Emitted |
+|---|---|
+| `rdf:type neo:Page` | always |
+| `neo:pageName` | when the name is not empty |
+| `dcterms:created`, `dcterms:modified` | as `xsd:dateTime`, when the stored timestamp parses |
+| `neo:lastEditor` | when not empty |
+| `neo:category` | one per category |
+| `neo:mainSubject` | when a Main Subject is set and is itself projected |
+| `neo:hasSubject` | one per projected Subject, the Main Subject included |
+
+That list is exhaustive. Page Properties contributed by extensions through
+[`PagePropertyProvider`](../extending/extending.md#page-property-providers) reach the Neo4j projection only, and
+nothing carries a page's namespace or wiki id.
 
 ## Endpoint
 


### PR DESCRIPTION
Two commits, both docs-only.

**1. Currency fixes** — brings the three RDF planning docs in line with what has since shipped, changing no decision they record.

- **`OntologyMapping.md` header and status** now describe a design doc whose implementation has shipped, not a
  pre-implementation strawman. The promise to consolidate the decisions into an ADR stays — no mapping/RDF ADR exists
  yet.
- **The stale grounds under the no-RDF-star decision** are corrected; the decision itself stands. QLever is now named
  as the primary target store rather than as representative of common target stores, since Oxigraph shipped as an
  engine option (#1235).
- **Other currency notes in `NativeRdfProjection.md`**: mapping-driven node synthesis reads as shipped (#1229, #1263),
  Q6 gains an as-built note for `$wgNeoWikiRdfBaseUri`, Q10 gains the tracking link to #1163, and the write path links
  its measured costs and ADR 29.
- **Link and state fixes**: batch ID minting reads as shipped (#1100) instead of "the current API mints one Subject at
  a time"; ShapeLanguages' "in review in #920" becomes the shipped `docs/rdf/ontology-mapping.md` reference; "ADR 25 in
  #973" becomes a link to the ADR file, matching how ADR 21 is linked (both occurrences).

**2. Structural condense** — both large planning docs now open on what still needs deciding and close on where the settled material went.

- **Open-questions-first.** Each doc gains a `Still open (2026-08)` block under its banner, one line per genuinely open
  question, anchor-linked to the full item. The open-questions sections keep only those items; each is now a heading so
  it can be linked to.
- **A `Decided` list at the bottom of each doc** collapses the answered questions to one line apiece — the answer and a
  link to the reference, PR or thread that owns it, no restated rationale. Question numbers are preserved, since
  discussions #996 and #999 cite them.
- **The shipped spec moved to its reference home.** `NativeRdfProjection.md`'s Namespaces, Projection and Sync
  Mechanism sections are replaced by a pointer block; what was missing from `docs/rdf/rdf-export.md` — the Subject,
  Statement, Relation and page-metadata triple shapes — was added there first, verified against `RdfPageProjector`,
  `RdfNamespaces` and `SparqlProjectionStore` and their tests. `OntologyMapping.md`'s strawman `CONSTRUCT` model is
  replaced by three lines pointing at the shipped format.
- Rationale sections (Projections-not-layers, Why-mapping-is-separate, Design Principles) are retained pending the ADR.
  `NativeRdfProjection.md` goes 374 → 150 lines, `OntologyMapping.md` 414 → 335.

Considered, omitted:

- Integrating the 2026-08 partner feedback on discussions #996 and #999 — deliberate position integration, queued
  separately, not mechanical currency.
- Writing the ontology-mapping ADR the doc promises; the rationale sections stay in place until it exists.
- Inline performance numbers; the write path links `docs/operations/performance.md` instead.
- An as-built banner on `ShapeLanguages.md`.

> <sub>AI-authored — Claude Code: edit spec written and diff-reviewed by `Fable 5 (max)`, executed by an `Opus 5 (1M context)` subagent, direction approved by @JeroenDeDauw across two rounds; diff not yet human-reviewed; docs-only — every link and anchor in the docs tree machine-checked, every issue/PR/config reference verified against the repo and GitHub, and the claims added to the published reference verified against master source and its tests; no code or tests touched.</sub>

