### PR TITLE
Make the Docker image's MariaDB and Neo4j addresses configurable

### DIFF
--- a/Docker/.env.dist
+++ b/Docker/.env.dist
@@ -47,5 +47,14 @@ MAILCATCHER_PORT=8025
 # here are not auto-loaded.
 # MW_EXTRA_EXTENSIONS_DIR=
 
+# Where the wiki reaches MariaDB and Neo4j, defaulting to this stack's db and neo services.
+# Set them in the environment rather than here, since a value here becomes a makefile assignment
+# that overrides `MARIADB_HOST=... make dev`. See Docker/README.md.
+# MARIADB_HOST=db
+# MARIADB_PORT=3306
+# NEO4J_SCHEME=bolt
+# NEO4J_HOST=neo
+# NEO4J_PORT=7687
+
 # v2: shared-backend mode (set to 1 to disable local db/neo and point at external).
 # SHARED_BACKEND=0

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -38,6 +38,31 @@ need to run two tools-mode stacks simultaneously.
 The MariaDB, (default) Neo4j, QLever and Oxigraph ports are not exposed to the host. Reach
 them from inside the stack via `make bash` or `docker compose exec`.
 
+## Backing service addresses
+
+Where the wiki reaches MariaDB and Neo4j, defaulting to this stack's own `db` and `neo` services.
+
+| Variable       | Default | Notes                                                    |
+|----------------|---------|----------------------------------------------------------|
+| `MARIADB_HOST` | `db`    | Also where `make install-db` installs                    |
+| `MARIADB_PORT` | `3306`  |                                                          |
+| `NEO4J_SCHEME` | `bolt`  | Plaintext. Any host outside this stack wants `bolt+s` or `neo4j+s` |
+| `NEO4J_HOST`   | `neo`   | Both the read and the write URL                          |
+| `NEO4J_PORT`   | `7687`  | The port the wiki dials, not the host publish port `NEO_BOLT_PORT` |
+
+Set them in the environment rather than in `Docker/.env`: a value there becomes a makefile
+assignment, which a later `MARIADB_HOST=... make dev` cannot override.
+
+An address outside this stack reaches the wiki, `make install-db` and the first-run seed, but not
+the rest of the tooling. `make load-neo4j-users` and the perf snapshot targets still act on the
+bundled `neo` and `db`, `make remove` still wipes only this stack's volumes, and the `mediawiki`
+service still waits on both bundled services being healthy. An external server also has to already
+carry the database, user and Neo4j accounts the bundled services create for themselves.
+
+`make reset` is the sharp edge: it wipes the bundled volumes and then reinstalls and reimports the
+demo data over whatever `MARIADB_HOST` and `NEO4J_HOST` point at, so against a populated external
+server it destroys data rather than being inert.
+
 ## Optional services
 
 The dev stack's core is `mediawiki`, `db` and `neo`; everything else is optional. `make dev` (and

--- a/Docker/SettingsTemplate.php
+++ b/Docker/SettingsTemplate.php
@@ -72,7 +72,7 @@ $wgEmailAuthentication = false;
 
 ## Database settings
 $wgDBtype = "mysql";
-$wgDBserver = "db:3306";
+$wgDBserver = ( getenv( 'MARIADB_HOST' ) ?: 'db' ) . ':' . ( getenv( 'MARIADB_PORT' ) ?: '3306' );
 $wgDBname = getenv( 'MARIADB_DATABASE' );
 $wgDBuser = getenv( 'MARIADB_USER' );
 $wgDBpassword = getenv( 'MARIADB_PASSWORD' );
@@ -225,8 +225,11 @@ wfLoadExtension( 'RedHerb', "$IP/extensions/NeoWiki/tests/RedHerb/extension.json
 
 $wgNeoWikiEnableDevelopmentUI = true;
 
-$wgNeoWikiNeo4jInternalWriteUrl = 'bolt://' . getenv( 'NEO4J_USERNAME' ) . ':' . getenv( 'NEO4J_PASSWORD' ) . '@neo:7687';
-$wgNeoWikiNeo4jInternalReadUrl = 'bolt://' . getenv( 'NEO4J_USERNAME_READ' ) . ':' . getenv( 'NEO4J_PASSWORD_READ' ) . '@neo:7687';
+$neo4jScheme = getenv( 'NEO4J_SCHEME' ) ?: 'bolt';
+$neo4jAddress = ( getenv( 'NEO4J_HOST' ) ?: 'neo' ) . ':' . ( getenv( 'NEO4J_PORT' ) ?: '7687' );
+
+$wgNeoWikiNeo4jInternalWriteUrl = $neo4jScheme . '://' . getenv( 'NEO4J_USERNAME' ) . ':' . getenv( 'NEO4J_PASSWORD' ) . '@' . $neo4jAddress;
+$wgNeoWikiNeo4jInternalReadUrl = $neo4jScheme . '://' . getenv( 'NEO4J_USERNAME_READ' ) . ':' . getenv( 'NEO4J_PASSWORD_READ' ) . '@' . $neo4jAddress;
 
 // SPARQL graph store (QLever) for the SPARQL projection plugin (#586). Both the demo stack and the
 // dev stack run the qlever service defined in docker-compose.yml by default and point the wiki at

--- a/Docker/docker-compose.ci.yml
+++ b/Docker/docker-compose.ci.yml
@@ -10,6 +10,12 @@ services:
       neo:
         condition: service_healthy
     environment:
+      # Duplicated from docker-compose.yml, which the image-build workflow replaces with this file.
+      - MARIADB_HOST=${MARIADB_HOST:-db}
+      - MARIADB_PORT=${MARIADB_PORT:-3306}
+      - NEO4J_SCHEME=${NEO4J_SCHEME:-bolt}
+      - NEO4J_HOST=${NEO4J_HOST:-neo}
+      - NEO4J_PORT=${NEO4J_PORT:-7687}
       - MARIADB_DATABASE
       - MARIADB_USER
       - MARIADB_PASSWORD

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -14,6 +14,13 @@ services:
       neo:
         condition: service_healthy
     environment:
+      # Where the wiki reaches the backing services, defaulted here so a Docker/.env without
+      # these still starts a working stack. See Docker/README.md.
+      - MARIADB_HOST=${MARIADB_HOST:-db}
+      - MARIADB_PORT=${MARIADB_PORT:-3306}
+      - NEO4J_SCHEME=${NEO4J_SCHEME:-bolt}
+      - NEO4J_HOST=${NEO4J_HOST:-neo}
+      - NEO4J_PORT=${NEO4J_PORT:-7687}
       - MARIADB_DATABASE
       - MARIADB_USER
       - MARIADB_PASSWORD

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,13 @@ endif
 include Docker/.env
 export
 
+# Blank counts as unset, so a value resolves the same way here as through docker-compose.yml's
+# ${VAR:-default} and SettingsTemplate.php's ?:. ?= would keep a blank and hand install.php a
+# hostless ":3306"; override is what makes that hold for `make MARIADB_HOST= ...` too, since a
+# command-line assignment otherwise outranks this one.
+override MARIADB_HOST := $(or $(strip $(MARIADB_HOST)),db)
+override MARIADB_PORT := $(or $(strip $(MARIADB_PORT)),3306)
+
 # ---- Project namespace and ports ---------------------------------------------
 
 # Derive a unique project name from the extension directory.
@@ -324,10 +331,12 @@ _wait-mw:
 
 # ---- First-run seed ----------------------------------------------------------
 
-# Idempotent: skips if the database already has a wiki installed.
+# Idempotent: skips if the database already has a wiki installed. The probe has to ask the same
+# server install-db writes to, or pointing MARIADB_HOST at an installed wiki reinstalls over it on
+# every run. It asks from the db container because that is where a mariadb client exists.
 .PHONY: _first-run-seed
 _first-run-seed:
-	@if $(DC_DEV) exec -T db sh -c "mariadb -u $$MARIADB_USER -p$$MARIADB_PASSWORD $$MARIADB_DATABASE -e 'SELECT 1 FROM page LIMIT 1' 2>/dev/null" >/dev/null 2>&1; then \
+	@if $(DC_DEV) exec -T db sh -c "mariadb -h $$MARIADB_HOST -P $$MARIADB_PORT -u $$MARIADB_USER -p$$MARIADB_PASSWORD $$MARIADB_DATABASE -e 'SELECT 1 FROM page LIMIT 1' 2>/dev/null" >/dev/null 2>&1; then \
 		echo "Wiki already initialized; skipping install-db."; \
 	else \
 		$(MAKE) --no-print-directory install-db; \
@@ -341,7 +350,7 @@ _first-run-seed:
 # $(DC) since the demo stack has no dev overlay. Idempotent like _first-run-seed.
 .PHONY: _first-run-seed-demo
 _first-run-seed-demo:
-	@if $(DC) exec -T db sh -c "mariadb -u $$MARIADB_USER -p$$MARIADB_PASSWORD $$MARIADB_DATABASE -e 'SELECT 1 FROM page LIMIT 1' 2>/dev/null" >/dev/null 2>&1; then \
+	@if $(DC) exec -T db sh -c "mariadb -h $$MARIADB_HOST -P $$MARIADB_PORT -u $$MARIADB_USER -p$$MARIADB_PASSWORD $$MARIADB_DATABASE -e 'SELECT 1 FROM page LIMIT 1' 2>/dev/null" >/dev/null 2>&1; then \
 		echo "Wiki already initialized; skipping install."; \
 	else \
 		$(MAKE) --no-print-directory install-db; \
@@ -353,11 +362,13 @@ _first-run-seed-demo:
 
 .PHONY: install-db load-neo4j-users setup-test-neo test-backends test-backends-stop
 
+# --dbserver must match MARIADB_HOST: a literal here installs the schema on a different server
+# than SettingsTemplate.php points the wiki at.
 install-db:
 	$(EXEC_MW_ROOT) mv LocalSettings.php __LocalSettings.php
 	$(EXEC_MW_ROOT) \
 		php maintenance/install.php --dbuser $(MARIADB_USER) --dbpass $(MARIADB_PASSWORD) \
-			--dbname $(MARIADB_DATABASE) --dbserver db:3306 --lang en \
+			--dbname $(MARIADB_DATABASE) --dbserver $(MARIADB_HOST):$(MARIADB_PORT) --lang en \
 			--pass $(MW_ADMIN_PASSWORD) \
 			--server $(MW_SERVER) \
 			SiteName AdminName


### PR DESCRIPTION
The published image bakes the MariaDB and Neo4j addresses into `LocalSettings.php` while reading the
database name, user and password from the environment, so it can only talk to the services
`docker-compose.yml` defines. A deployment that supplies its own database servers has to replace
`LocalSettings.php` wholesale to point the image anywhere.

Reported while converting the Compose setup to a Helm chart for a Kubernetes deployment:
https://github.com/ECHOLOT-ECCCH/echolot-main/issues/2#issuecomment-5330126007

`MARIADB_HOST`, `MARIADB_PORT`, `NEO4J_SCHEME`, `NEO4J_HOST` and `NEO4J_PORT` now carry those
addresses. Every default equals the literal it replaces, in the template and in both compose files,
so the demo and dev stacks are unchanged. `NEO4J_SCHEME` is included because an external Neo4j is
commonly reached over `bolt+s` or `neo4j+s`, which the previous literal could not express.

## Decisions worth attention

`install-db` held its own copy of `db:3306`, and the first-run seed probed the bundled `db`
container directly. Left alone, the first would install the schema on a different server than the
wiki reads, and the second would leave the "already installed?" guard blind to the configured
server, so `make dev` against an external MariaDB would reinstall over an existing wiki on every
run. Both now derive the address the way the wiki does.

The variables ship commented out in `.env.dist`, and the docs steer people to set them in the
environment. A value in `Docker/.env` becomes a makefile assignment, which outranks the
environment, so `MARIADB_HOST=... make dev` would be silently ignored. Make resolves the defaults
with `override` and `$(or ...)` rather than `?=`, so a blank or command-line-assigned value lands
on the same address that `${VAR:-default}` and `?:` produce in the other two layers.

The feature is deliberately partial. `make load-neo4j-users` and the perf snapshot targets still
act on the bundled containers, `make remove` still wipes only this stack's volumes, and the
`mediawiki` service still waits on `db` and `neo` being healthy. `make reset` is the sharp edge:
it wipes the bundled volumes and then reinstalls and reimports over whatever the variables point
at. `Docker/README.md` states all of this rather than leaving it to be discovered. Making the
bundled tooling follow an external address is the `SHARED_BACKEND` work already sketched in
`docker-compose.yml`.

## Considered, omitted

- `$wgSecretKey` and `$wgUpgradeKey` are also baked literals, so every deployment of the published
  image shares them. Worth its own change; neither is addressing.
- `NEO4J_URL_EXTERNAL` is declared and passed to the container but read by nothing.
- Credentials are still concatenated into the Bolt URL unencoded, so a password containing `@` or
  `:` misparses. Pre-existing, but more reachable now that managed Neo4j is a plausible target.
- `Neo4jQueryService` rethrows the driver's message as `BackendUnavailableException`, and
  `CypherQueryApi` returns it in the 503 body. That message carries the Bolt URI including
  credentials, and ten other call sites route the same class of message through
  `BackendFailureMessage::withoutCredentials` first. Pre-existing, but a backend that is remote and
  therefore reachably down makes it routine rather than theoretical. Worth fixing before external
  Neo4j is advertised.
- `MW_DB_HOST`, matching the `MW_SMTP_HOST` precedent for outbound addresses. `MARIADB_HOST` won
  because `MARIADB_DATABASE`, `MARIADB_USER` and `MARIADB_PASSWORD` are already read by both the
  image and the wiki.

## Testing

Built from scratch on a clean worktree: no `Docker/.env`, no volumes, fresh MediaWiki clone and
image build. `make dev` installs and seeds, the computed `$wgDBserver` and both Bolt URLs equal the
literals they replace, the wiki serves pages, and the demo data projects into Neo4j. The first-run
seed was exercised on both branches, installing against an empty server and skipping against a
populated one. Repointed at the same services under different network names, the database and Neo4j
paths both keep working. The image was also driven by environment variables alone under plain
`podman run`, with no Compose or Makefile, which is the deployment shape this is for. `install-db`
renders the configured address across unset, blank, padded, `.env`, environment and command-line
inputs. PHPUnit, PHPCS, PHPStan and the shell-script suites pass.

CI exercises only the default values, so a variable that silently stopped being consumed would
still pass. The override paths were therefore checked by hand.

> <sub>AI-authored — Claude Code, `Opus 5 (1M context)`; detailed ask from @malberts, one scope question answered and four follow-up corrections; diff not yet human-reviewed, three rounds of AI review applied; PHPUnit, PHPCS, PHPStan and shell suites green on a from-scratch stack, default and override paths exercised end to end, CI green.</sub>
