### PR TITLE
Default child-subject labels to the schema name in the subject creator

### DIFF
--- a/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
@@ -169,6 +169,7 @@ import { useSubjectStore } from '@/stores/SubjectStore.ts';
 import { useSchemaStore } from '@/stores/SchemaStore.ts';
 import { Schema } from '@/domain/Schema.ts';
 import { StatementList } from '@/domain/StatementList.ts';
+import { defaultSubjectLabel } from '@/domain/defaultSubjectLabel.ts';
 import { withoutMissingValueViolations, type SubjectViolation } from '@/domain/SubjectViolation';
 import { ValidationFailedError } from '@/persistence/ValidationFailedError';
 import { CdxMessage } from '@wikimedia/codex';
@@ -376,7 +377,7 @@ async function onSchemaSelected( schemaName: string ): Promise<void> {
 	}
 
 	selectedSchemaName.value = schemaName;
-	subjectLabel.value = String( mw.config.get( 'wgTitle' ) ?? '' );
+	subjectLabel.value = defaultSubjectLabel( props.pageHasMainSubject, pageName(), schemaName );
 	markChanged();
 
 	const currentSequence = ++requestSequence;
@@ -419,8 +420,12 @@ async function handleCreateSchema(): Promise<void> {
 	draftSchema.value = schema;
 	selectedSchemaName.value = schema.getName();
 	loadedSchema.value = schema;
-	subjectLabel.value = String( mw.config.get( 'wgTitle' ) ?? '' );
+	subjectLabel.value = defaultSubjectLabel( props.pageHasMainSubject, pageName(), schema.getName() );
 	markChanged();
+}
+
+function pageName(): string {
+	return String( mw.config.get( 'wgTitle' ) ?? '' );
 }
 
 const statements = computed( (): StatementList | null =>

--- a/resources/ext.neowiki/src/domain/defaultSubjectLabel.ts
+++ b/resources/ext.neowiki/src/domain/defaultSubjectLabel.ts
@@ -1,0 +1,9 @@
+/**
+ * Default label for a new Subject. The first Subject on a page is its Main
+ * Subject and represents the page's own topic, so it defaults to the page
+ * name; every further (Child) Subject defaults to its Schema name, since the
+ * page name would give all of them the same misleading label.
+ */
+export function defaultSubjectLabel( pageHasMainSubject: boolean, pageName: string, schemaName: string ): string {
+	return pageHasMainSubject ? schemaName : pageName;
+}

--- a/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectCreator/SubjectCreatorDialog.spec.ts
@@ -358,6 +358,16 @@ describe( 'SubjectCreatorDialog', () => {
 		expect( ( labelInput.element as HTMLInputElement ).value ).toBe( PAGE_TITLE );
 	} );
 
+	it( 'defaults label to the schema name when the page already has a main subject', async () => {
+		const wrapper = mountComponent( {}, { pageHasMainSubject: true } );
+
+		await wrapper.findComponent( SchemaPicker ).vm.$emit( 'select', SCHEMA_NAME );
+		await flushPromises();
+
+		const labelInput = wrapper.find( '.cdx-text-input-stub' );
+		expect( ( labelInput.element as HTMLInputElement ).value ).toBe( SCHEMA_NAME );
+	} );
+
 	it( 'calls createMainSubject on save with correct arguments', async () => {
 		const wrapper = mountComponent();
 
@@ -405,7 +415,7 @@ describe( 'SubjectCreatorDialog', () => {
 
 		expect( subjectStore.createChildSubject ).toHaveBeenCalledWith(
 			PAGE_ID,
-			PAGE_TITLE,
+			SCHEMA_NAME,
 			SCHEMA_NAME,
 			expect.any( StatementList ),
 			'test summary',
@@ -543,6 +553,17 @@ describe( 'SubjectCreatorDialog', () => {
 
 			const labelInput = wrapper.find( '.cdx-text-input-stub' );
 			expect( ( labelInput.element as HTMLInputElement ).value ).toBe( PAGE_TITLE );
+		} );
+
+		it( 'defaults label to the new schema name after schema creation when the page already has a main subject', async () => {
+			const wrapper = mountComponent( {}, { pageHasMainSubject: true } );
+
+			await switchToNewSchema( wrapper );
+
+			await clickContinue( wrapper );
+
+			const labelInput = wrapper.find( '.cdx-text-input-stub' );
+			expect( ( labelInput.element as HTMLInputElement ).value ).toBe( NEW_SCHEMA_NAME );
 		} );
 
 		it( 'saves schema and creates subject on final save', async () => {

--- a/resources/ext.neowiki/tests/domain/defaultSubjectLabel.unit.spec.ts
+++ b/resources/ext.neowiki/tests/domain/defaultSubjectLabel.unit.spec.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { defaultSubjectLabel } from '@/domain/defaultSubjectLabel';
+
+describe( 'defaultSubjectLabel', () => {
+	it( 'defaults the main subject to the page name', () => {
+		expect( defaultSubjectLabel( false, 'Acme Anvil', 'Product' ) ).toBe( 'Acme Anvil' );
+	} );
+
+	it( 'defaults a child subject to its schema name', () => {
+		expect( defaultSubjectLabel( true, 'Acme Anvil', 'Product' ) ).toBe( 'Product' );
+	} );
+} );


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/NeoWiki/issues/1140

Every subject created on a page defaulted its label to the page name, so all child subjects got the same
label as the main subject and the page. The creator now prefills the main subject with the page name and
child subjects with their schema name.

The rule lives in `domain/defaultSubjectLabel.ts` so the planned optional-label rework can reuse it as the
computed-fallback policy.

Known limitation, accepted: several child subjects of the same schema still get identical default labels;
the label remains editable in the creation dialog.

## Manual Browser Check

1. On a page whose main subject exists (demo data: `Acme Anvil`), open "Create subject" from the NeoWiki
   page-tools menu and select a schema: the label field prefills with the schema name.
2. On a page without subjects (demo data: `Developers`), do the same: the label field prefills with the
   page name.
3. In the "Create new" schema flow, the label prefills the same way after Continue.

> <sub>AI-authored — Claude Code, `Fable 5 (xhigh)`; parallel step for #1140 proposed by @alistair3149 in discussion, no redirections; diff not yet human-reviewed and no subagent review round (20-line change); TDD (3 new specs seen red then green, 1 expectation updated for the changed behavior), full vitest + stylelint + vue-tsc + build green, both prefill cases browser-verified on the demo data.</sub>