### PR TITLE
Run the schema generators through maintenance/run.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,15 +48,15 @@
 			"cd ${MW_INSTALL_PATH:-../..} && if [ -f phpunit.xml.template ]; then composer phpunit:config; fi && vendor/bin/phpunit -c extensions/NeoWiki/phpunit.xml.dist --bootstrap tests/phpunit/bootstrap.php"
 		],
 		"dbschema": [
-			"php ../../maintenance/generateSchemaSql.php --json sql/neowiki_rebuild_runs.json --sql sql/mysql/neowiki_rebuild_runs.sql --type mysql",
-			"php ../../maintenance/generateSchemaSql.php --json sql/neowiki_rebuild_runs.json --sql sql/sqlite/neowiki_rebuild_runs.sql --type sqlite",
-			"php ../../maintenance/generateSchemaSql.php --json sql/neowiki_rebuild_runs.json --sql sql/postgres/neowiki_rebuild_runs.sql --type postgres",
-			"php ../../maintenance/generateSchemaChangeSql.php --json sql/abstractSchemaChanges/patch-neowiki_rebuild_runs-nwrr_phase.json --sql sql/mysql/patch-neowiki_rebuild_runs-nwrr_phase.sql --type mysql",
-			"php ../../maintenance/generateSchemaChangeSql.php --json sql/abstractSchemaChanges/patch-neowiki_rebuild_runs-nwrr_phase.json --sql sql/sqlite/patch-neowiki_rebuild_runs-nwrr_phase.sql --type sqlite",
-			"php ../../maintenance/generateSchemaChangeSql.php --json sql/abstractSchemaChanges/patch-neowiki_rebuild_runs-nwrr_phase.json --sql sql/postgres/patch-neowiki_rebuild_runs-nwrr_phase.sql --type postgres",
-			"php ../../maintenance/generateSchemaSql.php --json sql/neowiki_subject_page.json --sql sql/mysql/neowiki_subject_page.sql --type mysql",
-			"php ../../maintenance/generateSchemaSql.php --json sql/neowiki_subject_page.json --sql sql/sqlite/neowiki_subject_page.sql --type sqlite",
-			"php ../../maintenance/generateSchemaSql.php --json sql/neowiki_subject_page.json --sql sql/postgres/neowiki_subject_page.sql --type postgres"
+			"php ../../maintenance/run.php generateSchemaSql --json sql/neowiki_rebuild_runs.json --sql sql/mysql/neowiki_rebuild_runs.sql --type mysql",
+			"php ../../maintenance/run.php generateSchemaSql --json sql/neowiki_rebuild_runs.json --sql sql/sqlite/neowiki_rebuild_runs.sql --type sqlite",
+			"php ../../maintenance/run.php generateSchemaSql --json sql/neowiki_rebuild_runs.json --sql sql/postgres/neowiki_rebuild_runs.sql --type postgres",
+			"php ../../maintenance/run.php generateSchemaChangeSql --json sql/abstractSchemaChanges/patch-neowiki_rebuild_runs-nwrr_phase.json --sql sql/mysql/patch-neowiki_rebuild_runs-nwrr_phase.sql --type mysql",
+			"php ../../maintenance/run.php generateSchemaChangeSql --json sql/abstractSchemaChanges/patch-neowiki_rebuild_runs-nwrr_phase.json --sql sql/sqlite/patch-neowiki_rebuild_runs-nwrr_phase.sql --type sqlite",
+			"php ../../maintenance/run.php generateSchemaChangeSql --json sql/abstractSchemaChanges/patch-neowiki_rebuild_runs-nwrr_phase.json --sql sql/postgres/patch-neowiki_rebuild_runs-nwrr_phase.sql --type postgres",
+			"php ../../maintenance/run.php generateSchemaSql --json sql/neowiki_subject_page.json --sql sql/mysql/neowiki_subject_page.sql --type mysql",
+			"php ../../maintenance/run.php generateSchemaSql --json sql/neowiki_subject_page.json --sql sql/sqlite/neowiki_subject_page.sql --type sqlite",
+			"php ../../maintenance/run.php generateSchemaSql --json sql/neowiki_subject_page.json --sql sql/postgres/neowiki_subject_page.sql --type postgres"
 		]
 	},
 	"scripts-descriptions": {


### PR DESCRIPTION
Based on https://github.com/ProfessionalWiki/NeoWiki/pull/1310, which adds three more lines to the same script.

MediaWiki's entry point for maintenance scripts is `run.php`, which resolves a script by name. Everything else in
this repository already goes through it — the Makefile for `update`, `importDump` and the NeoWiki scripts, and the
installation and upgrading docs. `composer dbschema` calling `maintenance/generateSchemaSql.php` by path was the
last place that reached past it. The two remaining direct calls are both to `install.php`, which runs before there
is an installation for `run.php` to bootstrap.

Regenerating through `run.php` produces every committed SQL file byte for byte: `composer dbschema` on this branch
leaves `sql/` with no diff, and a deliberately mistyped script name exits 1, so that is a real check rather than a
silent no-op.

> <sub>AI-authored — Claude Code, `Opus 5 (1M context, xhigh)`; one-line ask from @alistair3149 including the reason it should be based on #1310, no redirections; diff not yet human-reviewed; verified by regenerating all nine files through the new form and diffing against the committed SQL, with the mistyped-name negative case run to prove the check bites, plus `composer validate` and the schema drift test.</sub>
