### PR TITLE
Wait for the backends to be healthy, not merely created

### DIFF
--- a/Docker/docker-compose.ci.yml
+++ b/Docker/docker-compose.ci.yml
@@ -4,9 +4,13 @@ services:
     ports:
       - "127.0.0.1:${MW_SERVER_PORT}:80"
       - "127.0.0.1:8486:8486"
+    # Waits for the healthchecks below rather than just for the containers to appear: the wiki talks to
+    # both on startup, and a bare `depends_on` only orders creation.
     depends_on:
-      - db
-      - neo
+      db:
+        condition: service_healthy
+      neo:
+        condition: service_healthy
     environment:
       - MARIADB_DATABASE
       - MARIADB_USER

--- a/Docker/docker-compose.ci.yml
+++ b/Docker/docker-compose.ci.yml
@@ -4,8 +4,6 @@ services:
     ports:
       - "127.0.0.1:${MW_SERVER_PORT}:80"
       - "127.0.0.1:8486:8486"
-    # Waits for the healthchecks below rather than just for the containers to appear: the wiki talks to
-    # both on startup, and a bare `depends_on` only orders creation.
     depends_on:
       db:
         condition: service_healthy

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -8,9 +8,13 @@ services:
       - mediawiki-images-data:/var/www/html/w/images
       # Uncomment to use custom LocalSettings.
       # - ./LocalSettings.php:/var/www/html/w/LocalSettings.php:ro
+    # Waits for the healthchecks below rather than just for the containers to appear: the wiki talks to
+    # both on startup, and a bare `depends_on` only orders creation.
     depends_on:
-      - db
-      - neo
+      db:
+        condition: service_healthy
+      neo:
+        condition: service_healthy
     environment:
       - MARIADB_DATABASE
       - MARIADB_USER

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -8,8 +8,6 @@ services:
       - mediawiki-images-data:/var/www/html/w/images
       # Uncomment to use custom LocalSettings.
       # - ./LocalSettings.php:/var/www/html/w/LocalSettings.php:ro
-    # Waits for the healthchecks below rather than just for the containers to appear: the wiki talks to
-    # both on startup, and a bare `depends_on` only orders creation.
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
`docker-compose.yml` and `docker-compose.ci.yml` both describe when MariaDB and Neo4j are ready, and both had the wiki depend on them in the short form:

```yaml
depends_on:
  - db
  - neo
```

Short-form `depends_on` waits for a container to be *created*, not to be ready, so those healthchecks gated nothing. The wiki started while MariaDB was still initialising and Neo4j was still around twenty seconds from answering a query, and the actual waiting was done by `/wait-for-it.sh` calls inside `install-db` and `wait-for-neo4j`. Naming the condition moves the wait to where the readiness is already described.

The wiki's own healthcheck is deliberately left ungated: it greps `Special:Version`, which cannot pass until `install-db` has run, so making `caddy` depend on it would deadlock a first bring-up.

## Considered, omitted

* **Changing Neo4j's probe to a Cypher query.** The current probe fetches `/browser` over HTTP on 7474, which looked weaker than asking the database to answer. Measured on a cold container, both become true in the same second, so the HTTP probe is already a readiness signal and the change would buy nothing. (This is not the same situation as a probe against the *bolt* port, which answers HTTP long before the database can serve — that one is genuinely misleading.)
* **Deleting the now-redundant `/wait-for-it.sh` calls** in `install-db` and `wait-for-neo4j`. They are no-ops once the gate holds, but `wait-for-neo4j` is called directly by `build-docker.yml` on #1257, so removing the target now would collide. Worth a follow-up once that lands.
* **Gating the `test_*` backends** in `docker-compose.dev.yml`. They have healthchecks and nothing depends on them — `make test-backends` polls from the host, so `docker compose up --wait` is the right tool there rather than `depends_on`. Separate change.

## Verification

No CI covers this: `build-docker.yml`, the only workflow that uses these files, runs on pushes to master. So it was checked by hand on the dev stack.

Both files pass `docker compose config`. On a **cold start with volumes destroyed**, `db` and `neo` start at t=0 and `mediawiki` at t=16s — previously it started immediately alongside them — and the wiki then installs, imports the demo content and serves `Special:Version` with HTTP 200 in 53s total. A warm restart shows the same ordering at 19s. MariaDB's healthcheck retry budget survives a first-time data-directory init, which was the main risk of failing closed.

`make wait-for-neo4j` now reports `neo:7687 is available after 0 seconds`, which is the redundancy this makes visible.

Unrelated pre-existing bug found while testing: `make load-neo4j-users` is not idempotent and fails with `user already exists` on a second run against a populated volume.

<sub>AI-authored — Claude Code, `Opus 5 (1M context)`; investigation, change and hand-verification in-session; not yet human-reviewed.</sub>
