### PR TITLE
Add code-facing naming conventions doc

### DIFF
--- a/docs/naming.md
+++ b/docs/naming.md
@@ -1,0 +1,52 @@
+---
+title: Naming Conventions
+order: 3
+---
+# Naming Conventions
+
+Code-facing naming rules for NeoWiki development. Domain vocabulary is defined in the [Glossary](glossary.md);
+this page covers names that never reach users.
+
+## Data access and selection
+
+- `<X>Lookup` — a read-only data-access interface (e.g. `SubjectLookup`).
+- `<X>Repository` — a read-write data-access interface (e.g. `SubjectRepository`).
+- `<X>Picker` — a UI component for selecting an existing X (e.g. `SchemaPicker`).
+
+A UI component never shares its name with a data-access interface.
+
+## "Store"
+
+Always qualify which store is meant:
+
+- **Pinia store** — a frontend state store, e.g. `SubjectStore`
+  ([ADR 30](adr/030-frontend-store-registry-semantics.md)).
+- **Graph Store** — a configured projection target ([Glossary](glossary.md)).
+- A concrete technology name ("SPARQL store", "triple store") only when the statement is about that technology.
+
+Bare "store" is ambiguous across these three; write the qualified form in identifiers, docs, and discussion.
+
+## Registry
+
+`<X>Registry` is reserved for extension-point lookup tables (`PropertyTypeRegistry`, `ViewTypeRegistry`).
+Pinia stores follow registry semantics (ADR 30) but are not named `Registry`.
+
+## Vue component suffixes
+
+Components are named noun-first with a role suffix:
+
+- `<X>Display` — renders an X read-only.
+- `<X>Input` — a form control for entering a value.
+- `<X>Editor` — edits an existing X.
+- `<X>Creator` — creates a new X.
+- `<X>Picker` — selects an existing X.
+- `<X>Dialog` — a modal container; combined as `<X><Role>Dialog` (e.g. `SubjectCreatorDialog`).
+
+## Known collisions, unresolved
+
+Do not add new uses of these names until the linked decision lands:
+
+- `RelationType` currently names both the graph edge label and the `relation` Property Type
+  ([#630](https://github.com/ProfessionalWiki/NeoWiki/issues/630)).
+- `Neo4jPlugin` vs `GraphDatabasePlugin`: which concept "Plugin" names is unsettled
+  ([#1001](https://github.com/ProfessionalWiki/NeoWiki/pull/1001)).


### PR DESCRIPTION
Codifies the naming rules that keep implementation names from colliding, separate from the domain vocabulary in the glossary:

* Lookup (read port) vs Repository (read-write port) vs Picker (UI widget) — the rule applied when SchemaLookup.vue became SchemaPicker.vue, now written down.
* The three meanings of "store" (Pinia store, Graph Store, concrete technology) and the requirement to qualify.
* Registry reserved for extension-point lookup tables.
* Vue component role suffixes (Display, Input, Editor, Creator, Picker, Dialog).
* Known unresolved collisions (RelationType, Plugin) flagged so they are not propagated before the linked decisions land.

Part of the ubiquitous-language cleanup deferred in https://github.com/ProfessionalWiki/NeoWiki/pull/1001. A follow-up in NeoWiki-Docker loads this file into agent context alongside the glossary.

> <sub>AI-authored — Claude Code, `Fable 5 (max)`; scope proposed from an in-session glossary audit, package approved by @JeroenDeDauw; diff not yet human-reviewed; rules derived from existing code patterns (SchemaPicker rename, contract files, registry classes) rather than invented, but the suffix taxonomy is a codification the team has not yet ratified.</sub>