### PR TITLE
Stub the schema-picker store method the picker actually calls

### DIFF
--- a/resources/ext.neowiki/tests/components/common/SchemaPicker.spec.ts
+++ b/resources/ext.neowiki/tests/components/common/SchemaPicker.spec.ts
@@ -326,7 +326,7 @@ describe( 'SchemaPicker', () => {
 		// network: the field must end up focused with its list open regardless.
 		it( 'lists every schema straight away when focused, without waiting for a second focus', async () => {
 			let deliverSchemas: ( summaries: typeof SUMMARIES ) => void = () => undefined;
-			schemaStore.getAllSchemaSummaries = vi.fn().mockReturnValue(
+			schemaStore.fetchAllSchemaSummaries = vi.fn().mockReturnValue(
 				new Promise( ( resolve ) => {
 					deliverSchemas = resolve;
 				} ),


### PR DESCRIPTION
The schema-picker focus test stubbed `getAllSchemaSummaries`, which #1215 renamed to
`fetchAllSchemaSummaries`. Assigning to a name the store no longer has fails `vue-tsc`, so the
TypeScript Build job is red on master since #1174, and on every pull request built against it.

The stub was also inert: the picker kept using the immediately-resolving mock from `beforeEach`,
so the test passed without ever exercising the case it describes — schemas arriving only after
`focus()` was called. With the name corrected it fails when `focus()` no longer waits for them.

<sub>AI-authored — Claude Code, `Opus 5 (xhigh)`; one-line ask from @alistair3149 to look into a CI failure, no redirection; diff not yet human-reviewed; verified locally in a dev-stack worktree — `npm run build` clean, vitest 1246/1246, eslint and stylelint clean, and the corrected test confirmed failing against a mutated `SchemaPicker.focus()` that drops its `await schemasReady`.</sub>