### PR TITLE
Rename the native RDF term namespace from /ontology/ to /vocab/

### DIFF
--- a/docs/rdf/rdf-export.md
+++ b/docs/rdf/rdf-export.md
@@ -27,7 +27,7 @@ All NeoWiki IRIs live under `$base` (`$wgNeoWikiRdfBaseUri`). Standard vocabular
 
 | Prefix | Namespace | Used for |
 |---|---|---|
-| `neo:` | `$base/ontology/` | NeoWiki vocabulary terms (`neo:Page`, `neo:Relation`, `neo:hasSubject`, `neo:source`, …) |
+| `neo:` | `$base/vocab/` | NeoWiki vocabulary terms (`neo:Page`, `neo:Relation`, `neo:hasSubject`, `neo:source`, …) |
 | `neo-subj:` | `$base/entity/` | Subject IRIs (`neo-subj:s1demo8aaaaaab5`) |
 | `neo-prop:` | `$base/prop/` | Property and Relation-type predicates (`neo-prop:Has_author`) |
 | `neo-schema:` | `$base/schema/` | Schema classes (`neo-schema:Person`) |

--- a/src/Domain/Rdf/RdfNamespaces.php
+++ b/src/Domain/Rdf/RdfNamespaces.php
@@ -111,7 +111,7 @@ readonly class RdfNamespaces {
 	}
 
 	public function term( string $localName ): Iri {
-		return new Iri( $this->baseUri . '/ontology/' . $localName );
+		return new Iri( $this->baseUri . '/vocab/' . $localName );
 	}
 
 	public function rdfType(): Iri {
@@ -183,7 +183,7 @@ readonly class RdfNamespaces {
 	 */
 	public function prefixMap(): array {
 		return [
-			'neo' => $this->baseUri . '/ontology/',
+			'neo' => $this->baseUri . '/vocab/',
 			'neo-subj' => $this->subjectIriBase(),
 			'neo-prop' => $this->baseUri . '/prop/',
 			'neo-schema' => $this->baseUri . '/schema/',

--- a/tests/phpunit/Application/Rdf/RdfPageProjectorTest.php
+++ b/tests/phpunit/Application/Rdf/RdfPageProjectorTest.php
@@ -127,7 +127,7 @@ class RdfPageProjectorTest extends TestCase {
 
 	private function completeExampleTriG(): string {
 		return <<<TRIG
-			@prefix neo: <https://wiki.example/ontology/> .
+			@prefix neo: <https://wiki.example/vocab/> .
 			@prefix neo-subj: <https://wiki.example/entity/> .
 			@prefix neo-prop: <https://wiki.example/prop/> .
 			@prefix neo-schema: <https://wiki.example/schema/> .
@@ -398,7 +398,7 @@ class RdfPageProjectorTest extends TestCase {
 
 	private function acmeSubjectTriG(): string {
 		return <<<TRIG
-			@prefix neo: <https://wiki.example/ontology/> .
+			@prefix neo: <https://wiki.example/vocab/> .
 			@prefix neo-subj: <https://wiki.example/entity/> .
 			@prefix neo-prop: <https://wiki.example/prop/> .
 			@prefix neo-schema: <https://wiki.example/schema/> .
@@ -495,7 +495,7 @@ class RdfPageProjectorTest extends TestCase {
 
 	private function expectedTriGForTextProperty( string $predicateIri ): string {
 		return <<<TRIG
-			@prefix neo: <https://wiki.example/ontology/> .
+			@prefix neo: <https://wiki.example/vocab/> .
 			@prefix neo-subj: <https://wiki.example/entity/> .
 			@prefix neo-schema: <https://wiki.example/schema/> .
 			@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .

--- a/tests/phpunit/Domain/Rdf/RdfNamespacesTest.php
+++ b/tests/phpunit/Domain/Rdf/RdfNamespacesTest.php
@@ -154,9 +154,9 @@ class RdfNamespacesTest extends TestCase {
 		);
 	}
 
-	public function testVocabularyTermUsesOntologyPath(): void {
+	public function testVocabularyTermUsesVocabPath(): void {
 		$this->assertSame(
-			'https://wiki.example/ontology/hasSubject',
+			'https://wiki.example/vocab/hasSubject',
 			$this->namespaces()->term( RdfNamespaces::TERM_HAS_SUBJECT )->value
 		);
 	}
@@ -182,7 +182,7 @@ class RdfNamespacesTest extends TestCase {
 	public function testPrefixMapCoversEveryNeoAndStandardNamespace(): void {
 		$this->assertSame(
 			[
-				'neo' => 'https://wiki.example/ontology/',
+				'neo' => 'https://wiki.example/vocab/',
 				'neo-subj' => 'https://wiki.example/entity/',
 				'neo-prop' => 'https://wiki.example/prop/',
 				'neo-schema' => 'https://wiki.example/schema/',


### PR DESCRIPTION
The native RDF projection now emits its `neo:` terms under `<baseUri>/vocab/` instead of `<baseUri>/ontology/`. These terms are the wiki's own local vocabulary of names, not an ontology in the sense of a shared conceptualization — a distinction raised in partner review of the mapping docs (https://github.com/ProfessionalWiki/NeoWiki/discussions/996#discussioncomment-17920073). NeoWiki is not in production, so there are no published IRIs or stored exports to migrate; the same rename after release would invalidate all of them.

> <sub>AI-authored — Claude Code, `Opus 5 (max)`; detailed spec from @JeroenDeDauw, no revisions; diff not yet human-reviewed; full PHPUnit suite and phpcs/phpstan run locally, both green.</sub>
