### PR TITLE
Bypass the browser cache when reading a page's base revision before saving

### DIFF
--- a/resources/ext.neowiki/src/persistence/MediaWikiPageSaver.ts
+++ b/resources/ext.neowiki/src/persistence/MediaWikiPageSaver.ts
@@ -45,9 +45,14 @@ export class MediaWikiPageSaver implements PageSaver {
 		} );
 	}
 
-	private async getPageRevision( pageName: string ): Promise<string | undefined> {
+	/**
+	 * The page's current revision id, or undefined for a page that does not exist yet.
+	 * Cache-Control keeps the browser from answering from its cache, which would make the
+	 * save carry a stale base revision (#1303).
+	 */
+	private async getPageRevision( pageName: string ): Promise<number | undefined> {
 		try {
-			const page = await this.rest.get( `/v1/page/${ pageName }`, {} );
+			const page = await this.rest.get( `/v1/page/${ pageName }`, {}, { 'Cache-Control': 'no-cache' } );
 			return page.latest.id;
 		} catch ( _error ) {
 			return undefined;


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/1302

Saving a Schema or Layout a second time in the same page session failed with a 409 in Firefox: `MediaWikiPageSaver` reads the base revision for `latest.id` with `GET /v1/page/{title}` right before the `PUT`, that response is cacheable (`Cache-Control: max-age=5`, plus a 301 for titles with spaces), and Firefox kept serving it from its HTTP cache after the first save. The lookup now sends `Cache-Control: no-cache`, so the browser revalidates instead of answering from cache; a page that does not exist yet still gets no `latest`, so the update creates it.

Reading the current revision right before writing is the smallest fix, not the last word: the base revision should be the revision the author loaded, so that a 409 means a real concurrent edit — tracked separately.

## Manual Browser Check

1. In Firefox, open a Subject page (e.g. `Validation Clean` on a dev wiki with demo data), click the infobox Edit, then the schema link, change anything and save.
2. Repeat step 1 without reloading the page. Before this change the second save fails with a 409 toast; now it saves.

<sub>AI-authored — Claude Code, Fable 5; diagnosed from the dev stack's Apache access log, then implemented; verified with eslint/stylelint, vue-tsc/vite build, the persistence/SchemaEditor/SchemasPage/stores vitest folders, and two consecutive saves through the subject-editor route on a dev wiki with the header visible on each pre-save GET; no unit test, since the class only forwards calls to `mw.Rest`/`mw.Api` and a spec would assert call arguments against fakes.</sub>
