### PR TITLE
Mark the REST read endpoints as read-only and uncacheable by shared caches

### DIFF
--- a/docs/rdf/rdf-export.md
+++ b/docs/rdf/rdf-export.md
@@ -106,7 +106,8 @@ falling back to the `Accept` header, then to TriG; a value other than `trig` or 
 | `turtle` | `text/turtle` | `text/turtle; charset=utf-8` | no (same triples, no graph wrapper) |
 
 Responses carry `Content-Disposition: inline` with a filename of the page or Subject ID plus the format's
-extension (`42.trig`, `42.ttl`).
+extension (`42.trig`, `42.ttl`). A response that the `Accept` header selected also carries `Vary: Accept`;
+passing `format` fixes the serialization, and those responses do not vary.
 
 Both endpoints and the concept-URI negotiator answer one indistinguishable `404` when the page or Subject does
 not exist, the caller may not read it, or NeoWiki cannot describe it; a malformed Subject ID returns `400`.

--- a/src/EntryPoints/REST/ExportPageRdfApi.php
+++ b/src/EntryPoints/REST/ExportPageRdfApi.php
@@ -25,6 +25,7 @@ use Wikimedia\RequestTimeout\TimeoutException;
 class ExportPageRdfApi extends SimpleHandler {
 
 	use RdfFormatNegotiation;
+	use ReadOnlyEndpoint;
 
 	public function run( int $pageId ): Response {
 		$extension = NeoWikiExtension::getInstance();

--- a/src/EntryPoints/REST/ExportSubjectRdfApi.php
+++ b/src/EntryPoints/REST/ExportSubjectRdfApi.php
@@ -26,6 +26,7 @@ use Wikimedia\ParamValidator\ParamValidator;
 class ExportSubjectRdfApi extends SimpleHandler {
 
 	use RdfFormatNegotiation;
+	use ReadOnlyEndpoint;
 
 	public function run( string $subjectId ): Response {
 		// Validate the ID shape first, so a malformed value is a clean 400 rather than reaching

--- a/src/EntryPoints/REST/GetGraphStoresApi.php
+++ b/src/EntryPoints/REST/GetGraphStoresApi.php
@@ -17,6 +17,7 @@ use ProfessionalWiki\NeoWiki\Presentation\GraphStoreStatusSerializer;
 class GetGraphStoresApi extends SimpleHandler {
 
 	use GraphStoreAdminAccess;
+	use ReadOnlyEndpoint;
 
 	public function run(): Response {
 		$refusal = $this->refuseWithoutTheAdminRight();
@@ -33,10 +34,6 @@ class GetGraphStoresApi extends SimpleHandler {
 				NeoWikiExtension::getInstance()->newGraphStoreStatusLookup()->getStatuses()
 			),
 		] );
-	}
-
-	public function needsWriteAccess(): bool {
-		return false;
 	}
 
 }

--- a/src/EntryPoints/REST/GetLayoutApi.php
+++ b/src/EntryPoints/REST/GetLayoutApi.php
@@ -13,6 +13,8 @@ use Wikimedia\ParamValidator\ParamValidator;
 
 class GetLayoutApi extends SimpleHandler {
 
+	use ReadOnlyEndpoint;
+
 	public function run( string $layoutName ): Response {
 		$presenter = new RestGetLayoutPresenter();
 

--- a/src/EntryPoints/REST/GetLayoutSummariesApi.php
+++ b/src/EntryPoints/REST/GetLayoutSummariesApi.php
@@ -15,6 +15,7 @@ use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 class GetLayoutSummariesApi extends SimpleHandler {
 
 	use CursorPaginationTrait;
+	use ReadOnlyEndpoint;
 
 	public function run(): Response {
 		$params = $this->getValidatedParams();

--- a/src/EntryPoints/REST/GetMappingSummariesApi.php
+++ b/src/EntryPoints/REST/GetMappingSummariesApi.php
@@ -14,6 +14,7 @@ use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 class GetMappingSummariesApi extends SimpleHandler {
 
 	use CursorPaginationTrait;
+	use ReadOnlyEndpoint;
 
 	public function run(): Response {
 		$params = $this->getValidatedParams();

--- a/src/EntryPoints/REST/GetPageSubjectsApi.php
+++ b/src/EntryPoints/REST/GetPageSubjectsApi.php
@@ -12,6 +12,8 @@ use Wikimedia\ParamValidator\ParamValidator;
 
 class GetPageSubjectsApi extends SimpleHandler {
 
+	use ReadOnlyEndpoint;
+
 	private const string EXPAND_SCHEMAS = 'schemas';
 	private const string EXPAND_RELATIONS = 'relations';
 

--- a/src/EntryPoints/REST/GetSchemaApi.php
+++ b/src/EntryPoints/REST/GetSchemaApi.php
@@ -13,6 +13,8 @@ use Wikimedia\ParamValidator\ParamValidator;
 
 class GetSchemaApi extends SimpleHandler {
 
+	use ReadOnlyEndpoint;
+
 	public function run( string $schemaName ): Response {
 		$presenter = new RestGetSchemaPresenter();
 

--- a/src/EntryPoints/REST/GetSchemaNamesApi.php
+++ b/src/EntryPoints/REST/GetSchemaNamesApi.php
@@ -13,6 +13,8 @@ use Wikimedia\ParamValidator\ParamValidator;
 
 class GetSchemaNamesApi extends SimpleHandler {
 
+	use ReadOnlyEndpoint;
+
 	public function run( string $search ): Response {
 		$schemaNames = array_map(
 			function ( TitleValue $title ): string {

--- a/src/EntryPoints/REST/GetSchemaSummariesApi.php
+++ b/src/EntryPoints/REST/GetSchemaSummariesApi.php
@@ -15,6 +15,7 @@ use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 class GetSchemaSummariesApi extends SimpleHandler {
 
 	use CursorPaginationTrait;
+	use ReadOnlyEndpoint;
 
 	public function run(): Response {
 		$params = $this->getValidatedParams();

--- a/src/EntryPoints/REST/GetSubjectApi.php
+++ b/src/EntryPoints/REST/GetSubjectApi.php
@@ -16,6 +16,8 @@ use Wikimedia\ParamValidator\ParamValidator;
 
 class GetSubjectApi extends SimpleHandler {
 
+	use ReadOnlyEndpoint;
+
 	private const string EXPAND_PAGE = 'page';
 	private const string EXPAND_RELATIONS = 'relations';
 

--- a/src/EntryPoints/REST/GetSubjectEditNoticesApi.php
+++ b/src/EntryPoints/REST/GetSubjectEditNoticesApi.php
@@ -5,12 +5,15 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\EntryPoints\REST;
 
 use MediaWiki\Rest\Response;
+use MediaWiki\Rest\ResponseInterface;
 use MediaWiki\Rest\SimpleHandler;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Presentation\RestGetSubjectEditNoticesPresenter;
 use Wikimedia\ParamValidator\ParamValidator;
 
 class GetSubjectEditNoticesApi extends SimpleHandler {
+
+	use ReadOnlyEndpoint;
 
 	public function run( int $pageId ): Response {
 		$presenter = new RestGetSubjectEditNoticesPresenter();
@@ -20,16 +23,18 @@ class GetSubjectEditNoticesApi extends SimpleHandler {
 			schemaName: $this->getValidatedParams()['schema'],
 		);
 
-		$response = $this->getResponseFactory()->createJson( $presenter->getJsonArray() );
-
-		// Notices depend on the viewer and on state that changes without an edit, such as approval.
-		$response->setHeader( 'Cache-Control', 'private, no-store' );
-
-		return $response;
+		return $this->getResponseFactory()->createJson( $presenter->getJsonArray() );
 	}
 
-	public function needsWriteAccess(): bool {
-		return false;
+	/**
+	 * Notices depend on the viewer and on state that changes without an edit, such as approval, so
+	 * they may not be stored at all. Doing this in run() would not hold: core overwrites the header
+	 * afterwards whenever the session is persistent.
+	 */
+	public function applyCacheControl( ResponseInterface $response ): void {
+		parent::applyCacheControl( $response );
+
+		$response->setHeader( 'Cache-Control', 'private,no-store' );
 	}
 
 	public function getParamSettings(): array {

--- a/src/EntryPoints/REST/GetSubjectLabelsApi.php
+++ b/src/EntryPoints/REST/GetSubjectLabelsApi.php
@@ -14,6 +14,8 @@ use Wikimedia\ParamValidator\TypeDef\IntegerDef;
 
 class GetSubjectLabelsApi extends SimpleHandler {
 
+	use ReadOnlyEndpoint;
+
 	public function run(): Response {
 		$params = $this->getValidatedParams();
 

--- a/src/EntryPoints/REST/RdfFormatNegotiation.php
+++ b/src/EntryPoints/REST/RdfFormatNegotiation.php
@@ -46,6 +46,16 @@ trait RdfFormatNegotiation {
 		return $this->formatFromAcceptHeader();
 	}
 
+	/**
+	 * Always declaring `Vary: Accept` would split a fixed-format URL's cache entries across every
+	 * `Accept` value clients happen to send.
+	 */
+	private function formatCameFromAcceptHeader(): bool {
+		$requested = $this->getValidatedParams()['format'] ?? null;
+
+		return $requested !== self::FORMAT_TURTLE && $requested !== self::FORMAT_TRIG;
+	}
+
 	private function formatFromAcceptHeader(): RdfFormat {
 		$accept = $this->getRequest()->getHeaderLine( 'Accept' );
 
@@ -67,6 +77,9 @@ trait RdfFormatNegotiation {
 			'Content-Disposition',
 			'inline; filename="' . $filenameStem . '.' . $this->fileExtension( $format ) . '"'
 		);
+		if ( $this->formatCameFromAcceptHeader() ) {
+			$response->addHeader( 'Vary', 'Accept' );
+		}
 		$response->setBody( new StringStream( $document ) );
 
 		return $response;

--- a/src/EntryPoints/REST/ReadOnlyEndpoint.php
+++ b/src/EntryPoints/REST/ReadOnlyEndpoint.php
@@ -1,0 +1,43 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\EntryPoints\REST;
+
+use MediaWiki\Rest\ResponseInterface;
+
+/**
+ * Marks a REST endpoint as read-only: it needs no write access, and its response must not be stored
+ * by a shared cache.
+ *
+ * What these endpoints return depends on what the caller may read (#1046), and MediaWiki's REST layer
+ * sends no `Vary: Cookie`, so a shared cache keying on the URL alone may serve one caller's response
+ * to another. {@see \MediaWiki\Rest\Handler::applyCacheControl} closes that only for a persistent
+ * session; a cookieless anonymous GET gets no header at all, so the fallback below repeats core's
+ * string for it. The price is that anonymous RDF exports stop being CDN-cacheable.
+ *
+ * Core applies this only to what `execute()` returns: a 403 from the basic authorizer, a 304 from
+ * `checkPreconditions()`, and any thrown error escape it. `must-revalidate` stays inert until a
+ * handler offers an `ETag` or `Last-Modified` (#1212).
+ *
+ * Declaring write access instead would make {@see \MediaWiki\Rest\CorsUtils::authorize} reject
+ * anonymous cross-origin requests from unlisted origins.
+ *
+ * Used only by {@see \MediaWiki\Rest\Handler} subclasses, whose applyCacheControl() it extends; a
+ * handler needing something stricter overrides it, as {@see GetSubjectEditNoticesApi} does.
+ */
+trait ReadOnlyEndpoint {
+
+	public function needsWriteAccess(): bool {
+		return false;
+	}
+
+	public function applyCacheControl( ResponseInterface $response ): void {
+		parent::applyCacheControl( $response );
+
+		if ( $response->getHeaderLine( 'Cache-Control' ) === '' ) {
+			$response->setHeader( 'Cache-Control', 'private,must-revalidate,s-maxage=0' );
+		}
+	}
+
+}

--- a/src/EntryPoints/REST/ResolveSubjectIriApi.php
+++ b/src/EntryPoints/REST/ResolveSubjectIriApi.php
@@ -35,6 +35,8 @@ use Wikimedia\ParamValidator\ParamValidator;
  */
 class ResolveSubjectIriApi extends SimpleHandler {
 
+	use ReadOnlyEndpoint;
+
 	public function run( string $subjectId ): Response {
 		if ( !SubjectId::isValid( $subjectId ) ) {
 			return $this->getResponseFactory()->createHttpError( 400, [
@@ -53,7 +55,7 @@ class ResolveSubjectIriApi extends SimpleHandler {
 		$rdfFormat = $this->negotiatedRdfFormat();
 
 		if ( $rdfFormat !== null ) {
-			return $this->getResponseFactory()->createSeeOther( $this->subjectRdfUrl( $subjectId, $rdfFormat ) );
+			return $this->negotiatedRedirect( $this->subjectRdfUrl( $subjectId, $rdfFormat ) );
 		}
 
 		return $this->hostingPageRedirect( $subjectId, $hostingPage );
@@ -95,7 +97,18 @@ class ResolveSubjectIriApi extends SimpleHandler {
 			return $this->noDataResponse( $subjectId );
 		}
 
-		return $this->getResponseFactory()->createSeeOther( $this->hostingPageUrl( $title, $subjectId ) );
+		return $this->negotiatedRedirect( $this->hostingPageUrl( $title, $subjectId ) );
+	}
+
+	/**
+	 * Where a redirect points is chosen from the `Accept` header, so a cache must key on it. The 400
+	 * and 404 replies are the same for every representation and carry no Vary.
+	 */
+	private function negotiatedRedirect( string $url ): Response {
+		$response = $this->getResponseFactory()->createSeeOther( $url );
+		$response->addHeader( 'Vary', 'Accept' );
+
+		return $response;
 	}
 
 	private function hostingPageUrl( Title $title, string $subjectId ): string {

--- a/tests/phpunit/EntryPoints/REST/ExportPageRdfApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ExportPageRdfApiTest.php
@@ -81,6 +81,14 @@ JSON
 		);
 	}
 
+	public function testExportVariesOnAcceptWhenTheHeaderPicksTheSerialization(): void {
+		$this->assertSame( 'Accept', $this->export()->getHeaderLine( 'Vary' ) );
+	}
+
+	public function testExportDoesNotVaryWhenTheFormatParameterFixesTheSerialization(): void {
+		$this->assertSame( '', $this->export( [ 'format' => 'turtle' ] )->getHeaderLine( 'Vary' ) );
+	}
+
 	public function testDefaultsToTriGWithTheNativeProjectionsPageNamedGraph(): void {
 		$response = $this->export();
 		$body = $response->getBody()->getContents();

--- a/tests/phpunit/EntryPoints/REST/ExportSubjectRdfApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ExportSubjectRdfApiTest.php
@@ -91,6 +91,14 @@ JSON
 		);
 	}
 
+	public function testExportVariesOnAcceptWhenTheHeaderPicksTheSerialization(): void {
+		$this->assertSame( 'Accept', $this->export()->getHeaderLine( 'Vary' ) );
+	}
+
+	public function testExportDoesNotVaryWhenTheFormatParameterFixesTheSerialization(): void {
+		$this->assertSame( '', $this->export( [ 'format' => 'turtle' ] )->getHeaderLine( 'Vary' ) );
+	}
+
 	public function testDefaultsToTriGWithTheHostingPagesNamedGraph(): void {
 		$response = $this->export();
 		$body = $response->getBody()->getContents();

--- a/tests/phpunit/EntryPoints/REST/GetSubjectEditNoticesApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/GetSubjectEditNoticesApiTest.php
@@ -58,6 +58,24 @@ class GetSubjectEditNoticesApiTest extends NeoWikiIntegrationTestCase {
 		return array_column( $body['notices'], 'key' );
 	}
 
+	/**
+	 * The default HandlerTestTrait session is persistent, which is the case MediaWiki overwrites.
+	 */
+	public function testNoticesAreNeverStored(): void {
+		$handler = new GetSubjectEditNoticesApi();
+
+		$response = $this->executeHandler(
+			$handler,
+			new RequestData( [
+				'method' => 'GET',
+				'pathParams' => [ 'pageId' => (string)$this->createPage( 'GetSubjectEditNoticesApiTest_Uncached' ) ],
+			] )
+		);
+		$handler->applyCacheControl( $response );
+
+		$this->assertSame( 'private,no-store', $response->getHeaderLine( 'Cache-Control' ) );
+	}
+
 	public function testPageWithoutNoticesYieldsAnEmptyList(): void {
 		$pageId = $this->createPage( 'GetSubjectEditNoticesApiTest_Plain' );
 

--- a/tests/phpunit/EntryPoints/REST/ReadOnlyEndpointTest.php
+++ b/tests/phpunit/EntryPoints/REST/ReadOnlyEndpointTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\REST;
+
+use MediaWiki\Rest\RequestData;
+use MediaWiki\Session\Session;
+use MediaWiki\Session\SessionId;
+use MediaWiki\Session\SessionProviderInterface;
+use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+
+/**
+ * Every registered GET route must behave as a read endpoint. Driven off the route registrations so a
+ * route added later cannot quietly opt out.
+ *
+ * Most tests use a non-persistent session: core overwrites the header for a persistent one, so the
+ * cookieless anonymous case is the only one where NeoWiki's own value survives.
+ *
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\REST\ReadOnlyEndpoint
+ */
+class ReadOnlyEndpointTest extends NeoWikiIntegrationTestCase {
+	use HandlerTestTrait;
+
+	/**
+	 * @dataProvider readRouteProvider
+	 */
+	public function testReadResponsesAreNotStorableBySharedCaches( string $path, string $factory ): void {
+		$cacheControl = $this->cacheControlOf( $factory, $this->anonymousSession() );
+
+		$this->assertTrue(
+			str_contains( $cacheControl, 'private' ) || str_contains( $cacheControl, 'no-store' ),
+			"GET $path must keep its response out of shared caches: the body depends on the "
+				. "requester's read rights. Cache-Control was '$cacheControl'."
+		);
+	}
+
+	/**
+	 * @dataProvider readRouteProvider
+	 */
+	public function testReadEndpointsDoNotDeclareWriteAccess( string $path, string $factory ): void {
+		$this->assertFalse(
+			$factory()->needsWriteAccess(),
+			"GET $path declares write access, which makes CorsUtils reject anonymous cross-origin reads\n"
+				. 'from unlisted origins.'
+		);
+	}
+
+	public function testAnonymousAndLoggedInCallersGetTheSameValue(): void {
+		$factory = $this->firstReadRouteFactory();
+
+		$anonymous = $this->cacheControlOf( $factory, $this->anonymousSession() );
+
+		$this->assertSame( 'private,must-revalidate,s-maxage=0', $anonymous );
+		$this->assertSame( $anonymous, $this->cacheControlOf( $factory, $this->getSession( true ) ) );
+	}
+
+	private function cacheControlOf( string $factory, Session $session ): string {
+		$handler = $factory();
+
+		$this->initHandler( $handler, new RequestData( [ 'method' => 'GET' ] ), session: $session );
+
+		$response = $handler->getResponseFactory()->create();
+		$handler->applyCacheControl( $response );
+
+		return $response->getHeaderLine( 'Cache-Control' );
+	}
+
+	private function firstReadRouteFactory(): string {
+		foreach ( self::readRouteProvider() as [ $path, $factory ] ) {
+			return $factory;
+		}
+
+		$this->fail( 'No GET routes are registered.' );
+	}
+
+	/**
+	 * Forked from MediaWiki's SessionHelperTestTrait::getSession(), which hardcodes isPersistent()
+	 * to true and so cannot express the anonymous case.
+	 */
+	private function anonymousSession(): Session {
+		$provider = $this->createMock( SessionProviderInterface::class );
+		$provider->method( 'safeAgainstCsrf' )->willReturn( true );
+
+		$session = $this->createMock( Session::class );
+		$session->method( 'getSessionId' )->willReturn( new SessionId( 'test' ) );
+		$session->method( 'getProvider' )->willReturn( $provider );
+		$session->method( 'isPersistent' )->willReturn( false );
+
+		return $session;
+	}
+
+	/**
+	 * @return iterable<string, array{string, string}> route path and handler factory, per GET route.
+	 */
+	public static function readRouteProvider(): iterable {
+		foreach ( self::registeredRoutes() as $route ) {
+			// Mirrors ExtraRoutesModule: an absent method means GET, and a bare string is one method.
+			$methods = isset( $route['method'] ) ? (array)$route['method'] : [ 'GET' ];
+
+			if ( in_array( 'GET', $methods, true ) ) {
+				yield $route['path'] => [ $route['path'], '\\' . $route['factory'] ];
+			}
+		}
+	}
+
+	/**
+	 * Routes come from two places: extension.json, and the per-plugin files the graph plugins add to
+	 * $wgRestAPIAdditionalRouteFiles when their store is configured.
+	 *
+	 * @return iterable<array<string, mixed>>
+	 */
+	private static function registeredRoutes(): iterable {
+		$extensionRoot = __DIR__ . '/../../../../';
+
+		yield from self::readJson( $extensionRoot . 'extension.json' )['RestRoutes'];
+
+		foreach ( glob( $extensionRoot . 'src/GraphDatabasePlugins/*/EntryPoints/REST/*Routes.json' ) as $file ) {
+			yield from self::readJson( $file );
+		}
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	private static function readJson( string $path ): array {
+		return json_decode( (string)file_get_contents( $path ), true );
+	}
+
+}

--- a/tests/phpunit/EntryPoints/REST/ResolveSubjectIriApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ResolveSubjectIriApiTest.php
@@ -146,6 +146,11 @@ class ResolveSubjectIriApiTest extends NeoWikiIntegrationTestCase {
 		$this->assertSubjectRdfLocation( $response, 'trig' );
 	}
 
+	public function testNegotiatedRedirectsVaryOnAccept(): void {
+		$this->assertSame( 'Accept', $this->deref( [ 'Accept' => 'application/trig' ] )->getHeaderLine( 'Vary' ) );
+		$this->assertSame( 'Accept', $this->deref( [ 'Accept' => 'text/html' ] )->getHeaderLine( 'Vary' ) );
+	}
+
 	public function testReturns404ForAnUnknownSubject(): void {
 		$response = $this->deref( subjectId: self::ABSENT_ID );
 


### PR DESCRIPTION

For https://github.com/ProfessionalWiki/NeoWiki/issues/1212

What a read endpoint returns depends on what the requester may read (#1046), so none of
those responses may be stored by a shared cache. `Handler::applyCacheControl` closes that
only for a persistent session — a logged-in reader, or an anonymous one carrying session
cookies — and sets no `Cache-Control` at all for a cookieless anonymous GET, while its REST
layer never sends
`Vary: Cookie`. An intermediary may therefore store a permission-dependent body keyed on the
URL alone. The new `ReadOnlyEndpoint` trait fills the gap with the value MediaWiki itself
uses, so both cases get identical semantics.

The same overwrite silently defeated the edit-notices endpoint. It set `no-store` in `run()`
because notices depend on the viewer and on state that changes without an edit, such as
approval; MediaWiki replaced that with `must-revalidate` for exactly the logged-in readers it
was protecting. Setting the header from `applyCacheControl()` instead makes it hold.

The read handlers also inherited `needsWriteAccess(): true` from `Handler`. That check is
inert for read-only mode, but `CorsUtils::authorize` uses it to reject cross-origin requests
from anonymous users on origins outside `$wgCrossSiteAJAXdomains`, so an anonymous third-party
browser client could not read Schemas or Subjects. The trait declares the truth; genuine write endpoints stay
rejected.

Finally, the RDF exporters and the concept-URI resolver pick what to return from the `Accept`
header and sent no `Vary`, so a cache could answer one representation with another. They now
send `Vary: Accept` when the header actually chose; supplying `format` fixes the
serialization, so those responses do not vary and their cache entries stay unsplit. The 400
and 404 replies do not vary either, keeping the #1046 indistinguishability. `docs/rdf/rdf-export.md`
records that rule beside the `format`-and-`Accept` table it belongs to.

This adds no `ETag` or `Last-Modified`, so it does not make anything cacheable that was not
before, and it is not the fix for #1212 — that issue is about the missing validators, and its
premise that the endpoints need a `Cache-Control` directive turned out to be already provided
wherever the session is persistent. #1212 has been rescoped accordingly.

One consequence worth naming: the RDF exports become non-shared-cacheable for anonymous
callers too, where before they carried no directive and a CDN could hold them. Those exports
are read-gated per page, so a wiki wanting them on a CDN should opt in deliberately rather
than inherit it from a missing header.

## How to verify

The change is invisible in the UI; it shows up in response headers.

```sh
curl -sD- -o/dev/null "$WIKI/rest.php/neowiki/v0/schemas?limit=2"      | grep -i cache-control
curl -sD- -o/dev/null "$WIKI/rest.php/neowiki/v0/page/1/editNotices"   | grep -i cache-control
curl -sD- -o/dev/null -H 'Accept: text/turtle' "$WIKI/rest.php/neowiki/v0/page/1/rdf" | grep -i vary
curl -sD- -o/dev/null "$WIKI/rest.php/neowiki/v0/page/1/rdf?format=turtle"            | grep -i vary
```

Expect `private,must-revalidate,s-maxage=0`, `private,no-store`, `Vary: Accept`, and no
`Vary: Accept` respectively — the last three unchanged whether or not you are logged in.

Considered, omitted: an `ETag` on the single-page endpoints. It has to fold the live read
decision in to avoid serving a 304 that bypasses the #1046 gates, which makes it per-user and
worth only the body bytes of a revalidation; and it risks reopening the existence oracle
#1046 closed, since these handlers answer 200-with-null for both absent and denied. Left for
#1212 behind a measurement. Also omitted: routing the five read-only POST handlers through
the trait. Their `needsWriteAccess()` is already correct, the cache-control half cannot apply
to a POST, and one of them mints identifiers, so the name would misdescribe it.

> <sub>AI-authored — Claude Code, `Opus 5 (1M context, xhigh)`; open-ended "look into #1212" from @alistair3149, who then picked this scope from four researched options; diff not yet human-reviewed; contract test written first and seen failing for each endpoint before the fix; 1909 non-Database tests, all 30 REST test classes, phpcs and phpstan green; each of the three defects also reproduced live by reverting the file on a running dev wiki, and the headers, the CORS behaviour, the subject editor, Special:Schemas, the Data tab and the Turtle export checked in a browser anonymously and logged in; a code review and a fresh-context prose review were run and applied.</sub>

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

