### PR TITLE
Restore the type-specific attributes when the Property Type changes back

### DIFF
--- a/resources/ext.neowiki/src/components/SchemaEditor/PropertyDefinitionEditor.vue
+++ b/resources/ext.neowiki/src/components/SchemaEditor/PropertyDefinitionEditor.vue
@@ -67,7 +67,7 @@
 </template>
 
 <script setup lang="ts">
-import { PropertyDefinition, PropertyName, withConstraintSeverity, withoutSeveritiesOfClearedConstraints } from '@/domain/PropertyDefinition.ts';
+import { PropertyDefinition, PropertyName, type TypeSpecificAttributes, typeSpecificAttributesOf, withConstraintSeverity, withoutSeveritiesOfClearedConstraints } from '@/domain/PropertyDefinition.ts';
 import type { Severity } from '@/domain/Severity.ts';
 import SeverityInput from '@/components/SchemaEditor/Property/SeverityInput.vue';
 import { CdxCheckbox, CdxField, CdxSelect, CdxTextArea, CdxTextInput, type MenuItemData } from '@wikimedia/codex';
@@ -139,25 +139,43 @@ function updatePropertyAttributes<T extends PropertyDefinition>( attributes: Par
 
 const propertyTypeRegistry = NeoWikiServices.getPropertyTypeRegistry();
 
+// What each type held when the author last left it. The serializer writes whatever the
+// definition carries, so the outgoing type's fields have to come off it on a type change;
+// keeping them here lets switching back restore the author's work instead of resetting it.
+const attributesPerType = ref<Record<string, TypeSpecificAttributes>>( {} );
+
 // Rebuild the property when the type changes so its type-specific fields are
 // initialized (e.g. a Select gets an empty options list). Otherwise the editors
 // for the new type would receive a property missing the fields they expect.
-// The type-specific Constraints go, and their severities with them; required is
-// shared by every type, so it keeps its severity along with its value.
+// required is shared by every type, so it keeps its severity along with its value.
 function changePropertyType( type: string ): void {
-	const requiredSeverity = localProperty.value.constraintSeverities?.required;
+	const previous = localProperty.value as PropertyDefinition;
 
-	localProperty.value = propertyTypeRegistry.getType( type ).createPropertyDefinitionFromJson(
+	attributesPerType.value = {
+		...attributesPerType.value,
+		[ previous.type ]: typeSpecificAttributesOf( previous )
+	};
+
+	const remembered = attributesPerType.value[ type ];
+	const requiredSeverity = previous.constraintSeverities?.required;
+	const constraintSeverities: Record<string, Severity> = {
+		...remembered?.severities,
+		...( requiredSeverity === undefined ? {} : { required: requiredSeverity } )
+	};
+
+	const rebuilt = propertyTypeRegistry.getType( type ).createPropertyDefinitionFromJson(
 		{
-			name: localProperty.value.name,
+			name: previous.name,
 			type: type,
-			description: localProperty.value.description,
-			required: localProperty.value.required,
+			description: previous.description,
+			required: previous.required,
 			default: undefined,
-			...( requiredSeverity === undefined ? {} : { constraintSeverities: { required: requiredSeverity } } )
+			...( Object.keys( constraintSeverities ).length > 0 ? { constraintSeverities } : {} )
 		} as PropertyDefinition,
 		{}
 	);
+
+	localProperty.value = { ...rebuilt, ...remembered?.values } as PropertyDefinition;
 }
 
 const componentRegistry = NeoWikiServices.getComponentRegistry();

--- a/resources/ext.neowiki/src/domain/PropertyDefinition.ts
+++ b/resources/ext.neowiki/src/domain/PropertyDefinition.ts
@@ -105,6 +105,39 @@ function constraintIsCleared( value: unknown ): boolean {
 	return value === false || ( Array.isArray( value ) && value.length === 0 );
 }
 
+/**
+ * The fields every Property Type has. Anything else on a definition belongs to a single
+ * type, so it cannot travel to a type that does not declare it.
+ */
+const SHARED_FIELDS = [ 'name', 'type', 'description', 'required', 'default', 'constraintSeverities' ];
+
+export interface TypeSpecificAttributes {
+
+	readonly values: Record<string, unknown>;
+	readonly severities: Record<string, Severity>;
+
+}
+
+/**
+ * The parts of a definition that belong to its Property Type: the type-specific fields and
+ * the severities of the Constraints those fields back. `required` is shared by every type,
+ * so its severity is not part of this and travels with the property instead.
+ */
+export function typeSpecificAttributesOf( property: PropertyDefinition ): TypeSpecificAttributes {
+	const severities: Record<string, Severity> = { ...property.constraintSeverities };
+	delete severities.required;
+
+	const values: Record<string, unknown> = {};
+
+	for ( const [ field, value ] of Object.entries( property ) ) {
+		if ( !SHARED_FIELDS.includes( field ) ) {
+			values[ field ] = value;
+		}
+	}
+
+	return { values, severities };
+}
+
 export interface MultiStringProperty extends PropertyDefinition {
 
 	readonly multiple: boolean;

--- a/resources/ext.neowiki/tests/components/SchemaEditor/PropertyDefinitionEditor.spec.ts
+++ b/resources/ext.neowiki/tests/components/SchemaEditor/PropertyDefinitionEditor.spec.ts
@@ -95,6 +95,39 @@ describe( 'PropertyDefinitionEditor', () => {
 		expect( lastEmittedProperty( wrapper ).constraintSeverities ).toEqual( { required: 'error' } );
 	} );
 
+	it( 'does not carry the type-specific attributes onto the new type', async () => {
+		const wrapper = newWrapper( newTextProperty( { name: 'Status', minLength: 2, maxLength: 8 } ) );
+
+		await changeTypeTo( wrapper, 'url' );
+
+		const property = lastEmittedProperty( wrapper );
+		expect( property ).not.toHaveProperty( 'minLength' );
+		expect( property ).not.toHaveProperty( 'maxLength' );
+	} );
+
+	it( 'restores the type-specific attributes when the type changes back', async () => {
+		const wrapper = newWrapper( newTextProperty( { name: 'Status', minLength: 2, maxLength: 8 } ) );
+
+		await changeTypeTo( wrapper, 'url' );
+		await changeTypeTo( wrapper, 'text' );
+
+		const property = lastEmittedProperty( wrapper ) as TextProperty;
+		expect( property.minLength ).toBe( 2 );
+		expect( property.maxLength ).toBe( 8 );
+	} );
+
+	it( 'restores the severities of the type-specific Constraints when the type changes back', async () => {
+		const wrapper = newWrapper( {
+			...newTextProperty( { name: 'Status', minLength: 2 } ),
+			constraintSeverities: { minLength: 'error' },
+		} );
+
+		await changeTypeTo( wrapper, 'url' );
+		await changeTypeTo( wrapper, 'text' );
+
+		expect( lastEmittedProperty( wrapper ).constraintSeverities ).toEqual( { minLength: 'error' } );
+	} );
+
 	describe( 'unsetting a Constraint', () => {
 		it( 'keeps the severity of a bound that is cleared, since a bound being typed reads as cleared', async () => {
 			const wrapper = newWrapper( {

--- a/resources/ext.neowiki/tests/domain/PropertyDefinition.spec.ts
+++ b/resources/ext.neowiki/tests/domain/PropertyDefinition.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { withConstraintSeverity, withoutSeveritiesOfClearedConstraints } from '@/domain/PropertyDefinition';
+import { typeSpecificAttributesOf, withConstraintSeverity, withoutSeveritiesOfClearedConstraints } from '@/domain/PropertyDefinition';
 import { newNumberProperty } from '@/domain/propertyTypes/Number';
 import { newSelectProperty } from '@/domain/propertyTypes/Select';
 import { newTextProperty } from '@/domain/propertyTypes/Text';
@@ -109,5 +109,45 @@ describe( 'withoutSeveritiesOfClearedConstraints', () => {
 		expect( withoutSeveritiesOfClearedConstraints( property, { description: '' } ) ).toEqual( {
 			constraintSeverities: { minimum: 'error' },
 		} );
+	} );
+} );
+
+describe( 'typeSpecificAttributesOf', () => {
+	it( 'returns the fields that belong to the Property Type', () => {
+		const property = newTextProperty( { name: 'Title', description: 'A title', required: true, minLength: 2, maxLength: 8 } );
+
+		expect( typeSpecificAttributesOf( property ).values ).toEqual( {
+			minLength: 2,
+			maxLength: 8,
+			multiple: false,
+			uniqueItems: true,
+		} );
+	} );
+
+	it( 'keeps the severities of the type-specific Constraints', () => {
+		const property = {
+			...newTextProperty( { minLength: 2 } ),
+			constraintSeverities: { minLength: 'error' as const, uniqueItems: 'error' as const },
+		};
+
+		expect( typeSpecificAttributesOf( property ).severities ).toEqual( {
+			minLength: 'error',
+			uniqueItems: 'error',
+		} );
+	} );
+
+	it( 'leaves the severity of required behind, since required is shared by every type', () => {
+		const property = {
+			...newTextProperty( { required: true, minLength: 2 } ),
+			constraintSeverities: { required: 'error' as const, minLength: 'error' as const },
+		};
+
+		expect( typeSpecificAttributesOf( property ).severities ).toEqual( { minLength: 'error' } );
+	} );
+
+	it( 'returns no severities when only required is annotated', () => {
+		const property = { ...newTextProperty(), constraintSeverities: { required: 'error' as const } };
+
+		expect( typeSpecificAttributesOf( property ).severities ).toEqual( {} );
 	} );
 } );


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/NeoWiki/pull/1301#issuecomment-5383016160.

Changing a property's type discards the fields the new type does not have, because `SchemaSerializer` writes whatever the definition carries (`...propertyWithoutName`) rather than emitting a type-driven field list — a stale `minLength` left on a `url` property would reach the stored Schema. Switching away and back therefore reset the author's work: text with a character length, changed to URL and back to text, came back empty.

The editor now remembers each type's own fields and the severities of the Constraints they back, for as long as the dialog is open, and restores them when the author returns to that type. The definition itself still carries only the current type's fields, so nothing new can be serialized. `required` is shared by every type and keeps travelling with the property, as before.

`typeSpecificAttributesOf` splits a definition into the shared fields and the type's own. It lives in `domain/PropertyDefinition.ts` beside `withConstraintSeverity` and `withoutSeveritiesOfClearedConstraints` rather than in the component — the project prefers logic in TypeScript over Vue, and it also keeps `Object.entries` out of a `.vue` file, where the ES baseline rejects it.

The memory is a component-scoped `ref`, and `SchemaEditor` keys the editor on the selected property name, so it is remounted per property and nothing carries between properties.

**This is not a regression from #1301.** `changePropertyType` has rebuilt from an empty attribute set since [#957](https://github.com/ProfessionalWiki/NeoWiki/pull/957); #1301 only added the `required`-severity carry-over on top. Answering the "unsure if added by this pr" in the comment.

## Considered, omitted

- Restoring `default` on the way back. It is deliberately cleared on a type change and a remembered value could be invalid for the type it returns to, so it stays cleared.
- Making `SchemaSerializer` emit a type-driven field list, which would remove the underlying hazard rather than working around it. That is a larger change to the save path and wants its own PR.

## Manual Browser Check

1. On a dev wiki with demo data, open `Schema:Everything` and click the edit pencil.
2. Select *string/text*. Under "Character length" set Minimum to `2` and Maximum to `8`.
3. Change the Property Type to **URL**. The length fields disappear, as they should — URL has no character length.
4. Change the type back to **Text**. Minimum reads `2` and Maximum reads `8` again; before this change both were empty.
5. Set a severity on one of the bounds, switch type away and back, and confirm the severity returns with the bound.
6. Select a different property in the list, then return to *string/text*: it shows the saved values, not anything left over from step 2.

<sub>AI-authored — Claude Code, `Opus 5 (1M context)`; reported by @JeroenDeDauw on #1301; regression tests written first and seen failing; vitest 125 files/1453 tests, vue-tsc build and eslint/stylelint green locally; the reported round trip reproduced and re-checked in a browser on a dev wiki.</sub>
