### PR TITLE
Make the subject label editable in place in the subject editor dialog

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -525,6 +525,8 @@
 				"neowiki-delete-error",
 				"neowiki-subject-editor-title",
 				"neowiki-subject-editor-save",
+				"neowiki-subject-editor-label-field",
+				"neowiki-subject-editor-rename",
 				"neowiki-schema-editor-new-property",
 				"neowiki-schema-editor-delete-property",
 				"neowiki-schema-editor-optional",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -118,6 +118,8 @@
 
 	"neowiki-subject-editor-title": "Editing $1",
 	"neowiki-subject-editor-save": "Save changes",
+	"neowiki-subject-editor-label-field": "Subject label",
+	"neowiki-subject-editor-rename": "Rename subject",
 
 	"neowiki-schema-editor-new-property": "Add property definition",
 	"neowiki-schema-editor-delete-property": "Delete property definition",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -61,6 +61,8 @@
 	"neowiki-schema-editor-description": "Label for the description field in the schema editor.",
 	"neowiki-schema-editor-description-placeholder": "Placeholder text for the description field in the schema editor.",
 
+	"neowiki-subject-editor-label-field": "Accessibility label for the input shown in place of the dialog title while renaming a subject in the subject editor dialog.",
+	"neowiki-subject-editor-rename": "Accessibility label for the button next to the subject editor dialog title that starts renaming the subject.",
 	"neowiki-subject-editor-summary-default": "Default edit summary used when updating a subject via the UI.",
 	"neowiki-subject-editor-success": "Success notification shown after updating a subject. $1 is the subject label.",
 	"neowiki-subject-editor-error": "Error notification title shown when updating a subject fails. $1 is the subject label.",
@@ -218,7 +220,7 @@
 	"neowiki-field-unregistered-type": "Validation warning shown when a Statement's Property Type is not registered, because the extension providing it is disabled or failed to load. The value is preserved but cannot be displayed or edited. $1 is the property type name.",
 	"neowiki-field-min-length": "Validation error shown when a text value is shorter than the property's minimum length. $1 is the minimum number of characters.",
 	"neowiki-field-max-length": "Validation error shown when a text value is longer than the property's maximum length. $1 is the maximum number of characters.",
-	"neowiki-field-label-required": "Form-level error shown when the backend reports the Subject is missing its required display label.",
+	"neowiki-field-label-required": "Form-level error shown when the backend reports the Subject is missing its required display label. Also shown as an error toast when the user tries to save a subject with a blank label in the subject editor dialog.",
 	"neowiki-field-relation-target-schema-mismatch": "Validation error shown when a relation points to a subject whose schema is not the relation's declared target schema. $1 is the required target schema; $2 is the schema the target subject actually uses.",
 	"neowiki-field-relation-target-not-found": "Validation warning shown when a relation points to a subject ID that does not resolve to an existing subject. $1 is the target subject ID. Non-blocking: the target may be created later (for example during import), mirroring wiki red links.",
 	"neowiki-select-placeholder": "Placeholder text shown in the select dropdown before any option is chosen.",

--- a/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditorDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditorDialog.vue
@@ -8,9 +8,25 @@
 		>
 			<template #header>
 				<div class="cdx-dialog__header__title-group">
-					<h2 class="cdx-dialog__header__title">
-						{{ $i18n( 'neowiki-subject-editor-title', props.subject.getLabel() ).text() }}
-					</h2>
+					<div class="cdx-dialog__header__title ext-neowiki-subject-editor-dialog__title">
+						<EditableText
+							:model-value="subjectLabel"
+							:edit-button-label="$i18n( 'neowiki-subject-editor-rename' ).text()"
+							:input-aria-label="$i18n( 'neowiki-subject-editor-label-field' ).text()"
+							:placeholder="$i18n( 'neowiki-subject-editor-label-field' ).text()"
+							:status="labelViolation ? 'error' : 'default'"
+							:required="true"
+							@update:model-value="onLabelEdited"
+						/>
+					</div>
+
+					<p
+						v-if="labelViolation"
+						class="ext-neowiki-subject-editor-dialog__label-error"
+						role="alert"
+					>
+						{{ formatViolationMessage( labelViolation ) }}
+					</p>
 
 					<p class="cdx-dialog__header__subtitle">
 						<I18nSlot
@@ -104,6 +120,7 @@ import SubjectEditor from '@/components/SubjectEditor/SubjectEditor.vue';
 import SummaryAction from '@/components/common/SummaryAction.vue';
 import I18nSlot from '@/components/common/I18nSlot.vue';
 import { CdxButton, CdxDialog, CdxIcon, CdxMessage } from '@wikimedia/codex';
+import EditableText from '@/components/common/EditableText.vue';
 import { cdxIconClose } from '@wikimedia/codex-icons';
 import { StatementList } from '@/domain/StatementList.ts';
 import { Subject } from '@/domain/Subject.ts';
@@ -140,6 +157,8 @@ interface SubjectEditorInstance {
 
 const isSchemaEditorOpen = ref( false );
 const subjectEditorRef = ref<SubjectEditorInstance | null>( null );
+// Initialized by the immediate props.subject watch below.
+const subjectLabel = ref( '' );
 // Mirrors the prop so a schema saved through the nested SchemaEditorDialog takes effect here
 // without waiting for the host to pass a new one down.
 const currentSchema = shallowRef<Schema>( props.schema );
@@ -158,7 +177,7 @@ const { violations: serverViolations, revalidate, flush, reset } = useSubjectVal
 			// field the user is still on their way to filling in.
 			return await subjectStore.validateSubjectUpdate(
 				props.subject.getId(),
-				props.subject.getLabel(),
+				subjectLabel.value.trim(),
 				new StatementList( statements )
 			);
 		} catch ( error ) {
@@ -189,6 +208,18 @@ function handleEditorBlur(): void {
 	}
 }
 
+// EditableText commits once per edit, so a commit is both the change and the
+// end of the interaction: validate immediately rather than waiting for a blur.
+function onLabelEdited( value: string ): void {
+	subjectLabel.value = value;
+	handleEditorChange();
+	handleEditorBlur();
+}
+
+const labelViolation = computed<SubjectViolation | null>( () =>
+	serverViolations.value.find( ( v ) => v.code === 'label-required' ) ?? null
+);
+
 const anchorlessViolations = computed<SubjectViolation[]>( () => {
 	// SubjectEditor renders one field per entry in `statements`, which the
 	// schema materialises from its property definitions (so empty/missing
@@ -199,6 +230,10 @@ const anchorlessViolations = computed<SubjectViolation[]>( () => {
 		[ ...statements.value ].map( ( s ) => s.propertyName.toString() )
 	);
 	return serverViolations.value.filter( ( v ) => {
+		// label-required renders at the label itself, in the dialog header.
+		if ( v.code === 'label-required' ) {
+			return false;
+		}
 		if ( v.propertyName === null ) {
 			return true;
 		}
@@ -230,6 +265,7 @@ function onDialogUpdateOpen( value: boolean ): void {
 
 watch( () => props.open, ( isOpen ) => {
 	if ( isOpen ) {
+		subjectLabel.value = props.subject.getLabel();
 		resetChanged();
 		reset();
 	}
@@ -246,6 +282,7 @@ watch( subjectEditorRef, ( editor ) => {
 } );
 
 watch( () => props.subject, ( newSubject ) => {
+	subjectLabel.value = newSubject.getLabel();
 	checkEditPermission( newSubject.getSchemaName() );
 }, { immediate: true } );
 
@@ -260,6 +297,13 @@ const statements = computed( (): StatementList =>
 const handleSave = async ( summary: string ): Promise<void> => {
 	await nextTick();
 
+	const label = subjectLabel.value.trim();
+
+	if ( !label ) {
+		mw.notify( mw.msg( 'neowiki-field-label-required' ), { type: 'error' } );
+		return;
+	}
+
 	if ( !subjectEditorRef.value ) {
 		return;
 	}
@@ -269,7 +313,9 @@ const handleSave = async ( summary: string ): Promise<void> => {
 	const updatedStatements = subjectEditorRef.value.getSubjectData();
 	// Filter out statements that don't have a value set.
 	const statementsToSave = [ ...updatedStatements ].filter( ( statement ) => statement.hasValue() );
-	const updatedSubject = props.subject.withStatements( new StatementList( statementsToSave ) );
+	const updatedSubject = props.subject
+		.withLabel( label )
+		.withStatements( new StatementList( statementsToSave ) );
 	const subjectName = updatedSubject.getLabel();
 	const editSummary = summary || mw.msg( 'neowiki-subject-editor-summary-default' );
 
@@ -326,6 +372,30 @@ defineExpose( { hasChanged } );
 		justify-content: flex-end;
 		box-sizing: @box-sizing-base;
 		width: @size-full;
+
+		/* Secondary to the title, like the statement-field labels below.
+			Nested under the header to out-rank Codex's runtime-injected
+			two-class subtitle rule. */
+		.cdx-dialog__header__subtitle {
+			font-size: @font-size-small;
+		}
+	}
+
+	/* The title row's edit button already provides vertical air; Codex's
+		default gap on top of it reads too wide. */
+	.cdx-dialog__header__title-group {
+		gap: 0;
+	}
+
+	&__title {
+		display: flex;
+		min-width: 0;
+	}
+
+	&__label-error {
+		color: @color-error;
+		font-size: @font-size-small;
+		margin: @spacing-25 0 0;
 	}
 }
 </style>

--- a/resources/ext.neowiki/src/components/common/EditableText.vue
+++ b/resources/ext.neowiki/src/components/common/EditableText.vue
@@ -1,0 +1,162 @@
+<template>
+	<span class="ext-neowiki-editable-text">
+		<template v-if="!editing">
+			<span
+				class="ext-neowiki-editable-text__text"
+				:class="{ 'ext-neowiki-editable-text__text--placeholder': modelValue === '' }"
+			>{{ displayText }}</span>
+			<CdxButton
+				ref="editButtonRef"
+				class="ext-neowiki-editable-text__edit-button"
+				weight="quiet"
+				type="button"
+				:aria-label="editButtonLabel"
+				@click="startEditing"
+			>
+				<CdxIcon :icon="cdxIconEdit" size="small" />
+			</CdxButton>
+		</template>
+		<CdxTextInput
+			v-else
+			ref="inputRef"
+			v-model="draft"
+			class="ext-neowiki-editable-text__input"
+			:status="status ?? 'default'"
+			:aria-label="inputAriaLabel"
+			:aria-invalid="status === 'error' ? 'true' : undefined"
+			@keydown.enter="commitViaKeyboard"
+			@keyup.esc.stop="cancel"
+			@blur="commit"
+		/>
+	</span>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, ref, watch } from 'vue';
+import { CdxButton, CdxIcon, CdxTextInput } from '@wikimedia/codex';
+import { cdxIconEdit } from '@wikimedia/codex-icons';
+
+/**
+ * Inline edit-in-place for a single line of text: renders the value as plain
+ * text (styled by its context - it inherits font properties) with a quiet edit
+ * button that swaps in a text input. Enter and blur commit the draft, Escape
+ * discards it. Committing only emits when the draft differs from the value;
+ * persistence is the host's concern. With `required`, a blank draft still
+ * emits (so the host's validation can flag it) but the input stays open,
+ * keeping the error state anchored to a visible field; Escape still reverts.
+ */
+const props = defineProps<{
+	modelValue: string;
+	editButtonLabel: string;
+	inputAriaLabel: string;
+	placeholder?: string;
+	status?: 'default' | 'error';
+	required?: boolean;
+}>();
+
+const emit = defineEmits<{ 'update:modelValue': [ value: string ] }>();
+
+const editing = ref( false );
+const draft = ref( '' );
+const inputRef = ref<InstanceType<typeof CdxTextInput> | null>( null );
+const editButtonRef = ref<InstanceType<typeof CdxButton> | null>( null );
+
+const displayText = computed( () => props.modelValue === '' ? ( props.placeholder ?? '' ) : props.modelValue );
+
+async function startEditing(): Promise<void> {
+	draft.value = props.modelValue;
+	editing.value = true;
+	await nextTick();
+	inputRef.value?.focus();
+}
+
+async function commitViaKeyboard( event: KeyboardEvent ): Promise<void> {
+	// The Enter that confirms an IME composition is not a commit.
+	if ( event.isComposing ) {
+		return;
+	}
+
+	commit();
+
+	if ( !editing.value ) {
+		await focusEditButton();
+	}
+}
+
+function commit(): void {
+	// The blur that follows an Escape or an Enter must not commit again.
+	if ( !editing.value ) {
+		return;
+	}
+
+	if ( !props.required || draft.value.trim() !== '' ) {
+		editing.value = false;
+	}
+
+	if ( draft.value !== props.modelValue ) {
+		emit( 'update:modelValue', draft.value );
+	}
+}
+
+async function cancel( event: KeyboardEvent ): Promise<void> {
+	// The Escape that cancels an IME composition is not a cancel. This runs on
+	// keyup because Codex dialogs close on the Escape KEYUP: a keydown-time
+	// cancel would unmount the input and let the release close the host dialog.
+	if ( event.isComposing ) {
+		return;
+	}
+
+	editing.value = false;
+	await focusEditButton();
+}
+
+// A value replaced by the host mid-edit invalidates the draft: abort rather
+// than commit an old subject's draft against the new one. The comparison
+// keeps the required-blank flow open: its own emit echoes back as a
+// modelValue equal to the draft.
+watch( () => props.modelValue, () => {
+	if ( editing.value && props.modelValue !== draft.value ) {
+		editing.value = false;
+	}
+} );
+
+async function focusEditButton(): Promise<void> {
+	await nextTick();
+	( editButtonRef.value?.$el as HTMLElement | undefined )?.focus();
+}
+</script>
+
+<style lang="less">
+@import ( reference ) '@wikimedia/codex-design-tokens/theme-wikimedia-ui.less';
+
+.ext-neowiki-editable-text {
+	display: inline-flex;
+	align-items: center;
+	gap: @spacing-25;
+	min-width: 0;
+
+	&__text {
+		overflow-wrap: anywhere;
+		min-width: 0;
+
+		&--placeholder {
+			color: @color-subtle;
+		}
+	}
+
+	&__input {
+		flex: 1;
+
+		/* Match the display mode's height (set by the 32px edit button),
+			so toggling modes does not shift the surrounding layout. */
+		.cdx-text-input__input {
+			font-size: inherit;
+			font-weight: inherit;
+			line-height: inherit;
+			padding-top: 0;
+			padding-bottom: 0;
+			min-height: @min-size-interactive-pointer;
+		}
+	}
+}
+</style>

--- a/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditorDialog.spec.ts
@@ -542,4 +542,157 @@ describe( 'SubjectEditorDialog', () => {
 			expect( passed ).toEqual( [ existingViolation ] );
 		} );
 	} );
+
+	describe( 'Label editing', () => {
+		function titleText( wrapper: VueWrapper ): string {
+			return wrapper.find( '.ext-neowiki-editable-text__text' ).text();
+		}
+
+		async function editLabel( wrapper: VueWrapper, value: string ): Promise<void> {
+			await wrapper.find( 'button[aria-label="neowiki-subject-editor-rename"]' ).trigger( 'click' );
+			const input = wrapper.find( '.ext-neowiki-editable-text input' );
+			await input.setValue( value );
+			await input.trigger( 'keydown.enter' );
+		}
+
+		it( 'shows the current label as the dialog title', async () => {
+			const wrapper = mountComponent( false, validationTestStubs );
+			await flushPromises();
+
+			expect( titleText( wrapper ) ).toBe( 'Test Subject' );
+		} );
+
+		it( 'enables save after the label is edited', async () => {
+			const wrapper = mountComponent( false, validationTestStubs );
+			await flushPromises();
+
+			await editLabel( wrapper, 'Renamed Subject' );
+
+			expect( wrapper.findComponent( SummaryAction ).props( 'saveDisabled' ) ).toBe( false );
+		} );
+
+		it( 'saves the subject with the edited label', async () => {
+			const onSave = vi.fn().mockResolvedValue( undefined );
+			const wrapper = mountComponent( false, validationTestStubs, onSave );
+			await flushPromises();
+
+			await editLabel( wrapper, 'Renamed Subject' );
+			await wrapper.findComponent( SummaryAction ).vm.$emit( 'save', '' );
+			await flushPromises();
+
+			expect( ( onSave.mock.calls[ 0 ][ 0 ] as Subject ).getLabel() ).toBe( 'Renamed Subject' );
+		} );
+
+		it( 'trims the label on save', async () => {
+			const onSave = vi.fn().mockResolvedValue( undefined );
+			const wrapper = mountComponent( false, validationTestStubs, onSave );
+			await flushPromises();
+
+			await editLabel( wrapper, '  Renamed Subject  ' );
+			await wrapper.findComponent( SummaryAction ).vm.$emit( 'save', '' );
+			await flushPromises();
+
+			expect( ( onSave.mock.calls[ 0 ][ 0 ] as Subject ).getLabel() ).toBe( 'Renamed Subject' );
+		} );
+
+		it( 'does not save when the label is blank', async () => {
+			const onSave = vi.fn().mockResolvedValue( undefined );
+			const wrapper = mountComponent( false, validationTestStubs, onSave );
+			await flushPromises();
+
+			await editLabel( wrapper, '   ' );
+			await wrapper.findComponent( SummaryAction ).vm.$emit( 'save', '' );
+			await flushPromises();
+
+			expect( onSave ).not.toHaveBeenCalled();
+			expect( ( mw.notify as Mock ).mock.calls ).toContainEqual( [
+				expect.stringContaining( 'neowiki-field-label-required' ),
+				{ type: 'error' },
+			] );
+		} );
+
+		it( 'sends the edited label trimmed to the dry-run validation', async () => {
+			const validate = vi.fn().mockResolvedValue( [] );
+			useSubjectStore().validateSubjectUpdate = validate;
+			const wrapper = mountComponent( false, validationTestStubs );
+			await flushPromises();
+
+			await editLabel( wrapper, '  Renamed Subject  ' );
+			await flushPromises();
+
+			const lastCall = validate.mock.calls[ validate.mock.calls.length - 1 ];
+			expect( lastCall[ 1 ] ).toBe( 'Renamed Subject' );
+		} );
+
+		it( 'points assistive technology at the label error', async () => {
+			const labelRequired: SubjectViolation = {
+				propertyName: null, code: 'label-required', args: [], valuePartIndex: null,
+			};
+			useSubjectStore().validateSubjectUpdate = vi.fn().mockResolvedValue( [ labelRequired ] );
+			const wrapper = mountComponent( false, validationTestStubs );
+			await flushPromises();
+
+			await wrapper.find( 'button[aria-label="neowiki-subject-editor-rename"]' ).trigger( 'click' );
+
+			const error = wrapper.find( '.ext-neowiki-subject-editor-dialog__label-error' );
+			const input = wrapper.find( '.ext-neowiki-editable-text input' );
+			expect( error.attributes( 'role' ) ).toBe( 'alert' );
+			expect( input.attributes( 'aria-invalid' ) ).toBe( 'true' );
+		} );
+
+		it( 'keeps the rename input open in error state when the label is committed blank', async () => {
+			const labelRequired: SubjectViolation = {
+				propertyName: null, code: 'label-required', args: [], valuePartIndex: null,
+			};
+			useSubjectStore().validateSubjectUpdate = vi.fn().mockResolvedValue( [ labelRequired ] );
+			const wrapper = mountComponent( false, validationTestStubs );
+			await flushPromises();
+
+			await editLabel( wrapper, '' );
+			await flushPromises();
+
+			expect( wrapper.find( '.ext-neowiki-editable-text input' ).exists() ).toBe( true );
+			expect( wrapper.find( '.cdx-text-input--status-error' ).exists() ).toBe( true );
+		} );
+
+		it( 'routes the label-required violation to the title area instead of the banner', async () => {
+			const labelRequired: SubjectViolation = {
+				propertyName: null, code: 'label-required', args: [], valuePartIndex: null,
+			};
+			useSubjectStore().validateSubjectUpdate = vi.fn().mockResolvedValue( [ labelRequired ] );
+			const wrapper = mountComponent( false, validationTestStubs );
+			await flushPromises();
+
+			expect( wrapper.find( '.ext-neowiki-subject-editor-dialog__label-error' ).text() )
+				.toContain( 'neowiki-field-label-required' );
+			expect( wrapper.find( '.ext-neowiki-subject-editor__form-errors' ).exists() ).toBe( false );
+		} );
+
+		it( 'follows the label when the host replaces the subject', async () => {
+			const wrapper = mountComponent( false, validationTestStubs );
+			await flushPromises();
+
+			await wrapper.setProps( {
+				subject: new Subject(
+					new SubjectId( 's1demo5sssssss1' ),
+					'Renamed Subject',
+					'TestSchema',
+					new StatementList( [] ),
+				),
+			} );
+
+			expect( titleText( wrapper ) ).toBe( 'Renamed Subject' );
+		} );
+
+		it( 'resets the label to the stored one when the dialog reopens', async () => {
+			const wrapper = mountComponent( false, validationTestStubs );
+			await flushPromises();
+
+			await editLabel( wrapper, 'Renamed Subject' );
+			await wrapper.setProps( { open: false } );
+			await wrapper.setProps( { open: true } );
+
+			expect( titleText( wrapper ) ).toBe( 'Test Subject' );
+		} );
+	} );
 } );

--- a/resources/ext.neowiki/tests/components/common/EditableText.spec.ts
+++ b/resources/ext.neowiki/tests/components/common/EditableText.spec.ts
@@ -1,0 +1,267 @@
+import { mount, VueWrapper, DOMWrapper } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import { nextTick } from 'vue';
+import EditableText from '@/components/common/EditableText.vue';
+
+describe( 'EditableText', () => {
+	const mountComponent = ( props: Partial<InstanceType<typeof EditableText>['$props']> = {} ): VueWrapper =>
+		mount( EditableText, {
+			props: {
+				modelValue: 'Acme Anvil',
+				editButtonLabel: 'Rename',
+				inputAriaLabel: 'Subject label',
+				...props,
+			},
+		} );
+
+	function editButton( wrapper: VueWrapper ): DOMWrapper<Element> {
+		return wrapper.find( 'button[aria-label="Rename"]' );
+	}
+
+	async function startEditing( wrapper: VueWrapper ): Promise<DOMWrapper<Element>> {
+		await editButton( wrapper ).trigger( 'click' );
+		return wrapper.find( 'input' );
+	}
+
+	it( 'shows the value as text', () => {
+		const wrapper = mountComponent();
+
+		expect( wrapper.find( '.ext-neowiki-editable-text__text' ).text() ).toBe( 'Acme Anvil' );
+	} );
+
+	it( 'shows the placeholder when the value is empty', () => {
+		const wrapper = mountComponent( { modelValue: '', placeholder: 'Unnamed' } );
+
+		expect( wrapper.find( '.ext-neowiki-editable-text__text' ).text() ).toBe( 'Unnamed' );
+	} );
+
+	it( 'opens an input holding the current value when the edit button is clicked', async () => {
+		const wrapper = mountComponent();
+
+		const input = await startEditing( wrapper );
+
+		expect( ( input.element as HTMLInputElement ).value ).toBe( 'Acme Anvil' );
+	} );
+
+	it( 'commits the draft on Enter', async () => {
+		const wrapper = mountComponent();
+
+		const input = await startEditing( wrapper );
+		await input.setValue( 'Renamed Anvil' );
+		await input.trigger( 'keydown.enter' );
+
+		expect( wrapper.emitted( 'update:modelValue' ) ).toEqual( [ [ 'Renamed Anvil' ] ] );
+	} );
+
+	it( 'commits the draft on blur', async () => {
+		const wrapper = mountComponent();
+
+		const input = await startEditing( wrapper );
+		await input.setValue( 'Renamed Anvil' );
+		await input.trigger( 'blur' );
+
+		expect( wrapper.emitted( 'update:modelValue' ) ).toEqual( [ [ 'Renamed Anvil' ] ] );
+	} );
+
+	it( 'returns to display mode after committing', async () => {
+		const wrapper = mountComponent();
+
+		const input = await startEditing( wrapper );
+		await input.trigger( 'keydown.enter' );
+
+		expect( wrapper.find( 'input' ).exists() ).toBe( false );
+		expect( wrapper.find( '.ext-neowiki-editable-text__text' ).exists() ).toBe( true );
+	} );
+
+	it( 'does not emit when the draft equals the value', async () => {
+		const wrapper = mountComponent();
+
+		const input = await startEditing( wrapper );
+		await input.trigger( 'keydown.enter' );
+
+		expect( wrapper.emitted( 'update:modelValue' ) ).toBeUndefined();
+	} );
+
+	it( 'discards the draft on Escape', async () => {
+		const wrapper = mountComponent();
+
+		const input = await startEditing( wrapper );
+		await input.setValue( 'Renamed Anvil' );
+		await input.trigger( 'keyup.esc' );
+
+		expect( wrapper.emitted( 'update:modelValue' ) ).toBeUndefined();
+		expect( wrapper.find( 'input' ).exists() ).toBe( false );
+	} );
+
+	it( 'does not commit the blur that follows an Escape', async () => {
+		const wrapper = mountComponent();
+
+		const input = await startEditing( wrapper );
+		await input.setValue( 'Renamed Anvil' );
+		await input.trigger( 'keyup.esc' );
+		await input.trigger( 'blur' );
+
+		expect( wrapper.emitted( 'update:modelValue' ) ).toBeUndefined();
+	} );
+
+	it( 'stops the Escape keyup from reaching ancestors, so a host dialog stays open', async () => {
+		const escapeReachedAncestor = vi.fn();
+		document.body.addEventListener( 'keyup', escapeReachedAncestor );
+		const wrapper = mount( EditableText, {
+			attachTo: document.body,
+			props: {
+				modelValue: 'Acme Anvil',
+				editButtonLabel: 'Rename',
+				inputAriaLabel: 'Subject label',
+			},
+		} );
+
+		const input = await startEditing( wrapper );
+		await input.trigger( 'keyup.esc' );
+
+		expect( escapeReachedAncestor ).not.toHaveBeenCalled();
+		document.body.removeEventListener( 'keyup', escapeReachedAncestor );
+		wrapper.unmount();
+	} );
+
+	it( 'ignores an Enter that confirms text composition', async () => {
+		const wrapper = mountComponent();
+
+		const input = await startEditing( wrapper );
+		await input.setValue( 'Renamed Anvil' );
+		await input.trigger( 'keydown.enter', { isComposing: true } );
+
+		expect( wrapper.emitted( 'update:modelValue' ) ).toBeUndefined();
+		expect( wrapper.find( 'input' ).exists() ).toBe( true );
+	} );
+
+	it( 'ignores an Escape that cancels text composition', async () => {
+		const wrapper = mountComponent();
+
+		const input = await startEditing( wrapper );
+		await input.setValue( 'Renamed Anvil' );
+		await input.trigger( 'keyup.esc', { isComposing: true } );
+
+		expect( wrapper.find( 'input' ).exists() ).toBe( true );
+	} );
+
+	it( 'aborts editing when the value changes underneath the edit', async () => {
+		const wrapper = mountComponent();
+
+		await startEditing( wrapper );
+		await wrapper.setProps( { modelValue: 'Replaced Subject' } );
+
+		expect( wrapper.find( 'input' ).exists() ).toBe( false );
+		expect( wrapper.emitted( 'update:modelValue' ) ).toBeUndefined();
+	} );
+
+	it( 'keeps the input open when a required value is committed blank', async () => {
+		const wrapper = mountComponent( { required: true } );
+
+		const input = await startEditing( wrapper );
+		await input.setValue( '   ' );
+		await input.trigger( 'keydown.enter' );
+
+		expect( wrapper.find( 'input' ).exists() ).toBe( true );
+	} );
+
+	it( 'emits the blank draft while staying open, so the host can flag it', async () => {
+		const wrapper = mountComponent( { required: true } );
+
+		const input = await startEditing( wrapper );
+		await input.setValue( '' );
+		await input.trigger( 'keydown.enter' );
+
+		expect( wrapper.emitted( 'update:modelValue' ) ).toEqual( [ [ '' ] ] );
+	} );
+
+	it( 'closes on a blank commit when the value is not required', async () => {
+		const wrapper = mountComponent();
+
+		const input = await startEditing( wrapper );
+		await input.setValue( '' );
+		await input.trigger( 'keydown.enter' );
+
+		expect( wrapper.find( 'input' ).exists() ).toBe( false );
+	} );
+
+	it( 'still discards a blank draft on Escape when required', async () => {
+		const wrapper = mountComponent( { required: true } );
+
+		const input = await startEditing( wrapper );
+		await input.setValue( '' );
+		await input.trigger( 'keyup.esc' );
+
+		expect( wrapper.find( 'input' ).exists() ).toBe( false );
+		expect( wrapper.emitted( 'update:modelValue' ) ).toBeUndefined();
+	} );
+
+	it( 'marks the input with the given status', async () => {
+		const wrapper = mountComponent( { status: 'error' } );
+
+		await startEditing( wrapper );
+
+		expect( wrapper.find( '.cdx-text-input' ).classes() ).toContain( 'cdx-text-input--status-error' );
+	} );
+
+	it( 'labels the input for assistive technology', async () => {
+		const wrapper = mountComponent();
+
+		const input = await startEditing( wrapper );
+
+		expect( input.attributes( 'aria-label' ) ).toBe( 'Subject label' );
+	} );
+
+	it( 'marks the input invalid for assistive technology when in error', async () => {
+		const wrapper = mountComponent( { status: 'error' } );
+
+		const input = await startEditing( wrapper );
+
+		expect( input.attributes( 'aria-invalid' ) ).toBe( 'true' );
+	} );
+
+	describe( 'focus management', () => {
+		function mountAttached(): VueWrapper {
+			return mount( EditableText, {
+				attachTo: document.body,
+				props: {
+					modelValue: 'Acme Anvil',
+					editButtonLabel: 'Rename',
+					inputAriaLabel: 'Subject label',
+				},
+			} );
+		}
+
+		it( 'focuses the input when editing starts', async () => {
+			const wrapper = mountAttached();
+
+			const input = await startEditing( wrapper );
+
+			expect( document.activeElement ).toBe( input.element );
+			wrapper.unmount();
+		} );
+
+		it( 'returns focus to the edit button after committing with Enter', async () => {
+			const wrapper = mountAttached();
+
+			const input = await startEditing( wrapper );
+			await input.setValue( 'Renamed Anvil' );
+			await input.trigger( 'keydown.enter' );
+			await nextTick();
+
+			expect( document.activeElement ).toBe( editButton( wrapper ).element );
+			wrapper.unmount();
+		} );
+
+		it( 'returns focus to the edit button after cancelling with Escape', async () => {
+			const wrapper = mountAttached();
+
+			const input = await startEditing( wrapper );
+			await input.trigger( 'keyup.esc' );
+			await nextTick();
+
+			expect( document.activeElement ).toBe( editButton( wrapper ).element );
+			wrapper.unmount();
+		} );
+	} );
+} );


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/NeoWiki/issues/1140

The subject label could not be changed after creation. The edit dialog's title is now the label itself,
edited in place: a pencil button next to the title swaps it for an input; Enter or blur commits, Escape
reverts. The label stays out of the statement form, since it is the subject's identity rather than one of
its statements.

* New reusable `EditableText` component (`components/common/`): inline edit-in-place with commit/cancel
  semantics, IME-composition guards, focus restoration, and a `required` mode that keeps a blank draft
  open in error state instead of returning to display mode. Intended second consumer: the schema
  description editor.
* `SubjectEditorDialog`: title replaced by the component; `label-required` violations render at the title
  (input error status, `role="alert"` message) instead of the form-level banner; blank labels cannot be
  saved; header polish (title-group gap, subtitle size).
* The backend already supported label replacement (`ReplaceSubjectApi`); this is a frontend-only change.

Escape cancels on keyup with stopped propagation because Codex dialogs close on the Escape keyup: a
keydown-time cancel would unmount the input and let the release close the dialog.

Considered, omitted: `aria-describedby` from the input to the error message. Codex's `TextInput` binds
that attribute from its private `CdxField` injection (a Symbol), so it cannot be set from outside;
`role="alert"` plus `aria-invalid` carry the announcement instead.

## Manual Browser Check

1. Open a page whose main subject has an infobox (demo data: `Acme Anvil`) and click the infobox's edit button.
2. The dialog title is the subject label with a pencil button next to it; the body contains only statement fields.
3. Click the pencil, type a new label, press Enter: the title updates, focus returns to the pencil, and Save changes enables.
4. Save. The success toast and the infobox header show the new label; reload the page and confirm it persisted.
5. Reopen the editor, click the pencil, delete the text, press Enter: the input stays open with a red border and "Please provide a label for the subject." below the title; Save changes refuses with an error toast.
6. Press Escape while renaming: the draft is discarded, the previous label returns, and the dialog itself stays open.

> <sub>AI-authored — Claude Code, `Fable 5 (xhigh)`; #1140 worked through with @alistair3149, who picked the editable-title direction from a mock comparison; ~6 rounds of UX steering; UI checked in-browser by @alistair3149, diff not yet human-reviewed; TDD (all new specs seen red then green), two subagent review rounds acted on, full vitest + stylelint + vue-tsc + build green, browser-verified end to end incl. Neo4j persistence and the Escape/dialog interaction.</sub>