### PR TITLE
Cover the subject editor's untested guards and walk semantics

### DIFF
--- a/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditPane.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditPane.spec.ts
@@ -195,9 +195,11 @@ describe( 'SubjectEditPane', () => {
 	} );
 
 	it( 'routes anchorless server violations to the banner and anchored ones to the field', async () => {
-		// A schema that declares 'Name', so its violation has a field on screen to anchor to.
-		// 'Ghost' has none, making it anchorless despite naming a property.
-		const wrapper = mountPane( { subject: subjectWithOnlyName, schema: schemaWithNameAndAge } );
+		// A schema that declares 'Name', so its violation has a field on screen to anchor to;
+		// the subject holds no statements, so anchoring against the subject instead of the
+		// schema's rendered fields would misroute it. 'Ghost' is anchorless despite naming
+		// a property.
+		const wrapper = mountPane( { schema: schemaWithNameAndAge } );
 
 		( wrapper.vm as any ).setServerViolations( [
 			{ propertyName: null, code: 'some-subject-level-code', args: [], severity: 'error', valuePartIndex: null },

--- a/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditPane.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditPane.spec.ts
@@ -4,6 +4,7 @@ import { nextTick, toRaw } from 'vue';
 import { createPinia, setActivePinia } from 'pinia';
 import SubjectEditPane from '@/components/SubjectEditor/SubjectEditPane.vue';
 import SubjectEditor from '@/components/SubjectEditor/SubjectEditor.vue';
+import SubjectViolationBanners from '@/components/common/SubjectViolationBanners.vue';
 import { Subject } from '@/domain/Subject.ts';
 import { Schema } from '@/domain/Schema.ts';
 import { PropertyDefinitionList } from '@/domain/PropertyDefinitionList.ts';
@@ -194,16 +195,23 @@ describe( 'SubjectEditPane', () => {
 	} );
 
 	it( 'routes anchorless server violations to the banner and anchored ones to the field', async () => {
-		const wrapper = mountPane();
+		// A schema that declares 'Name', so its violation has a field on screen to anchor to.
+		// 'Ghost' has none, making it anchorless despite naming a property.
+		const wrapper = mountPane( { subject: subjectWithOnlyName, schema: schemaWithNameAndAge } );
 
 		( wrapper.vm as any ).setServerViolations( [
 			{ propertyName: null, code: 'some-subject-level-code', args: [], severity: 'error', valuePartIndex: null },
 			{ propertyName: 'Name', code: 'some-field-code', args: [], severity: 'error', valuePartIndex: null },
+			{ propertyName: 'Ghost', code: 'some-unrendered-code', args: [], severity: 'error', valuePartIndex: null },
 		] as SubjectViolation[] );
 		await nextTick();
 
-		expect( wrapper.find( '.cdx-message--error' ).exists() ).toBe( true );
-		expect( wrapper.findComponent( SubjectEditor ).props( 'serverViolations' ) ).toHaveLength( 2 );
+		const bannered = wrapper.findComponent( SubjectViolationBanners )
+			.props( 'violations' ) as SubjectViolation[];
+		expect( bannered.map( ( violation ) => violation.code ) )
+			.toStrictEqual( [ 'some-subject-level-code', 'some-unrendered-code' ] );
+		// The field-anchored one still reaches the editor, which renders it at its field.
+		expect( wrapper.findComponent( SubjectEditor ).props( 'serverViolations' ) ).toHaveLength( 3 );
 	} );
 
 	// The host replaces the Subject when it opens the editor on another root; the pane starts

--- a/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditorDialog.spec.ts
@@ -1246,6 +1246,29 @@ describe( 'SubjectEditorDialog', () => {
 			expect( wrapper.findAllComponents( SubjectEditPane ) ).toHaveLength( 2 );
 		} );
 
+		// The open-panes check above cannot catch this click: its pane does not exist yet.
+		it( 'does not duplicate a pane when a second click lands while the target is still loading', async () => {
+			const { wrapper, mockSubjectRepository } = mountWithTargetRepos();
+			await flushPromises();
+			let resolveFetch!: ( subject: Subject ) => void;
+			mockSubjectRepository.getSubject.mockImplementationOnce(
+				() => new Promise( ( resolve ) => {
+					resolveFetch = resolve;
+				} ),
+			);
+
+			wrapper.findComponent( SubjectEditPane ).vm.$emit( 'edit-relation-target', new SubjectId( 's22222222222222' ) );
+			await nextTick();
+			wrapper.findComponent( SubjectEditPane ).vm.$emit( 'edit-relation-target', new SubjectId( 's22222222222222' ) );
+			await nextTick();
+
+			resolveFetch( targetSubject( 's22222222222222', 'Target subject' ) );
+			await flushPromises();
+
+			expect( mockSubjectRepository.getSubject ).toHaveBeenCalledTimes( 1 );
+			expect( wrapper.findAllComponents( SubjectEditPane ) ).toHaveLength( 2 );
+		} );
+
 		// teleport:false throughout: the teleport stub used elsewhere in this file re-creates
 		// its subtree on every re-render of the teleporting component, where the real Teleport
 		// patches in place. Under the stub these assertions would fail for a reason that cannot
@@ -1499,6 +1522,24 @@ describe( 'SubjectEditorDialog', () => {
 					settle( new Error( 'Boom' ) );
 					await flushPromises();
 					expect( wrapper.findComponent( SummaryAction ).props( 'saveDisabled' ) ).toBe( false );
+				} );
+
+				// The header's close button sits outside both inert regions, so this early
+				// return is the only thing between a mid-write click and a discard
+				// confirmation raised over Subjects the loop is still writing.
+				it( 'ignores the close button until the save settles', async () => {
+					const { onSave, settle } = deferredSave();
+					const { wrapper } = await mountWithSecondPaneOpen( { onSave } );
+					await makePaneDirty( wrapper, 0 );
+					await triggerSave( wrapper, '' );
+
+					await wrapper.find( '.cdx-dialog__header__close-button' ).trigger( 'click' );
+
+					expect( wrapper.findComponent( CloseConfirmationDialog ).props( 'open' ) ).toBe( false );
+					expect( wrapper.emitted( 'update:open' ) ).toBeUndefined();
+
+					settle( new Error( 'Boom' ) );
+					await flushPromises();
 				} );
 
 				it( 'makes the form and the header inert until the save settles', async () => {

--- a/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditorDialog.spec.ts
@@ -1248,7 +1248,7 @@ describe( 'SubjectEditorDialog', () => {
 
 		// The open-panes check above cannot catch this click: its pane does not exist yet.
 		it( 'does not duplicate a pane when a second click lands while the target is still loading', async () => {
-			const { wrapper, mockSubjectRepository } = mountWithTargetRepos();
+			const { wrapper, mockSubjectRepository, target } = mountWithTargetRepos();
 			await flushPromises();
 			let resolveFetch!: ( subject: Subject ) => void;
 			mockSubjectRepository.getSubject.mockImplementationOnce(
@@ -1262,7 +1262,7 @@ describe( 'SubjectEditorDialog', () => {
 			wrapper.findComponent( SubjectEditPane ).vm.$emit( 'edit-relation-target', new SubjectId( 's22222222222222' ) );
 			await nextTick();
 
-			resolveFetch( targetSubject( 's22222222222222', 'Target subject' ) );
+			resolveFetch( target );
 			await flushPromises();
 
 			expect( mockSubjectRepository.getSubject ).toHaveBeenCalledTimes( 1 );
@@ -1527,8 +1527,8 @@ describe( 'SubjectEditorDialog', () => {
 				// The header's close button sits outside both inert regions, so this early
 				// return is the only thing between a mid-write click and a discard
 				// confirmation raised over Subjects the loop is still writing.
-				it( 'ignores the close button until the save settles', async () => {
-					const { onSave, settle } = deferredSave();
+				it( 'ignores the close button while a save is writing', async () => {
+					const { onSave } = deferredSave();
 					const { wrapper } = await mountWithSecondPaneOpen( { onSave } );
 					await makePaneDirty( wrapper, 0 );
 					await triggerSave( wrapper, '' );
@@ -1537,9 +1537,6 @@ describe( 'SubjectEditorDialog', () => {
 
 					expect( wrapper.findComponent( CloseConfirmationDialog ).props( 'open' ) ).toBe( false );
 					expect( wrapper.emitted( 'update:open' ) ).toBeUndefined();
-
-					settle( new Error( 'Boom' ) );
-					await flushPromises();
 				} );
 
 				it( 'makes the form and the header inert until the save settles', async () => {

--- a/resources/ext.neowiki/tests/components/SubjectEditor/SubjectTreeWalk.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectEditor/SubjectTreeWalk.spec.ts
@@ -198,35 +198,18 @@ describe( 'walkSubjectTree', () => {
 	} );
 
 	it( 'expands a Subject reached by a second path even after its first occurrence expanded', () => {
-		// root --Left--> B --Shared--> S --Link--> E and root --Right--> C --Shared--> S: one
-		// converged-upon Subject with a descendant of its own. Convergence is ordinary, not a
-		// cycle, so S expands on both paths; a walk sharing one visited set across branches
-		// would show E under the first S alone.
-		const diamondSchema = relationSchema( 'Diamond', [ 'Left', 'Branch' ], [ 'Right', 'Branch' ] );
-		const branchSchema = relationSchema( 'Branch', [ 'Shared', 'Link' ] );
+		// A --Knows--> B and A --Likes--> B, with B --Knows--> C: one converged-upon Subject
+		// with a descendant of its own. Convergence is ordinary, not a cycle, so B expands on
+		// both paths; a walk sharing one visited set across branches would show C under the
+		// first B alone.
+		const twoWaysSchema = relationSchema( 'TwoWays', [ 'Knows', 'TwoWays' ], [ 'Likes', 'TwoWays' ] );
+		const a = subjectWith( A_ID, 'TwoWays', 'A', relationsTo( 'Knows', B_ID ), relationsTo( 'Likes', B_ID ) );
+		const b = subjectWith( B_ID, 'TwoWays', 'B', relationsTo( 'Knows', C_ID ) );
+		const c = subjectWith( C_ID, 'TwoWays', 'C' );
 
-		const root = subjectWith(
-			A_ID,
-			'Diamond',
-			'Root',
-			relationsTo( 'Left', B_ID ),
-			relationsTo( 'Right', C_ID ),
-		);
-		const left = subjectWith( B_ID, 'Branch', 'Left branch', relationsTo( 'Shared', SHARED_ID ) );
-		const right = subjectWith( C_ID, 'Branch', 'Right branch', relationsTo( 'Shared', SHARED_ID ) );
-		const shared = subjectWith( SHARED_ID, 'Link', 'Shared', relationsTo( 'Link', E_ID ) );
-		const leaf = subjectWith( E_ID, 'Link', 'Leaf' );
+		const result = walk( a, twoWaysSchema, [ a, b, c ] );
 
-		const result = walk(
-			root,
-			diamondSchema,
-			[ root, left, right, shared, leaf ],
-			[ diamondSchema, branchSchema, linkSchema ],
-		);
-
-		expect( idsOf( result.root ) ).toStrictEqual(
-			[ A_ID, B_ID, SHARED_ID, E_ID, C_ID, SHARED_ID, E_ID ],
-		);
+		expect( idsOf( result.root ) ).toStrictEqual( [ A_ID, B_ID, C_ID, B_ID, C_ID ] );
 	} );
 
 	// The form shows one slot per relation, so the same target can be picked twice under one

--- a/resources/ext.neowiki/tests/components/SubjectEditor/SubjectTreeWalk.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectEditor/SubjectTreeWalk.spec.ts
@@ -197,6 +197,38 @@ describe( 'walkSubjectTree', () => {
 		expect( new Set( keysOf( result.root ) ).size ).toBe( keysOf( result.root ).length );
 	} );
 
+	it( 'expands a Subject reached by a second path even after its first occurrence expanded', () => {
+		// root --Left--> B --Shared--> S --Link--> E and root --Right--> C --Shared--> S: one
+		// converged-upon Subject with a descendant of its own. Convergence is ordinary, not a
+		// cycle, so S expands on both paths; a walk sharing one visited set across branches
+		// would show E under the first S alone.
+		const diamondSchema = relationSchema( 'Diamond', [ 'Left', 'Branch' ], [ 'Right', 'Branch' ] );
+		const branchSchema = relationSchema( 'Branch', [ 'Shared', 'Link' ] );
+
+		const root = subjectWith(
+			A_ID,
+			'Diamond',
+			'Root',
+			relationsTo( 'Left', B_ID ),
+			relationsTo( 'Right', C_ID ),
+		);
+		const left = subjectWith( B_ID, 'Branch', 'Left branch', relationsTo( 'Shared', SHARED_ID ) );
+		const right = subjectWith( C_ID, 'Branch', 'Right branch', relationsTo( 'Shared', SHARED_ID ) );
+		const shared = subjectWith( SHARED_ID, 'Link', 'Shared', relationsTo( 'Link', E_ID ) );
+		const leaf = subjectWith( E_ID, 'Link', 'Leaf' );
+
+		const result = walk(
+			root,
+			diamondSchema,
+			[ root, left, right, shared, leaf ],
+			[ diamondSchema, branchSchema, linkSchema ],
+		);
+
+		expect( idsOf( result.root ) ).toStrictEqual(
+			[ A_ID, B_ID, SHARED_ID, E_ID, C_ID, SHARED_ID, E_ID ],
+		);
+	} );
+
 	// The form shows one slot per relation, so the same target can be picked twice under one
 	// property; the tree shows related Subjects, and every key has to be unique tree-wide.
 	describe( 'a target listed twice under one property', () => {


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1323

That PR's review ran a mutation pass over the new tests; four defects survived the whole suite. One test per gap, each seen failing under exactly the mutation it guards against:

- **Per-path visited semantics of the tree walk.** Sharing one visited set across branches — the obvious refactor — silently prunes the descendants of a Subject reached by a second path, the converging shape CIDOC-style data produces. Every existing diamond fixture converged on a leaf, so nothing caught it.
- **Close during a save.** The header's close button sits outside both inert regions; without its guard, a mid-write click raises a discard confirmation over Subjects the loop is still writing.
- **Double-click on a loading target.** Without the in-flight dedupe, the second click appends a duplicate pane with the same key; the existing dedupe test only covered already-open panes.
- **Violation routing.** The routing test's zero-property schema left its anchored field unrendered, so banner-everything passed. The fixture now renders the anchored field and covers the unrendered-property case too.

> <sub>AI-authored — Claude Code, `Fable 5 (max)`; one-line ask from @JeroenDeDauw following the fresh-session review of the pull request above, no revisions; diff not yet human-reviewed; each test kill-verified against its mutation and green on the real code, scoped vitest + lint green on this branch, CI green.</sub>
