### PR TITLE
Call the subject picker a picker in its message documentation

### DIFF
--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -67,7 +67,7 @@
 	"neowiki-subject-editor-success": "Success notification shown after updating a subject. $1 is the subject label.",
 	"neowiki-subject-editor-error": "Error notification title shown when updating a subject fails. $1 is the subject label.",
 	"neowiki-subject-editor-validation-failed": "Toast title shown when the backend rejects a Subject save under enforcement. $1 is the Subject label.",
-	"neowiki-subject-picker-placeholder": "Placeholder text shown in the subject search input field.",
+	"neowiki-subject-picker-placeholder": "Placeholder text shown in the subject picker input field.",
 	"neowiki-schema-picker-placeholder": "Placeholder text shown in the schema picker input field.",
 	"neowiki-subject-picker-no-results": "Message shown in the subject picker dropdown when no subjects match the search query.",
 	"neowiki-subject-picker-no-match": "Error message shown in the subject picker when the user types text but does not select a subject from the dropdown results.",


### PR DESCRIPTION
One-word qqq fix from the text-review pass over https://github.com/ProfessionalWiki/NeoWiki/pull/1296: the placeholder entry said "subject search input field" while its sibling entries and the schema-picker line say "picker", leaving a translator unsure whether one widget or two are described.

Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1296 — that PR merged while its text review was in flight, so this lands separately.

> <sub>AI-authored — Claude Code, `Opus 5 (max)` text-review pass, delivered as a follow-up by `Fable 5 (max)`; part of a review package requested by @JeroenDeDauw; diff not yet human-reviewed; qqq-only change, sibling entries checked for consistency.</sub>