### PR TITLE
Fix two defects found reviewing the subject-page index

### DIFF
--- a/maintenance/RebuildSubjectPageIndex.php
+++ b/maintenance/RebuildSubjectPageIndex.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Maintenance;
 
 use MediaWiki\Maintenance\LoggedUpdateMaintenance;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\DatabaseSubjectPageIndex;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\DatabaseSubjectPageIndexRebuilder;
 
 $basePath = getenv( 'MW_INSTALL_PATH' ) !== false ? getenv( 'MW_INSTALL_PATH' ) : __DIR__ . '/../../..';
@@ -37,6 +38,15 @@ class RebuildSubjectPageIndex extends LoggedUpdateMaintenance {
 	}
 
 	protected function doDBUpdates(): bool {
+		// update.php runs its post-update scripts outside doUpdates(), so this one runs even when the
+		// run was told to apply no schema changes: --schema writes the CREATE TABLE to a file and
+		// --noschema skips it entirely, and either way the table this fills is not there. Reported as
+		// not done, so the run that does create the table still fills it.
+		if ( !$this->indexTableExists() ) {
+			$this->output( "The NeoWiki subject -> page index table does not exist yet; nothing to rebuild.\n" );
+			return false;
+		}
+
 		$this->output( "Rebuilding the NeoWiki subject -> page index...\n" );
 
 		// Left at 0 when there is nothing to index, so the closing line is right either way.
@@ -50,6 +60,10 @@ class RebuildSubjectPageIndex extends LoggedUpdateMaintenance {
 		$this->output( "Done. Indexed $indexed pages holding Subjects.\n" );
 
 		return true;
+	}
+
+	private function indexTableExists(): bool {
+		return $this->getDB( DB_PRIMARY )->tableExists( DatabaseSubjectPageIndex::TABLE, __METHOD__ );
 	}
 
 	/**

--- a/tests/phpunit/Persistence/DatabaseSchemaTest.php
+++ b/tests/phpunit/Persistence/DatabaseSchemaTest.php
@@ -7,6 +7,7 @@ namespace ProfessionalWiki\NeoWiki\Tests\Persistence;
 use GenerateSchemaChangeSql;
 use GenerateSchemaSql;
 use MediaWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphStoreName;
 
 /**
  * The per-DBMS SQL that update.php applies is generated from the abstract schema and committed
@@ -16,6 +17,28 @@ use MediaWikiIntegrationTestCase;
  * @coversNothing
  */
 class DatabaseSchemaTest extends MediaWikiIntegrationTestCase {
+
+	/**
+	 * The longest name a store may be called and the width of the column its runs are filed under are
+	 * declared in two places that know nothing about each other. Narrowing the column alone would leave
+	 * accepted names the records cannot hold whole, and every lookup for such a store would then match
+	 * nothing. Read off the abstract schema rather than off a per-DBMS file, so this holds wherever the
+	 * suite runs — only MySQL materialises the width at all.
+	 */
+	public function testTheStoreNameLimitIsTheWidthOfTheColumnItIsFiledUnder(): void {
+		$schema = json_decode(
+			(string)file_get_contents( dirname( __DIR__, 3 ) . '/sql/neowiki_rebuild_runs.json' ),
+			true
+		);
+
+		$columns = array_column( $schema[0]['columns'], null, 'name' );
+
+		$this->assertSame(
+			GraphStoreName::MAX_LENGTH,
+			$columns['nwrr_store']['type'] === 'binary' ? $columns['nwrr_store']['options']['length'] : null,
+			'GraphStoreName::MAX_LENGTH and the nwrr_store column width have to agree'
+		);
+	}
 
 	/**
 	 * @dataProvider tableProvider


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1310

Two defects found while reviewing #1310, fixed against its head.

**`update.php --schema` and `--noschema` die on a wiki that has no index table yet.** The backfill is registered
with `addPostDatabaseUpdateMaintenance`, and that loop runs at `maintenance/update.php:197`, outside `doUpdates()`.
A run told to apply no schema changes therefore skips the `CREATE TABLE` and then runs the rebuild against a table
that is not there: both forms exit 1 with `Table 'neowiki_subject_page' doesn't exist`. The rebuild now reports
itself as not done when the table is absent, so the run that does create the table still fills it.

**The rename to `DatabaseSchemaTest` dropped an unrelated assertion.** `testTheStoreNameLimitIsTheWidthOfTheColumnItIsFiledUnder`
pinned `GraphStoreName::MAX_LENGTH` against the declared width of the `nwrr_store` column, so that narrowing one
alone could not leave accepted store names whose rebuild records cannot hold them whole. Nothing else pins the two
together. Restored unchanged.

The review found further blocking issues that are not fixed here, because the fix is a design decision for the
author: the index write is not safe against a concurrent writer outside PageUpdater's page lock (a rebuild running
while the wiki takes edits fails the user's save with MariaDB error 1020), the rebuild can overwrite fresh index
rows with a stale Subject set, and it deletes a page's rows outright when that page's subject slot holds
unparseable JSON. Those were reported to @alistair3149 separately.

> <sub>AI-authored — Claude Code, `Opus 5 (1M context, xhigh)`; review of #1310 requested by @alistair3149 via /pr-review, no redirections on content; diff not yet human-reviewed; both fixes verified on a live dev wiki — the updater guard against `update.php` plain, `--schema` and `--noschema`, the restored assertion mutation-checked — plus phpcs, phpstan and the affected PHPUnit classes green locally.</sub>
