### PR TITLE
Detect an unreachable SPARQL store by probing it in initialize()

### DIFF
--- a/src/Domain/GraphDatabase/GraphDatabasePlugin.php
+++ b/src/Domain/GraphDatabase/GraphDatabasePlugin.php
@@ -33,6 +33,8 @@ interface GraphDatabasePlugin {
 	 * run it every time. update.php calls this so an ordinary install or upgrade establishes those
 	 * structures, and a rebuild calls it on the store it is scoped to before re-projecting into it, so a
 	 * rebuilt graph carries them; the incremental per-edit path does not.
+	 *
+	 * A backend with no such structures still has to reach its store here and throw when it cannot.
 	 */
 	public function initialize(): void;
 

--- a/src/Domain/Rdf/RdfNamespaces.php
+++ b/src/Domain/Rdf/RdfNamespaces.php
@@ -110,6 +110,15 @@ readonly class RdfNamespaces {
 		return new Iri( $this->baseUri . '/graph/' . self::localName( $projection ) . '/page/' . $id->id );
 	}
 
+	/**
+	 * A named graph reserved for probing whether a store can be reached, so an update naming it is
+	 * harmless whatever the store holds: nothing writes to it. No page graph can collide with it,
+	 * whatever a projection is named, since every IRI that {@see graph()} mints ends in `/page/{id}`.
+	 */
+	public function probeGraph(): Iri {
+		return new Iri( $this->baseUri . '/graph/liveness-probe' );
+	}
+
 	public function term( string $localName ): Iri {
 		return new Iri( $this->baseUri . '/ontology/' . $localName );
 	}

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -233,17 +233,17 @@ class NeoWikiHooks {
 		$updater->output(
 			"failed.\n"
 			. '...' . $reason . "\n"
-			. "...Re-run update.php once the cause is resolved. While a backend is unreachable, Subject\n"
-			. "...editing and display and every graph read fail, and the edits made meanwhile are missing\n"
-			. "...from the projection: run RebuildGraphDatabases.php to reconcile it.\n"
+			. "...Re-run update.php once the cause is resolved. The reads the backend serves fail while\n"
+			. "...it is unreachable, and the edits made meanwhile are missing from its projection: run\n"
+			. "...RebuildGraphDatabases.php to reconcile it.\n"
 		);
 
 		// Logged as well, because update.php --quiet discards everything written to the updater, which
 		// would otherwise leave a failed initialization with no trace anywhere. The redacted reason
 		// rather than the exception, so that what is kept out of the terminal stays out of the log too.
 		LoggerFactory::getInstance( 'NeoWiki' )->error(
-			'NeoWiki failed to initialize its graph databases during update.php. The wiki is updated, but '
-			. 'the store-level structures its projection relies on are missing. Underlying error: ' . $reason
+			'NeoWiki failed to initialize its graph databases during update.php. The wiki itself is updated. '
+			. 'Underlying error: ' . $reason
 		);
 	}
 

--- a/src/GraphDatabasePlugins/Sparql/Persistence/SparqlProjectionStore.php
+++ b/src/GraphDatabasePlugins/Sparql/Persistence/SparqlProjectionStore.php
@@ -45,9 +45,13 @@ readonly class SparqlProjectionStore implements GraphDatabasePlugin {
 	) {
 	}
 
+	/**
+	 * Reaching the store is all there is to prepare: a SPARQL graph store has no store-level structures
+	 * (e.g. uniqueness constraints) to create up front, unlike Neo4j. The store is reached rather than
+	 * assumed, as {@see GraphDatabasePlugin::initialize()} requires (#1279).
+	 */
 	public function initialize(): void {
-		// Nothing to prepare: a SPARQL graph store has no store-level structures (e.g. uniqueness
-		// constraints) to create up front, unlike Neo4j.
+		$this->endpoint->postUpdate( $this->dropGraph( $this->namespaces->probeGraph() ) );
 	}
 
 	public function savePage( Page $page ): void {
@@ -99,10 +103,12 @@ readonly class SparqlProjectionStore implements GraphDatabasePlugin {
 	}
 
 	private function dropGraph( Iri $graph ): string {
-		// DROP SILENT so the first save of a new page does not error on a not-yet-existing graph. The
-		// graph IRI is built from trusted config (the base URI), an integer page id, and the projection
-		// name — the one untrusted part, since a Mapping target is author-controlled. RdfNamespaces::graph()
-		// percent-encodes it, `>` included, so it cannot close the <...> early and forge an update clause.
+		// DROP SILENT so a graph that need not exist is not an error: the first save of a new page names
+		// one, and so does every probe — without SILENT a healthy store answers those with a failure. The
+		// graph IRI is built from trusted config (the base URI) plus, for a page graph, an integer page id
+		// and the projection name — the one untrusted part, since a Mapping target is author-controlled.
+		// RdfNamespaces::graph() percent-encodes it, `>` included, so it cannot close the <...> early and
+		// forge an update clause.
 		return 'DROP SILENT GRAPH <' . $graph->value . '>';
 	}
 

--- a/tests/RedHerb/src/RedHerbGraphDatabasePlugin.php
+++ b/tests/RedHerb/src/RedHerbGraphDatabasePlugin.php
@@ -22,8 +22,7 @@ class RedHerbGraphDatabasePlugin implements GraphDatabasePlugin {
 	public array $deletedPageIds = [];
 
 	public function initialize(): void {
-		// A real backend would create its store-level structures (e.g. uniqueness constraints) here.
-		// This example store needs none, so initialization is a no-op.
+		// This example store is this object, so there is nothing to create and nothing to reach.
 	}
 
 	public function savePage( Page $page ): void {

--- a/tests/phpunit/Domain/Rdf/RdfNamespacesTest.php
+++ b/tests/phpunit/Domain/Rdf/RdfNamespacesTest.php
@@ -118,6 +118,13 @@ class RdfNamespacesTest extends TestCase {
 		);
 	}
 
+	public function testProbeGraphIriUsesTheReservedProbePath(): void {
+		$this->assertSame(
+			'https://wiki.example/graph/liveness-probe',
+			$this->namespaces()->probeGraph()->value
+		);
+	}
+
 	public function testSubjectAnchoredSynthesizedNodeIriUsesNodePathUnderTheSubjectId(): void {
 		$this->assertSame(
 			'https://wiki.example/node/s1demo8aaaaaab5/birth',

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/Integration/QuerySparqlEndToEndTestCase.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/Integration/QuerySparqlEndToEndTestCase.php
@@ -157,6 +157,12 @@ abstract class QuerySparqlEndToEndTestCase extends NeoWikiIntegrationTestCase {
 		return $entry;
 	}
 
+	public function testALiveStoreAcceptsTheLivenessProbe(): void {
+		$this->expectNotToPerformAssertions();
+
+		NeoWikiExtension::getInstance()->getNamedGraphDatabasePlugins()['native']->initialize();
+	}
+
 	public function testSubjectLabelRoundTripsThroughTheSparqlQueryService(): void {
 		$subjectId = TestSubject::uniqueId();
 		$initialLabel = 'System test subject ' . uniqid( '', true );

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/Persistence/SparqlProjectionStoreTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/Persistence/SparqlProjectionStoreTest.php
@@ -25,6 +25,7 @@ use ProfessionalWiki\NeoWiki\Infrastructure\Rdf\HardfRdfSerializer;
 use ProfessionalWiki\NeoWiki\Tests\Domain\Rdf\ParsedRdf;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\CapturingSparqlUpdateEndpoint;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\FixedPageProjector;
+use RuntimeException;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Persistence\SparqlProjectionStore
@@ -40,6 +41,26 @@ class SparqlProjectionStoreTest extends TestCase {
 	protected function setUp(): void {
 		$this->ns = new RdfNamespaces( self::BASE );
 		$this->endpoint = new CapturingSparqlUpdateEndpoint();
+	}
+
+	public function testInitializeProbesTheUpdateEndpoint(): void {
+		$this->newStore( $this->resolverReturning( $this->personQuads() ), 'native' )->initialize();
+
+		$this->assertSame(
+			[ 'DROP SILENT GRAPH <https://wiki.example/graph/liveness-probe>' ],
+			$this->endpoint->updates,
+			'A rebuild reads a store whose initialize() throws as one it cannot reach, so initialize() '
+				. 'has to reach the store rather than assume it is there.'
+		);
+	}
+
+	public function testInitializeFailsWhenTheStoreWillNotTakeUpdates(): void {
+		$this->endpoint = new CapturingSparqlUpdateEndpoint( new RuntimeException( 'endpoint unreachable' ) );
+		$store = $this->newStore( $this->resolverReturning( $this->personQuads() ), 'native' );
+
+		$this->expectExceptionMessage( 'endpoint unreachable' );
+
+		$store->initialize();
 	}
 
 	public function testSavePersistsDropThenInsertDataForThePageGraph(): void {
@@ -119,6 +140,17 @@ class SparqlProjectionStoreTest extends TestCase {
 			'DROP SILENT GRAPH <https://wiki.example/graph/bogus/page/42>',
 			$this->endpoint->lastUpdate(),
 			'The store names its own graph, so a delete needs no projection resolution.'
+		);
+	}
+
+	public function testInitializeWorksEvenWhenProjectionIsUnknown(): void {
+		$this->newStore( $this->unknownProjectionResolver( [ 'native' ] ), 'bogus' )->initialize();
+
+		$this->assertSame(
+			[ 'DROP SILENT GRAPH <https://wiki.example/graph/liveness-probe>' ],
+			$this->endpoint->updates,
+			'A store whose Mapping is broken is still reachable; reading it as gone would rewind the '
+				. 'rebuild cursor into pages that will never project.'
 		);
 	}
 

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/SparqlGraphProjectionTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/SparqlGraphProjectionTest.php
@@ -8,14 +8,21 @@ use MediaWiki\Deferred\DeferredUpdates;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
 use MockHttpTrait;
+use ProfessionalWiki\NeoWiki\Application\GraphRebuild\GraphRebuildCoordinator;
+use ProfessionalWiki\NeoWiki\Application\GraphRebuild\NullRebuildBatchObserver;
+use ProfessionalWiki\NeoWiki\Domain\GraphRebuild\RebuildRun;
+use ProfessionalWiki\NeoWiki\Domain\GraphRebuild\RebuildStatus;
+use ProfessionalWiki\NeoWiki\Domain\GraphRebuild\RebuildTrigger;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
 
 /**
- * Proves that a configured SPARQL store participates in the real hook-facing write path: a page edit
- * that stores a Subject sends the store its DROP/INSERT update, a deletion sends the DROP, and a
- * failing store does not abort the edit (the per-plugin failure isolation covers the new plugin). The
- * HTTP layer is faked, so no live SPARQL endpoint is needed.
+ * Proves that a configured SPARQL store participates in the real write paths: a page edit that stores
+ * a Subject sends the store its DROP/INSERT update, a deletion sends the DROP, a failing store does
+ * not abort the edit (the per-plugin failure isolation covers the new plugin), and a rebuild against
+ * an unreachable store ends before walking the wiki. The HTTP layer is faked, so no live SPARQL
+ * endpoint is needed.
  *
  * Neo4j is switched off for these tests (runWithoutGraphBackend), so the SPARQL plugin is exercised on
  * its own and the assertions do not depend on a live Neo4j.
@@ -101,6 +108,22 @@ class SparqlGraphProjectionTest extends NeoWikiIntegrationTestCase {
 
 		$this->assertNotNull( $revision, 'the edit must still commit despite the SPARQL endpoint failing' );
 		$this->assertGreaterThan( 0, $revision->getPageId() );
+	}
+
+	public function testRebuildingAnUnreachableSparqlStoreEndsBeforeWalkingTheWiki(): void {
+		$this->installMockHttp( $this->makeFakeHttpRequest( 'connection refused', 0 ) );
+		$this->overrideConfigValue( 'NeoWikiSparqlStores', [ [ 'updateUrl' => self::ENDPOINT ] ] );
+
+		$run = $this->runWithoutGraphBackend( function (): RebuildRun {
+			$this->createPageWithSubjects( 'Page the rebuild must not walk', TestSubject::build() );
+
+			return NeoWikiExtension::getInstance()
+				->newGraphRebuildCoordinator( GraphRebuildCoordinator::BACKGROUND_BATCH_SIZE )
+				->rebuild( 'native', RebuildTrigger::Cli, 200, new NullRebuildBatchObserver() );
+		} );
+
+		$this->assertSame( RebuildStatus::Failed, $run->status );
+		$this->assertSame( 0, $run->processed, 'the walk never starts against a store that cannot be opened' );
 	}
 
 	private function capturingHttp(): callable {

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/SparqlGraphProjectionTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/SparqlGraphProjectionTest.php
@@ -123,7 +123,8 @@ class SparqlGraphProjectionTest extends NeoWikiIntegrationTestCase {
 		} );
 
 		$this->assertSame( RebuildStatus::Failed, $run->status );
-		$this->assertSame( 0, $run->processed, 'the walk never starts against a store that cannot be opened' );
+		$this->assertSame( 0, $run->processed, 'nothing is projected into a store that never opened' );
+		$this->assertSame( 0, $run->failed, 'and the walk never starts, so no page is pushed at it to fail' );
 	}
 
 	private function capturingHttp(): callable {

--- a/tests/phpunit/TestDoubles/CapturingSparqlUpdateEndpoint.php
+++ b/tests/phpunit/TestDoubles/CapturingSparqlUpdateEndpoint.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Tests\TestDoubles;
 
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlUpdateEndpoint;
+use Throwable;
 
 /**
  * Records the SPARQL updates posted to it, so tests can assert on the exact update string the store
@@ -17,8 +18,21 @@ class CapturingSparqlUpdateEndpoint implements SparqlUpdateEndpoint {
 	 */
 	public array $updates = [];
 
+	/**
+	 * @param Throwable|null $failure What posting throws, standing in for a store that cannot take
+	 *        updates. Posting records the update before throwing, so a test can still see what was sent.
+	 */
+	public function __construct(
+		private readonly ?Throwable $failure = null
+	) {
+	}
+
 	public function postUpdate( string $update ): void {
 		$this->updates[] = $update;
+
+		if ( $this->failure !== null ) {
+			throw $this->failure;
+		}
 	}
 
 	public function lastUpdate(): string {


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/1279

A rebuild asks a store whether it is still there by calling `initialize()` and reading a throw as
"cannot be reached": when a run starts, when a background batch picks it back up, and whenever a
whole batch has failed — the last being what ends a run with its cursor rewound to that batch rather
than walking on. `SparqlProjectionStore::initialize()` was a no-op that could never throw, so every
guard was dead for every SPARQL store. A rebuild against a stopped store walked the entire wiki,
failed every page one at a time, and reported itself as succeeded.

`initialize()` now reaches the store: it sends the update endpoint a
`DROP SILENT GRAPH <{base}/graph/liveness-probe>`, minted in `RdfNamespaces`, where every page graph
ends in `/page/{id}` — so nothing else can name the probe graph and nothing writes to it. Dropping an
absent graph leaves the store untouched, asks no more of an engine than `deletePage()` already does,
and goes to the update endpoint under the store's own credentials, because an endpoint that will not
take the probe will not take a save either. It resolves no projection, so a broken Mapping cannot
read as a store that is gone. A page save never probes — that path does not initialize; the probe
fires once per run start, background batch, wholly failed batch, and update.php — on QLever at the
measured 591k-triple store size, ~0.2s per probe against batches costing minutes.

The plugin contract now obliges a backend with nothing to create to still reach its store here,
with the RedHerb example noting why its in-process store conforms as a no-op.
The update.php failure report no longer claims subject editing and display fail — false for a SPARQL
store, which can now trigger it: only the backend's own reads fail, and edits made meanwhile are
missing from its projection until a rebuild.

Verification with QLever stopped (rebuild scoped to its `native` store, 121 pages): master walks all
121 pages in 3m57s and reports `succeeded`; this branch ends in 2.7s with
`The SPARQL update to <http://qlever:7019/> failed with HTTP status 0` and a `--resume` hint. A
healthy rebuild is unchanged (121/121, same triples as master). Four tests pin the behaviour: the
probe update string, that `initialize()` resolves no projection, that a rebuild through a store built
from `$wgNeoWikiSparqlStores` ends before walking the wiki (seen failing on master), and that every
live engine the end-to-end suite runs against accepts the probe (QLever and Oxigraph; Fuseki checked
by hand). Unauthenticated, QLever answers `500`, so a credential failure surfaces as a store failure
too.

Considered, omitted:

* The issue's two alternatives — a dedicated liveness method on the plugin contract, or the rebuild
  probing SPARQL stores with an update of its own. Both add surface for what `initialize()` already
  promises.
* Letting `CompositeGraphDatabasePlugin::initialize()` carry on past a failing plugin: on update.php
  an unreachable SPARQL store now stops the plugins queued behind it, as an unreachable Neo4j already
  does, and Neo4j initializes first, so its constraints are never the casualty.
* Restating the obligation in docs/extending/extending.md — the contract's home is the
  `GraphDatabasePlugin` docblock, and the guide already notes the rebuild asks `initialize()`
  whether the store is still there.
* #1259, the misreported sync state visible in the master run above.

> <sub>AI-authored — Claude Code, `Opus 5 (max)` implementation and review fixes, `Fable 5 (max)` orchestration and final pass; from @JeroenDeDauw's in-session delegation of the pre-verified issue, one adversarial review round applied; diff not yet human-reviewed; new tests seen failing first (the rebuild-level one against master's production code), full PHPUnit suite plus phpcs and phpstan green locally, CI green, probe accepted by live QLever and Oxigraph (Fuseki by hand), dead-store and healthy rebuilds checked live on the dev stack.</sub>
