### PR TITLE
Revalidate the Subject editor when its Schema changes

### DIFF
--- a/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditPane.vue
+++ b/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditPane.vue
@@ -197,14 +197,17 @@ function handleClearViolation( payload: { propertyName: string; valuePartIndex: 
 	);
 }
 
-// Existing subjects are expected to be complete, so validate as soon as the
-// editor mounts: pre-existing violations (e.g. a now-empty required field)
-// surface immediately, without the user having to touch a field first.
-watch( subjectEditorRef, ( editor ) => {
+// Existing subjects are expected to be complete, so validate as soon as the editor
+// mounts, and again whenever the Schema it validates against changes: the violations
+// are a snapshot of a server response, so a Schema edit invalidates them until the
+// next run. flush() rather than revalidate(), which a zero debounce turns into a
+// no-op — blur-only wikis need the refresh too. Post-flush, so the validator reads
+// the fields the new Schema produced, not the ones it replaced.
+watch( [ subjectEditorRef, () => props.schema ], ( [ editor ] ) => {
 	if ( editor ) {
 		flush();
 	}
-} );
+}, { flush: 'post' } );
 
 // A replaced Subject starts the pane over. Drop the harvest, or a reopened pane seeds the
 // tree with relations the form no longer displays.

--- a/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditPane.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditPane.spec.ts
@@ -348,4 +348,51 @@ describe( 'SubjectEditPane', () => {
 		);
 	} );
 
+	function schemaWithTextProperty( propertyName: string ): Schema {
+		return new Schema(
+			'TestSchema',
+			'A test schema',
+			new PropertyDefinitionList( [ newTextProperty( { name: propertyName } ) ] ),
+		);
+	}
+
+	function sentPropertyNames( validate: ReturnType<typeof vi.fn>, call: number ): string[] {
+		const statements = validate.mock.calls[ call ][ 2 ] as StatementList;
+		return [ ...statements ].map( ( s ) => s.propertyName.toString() );
+	}
+
+	it( 'revalidates when the schema prop is replaced', async () => {
+		const violation: SubjectViolation = {
+			propertyName: 'Name', code: 'max-length', args: [ 5 ], severity: 'error', valuePartIndex: null,
+		};
+		const validate = vi.fn().mockResolvedValueOnce( [ violation ] ).mockResolvedValue( [] );
+		useSubjectStore().validateSubjectUpdate = validate;
+		const wrapper = mountPane( { subject: subjectWithOnlyName, schema: schemaWithTextProperty( 'Name' ) } );
+		await flushPromises();
+		expect( wrapper.findComponent( SubjectEditor ).props( 'serverViolations' ) ).toEqual( [ violation ] );
+
+		await wrapper.setProps( { schema: schemaWithTextProperty( 'Name' ) } );
+		await flushPromises();
+
+		expect( wrapper.findComponent( SubjectEditor ).props( 'serverViolations' ) ).toEqual( [] );
+	} );
+
+	// The schema decides which fields the editor renders, so reading the form any earlier
+	// validates the fields the replaced schema was showing.
+	it( 'reads the form under the new schema, not the one it replaced', async () => {
+		const validate = vi.fn().mockResolvedValue( [] );
+		useSubjectStore().validateSubjectUpdate = validate;
+		const wrapper = mountPane( { subject: subjectWithOnlyName, schema: schemaWithTextProperty( 'Name' ) } );
+		await flushPromises();
+		expect( sentPropertyNames( validate, 0 ) ).toEqual( [ 'Name' ] );
+
+		await wrapper.setProps( { schema: schemaWithTextProperty( 'Nickname' ) } );
+		await flushPromises();
+
+		// The renamed field starts empty, so a read of the new form sends no values; the
+		// old form would still have sent Name.
+		expect( validate ).toHaveBeenCalledTimes( 2 );
+		expect( sentPropertyNames( validate, 1 ) ).toEqual( [] );
+	} );
+
 } );

--- a/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditorDialog.spec.ts
@@ -726,6 +726,48 @@ describe( 'SubjectEditorDialog', () => {
 			const passed = wrapper.findComponent( SubjectEditor ).props( 'serverViolations' ) as SubjectViolation[];
 			expect( passed ).toEqual( [ existingViolation ] );
 		} );
+
+		it( 'drops a violation the schema saved through the nested schema editor resolves', async () => {
+			useSubjectStore().validateSubjectUpdate = vi.fn()
+				.mockResolvedValueOnce( [ dryRunViolation ] )
+				.mockResolvedValue( [] );
+			const wrapper = mountComponent( true, validationTestStubs );
+			await flushPromises();
+			expect( wrapper.findComponent( SubjectEditor ).props( 'serverViolations' ) ).toEqual( [ dryRunViolation ] );
+
+			wrapper.findComponent( SchemaEditorDialog ).vm.$emit( 'saved', schemaWithProperty( 'name' ) );
+			await flushPromises();
+
+			expect( wrapper.findComponent( SubjectEditor ).props( 'serverViolations' ) ).toEqual( [] );
+		} );
+
+		it( 'surfaces a violation the schema saved through the nested schema editor introduces', async () => {
+			useSubjectStore().validateSubjectUpdate = vi.fn()
+				.mockResolvedValueOnce( [] )
+				.mockResolvedValue( [ dryRunViolation ] );
+			const wrapper = mountComponent( true, validationTestStubs );
+			await flushPromises();
+			expect( wrapper.findComponent( SubjectEditor ).props( 'serverViolations' ) ).toEqual( [] );
+
+			wrapper.findComponent( SchemaEditorDialog ).vm.$emit( 'saved', schemaWithProperty( 'name' ) );
+			await flushPromises();
+
+			expect( wrapper.findComponent( SubjectEditor ).props( 'serverViolations' ) ).toEqual( [ dryRunViolation ] );
+		} );
+
+		it( 'leaves a schema change alone while the dialog is closed', async () => {
+			const validate = vi.fn().mockResolvedValue( [] );
+			useSubjectStore().validateSubjectUpdate = validate;
+			const wrapper = mountComponent( true, validationTestStubs );
+			await flushPromises();
+			await wrapper.setProps( { open: false } );
+			validate.mockClear();
+
+			await wrapper.setProps( { schema: schemaWithProperty( 'nickname' ) } );
+			await flushPromises();
+
+			expect( validate ).not.toHaveBeenCalled();
+		} );
 	} );
 
 	describe( 'Unparseable field input', () => {


### PR DESCRIPTION
Editing a Subject's Schema through the subject editor's header link left
the violations on screen answering the old Schema: with Score capped at
100, a value of 200 kept showing "Maximum value is 100." after the Schema
was saved with a cap of 1000. A Schema edit that introduced a violation
showed nothing at all.

Everything else the Schema decides is derived at render time and followed
the save already. The violations do not: they are a snapshot of a server
response, and a Schema save was not among the things that trigger a fresh
one. The nested schema editor is a sibling dialog, so nothing remounted
the subject editor either. The backend needs no change; it already
validates against the saved Schema on the next call.

Each edit pane's validate-on-mount watcher now also watches the Schema
it validates against, which covers the nested schema editor's save
reaching the root pane and the dialog replacing a pane's Schema.
Non-obvious in it: `flush: 'post'`, since the validator reads the fields
off the editor, which before the re-render still holds the ones the save
replaced.

> <sub>AI-authored — Claude Code, `Opus 5 (max)` implementation, `Fable 5 (max)` diagnosis, spec, review, and the port onto the multi-pane editor; delegated by @JeroenDeDauw; not yet human-reviewed. The new tests fail without the watcher and each of its elements is mutation-tested; full TS suite, build, and lint green locally; the symptom walked in the browser before the fix (red) and on this branch (green).</sub>
