### PR TITLE
Give StringValue a canonical form without empty parts

### DIFF
--- a/src/Application/SelectStatementResolver.php
+++ b/src/Application/SelectStatementResolver.php
@@ -96,6 +96,13 @@ readonly class SelectStatementResolver {
 	}
 
 	private function resolveSingle( string $propertyName, SelectProperty $property, mixed $value ): string {
+		// An empty value is a cleared field, not a reference to an option. Left in place for
+		// StatementListBuilder to drop, the way the validate paths already treat it, rather than
+		// answering 400 to a caller clearing a select.
+		if ( is_string( $value ) && trim( $value ) === '' ) {
+			return $value;
+		}
+
 		if ( !is_string( $value ) && !is_array( $value ) ) {
 			throw new InvalidArgumentException(
 				"Select value for \"{$propertyName}\" must be a string or object"

--- a/src/Domain/Value/StringValue.php
+++ b/src/Domain/Value/StringValue.php
@@ -11,10 +11,6 @@ readonly class StringValue implements NeoValue {
 	 */
 	public array $strings;
 
-	/**
-	 * Canonical form: a part without content does not exist, and a part with content is stored as
-	 * it was written.
-	 */
 	public function __construct( string ...$strings ) {
 		$this->strings = array_values(
 			array_filter( $strings, static fn ( string $part ): bool => trim( $part ) !== '' )

--- a/src/Domain/Value/StringValue.php
+++ b/src/Domain/Value/StringValue.php
@@ -11,8 +11,14 @@ readonly class StringValue implements NeoValue {
 	 */
 	public array $strings;
 
+	/**
+	 * Canonical form: a part without content does not exist, and a part with content is stored as
+	 * it was written.
+	 */
 	public function __construct( string ...$strings ) {
-		$this->strings = $strings;
+		$this->strings = array_values(
+			array_filter( $strings, static fn ( string $part ): bool => trim( $part ) !== '' )
+		);
 	}
 
 	public function getType(): ValueType {

--- a/tests/phpunit/Application/Actions/ReplaceSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/ReplaceSubjectActionTest.php
@@ -180,6 +180,152 @@ class ReplaceSubjectActionTest extends TestCase {
 		$this->assertNull( $persisted->getStatements()->getStatement( new PropertyName( 'Keep' ) ) );
 	}
 
+	public function testEmptyStringValueDeletesTheStatement(): void {
+		$subject = TestSubject::build( id: new SubjectId( self::SUBJECT_ID ) );
+		$this->subjectRepository->updateSubject( $subject );
+
+		$action = $this->newAction();
+		$action->replace(
+			new SubjectId( self::SUBJECT_ID ),
+			'Label',
+			[ 'Website' => [ 'propertyType' => 'url', 'value' => 'https://example.com' ] ],
+			null
+		);
+
+		$action->replace(
+			new SubjectId( self::SUBJECT_ID ),
+			'Label',
+			[ 'Website' => [ 'propertyType' => 'url', 'value' => '' ] ],
+			null
+		);
+
+		$persisted = $this->subjectRepository->getSubject( new SubjectId( self::SUBJECT_ID ) );
+
+		$this->assertNull( $persisted->getStatements()->getStatement( new PropertyName( 'Website' ) ) );
+	}
+
+	public function testEmptySelectValueDeletesTheStatement(): void {
+		$this->registerSchemaWithSelect();
+		$this->subjectRepository->updateSubject( TestSubject::build(
+			id: new SubjectId( self::SUBJECT_ID ),
+			schemaName: new SchemaName( self::SCHEMA_NAME ),
+		) );
+
+		$action = $this->newAction();
+		$action->replace(
+			new SubjectId( self::SUBJECT_ID ),
+			'Label',
+			[ 'Status' => [ 'propertyType' => 'select', 'value' => 'Approved' ] ],
+			null
+		);
+
+		$action->replace(
+			new SubjectId( self::SUBJECT_ID ),
+			'Label',
+			[ 'Status' => [ 'propertyType' => 'select', 'value' => '' ] ],
+			null
+		);
+
+		$persisted = $this->subjectRepository->getSubject( new SubjectId( self::SUBJECT_ID ) );
+
+		$this->assertNull( $persisted->getStatements()->getStatement( new PropertyName( 'Status' ) ) );
+	}
+
+	/**
+	 * Both sides of the violation diff drop empty parts, so a request that echoes one back leaves
+	 * the violations of the parts around it on the same part index. A violation that moved would
+	 * read as new, and enforcement blocks new blocking violations.
+	 */
+	public function testEchoingBackAnEmptyPartIsNotBlocked(): void {
+		$this->registerSchemaWithMultiValueWebsite();
+		$this->subjectRepository->updateSubject( TestSubject::build(
+			id: new SubjectId( self::SUBJECT_ID ),
+			schemaName: new SchemaName( self::SCHEMA_NAME ),
+			statements: new StatementList( [
+				TestStatement::build(
+					property: 'Website',
+					value: new StringValue( '', 'not a url' ),
+					propertyType: 'url'
+				),
+			] ),
+		) );
+
+		$this->newAction( validationEnforced: true )->replace(
+			new SubjectId( self::SUBJECT_ID ),
+			'Label',
+			[ 'Website' => [ 'propertyType' => 'url', 'value' => [ '', 'not a url' ] ] ],
+			null
+		);
+
+		$this->assertFalse( $this->presenterSpy->validationFailed );
+		$this->assertSame(
+			[ 'not a url' ],
+			$this->subjectRepository
+				->getSubject( new SubjectId( self::SUBJECT_ID ) )
+				->getStatements()
+				->getStatement( new PropertyName( 'Website' ) )
+				?->getValue()
+				->toScalars()
+		);
+	}
+
+	/**
+	 * The Statement the write drops carries the same `required` violation the Subject-level check
+	 * raises once it is gone, so clearing a required property is not a new violation either.
+	 */
+	public function testClearingARequiredPropertyIsNotBlocked(): void {
+		$this->registerSchemaWithRequiredWebsite();
+		$this->subjectRepository->updateSubject( TestSubject::build(
+			id: new SubjectId( self::SUBJECT_ID ),
+			schemaName: new SchemaName( self::SCHEMA_NAME ),
+			statements: new StatementList( [
+				TestStatement::build( property: 'Website', value: new StringValue( '' ), propertyType: 'url' ),
+			] ),
+		) );
+
+		$this->newAction( validationEnforced: true )->replace(
+			new SubjectId( self::SUBJECT_ID ),
+			'Label',
+			[ 'Website' => [ 'propertyType' => 'url', 'value' => '' ] ],
+			null
+		);
+
+		$this->assertFalse( $this->presenterSpy->validationFailed );
+		$this->assertNull(
+			$this->subjectRepository
+				->getSubject( new SubjectId( self::SUBJECT_ID ) )
+				->getStatements()
+				->getStatement( new PropertyName( 'Website' ) )
+		);
+	}
+
+	private function registerSchemaWithMultiValueWebsite(): void {
+		$this->registerSchemaWithWebsite( required: false, multiple: true );
+	}
+
+	private function registerSchemaWithRequiredWebsite(): void {
+		$this->registerSchemaWithWebsite( required: true, multiple: false );
+	}
+
+	private function registerSchemaWithWebsite( bool $required, bool $multiple ): void {
+		$this->schemaLookup->updateSchema( new Schema(
+			name: new SchemaName( self::SCHEMA_NAME ),
+			description: '',
+			properties: new PropertyDefinitions( [
+				'Website' => new UrlProperty(
+					core: new PropertyCore(
+						description: '',
+						required: $required,
+						default: null,
+						constraintSeverities: [ 'required' => Severity::Error ]
+					),
+					multiple: $multiple,
+					uniqueItems: false,
+				),
+			] )
+		) );
+	}
+
 	public function testCommentIsForwarded(): void {
 		$subject = TestSubject::build( id: new SubjectId( self::SUBJECT_ID ) );
 		$this->subjectRepository->updateSubject( $subject );

--- a/tests/phpunit/Application/SelectStatementResolverTest.php
+++ b/tests/phpunit/Application/SelectStatementResolverTest.php
@@ -166,6 +166,39 @@ class SelectStatementResolverTest extends TestCase {
 		$this->assertSame( 'Nonexistent', $resolved['Status']['value'] );
 	}
 
+	public function testLeavesEmptyValueInPlace(): void {
+		$patch = [
+			'Status' => [ 'propertyType' => 'select', 'value' => '' ],
+		];
+
+		$resolved = $this->newResolver()->resolve( $this->newSchemaWithSelect(), $patch );
+
+		$this->assertSame( $patch, $resolved );
+	}
+
+	public function testLeavesWhitespaceOnlyValueInPlace(): void {
+		$patch = [
+			'Status' => [ 'propertyType' => 'select', 'value' => ' ' ],
+		];
+
+		$resolved = $this->newResolver()->resolve( $this->newSchemaWithSelect(), $patch );
+
+		$this->assertSame( $patch, $resolved );
+	}
+
+	public function testResolvesListContainingAnEmptyValue(): void {
+		$patch = [
+			'Status' => [
+				'propertyType' => 'select',
+				'value' => [ '', 'Approved' ],
+			],
+		];
+
+		$resolved = $this->newResolver()->resolve( $this->newSchemaWithSelect( multiple: true ), $patch );
+
+		$this->assertSame( [ '', 'opt2' ], $resolved['Status']['value'] );
+	}
+
 	public function testThrowsOnUnknownValueForKnownSelectProperty(): void {
 		$patch = [
 			'Status' => [ 'propertyType' => 'select', 'value' => 'Nonexistent' ],

--- a/tests/phpunit/Application/StatementListBuilderTest.php
+++ b/tests/phpunit/Application/StatementListBuilderTest.php
@@ -72,12 +72,68 @@ class StatementListBuilderTest extends TestCase {
 		$this->assertNull( $list->getStatement( new PropertyName( 'Dropped' ) ) );
 	}
 
+	public function testScalarEmptyStringIsDropped(): void {
+		$list = $this->newBuilder()->build( [
+			'Kept' => [ 'propertyType' => 'text', 'value' => 'yes' ],
+			'Dropped' => [ 'propertyType' => 'text', 'value' => '' ],
+		] );
+
+		$this->assertNotNull( $list->getStatement( new PropertyName( 'Kept' ) ) );
+		$this->assertNull( $list->getStatement( new PropertyName( 'Dropped' ) ) );
+	}
+
+	public function testListWithOnlyAnEmptyPartIsDropped(): void {
+		$list = $this->newBuilder()->build( [
+			'Dropped' => [ 'propertyType' => 'text', 'value' => [ '' ] ],
+		] );
+
+		$this->assertNull( $list->getStatement( new PropertyName( 'Dropped' ) ) );
+	}
+
+	public function testWhitespaceOnlyPartIsDropped(): void {
+		$list = $this->newBuilder()->build( [
+			'Dropped' => [ 'propertyType' => 'text', 'value' => [ ' ' ] ],
+		] );
+
+		$this->assertNull( $list->getStatement( new PropertyName( 'Dropped' ) ) );
+	}
+
+	public function testStatementWithSomeEmptyPartsKeepsTheOthers(): void {
+		$list = $this->newBuilder()->build( [
+			'Aliases' => [ 'propertyType' => 'text', 'value' => [ 'a', '', ' b ' ] ],
+		] );
+
+		$statement = $list->getStatement( new PropertyName( 'Aliases' ) );
+
+		$this->assertNotNull( $statement );
+		$this->assertSame( [ 'a', ' b ' ], $statement->getValue()->toScalars() );
+	}
+
+	public function testNullValueOfStringTypeIsDropped(): void {
+		$list = $this->newBuilder()->build( [
+			'Dropped' => [ 'propertyType' => 'text', 'value' => null ],
+		] );
+
+		$this->assertNull( $list->getStatement( new PropertyName( 'Dropped' ) ) );
+	}
+
 	public function testUnregisteredTypeStatementIsNotDroppedAsEmpty(): void {
 		$list = $this->newBuilder()->build( [
 			'Swatch' => [ 'propertyType' => 'color', 'value' => [] ],
 		] );
 
 		$this->assertNotNull( $list->getStatement( new PropertyName( 'Swatch' ) ) );
+	}
+
+	public function testUnregisteredTypeKeepsEmptyStringValue(): void {
+		$list = $this->newBuilder()->build( [
+			'Swatch' => [ 'propertyType' => 'color', 'value' => '' ],
+		] );
+
+		$statement = $list->getStatement( new PropertyName( 'Swatch' ) );
+
+		$this->assertNotNull( $statement );
+		$this->assertEquals( new UnregisteredTypeValue( 'color', '' ), $statement->getValue() );
 	}
 
 	public function testNullValueIsDropped(): void {

--- a/tests/phpunit/Domain/PropertyType/Types/TextTypeValidateTest.php
+++ b/tests/phpunit/Domain/PropertyType/Types/TextTypeValidateTest.php
@@ -106,14 +106,14 @@ class TextTypeValidateTest extends TestCase {
 		$this->assertSame( [], $violations );
 	}
 
-	public function testRequiredAndUniqueViolationsBothReturnedWhenBothConditionsTrigger(): void {
+	public function testLengthAndUniqueViolationsBothReturnedWhenBothConditionsTrigger(): void {
 		$violations = $this->type->validate(
-			new StringValue( '', '' ),
-			$this->newProperty( required: true, uniqueItems: true ),
+			new StringValue( 'ab', 'ab' ),
+			$this->newProperty( required: false, uniqueItems: true, minLength: 3 ),
 		);
 
 		$codes = array_map( fn( $v ) => $v->code, $violations );
-		$this->assertContains( 'required', $codes );
+		$this->assertContains( 'min-length', $codes );
 		$this->assertContains( 'unique', $codes );
 	}
 

--- a/tests/phpunit/Domain/Value/StringValueTest.php
+++ b/tests/phpunit/Domain/Value/StringValueTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Domain\Value;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Domain\Value\StringValue
+ */
+class StringValueTest extends TestCase {
+
+	/**
+	 * @dataProvider contentlessPartsProvider
+	 */
+	public function testPartsWithoutContentAreNotStored( StringValue $value ): void {
+		$this->assertSame( [], $value->toScalars() );
+	}
+
+	/**
+	 * @dataProvider contentlessPartsProvider
+	 */
+	public function testValueOfPartsWithoutContentIsEmpty( StringValue $value ): void {
+		$this->assertTrue( $value->isEmpty() );
+	}
+
+	public static function contentlessPartsProvider(): iterable {
+		yield 'empty part' => [ new StringValue( '' ) ];
+		yield 'space' => [ new StringValue( ' ' ) ];
+		yield 'tab and newline' => [ new StringValue( "\t\n " ) ];
+		yield 'several blank parts' => [ new StringValue( '', ' ' ) ];
+	}
+
+	public function testValueWithoutPartsIsEmpty(): void {
+		$this->assertTrue( ( new StringValue() )->isEmpty() );
+	}
+
+	public function testPartsWithContentAreStoredAsWritten(): void {
+		$value = new StringValue( 'a', '', ' b ' );
+
+		$this->assertSame( [ 'a', ' b ' ], $value->toScalars() );
+	}
+
+	public function testValueWithContentIsNotEmpty(): void {
+		$this->assertFalse( ( new StringValue( '', 'a' ) )->isEmpty() );
+	}
+
+	public function testZeroIsContent(): void {
+		$value = new StringValue( '0' );
+
+		$this->assertSame( [ '0' ], $value->toScalars() );
+		$this->assertFalse( $value->isEmpty() );
+	}
+
+}

--- a/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ReplaceSubjectApiTest.php
@@ -278,6 +278,30 @@ class ReplaceSubjectApiTest extends NeoWikiIntegrationTestCase {
 		$this->assertSame( [ 'Founded at' ], array_keys( $subject->getStatements()->asArray() ) );
 	}
 
+	public function testEmptyStringValueClearsTheStatement(): void {
+		$this->createPages();
+
+		$bodyWithTwoStatements = $this->validBody();
+		$bodyWithTwoStatements['statements'] = $this->twoStatements();
+		$this->executeHandler(
+			$this->newReplaceSubjectApi(),
+			$this->createRequestData( $bodyWithTwoStatements )
+		);
+
+		$bodyClearingOne = $this->validBody();
+		$bodyClearingOne['statements'] = [
+			'Founded at' => [ 'propertyType' => 'number', 'value' => 2019 ],
+			'Website' => [ 'propertyType' => 'url', 'value' => '' ],
+		];
+		$this->executeHandler(
+			$this->newReplaceSubjectApi(),
+			$this->createRequestData( $bodyClearingOne )
+		);
+
+		$subject = $this->getSubjectFromRepository( 'sTestSA11111111' );
+		$this->assertSame( [ 'Founded at' ], array_keys( $subject->getStatements()->asArray() ) );
+	}
+
 	public function testEmptyStatementsMapClearsAll(): void {
 		$this->createPages();
 

--- a/tests/phpunit/Persistence/MediaWiki/Subject/StatementDeserializerTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/Subject/StatementDeserializerTest.php
@@ -82,6 +82,18 @@ class StatementDeserializerTest extends TestCase {
 		);
 	}
 
+	public function testDropsStoredPartsWithoutContent(): void {
+		$statement = $this->newDeserializer()->deserialize(
+			'MyText',
+			[
+				'propertyType' => 'text',
+				'value' => [ '', 'Foo' ],
+			]
+		);
+
+		$this->assertSame( [ 'Foo' ], $statement->getValue()->toScalars() );
+	}
+
 	public function testDeserializesRelation(): void {
 		$this->assertEquals(
 			new Statement(


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/1209

`docs/api/subject-format.md` promises that a Statement whose value is empty for its type is dropped without error.
A JSON `""` (or `[""]`, `[" "]`) instead became `StringValue([''])` and reached validation and persistence, storing
a junk empty part in the revision slot and the graph projections.

`StringValue` now has a canonical form: its constructor drops parts that trim to empty, and parts with content are
stored as written — an "empty but has parts" state can no longer exist. A value built from `""` has no parts, so
the builder's existing emptiness gate drops the Statement on every endpoint that takes `statements`.

The canonicalization applies wherever the value is constructed — the request path and the stored-slot path alike —
so the two sides of the violation diff see the same part positions: a pre-existing violation on stored data cannot
newly block a write under enforcement (regression test: a stored `['', 'not a url']` echoed back with enforcement
on). Validators never see empty parts, from requests or from storage.

Two further behavior changes:

* `SelectStatementResolver` treated `""` as an unknown option and answered 400 while the validate endpoints left it
  in place, so the dry run said clean and the save failed. Clearing a select with `""` now behaves like every other
  string type; writes that previously answered 400 succeed.
* Values stored with empty or whitespace-only parts read back without them: they stop rendering in the
  parser-function and Lua read paths, REST reads return the canonical parts, and the next write persists them.

Out of scope: empty number, boolean and relation values still answer 500
(https://github.com/ProfessionalWiki/NeoWiki/issues/1291), and parts with content are never trimmed.
https://github.com/ProfessionalWiki/NeoWiki/issues/1208 narrows to its padded-value point — the empty-part state
it describes is no longer representable. Docs are unchanged: for string values the documented sentence now holds
as written.

> <sub>AI-authored — Claude Code, `Opus 5 (max)`; open question + go-ahead from @JeroenDeDauw, design redirected once by him mid-review; diff not yet human-reviewed; new tests mutation-tested, full PHPUnit and phpcs/phpstan green locally, CI green.</sub>

<details><summary>Production notes</summary>

Design by `Fable 5 (max)` and @JeroenDeDauw; implementation by `Opus 5 (max)` subagents. An independent AI review
pass verified behavior live over REST mid-development.

</details>