### PR TITLE
Give the guide stubs a human style pass

### DIFF
--- a/docs/guide/author-an-ontology-mapping.md
+++ b/docs/guide/author-an-ontology-mapping.md
@@ -17,9 +17,9 @@ Go to **Special:Mappings** and choose **Create**. The name you give becomes the 
 ## 2. Write the mapping
 
 The fastest start is copying a shipped example and swapping in your own Schema and property names: `Mapping:EDM`
-(flat term substitution) or `Mapping:CIDOC-CRM` (synthesizes intermediate event nodes). Read their raw JSON on the
-sandbox — [EDM](https://neowiki.dev/wiki/Mapping:EDM?action=raw),
-[CIDOC-CRM](https://neowiki.dev/wiki/Mapping:CIDOC-CRM?action=raw) — or
+(flat term substitution) or `Mapping:CIDOC-CRM` (synthesizes intermediate event nodes). Read their raw JSON on the sandbox
+([EDM](https://neowiki.dev/wiki/Mapping:EDM?action=raw),
+[CIDOC-CRM](https://neowiki.dev/wiki/Mapping:CIDOC-CRM?action=raw)) or
 [in the repository](https://github.com/ProfessionalWiki/NeoWiki/tree/master/DemoData/Mapping).
 
 There is no form-based editor: the content is JSON, edited in the normal page editor. Saving validates the mapping
@@ -27,7 +27,7 @@ and reports errors, and the page's read view shows a summary of the mapped Schem
 
 ## 3. See the projection
 
-Exports are produced on demand from current data, so a saved Mapping — or an edit to one — takes effect right away.
+Exports are produced on demand from current data, so a new or edited Mapping takes effect right away.
 On any page with Subjects, the **Data** tab offers per-projection RDF downloads, as Turtle or TriG. Per-Subject
 exports, the REST endpoint, and the bulk dump are in [RDF Export](../rdf/rdf-export.md).
 

--- a/docs/guide/author-an-ontology-mapping.md
+++ b/docs/guide/author-an-ontology-mapping.md
@@ -17,8 +17,8 @@ Go to **Special:Mappings** and choose **Create**. The name you give becomes the 
 ## 2. Write the mapping
 
 The fastest start is copying a shipped example and swapping in your own Schema and property names: `Mapping:EDM`
-(flat term substitution) or `Mapping:CIDOC-CRM` (synthesizes intermediate event nodes). Read their raw JSON on the sandbox
-([EDM](https://neowiki.dev/wiki/Mapping:EDM?action=raw),
+(flat term substitution) or `Mapping:CIDOC-CRM` (synthesizes intermediate event nodes). Read their raw JSON on
+the sandbox ([EDM](https://neowiki.dev/wiki/Mapping:EDM?action=raw),
 [CIDOC-CRM](https://neowiki.dev/wiki/Mapping:CIDOC-CRM?action=raw)) or
 [in the repository](https://github.com/ProfessionalWiki/NeoWiki/tree/master/DemoData/Mapping).
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -5,21 +5,21 @@ order: 1
 
 # Getting started
 
-In one sitting: from an empty page to structured, queryable data. Work on the public sandbox at
-[neowiki.dev](https://neowiki.dev) — create an account first (anonymous editing is off), then edit freely; it is a
-sandbox and resets periodically — or on [your own wiki](../operations/installation.md).
+Turn a wiki page into structured, queryable data in a few minutes. Try it on the public sandbox at
+[neowiki.dev](https://neowiki.dev) (create an account, then experiment freely: it is a sandbox and resets
+periodically) or on [your own wiki](../operations/installation.md).
 
 ## 1. Create a Schema
 
 A Schema describes a kind of thing: a Person, a Building, a Painting. Go to **Special:Schemas** and create one, then
-use **Add property definition** for each fact you want to record, giving it a name and a Property Type — text,
+use **Add property definition** for each fact you want to record, giving it a name and a Property Type: text,
 number, date, relation, and so on.
 
 ## 2. Create a Subject
 
 A Subject is one thing described with a Schema. Open any wiki page and pick **Create subject** from the page tools,
-fill in the values, and save. The page's Main Subject renders automatically as an infobox, and the page's **Data**
-tab lists every Subject on the page.
+fill in the values, and save. The page's Main Subject renders automatically as an infobox, and the **Data** tab
+lets you view and edit all its Subjects.
 
 ## 3. Render a View in wikitext
 
@@ -40,12 +40,12 @@ Add a query to any page. This one lists the stored pages, whatever your data mod
 {{#cypher_raw: MATCH (p:Page) RETURN p.name }}
 ```
 
-Needs a Neo4j backend, which the sandbox and the Docker install have.
+This needs a Neo4j backend; the sandbox and the Docker install have one.
 
 ## Where next
 
-* [Author an ontology mapping](author-an-ontology-mapping.md) — publish your Subjects in EDM, CIDOC-CRM, or another
+* [Author an ontology mapping](author-an-ontology-mapping.md): publish your Subjects in EDM, CIDOC-CRM, or another
   vocabulary
-* [Glossary](../glossary.md) — the vocabulary the UI and these docs share
+* [Glossary](../glossary.md): the vocabulary the UI and these docs share
 
 Tell us what this guide is missing: https://github.com/ProfessionalWiki/NeoWiki/issues/1336.


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1337

Redoes the Getting started intro, says the Data tab edits as well as lists, and drops em-dashes
from the guide prose. The landing page's new bullets keep that file's existing "link — description"
list convention. Verified before keeping it: the Main Subject still auto-renders as an infobox by
default (`$wgNeoWikiAutoRenderMainSubject`).

> <sub>AI-authored — Claude Code, `Fable 5 (max)`; reworded per @JeroenDeDauw's line-by-line feedback; not yet human-reviewed; auto-render default verified in extension.json, line lengths and links checked.</sub>
