### PR TITLE
Add user guide stubs and a landing page split by audience

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -15,6 +15,7 @@ Every page sits in one genre. Write to that genre's reader and register.
 
 | Where | Reader, and the decision they make | Register, and what to keep out |
 | --- | --- | --- |
+| `guide/` | Wiki users and admins with a task to accomplish, deciding what to do next in the UI | Task steps in UI vocabulary (Special pages, buttons, tabs), linking to reference pages for contracts; no wire formats, no PHP, no restated contracts |
 | `glossary.md`, `qualifiers-and-references.md` | New users and evaluators forming the mental model | Intended design; no dev-state caveats, no mechanism |
 | `api/` | API consumers deciding what a request or response means and what to do next | Wire-format vocabulary; no PHP class names |
 | `authoring/`, `rdf/` | Admins and integrators looking up exact behavior | Contracts, signatures, examples; no narration |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,12 +1,9 @@
 # NeoWiki Documentation
 
-The user guide is for working with structured data on a wiki that runs NeoWiki. The developer reference covers
-everything else: building on it, integrating with it, and running it. New to NeoWiki? Try the live sandbox at
-[neowiki.dev](https://neowiki.dev), or [install it locally](operations/installation.md).
+New to NeoWiki? Try the live sandbox at [neowiki.dev](https://neowiki.dev), or
+[install it locally](operations/installation.md).
 
 ## Use NeoWiki
-
-Task guides for working on a wiki that runs NeoWiki.
 
 * [Getting started](guide/getting-started.md) — your first Schema, Subject, View, and query
 * [Author an ontology mapping](guide/author-an-ontology-mapping.md) — publish Subjects in EDM, CIDOC-CRM, or another
@@ -21,8 +18,6 @@ Task guides for working on a wiki that runs NeoWiki.
   and rank (for people coming from Wikibase)
 
 ## Developer reference
-
-Contracts and extension points for building on, integrating with, and running NeoWiki.
 
 ### Build on your wiki
 
@@ -48,7 +43,7 @@ Project Subjects to RDF, natively or mapped onto standard ontologies.
 
 * [RDF Export](rdf/rdf-export.md) — native RDF projection: config, IRI scheme, endpoint, bulk dump
 * [Ontology Mapping](rdf/ontology-mapping.md) — projecting into EDM, Dublin Core, … via Mapping pages
-* [Worked example: Person to EDM](rdf/person-to-edm.md) — end-to-end mapping walkthrough with findings
+* [Worked example: Person to EDM](rdf/person-to-edm.md) — end-to-end mapping walkthrough
 
 ### Extend NeoWiki
 
@@ -60,7 +55,7 @@ Project Subjects to RDF, natively or mapped onto standard ontologies.
 * [Installation](operations/installation.md) — the Docker demo, or adding NeoWiki to an existing MediaWiki
 * [Upgrading](operations/upgrading.md) — moving your wiki to the latest NeoWiki
 * [Maintenance](operations/maintenance.md) — rebuilding the graph, Neo4j outage behavior, and backups
-* [Performance](operations/performance.md) — measured write throughput, and how to re-run the measurement
+* [Performance](operations/performance.md) — measured write throughput
 
 ### Understand the architecture
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,17 @@
 # NeoWiki Documentation
 
-Technical documentation for developers building on, integrating with, or running NeoWiki. New to NeoWiki? Try the
-live sandbox at [neowiki.dev](https://neowiki.dev), or [install it locally](operations/installation.md).
+The user guide is for working with structured data on a wiki that runs NeoWiki. The developer reference covers
+everything else: building on it, integrating with it, and running it. New to NeoWiki? Try the live sandbox at
+[neowiki.dev](https://neowiki.dev), or [install it locally](operations/installation.md).
+
+## Use NeoWiki
+
+Task guides for working on a wiki that runs NeoWiki.
+
+* [Getting started](guide/getting-started.md) — your first Schema, Subject, View, and query
+* [Author an ontology mapping](guide/author-an-ontology-mapping.md) — publish Subjects in EDM, CIDOC-CRM, or another
+  vocabulary
+* [Keep your wiki current](guide/keep-your-wiki-current.md) — upgrade an evaluation wiki
 
 ## Learn the model
 
@@ -10,14 +20,18 @@ live sandbox at [neowiki.dev](https://neowiki.dev), or [install it locally](oper
 * [Qualifiers and References](qualifiers-and-references.md) — how NeoWiki models qualifiers, references,
   and rank (for people coming from Wikibase)
 
-## Build on your wiki
+## Developer reference
+
+Contracts and extension points for building on, integrating with, and running NeoWiki.
+
+### Build on your wiki
 
 Add and display structured data with wikitext and Lua.
 
 * [Parser Functions](authoring/parser-functions.md) — `{{#view}}`, `{{#neowiki_value}}`, and `{{#cypher_raw}}`
 * [Lua API](authoring/lua-api.md) — the `mw.neowiki` Scribunto library, including `nw.query()` for Cypher
 
-## Integrate over HTTP
+### Integrate over HTTP
 
 The REST and query APIs, and the JSON formats they exchange.
 
@@ -28,7 +42,7 @@ The REST and query APIs, and the JSON formats they exchange.
 * [Query API](api/query-api.md) — read-only Cypher endpoint over the graph backend
 * [Graph Model](api/graph-model.md) — Neo4j node and relationship structure
 
-## Publish as RDF
+### Publish as RDF
 
 Project Subjects to RDF, natively or mapped onto standard ontologies.
 
@@ -36,19 +50,19 @@ Project Subjects to RDF, natively or mapped onto standard ontologies.
 * [Ontology Mapping](rdf/ontology-mapping.md) — projecting into EDM, Dublin Core, … via Mapping pages
 * [Worked example: Person to EDM](rdf/person-to-edm.md) — end-to-end mapping walkthrough with findings
 
-## Extend NeoWiki
+### Extend NeoWiki
 
 * [Extending NeoWiki](extending/extending.md) — add property types and view types, contribute graph and RDF data,
   and reuse NeoWiki's UI from another extension (with the RedHerb example extension as a starting point)
 
-## Run NeoWiki
+### Run NeoWiki
 
 * [Installation](operations/installation.md) — the Docker demo, or adding NeoWiki to an existing MediaWiki
 * [Upgrading](operations/upgrading.md) — moving your wiki to the latest NeoWiki
 * [Maintenance](operations/maintenance.md) — rebuilding the graph, Neo4j outage behavior, and backups
 * [Performance](operations/performance.md) — measured write throughput, and how to re-run the measurement
 
-## Understand the architecture
+### Understand the architecture
 
 * [Architecture Decision Records](adr/001-domain-centric-architecture.md) — numbered, dated architectural decisions
 * [Planning docs](https://github.com/ProfessionalWiki/NeoWiki/tree/master/docs/planning) — work-in-progress
@@ -60,6 +74,7 @@ Project Subjects to RDF, natively or mapped onto standard ontologies.
 
 For contributors adding to these docs:
 
+* A task guide for people using the wiki → `guide/`
 * Cross-cutting, and every audience needs it (the Glossary, Qualifiers and References) → the docs root
 * Wikitext or Lua authoring on the wiki → `authoring/`
 * An HTTP API or a JSON data format → `api/`

--- a/docs/guide/author-an-ontology-mapping.md
+++ b/docs/guide/author-an-ontology-mapping.md
@@ -6,53 +6,36 @@ order: 2
 # Author an ontology mapping
 
 A Mapping page defines an ontology projection of your wiki's Subjects: the same data expressed in EDM, CIDOC-CRM, or
-another vocabulary. The built-in native projection needs no mapping.
-
-The format is specified in [Ontology Mapping](../rdf/ontology-mapping.md), and
+another vocabulary. The format is specified in [Ontology Mapping](../rdf/ontology-mapping.md), and
 [Person to EDM](../rdf/person-to-edm.md) walks one end to end.
 
 ## 1. Create the Mapping
 
 Go to **Special:Mappings** and choose **Create**. The name you give becomes the projection name, and the page
-`Mapping:<Name>` is created pre-filled with:
-
-```json
-{"version": 1, "prefixes": {}, "schemas": {}}
-```
-
-Editing needs the `neowiki-mapping-edit` right, which logged-in users have by default.
+`Mapping:<Name>` is created with an empty mapping.
 
 ## 2. Write the mapping
 
-There is no form-based editor: the content is JSON, edited in the normal page editor and syntax-highlighted when the
-CodeEditor extension is installed. Saving validates the mapping and reports errors, and the page's read view shows a
-summary of the mapped Schemas and prefixes.
-
-Keys under `schemas` are your wiki's Schema names, and the keys under a Schema entry's `properties` are that Schema's
-property names.
-
-The fastest start is copying a shipped example: `Mapping:EDM` (flat term substitution) or `Mapping:CIDOC-CRM`
-(synthesizes intermediate event nodes). Read their raw JSON on the sandbox —
-[EDM](https://neowiki.dev/wiki/Mapping:EDM?action=raw),
+The fastest start is copying a shipped example and swapping in your own Schema and property names: `Mapping:EDM`
+(flat term substitution) or `Mapping:CIDOC-CRM` (synthesizes intermediate event nodes). Read their raw JSON on the
+sandbox — [EDM](https://neowiki.dev/wiki/Mapping:EDM?action=raw),
 [CIDOC-CRM](https://neowiki.dev/wiki/Mapping:CIDOC-CRM?action=raw) — or
 [in the repository](https://github.com/ProfessionalWiki/NeoWiki/tree/master/DemoData/Mapping).
 
-## 3. Use the projection
+There is no form-based editor: the content is JSON, edited in the normal page editor. Saving validates the mapping
+and reports errors, and the page's read view shows a summary of the mapped Schemas and prefixes.
+
+## 3. See the projection
 
 Exports are produced on demand from current data, so a saved Mapping — or an edit to one — takes effect right away.
+On any page with Subjects, the **Data** tab offers per-projection RDF downloads, as Turtle or TriG. Per-Subject
+exports, the REST endpoint, and the bulk dump are in [RDF Export](../rdf/rdf-export.md).
 
-* On any page with Subjects, the **Data** tab offers per-projection RDF downloads, as Turtle or TriG.
-* Programmatically: `rest.php/neowiki/v0/page/{id}/rdf?projection=<Name>`
-* In bulk: `php maintenance/run.php NeoWiki:DumpRdf --projection=<Name>`
+## 4. Query the projection over SPARQL
 
-## Live SPARQL querying is separate
+Add the projection as a store entry in
+[`$wgNeoWikiSparqlStores`](../operations/installation.md#several-projections-in-one-store). After a Mapping change,
+such a store keeps the old vocabulary until it is rebuilt: **Special:GraphStores** flags it as
+[stale](../operations/maintenance.md#stale-stores) and offers **Rebuild**.
 
-To query the projection over SPARQL, configure it as a store entry in `$wgNeoWikiSparqlStores`, where
-[several projections can share one store](../operations/installation.md#several-projections-in-one-store).
-
-After a Mapping change such a store keeps the old vocabulary until it is rebuilt. **Special:GraphStores** flags it as
-[stale](../operations/maintenance.md#stale-stores) and offers **Rebuild**; `$wgNeoWikiAutoRebuildOnMappingChange`
-automates it.
-
-This guide is new and deliberately short. Tell us where it falls short:
-https://github.com/ProfessionalWiki/NeoWiki/issues/1336.
+Tell us what this guide is missing: https://github.com/ProfessionalWiki/NeoWiki/issues/1336.

--- a/docs/guide/author-an-ontology-mapping.md
+++ b/docs/guide/author-an-ontology-mapping.md
@@ -1,0 +1,58 @@
+---
+title: Author an ontology mapping
+order: 2
+---
+
+# Author an ontology mapping
+
+A Mapping page defines an ontology projection of your wiki's Subjects: the same data expressed in EDM, CIDOC-CRM, or
+another vocabulary. The built-in native projection needs no mapping.
+
+The format is specified in [Ontology Mapping](../rdf/ontology-mapping.md), and
+[Person to EDM](../rdf/person-to-edm.md) walks one end to end.
+
+## 1. Create the Mapping
+
+Go to **Special:Mappings** and choose **Create**. The name you give becomes the projection name, and the page
+`Mapping:<Name>` is created pre-filled with:
+
+```json
+{"version": 1, "prefixes": {}, "schemas": {}}
+```
+
+Editing needs the `neowiki-mapping-edit` right, which logged-in users have by default.
+
+## 2. Write the mapping
+
+There is no form-based editor: the content is JSON, edited in the normal page editor and syntax-highlighted when the
+CodeEditor extension is installed. Saving validates the mapping and reports errors, and the page's read view shows a
+summary of the mapped Schemas and prefixes.
+
+Keys under `schemas` are your wiki's Schema names, and the keys under a Schema entry's `properties` are that Schema's
+property names.
+
+The fastest start is copying a shipped example: `Mapping:EDM` (flat term substitution) or `Mapping:CIDOC-CRM`
+(synthesizes intermediate event nodes). Read their raw JSON on the sandbox —
+[EDM](https://neowiki.dev/wiki/Mapping:EDM?action=raw),
+[CIDOC-CRM](https://neowiki.dev/wiki/Mapping:CIDOC-CRM?action=raw) — or
+[in the repository](https://github.com/ProfessionalWiki/NeoWiki/tree/master/DemoData/Mapping).
+
+## 3. Use the projection
+
+Exports are produced on demand from current data, so a saved Mapping — or an edit to one — takes effect right away.
+
+* On any page with Subjects, the **Data** tab offers per-projection RDF downloads, as Turtle or TriG.
+* Programmatically: `rest.php/neowiki/v0/page/{id}/rdf?projection=<Name>`
+* In bulk: `php maintenance/run.php NeoWiki:DumpRdf --projection=<Name>`
+
+## Live SPARQL querying is separate
+
+To query the projection over SPARQL, configure it as a store entry in `$wgNeoWikiSparqlStores`, where
+[several projections can share one store](../operations/installation.md#several-projections-in-one-store).
+
+After a Mapping change such a store keeps the old vocabulary until it is rebuilt. **Special:GraphStores** flags it as
+[stale](../operations/maintenance.md#stale-stores) and offers **Rebuild**; `$wgNeoWikiAutoRebuildOnMappingChange`
+automates it.
+
+This guide is new and deliberately short. Tell us where it falls short:
+https://github.com/ProfessionalWiki/NeoWiki/issues/1336.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,0 +1,55 @@
+---
+title: Getting started
+order: 1
+---
+
+# Getting started
+
+In one sitting you will define a Schema, put a Subject on a page, render it, and query it. Work on the public sandbox
+at [neowiki.dev](https://neowiki.dev) — it resets periodically, so edit freely — or on
+[your own wiki](../operations/installation.md).
+
+## 1. Create a Schema
+
+A Schema describes a kind of thing: a Person, a Building, a Painting. Go to **Special:Schemas** and create one, then
+use **Add property definition** for each fact you want to record, giving it a name and a Property Type — text, number,
+date, relation, and so on. The [Glossary](../glossary.md) defines these concepts.
+
+## 2. Create a Subject
+
+A Subject is one thing described with a Schema. Open any wiki page and pick **Create subject** from the page tools.
+The dialog lets you use an existing Schema or create one in the flow. Fill in the values and save.
+
+## 3. See the data
+
+The page's Main Subject renders automatically as an infobox; the **Data** tab lists every Subject on the page.
+
+## 4. Render a View in wikitext
+
+Source edit any page and add:
+
+```
+{{#view:}}
+```
+
+With no id it renders the page's Main Subject. [Parser Functions](../authoring/parser-functions.md) covers the rest.
+
+## 5. Query
+
+Add a query to any page. This one lists the stored pages, whatever your data model:
+
+```
+{{#cypher_raw: MATCH (p:Page) RETURN p.name }}
+```
+
+It needs the Neo4j backend, which the demo and Docker stacks include.
+
+## Where next
+
+* [Author an ontology mapping](author-an-ontology-mapping.md) — publish your Subjects in EDM, CIDOC-CRM, or another
+  vocabulary
+* [Keep your wiki current](keep-your-wiki-current.md) — upgrade an evaluation wiki
+* [Glossary](../glossary.md) — the vocabulary the UI and these docs share
+
+This guide is new and deliberately short. Tell us where it falls short:
+https://github.com/ProfessionalWiki/NeoWiki/issues/1336.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -5,26 +5,23 @@ order: 1
 
 # Getting started
 
-In one sitting you will define a Schema, put a Subject on a page, render it, and query it. Work on the public sandbox
-at [neowiki.dev](https://neowiki.dev) — it resets periodically, so edit freely — or on
-[your own wiki](../operations/installation.md).
+In one sitting: from an empty page to structured, queryable data. Work on the public sandbox at
+[neowiki.dev](https://neowiki.dev) — create an account first (anonymous editing is off), then edit freely; it is a
+sandbox and resets periodically — or on [your own wiki](../operations/installation.md).
 
 ## 1. Create a Schema
 
 A Schema describes a kind of thing: a Person, a Building, a Painting. Go to **Special:Schemas** and create one, then
-use **Add property definition** for each fact you want to record, giving it a name and a Property Type — text, number,
-date, relation, and so on. The [Glossary](../glossary.md) defines these concepts.
+use **Add property definition** for each fact you want to record, giving it a name and a Property Type — text,
+number, date, relation, and so on.
 
 ## 2. Create a Subject
 
-A Subject is one thing described with a Schema. Open any wiki page and pick **Create subject** from the page tools.
-The dialog lets you use an existing Schema or create one in the flow. Fill in the values and save.
+A Subject is one thing described with a Schema. Open any wiki page and pick **Create subject** from the page tools,
+fill in the values, and save. The page's Main Subject renders automatically as an infobox, and the page's **Data**
+tab lists every Subject on the page.
 
-## 3. See the data
-
-The page's Main Subject renders automatically as an infobox; the **Data** tab lists every Subject on the page.
-
-## 4. Render a View in wikitext
+## 3. Render a View in wikitext
 
 Source edit any page and add:
 
@@ -32,9 +29,10 @@ Source edit any page and add:
 {{#view:}}
 ```
 
-With no id it renders the page's Main Subject. [Parser Functions](../authoring/parser-functions.md) covers the rest.
+With no id it renders the page's Main Subject. [Parser Functions](../authoring/parser-functions.md) covers the
+rest, and Layouts control which properties a View shows ([Glossary](../glossary.md#layout)).
 
-## 5. Query
+## 4. Query
 
 Add a query to any page. This one lists the stored pages, whatever your data model:
 
@@ -42,14 +40,12 @@ Add a query to any page. This one lists the stored pages, whatever your data mod
 {{#cypher_raw: MATCH (p:Page) RETURN p.name }}
 ```
 
-It needs the Neo4j backend, which the demo and Docker stacks include.
+Needs a Neo4j backend, which the sandbox and the Docker install have.
 
 ## Where next
 
 * [Author an ontology mapping](author-an-ontology-mapping.md) — publish your Subjects in EDM, CIDOC-CRM, or another
   vocabulary
-* [Keep your wiki current](keep-your-wiki-current.md) — upgrade an evaluation wiki
 * [Glossary](../glossary.md) — the vocabulary the UI and these docs share
 
-This guide is new and deliberately short. Tell us where it falls short:
-https://github.com/ProfessionalWiki/NeoWiki/issues/1336.
+Tell us what this guide is missing: https://github.com/ProfessionalWiki/NeoWiki/issues/1336.

--- a/docs/guide/keep-your-wiki-current.md
+++ b/docs/guide/keep-your-wiki-current.md
@@ -1,0 +1,30 @@
+---
+title: Keep your wiki current
+order: 3
+---
+
+# Keep your wiki current
+
+NeoWiki has no releases yet: the latest state is master. The demo Docker image is kept in sync with the public demo
+wiki, so once you have upgraded, your wiki has everything [neowiki.dev](https://neowiki.dev) shows.
+
+## Upgrade
+
+On a Docker install, `git pull` the repository the stack runs from, then:
+
+```sh
+make upgrade
+```
+
+[Upgrading](../operations/upgrading.md) covers what that does, and the steps for a manual install.
+
+To move the demo pages to the current demo set as well, see
+[refresh the demo content](../operations/upgrading.md#optional-refresh-the-demo-content).
+
+## If an upgrade breaks your data
+
+NeoWiki is pre-release, so breaking changes can land at any time. If an upgrade can no longer read your evaluation
+data, `make remove && make demo` starts fresh.
+
+This guide is new and deliberately short. Tell us where it falls short:
+https://github.com/ProfessionalWiki/NeoWiki/issues/1336.

--- a/docs/guide/keep-your-wiki-current.md
+++ b/docs/guide/keep-your-wiki-current.md
@@ -5,26 +5,18 @@ order: 3
 
 # Keep your wiki current
 
-NeoWiki has no releases yet: the latest state is master. The demo Docker image is kept in sync with the public demo
-wiki, so once you have upgraded, your wiki has everything [neowiki.dev](https://neowiki.dev) shows.
+NeoWiki has no releases yet: the latest state is master, and upgrading means moving to it.
 
-## Upgrade
-
-On a Docker install, `git pull` the repository the stack runs from, then:
+On a Docker install, back up anything you care about ([backups](../operations/maintenance.md#backups)), `git pull`
+the repository the stack runs from, then:
 
 ```sh
 make upgrade
 ```
 
-[Upgrading](../operations/upgrading.md) covers what that does, and the steps for a manual install.
+[Upgrading](../operations/upgrading.md) covers what that does, the steps for a manual install, and how to
+[refresh the demo content](../operations/upgrading.md#optional-refresh-the-demo-content) to the current set.
 
-To move the demo pages to the current demo set as well, see
-[refresh the demo content](../operations/upgrading.md#optional-refresh-the-demo-content).
+If an upgrade can no longer read your evaluation data, `make remove && make demo` starts fresh.
 
-## If an upgrade breaks your data
-
-NeoWiki is pre-release, so breaking changes can land at any time. If an upgrade can no longer read your evaluation
-data, `make remove && make demo` starts fresh.
-
-This guide is new and deliberately short. Tell us where it falls short:
-https://github.com/ProfessionalWiki/NeoWiki/issues/1336.
+Tell us what this guide is missing: https://github.com/ProfessionalWiki/NeoWiki/issues/1336.


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/NeoWiki/issues/1336

Adds docs/guide/ with three stub pages — Getting started, Author an ontology mapping, Keep your
wiki current — published thin on purpose so the gaps fill against real questions. Each page ends
with a feedback link to the issue. The landing page now routes by reader: the user guide first,
the developer reference grouped below it. docs/AGENTS.md gains the guide/ genre row. No reference
page changed.

Website counterpart: https://github.com/ProfessionalWiki/NeoWiki-Website/issues/115.

Considered, omitted:
- The Mapping skeleton JSON, the `neowiki-mapping-edit` right, the REST and bulk export commands,
  and `$wgNeoWikiAutoRebuildOnMappingChange` — all already homed in the format reference,
  installation, RDF export, and maintenance pages; the guides link instead of restating.
- A "which features does my install have" page — needs release notes to exist first.
- Moving the README's contributor routing ("Where each kind of doc lives") into docs/AGENTS.md —
  pre-existing structure question, out of this PR.

> <sub>AI-authored — Claude Code, `Opus 5 (max)` subagent drafting from a `Fable 5 (max)` spec, then cut to stub size by `Fable 5 (max)` after a blind `Opus 5 (max)` text review; asked by @JeroenDeDauw; not yet human-reviewed; UI claims verified against master source and the live sandbox, links and anchors checked.</sub>
