### PR TITLE
Show edit notices in the Subject editing interfaces

### DIFF
--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -15,7 +15,8 @@ Every endpoint is also published as a complete [OpenAPI 3.0 description](#full-s
 
 ## Permissions
 
-The Subject, page-subjects, subject-labels, Schema, Layout, Mapping, RDF export, and entity-dereference read endpoints
+The Subject, page-subjects, edit-notices, subject-labels, Schema, Layout, Mapping, RDF export, and entity-dereference
+read endpoints
 enforce the caller's per-page `read` permission; page protection and `$wgNamespaceProtection` do not restrict them,
 because MediaWiki's `read` action ignores both. When you may not read a page they respond as if the data were absent — a
 `null` value, an empty list, or a `404` — never a `403`. `GET /subject-labels` omits the labels of Subjects whose page
@@ -70,7 +71,7 @@ Subjects and arrange them.
 | Endpoint | Description |
 |---|---|
 | `GET /neowiki/v0/page/{pageId}/subjects` | List a page's main and child Subjects. `expand` with `schemas` or `relations`. |
-| `GET /neowiki/v0/page/{pageId}/editNotices` | List the notices to show before editing the page's Subjects. `schema` names the Schema being edited, enabling Schema-scoped notices. See [Edit notices](../authoring/edit-notices.md). |
+| `GET /neowiki/v0/page/{pageId}/editNotices` | List the notices to show before editing the page's Subjects, in display order. Optional `schema` adds notices scoped to that Schema. Returns `{notices: [{key, html}]}`. See [Edit notices](../authoring/edit-notices.md). |
 | `GET /neowiki/v0/page/{pageId}/rdf` | Export the page's Subjects and metadata as RDF. `format` is `trig` (default) or `turtle`; `projection` is `native` (default) or the name of a Mapping page. See [RDF export](../rdf/rdf-export.md) and [Ontology Mapping](../rdf/ontology-mapping.md). |
 | `POST /neowiki/v0/page/{pageId}/mainSubject` | Create the page's main Subject. |
 | `PUT /neowiki/v0/page/{pageId}/mainSubject` | Promote a child Subject to main, or clear it. |

--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -70,6 +70,7 @@ Subjects and arrange them.
 | Endpoint | Description |
 |---|---|
 | `GET /neowiki/v0/page/{pageId}/subjects` | List a page's main and child Subjects. `expand` with `schemas` or `relations`. |
+| `GET /neowiki/v0/page/{pageId}/editNotices` | List the notices to show before editing the page's Subjects. `schema` names the Schema being edited, enabling Schema-scoped notices. See [Edit notices](../authoring/edit-notices.md). |
 | `GET /neowiki/v0/page/{pageId}/rdf` | Export the page's Subjects and metadata as RDF. `format` is `trig` (default) or `turtle`; `projection` is `native` (default) or the name of a Mapping page. See [RDF export](../rdf/rdf-export.md) and [Ontology Mapping](../rdf/ontology-mapping.md). |
 | `POST /neowiki/v0/page/{pageId}/mainSubject` | Create the page's main Subject. |
 | `PUT /neowiki/v0/page/{pageId}/mainSubject` | Promote a child Subject to main, or clear it. |

--- a/docs/authoring/edit-notices.md
+++ b/docs/authoring/edit-notices.md
@@ -49,6 +49,13 @@ Check the [[Project:Naming|naming convention]] before changing a person's name.
 
 Anyone editing a Person Subject now sees that notice.
 
+## Known limitation
+
+Notices are chosen by the page being viewed, not by the page that stores the Subject. A Subject rendered on
+another page with `{{#view: <subjectId>}}` (see [Parser Functions](parser-functions.md)) therefore shows the
+viewing page's notices, and its own page's notices do not appear. Editing a Subject from its own page, which is
+the usual case, is unaffected.
+
 ## From an extension
 
 Extensions add notices of their own through `addSubjectEditNoticeProvider` — see

--- a/docs/authoring/edit-notices.md
+++ b/docs/authoring/edit-notices.md
@@ -4,59 +4,51 @@ order: 3
 ---
 # Edit Notices
 
-A message shown to users before they edit a Subject. Create one as an interface message; NeoWiki ships none, so a
-key resolves only once the corresponding `MediaWiki:` page exists.
+Interface messages shown to the user in the Subject editor, the Subject creator, and Manage subjects. NeoWiki ships
+none, so nothing appears until you create one.
 
-These are separate from MediaWiki's own edit notices, which stay with the wikitext editors.
+## Add a notice
 
-## Message keys
+Create the interface message whose key matches the scope you want:
 
-| Key | Applies to |
+| Create | Shown when editing |
 |---|---|
-| `MediaWiki:Neowiki-editnotice-{ns}` | Every Subject edit in namespace `{ns}` |
-| `MediaWiki:Neowiki-editnotice-{ns}-{dbkey}` | One page |
-| `MediaWiki:Neowiki-editnotice-schema-{Schema}` | Every Subject of that Schema, wiki-wide |
+| `MediaWiki:Neowiki-editnotice-{ns}` | Any Subject in namespace `{ns}` |
+| `MediaWiki:Neowiki-editnotice-{ns}-{dbkey}` | A Subject on one page |
+| `MediaWiki:Neowiki-editnotice-schema-{Schema}` | A Subject of one Schema, anywhere |
 
-`{ns}` is the numeric namespace ID, `0` for the main namespace. `{dbkey}` is the page title with spaces as
-underscores and without the namespace prefix, so `Help:New York` is `12-New_York`.
+`{ns}` is the numeric namespace ID, `0` for the main namespace. `{dbkey}` and `{Schema}` use underscores for spaces,
+and `{dbkey}` drops the namespace prefix, so `Help:New York` is `12-New_York` and a Schema named `Control Document`
+is `schema-Control_Document`.
 
-Where the namespace has subpages enabled, a notice applies to the page and everything beneath it:
-`Neowiki-editnotice-4-Handbook` also covers `Project:Handbook/Chapter1`. Elsewhere slashes become dashes, so
+Where the namespace has subpages enabled, a notice covers the page and everything beneath it:
+`Neowiki-editnotice-4-Handbook` also applies to `Project:Handbook/Chapter1`. Elsewhere slashes become dashes, so
 `Foo/Bar` in the main namespace is `0-Foo-Bar`.
 
-Matching notices are shown broadest first: namespace, then page, then Schema.
-
-## Content
-
-The message is wikitext and carries its own presentation: it renders as written, with no frame or icon
-added around it. Magic words resolve against the page being edited, making `{{PAGENAME}}` the page the user
-is on.
-
-Each notice is wrapped in `<div class="ext-neowiki-edit-notice" data-mw-neowiki-editnotice-key="...">`, so a
-notice can be styled by its key from `MediaWiki:Common.css`. Editors are bounded dialogs, so a notice longer
-than the space available scrolls rather than pushing the fields out of reach.
-
-Set a message to `-` to disable it. A message that renders to nothing is skipped rather than shown as an empty
-frame.
-
-## Example
-
-Create `MediaWiki:Neowiki-editnotice-schema-Person`:
+To warn anyone editing a Person Subject, create `MediaWiki:Neowiki-editnotice-schema-Person`:
 
 ```
 Check the [[Project:Naming|naming convention]] before changing a person's name.
 ```
 
-Anyone editing a Person Subject now sees that notice.
+## Write the content
+
+Magic words resolve against the page being edited, so `{{PAGENAME}}` is that page's name.
+
+To style a notice, target it in CSS by its key: each one is wrapped in
+`<div class="ext-neowiki-edit-notice" data-mw-neowiki-editnotice-key="...">`.
+
+## When several notices match
+
+All of them are shown, in this order: namespace, page, Schema, then any contributed by extensions. In the Subject
+creator the Schema notice appears only once a Schema has been chosen.
 
 ## Known limitation
 
-Notices are chosen by the page being viewed, not by the page that stores the Subject. A Subject rendered on
-another page with `{{#view: <subjectId>}}` (see [Parser Functions](parser-functions.md)) therefore shows the
-viewing page's notices, and its own page's notices do not appear. Editing a Subject from its own page, which is
-the usual case, is unaffected.
+Notices follow the page being viewed, not the page that stores the Subject. A Subject rendered elsewhere with
+`{{#view: <subjectId>}}` (see [Parser Functions](parser-functions.md)) therefore shows the viewing page's
+notices.
 
 ## From an extension
 
-Extensions add notices of their own through `addSubjectEditNoticeProvider` — see
-[Extending NeoWiki](../extending/extending.md).
+Extensions can add notices of their own — see [Extending NeoWiki](../extending/extending.md#edit-notices).

--- a/docs/authoring/edit-notices.md
+++ b/docs/authoring/edit-notices.md
@@ -28,8 +28,13 @@ Matching notices are shown broadest first: namespace, then page, then Schema.
 
 ## Content
 
-The message is wikitext, rendered inside a message frame, so keep it to a sentence or two with inline formatting.
-Magic words resolve against the page being edited, making `{{PAGENAME}}` the page the user is on.
+The message is wikitext and carries its own presentation: it renders as written, with no frame or icon
+added around it. Magic words resolve against the page being edited, making `{{PAGENAME}}` the page the user
+is on.
+
+Each notice is wrapped in `<div class="ext-neowiki-edit-notice" data-mw-neowiki-editnotice-key="...">`, so a
+notice can be styled by its key from `MediaWiki:Common.css`. Editors are bounded dialogs, so a notice longer
+than the space available scrolls rather than pushing the fields out of reach.
 
 Set a message to `-` to disable it. A message that renders to nothing is skipped rather than shown as an empty
 frame.

--- a/docs/authoring/edit-notices.md
+++ b/docs/authoring/edit-notices.md
@@ -1,0 +1,50 @@
+---
+title: Edit Notices
+order: 3
+---
+# Edit Notices
+
+A message shown to users before they edit a Subject. Create one as an interface message; NeoWiki ships none, so a
+key resolves only once the corresponding `MediaWiki:` page exists.
+
+These are separate from MediaWiki's own edit notices, which stay with the wikitext editors.
+
+## Message keys
+
+| Key | Applies to |
+|---|---|
+| `MediaWiki:Neowiki-editnotice-{ns}` | Every Subject edit in namespace `{ns}` |
+| `MediaWiki:Neowiki-editnotice-{ns}-{dbkey}` | One page |
+| `MediaWiki:Neowiki-editnotice-schema-{Schema}` | Every Subject of that Schema, wiki-wide |
+
+`{ns}` is the numeric namespace ID, `0` for the main namespace. `{dbkey}` is the page title with spaces as
+underscores and without the namespace prefix, so `Help:New York` is `12-New_York`.
+
+Where the namespace has subpages enabled, a notice applies to the page and everything beneath it:
+`Neowiki-editnotice-4-Handbook` also covers `Project:Handbook/Chapter1`. Elsewhere slashes become dashes, so
+`Foo/Bar` in the main namespace is `0-Foo-Bar`.
+
+Matching notices are shown broadest first: namespace, then page, then Schema.
+
+## Content
+
+The message is wikitext, rendered inside a message frame, so keep it to a sentence or two with inline formatting.
+Magic words resolve against the page being edited, making `{{PAGENAME}}` the page the user is on.
+
+Set a message to `-` to disable it. A message that renders to nothing is skipped rather than shown as an empty
+frame.
+
+## Example
+
+Create `MediaWiki:Neowiki-editnotice-schema-Person`:
+
+```
+Check the [[Project:Naming|naming convention]] before changing a person's name.
+```
+
+Anyone editing a Person Subject now sees that notice.
+
+## From an extension
+
+Extensions add notices of their own through `addSubjectEditNoticeProvider` — see
+[Extending NeoWiki](../extending/extending.md).

--- a/docs/extending/extending.md
+++ b/docs/extending/extending.md
@@ -107,6 +107,39 @@ extension prefix). The context exposes the page id, title and namespace, creatio
 categories, and last editor. Example:
 [`src/StaticPagePropertyProvider.php`](https://github.com/ProfessionalWiki/NeoWiki/blob/master/tests/RedHerb/src/StaticPagePropertyProvider.php).
 
+## Edit notices
+
+Show a message before a user edits a Subject, for instance to say a saved change stays hidden until it is reviewed.
+
+```php
+class ApprovalEditNoticeProvider implements SubjectEditNoticeProvider {
+
+	public function __construct(
+		private readonly MessageLocalizer $messageLocalizer
+	) {
+	}
+
+	public function getNotices( SubjectEditNoticeContext $context ): array {
+		return [ new SubjectEditNotice(
+			key: 'myext-approval',
+			html: $this->messageLocalizer->msg( 'myext-approval-notice' )->parse()
+		) ];
+	}
+
+}
+```
+
+Register with `NeoWikiRegistrar::addSubjectEditNoticeProvider()`. Providers run in registration order, after the
+notices wiki admins write as interface messages, and the first provider to claim a key keeps it. The context
+exposes the page id, database key and namespace, plus the Schema being edited when one is known.
+
+The `html` is used as given, so escape or parse it yourself. Keep it short: it renders inside a message frame in an
+editing dialog.
+
+Providers run only for pages the requesting user may read, and only after that check, so the main request context
+carries the page by the time a provider runs. Admin-written notices use the keys documented in
+[Edit notices](../authoring/edit-notices.md).
+
 ### Refreshing a page's data without an edit
 
 A page's graph data is written on edit and on full rebuild. When data your extension contributes through a

--- a/docs/extending/extending.md
+++ b/docs/extending/extending.md
@@ -107,7 +107,7 @@ extension prefix). The context exposes the page id, title and namespace, creatio
 categories, and last editor. Example:
 [`src/StaticPagePropertyProvider.php`](https://github.com/ProfessionalWiki/NeoWiki/blob/master/tests/RedHerb/src/StaticPagePropertyProvider.php).
 
-## Edit notices
+### Edit notices
 
 Show a message before a user edits a Subject, for instance to say a saved change stays hidden until it is reviewed.
 

--- a/docs/extending/extending.md
+++ b/docs/extending/extending.md
@@ -109,7 +109,7 @@ categories, and last editor. Example:
 
 ### Edit notices
 
-Show a message before a user edits a Subject, for instance to say a saved change stays hidden until it is reviewed.
+Show a message before a user edits a Subject.
 
 ```php
 class ApprovalEditNoticeProvider implements SubjectEditNoticeProvider {
@@ -130,15 +130,15 @@ class ApprovalEditNoticeProvider implements SubjectEditNoticeProvider {
 ```
 
 Register with `NeoWikiRegistrar::addSubjectEditNoticeProvider()`. Providers run in registration order, after the
-notices wiki admins write as interface messages, and the first provider to claim a key keeps it. The context
-exposes the page id, database key and namespace, plus the Schema being edited when one is known.
+notices wiki admins write as interface messages, and only for pages the requesting user may read.
+`SubjectEditNoticeContext` exposes `$pageId`, `$pageDbKey`, `$namespaceId`, and `$schemaName` when a Schema is
+known.
 
-The `html` is used as given, so escape or parse it yourself, and bring whatever presentation the notice needs:
-NeoWiki wraps it in a bare container and adds no frame, icon or colour of its own.
+Unlike an admin's wikitext, which MediaWiki's parser sanitizes, provider `html` is inserted as given: escape it
+yourself.
 
-Providers run only for pages the requesting user may read, and only after that check, so the main request context
-carries the page by the time a provider runs. Admin-written notices use the keys documented in
-[Edit notices](../authoring/edit-notices.md).
+Namespace your keys to your extension. A key reaches the browser as a styling handle, and the first provider to
+claim one keeps it. See [Edit notices](../authoring/edit-notices.md) for the keys admins use.
 
 ### Refreshing a page's data without an edit
 

--- a/docs/extending/extending.md
+++ b/docs/extending/extending.md
@@ -133,8 +133,8 @@ Register with `NeoWikiRegistrar::addSubjectEditNoticeProvider()`. Providers run 
 notices wiki admins write as interface messages, and the first provider to claim a key keeps it. The context
 exposes the page id, database key and namespace, plus the Schema being edited when one is known.
 
-The `html` is used as given, so escape or parse it yourself. Keep it short: it renders inside a message frame in an
-editing dialog.
+The `html` is used as given, so escape or parse it yourself, and bring whatever presentation the notice needs:
+NeoWiki wraps it in a bare container and adds no frame, icon or colour of its own.
 
 Providers run only for pages the requesting user may read, and only after that check, so the main request context
 carries the page by the time a provider runs. Admin-written notices use the keys documented in

--- a/extension.json
+++ b/extension.json
@@ -260,6 +260,11 @@
 			"factory": "ProfessionalWiki\\NeoWiki\\NeoWikiExtension::newGetPageSubjectsApi"
 		},
 		{
+			"path": "/neowiki/v0/page/{pageId}/editNotices",
+			"method": [ "GET" ],
+			"factory": "ProfessionalWiki\\NeoWiki\\NeoWikiExtension::newGetSubjectEditNoticesApi"
+		},
+		{
 			"path": "/neowiki/v0/page/{pageId}/rdf",
 			"method": [ "GET" ],
 			"factory": "ProfessionalWiki\\NeoWiki\\NeoWikiExtension::newExportPageRdfApi"

--- a/resources/ext.neowiki/src/NeoWikiExtension.ts
+++ b/resources/ext.neowiki/src/NeoWikiExtension.ts
@@ -27,6 +27,8 @@ import { HttpClient } from '@/infrastructure/HttpClient/HttpClient';
 import { ProductionHttpClient } from '@/infrastructure/HttpClient/ProductionHttpClient';
 import { RestSchemaRepository } from '@/persistence/RestSchemaRepository.ts';
 import { SchemaRepository } from '@/application/SchemaRepository.ts';
+import { RestEditNoticeRepository } from '@/persistence/RestEditNoticeRepository.ts';
+import { EditNoticeRepository } from '@/application/EditNoticeRepository.ts';
 import { LayoutRepository } from '@/application/LayoutRepository.ts';
 import { RestLayoutRepository } from '@/persistence/RestLayoutRepository.ts';
 import { LayoutSerializer } from '@/persistence/LayoutSerializer.ts';
@@ -211,6 +213,13 @@ export class NeoWikiExtension {
 			new SchemaSerializer(),
 			new SchemaDeserializer(),
 			new MediaWikiPageSaver( this.getMediaWiki() ),
+		);
+	}
+
+	public getEditNoticeRepository(): EditNoticeRepository {
+		return new RestEditNoticeRepository(
+			this.getMediaWiki().util.wikiScript( 'rest' ),
+			this.newHttpClient(),
 		);
 	}
 

--- a/resources/ext.neowiki/src/application/EditNoticeRepository.ts
+++ b/resources/ext.neowiki/src/application/EditNoticeRepository.ts
@@ -1,0 +1,8 @@
+import type { EditNotice } from '@/domain/EditNotice';
+
+export interface EditNoticeRepository {
+	/**
+	 * Naming the Schema being edited enables Schema-scoped notices.
+	 */
+	getNotices( pageId: number, schemaName?: string ): Promise<EditNotice[]>;
+}

--- a/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
@@ -199,7 +199,7 @@ const props = defineProps<{
 
 const selectedSchemaOption = ref( 'existing' );
 const selectedSchemaName = ref<string | null>( null );
-const { notices, loadNotices } = useEditNotices();
+const { notices, loadNotices } = useEditNotices( () => NeoWikiExtension.getInstance().getEditNoticeRepository() );
 
 const loadedSchema = ref<Schema | null>( null );
 const subjectLabel = ref( '' );

--- a/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectCreator/SubjectCreatorDialog.vue
@@ -44,6 +44,9 @@
 				</CdxButton>
 			</div>
 		</template>
+
+		<EditNoticeList :notices="notices" />
+
 		<template v-if="!selectedSchemaName">
 			<p>
 				{{ $i18n( 'neowiki-subject-creator-schema-title' ).text() }}
@@ -187,6 +190,8 @@ import { useSubjectValidation } from '@/composables/useSubjectValidation.ts';
 import { NeoWikiExtension } from '@/NeoWikiExtension.ts';
 import { NeoWikiServices } from '@/NeoWikiServices.ts';
 import { setPendingNotification } from '@/presentation/PendingNotification.ts';
+import EditNoticeList from '@/components/common/EditNoticeList.vue';
+import { useEditNotices } from '@/composables/useEditNotices.ts';
 
 const props = defineProps<{
 	pageHasMainSubject: boolean;
@@ -194,6 +199,8 @@ const props = defineProps<{
 
 const selectedSchemaOption = ref( 'existing' );
 const selectedSchemaName = ref<string | null>( null );
+const { notices, loadNotices } = useEditNotices();
+
 const loadedSchema = ref<Schema | null>( null );
 const subjectLabel = ref( '' );
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -207,6 +214,16 @@ const draftSchema = shallowRef<Schema | null>( null );
 let requestSequence = 0;
 
 const subjectStore = useSubjectStore();
+// Reloaded when the Schema is chosen too, since Schema-scoped notices cannot apply before there
+// is a Schema to scope them to.
+watch(
+	() => [ subjectStore.subjectCreatorOpen, selectedSchemaName.value ],
+	() => {
+		if ( subjectStore.subjectCreatorOpen ) {
+			loadNotices( Number( mw.config.get( 'wgArticleId' ) ), selectedSchemaName.value ?? undefined );
+		}
+	}
+);
 const schemaStore = useSchemaStore();
 const schemaRepo = NeoWikiServices.getSchemaRepository();
 const { canCreateSchemas, checkCreatePermission } = useSchemaPermissions();

--- a/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditorDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditorDialog.vue
@@ -268,6 +268,8 @@ function onDialogUpdateOpen( value: boolean ): void {
 	}
 }
 
+// Immediate, because the host renders this dialog with v-if: it mounts with open already true, so a
+// deferred watcher would never see the opening that created it.
 watch( () => props.open, ( isOpen ) => {
 	if ( isOpen ) {
 		subjectLabel.value = props.subject.getLabel();
@@ -276,7 +278,7 @@ watch( () => props.open, ( isOpen ) => {
 		// Fetched per opening: approval state and the viewer's permissions both change without an edit.
 		loadNotices( Number( mw.config.get( 'wgArticleId' ) ), props.subject.getSchemaName() );
 	}
-} );
+}, { immediate: true } );
 
 // Existing subjects are expected to be complete, so validate as soon as the
 // editor mounts for an open dialog: pre-existing violations (e.g. a now-empty

--- a/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditorDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditorDialog.vue
@@ -77,6 +77,8 @@
 				</ul>
 			</CdxMessage>
 
+			<EditNoticeList :notices="notices" />
+
 			<SubjectEditor
 				ref="subjectEditorRef"
 				:statements="statements"
@@ -129,6 +131,8 @@ import { Schema } from '@/domain/Schema.ts';
 import SchemaEditorDialog from '@/components/SchemaEditor/SchemaEditorDialog.vue';
 import type { SchemaSaveHandler } from '@/components/SchemaEditor/SchemaEditorDialog.vue';
 import CloseConfirmationDialog from '@/components/common/CloseConfirmationDialog.vue';
+import EditNoticeList from '@/components/common/EditNoticeList.vue';
+import { useEditNotices } from '@/composables/useEditNotices.ts';
 import { useSchemaPermissions } from '@/composables/useSchemaPermissions.ts';
 import { useChangeDetection } from '@/composables/useChangeDetection.ts';
 import { useCloseConfirmation } from '@/composables/useCloseConfirmation.ts';
@@ -163,6 +167,7 @@ const subjectLabel = ref( '' );
 // without waiting for the host to pass a new one down.
 const currentSchema = shallowRef<Schema>( props.schema );
 const { canEditSchema, checkEditPermission } = useSchemaPermissions();
+const { notices, loadNotices } = useEditNotices();
 const { hasChanged, markChanged, resetChanged } = useChangeDetection();
 
 const { violations: serverViolations, revalidate, flush, reset } = useSubjectValidation(
@@ -268,6 +273,8 @@ watch( () => props.open, ( isOpen ) => {
 		subjectLabel.value = props.subject.getLabel();
 		resetChanged();
 		reset();
+		// Fetched per opening: approval state and the viewer's permissions both change without an edit.
+		loadNotices( Number( mw.config.get( 'wgArticleId' ) ), props.subject.getSchemaName() );
 	}
 } );
 

--- a/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditorDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditorDialog.vue
@@ -167,7 +167,7 @@ const subjectLabel = ref( '' );
 // without waiting for the host to pass a new one down.
 const currentSchema = shallowRef<Schema>( props.schema );
 const { canEditSchema, checkEditPermission } = useSchemaPermissions();
-const { notices, loadNotices } = useEditNotices();
+const { notices, loadNotices } = useEditNotices( () => NeoWikiExtension.getInstance().getEditNoticeRepository() );
 const { hasChanged, markChanged, resetChanged } = useChangeDetection();
 
 const { violations: serverViolations, revalidate, flush, reset } = useSubjectValidation(
@@ -276,6 +276,11 @@ watch( () => props.open, ( isOpen ) => {
 		resetChanged();
 		reset();
 		// Fetched per opening: approval state and the viewer's permissions both change without an edit.
+		// Keyed on the page being viewed, which is the page storing this Subject except when
+		// {{#view: <subjectId>}} renders a Subject from elsewhere. Then the wrong page's notices are
+		// shown, a v1 limitation documented in docs/authoring/edit-notices.md: the frontend Subject
+		// carries no page id, so fixing it needs the endpoint to resolve the page from a Subject id
+		// and to read-gate on the page it resolved rather than the one asked for.
 		loadNotices( Number( mw.config.get( 'wgArticleId' ) ), props.subject.getSchemaName() );
 	}
 }, { immediate: true } );

--- a/resources/ext.neowiki/src/components/common/EditNoticeList.vue
+++ b/resources/ext.neowiki/src/components/common/EditNoticeList.vue
@@ -40,7 +40,9 @@ defineProps<{
 	margin-bottom: @spacing-100;
 
 	// Layout hygiene rather than presentation: an editor is a bounded dialog, so a long notice
-	// scrolls instead of pushing the fields and the save button out of reach.
+	// scrolls instead of pushing the fields and the save button out of reach. This bounds flow
+	// content only; a notice that positions itself out of flow is not contained by it, which is
+	// accepted since writing one requires the editinterface right.
 	max-height: 40vh;
 	overflow-y: auto;
 }

--- a/resources/ext.neowiki/src/components/common/EditNoticeList.vue
+++ b/resources/ext.neowiki/src/components/common/EditNoticeList.vue
@@ -1,0 +1,45 @@
+<template>
+	<div v-if="notices.length > 0" class="ext-neowiki-edit-notices">
+		<CdxMessage
+			v-for="notice in notices"
+			:key="notice.key"
+			class="ext-neowiki-edit-notices__notice"
+			type="notice"
+		>
+			<!--
+				The markup comes from the server: parsed wikitext, which MediaWiki's parser has already
+				sanitized, or an extension's own rendering, which the extension is responsible for
+				escaping. See docs/extending/extending.md.
+			-->
+			<!-- eslint-disable-next-line vue/no-v-html -->
+			<div v-html="notice.html" />
+		</CdxMessage>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { CdxMessage } from '@wikimedia/codex';
+import type { EditNotice } from '@/domain/EditNotice';
+
+defineProps<{
+	notices: EditNotice[];
+}>();
+</script>
+
+<style lang="less">
+@import ( reference ) '@wikimedia/codex-design-tokens/theme-wikimedia-ui.less';
+
+.ext-neowiki-edit-notices {
+	display: flex;
+	flex-direction: column;
+	gap: @spacing-50;
+	margin-bottom: @spacing-100;
+
+	// Notices are short by contract, but an admin can write anything, so cap the space one can
+	// take rather than letting it push the editor's own controls out of view.
+	&__notice {
+		max-height: 40vh;
+		overflow-y: auto;
+	}
+}
+</style>

--- a/resources/ext.neowiki/src/components/common/EditNoticeList.vue
+++ b/resources/ext.neowiki/src/components/common/EditNoticeList.vue
@@ -1,24 +1,28 @@
 <template>
 	<div v-if="notices.length > 0" class="ext-neowiki-edit-notices">
-		<CdxMessage
+		<!--
+			A bare container per notice, the way core wraps its own edit notices: whoever wrote the
+			notice decides how it looks, so imposing a message component here would nest a box inside
+			their box and add an icon they did not choose. The class and data attribute are hooks for
+			styling a notice, not styling of their own.
+
+			The markup comes from the server: parsed wikitext, which MediaWiki's parser has already
+			sanitized, or an extension's own rendering, which the extension is responsible for
+			escaping. See docs/extending/extending.md.
+		-->
+		<!-- eslint-disable vue/no-v-html -->
+		<div
 			v-for="notice in notices"
 			:key="notice.key"
-			class="ext-neowiki-edit-notices__notice"
-			type="notice"
-		>
-			<!--
-				The markup comes from the server: parsed wikitext, which MediaWiki's parser has already
-				sanitized, or an extension's own rendering, which the extension is responsible for
-				escaping. See docs/extending/extending.md.
-			-->
-			<!-- eslint-disable-next-line vue/no-v-html -->
-			<div v-html="notice.html" />
-		</CdxMessage>
+			class="ext-neowiki-edit-notice"
+			:data-mw-neowiki-editnotice-key="notice.key"
+			v-html="notice.html"
+		/>
+		<!-- eslint-enable vue/no-v-html -->
 	</div>
 </template>
 
 <script setup lang="ts">
-import { CdxMessage } from '@wikimedia/codex';
 import type { EditNotice } from '@/domain/EditNotice';
 
 defineProps<{
@@ -35,11 +39,9 @@ defineProps<{
 	gap: @spacing-50;
 	margin-bottom: @spacing-100;
 
-	// Notices are short by contract, but an admin can write anything, so cap the space one can
-	// take rather than letting it push the editor's own controls out of view.
-	&__notice {
-		max-height: 40vh;
-		overflow-y: auto;
-	}
+	// Layout hygiene rather than presentation: an editor is a bounded dialog, so a long notice
+	// scrolls instead of pushing the fields and the save button out of reach.
+	max-height: 40vh;
+	overflow-y: auto;
 }
 </style>

--- a/resources/ext.neowiki/src/composables/useEditNotices.ts
+++ b/resources/ext.neowiki/src/composables/useEditNotices.ts
@@ -1,0 +1,32 @@
+import { ref, type Ref } from 'vue';
+import type { EditNotice } from '@/domain/EditNotice';
+import { NeoWikiExtension } from '@/NeoWikiExtension.ts';
+
+interface EditNoticesComposable {
+	notices: Ref<EditNotice[]>;
+	loadNotices: ( pageId: number, schemaName?: string ) => Promise<void>;
+}
+
+/**
+ * Fetches the notices to show before a Subject is edited.
+ *
+ * Fetched on demand rather than with the page, because a notice can depend on the viewer and on
+ * state that changes without an edit, such as approval.
+ */
+export function useEditNotices(): EditNoticesComposable {
+	const notices = ref<EditNotice[]>( [] );
+
+	// Advisory to the last step: resolving the repository can fail too, and an editor must open
+	// whether or not its notices could be fetched.
+	async function loadNotices( pageId: number, schemaName?: string ): Promise<void> {
+		try {
+			notices.value = await NeoWikiExtension.getInstance()
+				.getEditNoticeRepository()
+				.getNotices( pageId, schemaName );
+		} catch {
+			notices.value = [];
+		}
+	}
+
+	return { notices, loadNotices };
+}

--- a/resources/ext.neowiki/src/composables/useEditNotices.ts
+++ b/resources/ext.neowiki/src/composables/useEditNotices.ts
@@ -1,6 +1,6 @@
 import { ref, type Ref } from 'vue';
 import type { EditNotice } from '@/domain/EditNotice';
-import { NeoWikiExtension } from '@/NeoWikiExtension.ts';
+import type { EditNoticeRepository } from '@/application/EditNoticeRepository';
 
 interface EditNoticesComposable {
 	notices: Ref<EditNotice[]>;
@@ -13,21 +13,22 @@ interface EditNoticesComposable {
  * Fetched on demand rather than with the page, because a notice can depend on the viewer and on
  * state that changes without an edit, such as approval.
  */
-export function useEditNotices(): EditNoticesComposable {
+/**
+ * The repository is resolved per call rather than passed ready-made: building it reaches the
+ * extension singleton, which must not happen while a component is setting up.
+ */
+export function useEditNotices( resolveRepository: () => EditNoticeRepository ): EditNoticesComposable {
 	const notices = ref<EditNotice[]>( [] );
 	// The creator refetches whenever the Schema changes, so two selections can be in flight at once.
 	// Only the newest request may write, or a slower earlier one lands on top of it.
 	let latestRequest = 0;
 
-	// Advisory to the last step: resolving the repository can fail too, and an editor must open
-	// whether or not its notices could be fetched.
+	// Advisory to the last step: an editor must open whether or not its notices could be fetched.
 	async function loadNotices( pageId: number, schemaName?: string ): Promise<void> {
 		const request = ++latestRequest;
 
 		try {
-			const fetched = await NeoWikiExtension.getInstance()
-				.getEditNoticeRepository()
-				.getNotices( pageId, schemaName );
+			const fetched = await resolveRepository().getNotices( pageId, schemaName );
 
 			if ( request === latestRequest ) {
 				notices.value = fetched;

--- a/resources/ext.neowiki/src/composables/useEditNotices.ts
+++ b/resources/ext.neowiki/src/composables/useEditNotices.ts
@@ -15,16 +15,27 @@ interface EditNoticesComposable {
  */
 export function useEditNotices(): EditNoticesComposable {
 	const notices = ref<EditNotice[]>( [] );
+	// The creator refetches whenever the Schema changes, so two selections can be in flight at once.
+	// Only the newest request may write, or a slower earlier one lands on top of it.
+	let latestRequest = 0;
 
 	// Advisory to the last step: resolving the repository can fail too, and an editor must open
 	// whether or not its notices could be fetched.
 	async function loadNotices( pageId: number, schemaName?: string ): Promise<void> {
+		const request = ++latestRequest;
+
 		try {
-			notices.value = await NeoWikiExtension.getInstance()
+			const fetched = await NeoWikiExtension.getInstance()
 				.getEditNoticeRepository()
 				.getNotices( pageId, schemaName );
+
+			if ( request === latestRequest ) {
+				notices.value = fetched;
+			}
 		} catch {
-			notices.value = [];
+			if ( request === latestRequest ) {
+				notices.value = [];
+			}
 		}
 	}
 

--- a/resources/ext.neowiki/src/domain/EditNotice.ts
+++ b/resources/ext.neowiki/src/domain/EditNotice.ts
@@ -1,0 +1,10 @@
+/**
+ * A message shown to the user before they edit a Subject.
+ *
+ * The html is rendered by whoever supplied the notice: parsed wikitext for the notices wiki admins
+ * write, or an extension's own markup.
+ */
+export interface EditNotice {
+	key: string;
+	html: string;
+}

--- a/resources/ext.neowiki/src/persistence/RestEditNoticeRepository.ts
+++ b/resources/ext.neowiki/src/persistence/RestEditNoticeRepository.ts
@@ -1,0 +1,43 @@
+import type { EditNotice } from '@/domain/EditNotice';
+import type { EditNoticeRepository } from '@/application/EditNoticeRepository';
+import type { HttpClient } from '@/infrastructure/HttpClient/HttpClient';
+
+export class RestEditNoticeRepository implements EditNoticeRepository {
+
+	public constructor(
+		private readonly mediaWikiRestApiUrl: string,
+		private readonly httpClient: HttpClient,
+	) {
+	}
+
+	/**
+	 * Notices are advisory, so every failure degrades to showing none. Refusing to open an editor
+	 * because a notice could not be fetched would trade a missing hint for a blocked edit.
+	 */
+	public async getNotices( pageId: number, schemaName?: string ): Promise<EditNotice[]> {
+		try {
+			const response = await this.httpClient.get( this.noticesUrl( pageId, schemaName ) );
+
+			if ( !response.ok ) {
+				return [];
+			}
+
+			const data = await response.json();
+
+			return Array.isArray( data?.notices ) ? data.notices : [];
+		} catch {
+			return [];
+		}
+	}
+
+	private noticesUrl( pageId: number, schemaName?: string ): string {
+		const url = `${ this.mediaWikiRestApiUrl }/neowiki/v0/page/${ pageId }/editNotices`;
+
+		if ( schemaName === undefined ) {
+			return url;
+		}
+
+		return `${ url }?${ new URLSearchParams( { schema: schemaName } ).toString() }`;
+	}
+
+}

--- a/resources/ext.neowiki/tests/components/common/EditNoticeList.spec.ts
+++ b/resources/ext.neowiki/tests/components/common/EditNoticeList.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { CdxMessage } from '@wikimedia/codex';
+import EditNoticeList from '@/components/common/EditNoticeList.vue';
+import type { EditNotice } from '@/domain/EditNotice';
+
+function mountList( notices: EditNotice[] ): VueWrapper {
+	return mount( EditNoticeList, { props: { notices } } );
+}
+
+describe( 'EditNoticeList', () => {
+
+	it( 'renders nothing when there are no notices', () => {
+		const wrapper = mountList( [] );
+
+		expect( wrapper.findComponent( CdxMessage ).exists() ).toBe( false );
+		expect( wrapper.text() ).toBe( '' );
+	} );
+
+	it( 'renders one message per notice', () => {
+		const wrapper = mountList( [
+			{ key: 'neowiki-editnotice-0', html: '<p>Namespace</p>' },
+			{ key: 'contentstabilization-approvalnotice', html: '<b>Needs review</b>' },
+		] );
+
+		expect( wrapper.findAllComponents( CdxMessage ) ).toHaveLength( 2 );
+	} );
+
+	it( 'renders the notice markup rather than escaping it', () => {
+		const wrapper = mountList( [
+			{ key: 'neowiki-editnotice-0', html: '<b>Approval needed</b>' },
+		] );
+
+		expect( wrapper.html() ).toContain( '<b>Approval needed</b>' );
+		expect( wrapper.text() ).toContain( 'Approval needed' );
+	} );
+
+	it( 'keeps notices in the order they were given', () => {
+		const wrapper = mountList( [
+			{ key: 'first', html: '<p>Broadest</p>' },
+			{ key: 'second', html: '<p>Narrowest</p>' },
+		] );
+
+		expect( wrapper.text().indexOf( 'Broadest' ) ).toBeLessThan( wrapper.text().indexOf( 'Narrowest' ) );
+	} );
+
+} );

--- a/resources/ext.neowiki/tests/components/common/EditNoticeList.spec.ts
+++ b/resources/ext.neowiki/tests/components/common/EditNoticeList.spec.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
 import { mount, type VueWrapper } from '@vue/test-utils';
-import { CdxMessage } from '@wikimedia/codex';
 import EditNoticeList from '@/components/common/EditNoticeList.vue';
 import type { EditNotice } from '@/domain/EditNotice';
 
@@ -13,17 +12,17 @@ describe( 'EditNoticeList', () => {
 	it( 'renders nothing when there are no notices', () => {
 		const wrapper = mountList( [] );
 
-		expect( wrapper.findComponent( CdxMessage ).exists() ).toBe( false );
+		expect( wrapper.find( '.ext-neowiki-edit-notice' ).exists() ).toBe( false );
 		expect( wrapper.text() ).toBe( '' );
 	} );
 
-	it( 'renders one message per notice', () => {
+	it( 'renders one container per notice', () => {
 		const wrapper = mountList( [
 			{ key: 'neowiki-editnotice-0', html: '<p>Namespace</p>' },
 			{ key: 'contentstabilization-approvalnotice', html: '<b>Needs review</b>' },
 		] );
 
-		expect( wrapper.findAllComponents( CdxMessage ) ).toHaveLength( 2 );
+		expect( wrapper.findAll( '.ext-neowiki-edit-notice' ) ).toHaveLength( 2 );
 	} );
 
 	it( 'renders the notice markup rather than escaping it', () => {
@@ -32,7 +31,28 @@ describe( 'EditNoticeList', () => {
 		] );
 
 		expect( wrapper.html() ).toContain( '<b>Approval needed</b>' );
-		expect( wrapper.text() ).toContain( 'Approval needed' );
+	} );
+
+	it( 'imposes no styling of its own on the notice', () => {
+		const wrapper = mountList( [
+			{ key: 'neowiki-editnotice-0', html: '<div class="my-own-banner">Styled by the author</div>' },
+		] );
+
+		const notice = wrapper.find( '.ext-neowiki-edit-notice' );
+
+		// A notice brings its own presentation, so the container adds a hook and nothing else. Wrapping
+		// it in a message component would put a box inside a box and impose an icon the author did not ask for.
+		expect( notice.element.children ).toHaveLength( 1 );
+		expect( notice.element.firstElementChild?.className ).toBe( 'my-own-banner' );
+	} );
+
+	it( 'names each notice so it can be targeted by CSS', () => {
+		const wrapper = mountList( [
+			{ key: 'contentstabilization-approvalnotice', html: '<p>Needs review</p>' },
+		] );
+
+		expect( wrapper.find( '.ext-neowiki-edit-notice' ).attributes( 'data-mw-neowiki-editnotice-key' ) )
+			.toBe( 'contentstabilization-approvalnotice' );
 	} );
 
 	it( 'keeps notices in the order they were given', () => {

--- a/resources/ext.neowiki/tests/composables/useEditNotices.spec.ts
+++ b/resources/ext.neowiki/tests/composables/useEditNotices.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { useEditNotices } from '@/composables/useEditNotices';
+import type { EditNotice } from '@/domain/EditNotice';
+import type { EditNoticeRepository } from '@/application/EditNoticeRepository';
+
+const PAGE_ID = 42;
+
+function repositoryReturning( notices: EditNotice[] ): EditNoticeRepository {
+	return { getNotices: () => Promise.resolve( notices ) };
+}
+
+describe( 'useEditNotices', () => {
+
+	it( 'exposes the notices the repository reports', async () => {
+		const notice = { key: 'neowiki-editnotice-0', html: '<p>Namespace</p>' };
+		const { notices, loadNotices } = useEditNotices( () => repositoryReturning( [ notice ] ) );
+
+		await loadNotices( PAGE_ID );
+
+		expect( notices.value ).toStrictEqual( [ notice ] );
+	} );
+
+	it( 'starts with no notices', () => {
+		expect( useEditNotices( () => repositoryReturning( [] ) ).notices.value ).toStrictEqual( [] );
+	} );
+
+	it( 'shows no notices rather than propagating a repository failure', async () => {
+		const failing: EditNoticeRepository = { getNotices: () => Promise.reject( new Error( 'network down' ) ) };
+		const { notices, loadNotices } = useEditNotices( () => failing );
+
+		await expect( loadNotices( PAGE_ID ) ).resolves.toBeUndefined();
+
+		expect( notices.value ).toStrictEqual( [] );
+	} );
+
+	it( 'shows no notices rather than propagating a failure to resolve the repository', async () => {
+		const { notices, loadNotices } = useEditNotices( () => {
+			throw new Error( 'extension not initialised' );
+		} );
+
+		await expect( loadNotices( PAGE_ID ) ).resolves.toBeUndefined();
+
+		expect( notices.value ).toStrictEqual( [] );
+	} );
+
+	it( 'lets the newest request win when an earlier one resolves later', async () => {
+		const slow = { key: 'stale', html: '<p>Stale</p>' };
+		const fast = { key: 'fresh', html: '<p>Fresh</p>' };
+		let call = 0;
+		const repository: EditNoticeRepository = {
+			getNotices: async () => {
+				call++;
+
+				if ( call === 1 ) {
+					await new Promise( ( resolve ) => {
+						setTimeout( resolve, 30 );
+					} );
+
+					return [ slow ];
+				}
+
+				return [ fast ];
+			},
+		};
+		const { notices, loadNotices } = useEditNotices( () => repository );
+
+		const first = loadNotices( PAGE_ID );
+		const second = loadNotices( PAGE_ID, 'Person' );
+		await Promise.all( [ first, second ] );
+
+		expect( notices.value ).toStrictEqual( [ fast ] );
+	} );
+
+} );

--- a/resources/ext.neowiki/tests/persistence/RestEditNoticeRepository.unit.spec.ts
+++ b/resources/ext.neowiki/tests/persistence/RestEditNoticeRepository.unit.spec.ts
@@ -58,11 +58,11 @@ describe( 'RestEditNoticeRepository', () => {
 	} );
 
 	it( 'shows no notices rather than breaking the editor when the request fails', async () => {
-		const httpClient = respondingWith(
-			`${ API_URL }/neowiki/v0/page/${ PAGE_ID }/editNotices`,
-			{ httpCode: 500 },
-			500,
-		);
+		// Rejecting rather than resolving, because ProductionHttpClient's validateStatus rejects any
+		// non-2xx that is not a 422, so a resolved error response is not a path production can take.
+		const httpClient: HttpClient = {
+			get: () => Promise.reject( new Error( 'Request failed with status code 500' ) ),
+		} as unknown as HttpClient;
 
 		expect( await newRepository( httpClient ).getNotices( PAGE_ID ) ).toStrictEqual( [] );
 	} );

--- a/resources/ext.neowiki/tests/persistence/RestEditNoticeRepository.unit.spec.ts
+++ b/resources/ext.neowiki/tests/persistence/RestEditNoticeRepository.unit.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { RestEditNoticeRepository } from '@/persistence/RestEditNoticeRepository';
+import { InMemoryHttpClient } from '@/infrastructure/HttpClient/InMemoryHttpClient';
+import type { HttpClient } from '@/infrastructure/HttpClient/HttpClient';
+
+const API_URL = 'https://example.com/rest.php';
+const PAGE_ID = 42;
+
+function newRepository( httpClient: HttpClient ): RestEditNoticeRepository {
+	return new RestEditNoticeRepository( API_URL, httpClient );
+}
+
+function respondingWith( url: string, body: unknown, status = 200 ): InMemoryHttpClient {
+	return new InMemoryHttpClient( {
+		[ url ]: new Response( JSON.stringify( body ), { status } ),
+	} );
+}
+
+describe( 'RestEditNoticeRepository', () => {
+
+	it( 'returns the notices the endpoint reports', async () => {
+		const httpClient = respondingWith(
+			`${ API_URL }/neowiki/v0/page/${ PAGE_ID }/editNotices`,
+			{ notices: [
+				{ key: 'neowiki-editnotice-0', html: '<p>Namespace</p>' },
+				{ key: 'contentstabilization-approvalnotice', html: '<b>Needs review</b>' },
+			] },
+		);
+
+		const notices = await newRepository( httpClient ).getNotices( PAGE_ID );
+
+		expect( notices ).toStrictEqual( [
+			{ key: 'neowiki-editnotice-0', html: '<p>Namespace</p>' },
+			{ key: 'contentstabilization-approvalnotice', html: '<b>Needs review</b>' },
+		] );
+	} );
+
+	it( 'returns nothing when the page has no notices', async () => {
+		const httpClient = respondingWith(
+			`${ API_URL }/neowiki/v0/page/${ PAGE_ID }/editNotices`,
+			{ notices: [] },
+		);
+
+		expect( await newRepository( httpClient ).getNotices( PAGE_ID ) ).toStrictEqual( [] );
+	} );
+
+	it( 'asks for Schema-scoped notices when the Schema is known', async () => {
+		const httpClient = respondingWith(
+			`${ API_URL }/neowiki/v0/page/${ PAGE_ID }/editNotices?schema=Control+Document`,
+			{ notices: [ { key: 'neowiki-editnotice-schema-Control_Document', html: '<p>Schema</p>' } ] },
+		);
+
+		const notices = await newRepository( httpClient ).getNotices( PAGE_ID, 'Control Document' );
+
+		expect( notices ).toStrictEqual( [
+			{ key: 'neowiki-editnotice-schema-Control_Document', html: '<p>Schema</p>' },
+		] );
+	} );
+
+	it( 'shows no notices rather than breaking the editor when the request fails', async () => {
+		const httpClient = respondingWith(
+			`${ API_URL }/neowiki/v0/page/${ PAGE_ID }/editNotices`,
+			{ httpCode: 500 },
+			500,
+		);
+
+		expect( await newRepository( httpClient ).getNotices( PAGE_ID ) ).toStrictEqual( [] );
+	} );
+
+	it( 'shows no notices rather than breaking the editor when the response is malformed', async () => {
+		const httpClient = respondingWith(
+			`${ API_URL }/neowiki/v0/page/${ PAGE_ID }/editNotices`,
+			{ unexpected: true },
+		);
+
+		expect( await newRepository( httpClient ).getNotices( PAGE_ID ) ).toStrictEqual( [] );
+	} );
+
+} );

--- a/src/Application/EditNotice/EditNoticeMessageRenderer.php
+++ b/src/Application/EditNotice/EditNoticeMessageRenderer.php
@@ -1,0 +1,18 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application\EditNotice;
+
+interface EditNoticeMessageRenderer {
+
+	/**
+	 * Renders an interface message to HTML, or returns null when it contributes nothing: the message
+	 * does not exist, an admin disabled it, or it renders empty.
+	 *
+	 * The page is passed so magic words inside a notice resolve against the page being edited rather
+	 * than against whatever page happens to be rendering.
+	 */
+	public function render( string $messageKey, int $namespaceId, string $pageDbKey ): ?string;
+
+}

--- a/src/Application/EditNotice/InterfaceMessageNoticeProvider.php
+++ b/src/Application/EditNotice/InterfaceMessageNoticeProvider.php
@@ -1,0 +1,65 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application\EditNotice;
+
+use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNotice;
+use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNoticeContext;
+use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNoticeProvider;
+
+/**
+ * Notices wiki admins write as interface messages, following the convention core uses for its own
+ * edit notices. None of these keys ship in the extension's i18n: a key only resolves once an admin
+ * creates the corresponding MediaWiki-namespace page.
+ */
+readonly class InterfaceMessageNoticeProvider implements SubjectEditNoticeProvider {
+
+	private const string KEY_PREFIX = 'neowiki-editnotice-';
+
+	public function __construct(
+		private EditNoticeMessageRenderer $renderer
+	) {
+	}
+
+	public function getNotices( SubjectEditNoticeContext $context ): array {
+		$notices = [];
+
+		foreach ( $this->messageKeys( $context ) as $messageKey ) {
+			$html = $this->renderer->render( $messageKey, $context->namespaceId, $context->pageDbKey );
+
+			if ( $html !== null ) {
+				$notices[] = new SubjectEditNotice( key: $messageKey, html: $html );
+			}
+		}
+
+		return $notices;
+	}
+
+	/**
+	 * Broadest first, so a page notice reads as a refinement of its namespace's.
+	 *
+	 * @return string[]
+	 */
+	private function messageKeys( SubjectEditNoticeContext $context ): array {
+		$keys = [
+			self::KEY_PREFIX . $context->namespaceId,
+			self::KEY_PREFIX . $context->namespaceId . '-' . self::asKeySegment( $context->pageDbKey ),
+		];
+
+		if ( $context->schemaName !== null ) {
+			$keys[] = self::KEY_PREFIX . 'schema-' . self::asKeySegment( $context->schemaName );
+		}
+
+		return $keys;
+	}
+
+	/**
+	 * A slash would make the message page a subpage, which collides with the language subpages the
+	 * MediaWiki namespace uses. Core flattens the same way.
+	 */
+	private static function asKeySegment( string $value ): string {
+		return strtr( $value, '/', '-' );
+	}
+
+}

--- a/src/Application/EditNotice/InterfaceMessageNoticeProvider.php
+++ b/src/Application/EditNotice/InterfaceMessageNoticeProvider.php
@@ -42,24 +42,56 @@ readonly class InterfaceMessageNoticeProvider implements SubjectEditNoticeProvid
 	 * @return string[]
 	 */
 	private function messageKeys( SubjectEditNoticeContext $context ): array {
-		$keys = [
-			self::KEY_PREFIX . $context->namespaceId,
-			self::KEY_PREFIX . $context->namespaceId . '-' . self::asKeySegment( $context->pageDbKey ),
-		];
+		$namespaceKey = self::KEY_PREFIX . $context->namespaceId;
 
-		if ( $context->schemaName !== null ) {
-			$keys[] = self::KEY_PREFIX . 'schema-' . self::asKeySegment( $context->schemaName );
+		return [
+			$namespaceKey,
+			...$this->pageKeys( $namespaceKey, $context ),
+			...$this->schemaKeys( $context ),
+		];
+	}
+
+	/**
+	 * Core gives a subpage-enabled namespace one key per ancestor, so a notice on a parent page
+	 * covers its whole subtree, and flattens the path everywhere else. Both branches are mirrored
+	 * so admins can carry their expectations over from core's edit notices.
+	 *
+	 * @return string[]
+	 */
+	private function pageKeys( string $namespaceKey, SubjectEditNoticeContext $context ): array {
+		if ( !$context->namespaceHasSubpages ) {
+			return [ $namespaceKey . '-' . self::asKeySegment( $context->pageDbKey ) ];
+		}
+
+		$keys = [];
+		$ancestorKey = $namespaceKey;
+
+		foreach ( explode( '/', $context->pageDbKey ) as $segment ) {
+			$ancestorKey .= '-' . self::asKeySegment( $segment );
+			$keys[] = $ancestorKey;
 		}
 
 		return $keys;
 	}
 
 	/**
+	 * @return string[]
+	 */
+	private function schemaKeys( SubjectEditNoticeContext $context ): array {
+		if ( $context->schemaName === null ) {
+			return [];
+		}
+
+		return [ self::KEY_PREFIX . 'schema-' . self::asKeySegment( $context->schemaName ) ];
+	}
+
+	/**
 	 * A slash would make the message page a subpage, which collides with the language subpages the
-	 * MediaWiki namespace uses. Core flattens the same way.
+	 * MediaWiki namespace uses. Spaces become underscores so the key names the message page an admin
+	 * actually creates, which is what the response echoes back.
 	 */
 	private static function asKeySegment( string $value ): string {
-		return strtr( $value, '/', '-' );
+		return strtr( $value, [ '/' => '-', ' ' => '_' ] );
 	}
 
 }

--- a/src/Application/EditNotice/SubjectEditNoticeContextFactory.php
+++ b/src/Application/EditNotice/SubjectEditNoticeContextFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application\EditNotice;
+
+use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNoticeContext;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+
+/**
+ * Resolves what a page id identifies into the shape edit notice providers are given. Separate from
+ * {@see \ProfessionalWiki\NeoWiki\Application\PageIdentifiersResolver} because notices are keyed by
+ * the database key, while that resolver answers with the prefixed title the graph projection stores.
+ */
+interface SubjectEditNoticeContextFactory {
+
+	/**
+	 * Null when no page carries this id.
+	 */
+	public function newContext( PageId $pageId, ?string $schemaName ): ?SubjectEditNoticeContext;
+
+}

--- a/src/Application/EditNotice/SubjectEditNoticeEnvironment.php
+++ b/src/Application/EditNotice/SubjectEditNoticeEnvironment.php
@@ -15,4 +15,9 @@ interface SubjectEditNoticeEnvironment {
 
 	public function prepareFor( SubjectEditNoticeContext $context ): void;
 
+	/**
+	 * Puts back what {@see prepareFor} replaced, so the rest of the request is unaffected.
+	 */
+	public function restore(): void;
+
 }

--- a/src/Application/EditNotice/SubjectEditNoticeEnvironment.php
+++ b/src/Application/EditNotice/SubjectEditNoticeEnvironment.php
@@ -1,0 +1,18 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application\EditNotice;
+
+use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNoticeContext;
+
+/**
+ * Makes the ambient request state agree with the page whose notices are being collected, before any
+ * provider runs. Providers are handed a context, but a third-party one may instead read the main
+ * request context, which outside a page request carries no page at all.
+ */
+interface SubjectEditNoticeEnvironment {
+
+	public function prepareFor( SubjectEditNoticeContext $context ): void;
+
+}

--- a/src/Application/Queries/GetSubjectEditNotices/GetSubjectEditNoticesPresenter.php
+++ b/src/Application/Queries/GetSubjectEditNotices/GetSubjectEditNoticesPresenter.php
@@ -1,0 +1,16 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application\Queries\GetSubjectEditNotices;
+
+use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNotice;
+
+interface GetSubjectEditNoticesPresenter {
+
+	/**
+	 * @param SubjectEditNotice[] $notices
+	 */
+	public function presentNotices( array $notices ): void;
+
+}

--- a/src/Application/Queries/GetSubjectEditNotices/GetSubjectEditNoticesQuery.php
+++ b/src/Application/Queries/GetSubjectEditNotices/GetSubjectEditNoticesQuery.php
@@ -1,0 +1,59 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application\Queries\GetSubjectEditNotices;
+
+use ProfessionalWiki\NeoWiki\Application\EditNotice\SubjectEditNoticeContextFactory;
+use ProfessionalWiki\NeoWiki\Application\PageReadAuthorizer;
+use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNotice;
+use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNoticeContext;
+use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNoticeProviderRegistry;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+
+readonly class GetSubjectEditNoticesQuery {
+
+	public function __construct(
+		private GetSubjectEditNoticesPresenter $presenter,
+		private SubjectEditNoticeProviderRegistry $registry,
+		private PageReadAuthorizer $readAuthorizer,
+		private SubjectEditNoticeContextFactory $contextFactory,
+	) {
+	}
+
+	public function execute( int $pageId, ?string $schemaName ): void {
+		$context = $this->resolveContext( new PageId( $pageId ), $schemaName );
+
+		$this->presenter->presentNotices(
+			$context === null ? [] : $this->collectNotices( $context )
+		);
+	}
+
+	/**
+	 * A denied page takes exactly the path a page without notices takes, so the response is
+	 * byte-identical to absence and cannot be used to probe page readability (#1046).
+	 */
+	private function resolveContext( PageId $pageId, ?string $schemaName ): ?SubjectEditNoticeContext {
+		if ( !$this->readAuthorizer->authorizeReadByPageId( $pageId ) ) {
+			return null;
+		}
+
+		return $this->contextFactory->newContext( $pageId, $schemaName );
+	}
+
+	/**
+	 * @return SubjectEditNotice[]
+	 */
+	private function collectNotices( SubjectEditNoticeContext $context ): array {
+		$notices = [];
+
+		foreach ( $this->registry->getProviders() as $provider ) {
+			foreach ( $provider->getNotices( $context ) as $notice ) {
+				$notices[] = $notice;
+			}
+		}
+
+		return $notices;
+	}
+
+}

--- a/src/Application/Queries/GetSubjectEditNotices/GetSubjectEditNoticesQuery.php
+++ b/src/Application/Queries/GetSubjectEditNotices/GetSubjectEditNoticesQuery.php
@@ -33,7 +33,13 @@ readonly class GetSubjectEditNoticesQuery {
 
 		$this->environment->prepareFor( $context );
 
-		$this->presenter->presentNotices( $this->collectNotices( $context ) );
+		try {
+			$notices = $this->collectNotices( $context );
+		} finally {
+			$this->environment->restore();
+		}
+
+		$this->presenter->presentNotices( $notices );
 	}
 
 	/**

--- a/src/Application/Queries/GetSubjectEditNotices/GetSubjectEditNoticesQuery.php
+++ b/src/Application/Queries/GetSubjectEditNotices/GetSubjectEditNoticesQuery.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Application\Queries\GetSubjectEditNotices;
 
 use ProfessionalWiki\NeoWiki\Application\EditNotice\SubjectEditNoticeContextFactory;
+use ProfessionalWiki\NeoWiki\Application\EditNotice\SubjectEditNoticeEnvironment;
 use ProfessionalWiki\NeoWiki\Application\PageReadAuthorizer;
 use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNotice;
 use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNoticeContext;
@@ -18,15 +19,21 @@ readonly class GetSubjectEditNoticesQuery {
 		private SubjectEditNoticeProviderRegistry $registry,
 		private PageReadAuthorizer $readAuthorizer,
 		private SubjectEditNoticeContextFactory $contextFactory,
+		private SubjectEditNoticeEnvironment $environment,
 	) {
 	}
 
 	public function execute( int $pageId, ?string $schemaName ): void {
 		$context = $this->resolveContext( new PageId( $pageId ), $schemaName );
 
-		$this->presenter->presentNotices(
-			$context === null ? [] : $this->collectNotices( $context )
-		);
+		if ( $context === null ) {
+			$this->presenter->presentNotices( [] );
+			return;
+		}
+
+		$this->environment->prepareFor( $context );
+
+		$this->presenter->presentNotices( $this->collectNotices( $context ) );
 	}
 
 	/**
@@ -47,13 +54,15 @@ readonly class GetSubjectEditNoticesQuery {
 	private function collectNotices( SubjectEditNoticeContext $context ): array {
 		$notices = [];
 
+		// Keyed while collecting, so a key claimed twice yields one notice rather than a duplicate a
+		// client would render twice. The first provider to claim a key keeps it.
 		foreach ( $this->registry->getProviders() as $provider ) {
 			foreach ( $provider->getNotices( $context ) as $notice ) {
-				$notices[] = $notice;
+				$notices[$notice->key] ??= $notice;
 			}
 		}
 
-		return $notices;
+		return array_values( $notices );
 	}
 
 }

--- a/src/Domain/EditNotice/SubjectEditNotice.php
+++ b/src/Domain/EditNotice/SubjectEditNotice.php
@@ -1,0 +1,22 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\EditNotice;
+
+/**
+ * A message shown to a user before they edit a Subject.
+ */
+readonly class SubjectEditNotice {
+
+	/**
+	 * @param string $key Identifies the notice across requests, so a client can key or dismiss one.
+	 * @param string $html Rendered, and already escaped or sanitized by whoever supplied it.
+	 */
+	public function __construct(
+		public string $key,
+		public string $html,
+	) {
+	}
+
+}

--- a/src/Domain/EditNotice/SubjectEditNotice.php
+++ b/src/Domain/EditNotice/SubjectEditNotice.php
@@ -11,7 +11,11 @@ readonly class SubjectEditNotice {
 
 	/**
 	 * @param string $key Identifies the notice across requests, so a client can key or dismiss one.
-	 * @param string $html Rendered, and already escaped or sanitized by whoever supplied it.
+	 * @param string $html Rendered, and already escaped or sanitized by whoever supplied it. For an
+	 *  admin-written notice that is MediaWiki's parser; the channel grants no capability an
+	 *  editinterface holder lacks, since they can already place parser-sanitized HTML on every page
+	 *  view through MediaWiki:Sitenotice. Note they cannot necessarily run script: editsitejs belongs
+	 *  to interface-admin, not sysop, so the parser is the guard here rather than a conceded right.
 	 */
 	public function __construct(
 		public string $key,

--- a/src/Domain/EditNotice/SubjectEditNoticeContext.php
+++ b/src/Domain/EditNotice/SubjectEditNoticeContext.php
@@ -18,8 +18,8 @@ readonly class SubjectEditNoticeContext {
 		public PageId $pageId,
 		public string $pageDbKey,
 		public int $namespaceId,
+		public bool $namespaceHasSubpages,
 		public ?string $schemaName = null,
-		public bool $namespaceHasSubpages = false,
 	) {
 	}
 

--- a/src/Domain/EditNotice/SubjectEditNoticeContext.php
+++ b/src/Domain/EditNotice/SubjectEditNoticeContext.php
@@ -1,0 +1,24 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\EditNotice;
+
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+
+readonly class SubjectEditNoticeContext {
+
+	/**
+	 * @param string $pageDbKey Unprefixed database key of the page being edited, e.g. "New_York" for "Help:New York"
+	 * @param int $namespaceId MediaWiki namespace ID, e.g. 0 for the main namespace or 12 for Help
+	 * @param string|null $schemaName Schema of the Subject being edited, absent when no Subject is in play yet
+	 */
+	public function __construct(
+		public PageId $pageId,
+		public string $pageDbKey,
+		public int $namespaceId,
+		public ?string $schemaName = null,
+	) {
+	}
+
+}

--- a/src/Domain/EditNotice/SubjectEditNoticeContext.php
+++ b/src/Domain/EditNotice/SubjectEditNoticeContext.php
@@ -12,12 +12,14 @@ readonly class SubjectEditNoticeContext {
 	 * @param string $pageDbKey Unprefixed database key of the page being edited, e.g. "New_York" for "Help:New York"
 	 * @param int $namespaceId MediaWiki namespace ID, e.g. 0 for the main namespace or 12 for Help
 	 * @param string|null $schemaName Schema of the Subject being edited, absent when no Subject is in play yet
+	 * @param bool $namespaceHasSubpages Whether the namespace treats slashes as subpage separators
 	 */
 	public function __construct(
 		public PageId $pageId,
 		public string $pageDbKey,
 		public int $namespaceId,
 		public ?string $schemaName = null,
+		public bool $namespaceHasSubpages = false,
 	) {
 	}
 

--- a/src/Domain/EditNotice/SubjectEditNoticeProvider.php
+++ b/src/Domain/EditNotice/SubjectEditNoticeProvider.php
@@ -7,6 +7,9 @@ namespace ProfessionalWiki\NeoWiki\Domain\EditNotice;
 interface SubjectEditNoticeProvider {
 
 	/**
+	 * The html of each notice is rendered as given, with no sanitization and no presentation added
+	 * by NeoWiki, so escape it yourself and bring whatever styling the notice needs.
+	 *
 	 * @return SubjectEditNotice[]
 	 */
 	public function getNotices( SubjectEditNoticeContext $context ): array;

--- a/src/Domain/EditNotice/SubjectEditNoticeProvider.php
+++ b/src/Domain/EditNotice/SubjectEditNoticeProvider.php
@@ -1,0 +1,14 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\EditNotice;
+
+interface SubjectEditNoticeProvider {
+
+	/**
+	 * @return SubjectEditNotice[]
+	 */
+	public function getNotices( SubjectEditNoticeContext $context ): array;
+
+}

--- a/src/Domain/EditNotice/SubjectEditNoticeProviderRegistry.php
+++ b/src/Domain/EditNotice/SubjectEditNoticeProviderRegistry.php
@@ -1,0 +1,27 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Domain\EditNotice;
+
+class SubjectEditNoticeProviderRegistry {
+
+	/**
+	 * @var SubjectEditNoticeProvider[]
+	 */
+	private array $providers = [];
+
+	public function addProvider( SubjectEditNoticeProvider $provider ): void {
+		$this->providers[] = $provider;
+	}
+
+	/**
+	 * Registration order is presentation order, so notices registered first are shown first.
+	 *
+	 * @return SubjectEditNoticeProvider[]
+	 */
+	public function getProviders(): array {
+		return $this->providers;
+	}
+
+}

--- a/src/EntryPoints/NeoWikiRegistrar.php
+++ b/src/EntryPoints/NeoWikiRegistrar.php
@@ -4,6 +4,8 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\EntryPoints;
 
+use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNoticeProvider;
+use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNoticeProviderRegistry;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphDatabasePlugin;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphDatabasePluginRegistry;
 use ProfessionalWiki\NeoWiki\Domain\Page\PagePropertyProvider;
@@ -23,6 +25,7 @@ readonly class NeoWikiRegistrar {
 		private PagePropertyProviderRegistry $pagePropertyProviderRegistry,
 		private GraphDatabasePluginRegistry $graphDatabasePluginRegistry,
 		private RdfValueMapperRegistry $rdfValueMapperRegistry,
+		private SubjectEditNoticeProviderRegistry $subjectEditNoticeProviderRegistry,
 	) {
 	}
 
@@ -45,6 +48,14 @@ readonly class NeoWikiRegistrar {
 	 */
 	public function addRdfValueMapper( string $propertyTypeName, callable $mapper ): void {
 		$this->rdfValueMapperRegistry->registerMapper( $propertyTypeName, $mapper );
+	}
+
+	/**
+	 * Registers a source of messages shown to users before they edit a Subject. Providers are
+	 * consulted in registration order, after the notices wiki admins write as interface messages.
+	 */
+	public function addSubjectEditNoticeProvider( SubjectEditNoticeProvider $provider ): void {
+		$this->subjectEditNoticeProviderRegistry->addProvider( $provider );
 	}
 
 	public function addPagePropertyProvider( PagePropertyProvider $provider ): void {

--- a/src/EntryPoints/REST/GetSubjectEditNoticesApi.php
+++ b/src/EntryPoints/REST/GetSubjectEditNoticesApi.php
@@ -4,8 +4,6 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\EntryPoints\REST;
 
-use MediaWiki\Context\RequestContext;
-use MediaWiki\MediaWikiServices;
 use MediaWiki\Rest\Response;
 use MediaWiki\Rest\SimpleHandler;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
@@ -15,8 +13,6 @@ use Wikimedia\ParamValidator\ParamValidator;
 class GetSubjectEditNoticesApi extends SimpleHandler {
 
 	public function run( int $pageId ): Response {
-		$this->giveProvidersTheirPageContext( $pageId );
-
 		$presenter = new RestGetSubjectEditNoticesPresenter();
 
 		NeoWikiExtension::getInstance()->newGetSubjectEditNoticesQuery( $presenter, $this->getAuthority() )->execute(
@@ -32,18 +28,8 @@ class GetSubjectEditNoticesApi extends SimpleHandler {
 		return $response;
 	}
 
-	/**
-	 * Providers may read the main request context rather than the context they are handed:
-	 * ContentStabilization does, when describing pending revisions. Outside a page request that
-	 * context carries no title, so it is set here. VisualEditor does the same for the same reason
-	 * (T307852).
-	 */
-	private function giveProvidersTheirPageContext( int $pageId ): void {
-		$title = MediaWikiServices::getInstance()->getTitleFactory()->newFromID( $pageId );
-
-		if ( $title !== null ) {
-			RequestContext::getMain()->setTitle( $title );
-		}
+	public function needsWriteAccess(): bool {
+		return false;
 	}
 
 	public function getParamSettings(): array {

--- a/src/EntryPoints/REST/GetSubjectEditNoticesApi.php
+++ b/src/EntryPoints/REST/GetSubjectEditNoticesApi.php
@@ -1,0 +1,66 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\EntryPoints\REST;
+
+use MediaWiki\Context\RequestContext;
+use MediaWiki\MediaWikiServices;
+use MediaWiki\Rest\Response;
+use MediaWiki\Rest\SimpleHandler;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+use ProfessionalWiki\NeoWiki\Presentation\RestGetSubjectEditNoticesPresenter;
+use Wikimedia\ParamValidator\ParamValidator;
+
+class GetSubjectEditNoticesApi extends SimpleHandler {
+
+	public function run( int $pageId ): Response {
+		$this->giveProvidersTheirPageContext( $pageId );
+
+		$presenter = new RestGetSubjectEditNoticesPresenter();
+
+		NeoWikiExtension::getInstance()->newGetSubjectEditNoticesQuery( $presenter, $this->getAuthority() )->execute(
+			pageId: $pageId,
+			schemaName: $this->getValidatedParams()['schema'],
+		);
+
+		$response = $this->getResponseFactory()->createJson( $presenter->getJsonArray() );
+
+		// Notices depend on the viewer and on state that changes without an edit, such as approval.
+		$response->setHeader( 'Cache-Control', 'private, no-store' );
+
+		return $response;
+	}
+
+	/**
+	 * Providers may read the main request context rather than the context they are handed:
+	 * ContentStabilization does, when describing pending revisions. Outside a page request that
+	 * context carries no title, so it is set here. VisualEditor does the same for the same reason
+	 * (T307852).
+	 */
+	private function giveProvidersTheirPageContext( int $pageId ): void {
+		$title = MediaWikiServices::getInstance()->getTitleFactory()->newFromID( $pageId );
+
+		if ( $title !== null ) {
+			RequestContext::getMain()->setTitle( $title );
+		}
+	}
+
+	public function getParamSettings(): array {
+		return [
+			'pageId' => [
+				self::PARAM_SOURCE => 'path',
+				ParamValidator::PARAM_TYPE => 'integer',
+				ParamValidator::PARAM_REQUIRED => true,
+				self::PARAM_DESCRIPTION => 'MediaWiki page ID.',
+			],
+			'schema' => [
+				self::PARAM_SOURCE => 'query',
+				ParamValidator::PARAM_TYPE => 'string',
+				ParamValidator::PARAM_REQUIRED => false,
+				self::PARAM_DESCRIPTION => 'Name of the Schema being edited. Enables Schema-scoped notices.',
+			],
+		];
+	}
+
+}

--- a/src/Infrastructure/MediaWikiEditNoticeMessageRenderer.php
+++ b/src/Infrastructure/MediaWikiEditNoticeMessageRenderer.php
@@ -1,0 +1,35 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Infrastructure;
+
+use MediaWiki\Title\TitleFactory;
+use MessageLocalizer;
+use ProfessionalWiki\NeoWiki\Application\EditNotice\EditNoticeMessageRenderer;
+
+readonly class MediaWikiEditNoticeMessageRenderer implements EditNoticeMessageRenderer {
+
+	public function __construct(
+		private MessageLocalizer $messageLocalizer,
+		private TitleFactory $titleFactory,
+	) {
+	}
+
+	public function render( string $messageKey, int $namespaceId, string $pageDbKey ): ?string {
+		$message = $this->messageLocalizer->msg( $messageKey )
+			->page( $this->titleFactory->makeTitle( $namespaceId, $pageDbKey ) );
+
+		// A key with no MediaWiki-namespace page behind it, or one an admin set to "-", contributes nothing.
+		if ( !$message->exists() || $message->isDisabled() ) {
+			return null;
+		}
+
+		$html = $message->parseAsBlock();
+
+		// Notices carry parser logic often enough that a non-empty message still renders to nothing,
+		// which would otherwise reach the client as an empty message frame. Core guards the same way.
+		return trim( $html ) === '' ? null : $html;
+	}
+
+}

--- a/src/Infrastructure/RequestContextSubjectEditNoticeEnvironment.php
+++ b/src/Infrastructure/RequestContextSubjectEditNoticeEnvironment.php
@@ -1,0 +1,31 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Infrastructure;
+
+use MediaWiki\Context\RequestContext;
+use MediaWiki\Title\TitleFactory;
+use ProfessionalWiki\NeoWiki\Application\EditNotice\SubjectEditNoticeEnvironment;
+use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNoticeContext;
+
+/**
+ * ContentStabilization reads the main request context when describing pending revisions, and
+ * VisualEditor sets the title for the same reason (T307852) — while calling it a dirty hack, which
+ * it is: this writes to process-global state. It runs only after the read gate has passed, so no
+ * title is published for a page the caller may not read.
+ */
+readonly class RequestContextSubjectEditNoticeEnvironment implements SubjectEditNoticeEnvironment {
+
+	public function __construct(
+		private TitleFactory $titleFactory
+	) {
+	}
+
+	public function prepareFor( SubjectEditNoticeContext $context ): void {
+		RequestContext::getMain()->setTitle(
+			$this->titleFactory->makeTitle( $context->namespaceId, $context->pageDbKey )
+		);
+	}
+
+}

--- a/src/Infrastructure/RequestContextSubjectEditNoticeEnvironment.php
+++ b/src/Infrastructure/RequestContextSubjectEditNoticeEnvironment.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Infrastructure;
 
 use MediaWiki\Context\RequestContext;
+use MediaWiki\Title\Title;
 use MediaWiki\Title\TitleFactory;
 use ProfessionalWiki\NeoWiki\Application\EditNotice\SubjectEditNoticeEnvironment;
 use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNoticeContext;
@@ -15,17 +16,27 @@ use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNoticeContext;
  * it is: this writes to process-global state. It runs only after the read gate has passed, so no
  * title is published for a page the caller may not read.
  */
-readonly class RequestContextSubjectEditNoticeEnvironment implements SubjectEditNoticeEnvironment {
+class RequestContextSubjectEditNoticeEnvironment implements SubjectEditNoticeEnvironment {
+
+	private ?Title $replacedTitle = null;
 
 	public function __construct(
-		private TitleFactory $titleFactory
+		private readonly TitleFactory $titleFactory
 	) {
 	}
 
 	public function prepareFor( SubjectEditNoticeContext $context ): void {
+		// What getTitle() answers rather than the raw internal value, which is private: it falls back
+		// to $wgTitle when unset, so restoring this keeps the answer the same either way.
+		$this->replacedTitle = RequestContext::getMain()->getTitle();
+
 		RequestContext::getMain()->setTitle(
 			$this->titleFactory->makeTitle( $context->namespaceId, $context->pageDbKey )
 		);
+	}
+
+	public function restore(): void {
+		RequestContext::getMain()->setTitle( $this->replacedTitle );
 	}
 
 }

--- a/src/Infrastructure/TitleBasedSubjectEditNoticeContextFactory.php
+++ b/src/Infrastructure/TitleBasedSubjectEditNoticeContextFactory.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Infrastructure;
 
+use MediaWiki\Title\NamespaceInfo;
 use MediaWiki\Title\TitleFactory;
 use ProfessionalWiki\NeoWiki\Application\EditNotice\SubjectEditNoticeContextFactory;
 use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNoticeContext;
@@ -12,7 +13,8 @@ use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 readonly class TitleBasedSubjectEditNoticeContextFactory implements SubjectEditNoticeContextFactory {
 
 	public function __construct(
-		private TitleFactory $titleFactory
+		private TitleFactory $titleFactory,
+		private NamespaceInfo $namespaceInfo,
 	) {
 	}
 
@@ -27,7 +29,8 @@ readonly class TitleBasedSubjectEditNoticeContextFactory implements SubjectEditN
 			pageId: $pageId,
 			pageDbKey: $title->getDBkey(),
 			namespaceId: $title->getNamespace(),
-			schemaName: $schemaName
+			schemaName: $schemaName,
+			namespaceHasSubpages: $this->namespaceInfo->hasSubpages( $title->getNamespace() ),
 		);
 	}
 

--- a/src/Infrastructure/TitleBasedSubjectEditNoticeContextFactory.php
+++ b/src/Infrastructure/TitleBasedSubjectEditNoticeContextFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Infrastructure;
+
+use MediaWiki\Title\TitleFactory;
+use ProfessionalWiki\NeoWiki\Application\EditNotice\SubjectEditNoticeContextFactory;
+use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNoticeContext;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+
+readonly class TitleBasedSubjectEditNoticeContextFactory implements SubjectEditNoticeContextFactory {
+
+	public function __construct(
+		private TitleFactory $titleFactory
+	) {
+	}
+
+	public function newContext( PageId $pageId, ?string $schemaName ): ?SubjectEditNoticeContext {
+		$title = $this->titleFactory->newFromID( $pageId->id );
+
+		if ( $title === null ) {
+			return null;
+		}
+
+		return new SubjectEditNoticeContext(
+			pageId: $pageId,
+			pageDbKey: $title->getDBkey(),
+			namespaceId: $title->getNamespace(),
+			schemaName: $schemaName
+		);
+	}
+
+}

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -53,6 +53,12 @@ use ProfessionalWiki\NeoWiki\Application\Queries\ValidateSubjectUpdate\ValidateS
 use ProfessionalWiki\NeoWiki\Infrastructure\IdGenerator;
 use ProfessionalWiki\NeoWiki\Infrastructure\ProductionIdGenerator;
 use ProfessionalWiki\NeoWiki\Persistence\CorePagePropertyProvider;
+use ProfessionalWiki\NeoWiki\Application\EditNotice\InterfaceMessageNoticeProvider;
+use ProfessionalWiki\NeoWiki\Application\Queries\GetSubjectEditNotices\GetSubjectEditNoticesPresenter;
+use ProfessionalWiki\NeoWiki\Application\Queries\GetSubjectEditNotices\GetSubjectEditNoticesQuery;
+use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNoticeProviderRegistry;
+use ProfessionalWiki\NeoWiki\Infrastructure\MediaWikiEditNoticeMessageRenderer;
+use ProfessionalWiki\NeoWiki\Infrastructure\TitleBasedSubjectEditNoticeContextFactory;
 use ProfessionalWiki\NeoWiki\Domain\Page\PagePropertyProviderRegistry;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\CompositeGraphDatabasePlugin;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\FailureIsolatingGraphDatabasePlugin;
@@ -99,6 +105,7 @@ use ProfessionalWiki\NeoWiki\EntryPoints\REST\CancelGraphStoreRebuildApi;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\CreateSubjectApi;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\DeleteSubjectApi;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\GetPageSubjectsApi;
+use ProfessionalWiki\NeoWiki\EntryPoints\REST\GetSubjectEditNoticesApi;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\GetSchemaApi;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\GetLayoutApi;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\GetGraphStoresApi;
@@ -196,6 +203,7 @@ class NeoWikiExtension {
 
 	private PropertyTypeRegistry $propertyTypeRegistry;
 	private PagePropertyProviderRegistry $pagePropertyProviderRegistry;
+	private SubjectEditNoticeProviderRegistry $subjectEditNoticeProviderRegistry;
 	private Neo4jValueBuilderRegistry $valueBuilderRegistry;
 	private RdfValueMapperRegistry $rdfValueMapperRegistry;
 	private bool $extensionsRegistered = false;
@@ -296,12 +304,35 @@ class NeoWikiExtension {
 				$this->getPagePropertyProviderRegistry(),
 				$this->getGraphDatabasePluginRegistry(),
 				$this->getRdfValueMapperRegistry(),
+				$this->getSubjectEditNoticeProviderRegistry(),
 			) ]
 		);
 	}
 
 	public function newSubjectContentDataDeserializer(): SubjectContentDataDeserializer {
 		return new SubjectContentDataDeserializer( new StatementDeserializer( $this->getPropertyTypeLookup() ) );
+	}
+
+	/**
+	 * Seeded with the interface-message source, so admin-written notices come before any an
+	 * extension contributes.
+	 */
+	public function getSubjectEditNoticeProviderRegistry(): SubjectEditNoticeProviderRegistry {
+		if ( !isset( $this->subjectEditNoticeProviderRegistry ) ) {
+			$this->subjectEditNoticeProviderRegistry = new SubjectEditNoticeProviderRegistry();
+			$this->subjectEditNoticeProviderRegistry->addProvider(
+				new InterfaceMessageNoticeProvider(
+					new MediaWikiEditNoticeMessageRenderer(
+						RequestContext::getMain(),
+						MediaWikiServices::getInstance()->getTitleFactory()
+					)
+				)
+			);
+		}
+
+		$this->ensureExtensionsRegistered();
+
+		return $this->subjectEditNoticeProviderRegistry;
 	}
 
 	public function getPagePropertyProviderRegistry(): PagePropertyProviderRegistry {
@@ -1328,6 +1359,20 @@ class NeoWikiExtension {
 		return $db;
 	}
 
+	public function newGetSubjectEditNoticesQuery(
+		GetSubjectEditNoticesPresenter $presenter,
+		Authority $authority
+	): GetSubjectEditNoticesQuery {
+		return new GetSubjectEditNoticesQuery(
+			presenter: $presenter,
+			registry: $this->getSubjectEditNoticeProviderRegistry(),
+			readAuthorizer: $this->newPageReadAuthorizer( $authority ),
+			contextFactory: new TitleBasedSubjectEditNoticeContextFactory(
+				MediaWikiServices::getInstance()->getTitleFactory()
+			),
+		);
+	}
+
 	public function newGetPageSubjectsQuery( GetPageSubjectsPresenter $presenter, Authority $authority ): GetPageSubjectsQuery {
 		return new GetPageSubjectsQuery(
 			presenter: $presenter,
@@ -1467,6 +1512,10 @@ class NeoWikiExtension {
 
 	public static function newGetSubjectApi(): GetSubjectApi|Response {
 		return new GetSubjectApi();
+	}
+
+	public static function newGetSubjectEditNoticesApi(): GetSubjectEditNoticesApi {
+		return new GetSubjectEditNoticesApi();
 	}
 
 	public static function newGetPageSubjectsApi(): GetPageSubjectsApi {

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -58,6 +58,7 @@ use ProfessionalWiki\NeoWiki\Application\Queries\GetSubjectEditNotices\GetSubjec
 use ProfessionalWiki\NeoWiki\Application\Queries\GetSubjectEditNotices\GetSubjectEditNoticesQuery;
 use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNoticeProviderRegistry;
 use ProfessionalWiki\NeoWiki\Infrastructure\MediaWikiEditNoticeMessageRenderer;
+use ProfessionalWiki\NeoWiki\Infrastructure\RequestContextSubjectEditNoticeEnvironment;
 use ProfessionalWiki\NeoWiki\Infrastructure\TitleBasedSubjectEditNoticeContextFactory;
 use ProfessionalWiki\NeoWiki\Domain\Page\PagePropertyProviderRegistry;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\CompositeGraphDatabasePlugin;
@@ -1368,6 +1369,10 @@ class NeoWikiExtension {
 			registry: $this->getSubjectEditNoticeProviderRegistry(),
 			readAuthorizer: $this->newPageReadAuthorizer( $authority ),
 			contextFactory: new TitleBasedSubjectEditNoticeContextFactory(
+				MediaWikiServices::getInstance()->getTitleFactory(),
+				MediaWikiServices::getInstance()->getNamespaceInfo()
+			),
+			environment: new RequestContextSubjectEditNoticeEnvironment(
 				MediaWikiServices::getInstance()->getTitleFactory()
 			),
 		);

--- a/src/Presentation/RestGetSubjectEditNoticesPresenter.php
+++ b/src/Presentation/RestGetSubjectEditNoticesPresenter.php
@@ -1,0 +1,30 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Presentation;
+
+use ProfessionalWiki\NeoWiki\Application\Queries\GetSubjectEditNotices\GetSubjectEditNoticesPresenter;
+use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNotice;
+
+class RestGetSubjectEditNoticesPresenter implements GetSubjectEditNoticesPresenter {
+
+	private array $apiResponse = [ 'notices' => [] ];
+
+	public function getJsonArray(): array {
+		return $this->apiResponse;
+	}
+
+	public function presentNotices( array $notices ): void {
+		$this->apiResponse = [
+			'notices' => array_map(
+				static fn ( SubjectEditNotice $notice ): array => [
+					'key' => $notice->key,
+					'html' => $notice->html,
+				],
+				array_values( $notices )
+			),
+		];
+	}
+
+}

--- a/tests/phpunit/Application/EditNotice/InterfaceMessageNoticeProviderTest.php
+++ b/tests/phpunit/Application/EditNotice/InterfaceMessageNoticeProviderTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Application\EditNotice;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\EditNotice\InterfaceMessageNoticeProvider;
+use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNoticeContext;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubEditNoticeMessageRenderer;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Application\EditNotice\InterfaceMessageNoticeProvider
+ */
+class InterfaceMessageNoticeProviderTest extends TestCase {
+
+	private function newContext( int $namespaceId = 0, string $dbKey = 'Berlin', ?string $schemaName = null ): SubjectEditNoticeContext {
+		return new SubjectEditNoticeContext(
+			pageId: new PageId( 42 ),
+			pageDbKey: $dbKey,
+			namespaceId: $namespaceId,
+			schemaName: $schemaName
+		);
+	}
+
+	private function newProvider( array $renderedMessages ): InterfaceMessageNoticeProvider {
+		return new InterfaceMessageNoticeProvider( new StubEditNoticeMessageRenderer( $renderedMessages ) );
+	}
+
+	public function testNoNoticesWhenNoMessagesExist(): void {
+		$provider = $this->newProvider( [] );
+
+		$this->assertSame( [], $provider->getNotices( $this->newContext() ) );
+	}
+
+	public function testNamespaceMessageBecomesNotice(): void {
+		$provider = $this->newProvider( [ 'neowiki-editnotice-0' => '<p>Namespace notice</p>' ] );
+
+		$notices = $provider->getNotices( $this->newContext() );
+
+		$this->assertCount( 1, $notices );
+		$this->assertSame( 'neowiki-editnotice-0', $notices[0]->key );
+		$this->assertSame( '<p>Namespace notice</p>', $notices[0]->html );
+	}
+
+	public function testPageMessageUsesNamespaceAndDbKey(): void {
+		$provider = $this->newProvider( [ 'neowiki-editnotice-4-Berlin' => '<p>Page notice</p>' ] );
+
+		$notices = $provider->getNotices( $this->newContext( namespaceId: 4 ) );
+
+		$this->assertCount( 1, $notices );
+		$this->assertSame( 'neowiki-editnotice-4-Berlin', $notices[0]->key );
+	}
+
+	public function testSlashesInDbKeyBecomeDashes(): void {
+		$provider = $this->newProvider( [ 'neowiki-editnotice-0-Europe-Berlin' => '<p>Subpage notice</p>' ] );
+
+		$notices = $provider->getNotices( $this->newContext( dbKey: 'Europe/Berlin' ) );
+
+		$this->assertCount( 1, $notices );
+	}
+
+	public function testSchemaMessageBecomesNoticeWhenSchemaIsKnown(): void {
+		$provider = $this->newProvider( [ 'neowiki-editnotice-schema-Person' => '<p>Schema notice</p>' ] );
+
+		$notices = $provider->getNotices( $this->newContext( schemaName: 'Person' ) );
+
+		$this->assertCount( 1, $notices );
+		$this->assertSame( 'neowiki-editnotice-schema-Person', $notices[0]->key );
+	}
+
+	public function testSchemaMessageIsNotConsultedWithoutASchema(): void {
+		$provider = $this->newProvider( [ 'neowiki-editnotice-schema-Person' => '<p>Schema notice</p>' ] );
+
+		$this->assertSame( [], $provider->getNotices( $this->newContext( schemaName: null ) ) );
+	}
+
+	public function testSlashesInSchemaNameBecomeDashes(): void {
+		$provider = $this->newProvider( [ 'neowiki-editnotice-schema-Person-Author' => '<p>Schema notice</p>' ] );
+
+		$notices = $provider->getNotices( $this->newContext( schemaName: 'Person/Author' ) );
+
+		$this->assertCount( 1, $notices );
+	}
+
+	public function testNoticesAreOrderedFromBroadestToNarrowest(): void {
+		$provider = $this->newProvider( [
+			'neowiki-editnotice-schema-Person' => '<p>Schema</p>',
+			'neowiki-editnotice-0-Berlin' => '<p>Page</p>',
+			'neowiki-editnotice-0' => '<p>Namespace</p>',
+		] );
+
+		$notices = $provider->getNotices( $this->newContext( schemaName: 'Person' ) );
+
+		$this->assertSame(
+			[ 'neowiki-editnotice-0', 'neowiki-editnotice-0-Berlin', 'neowiki-editnotice-schema-Person' ],
+			array_map( static fn ( $notice ) => $notice->key, $notices )
+		);
+	}
+
+}

--- a/tests/phpunit/Application/EditNotice/InterfaceMessageNoticeProviderTest.php
+++ b/tests/phpunit/Application/EditNotice/InterfaceMessageNoticeProviderTest.php
@@ -15,12 +15,18 @@ use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubEditNoticeMessageRenderer;
  */
 class InterfaceMessageNoticeProviderTest extends TestCase {
 
-	private function newContext( int $namespaceId = 0, string $dbKey = 'Berlin', ?string $schemaName = null ): SubjectEditNoticeContext {
+	private function newContext(
+		int $namespaceId = 0,
+		string $dbKey = 'Berlin',
+		?string $schemaName = null,
+		bool $namespaceHasSubpages = false
+	): SubjectEditNoticeContext {
 		return new SubjectEditNoticeContext(
 			pageId: new PageId( 42 ),
 			pageDbKey: $dbKey,
 			namespaceId: $namespaceId,
-			schemaName: $schemaName
+			schemaName: $schemaName,
+			namespaceHasSubpages: $namespaceHasSubpages
 		);
 	}
 
@@ -53,12 +59,47 @@ class InterfaceMessageNoticeProviderTest extends TestCase {
 		$this->assertSame( 'neowiki-editnotice-4-Berlin', $notices[0]->key );
 	}
 
-	public function testSlashesInDbKeyBecomeDashes(): void {
-		$provider = $this->newProvider( [ 'neowiki-editnotice-0-Europe-Berlin' => '<p>Subpage notice</p>' ] );
+	public function testSlashesAreFlattenedWhereTheNamespaceHasNoSubpages(): void {
+		$provider = $this->newProvider( [ 'neowiki-editnotice-0-Europe-Berlin' => '<p>Flattened</p>' ] );
 
 		$notices = $provider->getNotices( $this->newContext( dbKey: 'Europe/Berlin' ) );
 
 		$this->assertCount( 1, $notices );
+	}
+
+	public function testSubpageNamespaceGetsANoticePerAncestor(): void {
+		$provider = $this->newProvider( [
+			'neowiki-editnotice-4-Europe' => '<p>Subtree</p>',
+			'neowiki-editnotice-4-Europe-Berlin' => '<p>Leaf</p>',
+		] );
+
+		$notices = $provider->getNotices(
+			$this->newContext( namespaceId: 4, dbKey: 'Europe/Berlin', namespaceHasSubpages: true )
+		);
+
+		$this->assertSame(
+			[ 'neowiki-editnotice-4-Europe', 'neowiki-editnotice-4-Europe-Berlin' ],
+			array_map( static fn ( $notice ) => $notice->key, $notices )
+		);
+	}
+
+	public function testAncestorNoticeCoversItsSubpages(): void {
+		$provider = $this->newProvider( [ 'neowiki-editnotice-4-Handbook' => '<p>Subtree</p>' ] );
+
+		$notices = $provider->getNotices(
+			$this->newContext( namespaceId: 4, dbKey: 'Handbook/Chapter1', namespaceHasSubpages: true )
+		);
+
+		$this->assertCount( 1, $notices );
+	}
+
+	public function testSpacesInSchemaNameBecomeUnderscores(): void {
+		$provider = $this->newProvider( [ 'neowiki-editnotice-schema-Control_Document' => '<p>Schema</p>' ] );
+
+		$notices = $provider->getNotices( $this->newContext( schemaName: 'Control Document' ) );
+
+		$this->assertCount( 1, $notices );
+		$this->assertSame( 'neowiki-editnotice-schema-Control_Document', $notices[0]->key );
 	}
 
 	public function testSchemaMessageBecomesNoticeWhenSchemaIsKnown(): void {
@@ -82,6 +123,21 @@ class InterfaceMessageNoticeProviderTest extends TestCase {
 		$notices = $provider->getNotices( $this->newContext( schemaName: 'Person/Author' ) );
 
 		$this->assertCount( 1, $notices );
+	}
+
+	public function testThePageBeingEditedReachesTheRenderer(): void {
+		$renderer = new StubEditNoticeMessageRenderer( [] );
+
+		( new InterfaceMessageNoticeProvider( $renderer ) )
+			->getNotices( $this->newContext( namespaceId: 12, dbKey: 'New_York' ) );
+
+		$this->assertSame(
+			[ [ 12, 'New_York' ] ],
+			array_values( array_unique(
+				array_map( static fn ( array $call ) => [ $call['namespaceId'], $call['pageDbKey'] ], $renderer->calls ),
+				SORT_REGULAR
+			) )
+		);
 	}
 
 	public function testNoticesAreOrderedFromBroadestToNarrowest(): void {

--- a/tests/phpunit/Application/Queries/GetSubjectEditNotices/GetSubjectEditNoticesQueryTest.php
+++ b/tests/phpunit/Application/Queries/GetSubjectEditNotices/GetSubjectEditNoticesQueryTest.php
@@ -2,12 +2,14 @@
 
 declare( strict_types = 1 );
 
-namespace ProfessionalWiki\NeoWiki\Tests\Application\Queries;
+namespace ProfessionalWiki\NeoWiki\Tests\Application\Queries\GetSubjectEditNotices;
 
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Application\Queries\GetSubjectEditNotices\GetSubjectEditNoticesQuery;
 use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNotice;
+use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNoticeProvider;
 use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNoticeProviderRegistry;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\NullSubjectEditNoticeEnvironment;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\RecordingSchemaNoticeProvider;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubPageReadAuthorizer;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubSubjectEditNoticeContextFactory;
@@ -23,13 +25,13 @@ class GetSubjectEditNoticesQueryTest extends TestCase {
 
 	private SubjectEditNoticesPresenterSpy $presenter;
 
+	private NullSubjectEditNoticeEnvironment $environment;
+
 	protected function setUp(): void {
 		$this->presenter = new SubjectEditNoticesPresenterSpy();
+		$this->environment = new NullSubjectEditNoticeEnvironment();
 	}
 
-	/**
-	 * @param SubjectEditNoticeProviderRegistry|null $registry
-	 */
 	private function newQuery(
 		bool $readAllowed = true,
 		bool $pageExists = true,
@@ -39,11 +41,12 @@ class GetSubjectEditNoticesQueryTest extends TestCase {
 			$this->presenter,
 			$registry ?? new SubjectEditNoticeProviderRegistry(),
 			new StubPageReadAuthorizer( $readAllowed ),
-			new StubSubjectEditNoticeContextFactory( $pageExists )
+			new StubSubjectEditNoticeContextFactory( $pageExists ),
+			$this->environment
 		);
 	}
 
-	private function newRegistryWith( ...$providers ): SubjectEditNoticeProviderRegistry {
+	private function newRegistryWith( SubjectEditNoticeProvider ...$providers ): SubjectEditNoticeProviderRegistry {
 		$registry = new SubjectEditNoticeProviderRegistry();
 
 		foreach ( $providers as $provider ) {
@@ -102,6 +105,33 @@ class GetSubjectEditNoticesQueryTest extends TestCase {
 		$query->execute( pageId: self::PAGE_ID, schemaName: null );
 
 		$this->assertSame( [], $this->presenter->presentedKeys() );
+	}
+
+	public function testOneKeyClaimedTwiceYieldsOneNotice(): void {
+		$query = $this->newQuery( registry: $this->newRegistryWith(
+			new StubSubjectEditNoticeProvider( [ $this->newNotice( 'approval' ) ] ),
+			new StubSubjectEditNoticeProvider( [ $this->newNotice( 'approval' ), $this->newNotice( 'other' ) ] )
+		) );
+
+		$query->execute( pageId: self::PAGE_ID, schemaName: null );
+
+		$this->assertSame( [ 'approval', 'other' ], $this->presenter->presentedKeys() );
+	}
+
+	public function testProvidersRunAgainstThePagesOwnRequestState(): void {
+		$query = $this->newQuery();
+
+		$query->execute( pageId: self::PAGE_ID, schemaName: null );
+
+		$this->assertSame( self::PAGE_ID, $this->environment->preparedFor?->pageId->id );
+	}
+
+	public function testRequestStateIsUntouchedForAPageTheUserMayNotRead(): void {
+		$query = $this->newQuery( readAllowed: false );
+
+		$query->execute( pageId: self::PAGE_ID, schemaName: null );
+
+		$this->assertNull( $this->environment->preparedFor );
 	}
 
 	public function testSchemaNameReachesTheProviders(): void {

--- a/tests/phpunit/Application/Queries/GetSubjectEditNoticesQueryTest.php
+++ b/tests/phpunit/Application/Queries/GetSubjectEditNoticesQueryTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Application\Queries;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\Queries\GetSubjectEditNotices\GetSubjectEditNoticesQuery;
+use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNotice;
+use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNoticeProviderRegistry;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\RecordingSchemaNoticeProvider;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubPageReadAuthorizer;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubSubjectEditNoticeContextFactory;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubSubjectEditNoticeProvider;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SubjectEditNoticesPresenterSpy;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Application\Queries\GetSubjectEditNotices\GetSubjectEditNoticesQuery
+ */
+class GetSubjectEditNoticesQueryTest extends TestCase {
+
+	private const int PAGE_ID = 42;
+
+	private SubjectEditNoticesPresenterSpy $presenter;
+
+	protected function setUp(): void {
+		$this->presenter = new SubjectEditNoticesPresenterSpy();
+	}
+
+	/**
+	 * @param SubjectEditNoticeProviderRegistry|null $registry
+	 */
+	private function newQuery(
+		bool $readAllowed = true,
+		bool $pageExists = true,
+		?SubjectEditNoticeProviderRegistry $registry = null
+	): GetSubjectEditNoticesQuery {
+		return new GetSubjectEditNoticesQuery(
+			$this->presenter,
+			$registry ?? new SubjectEditNoticeProviderRegistry(),
+			new StubPageReadAuthorizer( $readAllowed ),
+			new StubSubjectEditNoticeContextFactory( $pageExists )
+		);
+	}
+
+	private function newRegistryWith( ...$providers ): SubjectEditNoticeProviderRegistry {
+		$registry = new SubjectEditNoticeProviderRegistry();
+
+		foreach ( $providers as $provider ) {
+			$registry->addProvider( $provider );
+		}
+
+		return $registry;
+	}
+
+	private function newNotice( string $key ): SubjectEditNotice {
+		return new SubjectEditNotice( key: $key, html: "<p>$key</p>" );
+	}
+
+	public function testPresentsNoticesFromARegisteredProvider(): void {
+		$query = $this->newQuery( registry: $this->newRegistryWith(
+			new StubSubjectEditNoticeProvider( [ $this->newNotice( 'approval' ) ] )
+		) );
+
+		$query->execute( pageId: self::PAGE_ID, schemaName: null );
+
+		$this->assertSame( [ 'approval' ], $this->presenter->presentedKeys() );
+	}
+
+	public function testProvidersAreConcatenatedInRegistrationOrder(): void {
+		$query = $this->newQuery( registry: $this->newRegistryWith(
+			new StubSubjectEditNoticeProvider( [ $this->newNotice( 'first' ), $this->newNotice( 'second' ) ] ),
+			new StubSubjectEditNoticeProvider( [ $this->newNotice( 'third' ) ] )
+		) );
+
+		$query->execute( pageId: self::PAGE_ID, schemaName: null );
+
+		$this->assertSame( [ 'first', 'second', 'third' ], $this->presenter->presentedKeys() );
+	}
+
+	public function testDeniedPageIsPresentedExactlyLikeAPageWithoutNotices(): void {
+		$query = $this->newQuery(
+			readAllowed: false,
+			registry: $this->newRegistryWith(
+				new StubSubjectEditNoticeProvider( [ $this->newNotice( 'secret' ) ] )
+			)
+		);
+
+		$query->execute( pageId: self::PAGE_ID, schemaName: null );
+
+		$this->assertSame( [], $this->presenter->presentedKeys() );
+	}
+
+	public function testMissingPageYieldsNoNotices(): void {
+		$query = $this->newQuery(
+			pageExists: false,
+			registry: $this->newRegistryWith(
+				new StubSubjectEditNoticeProvider( [ $this->newNotice( 'orphan' ) ] )
+			)
+		);
+
+		$query->execute( pageId: self::PAGE_ID, schemaName: null );
+
+		$this->assertSame( [], $this->presenter->presentedKeys() );
+	}
+
+	public function testSchemaNameReachesTheProviders(): void {
+		$provider = new RecordingSchemaNoticeProvider();
+		$query = $this->newQuery( registry: $this->newRegistryWith( $provider ) );
+
+		$query->execute( pageId: self::PAGE_ID, schemaName: 'Person' );
+
+		$this->assertSame( 'Person', $provider->receivedSchemaName );
+	}
+
+	public function testPageIdReachesTheProviders(): void {
+		$provider = new RecordingSchemaNoticeProvider();
+		$query = $this->newQuery( registry: $this->newRegistryWith( $provider ) );
+
+		$query->execute( pageId: self::PAGE_ID, schemaName: null );
+
+		$this->assertSame( self::PAGE_ID, $provider->receivedPageId );
+	}
+
+}

--- a/tests/phpunit/Domain/EditNotice/SubjectEditNoticeProviderRegistryTest.php
+++ b/tests/phpunit/Domain/EditNotice/SubjectEditNoticeProviderRegistryTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Domain\EditNotice;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNoticeProviderRegistry;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubSubjectEditNoticeProvider;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNoticeProviderRegistry
+ */
+class SubjectEditNoticeProviderRegistryTest extends TestCase {
+
+	public function testNewRegistryHasNoProviders(): void {
+		$registry = new SubjectEditNoticeProviderRegistry();
+
+		$this->assertSame( [], $registry->getProviders() );
+	}
+
+	public function testAddedProviderCanBeRetrieved(): void {
+		$registry = new SubjectEditNoticeProviderRegistry();
+		$provider = new StubSubjectEditNoticeProvider( [] );
+
+		$registry->addProvider( $provider );
+
+		$this->assertSame( [ $provider ], $registry->getProviders() );
+	}
+
+	public function testProvidersAreRetrievedInRegistrationOrder(): void {
+		$registry = new SubjectEditNoticeProviderRegistry();
+		$first = new StubSubjectEditNoticeProvider( [] );
+		$second = new StubSubjectEditNoticeProvider( [] );
+		$third = new StubSubjectEditNoticeProvider( [] );
+
+		$registry->addProvider( $first );
+		$registry->addProvider( $second );
+		$registry->addProvider( $third );
+
+		$this->assertSame( [ $first, $second, $third ], $registry->getProviders() );
+	}
+
+}

--- a/tests/phpunit/EntryPoints/NeoWikiRegistrarTest.php
+++ b/tests/phpunit/EntryPoints/NeoWikiRegistrarTest.php
@@ -6,6 +6,7 @@ namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints;
 
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphDatabasePluginRegistry;
+use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNoticeProviderRegistry;
 use ProfessionalWiki\NeoWiki\Domain\Page\PagePropertyProviderRegistry;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeRegistry;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\Types\TextType;
@@ -13,6 +14,7 @@ use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfValueMapperRegistry;
 use ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiRegistrar;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jValueBuilderRegistry;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpyGraphDatabasePlugin;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubSubjectEditNoticeProvider;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubPagePropertyProvider;
 
 /**
@@ -67,12 +69,23 @@ class NeoWikiRegistrarTest extends TestCase {
 		$this->assertTrue( $rdfValueMapperRegistry->hasMapper( 'custom' ) );
 	}
 
+	public function testAddSubjectEditNoticeProviderRegistersInRegistry(): void {
+		$noticeRegistry = new SubjectEditNoticeProviderRegistry();
+		$registrar = $this->newRegistrar( subjectEditNoticeProviderRegistry: $noticeRegistry );
+		$provider = new StubSubjectEditNoticeProvider( [] );
+
+		$registrar->addSubjectEditNoticeProvider( $provider );
+
+		$this->assertSame( [ $provider ], $noticeRegistry->getProviders() );
+	}
+
 	private function newRegistrar(
 		?PropertyTypeRegistry $propertyTypeRegistry = null,
 		?Neo4jValueBuilderRegistry $valueBuilderRegistry = null,
 		?PagePropertyProviderRegistry $pagePropertyProviderRegistry = null,
 		?GraphDatabasePluginRegistry $graphDatabasePluginRegistry = null,
 		?RdfValueMapperRegistry $rdfValueMapperRegistry = null,
+		?SubjectEditNoticeProviderRegistry $subjectEditNoticeProviderRegistry = null,
 	): NeoWikiRegistrar {
 		return new NeoWikiRegistrar(
 			propertyTypeRegistry: $propertyTypeRegistry ?? new PropertyTypeRegistry(),
@@ -80,6 +93,7 @@ class NeoWikiRegistrarTest extends TestCase {
 			pagePropertyProviderRegistry: $pagePropertyProviderRegistry ?? new PagePropertyProviderRegistry(),
 			graphDatabasePluginRegistry: $graphDatabasePluginRegistry ?? new GraphDatabasePluginRegistry(),
 			rdfValueMapperRegistry: $rdfValueMapperRegistry ?? new RdfValueMapperRegistry(),
+			subjectEditNoticeProviderRegistry: $subjectEditNoticeProviderRegistry ?? new SubjectEditNoticeProviderRegistry(),
 		);
 	}
 

--- a/tests/phpunit/EntryPoints/REST/GetSubjectEditNoticesApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/GetSubjectEditNoticesApiTest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\REST;
 
+use MediaWiki\Permissions\Authority;
 use MediaWiki\Rest\RequestData;
 use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\GetSubjectEditNoticesApi;
@@ -33,7 +34,7 @@ class GetSubjectEditNoticesApiTest extends NeoWikiIntegrationTestCase {
 	/**
 	 * @return array<string, mixed>
 	 */
-	private function requestNotices( int $pageId, ?string $schemaName = null, $authority = null ): array {
+	private function requestNotices( int $pageId, ?string $schemaName = null, ?Authority $authority = null ): array {
 		$queryParams = $schemaName === null ? [] : [ 'schema' => $schemaName ];
 
 		return json_decode(

--- a/tests/phpunit/EntryPoints/REST/GetSubjectEditNoticesApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/GetSubjectEditNoticesApiTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\REST;
+
+use MediaWiki\Rest\RequestData;
+use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
+use ProfessionalWiki\NeoWiki\EntryPoints\REST\GetSubjectEditNoticesApi;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiMockAuthorityTrait;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\REST\GetSubjectEditNoticesApi
+ * @covers \ProfessionalWiki\NeoWiki\Presentation\RestGetSubjectEditNoticesPresenter
+ * @covers \ProfessionalWiki\NeoWiki\Application\Queries\GetSubjectEditNotices\GetSubjectEditNoticesQuery
+ * @covers \ProfessionalWiki\NeoWiki\Infrastructure\TitleBasedSubjectEditNoticeContextFactory
+ * @group Database
+ */
+class GetSubjectEditNoticesApiTest extends NeoWikiIntegrationTestCase {
+	use HandlerTestTrait;
+	use NeoWikiMockAuthorityTrait;
+
+	private function createNoticeMessage( string $messageKey, string $content ): void {
+		$this->insertPage( 'MediaWiki:' . ucfirst( $messageKey ), $content );
+		$this->getServiceContainer()->getMessageCache()->enable();
+	}
+
+	private function createPage( string $title ): int {
+		return $this->insertPage( $title, 'Just wikitext.' )['id'];
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	private function requestNotices( int $pageId, ?string $schemaName = null, $authority = null ): array {
+		$queryParams = $schemaName === null ? [] : [ 'schema' => $schemaName ];
+
+		return json_decode(
+			$this->executeHandler(
+				new GetSubjectEditNoticesApi(),
+				new RequestData( [
+					'method' => 'GET',
+					'pathParams' => [ 'pageId' => (string)$pageId ],
+					'queryParams' => $queryParams,
+				] ),
+				authority: $authority
+			)->getBody()->getContents(),
+			true
+		);
+	}
+
+	/**
+	 * @return string[]
+	 */
+	private function noticeKeys( array $body ): array {
+		return array_column( $body['notices'], 'key' );
+	}
+
+	public function testPageWithoutNoticesYieldsAnEmptyList(): void {
+		$pageId = $this->createPage( 'GetSubjectEditNoticesApiTest_Plain' );
+
+		$this->assertSame( [ 'notices' => [] ], $this->requestNotices( $pageId ) );
+	}
+
+	public function testNamespaceAndPageNoticesAreReturned(): void {
+		$pageId = $this->createPage( 'GetSubjectEditNoticesApiTest_Noticed' );
+		$this->createNoticeMessage( 'neowiki-editnotice-0', 'Namespace wide' );
+		$this->createNoticeMessage( 'neowiki-editnotice-0-GetSubjectEditNoticesApiTest_Noticed', 'This page' );
+
+		$this->assertSame(
+			[ 'neowiki-editnotice-0', 'neowiki-editnotice-0-GetSubjectEditNoticesApiTest_Noticed' ],
+			$this->noticeKeys( $this->requestNotices( $pageId ) )
+		);
+	}
+
+	public function testSchemaNoticeIsReturnedOnlyWhenTheSchemaIsNamed(): void {
+		$pageId = $this->createPage( 'GetSubjectEditNoticesApiTest_Schema' );
+		$this->createNoticeMessage( 'neowiki-editnotice-schema-Person', 'Editing a Person' );
+
+		$this->assertSame( [], $this->noticeKeys( $this->requestNotices( $pageId ) ) );
+		$this->assertSame(
+			[ 'neowiki-editnotice-schema-Person' ],
+			$this->noticeKeys( $this->requestNotices( $pageId, schemaName: 'Person' ) )
+		);
+	}
+
+	public function testNoticeBodyIsRenderedHtml(): void {
+		$pageId = $this->createPage( 'GetSubjectEditNoticesApiTest_Html' );
+		$this->createNoticeMessage( 'neowiki-editnotice-0', "'''Approval needed'''" );
+
+		$html = $this->requestNotices( $pageId )['notices'][0]['html'];
+
+		$this->assertStringContainsString( '<b>Approval needed</b>', $html );
+	}
+
+	public function testNoticesOnAnUnreadablePageAreAbsent(): void {
+		$restrictedPageId = $this->createPage( 'GetSubjectEditNoticesApiTest_Restricted' );
+		$plainPageId = $this->createPage( 'GetSubjectEditNoticesApiTest_NoNotices' );
+		$this->createNoticeMessage( 'neowiki-editnotice-0', 'Namespace wide' );
+
+		$denied = $this->requestNotices(
+			$restrictedPageId,
+			authority: $this->authorityWithGlobalReadButNoPageRead()
+		);
+
+		// The page carries a notice and the plain one does not, yet a denied read must be
+		// indistinguishable from a page that simply has nothing to show.
+		$this->assertSame( [ 'notices' => [] ], $denied );
+		$this->assertNotSame( [], $this->noticeKeys( $this->requestNotices( $plainPageId ) ) );
+	}
+
+	public function testMissingPageYieldsAnEmptyList(): void {
+		$this->assertSame( [ 'notices' => [] ], $this->requestNotices( 999999 ) );
+	}
+
+}

--- a/tests/phpunit/Infrastructure/MediaWikiEditNoticeMessageRendererTest.php
+++ b/tests/phpunit/Infrastructure/MediaWikiEditNoticeMessageRendererTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Infrastructure;
+
+use MediaWiki\Context\RequestContext;
+use ProfessionalWiki\NeoWiki\Infrastructure\MediaWikiEditNoticeMessageRenderer;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Infrastructure\MediaWikiEditNoticeMessageRenderer
+ * @group Database
+ */
+class MediaWikiEditNoticeMessageRendererTest extends NeoWikiIntegrationTestCase {
+
+	private const string MESSAGE_KEY = 'neowiki-editnotice-0';
+
+	private const string PAGE_DB_KEY = 'Berlin';
+
+	private function newRenderer(): MediaWikiEditNoticeMessageRenderer {
+		return new MediaWikiEditNoticeMessageRenderer(
+			RequestContext::getMain(),
+			$this->getServiceContainer()->getTitleFactory()
+		);
+	}
+
+	private function render(): ?string {
+		return $this->newRenderer()->render( self::MESSAGE_KEY, NS_MAIN, self::PAGE_DB_KEY );
+	}
+
+	private function createMessagePage( string $content ): void {
+		$this->insertPage( 'MediaWiki:' . ucfirst( self::MESSAGE_KEY ), $content );
+		$this->getServiceContainer()->getMessageCache()->enable();
+	}
+
+	public function testRendersNothingWhenTheMessagePageDoesNotExist(): void {
+		$this->assertNull( $this->render() );
+	}
+
+	public function testRendersTheMessageContent(): void {
+		$this->createMessagePage( "'''Changes need approval'''" );
+
+		$html = $this->render();
+
+		$this->assertNotNull( $html );
+		$this->assertStringContainsString( 'Changes need approval', $html );
+		$this->assertStringContainsString( '<b>', $html );
+	}
+
+	public function testRendersNothingWhenAnAdminDisabledTheMessage(): void {
+		$this->createMessagePage( '-' );
+
+		$this->assertNull( $this->render() );
+	}
+
+	public function testRendersNothingWhenTheMessageRendersEmpty(): void {
+		$this->createMessagePage( '<!-- deliberately renders nothing -->' );
+
+		$this->assertNull( $this->render() );
+	}
+
+	public function testMagicWordsResolveAgainstThePageBeingEdited(): void {
+		$this->createMessagePage( 'Editing {{PAGENAME}}' );
+
+		$this->assertStringContainsString( 'Editing ' . self::PAGE_DB_KEY, (string)$this->render() );
+	}
+
+}

--- a/tests/phpunit/Infrastructure/RequestContextSubjectEditNoticeEnvironmentTest.php
+++ b/tests/phpunit/Infrastructure/RequestContextSubjectEditNoticeEnvironmentTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Infrastructure;
+
+use MediaWiki\Context\RequestContext;
+use MediaWiki\Title\Title;
+use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNoticeContext;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+use ProfessionalWiki\NeoWiki\Infrastructure\RequestContextSubjectEditNoticeEnvironment;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Infrastructure\RequestContextSubjectEditNoticeEnvironment
+ * @group Database
+ */
+class RequestContextSubjectEditNoticeEnvironmentTest extends NeoWikiIntegrationTestCase {
+
+	private function newEnvironment(): RequestContextSubjectEditNoticeEnvironment {
+		return new RequestContextSubjectEditNoticeEnvironment(
+			$this->getServiceContainer()->getTitleFactory()
+		);
+	}
+
+	private function newContext(): SubjectEditNoticeContext {
+		return new SubjectEditNoticeContext(
+			pageId: new PageId( 42 ),
+			pageDbKey: 'Berlin',
+			namespaceId: NS_HELP,
+			namespaceHasSubpages: false
+		);
+	}
+
+	public function testProvidersSeeThePageWhoseNoticesAreBeingCollected(): void {
+		$this->newEnvironment()->prepareFor( $this->newContext() );
+
+		$this->assertSame( 'Help:Berlin', RequestContext::getMain()->getTitle()?->getPrefixedText() );
+	}
+
+	public function testRestoringPutsBackTheTitleTheRequestArrivedWith(): void {
+		RequestContext::getMain()->setTitle( Title::newFromText( 'Original page' ) );
+		$environment = $this->newEnvironment();
+
+		$environment->prepareFor( $this->newContext() );
+		$environment->restore();
+
+		$this->assertSame( 'Original page', RequestContext::getMain()->getTitle()?->getPrefixedText() );
+	}
+
+}

--- a/tests/phpunit/TestDoubles/NullSubjectEditNoticeEnvironment.php
+++ b/tests/phpunit/TestDoubles/NullSubjectEditNoticeEnvironment.php
@@ -11,8 +11,14 @@ class NullSubjectEditNoticeEnvironment implements SubjectEditNoticeEnvironment {
 
 	public ?SubjectEditNoticeContext $preparedFor = null;
 
+	public bool $restored = false;
+
 	public function prepareFor( SubjectEditNoticeContext $context ): void {
 		$this->preparedFor = $context;
+	}
+
+	public function restore(): void {
+		$this->restored = true;
 	}
 
 }

--- a/tests/phpunit/TestDoubles/NullSubjectEditNoticeEnvironment.php
+++ b/tests/phpunit/TestDoubles/NullSubjectEditNoticeEnvironment.php
@@ -1,0 +1,18 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\TestDoubles;
+
+use ProfessionalWiki\NeoWiki\Application\EditNotice\SubjectEditNoticeEnvironment;
+use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNoticeContext;
+
+class NullSubjectEditNoticeEnvironment implements SubjectEditNoticeEnvironment {
+
+	public ?SubjectEditNoticeContext $preparedFor = null;
+
+	public function prepareFor( SubjectEditNoticeContext $context ): void {
+		$this->preparedFor = $context;
+	}
+
+}

--- a/tests/phpunit/TestDoubles/RecordingSchemaNoticeProvider.php
+++ b/tests/phpunit/TestDoubles/RecordingSchemaNoticeProvider.php
@@ -1,0 +1,26 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\TestDoubles;
+
+use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNoticeContext;
+use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNoticeProvider;
+
+/**
+ * Records the context it was handed, so tests can assert what reached the extension point.
+ */
+class RecordingSchemaNoticeProvider implements SubjectEditNoticeProvider {
+
+	public ?string $receivedSchemaName = null;
+
+	public ?int $receivedPageId = null;
+
+	public function getNotices( SubjectEditNoticeContext $context ): array {
+		$this->receivedSchemaName = $context->schemaName;
+		$this->receivedPageId = $context->pageId->id;
+
+		return [];
+	}
+
+}

--- a/tests/phpunit/TestDoubles/StubEditNoticeMessageRenderer.php
+++ b/tests/phpunit/TestDoubles/StubEditNoticeMessageRenderer.php
@@ -16,7 +16,14 @@ class StubEditNoticeMessageRenderer implements EditNoticeMessageRenderer {
 	) {
 	}
 
+	/**
+	 * @var array<int, array{key: string, namespaceId: int, pageDbKey: string}>
+	 */
+	public array $calls = [];
+
 	public function render( string $messageKey, int $namespaceId, string $pageDbKey ): ?string {
+		$this->calls[] = [ 'key' => $messageKey, 'namespaceId' => $namespaceId, 'pageDbKey' => $pageDbKey ];
+
 		return $this->renderedMessages[$messageKey] ?? null;
 	}
 

--- a/tests/phpunit/TestDoubles/StubEditNoticeMessageRenderer.php
+++ b/tests/phpunit/TestDoubles/StubEditNoticeMessageRenderer.php
@@ -1,0 +1,23 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\TestDoubles;
+
+use ProfessionalWiki\NeoWiki\Application\EditNotice\EditNoticeMessageRenderer;
+
+class StubEditNoticeMessageRenderer implements EditNoticeMessageRenderer {
+
+	/**
+	 * @param array<string, string> $renderedMessages Message key to rendered HTML. Absent keys render nothing.
+	 */
+	public function __construct(
+		private readonly array $renderedMessages
+	) {
+	}
+
+	public function render( string $messageKey, int $namespaceId, string $pageDbKey ): ?string {
+		return $this->renderedMessages[$messageKey] ?? null;
+	}
+
+}

--- a/tests/phpunit/TestDoubles/StubSubjectEditNoticeContextFactory.php
+++ b/tests/phpunit/TestDoubles/StubSubjectEditNoticeContextFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\TestDoubles;
+
+use ProfessionalWiki\NeoWiki\Application\EditNotice\SubjectEditNoticeContextFactory;
+use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNoticeContext;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
+
+class StubSubjectEditNoticeContextFactory implements SubjectEditNoticeContextFactory {
+
+	public function __construct(
+		private readonly bool $pageExists
+	) {
+	}
+
+	public function newContext( PageId $pageId, ?string $schemaName ): ?SubjectEditNoticeContext {
+		if ( !$this->pageExists ) {
+			return null;
+		}
+
+		return new SubjectEditNoticeContext(
+			pageId: $pageId,
+			pageDbKey: 'Berlin',
+			namespaceId: 0,
+			schemaName: $schemaName
+		);
+	}
+
+}

--- a/tests/phpunit/TestDoubles/StubSubjectEditNoticeContextFactory.php
+++ b/tests/phpunit/TestDoubles/StubSubjectEditNoticeContextFactory.php
@@ -24,6 +24,7 @@ class StubSubjectEditNoticeContextFactory implements SubjectEditNoticeContextFac
 			pageId: $pageId,
 			pageDbKey: 'Berlin',
 			namespaceId: 0,
+			namespaceHasSubpages: false,
 			schemaName: $schemaName
 		);
 	}

--- a/tests/phpunit/TestDoubles/StubSubjectEditNoticeProvider.php
+++ b/tests/phpunit/TestDoubles/StubSubjectEditNoticeProvider.php
@@ -1,0 +1,25 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\TestDoubles;
+
+use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNotice;
+use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNoticeContext;
+use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNoticeProvider;
+
+class StubSubjectEditNoticeProvider implements SubjectEditNoticeProvider {
+
+	/**
+	 * @param SubjectEditNotice[] $notices
+	 */
+	public function __construct(
+		private readonly array $notices
+	) {
+	}
+
+	public function getNotices( SubjectEditNoticeContext $context ): array {
+		return $this->notices;
+	}
+
+}

--- a/tests/phpunit/TestDoubles/SubjectEditNoticesPresenterSpy.php
+++ b/tests/phpunit/TestDoubles/SubjectEditNoticesPresenterSpy.php
@@ -1,0 +1,28 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\TestDoubles;
+
+use ProfessionalWiki\NeoWiki\Application\Queries\GetSubjectEditNotices\GetSubjectEditNoticesPresenter;
+use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNotice;
+
+class SubjectEditNoticesPresenterSpy implements GetSubjectEditNoticesPresenter {
+
+	/**
+	 * @var SubjectEditNotice[]
+	 */
+	private array $notices = [];
+
+	public function presentNotices( array $notices ): void {
+		$this->notices = $notices;
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public function presentedKeys(): array {
+		return array_map( static fn ( SubjectEditNotice $notice ): string => $notice->key, $this->notices );
+	}
+
+}


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/1262

Shows a message before a user edits a Subject, so an approval extension can warn that a saved change stays hidden until it is reviewed.

Two producers feed one ordered list. Wiki admins write notices as interface messages, following the convention core uses for its own edit notices:

```
MediaWiki:Neowiki-editnotice-{ns}
MediaWiki:Neowiki-editnotice-{ns}-{dbkey}
MediaWiki:Neowiki-editnotice-schema-{Schema}
```

Extensions register a provider through `NeoWikiRegistrar::addSubjectEditNoticeProvider()`. Exact key rules and the provider contract are in [`docs/authoring/edit-notices.md`](docs/authoring/edit-notices.md) and [`docs/extending/extending.md`](docs/extending/extending.md#edit-notices); the endpoint is in [`docs/api/rest-api.md`](docs/api/rest-api.md).

`GET /neowiki/v0/page/{pageId}/editNotices?schema={Name}` serves both. The editors fetch when they open rather than receiving notices with the page, because a notice can depend on the viewer and on state that changes without an edit. A denied read returns a body byte-identical to a page with no notices, so the endpoint cannot be used to probe page readability.

Core's `Title::getEditNotices()` is not reused. Those notices are authored for wikitext editing and would be noise in a Subject dialog, and the hook behind them receives only a title, so it cannot express Schema scope. An extension already implementing `TitleGetEditNotices` therefore needs a second handler.

A notice brings its own presentation; NeoWiki adds none.

Scope is the Subject editor, the Subject creator, and Manage subjects. The Schema, Layout and Mapping editors are not covered.

Known limitation, documented in `docs/authoring/edit-notices.md`: notices follow the page being viewed, so a Subject rendered elsewhere with `{{#view: <subjectId>}}` shows the viewing page's notices rather than its own.

Tests: unit tests cover key resolution across both of core's namespace branches, ordering, disabling with `-`, a message that parses to empty, and that a stale fetch cannot overwrite a newer one. Integration tests cover the three guards against real interface messages, and the endpoint's read gate by asserting a denied page returns exactly what a page with no notices returns.

## Manual Browser Check

1. Create `MediaWiki:Neowiki-editnotice-0` with any text, and `MediaWiki:Neowiki-editnotice-schema-<Schema>` for a Schema used on a page with a Subject.
2. Open that page and click the edit button on the infobox. Both notices appear above the fields, namespace first.
3. Open "Create subject" on the same page. Only the namespace notice appears, until a Schema is chosen.
4. Set `MediaWiki:Neowiki-editnotice-0` to `-`. It disappears from both.
5. Put `{{PAGENAME}}` in the page-scoped notice `MediaWiki:Neowiki-editnotice-0-<PageDbKey>`. It resolves to the page being edited.

To check that an admin's wikitext is sanitized, put `<script>alert(1)</script>`, `<img src=x onerror=alert(2)>` and `<div onclick="alert(3)">x</div>` in a notice. All three render as inert text or lose the handler; none execute. Provider HTML is deliberately not sanitized, and is documented as the extension's responsibility.

## Considered, omitted

- A severity per notice: no producer in scope needs more than one level, and `Domain\Validation\Severity` already exists if that changes.
- Title-keyed rather than pageId-keyed routing: only needed once the Schema, Layout and Mapping editors are covered, and those save by title.

<sub>AI-authored — Claude Code, `Opus 5 1M (xhigh)`; design steered by @alistair3149 across several rounds, including two reversals of the approach; full diff not yet human-reviewed; PHP and TypeScript suites, phpcs, phpstan and lint green, endpoint and rendering verified in a browser.</sub>
