### PR TITLE
Tighten naming conventions wording

### DIFF
--- a/docs/naming.md
+++ b/docs/naming.md
@@ -17,14 +17,12 @@ A UI component never shares its name with a data-access interface.
 
 ## "Store"
 
-Always qualify which store is meant:
+Always qualify which store is meant, in identifiers, docs, and discussion:
 
 - **Pinia store** — a frontend state store, e.g. `SubjectStore`
   ([ADR 30](adr/030-frontend-store-registry-semantics.md)).
 - **Graph Store** — a configured projection target ([Glossary](glossary.md)).
-- A concrete technology name ("SPARQL store", "triple store") only when the statement is about that technology.
-
-Bare "store" is ambiguous across these three; write the qualified form in identifiers, docs, and discussion.
+- **Technology name** — "SPARQL store", "triple store", used only when the statement is about that technology.
 
 ## Registry
 
@@ -42,7 +40,7 @@ Components are named noun-first with a role suffix:
 - `<X>Picker` — selects an existing X.
 - `<X>Dialog` — a modal container; combined as `<X><Role>Dialog` (e.g. `SubjectCreatorDialog`).
 
-## Known collisions, unresolved
+## Known unresolved collisions
 
 Do not add new uses of these names until the linked decision lands:
 


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1295, which merged before the text pass ran. Prose only; no rule changes what it permits or forbids.

* The "store" section's closing sentence restated its opening instruction and justified it. Its one piece of new content, the scope (identifiers, docs, discussion), moves into the instruction; the justification goes.
* The third "store" bullet gets the bold lead-in the other two have. `only` is retained, so the restriction is unchanged.
* `## Known collisions, unresolved` becomes `## Known unresolved collisions`, the phrasing #1295's own description uses. Nothing in either repo links to the page or its anchors.

Considered, omitted: `<X>Picker` is defined twice, under "Data access and selection" and again under "Vue component suffixes". Kept, because the first is what makes the Lookup/Picker collision rule below it actionable.

The pass also checked every identifier the page names against the code. Two of its claims did not hold at #1295's merge commit, and both are already answered elsewhere: `SubjectLookup` named both a read port and a Vue selection widget, which #1296 has since renamed; and "Graph Store" is cited as a Glossary term the glossary does not yet define, which #1294 adds. Neither needs a change here.

> <sub>AI-authored — Claude Code, `Opus 5 (max)`; delegated text-review pass on #1295 for @JeroenDeDauw, no redirection; diff not yet human-reviewed; verified the changed rules are meaning-invariant, that no inbound link targets the renamed heading, and checked every identifier the page names against the code.</sub>
