### PR TITLE
Persist the backing-service addresses and harden their failure paths

### DIFF
--- a/Docker/.env.dist
+++ b/Docker/.env.dist
@@ -48,8 +48,9 @@ MAILCATCHER_PORT=8025
 # MW_EXTRA_EXTENSIONS_DIR=
 
 # Where the wiki reaches MariaDB and Neo4j, defaulting to this stack's db and neo services.
-# Set them in the environment rather than here, since a value here becomes a makefile assignment
-# that overrides `MARIADB_HOST=... make dev`. See Docker/README.md.
+# Environment and make-command-line values beat these for one invocation. Unquoted values
+# without $ only: both make and docker compose read this file, and they parse quoting and $
+# differently. See Docker/README.md#backing-service-addresses.
 # MARIADB_HOST=db
 # MARIADB_PORT=3306
 # NEO4J_SCHEME=bolt

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -50,14 +50,21 @@ Where the wiki reaches MariaDB and Neo4j, defaulting to this stack's own `db` an
 | `NEO4J_HOST`   | `neo`   | Both the read and the write URL                          |
 | `NEO4J_PORT`   | `7687`  | The port the wiki dials, not the host publish port `NEO_BOLT_PORT` |
 
-Set them in the environment rather than in `Docker/.env`: a value there becomes a makefile
-assignment, which a later `MARIADB_HOST=... make dev` cannot override.
+Set them in `Docker/.env` so every shell and every later `make` invocation resolves the same
+servers. A value in the environment or on the `make` command line wins over `Docker/.env` for
+that one invocation, for `make` and raw `docker compose` commands alike; an invocation without
+it is back on `Docker/.env` or the defaults.
 
-An address outside this stack reaches the wiki, `make install-db` and the first-run seed, but not
-the rest of the tooling. `make load-neo4j-users` and the perf snapshot targets still act on the
-bundled `neo` and `db`, `make remove` still wipes only this stack's volumes, and the `mediawiki`
-service still waits on both bundled services being healthy. An external server also has to already
-carry the database, user and Neo4j accounts the bundled services create for themselves.
+The addresses reach the wiki, `make install-db`, the first-run seed, and the maintenance targets
+that run inside the `mediawiki` container (`make import-demo-data`, `make rebuild-graph-databases`,
+`make update-dot-php`); the wiki follows a change once `make dev` recreates its container. They
+are dialed from inside the stack's containers, so `localhost` names the container itself, not
+the docker host.
+
+`make load-neo4j-users` and the perf snapshot targets still act on the bundled `neo` and `db`,
+`make remove` still wipes only this stack's volumes, and the `mediawiki` service still waits on
+both bundled services being healthy. An external server also has to already carry the database,
+user and Neo4j accounts the bundled services create for themselves.
 
 `make reset` is the sharp edge: it wipes the bundled volumes and then reinstalls and reimports the
 demo data over whatever `MARIADB_HOST` and `NEO4J_HOST` point at, so against a populated external
@@ -128,9 +135,10 @@ To query it from the host, add the `docker-compose.tools.yml` overlay, which map
 (default 7019) — on the dev stack `make dev-tools` does that for you:
 
 ```sh
-# <project> is this stack's compose project name, which `docker compose ls` lists.
+# <project> is this stack's compose project name, which `docker compose ls` lists. Naming the
+# service keeps the command from recreating the rest of a running stack.
 docker compose -p <project> --env-file Docker/.env \
-  -f Docker/docker-compose.yml -f Docker/docker-compose.tools.yml up -d
+  -f Docker/docker-compose.yml -f Docker/docker-compose.tools.yml up -d qlever
 
 curl http://localhost:7019/ \
   --data-urlencode 'query=SELECT (COUNT(*) AS ?n) WHERE { GRAPH ?g { ?s ?p ?o } }' \
@@ -184,9 +192,10 @@ To query it from the host, add the `docker-compose.tools.yml` overlay, which map
 (default 7878) — on the dev stack `COMPOSE_PROFILES=oxigraph make dev-tools` does that for you:
 
 ```sh
-# <project> is this stack's compose project name, which `docker compose ls` lists.
+# <project> is this stack's compose project name, which `docker compose ls` lists. Naming the
+# service keeps the command from recreating the rest of a running stack.
 COMPOSE_PROFILES=oxigraph docker compose -p <project> --env-file Docker/.env \
-  -f Docker/docker-compose.yml -f Docker/docker-compose.tools.yml up -d
+  -f Docker/docker-compose.yml -f Docker/docker-compose.tools.yml up -d oxigraph
 
 curl http://localhost:7878/query \
   --data-urlencode 'query=SELECT (COUNT(*) AS ?n) WHERE { GRAPH ?g { ?s ?p ?o } }' \

--- a/Docker/tests/test-backing-services.sh
+++ b/Docker/tests/test-backing-services.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Exercise the backing-service address resolution (Makefile), via `make print-backing-services`.
+# Pure Makefile logic - no docker needed. Runs make in a sandbox holding a copy of the Makefile
+# and a synthetic Docker/.env, so the real checkout's .env is never read or written.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+PASSES=0
+FAILS=0
+color() { local c=$1; shift; printf '\033[%sm%s\033[0m\n' "$c" "$*"; }
+ok()   { color '32' "PASS: $*"; PASSES=$((PASSES + 1)); }
+fail() { color '31' "FAIL: $*"; FAILS=$((FAILS + 1)); }
+
+assert_eq() {
+    local got=$1 want=$2 msg=$3
+    if [ "$got" = "$want" ]; then ok "$msg"; else fail "$msg (got '$got', want '$want')"; fi
+}
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+mkdir "$SANDBOX/Docker"
+cp "$ROOT/Makefile" "$SANDBOX/Makefile"
+
+write_env() { printf '%s\n' "$@" > "$SANDBOX/Docker/.env"; }
+
+# One scrubbed environment for every nested make: the Makefile's global `export` — and MAKEFLAGS,
+# which carries the outer make's command-line variables — would otherwise leak the outer
+# `make test-scripts` state into the sandbox and beat the very precedence being tested.
+SCRUB=(env -u MAKEFLAGS -u MFLAGS \
+    -u MARIADB_HOST -u MARIADB_PORT -u NEO4J_SCHEME -u NEO4J_HOST -u NEO4J_PORT \
+    -u _ENV_MARIADB_HOST -u _ENV_MARIADB_PORT -u _ENV_NEO4J_SCHEME -u _ENV_NEO4J_HOST -u _ENV_NEO4J_PORT \
+    -u _SET_MARIADB_HOST -u _SET_MARIADB_PORT -u _SET_NEO4J_SCHEME -u _SET_NEO4J_HOST -u _SET_NEO4J_PORT)
+
+# Leading VAR=val arguments become environment values (set after the scrub).
+run_make() {
+    ( cd "$SANDBOX" && "${SCRUB[@]}" "$@" make -s print-backing-services )
+}
+
+# Arguments go to make itself, e.g. a command-line variable assignment.
+run_make_cli() {
+    ( cd "$SANDBOX" && "${SCRUB[@]}" make -s print-backing-services "$@" )
+}
+
+field() {
+    printf '%s\n' "$1" | grep "^$2:" | sed -E "s/^$2:[[:space:]]*//"
+}
+
+echo
+color '36' "Case 1: empty Docker/.env -> the documented defaults"
+write_env ""
+out="$(run_make 2>&1)"
+assert_eq "$(field "$out" mariadb)" "db:3306" "MariaDB defaults to db:3306"
+assert_eq "$(field "$out" neo4j)" "bolt://neo:7687" "Neo4j defaults to bolt://neo:7687"
+
+echo
+color '36' "Case 2: Docker/.env values beat the defaults"
+write_env "MARIADB_HOST=filedb" "MARIADB_PORT=3307" "NEO4J_SCHEME=neo4j+s" "NEO4J_HOST=fileneo" "NEO4J_PORT=7688"
+out="$(run_make 2>&1)"
+assert_eq "$(field "$out" mariadb)" "filedb:3307" "MariaDB address comes from Docker/.env"
+assert_eq "$(field "$out" neo4j)" "neo4j+s://fileneo:7688" "Neo4j address comes from Docker/.env"
+
+echo
+color '36' "Case 3: environment beats Docker/.env, as it does for docker compose"
+write_env "MARIADB_HOST=filedb" "NEO4J_HOST=fileneo"
+out="$(run_make MARIADB_HOST=envdb NEO4J_HOST=envneo 2>&1)"
+assert_eq "$(field "$out" mariadb)" "envdb:3306" "Environment MARIADB_HOST beats the Docker/.env value"
+assert_eq "$(field "$out" neo4j)" "bolt://envneo:7687" "Environment NEO4J_HOST beats the Docker/.env value"
+
+echo
+color '36' "Case 4: make command line beats Docker/.env"
+write_env "MARIADB_HOST=filedb"
+out="$(run_make_cli MARIADB_HOST=clidb 2>&1)"
+assert_eq "$(field "$out" mariadb)" "clidb:3306" "Command-line MARIADB_HOST beats the Docker/.env value"
+
+echo
+color '36' "Case 5: blank environment value hides Docker/.env and falls back to the default"
+write_env "MARIADB_HOST=filedb"
+out="$(run_make MARIADB_HOST= 2>&1)"
+assert_eq "$(field "$out" mariadb)" "db:3306" "Blank environment MARIADB_HOST resolves to the default"
+
+echo
+color '36' "Case 6: Docker/.env values survive trailing whitespace from inline comments"
+write_env "MARIADB_HOST=filedb # external box" "NEO4J_HOST=fileneo # external box"
+out="$(run_make 2>&1)"
+assert_eq "$(field "$out" mariadb)" "filedb:3306" "MARIADB_HOST is stripped of an inline comment's whitespace"
+assert_eq "$(field "$out" neo4j)" "bolt://fileneo:7687" "NEO4J_HOST is stripped of an inline comment's whitespace"
+
+echo
+if [ "$FAILS" -eq 0 ]; then color '32' "All $PASSES checks passed."; exit 0
+else color '31' "$FAILS check(s) failed ($PASSES passed)."; exit 1; fi

--- a/Makefile
+++ b/Makefile
@@ -7,15 +7,35 @@ ifeq ($(wildcard Docker/.env),)
 $(shell cp Docker/.env.dist Docker/.env)
 endif
 
+# The backing-service addresses (see Docker/README.md) may arrive from the environment or the
+# make command line as well as from Docker/.env. The include below would let a Docker/.env value
+# shadow both, so capture the pre-include view first: what each variable holds, and whether it
+# is set at all.
+_ENV_MARIADB_HOST := $(strip $(MARIADB_HOST))
+_ENV_MARIADB_PORT := $(strip $(MARIADB_PORT))
+_ENV_NEO4J_SCHEME := $(strip $(NEO4J_SCHEME))
+_ENV_NEO4J_HOST := $(strip $(NEO4J_HOST))
+_ENV_NEO4J_PORT := $(strip $(NEO4J_PORT))
+_SET_MARIADB_HOST := $(filter-out undefined,$(origin MARIADB_HOST))
+_SET_MARIADB_PORT := $(filter-out undefined,$(origin MARIADB_PORT))
+_SET_NEO4J_SCHEME := $(filter-out undefined,$(origin NEO4J_SCHEME))
+_SET_NEO4J_HOST := $(filter-out undefined,$(origin NEO4J_HOST))
+_SET_NEO4J_PORT := $(filter-out undefined,$(origin NEO4J_PORT))
+
 include Docker/.env
 export
 
-# Blank counts as unset, so a value resolves the same way here as through docker-compose.yml's
-# ${VAR:-default} and SettingsTemplate.php's ?:. ?= would keep a blank and hand install.php a
-# hostless ":3306"; override is what makes that hold for `make MARIADB_HOST= ...` too, since a
+# Environment beats Docker/.env beats the default, and a blank value resolves to the default —
+# a blank environment value hides Docker/.env, as it does for compose — matching the resolution
+# docker compose applies to ${VAR:-default} with --env-file, so make, raw compose commands and
+# the container agree on one server. ?= would keep a blank and hand install.php a hostless
+# ":3306"; override is what makes the resolution hold for `make MARIADB_HOST= ...` too, since a
 # command-line assignment otherwise outranks this one.
-override MARIADB_HOST := $(or $(strip $(MARIADB_HOST)),db)
-override MARIADB_PORT := $(or $(strip $(MARIADB_PORT)),3306)
+override MARIADB_HOST := $(or $(_ENV_MARIADB_HOST),$(if $(_SET_MARIADB_HOST),,$(strip $(MARIADB_HOST))),db)
+override MARIADB_PORT := $(or $(_ENV_MARIADB_PORT),$(if $(_SET_MARIADB_PORT),,$(strip $(MARIADB_PORT))),3306)
+override NEO4J_SCHEME := $(or $(_ENV_NEO4J_SCHEME),$(if $(_SET_NEO4J_SCHEME),,$(strip $(NEO4J_SCHEME))),bolt)
+override NEO4J_HOST := $(or $(_ENV_NEO4J_HOST),$(if $(_SET_NEO4J_HOST),,$(strip $(NEO4J_HOST))),neo)
+override NEO4J_PORT := $(or $(_ENV_NEO4J_PORT),$(if $(_SET_NEO4J_PORT),,$(strip $(NEO4J_PORT))),7687)
 
 # ---- Project namespace and ports ---------------------------------------------
 
@@ -141,7 +161,7 @@ help:
 
 # ---- Lifecycle (host only) ---------------------------------------------------
 
-.PHONY: up pull demo upgrade dev dev-tools _dev-tools-impl down remove logs ps print-services bash _preflight doctor
+.PHONY: up pull demo upgrade dev dev-tools _dev-tools-impl down remove logs ps print-services print-backing-services bash _preflight doctor
 
 # Fail fast on a broken Docker runtime (Docker or Compose missing, daemon down or
 # denied) before the lifecycle targets do expensive work. Source: Docker/scripts/preflight.sh.
@@ -284,6 +304,10 @@ print-services: ## Show the optional-service selection and resulting profiles
 	@echo "deselected: $(DESELECTED_SERVICES)"
 	@echo "profiles:   $(COMPOSE_PROFILES)"
 
+print-backing-services: ## Show the backing-service addresses this make invocation resolves
+	@echo "mariadb: $(MARIADB_HOST):$(MARIADB_PORT)"
+	@echo "neo4j:   $(NEO4J_SCHEME)://$(NEO4J_HOST):$(NEO4J_PORT)"
+
 bash: ## Shell into the mediawiki container
 	$(DC_DEV) exec mediawiki bash
 
@@ -315,6 +339,7 @@ test-scripts: ## Run shell-script tests (set-port.sh, preflight.sh, etc.)
 	@./Docker/tests/test-set-port.sh
 	@./Docker/tests/test-preflight.sh
 	@./Docker/tests/test-services.sh
+	@./Docker/tests/test-backing-services.sh
 
 # ---- Health gate -------------------------------------------------------------
 
@@ -334,9 +359,13 @@ _wait-mw:
 # Idempotent: skips if the database already has a wiki installed. The probe has to ask the same
 # server install-db writes to, or pointing MARIADB_HOST at an installed wiki reinstalls over it on
 # every run. It asks from the db container because that is where a mariadb client exists.
+# --connect-timeout keeps an unreachable external server from stalling every `make dev` for the
+# OS connect timeout (~2 minutes against a dropping firewall); the client's own default is no
+# limit. Generous, because a timeout against a reachable-but-slow installed server would read as
+# "not installed" and send the seed at it.
 .PHONY: _first-run-seed
 _first-run-seed:
-	@if $(DC_DEV) exec -T db sh -c "mariadb -h $$MARIADB_HOST -P $$MARIADB_PORT -u $$MARIADB_USER -p$$MARIADB_PASSWORD $$MARIADB_DATABASE -e 'SELECT 1 FROM page LIMIT 1' 2>/dev/null" >/dev/null 2>&1; then \
+	@if $(DC_DEV) exec -T db sh -c "mariadb --connect-timeout=15 -h $$MARIADB_HOST -P $$MARIADB_PORT -u $$MARIADB_USER -p$$MARIADB_PASSWORD $$MARIADB_DATABASE -e 'SELECT 1 FROM page LIMIT 1' 2>/dev/null" >/dev/null 2>&1; then \
 		echo "Wiki already initialized; skipping install-db."; \
 	else \
 		$(MAKE) --no-print-directory install-db; \
@@ -350,7 +379,7 @@ _first-run-seed:
 # $(DC) since the demo stack has no dev overlay. Idempotent like _first-run-seed.
 .PHONY: _first-run-seed-demo
 _first-run-seed-demo:
-	@if $(DC) exec -T db sh -c "mariadb -h $$MARIADB_HOST -P $$MARIADB_PORT -u $$MARIADB_USER -p$$MARIADB_PASSWORD $$MARIADB_DATABASE -e 'SELECT 1 FROM page LIMIT 1' 2>/dev/null" >/dev/null 2>&1; then \
+	@if $(DC) exec -T db sh -c "mariadb --connect-timeout=15 -h $$MARIADB_HOST -P $$MARIADB_PORT -u $$MARIADB_USER -p$$MARIADB_PASSWORD $$MARIADB_DATABASE -e 'SELECT 1 FROM page LIMIT 1' 2>/dev/null" >/dev/null 2>&1; then \
 		echo "Wiki already initialized; skipping install."; \
 	else \
 		$(MAKE) --no-print-directory install-db; \
@@ -364,16 +393,23 @@ _first-run-seed-demo:
 
 # --dbserver must match MARIADB_HOST: a literal here installs the schema on a different server
 # than SettingsTemplate.php points the wiki at.
+#
+# MW_CONFIG_FILE points the installer's LocalSettings.php detection at a nonexistent path and
+# --confpath sends the file it generates to a throwaway directory, so install.php runs while the
+# real LocalSettings.php stays in place: no settings-less window for web requests, and nothing
+# to restore after a failed, interrupted, or concurrent run. The leading mv restores a
+# LocalSettings.php that an earlier version of this target left parked as __LocalSettings.php.
 install-db:
-	$(EXEC_MW_ROOT) mv LocalSettings.php __LocalSettings.php
-	$(EXEC_MW_ROOT) \
-		php maintenance/install.php --dbuser $(MARIADB_USER) --dbpass $(MARIADB_PASSWORD) \
+	$(EXEC_MW_ROOT) bash -c '\
+		if [ -e __LocalSettings.php ]; then mv __LocalSettings.php LocalSettings.php; fi; \
+		rm -rf /tmp/neowiki-install && mkdir -p /tmp/neowiki-install && \
+		MW_CONFIG_FILE=/nonexistent php maintenance/install.php \
+			--confpath /tmp/neowiki-install \
+			--dbuser $(MARIADB_USER) --dbpass $(MARIADB_PASSWORD) \
 			--dbname $(MARIADB_DATABASE) --dbserver $(MARIADB_HOST):$(MARIADB_PORT) --lang en \
 			--pass $(MW_ADMIN_PASSWORD) \
 			--server $(MW_SERVER) \
-			SiteName AdminName
-	$(EXEC_MW_ROOT) rm LocalSettings.php
-	$(EXEC_MW_ROOT) mv __LocalSettings.php LocalSettings.php
+			SiteName AdminName'
 	$(EXEC_MW_ROOT) php maintenance/run.php update --quick
 
 load-neo4j-users:
@@ -385,6 +421,11 @@ load-neo4j-users:
 # The already-running check is a speed optimization, not a correctness requirement: the seed
 # is idempotent. Without it every `make phpunit filter=X` would pay a few seconds for the
 # compose up and the cypher-shell JVM.
+#
+# The first up is --no-recreate: it exists to start missing test backends, and must not recreate
+# the running wiki containers over config drift — e.g. the backing-service addresses resolving
+# differently in this shell than when the stack came up (see Docker/README.md). The second up is
+# scoped to the three test services so compose-file changes to them still apply.
 #
 # Inside the mediawiki container there is no compose to drive, so it can only report that the
 # backends are missing.
@@ -403,7 +444,8 @@ else
 			| grep -cE '^(test_neo|test_qlever|test_oxigraph)$$')" = "3" ]; then \
 		exit 0; \
 	fi; \
-	$(DC_TEST) up -d; \
+	$(DC_TEST) up -d --no-recreate; \
+	$(DC_TEST) up -d test_neo test_qlever test_oxigraph; \
 	$(MAKE) --no-print-directory setup-test-neo; \
 	$(EXEC_MW_ROOT) bash -c '/wait-for-it.sh test_qlever:7019 -t 120 && /wait-for-it.sh test_oxigraph:7878 -t 120'
 endif

--- a/tests/phpunit/NeoWikiIntegrationTestCase.php
+++ b/tests/phpunit/NeoWikiIntegrationTestCase.php
@@ -67,6 +67,16 @@ class NeoWikiIntegrationTestCase extends MediaWikiIntegrationTestCase {
 	}
 
 	protected function setUpNeo4j(): void {
+		// Outside the try: the catch below would turn the refusal into a skip. A wiki without a
+		// configured backend has nothing to wipe, so it keeps the skip path instead of failing.
+		if ( !$this->hasNeo4jTestOverrides() && $this->wikiHasNeo4jBackend() ) {
+			$this->fail(
+				'NEO4J_URL_OVERRIDE and NEO4J_URL_READ_OVERRIDE are not both set: refusing to touch'
+				. ' the Neo4j database the wiki itself is configured against. Graph tests only run'
+				. ' against a dedicated test instance (phpunit.xml.dist points at test_neo).'
+			);
+		}
+
 		try {
 			$client = NeoWikiExtension::getInstance()->getNeo4jClient();
 			$client->run( 'MATCH (n) DETACH DELETE n' );
@@ -77,6 +87,21 @@ class NeoWikiIntegrationTestCase extends MediaWikiIntegrationTestCase {
 		catch ( \Exception ) {
 			$this->markTestSkipped( 'Neo4j not available' );
 		}
+	}
+
+	private function hasNeo4jTestOverrides(): bool {
+		return $this->overrideIsUsable( getenv( 'NEO4J_URL_OVERRIDE' ) )
+			&& $this->overrideIsUsable( getenv( 'NEO4J_URL_READ_OVERRIDE' ) );
+	}
+
+	private function overrideIsUsable( string|false $override ): bool {
+		return $override !== false && $override !== '';
+	}
+
+	private function wikiHasNeo4jBackend(): bool {
+		$writeUrl = $this->getServiceContainer()->getMainConfig()->get( 'NeoWikiNeo4jInternalWriteUrl' );
+
+		return is_string( $writeUrl ) && $writeUrl !== '';
 	}
 
 	protected function createPageWithSubjects(

--- a/tests/phpunit/NeoWikiIntegrationTestCaseTest.php
+++ b/tests/phpunit/NeoWikiIntegrationTestCaseTest.php
@@ -4,6 +4,8 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Tests;
 
+use PHPUnit\Framework\AssertionFailedError;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpyGraphDatabasePlugin;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubPagePropertyProvider;
 
@@ -30,6 +32,37 @@ class NeoWikiIntegrationTestCaseTest extends NeoWikiIntegrationTestCase {
 			$spy->savedPages[0]->getProperties()->get( 'marker' ),
 			'the provider registered second still contributes its properties'
 		);
+	}
+
+	public function testSetUpNeo4jRefusesToWipeWithoutTestInstanceOverride(): void {
+		$originalWriteOverride = getenv( 'NEO4J_URL_OVERRIDE' );
+		$originalReadOverride = getenv( 'NEO4J_URL_READ_OVERRIDE' );
+		putenv( 'NEO4J_URL_OVERRIDE' );
+		putenv( 'NEO4J_URL_READ_OVERRIDE' );
+
+		// An unroutable sentinel as the wiki-configured URL: the guard must fire on configuration
+		// alone, and a regressed guard fails to connect instead of wiping a real graph.
+		$this->overrideConfigValue( 'NeoWikiNeo4jInternalWriteUrl', 'bolt://neo4j:password@sentinel.invalid:7687' );
+		NeoWikiExtension::resetInstance();
+
+		try {
+			$this->setUpNeo4j();
+			$guardFired = false;
+			$message = '';
+		} catch ( AssertionFailedError $error ) {
+			$guardFired = true;
+			$message = $error->getMessage();
+		} finally {
+			putenv( $originalWriteOverride === false ? 'NEO4J_URL_OVERRIDE' : "NEO4J_URL_OVERRIDE=$originalWriteOverride" );
+			putenv( $originalReadOverride === false ? 'NEO4J_URL_READ_OVERRIDE' : "NEO4J_URL_READ_OVERRIDE=$originalReadOverride" );
+			NeoWikiExtension::resetInstance();
+		}
+
+		$this->assertTrue(
+			$guardFired,
+			'setUpNeo4j must refuse to touch the Neo4j database the wiki itself is configured against'
+		);
+		$this->assertStringContainsString( 'NEO4J_URL_OVERRIDE', $message );
 	}
 
 }


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1308

The environment-only configuration of the five backing-service address variables was ambient and non-sticky: any later target containing `up -d`, run from a shell without the exports (`make phpunit` starting test backends, tomorrow's `make dev`), silently recreated the mediawiki container back onto the bundled services; persisting the exports in a shell profile leaked one external backend into every checkout and worktree; and the documented raw compose commands resolved the variables with the opposite precedence to make.

* Docker/.env is now where the addresses live. The Makefile captures the environment and command-line values before `include Docker/.env`, giving make the same precedence compose applies with `--env-file`: environment beats Docker/.env beats the default, and a blank value resolves to the default (a blank environment value hides Docker/.env, as it does for compose). Worktrees bootstrap their own .env, so stacks stay isolated. `make print-backing-services` shows the resolution, and Docker/tests/test-backing-services.sh pins the precedence table (part of `make test-scripts`).
* `make test-backends` starts missing containers with `--no-recreate`, so starting test backends no longer recreates the running wiki over config drift; a second up scoped to the three test services still applies compose-file changes to them.
* install-db runs install.php with `MW_CONFIG_FILE` pointing its LocalSettings.php detection at a nonexistent path and `--confpath` sending the generated file to a throwaway directory, so the real LocalSettings.php stays in place throughout: no settings-less window for web requests, and nothing to restore after a failed, interrupted, or concurrent run. A leading mv restores a LocalSettings.php still parked as `__LocalSettings.php` by the previous recipe.
* The first-run seed probes pass `--connect-timeout=15`, failing in seconds against an unreachable external server instead of stalling every `make dev` for the OS connect timeout (~2 minutes) — generous, so a reachable-but-slow installed server does not read as "not installed".
* setUpNeo4j refuses to run the test suite's `MATCH (n) DETACH DELETE n` unless NEO4J_URL_OVERRIDE and NEO4J_URL_READ_OVERRIDE are both set (empty counts as unset) while the wiki has a configured Neo4j backend, so the wipe can only ever hit the dedicated test instance — never the graph the wiki itself is configured against. Any phpunit invocation that bypasses NeoWiki's phpunit.xml.dist (MediaWiki core's standard entry point, in the dev stack or in any MediaWiki install carrying NeoWiki) previously wiped that configured graph, which with NEO4J_HOST can be a shared external one. Backend-less environments keep the "Neo4j not available" skip. The regression test points the configured URL at an unroutable sentinel, so a regressed guard fails to connect instead of wiping a real graph.
* Docker/README.md documents where to set the variables and the precedence, states which tooling the addresses reach and that they are dialed from inside the containers, and scopes the tools-overlay compose commands to the service they expose so they cannot recreate the rest of a running stack.

Each failure mode was reproduced on master in an isolated worktree stack, then shown fixed: test-backends recreating and repointing the wiki container, install-db stranding LocalSettings.php with broken reruns, the probe hanging past 20s against a blackholed address, and setUpNeo4j wiping the wiki's graph without the overrides. `make reset` exercises the new install-db happy path end to end.

Considered, omitted:

* A refusal at the URL-resolution point (NeoWikiConfigFactory declining the config fallback under MW_PHPUNIT_TEST) would also stop override-less page-saving tests from projecting into the wiki's graph; left out as a production-code change deserving its own discussion.
* The probe still cannot distinguish an unreachable server from an empty one; the timeout only bounds how long that ambiguity stalls `make dev`.
* Values in Docker/.env are parsed by both make and compose, which disagree on quoting and `$`; documented in `.env.dist` rather than normalized in make.
* `make -e test-scripts` already fails on master in the pre-existing test-services.sh; not addressed here.
* `--no-recreate` support under podman-compose was not verified on every version the repo's podman path may meet.

> <sub>AI-authored — Claude Code, `Fable 5 (ultracode)`; six findings picked by @alistair3149 from an in-session review of #1308, plus a README trim he requested; diff not yet human-reviewed; each fix reproduced-then-verified in a worktree stack, adversarial code-review findings verified and applied (incl. replacing the install flow with MW_CONFIG_FILE after an A/B check), harness and PHPUnit regression tests red→green and mutation-tested, non-Database lane (1909 tests) and phpcs+phpstan green locally, CI pending on the final push.</sub>
