### PR TITLE
Pin the annotated `multiple` form to its false value

### DIFF
--- a/resources/ext.neowiki/src/domain/SeverityNormalizer.ts
+++ b/resources/ext.neowiki/src/domain/SeverityNormalizer.ts
@@ -3,7 +3,8 @@ import { isSeverity, type Severity } from '@/domain/Severity';
 /**
  * Parses and serializes the two Schema-JSON forms a Constraint can take (ADR 26):
  * a bare scalar/array (default `warning` severity) or an object `{ value, severity }`
- * (booleans drop `value` and imply `true`; `options` carries the array in `value`).
+ * (booleans drop `value` and imply `true`, except `multiple`, whose object form carries
+ * `"value": false`; `options` carries the array in `value`).
  * Mirror of the backend's SeverityNormalizer (src/Domain/Validation/SeverityNormalizer.php).
  *
  * A value is treated as object-form iff it is an object carrying a `severity` key.
@@ -88,7 +89,8 @@ export function applySeverities(
 
 		// The mirror of the branch above for the Constraints that are active when false:
 		// the editor keeps the severity of a rule the author switched off, so that it
-		// survives switching it back on. Stored JSON never carries the inert annotation.
+		// survives switching it back on while the dialog is open. Emitting it would fail
+		// the save: schemaContentSchema.json pins `multiple`'s object form to `false`.
 		if ( result[ key ] === true && CONSTRAINTS_ACTIVE_WHEN_FALSE.includes( key ) ) {
 			continue;
 		}

--- a/resources/ext.neowiki/tests/domain/SeverityNormalizer.spec.ts
+++ b/resources/ext.neowiki/tests/domain/SeverityNormalizer.spec.ts
@@ -81,8 +81,8 @@ describe( 'applySeverities', () => {
 	it( 'keeps a false boolean value rather than implying true', () => {
 		// The value-less object form implies true, so emitting it for a `false` value
 		// would read back as `true` and silently enable a Constraint the author
-		// disabled. Core booleans are always true when annotated, but a custom
-		// Property Type's own boolean key carries no such guard.
+		// disabled. The content schema constrains the core booleans; a custom Property
+		// Type's own boolean key carries no such guard.
 		expect( applySeverities( { caseSensitive: false }, { caseSensitive: 'error' } ) ).toEqual(
 			{ caseSensitive: { value: false, severity: 'error' } },
 		);

--- a/src/Domain/Validation/SeverityNormalizer.php
+++ b/src/Domain/Validation/SeverityNormalizer.php
@@ -9,7 +9,8 @@ use InvalidArgumentException;
 /**
  * Parses and serializes the two Schema-JSON forms a Constraint can take (ADR 26):
  * a bare scalar/array (default `warning` severity) or an object `{ value, severity }`
- * (booleans drop `value` and imply `true`; `options` carries the array in `value`).
+ * (booleans drop `value` and imply `true`, except `multiple`, whose object form carries
+ * `"value": false`; `options` carries the array in `value`).
  *
  * A value is treated as object-form iff it is an array carrying a `severity` key. This is
  * intentionally permissive: being type-agnostic is what lets a custom Property Type's own
@@ -71,9 +72,7 @@ final class SeverityNormalizer {
 			}
 
 			// Only `true` may drop the value key: extract() reads the value-less form as true,
-			// so emitting it for `false` would flip a Constraint the author disabled. Core
-			// booleans are always true here (booleanConstraint forbids a value key), but a
-			// custom Property Type's own boolean key is not constrained that way.
+			// so emitting it for `false` would flip a Constraint the author disabled.
 			$json[$key] = $json[$key] === true
 				? [ 'severity' => $severity->value ]
 				: [ 'value' => $json[$key], 'severity' => $severity->value ];

--- a/src/Persistence/MediaWiki/schemaContentSchema.json
+++ b/src/Persistence/MediaWiki/schemaContentSchema.json
@@ -6,29 +6,25 @@
 			"enum": [ "error", "warning" ]
 		},
 		"booleanConstraint": {
-			"oneOf": [
-				{ "type": "boolean" },
-				{
-					"type": "object",
-					"required": [ "severity" ],
-					"additionalProperties": false,
-					"properties": { "severity": { "$ref": "#/$defs/severity" } }
-				}
-			]
+			"if": { "type": "object" },
+			"then": {
+				"required": [ "severity" ],
+				"additionalProperties": false,
+				"properties": { "severity": { "$ref": "#/$defs/severity" } }
+			},
+			"else": { "type": "boolean" }
 		},
-		"booleanConstraintWithValue": {
-			"oneOf": [
-				{ "type": "boolean" },
-				{
-					"type": "object",
-					"required": [ "severity" ],
-					"additionalProperties": false,
-					"properties": {
-						"value": { "type": "boolean" },
-						"severity": { "$ref": "#/$defs/severity" }
-					}
+		"booleanConstraintWithFalseValue": {
+			"if": { "type": "object" },
+			"then": {
+				"required": [ "value", "severity" ],
+				"additionalProperties": false,
+				"properties": {
+					"value": { "const": false },
+					"severity": { "$ref": "#/$defs/severity" }
 				}
-			]
+			},
+			"else": { "type": "boolean" }
 		},
 		"scalarConstraint": {
 			"if": { "type": "object" },
@@ -74,7 +70,7 @@
 						},
 						"default": true,
 						"required": { "$ref": "#/$defs/booleanConstraint" },
-						"multiple": { "$ref": "#/$defs/booleanConstraintWithValue" },
+						"multiple": { "$ref": "#/$defs/booleanConstraintWithFalseValue" },
 						"uniqueItems": { "$ref": "#/$defs/booleanConstraint" },
 						"minimum": { "$ref": "#/$defs/scalarConstraint" },
 						"maximum": { "$ref": "#/$defs/scalarConstraint" },

--- a/tests/phpunit/Domain/Validation/SeverityNormalizerTest.php
+++ b/tests/phpunit/Domain/Validation/SeverityNormalizerTest.php
@@ -89,9 +89,8 @@ class SeverityNormalizerTest extends TestCase {
 
 	/**
 	 * The value-less object form implies true, so emitting it for a `false` value would read
-	 * back as `true` and silently enable a Constraint the author disabled. Core booleans are
-	 * always true when annotated — the content schema forbids a `value` key on them — but a
-	 * custom Property Type's own boolean key carries no such guard.
+	 * back as `true` and silently enable a Constraint the author disabled. The content schema
+	 * constrains the core booleans; a custom Property Type's own boolean key carries no such guard.
 	 */
 	public function testApplyKeepsFalseBooleanValueRatherThanImplyingTrue(): void {
 		$this->assertSame(

--- a/tests/phpunit/Persistence/MediaWiki/SchemaContentValidatorTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/SchemaContentValidatorTest.php
@@ -270,22 +270,39 @@ JSON
 	}
 
 	/**
-	 * The Constraint applies when `multiple` is false, so the value-less form is inert. It must
-	 * still validate: SeverityNormalizer::apply re-emits an annotated `true` in exactly that
-	 * shape, so rejecting it would make an annotated Schema fail to save its own canonical output.
+	 * SeverityNormalizer::extract reads the value-less form as `true`, which switches the
+	 * single-value rule off rather than on. Accepting it would invert the intent of an author
+	 * who spells the annotation the way `required` and `uniqueItems` are spelled.
 	 */
-	public function testValuelessMultipleObjectFormPassesValidation(): void {
+	public function testValuelessMultipleObjectFormFailsValidation(): void {
 		$validator = SchemaContentValidator::newInstance();
 
-		$valid = $validator->validate(
-			$this->schemaWithProperty( '{ "type": "select", "multiple": { "severity": "error" } }' )
+		$this->assertFalse(
+			$validator->validate(
+				$this->schemaWithProperty( '{ "type": "select", "multiple": { "severity": "error" } }' )
+			)
 		);
 
-		if ( !$valid ) {
-			$this->assertSame( [], $validator->getErrors() );
-		}
+		$this->assertSame(
+			[ '/propertyDefinitions/offending/multiple' => 'The required properties (value) are missing' ],
+			$validator->getErrors()
+		);
+	}
 
-		$this->assertTrue( $valid );
+	/**
+	 * `{ "severity": … }` and `{ "value": true, … }` decode to the same state, so allowing both
+	 * would give one state two spellings. Pinning the value leaves exactly one.
+	 */
+	public function testMultipleObjectFormWithTrueValueFailsValidation(): void {
+		$validator = SchemaContentValidator::newInstance();
+
+		$this->assertFalse(
+			$validator->validate(
+				$this->schemaWithProperty(
+					'{ "type": "select", "multiple": { "value": true, "severity": "error" } }'
+				)
+			)
+		);
 	}
 
 	public function testMultipleObjectFormWithInvalidSeverityFailsValidation(): void {
@@ -301,8 +318,8 @@ JSON
 	}
 
 	/**
-	 * A stray key means a misspelled `severity`, which leaves an object where the parsers read a
-	 * boolean. Rejecting it at authoring time keeps that out of stored Schema JSON.
+	 * The fixture keeps a valid `severity` beside the stray key so the assertion turns on
+	 * `additionalProperties` alone rather than on the missing required key.
 	 */
 	public function testMultipleObjectFormWithUnknownKeyFailsValidation(): void {
 		$validator = SchemaContentValidator::newInstance();
@@ -310,7 +327,7 @@ JSON
 		$this->assertFalse(
 			$validator->validate(
 				$this->schemaWithProperty(
-					'{ "type": "select", "multiple": { "value": false, "sevrity": "error" } }'
+					'{ "type": "select", "multiple": { "value": false, "severity": "error", "sevrity": "warning" } }'
 				)
 			)
 		);
@@ -375,6 +392,11 @@ JSON
 			$validator->validate(
 				$this->schemaWithProperty( '{ "type": "text", "required": { "value": false, "severity": "error" } }' )
 			)
+		);
+
+		$this->assertSame(
+			[ '/propertyDefinitions/offending/required' => 'Additional object properties are not allowed: value' ],
+			$validator->getErrors()
 		);
 	}
 


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1315. Review fixes for that PR, so the base is its branch; retarget when it lands.

`multiple`'s object form left `value` optional, so `"multiple": { "severity": "error" }` validated. `SeverityNormalizer::extract` reads a value-less object as `true`, so that form switched the single-value rule **off** while looking like an annotation of it — the opposite of what `required` and `uniqueItems` mean when spelled the same way. Verified on a dev wiki: a `select` property carrying it accepted two values with no violation at all, where the bare form still raises a warning.

This reverses a decision #1315 states explicitly — that the value-less form "stays valid, because that is what canonical serialization emits for an annotated `true`". That reason is circular: `SeverityNormalizer::apply` only produces the form when `extract` read it from stored JSON that already contained it, and the form was only storable because `{ "value": true, … }` was. Nothing else emits it — no PHP path writes `toJson()` output back to a page, and the frontend serializer drops the annotation instead.

The object form now requires `"value": false`, which is what [ADR 26](https://github.com/ProfessionalWiki/NeoWiki/blob/master/docs/adr/026-validation-severity-levels.md) and the schema format reference already document. `{ "value": true, "severity": … }` goes with it: it decodes to the same state, and one state with two spellings is what let the misleading one through.

The three Constraint definitions now branch on `if`/`then`/`else` alike, as `scalarConstraint` already did. `oneOf` reports only its first branch, so every rejected object form came back as `The data (object) must match the type: boolean` — telling the author to drop the annotation when the fix is to complete it. Verdicts are unchanged across every input shape; a rejection now names the missing key, the stray key or the bad severity, and the tests pin those messages.

Nothing in the repository uses the rejected forms: all 21 `DemoData/Schema/*.json` still validate, and the only test asserting the value-less form was the one added by #1315. The permissive window never shipped — `multiple` is `{"type": "boolean"}` on master — so no stored Schema can carry a now-invalid form.

## Considered, omitted

- A polarity guard in `SeverityNormalizer::apply`, mirroring the frontend's. Measured: PHP already emits a form the content schema rejects for `required: false` and `uniqueItems: false`, both pre-existing. A guard for `multiple` alone would close one of three cases and make it the odd key out; closing all three belongs in its own change.
- Extending the same pinning to `customConstraint`, where an extension's own Constraint key can still take the value-less form. The core cannot know a custom key's polarity, so that needs a per-Property-Type declaration rather than a schema edit.

## Manual Browser Check

1. On a dev wiki with demo data, open `Schema:Everything` and click the edit pencil.
2. Select *select/select*. The "Allow multiple values" row ends with a grey ⚠▾. Open it, pick **Error**, and save. The stored JSON has `"multiple": { "value": false, "severity": "error" }` and the save reports no error.
3. Reopen the property: the control reads Error. Tick "Allow multiple values" and save. It still saves cleanly, and the stored JSON is a bare `"multiple": true` — the editor never emits a form the tightened validator rejects.
4. Via the API, save a Schema page whose property carries `"multiple": { "severity": "error" }`. The edit is rejected as `neowiki-schema-invalid`, and with `errorformat=plaintext` the detail reads `/propertyDefinitions/p/multiple: The required properties (value) are missing`.

Note for whoever restores an old revision: a Schema page already holding a rejected form cannot be undeleted, since `UndeletePage` validates the restored revision. Only reachable via XML import, which bypasses save validation.

<sub>AI-authored — Claude Code, `Opus 5 (1M context)`; found while reviewing #1315, then re-reviewed in a second pass whose findings (the misleading rejection message, three stale comments) are folded in; tests written first and seen failing; PHPUnit, phpcs/phpstan, vitest 125 files/1420 tests, vite build and eslint/stylelint green locally; editor round trip, API rejection text and all 21 demo schemas exercised on a dev wiki.</sub>
