### PR TITLE
Stop Schema-deletion tests racing their own caches

### DIFF
--- a/tests/phpunit/Application/SelectStatementResolverTest.php
+++ b/tests/phpunit/Application/SelectStatementResolverTest.php
@@ -26,11 +26,15 @@ class SelectStatementResolverTest extends TestCase {
 	}
 
 	private function newSchemaWithSelect( bool $multiple = false ): Schema {
+		return $this->newSchemaWithSelectNamed( 'Status', $multiple );
+	}
+
+	private function newSchemaWithSelectNamed( string $propertyName, bool $multiple ): Schema {
 		return new Schema(
 			name: new SchemaName( 'SomeSchema' ),
 			description: '',
 			properties: new PropertyDefinitions( [
-				'Status' => new SelectProperty(
+				$propertyName => new SelectProperty(
 					core: new PropertyCore( description: '', required: false, default: null ),
 					options: [
 						new SelectOption( id: 'opt1', label: 'Draft' ),
@@ -134,6 +138,30 @@ class SelectStatementResolverTest extends TestCase {
 		$resolved = $this->newResolver()->resolve( $this->newSchemaWithSelect(), $patch );
 
 		$this->assertSame( $patch, $resolved );
+	}
+
+	/**
+	 * PHP turns a decimal-integer array key into an int, so a select property named like a year
+	 * reaches the Schema lookups as one.
+	 */
+	public function testResolvesValueOfPropertyNamedLikeAnInteger(): void {
+		$patch = [
+			'2024' => [ 'propertyType' => 'select', 'value' => 'Draft' ],
+		];
+
+		$resolved = $this->newResolver()->resolve( $this->newSchemaWithSelectNamed( '2024', false ), $patch );
+
+		$this->assertSame( 'opt1', $resolved['2024']['value'] );
+	}
+
+	public function testResolveOrLeaveResolvesValueOfPropertyNamedLikeAnInteger(): void {
+		$patch = [
+			'2024' => [ 'propertyType' => 'select', 'value' => 'Draft' ],
+		];
+
+		$resolved = $this->newResolver()->resolveOrLeave( $this->newSchemaWithSelectNamed( '2024', false ), $patch );
+
+		$this->assertSame( 'opt1', $resolved['2024']['value'] );
 	}
 
 	public function testResolveOrLeaveResolvesKnownLabelToId(): void {

--- a/tests/phpunit/EntryPoints/REST/RemoveStatementApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/RemoveStatementApiTest.php
@@ -236,6 +236,8 @@ class RemoveStatementApiTest extends NeoWikiIntegrationTestCase {
 			)
 		);
 
+		$this->startFreshRequest();
+
 		$response = $this->executeHandler(
 			$this->newRemoveStatementApi(),
 			$this->newRequest( 'Website' )

--- a/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
@@ -129,6 +129,7 @@ class ReplaceSubjectApiTest extends NeoWikiIntegrationTestCase {
 				Title::newFromText( 'GoneSchema', NeoWikiExtension::NS_SCHEMA )
 			)
 		);
+		$this->startFreshRequest();
 
 		$response = $this->executeHandler(
 			$this->newReplaceSubjectApi(),
@@ -356,6 +357,7 @@ class ReplaceSubjectApiTest extends NeoWikiIntegrationTestCase {
 				Title::newFromText( 'OrphanSchema', NeoWikiExtension::NS_SCHEMA )
 			)
 		);
+		$this->startFreshRequest();
 
 		$response = $this->executeHandler(
 			$this->newReplaceSubjectApi(),

--- a/tests/phpunit/NeoWikiIntegrationTestCase.php
+++ b/tests/phpunit/NeoWikiIntegrationTestCase.php
@@ -358,6 +358,16 @@ class NeoWikiIntegrationTestCase extends MediaWikiIntegrationTestCase {
 		);
 	}
 
+	/**
+	 * Drops the state a real request would not inherit: MediaWiki's services, and the extension
+	 * singleton that pins the Schema lookup and its caches. A test that changes a page and then
+	 * reads it back otherwise depends on every cache in this process having noticed the change.
+	 */
+	protected function startFreshRequest(): void {
+		$this->resetServices();
+		NeoWikiExtension::resetInstance();
+	}
+
 	protected function readGraph( string $cypher, array $parameters = [] ): SummarizedResult {
 		return NeoWikiExtension::getInstance()->requireNeo4jPlugin()->getReadQueryEngine()->runReadQuery( $cypher, $parameters );
 	}


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1270

Review fixes for #1270.

## Three tests raced their own caches

`CachingSchemaLookup::getSchema()` answers from one of its two cache tiers unless the Schema page reports itself
absent. Page state and both tiers are per-process, so a test that deletes the Schema page and reads it back within
the same process rests on cache state it never forces.

All three tests built that way have now been seen failing on a randomly varying MediaWiki matrix leg, and passing
on re-run:

| Test | Seen failing in |
|---|---|
| `RemoveStatementApiTest::testUpdatedResponseOmitsTheSchemaWhenTheSchemaIsMissing` | [31707283505](https://github.com/ProfessionalWiki/NeoWiki/actions/runs/31707283505), [31709556928](https://github.com/ProfessionalWiki/NeoWiki/actions/runs/31709556928), [31709560451](https://github.com/ProfessionalWiki/NeoWiki/actions/runs/31709560451), and on `pr-1216-review-fixes` unchanged in [31725276831](https://github.com/ProfessionalWiki/NeoWiki/actions/runs/31725276831) |
| `ReplaceSubjectApiTest::testResponseIncludesSchemaNotFoundWhenSchemaMissing` | [31707283505](https://github.com/ProfessionalWiki/NeoWiki/actions/runs/31707283505) |
| `ReplaceSubjectApiTest::testUpdatedResponseOmitsTheSchemaWhenTheSchemaIsMissing` | [31740121873](https://github.com/ProfessionalWiki/NeoWiki/actions/runs/31740121873), on the non-blocking `master` leg |

Only the first is new in #1270; the other two predate it on `master`, so this is an existing pattern rather than
something the branch introduced.

Which cached state loses the race is not established. `startFreshRequest()` removes the dependency instead of
timing around it, by dropping what a real request would not inherit: MediaWiki's services, and the extension
singleton that pins the Schema lookup and its caches.

It is not reproducible locally, where the suite passes either way, so the evidence is CI sampling: 6 runs since
the fix, 30 PHPUnit legs including `master`, all green. Before it, this branch failed on 3 of 4 runs.

## The `SelectStatementResolver` casts had no test

The four `(string)` casts guarding `Schema::hasProperty` and `::getProperty` against an int array key are only
reachable for a select-typed property, and every existing case leaves the loop at the select-type check above
them. Reverting all four left the full suite green, so nothing pinned them.

## Considered, omitted

`Neo4jPageRelationUpdater::relationProperties` still assembles the relation property map with `array_merge`, so a
relation qualifier named like a decimal integer reaches Neo4j under a renumbered name while the revision slot
keeps the name the client sent. This is the sibling of the node property map fixed in `a123af7d`, and a fix plus
an integration test were written and dropped again.

The case is narrow enough not to be worth carrying. Qualifier names are free-form, so it is reachable, but only
canonical decimal integers within PHP's int range are affected and the trigger is machine-generated names. More to
the point, `SchemaPersistenceDeserializer` silently drops any integer-named property definition, so such a
property cannot be Schema-defined, validated, or rendered in the editor, and does not survive the next
full-Subject save from the UI. Patching consumption sites one at a time buys little while that holds.

`MappingContentValidator::numericNodeKeyErrors()` answers the same PHP behaviour by rejecting integer keys at save
time with a user-facing error. Deciding once whether integer-like property names are supported, and either
rejecting them at the boundary or fixing the Schema deserializer, would settle roughly eight sites in one place.

---
> <sub>AI-authored, Claude Code, `Opus 5 (1M context)`; produced by a PR review of #1270 requested by @malberts, scope cut twice on review; not yet human-reviewed beyond wording; the select-resolver test was seen failing before its production change, full PHPUnit suite and `make cs` green locally, and the cache fix is not locally reproducible so it rests on the CI sampling above.</sub>
