### PR TITLE
Show a Subject's Schema as one badge wherever it is named

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -490,7 +490,6 @@
 				"neowiki-property-type-unregistered-notification",
 				"neowiki-boolean-true",
 				"neowiki-boolean-false",
-				"neowiki-infobox-type",
 				"neowiki-infobox-edit-link",
 				"neowiki-field-required",
 				"neowiki-field-unique",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -78,7 +78,6 @@
 
 	"neowiki-schema-label": "Schema: $1",
 
-	"neowiki-infobox-type": "Type",
 	"neowiki-infobox-edit-link": "Edit",
 	"neowiki-field-required": "Please provide a value.",
 	"neowiki-field-unique": "All values must be unique.",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -123,7 +123,7 @@
 
 	"neowiki-subject-generated-name": "(unnamed $1)",
 
-	"neowiki-subject-editor-title": "Editing $1",
+	"neowiki-subject-editor-title": "Edit subject",
 	"neowiki-subject-editor-save": "Save changes",
 	"neowiki-subject-editor-label-field": "Subject label",
 	"neowiki-subject-editor-rename": "Rename subject",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -17,7 +17,7 @@
 	"action-neowiki-admin": "{{doc-action|neowiki-admin}}",
 	"specialpages-group-neowiki": "Group heading for NeoWiki special pages on [[Special:SpecialPages]].",
 	"neowiki-special-schemas": "Title and description of the [[Special:Schemas]] page.",
-	"neowiki-schema-label": "Label used to identify the schema. $1 is the schema name or link.",
+	"neowiki-schema-label": "Names a subject's schema. $1 is the schema name or a link to it. Also used as the accessible name of the schema badge, whose visible text is the bare name.",
 	"neowiki-cypher-raw-error-json-encode": "Error message shown when JSON encoding of query results fails.",
 
 	"neowiki-cypher-error-empty-query": "Error shown on the <code>{{#cypher_raw}}</code> parser function and the <code>nw.query()</code> Lua function when the supplied Cypher query is empty or only whitespace.",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -68,6 +68,7 @@
 
 	"neowiki-subject-generated-name": "The name shown for a subject that has no label of its own, so its name was derived from its schema rather than chosen by anyone. $1 is the schema name: a noun the wiki's own users invented, in an unknown language and grammatical gender, so do not inflect it, do not change its case, and make no word agree with it. The round brackets mark the whole string as a stand-in the system supplied rather than a name someone typed, as in {{msg-mw|Blanknamespace}}; use whichever brackets your language uses for that.",
 
+	"neowiki-subject-editor-title": "Title of the subject editor dialog, and its accessible name. Names the task rather than a subject: the dialog can edit several at once, and each one is named by the pane that edits it.",
 	"neowiki-subject-editor-label-field": "Accessibility label for the input shown in place of the dialog title while renaming a subject in the subject editor dialog.",
 	"neowiki-subject-editor-rename": "Accessibility label for the button next to the subject editor dialog title that starts renaming the subject.",
 	"neowiki-subject-editor-edit-target": "Aria-label of the per-target edit button shown beside a selected relation target in the subject editor. Clicking it opens that target subject for editing in a pane.",

--- a/resources/ext.neowiki/src/assets/mixins.less
+++ b/resources/ext.neowiki/src/assets/mixins.less
@@ -1,0 +1,21 @@
+/**
+ * Shared LESS mixins. Imported with `@import ( reference )`, so nothing here emits CSS on
+ * its own — only where a rule calls it.
+ */
+
+/**
+ * Removes an element from the visual layout while leaving it in the accessibility tree.
+ * `clip-path` rather than `display: none` or `visibility: hidden`, which would take it out of
+ * both; `nowrap` stops a long string being collapsed into the 1px box and read back wrapped.
+ */
+.ext-neowiki-visually-hidden() {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	margin: -1px;
+	padding: 0;
+	overflow: hidden;
+	clip-path: inset( 50% );
+	white-space: nowrap;
+	border: 0;
+}

--- a/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditPane.vue
+++ b/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditPane.vue
@@ -1,15 +1,12 @@
 <template>
-	<!-- The root pane goes unnamed: the dialog around it already names that same Subject. -->
 	<section
 		class="ext-neowiki-subject-edit-pane"
-		:aria-label="props.nested ? paneName : undefined"
+		:aria-label="paneName"
 	>
-		<!-- Only a nested pane carries these: the dialog's own header names the root Subject
-			and holds the field that renames it. -->
-		<div
-			v-if="props.nested"
-			class="ext-neowiki-subject-edit-pane__header"
-		>
+		<!-- Named here rather than in the dialog's header, for the root as well as a nested
+			pane: a header naming the root goes stale the moment another pane is opened, and
+			cannot follow without re-rendering CdxDialog. -->
+		<div class="ext-neowiki-subject-edit-pane__header">
 			<h3 class="ext-neowiki-subject-edit-pane__name">
 				<EditableText
 					:model-value="label"
@@ -20,19 +17,37 @@
 				/>
 			</h3>
 
-			<div
-				v-if="pageName !== null"
-				class="ext-neowiki-subject-edit-pane__storage"
-			>
-				<I18nSlot message-key="neowiki-subject-editor-stored-on">
-					<!-- A new tab: following the link in this one discards unsaved edits. -->
-					<a
-						class="ext-neowiki-subject-edit-pane__page"
-						:href="pageUrl"
-						target="_blank"
-						rel="noopener"
-					>{{ pageName }}</a>
-				</I18nSlot>
+			<div class="ext-neowiki-subject-edit-pane__meta">
+				<!-- The Schema the pane's Subject uses, beside the name it belongs to rather
+					than in a dialog header that cannot follow the pane. A real link, so it
+					carries the badge's own interactive styling and a destination; a plain
+					click opens the Schema editor instead, as the old header link did.
+
+					A new tab, for the reason the storage link below gives: this dialog holds
+					unsaved edits for every open pane and nothing guards a navigation away
+					from it. Withheld while the Subject is named after its Schema, so it is
+					not named twice. -->
+				<SchemaNameDisplay
+					v-if="schemaBadge !== null"
+					:schema-name="schemaBadge"
+					link="new-tab"
+					@click="openSchemaEditor"
+				/>
+
+				<div
+					v-if="props.nested && pageName !== null"
+					class="ext-neowiki-subject-edit-pane__storage"
+				>
+					<I18nSlot message-key="neowiki-subject-editor-stored-on">
+						<!-- A new tab: following the link in this one discards unsaved edits. -->
+						<a
+							class="ext-neowiki-subject-edit-pane__page"
+							:href="pageUrl"
+							target="_blank"
+							rel="noopener"
+						>{{ pageName }}</a>
+					</I18nSlot>
+				</div>
 			</div>
 		</div>
 
@@ -76,7 +91,9 @@ import SubjectViolationBanners from '@/components/common/SubjectViolationBanners
 import I18nSlot from '@/components/common/I18nSlot.vue';
 import { subjectLabelPlaceholder } from '@/presentation/subjectLabelPlaceholder.ts';
 import { subjectDisplayName } from '@/presentation/subjectDisplayName.ts';
+import { schemaNameToShow } from '@/presentation/schemaNameToShow.ts';
 import EditableText from '@/components/common/EditableText.vue';
+import SchemaNameDisplay from '@/components/common/SchemaNameDisplay.vue';
 import { StatementList } from '@/domain/StatementList.ts';
 import { Subject } from '@/domain/Subject.ts';
 import { enteredSubjectLabel } from '@/domain/enteredSubjectLabel.ts';
@@ -95,6 +112,8 @@ const props = defineProps<{
 	subject: Subject;
 	schema: Schema;
 	nested?: boolean;
+	// Whether this pane's Schema may be edited, so its name can offer the editor.
+	canEditSchema?: boolean;
 	// A Subject this editing session invented, which the server has never seen. It is validated
 	// as a creation rather than as an update, and the dialog writes it with a create.
 	isNew?: boolean;
@@ -105,6 +124,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
 	'edit-relation-target': [ SubjectId ];
+	'edit-schema': [];
 }>();
 
 provide( RelationTargetEditingKey, true );
@@ -129,6 +149,11 @@ const storedLabel = computed( (): string | null => enteredSubjectLabel( label.va
 
 const paneName = computed( (): string => storedLabel.value ?? subjectDisplayName( props.subject ) );
 
+// A label typed here counts before it is saved, as it does for `paneName`.
+const schemaBadge = computed( (): string | null =>
+	schemaNameToShow( props.subject.withLabel( storedLabel.value ) )
+);
+
 const pageName = computed( (): string | null =>
 	props.subject instanceof SubjectWithContext ?
 		props.subject.getPageIdentifiers().getPageName() :
@@ -140,6 +165,24 @@ const pageUrl = computed( (): string =>
 );
 
 const labelPlaceholder = computed( (): string => subjectLabelPlaceholder( props.subject ) );
+
+/**
+ * Opens the Schema editor in place of following the link, for a plain left click by someone
+ * who may edit it. Anything else — a modifier, the middle button, no edit right — is left to
+ * the browser, so the Schema page stays reachable and nothing here is a dead end.
+ */
+function openSchemaEditor( event: MouseEvent ): void {
+	if ( !props.canEditSchema || event.button !== 0 ) {
+		return;
+	}
+
+	if ( event.metaKey || event.ctrlKey || event.shiftKey || event.altKey ) {
+		return;
+	}
+
+	event.preventDefault();
+	emit( 'edit-schema' );
+}
 
 // EditableText commits once per edit, so a commit is both the change and the
 // end of the interaction: validate immediately rather than waiting for a blur.
@@ -291,26 +334,40 @@ defineExpose( {
 @import ( reference ) '@wikimedia/codex-design-tokens/theme-wikimedia-ui.less';
 
 .ext-neowiki-subject-edit-pane {
-	/* The name and where it is stored on one line, the name taking whatever the storage line
-		leaves. Baseline-aligned rather than centred, because the two differ in size. */
+	/* The name at the start, the Schema and where it is stored flush to the end. Baseline
+		rather than centre, because the three differ in size. Wrapping is the last resort: the
+		badge truncates first, and the row only breaks when even that leaves no room. */
 	&__header {
 		display: flex;
 		align-items: baseline;
-		justify-content: space-between;
-		gap: @spacing-50;
+		flex-wrap: wrap;
+		gap: @spacing-25 @spacing-50;
 		margin-bottom: @spacing-75;
 	}
 
-	/* Subordinate to the dialog's own title, which names the root Subject: a heading for
-		screen readers and outline tools, sized like the body around it. */
+	/* A heading for screen readers and outline tools, sized like the body around it. The
+		skin gives headings block padding of their own, which would push the row open.
+		It takes the free space, which is what puts the meta at the end of the row. */
 	&__name {
+		flex-grow: 1;
 		min-width: 0;
 		margin: 0;
+		padding-block: 0;
 		font-size: @font-size-medium;
 	}
 
+	/* Shrinkable, with `min-width: 0` so it may go below its content: the badge ellipsises
+		itself, but only once its parent is allowed to be narrower than the name inside it.
+		Under `flex-shrink: 0` a long Schema name pushed the row wider than the pane and the
+		whole form picked up a horizontal scrollbar. */
+	&__meta {
+		display: flex;
+		align-items: baseline;
+		gap: @spacing-50;
+		min-width: 0;
+	}
+
 	&__storage {
-		flex-shrink: 0;
 		color: @color-subtle;
 		font-size: @font-size-small;
 	}

--- a/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditorDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditorDialog.vue
@@ -7,59 +7,10 @@
 			:open="open"
 			class="ext-neowiki-ui ext-neowiki-subject-editor-dialog cdx-dialog--dividers"
 			:class="{ 'ext-neowiki-subject-editor-dialog--wide': showsNavigator }"
-			:title="$i18n( 'neowiki-subject-editor-title', subjectDisplayName( props.subject ) ).text()"
+			:title="$i18n( 'neowiki-subject-editor-title' ).text()"
+			:use-close-button="true"
 			@update:open="onDialogUpdateOpen"
 		>
-			<template #header>
-				<div
-					class="cdx-dialog__header__title-group"
-					:inert="saving || undefined"
-				>
-					<div class="cdx-dialog__header__title ext-neowiki-subject-editor-dialog__title">
-						<EditableText
-							:model-value="subjectLabel"
-							:edit-button-label="$i18n( 'neowiki-subject-editor-rename' ).text()"
-							:input-aria-label="$i18n( 'neowiki-subject-editor-label-field' ).text()"
-							:placeholder="labelPlaceholder"
-							@update:model-value="onLabelEdited"
-						/>
-					</div>
-
-					<p class="cdx-dialog__header__subtitle">
-						<I18nSlot
-							message-key="neowiki-schema-label"
-							class="ext-neowiki-subject-editor-dialog-schema"
-							text-class="ext-neowiki-subject-editor-dialog-schema__label"
-						>
-							<a
-								v-if="canEditSchema"
-								class="ext-neowiki-subject-editor-dialog-schema__link"
-								href="#"
-								@click.prevent="isSchemaEditorOpen = true"
-							>
-								{{ props.subject.getSchemaName() }}
-							</a>
-							<span
-								v-else
-								class="ext-neowiki-subject-editor-dialog-schema__name"
-							>
-								{{ props.subject.getSchemaName() }}
-							</span>
-						</I18nSlot>
-					</p>
-				</div>
-
-				<CdxButton
-					class="cdx-dialog__header__close-button"
-					weight="quiet"
-					type="button"
-					:aria-label="$i18n( 'cdx-dialog-close-button-label' ).text()"
-					@click="closeRequested"
-				>
-					<CdxIcon :icon="cdxIconClose" />
-				</CdxButton>
-			</template>
-
 			<!-- Only the navigator's surface is ever conditionally rendered, and the panes container
 				is deliberately unkeyed: a pane must never unmount, because its unsaved values live in
 				the ValueInput refs inside it. -->
@@ -123,7 +74,9 @@
 								:nested="pane.id !== rootPaneId"
 								:is-new="pane.isNew"
 								:unsaved-target-ids="draftIds"
+								:can-edit-schema="pane.id === rootPaneId && canEditSchema"
 								@edit-relation-target="openRelationTargetFromForm"
+								@edit-schema="openSchemaEditor( pane.id )"
 							/>
 						</div>
 					</div>
@@ -171,11 +124,8 @@ import SubjectEditPane from '@/components/SubjectEditor/SubjectEditPane.vue';
 import type { SubjectEditPaneExposes } from '@/components/SubjectEditor/SubjectEditPane.vue';
 import SubjectTree from '@/components/SubjectEditor/SubjectTree.vue';
 import SummaryAction from '@/components/common/SummaryAction.vue';
-import I18nSlot from '@/components/common/I18nSlot.vue';
-import EditableText from '@/components/common/EditableText.vue';
 import EditNoticeList from '@/components/common/EditNoticeList.vue';
-import { CdxButton, CdxDialog, CdxIcon, CdxMessage, useGeneratedId } from '@wikimedia/codex';
-import { cdxIconClose } from '@wikimedia/codex-icons';
+import { CdxDialog, CdxMessage, useGeneratedId } from '@wikimedia/codex';
 import { Subject } from '@/domain/Subject.ts';
 import { enteredSubjectLabel } from '@/domain/enteredSubjectLabel.ts';
 import { SubjectWithContext } from '@/domain/SubjectWithContext.ts';
@@ -198,7 +148,6 @@ import { ValidationFailedError } from '@/persistence/ValidationFailedError';
 import type { UnparseableInput } from '@/components/common/UnparseableInput.ts';
 import { NeoWikiServices } from '@/NeoWikiServices.ts';
 import { relationTargetsOf } from '@/components/SubjectEditor/SubjectTreeModel.ts';
-import { subjectLabelPlaceholder } from '@/presentation/subjectLabelPlaceholder.ts';
 import { subjectDisplayName } from '@/presentation/subjectDisplayName.ts';
 import { reachableTargetIds, writeOrder } from '@/components/SubjectEditor/SubjectDraftGraph.ts';
 import type { HeldSubject } from '@/components/SubjectEditor/SubjectDraftGraph.ts';
@@ -385,22 +334,25 @@ const showsNavigator = computed( (): boolean =>
 
 const openIds = computed( (): string[] => panes.value.map( ( pane ) => pane.id ) );
 
-// Owned by the pane that edits the Subject. Falls back to the prop for the first render,
-// before that pane has registered its ref.
-const subjectLabel = computed( (): string => rootPane.value?.label ?? props.subject.getLabel() ?? '' );
-
-const labelPlaceholder = computed( (): string => subjectLabelPlaceholder( props.subject ) );
-
-function onLabelEdited( value: string ): void {
-	rootPane.value?.setLabel( value );
-}
-
 // Keys the tree, and nothing else: re-keying the panes would unmount them and destroy
 // unsaved values. The tree remembers which fetches failed for the life of its mount, so
 // without a remount one transient failure would leave that branch empty for the rest of the
 // session. The two watchers further down bump it, an opening and a replaced root alike, and
 // a target fetch that outlives its opening is dropped by it: the hosts keep this dialog
 // mounted after it closes, so the fetch would otherwise land in the next opening.
+/**
+ * `SchemaEditorDialog` below is bound to the root's Schema, so only the root pane may open it —
+ * a nested pane would put the reader in front of a Schema they did not point at. The pane has a
+ * guard of its own; this one is where the consequence lives.
+ */
+function openSchemaEditor( paneId: string ): void {
+	if ( paneId !== rootPaneId.value ) {
+		return;
+	}
+
+	isSchemaEditorOpen.value = true;
+}
+
 const openEpoch = ref( 0 );
 
 // So a double-click on one target's edit button does not fire a second request. Keyed per
@@ -793,46 +745,15 @@ defineExpose( { hasChanged: anyChanged } );
 
 <style lang="less">
 @import ( reference ) '@wikimedia/codex-design-tokens/theme-wikimedia-ui.less';
-@import ( reference ) '@wikimedia/codex/mixins/link.less';
 
 .ext-neowiki-subject-editor-dialog {
-	&-schema {
-		&__link {
-			.cdx-mixin-link-base();
-		}
-
-		&__name {
-			color: @color-base;
-		}
-	}
-
-	/* Codex puts these on `.cdx-dialog__header--default`, a class it adds only to the header
-		it builds itself, so a slotted header never receives them and there is nothing here to
-		out-weigh — they are replicated, not overridden. */
+	/* Overrides, not replications: `.cdx-dialog__header`'s padding is unconditional in Codex,
+		and `align-items: baseline` comes from `--default`, which this header now carries again.
+		Both are deliberate departures — the header is one row of static text beside a 32px
+		close button, so the button sets the height and baseline sits the title high in it. */
 	.cdx-dialog__header {
-		display: flex;
-		align-items: baseline;
-		justify-content: flex-end;
-		box-sizing: @box-sizing-base;
-		width: @size-full;
-
-		/* Secondary to the title, like the statement-field labels below.
-			Nested under the header to out-rank Codex's runtime-injected
-			two-class subtitle rule. */
-		.cdx-dialog__header__subtitle {
-			font-size: @font-size-small;
-		}
-	}
-
-	/* The title row's edit button already provides vertical air; Codex's
-		default gap on top of it reads too wide. */
-	.cdx-dialog__header__title-group {
-		gap: 0;
-	}
-
-	&__title {
-		display: flex;
-		min-width: 0;
+		align-items: center;
+		padding-block: @spacing-50;
 	}
 
 	&--wide.cdx-dialog {

--- a/resources/ext.neowiki/src/components/SubjectEditor/SubjectTree.vue
+++ b/resources/ext.neowiki/src/components/SubjectEditor/SubjectTree.vue
@@ -5,6 +5,16 @@
 		:label="$i18n( 'neowiki-subject-tree-label' ).text()"
 		@select="selectItem"
 	>
+		<!-- Unlinked: the row is itself the click target. The dialog's own header still shows
+			the older "Schema: X" text until that header is converted. -->
+		<template #secondary="{ item }">
+			<SchemaNameDisplay
+				v-if="item.secondaryLabel"
+				:schema-name="item.secondaryLabel"
+				link="none"
+			/>
+		</template>
+
 		<!-- Rendered here rather than inside NeoTree: the dot carries an i18n message of its
 			own, and it belongs in the row a treeitem takes its accessible name from. -->
 		<template #trailing="{ item }">
@@ -17,6 +27,7 @@
 import { computed, shallowReactive, watch } from 'vue';
 import NeoTree from '@/components/common/NeoTree/NeoTree.vue';
 import UnsavedDot from '@/components/common/UnsavedDot.vue';
+import SchemaNameDisplay from '@/components/common/SchemaNameDisplay.vue';
 import type { NeoTreeItem } from '@/components/common/NeoTree/NeoTreeModel.ts';
 import { nodeFor, walkSubjectTree } from './SubjectTreeWalk.ts';
 import type { SubjectTreeWalkResult, WalkNode } from './SubjectTreeWalk.ts';
@@ -139,9 +150,8 @@ function toTreeItem( node: WalkNode ): NeoTreeItem<string> {
 	return {
 		key: node.key,
 		label: node.label,
-		// Set apart by Schema unless the name already names it: a Subject nobody named is shown as
-		// "(unnamed <Schema>)", and one labelled after its Schema reads the same as its Schema.
-		secondaryLabel: node.nameIsGenerated || node.schemaName === node.label ? undefined : node.schemaName,
+		// Withheld where the name already names the Schema; the walk decides that per node.
+		secondaryLabel: node.schemaLabel ?? undefined,
 		active: node.subjectId === props.activeId,
 		attrs: { 'data-mw-neowiki-subject-id': node.subjectId },
 		children: childItemsOf( node ),

--- a/resources/ext.neowiki/src/components/SubjectEditor/SubjectTreeWalk.ts
+++ b/resources/ext.neowiki/src/components/SubjectEditor/SubjectTreeWalk.ts
@@ -6,6 +6,7 @@
 import { relationTargetsOf } from './SubjectTreeModel.ts';
 import type { Subject } from '@/domain/Subject.ts';
 import { subjectDisplayName } from '@/presentation/subjectDisplayName.ts';
+import { schemaNameToShow } from '@/presentation/schemaNameToShow.ts';
 import type { Schema, SchemaName } from '@/domain/Schema.ts';
 
 // Levels of relation targets to walk from the root: person -> birth event -> time span is 2.
@@ -17,10 +18,8 @@ export interface WalkNode {
 	key: string;
 	subjectId: string;
 	label: string;
-	schemaName: string;
-	// Whether `label` is the marked stand-in rather than a name anyone chose, which already names
-	// the Schema and so makes a second Schema label on the row a repeat.
-	nameIsGenerated: boolean;
+	// The Schema label set beside the name, or null where the name already names the Schema.
+	schemaLabel: string | null;
 	// The relation property this node hangs under; the root hangs under none. The children
 	// of one property are contiguous, in the Schema's order.
 	propertyName?: string;
@@ -35,8 +34,7 @@ export function nodeFor( key: string, subjectId: string, subject: Subject | unde
 		key,
 		subjectId,
 		label: subject === undefined ? subjectId : subjectDisplayName( subject ),
-		schemaName: subject?.getSchemaName() ?? '',
-		nameIsGenerated: subject?.hasGeneratedDisplayName() ?? false,
+		schemaLabel: subject === undefined ? null : schemaNameToShow( subject ),
 		children: [],
 	};
 }

--- a/resources/ext.neowiki/src/components/SubjectsManager/DataExportButton.vue
+++ b/resources/ext.neowiki/src/components/SubjectsManager/DataExportButton.vue
@@ -269,6 +269,7 @@ function onFocusOut( event: FocusEvent ): void {
 
 <style lang="less">
 @import ( reference ) '@wikimedia/codex-design-tokens/theme-wikimedia-ui.less';
+@import ( reference ) '@/assets/mixins.less';
 
 .ext-neowiki-data-export {
 	position: relative;
@@ -309,15 +310,7 @@ function onFocusOut( event: FocusEvent ): void {
 	}
 
 	&__sr-only {
-		position: absolute;
-		width: 1px;
-		height: 1px;
-		margin: -1px;
-		padding: 0;
-		overflow: hidden;
-		clip-path: inset( 50% );
-		white-space: nowrap;
-		border: 0;
+		.ext-neowiki-visually-hidden();
 	}
 }
 </style>

--- a/resources/ext.neowiki/src/components/SubjectsManager/SubjectsManagerPage.vue
+++ b/resources/ext.neowiki/src/components/SubjectsManager/SubjectsManagerPage.vue
@@ -106,13 +106,12 @@
 								{{ subjectDisplayName( mainSubject ) }}
 							</span>
 							<span class="ext-neowiki-subjects-manager__row-subtitle">
-								<a
+								<SchemaNameDisplay
+									v-if="schemaNameToShow( mainSubject ) !== null"
 									class="ext-neowiki-subjects-manager__row-schema"
-									:href="schemaUrl( mainSubject.getSchemaName() )"
+									:schema-name="mainSubject.getSchemaName()"
 									@click.stop
-								>
-									{{ mainSubject.getSchemaName() }}
-								</a>
+								/>
 								<span class="ext-neowiki-subjects-manager__row-count">
 									{{ $i18n( 'neowiki-managesubjects-statement-count', statementCount( mainSubject ) ).text() }}
 								</span>
@@ -289,13 +288,12 @@
 									{{ subjectDisplayName( subject ) }}
 								</span>
 								<span class="ext-neowiki-subjects-manager__row-subtitle">
-									<a
+									<SchemaNameDisplay
+										v-if="schemaNameToShow( subject ) !== null"
 										class="ext-neowiki-subjects-manager__row-schema"
-										:href="schemaUrl( subject.getSchemaName() )"
+										:schema-name="subject.getSchemaName()"
 										@click.stop
-									>
-										{{ subject.getSchemaName() }}
-									</a>
+									/>
 									<span class="ext-neowiki-subjects-manager__row-count">
 										{{ $i18n( 'neowiki-managesubjects-statement-count', statementCount( subject ) ).text() }}
 									</span>
@@ -516,6 +514,7 @@ import { useSubjectPermissions } from '@/composables/useSubjectPermissions.ts';
 import { useSubjectDrag } from '@/composables/useSubjectDrag.ts';
 import { subjectRowDomId, subjectIdFromHash } from '@/presentation/subjectRowAnchor.ts';
 import { subjectDisplayName } from '@/presentation/subjectDisplayName.ts';
+import { schemaNameToShow } from '@/presentation/schemaNameToShow.ts';
 import { Subject } from '@/domain/Subject';
 import { Schema } from '@/domain/Schema';
 import { SubjectId } from '@/domain/SubjectId';
@@ -524,6 +523,7 @@ import SubjectEditorDialog from '@/components/SubjectEditor/SubjectEditorDialog.
 import SummaryAction from '@/components/common/SummaryAction.vue';
 import MoveSubjectDialog from '@/components/SubjectsManager/MoveSubjectDialog.vue';
 import I18nSlot from '@/components/common/I18nSlot.vue';
+import SchemaNameDisplay from '@/components/common/SchemaNameDisplay.vue';
 import SubjectStatementsView from '@/components/SubjectsManager/SubjectStatementsView.vue';
 import DataExportButton from '@/components/SubjectsManager/DataExportButton.vue';
 import { subjectExportUrls, pageExportUrls } from '@/presentation/DataExportMenu.ts';
@@ -626,10 +626,6 @@ const hasChildSubjects = computed( () => otherSubjects.value.length > 0 );
 const isCompletelyEmpty = computed( () => !hasMainSubject.value && !hasChildSubjects.value );
 
 const deletingSubjectName = computed( () => deletingSubject.value === null ? '' : subjectDisplayName( deletingSubject.value ) );
-
-function schemaUrl( name: string ): string {
-	return mw.util.getUrl( `Schema:${ name }` );
-}
 
 function subjectIri( id: string ): string {
 	return subjectIriBase + id;
@@ -1235,11 +1231,9 @@ onUnmounted( () => {
 		color: @color-subtle;
 	}
 
+	/* The badge ellipsises its own text; the row only has to let it shrink. */
 	&__row-schema {
 		min-width: 0;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
 	}
 
 	&__row-count {

--- a/resources/ext.neowiki/src/components/SubjectsManager/SubjectsManagerPage.vue
+++ b/resources/ext.neowiki/src/components/SubjectsManager/SubjectsManagerPage.vue
@@ -1300,7 +1300,8 @@ onUnmounted( () => {
 		}
 	}
 
-	&__row-count::before {
+	/* The separator belongs to the pair: a row whose badge is withheld draws none. */
+	&__row-schema + &__row-count::before {
 		content: '•';
 		margin-inline-end: @spacing-50;
 	}

--- a/resources/ext.neowiki/src/components/Views/Infobox.vue
+++ b/resources/ext.neowiki/src/components/Views/Infobox.vue
@@ -10,14 +10,15 @@
 				>
 					{{ subjectDisplayName( subject ) }}
 				</div>
+				<!-- Conditional on the badge, not the reverse: a wrapper left behind when the
+					badge withholds itself announces as an unnamed level-3 heading. -->
 				<div
+					v-if="schemaNameBadge !== null"
 					class="ext-neowiki-infobox__schema"
 					role="heading"
 					aria-level="3"
 				>
-					<a :href="schemaUrl">
-						{{ schema?.getName() }}
-					</a>
+					<SchemaNameDisplay :schema-name="schemaNameBadge" />
 				</div>
 			</div>
 			<CdxButton
@@ -68,6 +69,8 @@ import { useSchemaStore } from '@/stores/SchemaStore.ts';
 import { useLayoutStore } from '@/stores/LayoutStore.ts';
 import { NeoWikiServices } from '@/NeoWikiServices.ts';
 import SubjectEditorDialog from '@/components/SubjectEditor/SubjectEditorDialog.vue';
+import SchemaNameDisplay from '@/components/common/SchemaNameDisplay.vue';
+import { schemaNameToShow } from '@/presentation/schemaNameToShow.ts';
 import { subjectDisplayName } from '@/presentation/subjectDisplayName.ts';
 import { useSubjectStore } from '@/stores/SubjectStore.ts';
 import { CdxButton, CdxIcon } from '@wikimedia/codex';
@@ -126,12 +129,8 @@ function getComponent( propertyType: string ): Component {
 	return NeoWikiServices.getComponentRegistry().getValueDisplayComponent( propertyType );
 }
 
-const schemaUrl = computed( () => {
-	if ( !schema.value ) {
-		return '';
-	}
-	return mw.util.getUrl( `Schema:${ schema.value.getName() }` );
-} );
+// Null when the Subject is already named after its Schema, so the heading above goes with the badge.
+const schemaNameBadge = computed( (): string | null => schemaNameToShow( subject.value ) );
 
 const layout = computed( () => {
 	if ( !props.layoutName ) {
@@ -174,19 +173,18 @@ const resolvedProperties = computed( (): ResolvedProperty[] => {
 		display: flex;
 		align-items: flex-start;
 
+		/* A flex item's automatic minimum size is its max-content width, so without this the
+			badge's un-wrappable name floors the column and the header grows past the infobox
+			border. The badge ellipsises once allowed to be narrower than its text. */
 		&__text {
 			flex-grow: 1;
+			min-width: 0;
 		}
 	}
 
 	&__title {
 		font-size: @font-size-x-large;
 		font-weight: @font-weight-bold;
-	}
-
-	&__schema {
-		color: @color-subtle;
-		font-size: @font-size-small;
 	}
 
 	&__content {

--- a/resources/ext.neowiki/src/components/common/NeoTree/NeoTree.vue
+++ b/resources/ext.neowiki/src/components/common/NeoTree/NeoTree.vue
@@ -18,6 +18,13 @@
 				:select="selectItem"
 				:keydown="onKeydown"
 			>
+				<template #secondary="slotProps">
+					<slot
+						name="secondary"
+						v-bind="slotProps"
+					/>
+				</template>
+
 				<template #trailing="slotProps">
 					<slot
 						name="trailing"
@@ -45,10 +52,13 @@ const emit = defineEmits<{
 
 // Declared out here: a parenthesis anywhere inside a macro's type argument trips ESLint's
 // func-call-spacing, which reads it as the macro's own call.
-type TrailingSlot = ( slotProps: { item: NeoTreeItem<T> } ) => unknown;
+type NodeSlot = ( slotProps: { item: NeoTreeItem<T> } ) => unknown;
 
 defineSlots<{
-	trailing?: TrailingSlot;
+	// Replaces a node's plain `secondaryLabel` text, inside the same element, so a consumer
+	// can treat it without the tree knowing what it means.
+	secondary?: NodeSlot;
+	trailing?: NodeSlot;
 }>();
 
 // Printed order, which is both the order Up/Down move through and the order the element ids
@@ -226,9 +236,12 @@ function onKeydown( event: KeyboardEvent, item: NeoTreeItem<T> ): void {
 		white-space: nowrap;
 	}
 
-	/* Set apart by colour rather than size: the row already sits a step below body text. */
+	/* Set apart by colour rather than size: the row already sits a step below body text.
+		`min-width: 0` lets it shrink below its content, so a long label gives way to the
+		node's own name instead of squeezing it to nothing. */
 	&__node-secondary {
-		flex: none;
+		flex: 0 1 auto;
+		min-width: 0;
 		color: @color-subtle;
 	}
 }

--- a/resources/ext.neowiki/src/components/common/NeoTree/NeoTreeNode.vue
+++ b/resources/ext.neowiki/src/components/common/NeoTree/NeoTreeNode.vue
@@ -24,7 +24,10 @@
 			<span
 				v-if="item.secondaryLabel"
 				class="ext-neowiki-tree__node-secondary"
-			>{{ item.secondaryLabel }}</span>
+			><slot
+				name="secondary"
+				:item="item"
+			>{{ item.secondaryLabel }}</slot></span>
 			<slot
 				name="trailing"
 				:item="item"
@@ -59,6 +62,13 @@
 					:select="select"
 					:keydown="keydown"
 				>
+					<template #secondary="slotProps">
+						<slot
+							name="secondary"
+							v-bind="slotProps"
+						/>
+					</template>
+
 					<template #trailing="slotProps">
 						<slot
 							name="trailing"
@@ -78,7 +88,7 @@ import type { NeoTreeItem } from './NeoTreeModel.ts';
 // Declared out here for the reason given in NeoTree.vue.
 type NodeSelect = ( item: NeoTreeItem<T> ) => void;
 type NodeKeydown = ( event: KeyboardEvent, item: NeoTreeItem<T> ) => void;
-type TrailingSlot = ( slotProps: { item: NeoTreeItem<T> } ) => unknown;
+type NodeSlot = ( slotProps: { item: NeoTreeItem<T> } ) => unknown;
 
 const props = defineProps<{
 	item: NeoTreeItem<T>;
@@ -90,7 +100,8 @@ const props = defineProps<{
 }>();
 
 defineSlots<{
-	trailing?: TrailingSlot;
+	secondary?: NodeSlot;
+	trailing?: NodeSlot;
 }>();
 
 const elementId = computed( (): string => props.elementIds.get( props.item.key ) ?? '' );

--- a/resources/ext.neowiki/src/components/common/SchemaNameDisplay.vue
+++ b/resources/ext.neowiki/src/components/common/SchemaNameDisplay.vue
@@ -1,0 +1,136 @@
+<template>
+	<!-- A span where the surface owns the click: a link inside a tree row competes with it. -->
+	<component
+		:is="props.link === 'none' ? 'span' : 'a'"
+		class="ext-neowiki-schema-name"
+		:href="props.link === 'none' ? undefined : schemaUrl"
+		:target="props.link === 'new-tab' ? '_blank' : undefined"
+		:rel="props.link === 'new-tab' ? 'noopener' : undefined"
+	>
+		<span class="ext-neowiki-schema-name__noun">{{ accessibleName }}</span>
+		<span
+			class="ext-neowiki-schema-name__text"
+			aria-hidden="true"
+		>{{ props.schemaName }}</span>
+	</component>
+</template>
+
+<script lang="ts">
+/** Where following the link leaves the reader. */
+export type SchemaNameLink = 'same-tab' | 'new-tab' | 'none';
+</script>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+const props = withDefaults( defineProps<{
+	schemaName: string;
+	link?: SchemaNameLink;
+}>(), {
+	link: 'same-tab'
+} );
+
+const schemaUrl = computed( (): string => mw.util.getUrl( `Schema:${ props.schemaName }` ) );
+
+// The badge shows the bare name, so the noun reaches a screen reader through this instead;
+// the visible name is aria-hidden, or it would be announced twice.
+const accessibleName = computed( (): string =>
+	mw.message( 'neowiki-schema-label', props.schemaName ).text()
+);
+</script>
+
+<style lang="less">
+@import ( reference ) '@wikimedia/codex-design-tokens/theme-wikimedia-ui.less';
+@import ( reference ) '@/assets/mixins.less';
+
+/* Not a Codex InfoChip: that is a pill at `@font-size-small`, the size of a navigator row's
+	own text, and a wall of them down the navigator. Badge and chip stay distinct shapes for
+	distinct ideas — the chip means Property Type on the Schema page. */
+.ext-neowiki-schema-name {
+	display: inline-flex;
+	align-items: center;
+	box-sizing: @box-sizing-base;
+	max-width: @size-full;
+	min-height: @size-125;
+	border: @border-width-base @border-style-base @background-color-neutral;
+	border-radius: @border-radius-base;
+	padding: 0 @spacing-35;
+	background-color: @background-color-neutral-subtle;
+	color: @color-subtle;
+	font-size: @font-size-x-small;
+	line-height: @line-height-xx-small;
+
+	&__text {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	&__noun {
+		.ext-neowiki-visually-hidden();
+	}
+}
+
+/* Codex 2.6.2's progressive-action colours. The Codex MediaWiki serves has older values and
+	lacks the two subtle hover/active fills, and it defines the properties it does ship, so a
+	`var()` fallback would never reach ours — hence redefining them here. `@supports` because a
+	custom property holding an unsupported `light-dark()` is invalid at substitution, which would
+	leave the badge with no background rather than MediaWiki's older one.
+
+	Remove once MediaWiki 1.47 ships a Codex carrying these values. */
+@supports ( color: light-dark( #000, #fff ) ) {
+	.ext-neowiki-schema-name {
+		--background-color-progressive-subtle: light-dark( #e8eeff, #1b223d );
+		--background-color-progressive-subtle--hover: light-dark( #d9e2ff, #233566 );
+		--background-color-progressive-subtle--active: light-dark( #b6d4fb, #3056a9 );
+		--border-color-progressive--hover: light-dark( #3056a9, #88a3e8 );
+		--border-color-progressive--active: light-dark( #233566, #a6bbf5 );
+		--color-progressive: light-dark( #36c, #88a3e8 );
+		--color-progressive--hover: light-dark( #3056a9, #a6bbf5 );
+		--color-progressive--active: light-dark( #233566, #b6d4fb );
+	}
+}
+
+/* Where it links, the badge is Codex's normal-weight progressive-action button; the resting
+	border takes the fill so it reads flat until hovered, without leaving the box model.
+
+	Every state is spelled out because core styles `a:visited` and underlines `a:hover, a:focus`
+	at specificity (0,1,1) — a pseudo-class counts as a class — tying with a bare `a.<class>`
+	and winning on load order. Only `a.<class>:<state>` at (0,1,2) beats them, and the states
+	tie with one another, so source order decides among them too.
+
+	The subtle fills are `var()` calls because Codex 1.14 has no LESS variable for them. */
+a.ext-neowiki-schema-name {
+	&,
+	&:visited,
+	&:hover,
+	&:focus,
+	&:active {
+		text-decoration: none;
+	}
+
+	&,
+	&:visited {
+		border-color: @background-color-progressive-subtle;
+		background-color: @background-color-progressive-subtle;
+		color: @color-progressive;
+	}
+
+	&:hover {
+		border-color: @border-color-progressive--hover;
+		background-color: var( --background-color-progressive-subtle--hover, @background-color-progressive-subtle );
+		color: @color-progressive--hover;
+	}
+
+	&:active {
+		border-color: @border-color-progressive--active;
+		background-color: var( --background-color-progressive-subtle--active, @background-color-progressive-subtle );
+		color: @color-progressive--active;
+	}
+
+	&:focus-visible {
+		outline: @border-width-thick solid @outline-color-progressive--focus;
+	}
+}
+
+</style>

--- a/resources/ext.neowiki/src/presentation/schemaNameToShow.ts
+++ b/resources/ext.neowiki/src/presentation/schemaNameToShow.ts
@@ -1,0 +1,14 @@
+import type { Subject } from '@/domain/Subject.ts';
+
+/**
+ * The Schema name to show beside a Subject, or null when the Subject's own name is the Schema
+ * name already: a Subject with no label is shown under its Schema name (ADR 31), and one
+ * labelled after its Schema reads the same. Marked, "(unnamed <Schema>)" still names the
+ * Schema, which is why this takes the Subject rather than the name a surface shows for it.
+ *
+ * The badge does not apply this itself: a surface guards its own wrapper along with the
+ * name, since an emptied wrapper carrying a role is worse than a repeat.
+ */
+export function schemaNameToShow( subject: Subject ): string | null {
+	return subject.getDisplayName() === subject.getSchemaName() ? null : subject.getSchemaName();
+}

--- a/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditPane.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditPane.spec.ts
@@ -334,13 +334,13 @@ describe( 'SubjectEditPane', () => {
 			.toBe( 'Test Subject' );
 	} );
 
-	// The dialog already carries that name; a second region repeating it is one more boundary
-	// to cross on the way to the form.
-	it( 'leaves the root pane\'s region unnamed', () => {
+	// The dialog's own header no longer names any Subject, so the root's region carries the
+	// name like every other pane's.
+	it( 'names the root pane\'s region after its subject too', () => {
 		const wrapper = mountPane();
 
 		expect( wrapper.get( '.ext-neowiki-subject-edit-pane' ).attributes( 'aria-label' ) )
-			.toBeUndefined();
+			.toBe( 'Test Subject' );
 	} );
 
 	it( 'names the region of a label-less subject by its display name', () => {
@@ -348,6 +348,21 @@ describe( 'SubjectEditPane', () => {
 
 		expect( wrapper.get( '.ext-neowiki-subject-edit-pane' ).attributes( 'aria-label' ) )
 			.toBe( 'Test page' );
+	} );
+
+	describe( 'The Schema beside the name', () => {
+		it( 'shows the schema as a badge beside a labelled subject', () => {
+			const wrapper = mountPane();
+
+			expect( wrapper.get( '.ext-neowiki-schema-name__text' ).text() ).toBe( 'TestSchema' );
+		} );
+
+		// The pane already names such a Subject "(unnamed TestSchema)".
+		it( 'withholds the badge from a subject shown under its schema name', () => {
+			const wrapper = mountPane( { subject: schemaNamedSubject, nested: true } );
+
+			expect( wrapper.find( '.ext-neowiki-schema-name' ).exists() ).toBe( false );
+		} );
 	} );
 
 	// The field edits the stored label, which is empty here.
@@ -586,7 +601,7 @@ describe( 'SubjectEditPane', () => {
 		} );
 	} );
 
-	describe( 'Renaming from a nested pane', () => {
+	describe( 'Renaming from a pane', () => {
 		async function rename( wrapper: VueWrapper, name: string ): Promise<void> {
 			await wrapper.get( 'button[aria-label="neowiki-subject-editor-rename"]' ).trigger( 'click' );
 			const input = wrapper.get( '.ext-neowiki-editable-text__input input' );
@@ -602,12 +617,12 @@ describe( 'SubjectEditPane', () => {
 			expect( ( ( wrapper.vm as any ).buildUpdatedSubject() as Subject ).getLabel() ).toBe( 'Renamed' );
 		} );
 
-		// The dialog's own header renames the root Subject; a second field for it would be two
-		// places to type one name.
-		it( 'leaves the root pane without a rename control', () => {
+		// The dialog's header names no Subject now, so the root is renamed where every other
+		// pane is renamed: in the pane itself.
+		it( 'gives the root pane a rename control, like every other pane', () => {
 			const wrapper = mountPane();
 
-			expect( wrapper.findComponent( EditableText ).exists() ).toBe( false );
+			expect( wrapper.findComponent( EditableText ).exists() ).toBe( true );
 		} );
 
 		// The empty field stands for "no label", so it previews the name that choice leaves the
@@ -623,6 +638,15 @@ describe( 'SubjectEditPane', () => {
 
 			expect( wrapper.findComponent( EditableText ).props( 'placeholder' ) )
 				.toBe( 'neowiki-subject-editor-label-field' );
+		} );
+
+		// Named after its Schema until now, so the badge would have said the same thing twice.
+		it( 'shows the schema badge once a schema-named subject is given a label of its own', async () => {
+			const wrapper = mountPane( { subject: schemaNamedSubject, nested: true } );
+
+			await rename( wrapper, 'Alice' );
+
+			expect( wrapper.get( '.ext-neowiki-schema-name__text' ).text() ).toBe( 'TestSchema' );
 		} );
 	} );
 

--- a/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditorDialog.spec.ts
@@ -228,37 +228,101 @@ describe( 'SubjectEditorDialog', () => {
 		expect( editedPropertyNames( wrapper ) ).toEqual( [ 'nickname' ] );
 	} );
 
-	it( 'renders schema as a link when user has edit permissions', async () => {
+	// The Schema is shown by the pane that uses it, not by a header that names the root's
+	// whichever pane is on screen.
+	it( 'shows the schema in the pane rather than the dialog header', async () => {
 		const wrapper = mountComponent( true, {} );
 		await flushPromises();
 
-		const schemaLink = wrapper.find( '.ext-neowiki-subject-editor-dialog-schema__link' );
-		expect( schemaLink.exists() ).toBe( true );
-		expect( schemaLink.text() ).toBe( 'TestSchema' );
+		expect( wrapper.find( '.cdx-dialog__header__subtitle' ).exists() ).toBe( false );
+		expect( wrapper.get( '.ext-neowiki-subject-edit-pane__meta .ext-neowiki-schema-name__text' ).text() )
+			.toBe( 'TestSchema' );
 	} );
 
-	it( 'renders schema as plain text when user lacks edit permissions', async () => {
+	// The badge is a link to the Schema page whoever is looking, so it carries its own
+	// interactive styling; only the click is taken over, and only for someone who may edit.
+	it( 'lets the schema link navigate for a user who cannot edit it', async () => {
 		const wrapper = mountComponent( false, {} );
 		await flushPromises();
 
-		const schemaLink = wrapper.find( '.ext-neowiki-subject-editor-dialog-schema__link' );
-		expect( schemaLink.exists() ).toBe( false );
+		const badge = wrapper.get( '.ext-neowiki-subject-edit-pane__meta a.ext-neowiki-schema-name' );
+		const event = new MouseEvent( 'click', { button: 0, bubbles: true, cancelable: true } );
+		badge.element.dispatchEvent( event );
+		await flushPromises();
 
-		const schemaName = wrapper.find( '.ext-neowiki-subject-editor-dialog-schema__name' );
-		expect( schemaName.exists() ).toBe( true );
-		expect( schemaName.text() ).toBe( 'TestSchema' );
+		expect( event.defaultPrevented ).toBe( false );
+		expect( wrapper.findComponent( SchemaEditorDialog ).props( 'open' ) ).toBe( false );
 	} );
 
-	it( 'opens SchemaEditorDialog when schema link is clicked', async () => {
+	it( 'leaves a modified click to the browser, so the Schema page stays reachable', async () => {
 		const wrapper = mountComponent( true, {} );
 		await flushPromises();
 
-		const schemaLink = wrapper.find( 'a.ext-neowiki-subject-editor-dialog-schema__link' );
-		await schemaLink.trigger( 'click' );
+		const badge = wrapper.get( '.ext-neowiki-subject-edit-pane__meta a.ext-neowiki-schema-name' );
+		const event = new MouseEvent( 'click', { button: 0, ctrlKey: true, bubbles: true, cancelable: true } );
+		badge.element.dispatchEvent( event );
+		await flushPromises();
+
+		expect( event.defaultPrevented ).toBe( false );
+		expect( wrapper.findComponent( SchemaEditorDialog ).props( 'open' ) ).toBe( false );
+	} );
+
+	it( 'opens SchemaEditorDialog from the pane\'s schema badge', async () => {
+		const wrapper = mountComponent( true, {} );
+		await flushPromises();
+
+		const schemaBadge = wrapper.get( '.ext-neowiki-subject-edit-pane__meta a.ext-neowiki-schema-name' );
+		const event = new MouseEvent( 'click', { button: 0, bubbles: true, cancelable: true } );
+		schemaBadge.element.dispatchEvent( event );
+		await flushPromises();
 
 		const schemaEditorDialog = wrapper.findComponent( SchemaEditorDialog );
 		expect( schemaEditorDialog.exists() ).toBe( true );
 		expect( schemaEditorDialog.props( 'open' ) ).toBe( true );
+		// Asserted with the opening: without it the editor opens AND the link is followed,
+		// which in a dialog holding unsaved panes is the worse half of the pair.
+		expect( event.defaultPrevented ).toBe( true );
+	} );
+
+	// Every gesture a browser uses to open a link somewhere of the reader's choosing. Cmd is
+	// the one that matters most and the one a ctrl-only guard would silently drop on macOS.
+	it.each( [
+		[ 'a middle click', { button: 1 } ],
+		[ 'a ctrl click', { button: 0, ctrlKey: true } ],
+		[ 'a cmd click', { button: 0, metaKey: true } ],
+		[ 'a shift click', { button: 0, shiftKey: true } ],
+		[ 'an alt click', { button: 0, altKey: true } ],
+	] )( 'leaves %s to the browser rather than opening the schema editor', async ( _name, init ) => {
+		const wrapper = mountComponent( true, {} );
+		await flushPromises();
+
+		const schemaBadge = wrapper.get( '.ext-neowiki-subject-edit-pane__meta a.ext-neowiki-schema-name' );
+		const event = new MouseEvent( 'click', { bubbles: true, cancelable: true, ...init } );
+		schemaBadge.element.dispatchEvent( event );
+		await flushPromises();
+
+		expect( event.defaultPrevented ).toBe( false );
+		expect( wrapper.findComponent( SchemaEditorDialog ).props( 'open' ) ).toBe( false );
+	} );
+
+	// The dialog holds unsaved edits for every open pane and nothing guards a navigation away
+	// from it, so following this link must never replace the page the dialog is on.
+	it( 'opens the schema page in a new tab', async () => {
+		const wrapper = mountComponent( true, {} );
+		await flushPromises();
+
+		const badge = wrapper.get( '.ext-neowiki-subject-edit-pane__meta a.ext-neowiki-schema-name' );
+
+		expect( badge.attributes( 'target' ) ).toBe( '_blank' );
+		expect( badge.attributes( 'rel' ) ).toBe( 'noopener' );
+	} );
+
+	it( 'renders the dialog title as a visible heading', async () => {
+		const wrapper = mountComponent( true, {} );
+		await flushPromises();
+
+		expect( wrapper.get( '.cdx-dialog__header__title' ).text() )
+			.toBe( 'neowiki-subject-editor-title' );
 	} );
 
 	const saveButtonTestStubs = {
@@ -974,15 +1038,20 @@ describe( 'SubjectEditorDialog', () => {
 		} );
 
 		// Codex takes the dialog's accessible name from the title prop whenever a header slot
-		// replaces the rendered title.
-		it( 'names a label-less subject by its display name in the dialog\'s accessible name', async () => {
+		// replaces the rendered title. It names the task, not a Subject: the dialog edits
+		// several, and a name fixed at open would be wrong the moment another pane is shown.
+		it( 'names the dialog after the task rather than after a subject', async () => {
 			const wrapper = mountComponent(
 				false, validationTestStubs, undefined, mockSchema, {}, labellessSubject,
 			);
 			await flushPromises();
 
-			expect( wrapper.find( '.cdx-dialog' ).attributes( 'aria-label' ) )
-				.toBe( 'neowiki-subject-editor-title' + labellessSubject.getDisplayName() );
+			// Codex points the dialog at its own heading when nothing slots a header over it,
+			// so the announced name is the visible one rather than a parallel string.
+			const heading = wrapper.get( '.cdx-dialog__header__title' );
+			expect( wrapper.get( '.cdx-dialog' ).attributes( 'aria-labelledby' ) )
+				.toBe( heading.attributes( 'id' ) );
+			expect( heading.text() ).toBe( 'neowiki-subject-editor-title' );
 		} );
 
 		it( 'does not preview the removed label once a labelled subject is cleared', async () => {
@@ -1555,10 +1624,6 @@ describe( 'SubjectEditorDialog', () => {
 					return wrapper.get( '.ext-neowiki-subject-editor-dialog__content' );
 				}
 
-				function headerTitleGroup( wrapper: VueWrapper ): Omit<DOMWrapper<Element>, 'exists'> {
-					return wrapper.get( '.cdx-dialog__header__title-group' );
-				}
-
 				it( 'ignores a second Save', async () => {
 					const { onSave, settle } = deferredSave();
 					const { wrapper } = await mountWithSecondPaneOpen( { onSave } );
@@ -1600,19 +1665,35 @@ describe( 'SubjectEditorDialog', () => {
 					expect( wrapper.emitted( 'update:open' ) ).toBeUndefined();
 				} );
 
-				it( 'makes the form and the header inert until the save settles', async () => {
+				// The Schema editor is handed the root's Schema, so a nested pane's badge must
+				// not open it or it would edit a Schema the reader did not point at.
+				it( 'does not open the schema editor from a nested pane', async () => {
+					const { wrapper } = await mountWithSecondPaneOpen();
+
+					const badges = wrapper.findAll(
+						'.ext-neowiki-subject-edit-pane__meta a.ext-neowiki-schema-name',
+					);
+					expect( badges.length ).toBeGreaterThan( 1 );
+
+					const event = new MouseEvent( 'click', { button: 0, bubbles: true, cancelable: true } );
+					badges[ badges.length - 1 ].element.dispatchEvent( event );
+					await flushPromises();
+
+					expect( event.defaultPrevented ).toBe( false );
+					expect( wrapper.findComponent( SchemaEditorDialog ).props( 'open' ) ).toBe( false );
+				} );
+
+				it( 'makes the form inert until the save settles', async () => {
 					const { onSave, settle } = deferredSave();
 					const { wrapper } = await mountWithSecondPaneOpen( { onSave } );
 					await makePaneDirty( wrapper, 0 );
 
 					await triggerSave( wrapper, '' );
 					expect( content( wrapper ).attributes( 'inert' ) ).toBeDefined();
-					expect( headerTitleGroup( wrapper ).attributes( 'inert' ) ).toBeDefined();
 
 					settle( new Error( 'Boom' ) );
 					await flushPromises();
 					expect( content( wrapper ).attributes( 'inert' ) ).toBeUndefined();
-					expect( headerTitleGroup( wrapper ).attributes( 'inert' ) ).toBeUndefined();
 				} );
 			} );
 

--- a/resources/ext.neowiki/tests/components/SubjectEditor/SubjectTree.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectEditor/SubjectTree.spec.ts
@@ -2,6 +2,7 @@ import { mount, flushPromises, DOMWrapper, VueWrapper } from '@vue/test-utils';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createPinia, setActivePinia, type Pinia } from 'pinia';
 import SubjectTree from '@/components/SubjectEditor/SubjectTree.vue';
+import SchemaNameDisplay from '@/components/common/SchemaNameDisplay.vue';
 import { useSubjectStore } from '@/stores/SubjectStore.ts';
 import { SubjectId } from '@/domain/SubjectId.ts';
 import { createI18nMock, setupMwMock } from '../../VueTestHelpers.ts';
@@ -566,7 +567,10 @@ describe( 'SubjectTree', () => {
 		activePinia = createPinia();
 		setActivePinia( activePinia );
 		setupMwMock( {
-			functions: [ 'message', 'msg' ],
+			// `util` is stubbed although the tree's badge is unlinked and so never reaches
+			// mw.util.getUrl: without it, linking the badge fails as a TypeError in all 40
+			// tests here instead of in the one that checks it is unlinked.
+			functions: [ 'message', 'msg', 'util' ],
 			messages: {
 				'neowiki-subject-tree-not-linked': 'Not linked here',
 			},
@@ -823,6 +827,25 @@ describe( 'SubjectTree', () => {
 					row.get( '.ext-neowiki-tree__node-secondary' ).text(),
 				);
 			}
+		} );
+
+		it( 'shows a node\'s schema as the shared badge', async () => {
+			const wrapper = mountTree();
+			await flushPromises();
+
+			const badges = wrapper.findAllComponents( SchemaNameDisplay );
+
+			expect( badges.length ).toBe( 4 );
+			expect( badges.map( ( badge ) => badge.props( 'schemaName' ) ) )
+				.toEqual( [ 'Person', 'Name', 'Event', 'TimeSpan' ] );
+		} );
+
+		it( 'leaves the badge unlinked, so it cannot compete with the row it sits in', async () => {
+			const wrapper = mountTree();
+			await flushPromises();
+
+			expect( wrapper.findAll( '.ext-neowiki-tree__node-secondary a' ) ).toHaveLength( 0 );
+			expect( wrapper.findComponent( SchemaNameDisplay ).props( 'link' ) ).toBe( 'none' );
 		} );
 
 		it( 'marks the active node as selected', async () => {

--- a/resources/ext.neowiki/tests/components/SubjectsManager/SubjectsManagerPage.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectsManager/SubjectsManagerPage.spec.ts
@@ -14,6 +14,7 @@ import { subjectRowDomId } from '@/presentation/subjectRowAnchor.ts';
 import SummaryAction from '@/components/common/SummaryAction.vue';
 import SubjectEditorDialog from '@/components/SubjectEditor/SubjectEditorDialog.vue';
 import MoveSubjectDialog from '@/components/SubjectsManager/MoveSubjectDialog.vue';
+import SchemaNameDisplay from '@/components/common/SchemaNameDisplay.vue';
 import { Service } from '@/NeoWikiServices.ts';
 import { newSchema } from '@/TestHelpers.ts';
 
@@ -272,6 +273,15 @@ describe( 'SubjectsManagerPage rows without a stored label', () => {
 
 		const names = wrapper.findAll( '.ext-neowiki-subjects-manager__row-label' ).map( ( el ) => el.text() );
 		expect( names ).toEqual( [ 'Host Page', '(unnamed Person)' ] );
+	} );
+
+	// The main row is named after its page, so 'Person' still tells the reader something. The
+	// child row already reads "(unnamed Person)", so saying it again says nothing.
+	it( 'shows the schema beside the main row only', async () => {
+		const wrapper = await mountPage();
+
+		expect( rowFor( wrapper, ID_A ).findComponent( SchemaNameDisplay ).props( 'schemaName' ) ).toBe( 'Person' );
+		expect( rowFor( wrapper, ID_B ).findComponent( SchemaNameDisplay ).exists() ).toBe( false );
 	} );
 
 } );

--- a/resources/ext.neowiki/tests/components/Views/Infobox.spec.ts
+++ b/resources/ext.neowiki/tests/components/Views/Infobox.spec.ts
@@ -149,7 +149,9 @@ describe( 'Infobox', () => {
 	it( 'renders statements correctly', () => {
 		const wrapper = mountComponent( mockSubject, false );
 
-		const schema = wrapper.find( '.ext-neowiki-infobox__schema' );
+		// The badge's visible text, not the wrapper's: the wrapper also holds the
+		// visually-hidden noun that names the concept for a screen reader.
+		const schema = wrapper.find( '.ext-neowiki-schema-name__text' );
 		expect( schema.text() ).toBe( 'TestSchema' );
 
 		const statementElements = wrapper.findAll( '.ext-neowiki-infobox__item' );
@@ -229,12 +231,39 @@ describe( 'Infobox', () => {
 		expect( dialog.props( 'schema' ) ).toStrictEqual( freshSchema );
 	} );
 
+	it( 'shows no schema badge for a subject already named after its schema', () => {
+		// ADR 31: a Subject with no label of its own is shown under its Schema name, and the
+		// infobox used to print that name in the title and again underneath.
+		const labelless = new Subject(
+			new SubjectId( 's1demo5sssssss2' ),
+			null,
+			'TestSchema',
+			true,
+			'TestSchema',
+			new StatementList( [] ),
+		);
+		subjectStore.setSubject( labelless );
+
+		const wrapper = mountComponent( labelless, false );
+
+		expect( wrapper.find( '.ext-neowiki-infobox__title' ).text() ).toBe( '(unnamed TestSchema)' );
+		expect( wrapper.find( '.ext-neowiki-schema-name' ).exists() ).toBe( false );
+		// And the heading around it goes too: a wrapper left behind is an empty
+		// `role="heading"`, which assistive technology announces as an unnamed level 3.
+		expect( wrapper.find( '.ext-neowiki-infobox__schema' ).exists() ).toBe( false );
+	} );
+
 	it( 'renders schema name as a link to the Schema page', () => {
 		const wrapper = mountComponent( mockSubject, false );
 
 		const schemaLink = wrapper.find( '.ext-neowiki-infobox__schema a' );
-		expect( schemaLink.text() ).toBe( 'TestSchema' );
+		// Asserted before the attribute checks below: a missed find() yields an empty wrapper
+		// whose attributes() are all undefined, which would satisfy them silently.
+		expect( schemaLink.exists() ).toBe( true );
+		expect( schemaLink.get( '.ext-neowiki-schema-name__text' ).text() ).toBe( 'TestSchema' );
 		expect( schemaLink.attributes( 'href' ) ).toBe( '/wiki/Schema:TestSchema' );
+		// Same tab: nothing on an article is at risk of being lost by navigating.
+		expect( schemaLink.attributes( 'target' ) ).toBeUndefined();
 	} );
 
 	describe( 'rendering a Subject saved against an out-of-band Schema change', () => {

--- a/resources/ext.neowiki/tests/components/common/NeoTree/NeoTree.spec.ts
+++ b/resources/ext.neowiki/tests/components/common/NeoTree/NeoTree.spec.ts
@@ -391,6 +391,49 @@ describe( 'NeoTree', () => {
 		} );
 	} );
 
+	describe( 'The secondary slot', () => {
+		// Every item carries a secondary label: the slot decorates that label rather than
+		// replacing the decision to show one — see the last test in this block.
+		const labelled: NeoTreeItem<string> = item( 'root', 'Root', {
+			secondaryLabel: 'Person',
+			children: [ item( 'child', 'Child', { groupLabel: 'Born', secondaryLabel: 'Birth' } ) ],
+		} );
+
+		it( 'renders the slot for every item, nested ones included', () => {
+			const wrapper = mountTree( [ labelled ], {
+				slots: { secondary: '<i class="mark">{{ params.item.key }}</i>' },
+			} );
+
+			expect( wrapper.findAll( '.mark' ).map( ( mark ) => mark.text() ) )
+				.toEqual( [ 'root', 'child' ] );
+		} );
+
+		it( 'renders the slot inside the element the plain secondary label would occupy', () => {
+			const wrapper = mountTree(
+				[ item( 'root', 'Root', { secondaryLabel: 'Person' } ) ],
+				{ slots: { secondary: '<i class="mark">badge</i>' } },
+			);
+
+			const secondary = row( node( wrapper, 'root' ) ).get( '.ext-neowiki-tree__node-secondary' );
+
+			// The slot replaces the text rather than joining it, so nothing says "Person" twice.
+			expect( secondary.get( '.mark' ).text() ).toBe( 'badge' );
+			expect( secondary.text() ).toBe( 'badge' );
+		} );
+
+		// Pinning a real limit of the slot rather than an accident: the row shows a secondary
+		// element only when the item has a secondary label, so slot content alone cannot put
+		// one there. A consumer that wants to decorate must still supply the label.
+		it( 'renders nothing for an item with no secondary label, slot or not', () => {
+			const wrapper = mountTree(
+				[ item( 'root', 'Root' ) ],
+				{ slots: { secondary: '<i class="mark">badge</i>' } },
+			);
+
+			expect( wrapper.find( '.mark' ).exists() ).toBe( false );
+		} );
+	} );
+
 	describe( 'Item labels', () => {
 		it( 'prints the secondary label after the label, set apart from it', () => {
 			const wrapper = mountTree( [ item( 'root', 'Root', { secondaryLabel: 'Person' } ) ] );

--- a/resources/ext.neowiki/tests/components/common/SchemaNameDisplay.spec.ts
+++ b/resources/ext.neowiki/tests/components/common/SchemaNameDisplay.spec.ts
@@ -1,0 +1,66 @@
+import { mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it } from 'vitest';
+import SchemaNameDisplay from '@/components/common/SchemaNameDisplay.vue';
+import type { SchemaNameLink } from '@/components/common/SchemaNameDisplay.vue';
+import { setupMwMock } from '../../VueTestHelpers.ts';
+
+interface BadgeProps {
+	schemaName: string;
+	link?: SchemaNameLink;
+}
+
+function newWrapper( props: BadgeProps ): ReturnType<typeof mount> {
+	return mount( SchemaNameDisplay, { props } );
+}
+
+describe( 'SchemaNameDisplay', () => {
+	beforeEach( () => {
+		setupMwMock( { functions: [ 'message', 'util' ] } );
+	} );
+
+	it( 'shows the schema name', () => {
+		const wrapper = newWrapper( { schemaName: 'Company' } );
+
+		// The visible span, not wrapper.text(): that also holds the visually-hidden noun,
+		// which contains the name, so a `toContain` on it survives an empty badge.
+		expect( wrapper.get( '.ext-neowiki-schema-name__text' ).text() ).toBe( 'Company' );
+	} );
+
+	it( 'links to the schema page by default', () => {
+		const wrapper = newWrapper( { schemaName: 'Company' } );
+
+		expect( wrapper.get( 'a' ).attributes( 'href' ) ).toBe( '/wiki/Schema:Company' );
+	} );
+
+	it( 'opens in a new tab when asked, so leaving does not discard unsaved edits', () => {
+		const wrapper = newWrapper( { schemaName: 'Company', link: 'new-tab' } );
+		const anchor = wrapper.get( 'a' );
+
+		expect( anchor.attributes( 'target' ) ).toBe( '_blank' );
+		expect( anchor.attributes( 'rel' ) ).toBe( 'noopener' );
+	} );
+
+	it( 'stays in the same tab by default', () => {
+		const wrapper = newWrapper( { schemaName: 'Company' } );
+
+		expect( wrapper.get( 'a' ).attributes( 'target' ) ).toBeUndefined();
+	} );
+
+	it( 'renders no link where the surface owns the click', () => {
+		const wrapper = newWrapper( { schemaName: 'Company', link: 'none' } );
+
+		expect( wrapper.find( 'a' ).exists() ).toBe( false );
+		expect( wrapper.get( '.ext-neowiki-schema-name__text' ).text() ).toBe( 'Company' );
+	} );
+
+	it( 'names the concept for assistive technology, and only once', () => {
+		const wrapper = newWrapper( { schemaName: 'Company' } );
+
+		// The noun reaches a screen reader through the hidden span; the visible name is
+		// hidden from it, so the badge is announced "Schema: Company" rather than twice.
+		expect( wrapper.get( '.ext-neowiki-schema-name__noun' ).text() )
+			.toBe( 'neowiki-schema-labelCompany' );
+		expect( wrapper.get( '.ext-neowiki-schema-name__text' ).attributes( 'aria-hidden' ) )
+			.toBe( 'true' );
+	} );
+} );

--- a/resources/ext.neowiki/tests/presentation/schemaNameToShow.spec.ts
+++ b/resources/ext.neowiki/tests/presentation/schemaNameToShow.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { schemaNameToShow } from '@/presentation/schemaNameToShow.ts';
+import { newSubject } from '@/TestHelpers.ts';
+
+describe( 'schemaNameToShow', () => {
+	it( 'shows the schema name beside a differently named subject', () => {
+		expect( schemaNameToShow( newSubject( { label: 'ACME Inc', schemaName: 'Company' } ) ) ).toBe( 'Company' );
+	} );
+
+	it( 'withholds the schema name beside a subject nobody named, which is shown under it already', () => {
+		const unnamed = newSubject( { label: null, displayNameIsGenerated: true, schemaName: 'Appellation' } );
+
+		expect( schemaNameToShow( unnamed ) ).toBeNull();
+	} );
+
+	it( 'withholds the schema name beside a subject someone labelled after it', () => {
+		expect( schemaNameToShow( newSubject( { label: 'Appellation', schemaName: 'Appellation' } ) ) ).toBeNull();
+	} );
+
+	it( 'compares exactly, so a differing case is still worth showing', () => {
+		expect( schemaNameToShow( newSubject( { label: 'appellation', schemaName: 'Appellation' } ) ) ).toBe( 'Appellation' );
+	} );
+} );


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/NeoWiki/issues/1328

A Subject's Schema was drawn four ways: a permission-gated link in the editor header that opened the
Schema editor rather than navigating, subtle text beside a navigator row, a subtitle link in the
infobox, and another beside a statement count in the Subjects manager. Nothing about any of them said
"this string is a Schema" — the register they share is also the register of statement counts, subject
ids and the tree's group captions.

`SchemaNameDisplay` renders the bare name as a badge and owns the rules each surface used to decide
for itself: where the link goes, whether it opens a tab of its own, and when the name is withheld
because it would only repeat the name beside it.

## Decisions worth challenging

**A badge, deliberately not a `CdxInfoChip`.** A chip is a bordered pill at `@font-size-small`, which
is the size of a navigator row's own text; thirteen of them down the demo wiki's tree read as a wall.
The badge is a step smaller, filled rather than outlined, and on `@background-color-neutral` rather
than `-subtle`, which would all but vanish on a hovered row and clash on a selected one. Chip and
badge stay distinct shapes for distinct ideas — the chip means Property Type on the Schema page, and
this PR leaves it alone.

**The tree gets a slot rather than a stylesheet.** `NeoTree` gains a `secondary` slot, rendered
inside the element that held the plain text, so the tree learns nothing about Schemas and one
component still owns the badge. The row's DOM is unchanged, which matters:
`SubjectTree.spec.ts:809` asserts a row's children and text exactly, to catch a re-introduced glyph,
and it still does.

**Always a link, and the withholding rule moves in.** Reading a Schema is not an edit right, so the
badge no longer hides behind `neowiki-schema-edit`. `schemaNameToShow` takes the Subject and answers for every surface, so a Subject whose own name is its
Schema name (ADR 31) shows it once — the infobox and the Subjects manager printed it twice before. It reads
the Subject rather than the name a surface shows, since `(unnamed Company)` names the Schema too.

**Not here: the editor's own header.** It keeps `Schema: Company` for now. The follow-up removes that
subtitle wholesale, and changing its click target here would quietly retire the only in-dialog route
to the Schema editor — a call that belongs with the PR redesigning that header. So this PR leaves the
editor header inconsistent with the tree below it, on purpose and briefly.

Also here: `neowiki-infobox-type` is deleted, being declared and defined but referenced by no code;
`DataExportButton`'s copy of the visually-hidden rules moves to a shared mixin.

## Testing

All tests pass. The new ones were mutation-verified: disabling the withholding rule, making `new-tab` stop
opening one, linking the tree's badge, removing the badge from the tree, dropping the guard at a manager row,
handing the tree the bare Schema name, and ignoring the label typed in a pane each turn a test red by name.
Several of those found real gaps — the first cut of this PR had no test that would have noticed a surface
forgetting to withhold the badge.

## Manual Browser Check

On a wiki with the demo data, logged in:

1. Open `ACME Inc`. Under the infobox title, `Company` is a small filled badge, not blue link text.
   It links to `Schema:Company` in the same tab. Hovering underlines it.
2. Open a page whose Main Subject has no label of its own — its title already is its Schema name.
   The badge is absent rather than repeating the title. (`Special:Subjects` on such a page shows the
   same: the row named after its Schema carries no badge, one named after its page does.)
3. Click the infobox pencil. Every navigator row carries the same badge. Rows stay 32px; the badge
   does not push them taller. The badge is not a link here — the row is the click target.
4. Select a row. The badge still separates from the selected row's blue-tinted background.
5. Switch the skin to dark. The badge follows: dark fill, light text, same contrast relationship.
6. With a screen reader, the badge announces "Schema: Company" — the noun is present once, not twice.
7. The dialog header still reads `Schema: Company` as a link that opens the Schema editor. That is
   deliberate for this PR; the follow-up removes it.

> <sub>AI-authored — Claude Code, `Opus 5 (1M context)`; design chosen by @alistair3149 from options put to them in a design artifact, including the badge-not-chip call and the decision to unify behaviour as well as appearance; diff not yet human-reviewed; verified: 1689 vitest tests, lint and build green locally, six mutations confirmed red, and the badge checked in a browser against a dev wiki in light and dark, in the infobox, the Subjects manager and the editor's navigator.</sub>


