### PR TITLE
Describe a Mapping's unit as a projection, not a target ontology

### DIFF
--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -96,8 +96,8 @@ A Layout defines how a Subject is displayed.
 
 ### Mappings
 
-An ontology Mapping projects native Schemas to a target ontology. For the format and concepts, see
-[Ontology Mapping](../rdf/ontology-mapping.md).
+An ontology Mapping defines one projection: it projects native Schemas into a target ontology. For the format
+and concepts, see [Ontology Mapping](../rdf/ontology-mapping.md).
 
 | Endpoint | Description |
 |---|---|

--- a/docs/planning/OntologyMapping.md
+++ b/docs/planning/OntologyMapping.md
@@ -9,9 +9,10 @@ Status: Implemented; open questions still under discussion with ECHOLOT partners
 
 Discussion: [#996](https://github.com/ProfessionalWiki/NeoWiki/discussions/996).
 
-> **As-built (2026-08).** Mappings are pages in a `Mapping:` namespace — one page per target ontology, the
-> page title being the target name ([#1065](https://github.com/ProfessionalWiki/NeoWiki/discussions/1065)) —
-> and an ontology projection is selectable alongside the native one on the RDF export endpoint and `DumpRdf`.
+> **As-built (2026-08).** Mappings are pages in a `Mapping:` namespace — one page per projection, holding
+> every mapped Schema, the page title being the projection name
+> ([#1065](https://github.com/ProfessionalWiki/NeoWiki/discussions/1065)) — and an ontology projection is
+> selectable alongside the native one on the RDF export endpoint and `DumpRdf`.
 > The near-1:1 term-substitution tier shipped first (2026-07); the **structural tier** followed as an optional
 > addition to the same format: node synthesis with deterministic IRIs, and contraction as source-side
 > contributions. See the [Ontology Mapping reference](../rdf/ontology-mapping.md) and the worked
@@ -157,7 +158,7 @@ remove the requirement (Q10).
 
 ## The shipped format
 
-A Mapping is a JSON page in the `Mapping:` namespace, one per target ontology, declaring per Schema how the Subject,
+A Mapping is a JSON page in the `Mapping:` namespace that defines one projection, declaring per Schema how the Subject,
 its properties, its synthesized nodes, and its contributions project. It is specified in the
 [Ontology Mapping reference](../rdf/ontology-mapping.md).
 
@@ -298,9 +299,11 @@ Answered by the shipped implementation. Numbers are the original question number
 - **Q2 — expressiveness for node synthesis.** The format expresses both directions natively: synthesized nodes for
   expansion, contributions for contraction. Neither SHACL Advanced Features nor `CONSTRUCT` became the substrate
   ([reference](../rdf/ontology-mapping.md)).
-- **Q6 — one mapping per target vs combined.** One Mapping page per target ontology, holding an entry for every mapped
+- **Q6 — one mapping per target vs combined.** One Mapping page per projection, holding an entry for every mapped
   Schema ([#1086](https://github.com/ProfessionalWiki/NeoWiki/pull/1086),
-  [discussion #1065](https://github.com/ProfessionalWiki/NeoWiki/discussions/1065)).
+  [discussion #1065](https://github.com/ProfessionalWiki/NeoWiki/discussions/1065)). A projection is not an ontology:
+  two Mapping pages can both use CIDOC-CRM terms, each defining its own shape
+  ([#996 comment](https://github.com/ProfessionalWiki/NeoWiki/discussions/996#discussioncomment-17920073), 2026-08-06).
 - **Q7 — where Mappings live.** Pages in the `Mapping:` namespace, listed on `Special:Mappings` and gated by the
   `neowiki-mapping-edit` right ([reference](../rdf/ontology-mapping.md#ontology-mappings-are-wiki-pages)).
 - **Q8 — language tags in a mapping.** A mapped property or contribution takes a `lang` tag, applied to the plain-string

--- a/docs/rdf/ontology-mapping.md
+++ b/docs/rdf/ontology-mapping.md
@@ -25,13 +25,13 @@ and mapped output side by side.
 ## Ontology Mappings are wiki pages
 
 A Mapping is a page in the **`Mapping:` namespace** with content model `NeoWikiMapping` (JSON), gated by the
-`neowiki-mapping-edit` right. There is **one Mapping page per target ontology**, and the page title is the
+`neowiki-mapping-edit` right. Each Mapping page defines **one projection**, and the page title is the
 projection name you pass to the export surfaces: the page `Mapping:EDM` defines the `EDM` projection. The
 `Special:Mappings` page lists every Mapping on the wiki.
 
-A single page holds an entry for **every mapped Schema** — map a Schema to an ontology by adding an entry to
-that ontology's page, not by creating a page. A Schema maps to several ontologies through one entry on each
-ontology's page.
+A single page holds an entry for **every mapped Schema** — map a Schema by adding an entry to the
+projection's page, not by creating a page. A Schema can take part in several projections, through one entry on
+each page.
 
 The name **`native`** is reserved for the built-in [native projection](rdf-export.md), so a `Mapping:Native`
 page is rejected on save.
@@ -188,7 +188,7 @@ prefix (`EDM`), or `native` for the built-in projection. See
 
 ## Authoring a Mapping
 
-1. Create a page in the `Mapping:` namespace named after the target ontology (`Mapping:EDM`), or edit the
+1. Create a page in the `Mapping:` namespace whose title is the projection name (`Mapping:EDM`), or edit an
    existing one.
 2. Declare the page-level `prefixes` you will use.
 3. Add an entry under `schemas` for each Schema to project: give the Subject a `subject.class` and map the

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -286,7 +286,7 @@
 	"neowiki-managesubjects-export-format-trig": "Level-1 export menu item selecting the TriG serialization; reveals the projection list. \"TriG\" is the RDF serialization format name and is not translated.",
 	"neowiki-managesubjects-export-back": "Export menu item that returns from the projection list to the serialization choice.",
 	"neowiki-managesubjects-export-choose-format": "Announced to screen-reader users when the data export menu returns to its list of export formats (JSON, Turtle, TriG).",
-	"neowiki-managesubjects-export-choose-projection": "Announced to screen-reader users when the data export menu shows its list of projections after a format is chosen. A projection is the ontology/vocabulary the data is exported as, e.g. EDM or CIDOC-CRM.",
+	"neowiki-managesubjects-export-choose-projection": "Announced to screen-reader users when the data export menu shows its list of projections after a format is chosen. A projection is a named RDF rendering of the data, e.g. EDM or CIDOC-CRM.",
 	"neowiki-managesubjects-export-native": "Display name of the native (NeoWiki-vocabulary) RDF projection, shown in the projection list of the data export menu.",
 	"action-subjects": "Description of the Subject management action used by MediaWiki when generating action descriptions.",
 	"neowiki-config-invalid": "Heading shown above the list of errors when an edit to the MediaWiki:NeoWiki JSON configuration page is rejected.",


### PR DESCRIPTION
The Mapping docs called the unit a Mapping page corresponds to a "target ontology". The unit is the projection — the docs' existing term for a named RDF rendering — and one ontology can back several of them: two Mapping pages can both use CIDOC-CRM terms, each defining its own shape. Raised in partner review ([#996 comment](https://github.com/ProfessionalWiki/NeoWiki/discussions/996#discussioncomment-17920073)). The planning doc's Q6 entry now records that distinction; the reference, API, and message docs swap the term.

Sibling of the `/vocab/` namespace rename (https://github.com/ProfessionalWiki/NeoWiki/pull/1285).

Considered, omitted: a positive reference-doc sentence that two Mappings may share an ontology's terms (the contract no longer restricts it; the rationale lives in the planning doc's Q6 entry); Mapping-page title-normalization and page-move semantics (pre-existing contract gap, separate change if wanted).

> <sub>AI-authored — Claude Code, `Fable 5 (max)`; table-level spec from @JeroenDeDauw, two revision rounds; diff not yet human-reviewed; blind-judge and fresh-context text-review passes applied, qqq.json validity checked locally.</sub>