### PR TITLE
Gate parse-time reads on the user the page is parsed for

### DIFF
--- a/docs/adr/027-access-control.md
+++ b/docs/adr/027-access-control.md
@@ -53,6 +53,17 @@ Constraints the model rests on:
   by the wiki-level `neowiki-query` right; granting that right gives read access to everything the wiki projects into
   the store. Exposing a store directly (which ADR 19 allows for SPARQL) is a different surface: see the projection
   decision below.
+- **Parse-time reads run as the user the page is parsed for, and their output is cached per access class.**
+  The parser functions and the Lua library read as the user recorded in the parser options: the viewer on a
+  page view, or the anonymous user for the save-time parse, the job queue, and Parsoid renders. They are gated
+  like the REST endpoints: page `read` for page-attributable reads, `neowiki-query` for raw queries. Query
+  limits use the default tier regardless of user. Output that depends on such a read is parser-cached under
+  the parsing user's access class, derived from the user's effective groups and the wiki-level `read` and
+  `neowiki-query` grants, so a cached copy is shared only within one class. The class is a proxy for the
+  permission hooks: exact wherever page access follows group membership, wrong for hooks that grant per
+  user (the revision-deletion rights included), so wikis with such hooks must run without a parser cache.
+  `{{#view}}` needs no class: it emits a marker at parse time, and the Subject behind it is fetched per
+  viewer over REST, under that viewer's permissions.
 - **Raw queries will support server-side filter injection.** A deployment can register scoping predicates (such as
   restricting to the current wiki) that core applies to every caller-supplied query, so scoping is enforced rather
   than left to each caller.
@@ -64,13 +75,6 @@ Constraints the model rests on:
 
 These decisions remain open at acceptance; each is deferred to the tracking issue named with it.
 
-- **Parse-time read semantics.** Today the parse path is inconsistent
-  ([#1059](https://github.com/ProfessionalWiki/NeoWiki/issues/1059)): Schema lookups are gated per user but their
-  output is parser-cached user-agnostically; subject accessors (`{{#neowiki_value}}` and the `nw` data accessors)
-  check only revision-deletion visibility, not page `read`; `{{#cypher_raw}}`, `{{#sparql_raw}}`, `nw.query` and
-  `nw.sparqlQuery` check nothing. `{{#view}}` is the leak-free pattern: a placeholder rendered at parse time, data
-  fetched per user over REST. Deferred to [#1059](https://github.com/ProfessionalWiki/NeoWiki/issues/1059): the
-  parse-path rule and what it means for each surface.
 - **Cross-wiki subject display.** Rendering a subject from another wiki goes through REST, not Cypher, so query-side
   scoping does not cover it. Deferred to [#1341](https://github.com/ProfessionalWiki/NeoWiki/issues/1341): the
   check and the degradation behavior when the schema or subject is not accessible. Relates to
@@ -87,8 +91,22 @@ These decisions remain open at acceptance; each is deferred to the tracking issu
 ## Consequences
 
 - Every new surface that exposes NeoWiki data must be classified: page-attributable (per-row gate), raw query
-  (whole-store semantics), projection/dump (no permission checks), or parse-time (pending above). There is no
-  unclassified option.
+  (whole-store semantics), projection/dump (no permission checks), or parse-time (parsing user's authority,
+  output keyed by access class). There is no unclassified option.
+- A page that reads Subjects or runs queries at parse time holds one parser-cache entry per access class
+  among its viewers. Current-revision views of other pages are unaffected; old-revision views are keyed per
+  class wiki-wide, because core's revision-output cache keys on every cache-varying option rather than the
+  ones a page used. Saving such a page parses it twice when the editor is logged in: once canonically, once
+  for the editor's class, as pages using `{{int:}}` already do for editors with a non-default interface
+  language.
+- Restricting content does not invalidate what is already cached: the class describes the reader, not the
+  page, so a page that embeds newly restricted data keeps serving it to its class until the page is edited
+  or purged, or `$wgParserCacheExpireTime` elapses.
+- Data derived from the canonical parse is computed as the anonymous user: the categories, page properties and
+  links tables written on save and by jobs, and the categories and parser properties of the Page node in graph
+  projections. On a wiki where anonymous users cannot read, a category or page property derived from a
+  parse-time read is therefore never set. A designated reader for canonical parses would lift this; it is not
+  decided.
 - Restricting a page does not remove its data from stores; it changes what the backend returns.
 - The filter-injection extension point must be designed and implemented for farms like BlueSpice Galaxy.
 - Dumps and projections contain restricted content (unless it is omitted via a non-permission mechanism such as the
@@ -100,6 +118,13 @@ These decisions remain open at acceptance; each is deferred to the tracking issu
   QLever, and unable to express hook-based MediaWiki permissions. Rejected, consistent with ADR 13.
 - **Project ACL state into the graph for pre-query trimming** (user groups, restriction markers): re-implements an
   open set of permission hooks as data and goes stale, because permission changes produce no revision to sync on.
+- **Evaluate parse-time reads as a fixed anonymous authority**: user-independent output by construction, but
+  every privileged reader sees less than they may read, and on a private wiki the functions show nothing.
+- **Cache the superset and trim per viewer after the cache**, as core does for section edit links: sound for opaque
+  display fragments, but the cache then holds restricted data for every consumer that bypasses the output pipeline,
+  and an ungated parse leaks through categories, page properties and Lua control flow, which no HTML trim retracts.
+- **Leave the cache alone and require wikis with restricted content to disable it**: no machinery, but nothing
+  detects a violation, and a privileged first parse silently caches restricted values for everyone.
 
 ## Related
 

--- a/docs/api/query-api.md
+++ b/docs/api/query-api.md
@@ -125,7 +125,8 @@ Two resource tiers control per-query timeout and row cap:
 | `default` | Any user with `neowiki-query` | 30 s | 5,000 rows |
 | `expensive` | Any user with the core `apihighlimits` right | 300 s | 50,000 rows |
 
-The tier is selected automatically from the caller's rights; it cannot be requested per call.
+The tier is selected automatically from the caller's rights; it cannot be requested per call. Queries run from
+wikitext or Lua always use the `default` tier.
 
 ### Rate limits
 
@@ -143,7 +144,7 @@ Defaults shipped by NeoWiki:
 
 | Right | Default groups | Purpose |
 |---|---|---|
-| `neowiki-query` | `*` (everyone, including anonymous visitors) | Required to call the query endpoint. |
+| `neowiki-query` | `*` (everyone, including anonymous visitors) | Required to call the query endpoints and to run queries from wikitext or Lua. |
 | `apihighlimits` | `bot`, `sysop` (core defaults) | Grants the `expensive` resource tier. |
 
 ## SPARQL query endpoint

--- a/docs/authoring/lua-api.md
+++ b/docs/authoring/lua-api.md
@@ -55,8 +55,8 @@ The first value of the property, type-converted for Lua:
 | `boolean` | boolean |
 | `relation` | string (the target Subject's display name, or its Subject ID when the target cannot be looked up) |
 
-Returns `nil` when the Subject does not exist, has no value for the property, or the value is
-empty.
+Returns `nil` when the Subject does not exist or its page is not readable (see
+[Permissions](#permissions)), has no value for the property, or the value is empty.
 
 #### Examples
 
@@ -110,7 +110,7 @@ Returns the full data of a page's Main Subject as a Lua table.
 #### Returns
 
 A Subject table (see [Subject table format](#subject-table-format)) or `nil` if the page does not
-exist or has no Main Subject.
+exist, is not readable (see [Permissions](#permissions)), or has no Main Subject.
 
 #### Examples
 
@@ -135,7 +135,7 @@ Returns the full data of any Subject by its ID, regardless of which page it live
 #### Returns
 
 A Subject table (see [Subject table format](#subject-table-format)) or `nil` if no Subject exists
-with that ID (or the ID is malformed).
+with that ID, the ID is malformed, or its page is not readable (see [Permissions](#permissions)).
 
 #### Examples
 
@@ -154,8 +154,8 @@ Returns every Child Subject on a page as a 1-indexed Lua table.
 #### Returns
 
 A 1-indexed Lua table of Subject tables (see [Subject table format](#subject-table-format)).
-Returns an empty table `{}` (not `nil`) if the page has no Child Subjects, so it's safe to
-iterate the result directly with `ipairs`.
+Returns an empty table `{}` (not `nil`) if the page has no Child Subjects or is not readable (see
+[Permissions](#permissions)), so it's safe to iterate the result directly with `ipairs`.
 
 #### Examples
 
@@ -202,6 +202,7 @@ Scalar values come back as strings, numbers, booleans, or `nil`. Nested Cypher l
 
 Always throws on failure; wrap in `pcall` if you need graceful degradation.
 
+- A missing `neowiki-query` right (see [Permissions](#permissions)).
 - Empty or whitespace-only `cypher`.
 - Write or non-read-only queries.
 - Cypher syntax errors, missing parameters, or database errors.
@@ -252,6 +253,7 @@ each binding is a string-keyed table of RDF terms (`{ type, value, datatype?, ['
 
 Always throws on failure; wrap in `pcall` if you need graceful degradation.
 
+- A missing `neowiki-query` right (see [Permissions](#permissions)).
 - Empty or whitespace-only `sparql`.
 - A query the store rejects (e.g. a SPARQL syntax error), or the store being unavailable.
 
@@ -286,8 +288,9 @@ Returns a Schema as a Lua table so a module can inspect it at runtime.
 
 #### Returns
 
-A Schema table, or `nil` if no Schema with that name exists. An empty or whitespace-only `name`
-and the reserved names `page` and `subject` also return `nil`. Guard with `if schema then`.
+A Schema table, or `nil` if no Schema with that name exists or its page is not readable (see
+[Permissions](#permissions)). An empty or whitespace-only `name` and the reserved names `page` and
+`subject` also return `nil`. Guard with `if schema then`.
 
 Top-level fields:
 
@@ -402,6 +405,13 @@ Notes:
   the target cannot be looked up at all (e.g. a broken reference).
 - Per-relation `properties` (qualifiers) are not currently exposed via Lua. Use the REST API if
   you need them.
+
+## Permissions
+
+The [parser function rules](parser-functions.md#permissions) apply: every function reads as the user
+the page is parsed for. In Lua, Subjects and Schemas that user cannot read come back as `nil` or an
+empty table, a relation to such a Subject shows the Subject ID as its label, and `nw.query` and
+`nw.sparqlQuery` throw without the `neowiki-query` right.
 
 ## Performance
 

--- a/docs/authoring/parser-functions.md
+++ b/docs/authoring/parser-functions.md
@@ -22,7 +22,9 @@ For definitions of terms like Subject, Schema, and Layout, see the [Glossary](..
 Every parser function reads as the user the page is parsed for. Subjects that user cannot read are
 treated as absent. `{{#cypher_raw}}` and `{{#sparql_raw}}` need the `neowiki-query` right.
 `{{#view}}` only places a marker at parse time; the Subject it shows is fetched per viewer over the
-REST API, under that viewer's permissions.
+REST API, under that viewer's permissions. Output of the other functions is cached separately for
+readers with different groups or rights, so what one reader may see does not reach another through
+the parser cache.
 
 ## `{{#view}}`
 

--- a/docs/authoring/parser-functions.md
+++ b/docs/authoring/parser-functions.md
@@ -17,6 +17,13 @@ For programmatic access from Lua modules, see the [Lua API](lua-api.md).
 
 For definitions of terms like Subject, Schema, and Layout, see the [Glossary](../glossary.md).
 
+## Permissions
+
+Every parser function reads as the user the page is parsed for. Subjects that user cannot read are
+treated as absent. `{{#cypher_raw}}` and `{{#sparql_raw}}` need the `neowiki-query` right.
+`{{#view}}` only places a marker at parse time; the Subject it shows is fetched per viewer over the
+REST API, under that viewer's permissions.
+
 ## `{{#view}}`
 
 Renders a Subject as HTML on the page using a [View Type](../glossary.md#view-type) (currently
@@ -90,7 +97,7 @@ Returns the value of a single property from a Subject, formatted as a string.
 | `text`, `url`, `select`, `date`, `dateTime` | The string value. Multiple values joined with `separator`. |
 | `number` | The number, e.g. `42` or `19.99`. |
 | `boolean` | `true` or `false`. |
-| `relation` | The target Subject's display name. Multiple targets joined with `separator`. Falls back to the target Subject ID when the target cannot be looked up. |
+| `relation` | The target Subject's display name. Multiple targets joined with `separator`. Falls back to the target Subject ID when the target cannot be looked up or its page is not readable. |
 
 Boolean and number values are always rendered, even for `false` and `0` — these are not treated
 as "empty".
@@ -106,6 +113,7 @@ HTML-encoded text — a value of `Engineers & Designers` arrives as `Engineers &
 ### Returns empty when
 
 - The Subject does not exist on the page (or named page), or the Subject ID was not found.
+- The Subject's page is not readable (see [Permissions](#permissions)).
 - The Subject has no value for that property.
 - The value is an empty collection (e.g. a multi-valued text property with no entries).
 
@@ -144,9 +152,10 @@ For formatted result rendering, build it in a template with Lua
 
 - Only read queries are allowed. Anything that creates, modifies, or deletes data is rejected,
   including `CALL` (even for read-only procedures).
-- Results are capped at the `maxRows` limit from `$wgNeoWikiQueryLimits` (higher for users with
-  `apihighlimits`); rows beyond it are dropped silently. Queries also stop at that tier's
-  `timeoutSeconds`.
+- Requires the `neowiki-query` right (see [Permissions](#permissions)).
+- Results are capped at the `maxRows` and stopped at the `timeoutSeconds` of the `default` tier of
+  `$wgNeoWikiQueryLimits` (see [Limits and tiers](../api/query-api.md#limits-and-tiers)); rows beyond
+  the cap are dropped silently.
 - Errors (rejected queries, syntax errors, the database being unavailable, etc.) render as a
   styled error message in place of the result.
 - Output is HTML-escaped, so query results containing `<`, `>`, `&`, etc. display safely.
@@ -180,8 +189,10 @@ document — the standard `head` / `results` structure (or `boolean` for an `ASK
 ### Notes
 
 - Read-only: the query cannot modify the store.
-- No row cap is applied — the full results document is returned. Queries stop at the
-  `timeoutSeconds` from `$wgNeoWikiQueryLimits` (higher for users with `apihighlimits`).
+- Requires the `neowiki-query` right (see [Permissions](#permissions)).
+- No row cap is applied — the full results document is returned. Queries stop at the `timeoutSeconds`
+  of the `default` tier of `$wgNeoWikiQueryLimits` (see
+  [Limits and tiers](../api/query-api.md#limits-and-tiers)).
 - Errors (a query the store rejects, the store being unavailable, etc.) render as a styled error message
   in place of the result.
 - Output is HTML-escaped, so results containing `<`, `>`, `&`, etc. display safely.

--- a/docs/extending/extending.md
+++ b/docs/extending/extending.md
@@ -231,7 +231,8 @@ you to remove pages that are already gone from your store.
 - `newSubjectPermissionHints( Authority )` — side-effect-free subject permission checks, for showing or
   hiding affordances. A positive answer is a hint, not authorization to write.
 - `newPageSubjectsLookup()` — look up the subjects on a page.
-- `newSubjectContentRepository()` — read Subject data by id.
+- `newSubjectContentRepository( Authority )` — read and write a page's Subject slot; the authority sets the
+  revision-deletion audience, it does not gate the read on the page's `read` permission.
 - `newFrontendModuleLoader()` — mount NeoWiki's UI on any page.
 
 Examples: [`src/RedHerbSidebarHook.php`](https://github.com/ProfessionalWiki/NeoWiki/blob/master/tests/RedHerb/src/RedHerbSidebarHook.php)
@@ -239,13 +240,13 @@ and [`src/Specials/SpecialRedHerbSubjectFinder.php`](https://github.com/Professi
 
 ### Running Cypher queries
 
-To run a read-only Cypher query from PHP, use `NeoWikiExtension::getInstance()->newCypherQueryService()`.
-It rejects write queries, enforces the timeout against the backend, and truncates results to the row cap;
-resolve the limits configured in [`$wgNeoWikiQueryLimits`](../api/query-api.md) with
-`Neo4jQueryLimits::forUser()`:
+To run a read-only Cypher query from PHP, use `NeoWikiExtension::getInstance()->newCypherQueryService( $authority )`
+with the `Authority` the query runs for. The service checks that authority's `neowiki-query` right, rejects write
+queries, enforces the timeout against the backend, and truncates results to the row cap; resolve the limits
+configured in [`$wgNeoWikiQueryLimits`](../api/query-api.md) with `Neo4jQueryLimits::forUser()`:
 
 ```php
-$result = NeoWikiExtension::getInstance()->newCypherQueryService()->execute( new Neo4jQueryRequest(
+$result = NeoWikiExtension::getInstance()->newCypherQueryService( $this->getAuthority() )->execute( new Neo4jQueryRequest(
 	cypher: 'MATCH (s:Subject:Person) WHERE s.`Birth year` > $minYear RETURN s.name AS name',
 	parameters: [ 'minYear' => 2000 ],
 	limits: Neo4jQueryLimits::forUser( $this->getUser() ),
@@ -253,12 +254,11 @@ $result = NeoWikiExtension::getInstance()->newCypherQueryService()->execute( new
 ```
 
 `execute()` returns a `Neo4jQueryResult` (columns, rows, truncation flag) and throws a `QueryException`
-subclass on failure; `newCypherQueryService()` itself throws a `LogicException` on a wiki with no Neo4j
-backend configured.
+subclass on failure, `QueryPermissionDeniedException` when the authority lacks the right;
+`newCypherQueryService()` itself throws a `LogicException` on a wiki with no Neo4j backend configured.
 
-The `User` in `forUser()` only sizes the limits: how heavy a single query may be, not whether the user may
-query at all or how often. When running user-supplied queries, check the `neowiki-query` right and rate
-limit yourself, as the [Query API](../api/query-api.md) endpoint does.
+The `User` in `forUser()` only sizes the limits: how heavy a single query may be, not how often. When running
+user-supplied queries, rate limit yourself, as the [Query API](../api/query-api.md) endpoint does.
 
 Two sharp edges: the write check is a keyword check plus `EXPLAIN`, and the keyword check also rejects `CALL` and
 `SHOW`, even for read-only procedures (see the [parser function notes](../authoring/parser-functions.md)). And the

--- a/docs/operations/installation.md
+++ b/docs/operations/installation.md
@@ -195,6 +195,10 @@ default.
 `neowiki-schema-edit`, `neowiki-layout-edit` and `neowiki-mapping-edit` — gate editing in NeoWiki's own namespaces and
 are granted to logged-in users.
 
+Parser functions and Lua read as the user the page is parsed for, and their output is parser-cached per combination
+of user groups and wiki-level rights. A permission extension that grants page access per user rather than per group
+is not followed by that cache key: run such a wiki with the parser cache off (`$wgParserCacheType = CACHE_NONE`).
+
 ## On-wiki configuration
 
 A wiki administrator without server access can set part of NeoWiki's configuration on the `MediaWiki:NeoWiki`

--- a/docs/operations/upgrading.md
+++ b/docs/operations/upgrading.md
@@ -55,5 +55,9 @@ php maintenance/run.php NeoWiki:RebuildGraphDatabases
 [Rebuild](maintenance.md#rebuilding-the-graph) after every upgrade: with no release notes there is no way to tell
 whether the new version changed the projected shape, and rebuilds are quick at evaluation scale.
 
+If your install predates September 2026 and holds restricted content, run `php maintenance/run.php refreshLinks`
+once: categories and page properties that earlier parses derived from Subject data were recorded without a
+permission check, and MediaWiki rewrites those tables only on an edit, not on a view.
+
 If your Subjects predate the optional Subject label, run
 [clearing default Subject labels](maintenance.md#clearing-default-subject-labels) once, before that rebuild.

--- a/extension.json
+++ b/extension.json
@@ -44,6 +44,8 @@
 
 		"LoadExtensionSchemaUpdates": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onLoadExtensionSchemaUpdates",
 
+		"ParserOptionsRegister": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onParserOptionsRegister",
+		"PageRenderingHash": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onPageRenderingHash",
 		"ParserFirstCallInit": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onParserFirstCallInit",
 
 		"RevisionFromEditComplete": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onRevisionFromEditComplete",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -164,6 +164,7 @@
 
 	"neowiki-cypher-raw-error-json-encode": "Failed to encode query result as JSON",
 
+	"neowiki-cypher-error-permission-denied": "You do not have permission to run Cypher queries.",
 	"neowiki-cypher-error-empty-query": "The Cypher query must not be empty.",
 	"neowiki-cypher-error-write-query": "Only read-only Cypher queries are allowed.",
 	"neowiki-cypher-error-syntax": "The Cypher query has a syntax error: $1",
@@ -174,6 +175,7 @@
 
 	"neowiki-sparql-raw-error-json-encode": "Failed to encode query result as JSON",
 
+	"neowiki-sparql-error-permission-denied": "You do not have permission to run SPARQL queries.",
 	"neowiki-sparql-error-empty-query": "The SPARQL query must not be empty.",
 	"neowiki-sparql-error-syntax": "The SPARQL query was rejected by the store: $1",
 	"neowiki-sparql-error-store-unavailable": "The SPARQL store is currently unavailable.",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -20,6 +20,7 @@
 	"neowiki-schema-label": "Label used to identify the schema. $1 is the schema name or link.",
 	"neowiki-cypher-raw-error-json-encode": "Error message shown when JSON encoding of query results fails.",
 
+	"neowiki-cypher-error-permission-denied": "Error shown on the <code>{{#cypher_raw}}</code> parser function and the <code>nw.query()</code> Lua function when the user the page is parsed for lacks the <code>neowiki-query</code> right.",
 	"neowiki-cypher-error-empty-query": "Error shown on the <code>{{#cypher_raw}}</code> parser function and the <code>nw.query()</code> Lua function when the supplied Cypher query is empty or only whitespace.",
 	"neowiki-cypher-error-write-query": "Error shown on the <code>{{#cypher_raw}}</code> parser function and the <code>nw.query()</code> Lua function when the query contains a write operation. Cypher queries from wikitext are restricted to read-only.",
 	"neowiki-cypher-error-syntax": "Error shown when Neo4j reports a syntax error for a Cypher query run from wikitext. $1 is the verbatim Neo4j-supplied syntax detail and is not translatable.",
@@ -30,6 +31,7 @@
 
 	"neowiki-sparql-raw-error-json-encode": "Error message shown when JSON encoding of SPARQL query results fails.",
 
+	"neowiki-sparql-error-permission-denied": "Error shown on the <code>{{#sparql_raw}}</code> parser function and the <code>nw.sparqlQuery()</code> Lua function when the user the page is parsed for lacks the <code>neowiki-query</code> right.",
 	"neowiki-sparql-error-empty-query": "Error shown on the <code>{{#sparql_raw}}</code> parser function and the <code>nw.sparqlQuery()</code> Lua function when the supplied SPARQL query is empty or only whitespace.",
 	"neowiki-sparql-error-syntax": "Error shown when the SPARQL store rejects a query run from wikitext (a 4xx response, most commonly a syntax error). $1 is the verbatim store-supplied detail and is not translatable.",
 	"neowiki-sparql-error-store-unavailable": "Error shown when the SPARQL store cannot be reached for a query run from wikitext (a 5xx response or a transport error). The underlying connection detail is intentionally omitted.",

--- a/src/Application/RawQueryAuthorizer.php
+++ b/src/Application/RawQueryAuthorizer.php
@@ -1,0 +1,17 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application;
+
+/**
+ * Authorizes running a caller-supplied Cypher or SPARQL query. A raw query has whole-store read
+ * semantics (ADR 27): its rows are not attributable to pages, so nothing is trimmed per row and the
+ * whole surface is gated by one wiki-level decision instead. The query services check this
+ * themselves, so every surface that runs a raw query (REST, wikitext, Lua) is gated the same way.
+ */
+interface RawQueryAuthorizer {
+
+	public function authorizeRawQuery(): bool;
+
+}

--- a/src/Application/SubjectResolver.php
+++ b/src/Application/SubjectResolver.php
@@ -20,10 +20,16 @@ class SubjectResolver {
 	 */
 	private array $pageSubjectsByPageId = [];
 
+	/**
+	 * Every read goes through the page hosting the Subject, and a page the reader may not read
+	 * answers like a page without Subjects (ADR 27): the parse-time surfaces built on this
+	 * resolver cannot tell a restricted page from an empty one. A Subject no page hosts resolves
+	 * to nothing for the same reason: there is no page to read it off.
+	 */
 	public function __construct(
 		private readonly SubjectContentRepository $subjectContentRepository,
-		private readonly SubjectLookup $subjectLookup,
 		private readonly PageIdentifiersLookup $pageIdentifiersLookup,
+		private readonly PageReadAuthorizer $readAuthorizer,
 	) {
 	}
 
@@ -32,8 +38,12 @@ class SubjectResolver {
 			return null;
 		}
 
+		$subjectId = new SubjectId( $subjectIdText );
+
 		try {
-			return $this->subjectLookup->getSubject( new SubjectId( $subjectIdText ) );
+			$page = $this->pageIdentifiersLookup->getPageIdOfSubject( $subjectId );
+
+			return $page === null ? null : $this->getPageSubjects( $page->getId() )?->getAllSubjects()->getSubject( $subjectId );
 		} catch ( Exception ) {
 			return null;
 		}
@@ -54,6 +64,10 @@ class SubjectResolver {
 	}
 
 	public function getPageSubjectsByTitle( Title $title ): ?PageSubjects {
+		if ( !$this->readAuthorizer->authorizeReadByPageTitle( $title ) ) {
+			return null;
+		}
+
 		return $this->subjectContentRepository
 			->getSubjectContentByPageTitle( $title )
 			?->getPageSubjects();
@@ -80,10 +94,6 @@ class SubjectResolver {
 		return $relation->targetId->text;
 	}
 
-	/**
-	 * Reading the hosting page costs no more than asking the Subject lookup for the Subject alone:
-	 * that lookup resolves the page and loads all its Subjects too, then drops the placement.
-	 */
 	private function resolveDisplayNameOnHostingPage( SubjectId $subjectId ): ?string {
 		$page = $this->pageIdentifiersLookup->getPageIdOfSubject( $subjectId );
 
@@ -102,14 +112,16 @@ class SubjectResolver {
 	}
 
 	/**
-	 * One read per page for the resolver's lifetime, which is one parse: the relations a page renders
-	 * mostly point at Subjects of that same page, and each would otherwise load the whole slot again.
+	 * One read, and one read check, per page for the resolver's lifetime: the relations a page
+	 * renders mostly point at Subjects of that same page, and each would otherwise load the whole
+	 * slot again. The Lua library keeps one resolver per parse; {{#neowiki_value}} builds one per
+	 * call, so there the memo only spans that call's relation labels.
 	 */
 	private function getPageSubjects( PageId $pageId ): ?PageSubjects {
 		if ( !array_key_exists( $pageId->id, $this->pageSubjectsByPageId ) ) {
-			$this->pageSubjectsByPageId[$pageId->id] = $this->subjectContentRepository
-				->getSubjectContentByPageId( $pageId )
-				?->getPageSubjects();
+			$this->pageSubjectsByPageId[$pageId->id] = $this->readAuthorizer->authorizeReadByPageId( $pageId )
+				? $this->subjectContentRepository->getSubjectContentByPageId( $pageId )?->getPageSubjects()
+				: null;
 		}
 
 		return $this->pageSubjectsByPageId[$pageId->id];

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -259,7 +259,7 @@ class NeoWikiHooks {
 			'view',
 			static function ( Parser $parser, string ...$args ): string|array {
 				$parserFunction = new ViewParserFunction(
-					NeoWikiExtension::getInstance()->newSubjectContentRepository()
+					NeoWikiExtension::getInstance()->newSubjectContentRepository( ParserAuthority::of( $parser ) )
 				);
 				return $parserFunction->handle( $parser, ...$args );
 			}
@@ -269,7 +269,7 @@ class NeoWikiHooks {
 			'neowiki_value',
 			static function ( Parser $parser, string ...$args ): string|array {
 				$parserFunction = new NeoWikiValueParserFunction(
-					NeoWikiExtension::getInstance()->newSubjectResolver()
+					NeoWikiExtension::getInstance()->newSubjectResolver( ParserAuthority::of( $parser ) )
 				);
 				return $parserFunction->handle( $parser, ...$args );
 			}

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -21,6 +21,7 @@ use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Revision\SlotRoleRegistry;
 use MediaWiki\Title\ForeignTitle;
 use MediaWiki\Title\Title;
+use MediaWiki\User\User;
 use MediaWiki\User\UserIdentity;
 use MessageLocalizer;
 use ProfessionalWiki\NeoWiki\Application\Rdf\RdfPageProjector;
@@ -251,6 +252,22 @@ class NeoWikiHooks {
 		);
 	}
 
+	/**
+	 * @param array<string, mixed> $defaults
+	 * @param array<string, bool> $inCacheKey
+	 * @param array<string, callable> $lazyOptions
+	 */
+	public static function onParserOptionsRegister( array &$defaults, array &$inCacheKey, array &$lazyOptions ): void {
+		ParserAuthority::registerAccessClassOption( $defaults, $inCacheKey );
+	}
+
+	/**
+	 * @param string[] $forOptions
+	 */
+	public static function onPageRenderingHash( string &$confstr, User $user, array &$forOptions ): void {
+		ParserAuthority::appendAccessClassToRenderingHash( $confstr, $user, $forOptions );
+	}
+
 	public static function onParserFirstCallInit( Parser $parser ): void {
 		NeoWikiExtension::getInstance()->getNeo4jPlugin()?->registerParserFunctions( $parser );
 		NeoWikiExtension::getInstance()->getFirstSparqlPlugin()?->registerParserFunctions( $parser );
@@ -258,9 +275,7 @@ class NeoWikiHooks {
 		$parser->setFunctionHook(
 			'view',
 			static function ( Parser $parser, string ...$args ): string|array {
-				$parserFunction = new ViewParserFunction(
-					NeoWikiExtension::getInstance()->newSubjectContentRepository( ParserAuthority::of( $parser ) )
-				);
+				$parserFunction = new ViewParserFunction( NeoWikiExtension::getInstance()->newPageSubjectsLookup() );
 				return $parserFunction->handle( $parser, ...$args );
 			}
 		);

--- a/src/EntryPoints/ParserAuthority.php
+++ b/src/EntryPoints/ParserAuthority.php
@@ -1,0 +1,25 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\EntryPoints;
+
+use MediaWiki\MediaWikiServices;
+use MediaWiki\Parser\Parser;
+use MediaWiki\Permissions\Authority;
+
+/**
+ * The authority every parse-time read runs against: the user the page is being parsed for. That is
+ * the viewer on a page-view cache miss, the previewing editor on a classic preview, and the anonymous
+ * canonical user on save, in jobs, and in every Parsoid render (VisualEditor included). The request
+ * context's user is the wrong choice here: it is the saver during the canonical parse of an edit, and
+ * whoever runs the job queue otherwise, neither of which matches the identity the parser cache files
+ * the output under.
+ */
+class ParserAuthority {
+
+	public static function of( Parser $parser ): Authority {
+		return MediaWikiServices::getInstance()->getUserFactory()->newFromUserIdentity( $parser->getUserIdentity() );
+	}
+
+}

--- a/src/EntryPoints/ParserAuthority.php
+++ b/src/EntryPoints/ParserAuthority.php
@@ -7,6 +7,9 @@ namespace ProfessionalWiki\NeoWiki\EntryPoints;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Permissions\Authority;
+use MediaWiki\User\UserIdentity;
+use ProfessionalWiki\NeoWiki\Infrastructure\UserAccessClass;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 
 /**
  * The authority every parse-time read runs against: the user the page is being parsed for. That is
@@ -15,11 +18,52 @@ use MediaWiki\Permissions\Authority;
  * context's user is the wrong choice here: it is the saver during the canonical parse of an edit, and
  * whoever runs the job queue otherwise, neither of which matches the identity the parser cache files
  * the output under.
+ *
+ * Obtaining the authority is also what makes the parse's output depend on who that user is, so
+ * {@see self::of()} records the access-class parser option as used: the parser cache then files the
+ * output under the user's access class ({@see UserAccessClass}) instead of sharing it across users.
+ * Pages that never obtain a parsing authority keep one cache entry for everyone.
+ *
+ * The option itself carries no value. Its class enters the cache key through the PageRenderingHash
+ * hook, and only for a page that recorded the option: a lazily valued option would be loaded for
+ * every logged-in edit of every page by core's cache-key comparison, sending all of them down the
+ * deferred parser-cache path.
  */
 class ParserAuthority {
 
+	public const string ACCESS_CLASS_OPTION = 'neowikiAccessClass';
+
 	public static function of( Parser $parser ): Authority {
+		$parser->getOptions()->getOption( self::ACCESS_CLASS_OPTION );
+
 		return MediaWikiServices::getInstance()->getUserFactory()->newFromUserIdentity( $parser->getUserIdentity() );
+	}
+
+	/**
+	 * The ParserOptionsRegister hook body.
+	 *
+	 * @param array<string, mixed> $defaults
+	 * @param array<string, bool> $inCacheKey
+	 */
+	public static function registerAccessClassOption( array &$defaults, array &$inCacheKey ): void {
+		$defaults[self::ACCESS_CLASS_OPTION] = null;
+		$inCacheKey[self::ACCESS_CLASS_OPTION] = true;
+	}
+
+	/**
+	 * The PageRenderingHash hook body: the parsing user's access class, for a page that recorded the
+	 * option. Every reader gets one, so a page that reads Subjects also stops reusing whatever was
+	 * cached for it before NeoWiki began keying by class.
+	 *
+	 * @param string[] $usedOptions
+	 */
+	public static function appendAccessClassToRenderingHash( string &$hash, UserIdentity $user, array $usedOptions ): void {
+		if ( !in_array( self::ACCESS_CLASS_OPTION, $usedOptions, true ) ) {
+			return;
+		}
+
+		$hash .= '!' . self::ACCESS_CLASS_OPTION . '='
+			. NeoWikiExtension::getInstance()->newUserAccessClass()->of( $user );
 	}
 
 }

--- a/src/EntryPoints/Scribunto/ScribuntoLuaLibrary.php
+++ b/src/EntryPoints/Scribunto/ScribuntoLuaLibrary.php
@@ -8,7 +8,10 @@ use Exception;
 use InvalidArgumentException;
 use MediaWiki\Extension\Scribunto\Engines\LuaCommon\LibraryBase;
 use MediaWiki\Extension\Scribunto\Engines\LuaCommon\LuaError;
+use MediaWiki\Permissions\Authority;
+use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\EntryPoints\ParserAuthority;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\QueryException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\CypherErrorMessage;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\Lua\CypherQueryRunner;
@@ -23,15 +26,24 @@ class ScribuntoLuaLibrary extends LibraryBase {
 	private ?SchemaLuaSerializer $schemaLuaSerializer = null;
 	private ?CypherQueryRunner $cypherQueryRunner = null;
 	private ?SparqlQueryRunner $sparqlQueryRunner = null;
+	private ?SchemaLookup $schemaLookup = null;
 
 	private function getSubjectDataLookup(): SubjectDataLookup {
 		if ( $this->subjectDataLookup === null ) {
 			$this->subjectDataLookup = new SubjectDataLookup(
-				NeoWikiExtension::getInstance()->newSubjectResolver(),
+				NeoWikiExtension::getInstance()->newSubjectResolver( $this->getParserAuthority() ),
 			);
 		}
 
 		return $this->subjectDataLookup;
+	}
+
+	private function getSchemaLookup(): SchemaLookup {
+		if ( $this->schemaLookup === null ) {
+			$this->schemaLookup = NeoWikiExtension::getInstance()->getSchemaLookupFor( $this->getParserAuthority() );
+		}
+
+		return $this->schemaLookup;
 	}
 
 	private function getSchemaLuaSerializer(): SchemaLuaSerializer {
@@ -43,19 +55,23 @@ class ScribuntoLuaLibrary extends LibraryBase {
 
 	private function getCypherQueryRunner(): CypherQueryRunner {
 		if ( $this->cypherQueryRunner === null ) {
-			$this->cypherQueryRunner = new CypherQueryRunner(
-				NeoWikiExtension::getInstance()->newCypherQueryService()
-			);
+			$this->cypherQueryRunner = NeoWikiExtension::getInstance()->newCypherQueryRunner( $this->getParser() );
 		}
 
 		return $this->cypherQueryRunner;
 	}
 
+	/**
+	 * Every read this library performs runs against the user the page is parsed for
+	 * ({@see ParserAuthority}), so a module cannot read more than the reader may.
+	 */
+	private function getParserAuthority(): Authority {
+		return ParserAuthority::of( $this->getParser() );
+	}
+
 	private function getSparqlQueryRunner(): SparqlQueryRunner {
 		if ( $this->sparqlQueryRunner === null ) {
-			$this->sparqlQueryRunner = new SparqlQueryRunner(
-				NeoWikiExtension::getInstance()->newSparqlQueryService()
-			);
+			$this->sparqlQueryRunner = NeoWikiExtension::getInstance()->newSparqlQueryRunner( $this->getParser() );
 		}
 
 		return $this->sparqlQueryRunner;
@@ -176,7 +192,7 @@ class ScribuntoLuaLibrary extends LibraryBase {
 			return [ null ];
 		}
 
-		$schema = NeoWikiExtension::getInstance()->getSchemaLookup()->getSchema( $name );
+		$schema = $this->getSchemaLookup()->getSchema( $name );
 
 		if ( $schema === null ) {
 			return [ null ];

--- a/src/EntryPoints/Scribunto/ScribuntoLuaLibrary.php
+++ b/src/EntryPoints/Scribunto/ScribuntoLuaLibrary.php
@@ -63,7 +63,8 @@ class ScribuntoLuaLibrary extends LibraryBase {
 
 	/**
 	 * Every read this library performs runs against the user the page is parsed for
-	 * ({@see ParserAuthority}), so a module cannot read more than the reader may.
+	 * ({@see ParserAuthority}), so a module cannot read more than the reader may, and the parse
+	 * is keyed by that user's access class in the parser cache.
 	 */
 	private function getParserAuthority(): Authority {
 		return ParserAuthority::of( $this->getParser() );

--- a/src/EntryPoints/SpecialPages/SpecialNeoJson.php
+++ b/src/EntryPoints/SpecialPages/SpecialNeoJson.php
@@ -62,7 +62,8 @@ class SpecialNeoJson extends SpecialPage {
 	}
 
 	private function getNeoJson( Title $title ): string {
-		$content = NeoWikiExtension::getInstance()->newSubjectContentRepository()->getSubjectContentByPageTitle( $title );
+		$content = NeoWikiExtension::getInstance()->newSubjectContentRepository( $this->getAuthority() )
+			->getSubjectContentByPageTitle( $title );
 		return $content?->getText() ?? '';
 	}
 
@@ -100,7 +101,7 @@ class SpecialNeoJson extends SpecialPage {
 			NeoWikiExtension::getInstance()->newSubjectContentDataDeserializer()->deserialize( $formData['json'] )
 		);
 
-		NeoWikiExtension::getInstance()->newSubjectContentRepository()->editSubjectContent(
+		NeoWikiExtension::getInstance()->newSubjectContentRepository( $this->getAuthority() )->editSubjectContent(
 			$content,
 			new PageId( $title->getId() ),
 			'Update Subject'

--- a/src/EntryPoints/ViewParserFunction.php
+++ b/src/EntryPoints/ViewParserFunction.php
@@ -5,7 +5,8 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\EntryPoints;
 
 use MediaWiki\Parser\Parser;
-use ProfessionalWiki\NeoWiki\Application\SubjectContentRepository;
+use ProfessionalWiki\NeoWiki\Application\PageSubjectsLookup;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Presentation\ViewHtmlBuilder;
 
 class ViewParserFunction {
@@ -13,8 +14,13 @@ class ViewParserFunction {
 	private const string ARG_SUBJECT = 'subject';
 	private const string ARG_LAYOUT = 'layout';
 
+	/**
+	 * Emits a marker that the frontend fills per viewer over the REST API, so the parse-time work is
+	 * the same for every reader: the page's Main Subject id is read publicly, not as a parsing
+	 * authority ({@see ParserAuthority}), and the output stays out of the per-class cache keying.
+	 */
 	public function __construct(
-		private readonly SubjectContentRepository $subjectContentRepository
+		private readonly PageSubjectsLookup $pageSubjectsLookup
 	) {
 	}
 
@@ -138,12 +144,13 @@ class ViewParserFunction {
 			return null;
 		}
 
-		$subject = $this->subjectContentRepository
-			->getSubjectContentByPageTitle( $title )
-			?->getPageSubjects()
-			->getMainSubject();
+		$pageId = $title->getArticleID();
 
-		return $subject?->getId()->text;
+		if ( $pageId === 0 ) {
+			return null;
+		}
+
+		return $this->pageSubjectsLookup->getMainSubjectId( new PageId( $pageId ) )?->text;
 	}
 
 }

--- a/src/GraphDatabasePlugins/Neo4j/Application/Exception/QueryPermissionDeniedException.php
+++ b/src/GraphDatabasePlugins/Neo4j/Application/Exception/QueryPermissionDeniedException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception;
+
+class QueryPermissionDeniedException extends QueryException {
+
+	public function errorType(): string {
+		return 'permissionDenied';
+	}
+
+}

--- a/src/GraphDatabasePlugins/Neo4j/Application/Neo4jQueryLimits.php
+++ b/src/GraphDatabasePlugins/Neo4j/Application/Neo4jQueryLimits.php
@@ -16,13 +16,25 @@ readonly class Neo4jQueryLimits {
 	}
 
 	public static function forUser( User $user ): self {
-		/** @var array<string, array{timeoutSeconds: int, maxRows: int}> $config */
-		$config = MediaWikiServices::getInstance()->getMainConfig()->get( 'NeoWikiQueryLimits' );
-
 		$tier = MediaWikiServices::getInstance()->getPermissionManager()
 			->userHasRight( $user, 'apihighlimits' )
 				? 'expensive'
 				: 'default';
+
+		return self::forTier( $tier );
+	}
+
+	/**
+	 * The tier for parse-time queries. Parse output is shared through the parser cache, so the
+	 * limits it was produced under must not depend on who happened to parse.
+	 */
+	public static function defaultTier(): self {
+		return self::forTier( 'default' );
+	}
+
+	private static function forTier( string $tier ): self {
+		/** @var array<string, array{timeoutSeconds: int, maxRows: int}> $config */
+		$config = MediaWikiServices::getInstance()->getMainConfig()->get( 'NeoWikiQueryLimits' );
 
 		return new self(
 			timeoutSeconds: (int)$config[$tier]['timeoutSeconds'],

--- a/src/GraphDatabasePlugins/Neo4j/Application/Neo4jQueryService.php
+++ b/src/GraphDatabasePlugins/Neo4j/Application/Neo4jQueryService.php
@@ -6,12 +6,14 @@ namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application;
 
 use Laudis\Neo4j\Databags\SummarizedResult;
 use Laudis\Neo4j\Exception\Neo4jException;
+use ProfessionalWiki\NeoWiki\Application\RawQueryAuthorizer;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\BackendUnavailableException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\CypherSyntaxException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\EmptyQueryException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\InternalQueryException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\ParameterMissingException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\QueryException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\QueryPermissionDeniedException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\QueryTimeoutException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\WriteQueryRejectedException;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\BackendFailureMessage;
@@ -24,10 +26,16 @@ readonly class Neo4jQueryService {
 		private Neo4jReadQueryEngine $queryEngine,
 		private CypherQueryValidator $validator,
 		private Neo4jResultNormalizer $normalizer,
+		private RawQueryAuthorizer $authorizer,
 	) {
 	}
 
 	public function execute( Neo4jQueryRequest $request ): Neo4jQueryResult {
+		// Before the validator: EXPLAIN-based validation reaches the store too.
+		if ( !$this->authorizer->authorizeRawQuery() ) {
+			throw new QueryPermissionDeniedException( 'You do not have permission to run queries.' );
+		}
+
 		$cypher = trim( $request->cypher );
 
 		if ( $cypher === '' ) {

--- a/src/GraphDatabasePlugins/Neo4j/EntryPoints/CypherErrorMessage.php
+++ b/src/GraphDatabasePlugins/Neo4j/EntryPoints/CypherErrorMessage.php
@@ -25,6 +25,7 @@ readonly class CypherErrorMessage {
 
 	public static function for( QueryException $error ): self {
 		return match ( $error->errorType() ) {
+			'permissionDenied' => new self( 'neowiki-cypher-error-permission-denied', [] ),
 			'emptyQuery' => new self( 'neowiki-cypher-error-empty-query', [] ),
 			'writeQueryRejected' => new self( 'neowiki-cypher-error-write-query', [] ),
 			'backendUnavailable' => new self( 'neowiki-cypher-error-backend-unavailable', [] ),

--- a/src/GraphDatabasePlugins/Neo4j/EntryPoints/Lua/CypherQueryRunner.php
+++ b/src/GraphDatabasePlugins/Neo4j/EntryPoints/Lua/CypherQueryRunner.php
@@ -4,7 +4,6 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\Lua;
 
-use MediaWiki\Context\RequestContext;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jQueryLimits;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jQueryRequest;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jQueryService;
@@ -13,6 +12,7 @@ class CypherQueryRunner {
 
 	public function __construct(
 		private readonly Neo4jQueryService $queryService,
+		private readonly Neo4jQueryLimits $limits,
 	) {
 	}
 
@@ -21,7 +21,7 @@ class CypherQueryRunner {
 			new Neo4jQueryRequest(
 				cypher: $cypher,
 				parameters: $params,
-				limits: Neo4jQueryLimits::forUser( RequestContext::getMain()->getUser() ),
+				limits: $this->limits,
 			)
 		);
 

--- a/src/GraphDatabasePlugins/Neo4j/EntryPoints/ParserFunction/CypherRawParserFunction.php
+++ b/src/GraphDatabasePlugins/Neo4j/EntryPoints/ParserFunction/CypherRawParserFunction.php
@@ -4,7 +4,6 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\ParserFunction;
 
-use MediaWiki\Context\RequestContext;
 use MediaWiki\Parser\Parser;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\QueryException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jQueryLimits;
@@ -16,6 +15,7 @@ class CypherRawParserFunction {
 
 	public function __construct(
 		private readonly Neo4jQueryService $queryService,
+		private readonly Neo4jQueryLimits $limits,
 	) {
 	}
 
@@ -28,7 +28,7 @@ class CypherRawParserFunction {
 				new Neo4jQueryRequest(
 					cypher: $cypherQuery,
 					parameters: [],
-					limits: Neo4jQueryLimits::forUser( RequestContext::getMain()->getUser() ),
+					limits: $this->limits,
 				)
 			);
 		} catch ( QueryException $e ) {

--- a/src/GraphDatabasePlugins/Neo4j/EntryPoints/REST/CypherQueryApi.php
+++ b/src/GraphDatabasePlugins/Neo4j/EntryPoints/REST/CypherQueryApi.php
@@ -13,6 +13,7 @@ use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\Em
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\InternalQueryException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\ParameterMissingException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\QueryException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\QueryPermissionDeniedException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\QueryTimeoutException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\WriteQueryRejectedException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jQueryLimits;
@@ -29,13 +30,7 @@ class CypherQueryApi extends SimpleHandler {
 	}
 
 	public function run(): Response {
-		$authority = $this->getAuthority();
-
-		if ( !$authority->isAllowed( 'neowiki-query' ) ) {
-			return $this->errorResponse( 403, 'permissionDenied', 'You do not have permission to run queries.' );
-		}
-
-		$user = MediaWikiServices::getInstance()->getUserFactory()->newFromAuthority( $authority );
+		$user = MediaWikiServices::getInstance()->getUserFactory()->newFromAuthority( $this->getAuthority() );
 
 		if ( $user->pingLimiter( 'neowiki-query' ) ) {
 			return $this->errorResponse( 429, 'rateLimitExceeded', 'Query rate limit exceeded.' );
@@ -72,6 +67,7 @@ class CypherQueryApi extends SimpleHandler {
 
 	private function mapException( QueryException $e ): Response {
 		$status = match ( true ) {
+			$e instanceof QueryPermissionDeniedException => 403,
 			$e instanceof EmptyQueryException         => 400,
 			$e instanceof ParameterMissingException   => 400,
 			$e instanceof CypherSyntaxException       => 400,

--- a/src/GraphDatabasePlugins/Neo4j/Neo4jPlugin.php
+++ b/src/GraphDatabasePlugins/Neo4j/Neo4jPlugin.php
@@ -113,7 +113,7 @@ readonly class Neo4jPlugin {
 
 	/**
 	 * Parse-time queries run as the user the page is parsed for, and always at the default tier: the
-	 * output is parser-cached, so neither may depend on who happened to parse.
+	 * output is parser-cached under that user's access class, and may vary by nothing else.
 	 */
 	private function newParseTimeQueryService( Parser $parser ): Neo4jQueryService {
 		return $this->newQueryService( ParserAuthority::of( $parser ) );

--- a/src/GraphDatabasePlugins/Neo4j/Neo4jPlugin.php
+++ b/src/GraphDatabasePlugins/Neo4j/Neo4jPlugin.php
@@ -6,13 +6,17 @@ namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j;
 
 use Laudis\Neo4j\Contracts\ClientInterface;
 use MediaWiki\Parser\Parser;
+use MediaWiki\Permissions\Authority;
 use ProfessionalWiki\NeoWiki\Application\SchemaLookup;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphDatabasePlugin;
+use ProfessionalWiki\NeoWiki\EntryPoints\ParserAuthority;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\CompositeCypherQueryValidator;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\ExplainCypherQueryValidator;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\KeywordCypherQueryValidator;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jQueryLimits;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jQueryService;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jReadQueryEngine;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\Lua\CypherQueryRunner;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\ParserFunction\CypherRawParserFunction;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jClientReadQueryEngine;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jConstraintUpdater;
@@ -21,6 +25,7 @@ use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jResultN
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jSubjectUpdaterFactory;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jValueBuilderRegistry;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jWriteQueryEngine;
+use ProfessionalWiki\NeoWiki\Infrastructure\AuthorityBasedRawQueryAuthorizer;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -90,17 +95,31 @@ readonly class Neo4jPlugin {
 	}
 
 	public function registerParserFunctions( Parser $parser ): void {
-		$queryService = $this->newQueryService();
-
 		$parser->setFunctionHook(
 			'cypher_raw',
-			static function ( Parser $parser, string $cypherQuery ) use ( $queryService ): array {
-				return ( new CypherRawParserFunction( $queryService ) )->handle( $parser, $cypherQuery );
+			function ( Parser $parser, string $cypherQuery ): array {
+				return $this->newRawParserFunction( $parser )->handle( $parser, $cypherQuery );
 			}
 		);
 	}
 
-	public function newQueryService(): Neo4jQueryService {
+	public function newRawParserFunction( Parser $parser ): CypherRawParserFunction {
+		return new CypherRawParserFunction( $this->newParseTimeQueryService( $parser ), Neo4jQueryLimits::defaultTier() );
+	}
+
+	public function newLuaQueryRunner( Parser $parser ): CypherQueryRunner {
+		return new CypherQueryRunner( $this->newParseTimeQueryService( $parser ), Neo4jQueryLimits::defaultTier() );
+	}
+
+	/**
+	 * Parse-time queries run as the user the page is parsed for, and always at the default tier: the
+	 * output is parser-cached, so neither may depend on who happened to parse.
+	 */
+	private function newParseTimeQueryService( Parser $parser ): Neo4jQueryService {
+		return $this->newQueryService( ParserAuthority::of( $parser ) );
+	}
+
+	public function newQueryService( Authority $authority ): Neo4jQueryService {
 		return new Neo4jQueryService(
 			$this->readQueryEngine,
 			new CompositeCypherQueryValidator( [
@@ -108,6 +127,7 @@ readonly class Neo4jPlugin {
 				new ExplainCypherQueryValidator( $this->readOnlyClient ),
 			] ),
 			new Neo4jResultNormalizer(),
+			new AuthorityBasedRawQueryAuthorizer( $authority ),
 		);
 	}
 

--- a/src/GraphDatabasePlugins/Sparql/Application/Exception/SparqlQueryPermissionDeniedException.php
+++ b/src/GraphDatabasePlugins/Sparql/Application/Exception/SparqlQueryPermissionDeniedException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception;
+
+class SparqlQueryPermissionDeniedException extends SparqlQueryException {
+
+	public function errorType(): string {
+		return 'permissionDenied';
+	}
+
+}

--- a/src/GraphDatabasePlugins/Sparql/Application/SparqlQueryLimits.php
+++ b/src/GraphDatabasePlugins/Sparql/Application/SparqlQueryLimits.php
@@ -22,13 +22,25 @@ readonly class SparqlQueryLimits {
 	}
 
 	public static function forUser( User $user ): self {
-		/** @var array<string, array{timeoutSeconds: int, maxRows: int}> $config */
-		$config = MediaWikiServices::getInstance()->getMainConfig()->get( 'NeoWikiQueryLimits' );
-
 		$tier = MediaWikiServices::getInstance()->getPermissionManager()
 			->userHasRight( $user, 'apihighlimits' )
 				? 'expensive'
 				: 'default';
+
+		return self::forTier( $tier );
+	}
+
+	/**
+	 * The tier for parse-time queries. Parse output is shared through the parser cache, so the
+	 * limits it was produced under must not depend on who happened to parse.
+	 */
+	public static function defaultTier(): self {
+		return self::forTier( 'default' );
+	}
+
+	private static function forTier( string $tier ): self {
+		/** @var array<string, array{timeoutSeconds: int, maxRows: int}> $config */
+		$config = MediaWikiServices::getInstance()->getMainConfig()->get( 'NeoWikiQueryLimits' );
 
 		return new self(
 			timeoutSeconds: (int)$config[$tier]['timeoutSeconds'],

--- a/src/GraphDatabasePlugins/Sparql/Application/SparqlQueryService.php
+++ b/src/GraphDatabasePlugins/Sparql/Application/SparqlQueryService.php
@@ -4,10 +4,12 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application;
 
+use ProfessionalWiki\NeoWiki\Application\RawQueryAuthorizer;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\EmptySparqlQueryException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\InternalSparqlQueryException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlQueryException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlQueryFailedException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlQueryPermissionDeniedException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlStoreUnavailableException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlSyntaxException;
 
@@ -30,10 +32,15 @@ readonly class SparqlQueryService {
 
 	public function __construct(
 		private SparqlQueryEndpoint $endpoint,
+		private RawQueryAuthorizer $authorizer,
 	) {
 	}
 
 	public function execute( SparqlQueryRequest $request ): SparqlQueryResult {
+		if ( !$this->authorizer->authorizeRawQuery() ) {
+			throw new SparqlQueryPermissionDeniedException( 'You do not have permission to run queries.' );
+		}
+
 		$sparql = trim( $request->sparql );
 
 		if ( $sparql === '' ) {

--- a/src/GraphDatabasePlugins/Sparql/EntryPoints/Lua/SparqlQueryRunner.php
+++ b/src/GraphDatabasePlugins/Sparql/EntryPoints/Lua/SparqlQueryRunner.php
@@ -4,7 +4,6 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\EntryPoints\Lua;
 
-use MediaWiki\Context\RequestContext;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryLimits;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryRequest;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryService;
@@ -18,6 +17,7 @@ class SparqlQueryRunner {
 
 	public function __construct(
 		private readonly SparqlQueryService $queryService,
+		private readonly SparqlQueryLimits $limits,
 	) {
 	}
 
@@ -28,7 +28,7 @@ class SparqlQueryRunner {
 		$result = $this->queryService->execute(
 			new SparqlQueryRequest(
 				sparql: $sparql,
-				limits: SparqlQueryLimits::forUser( RequestContext::getMain()->getUser() ),
+				limits: $this->limits,
 			)
 		);
 

--- a/src/GraphDatabasePlugins/Sparql/EntryPoints/ParserFunction/SparqlRawParserFunction.php
+++ b/src/GraphDatabasePlugins/Sparql/EntryPoints/ParserFunction/SparqlRawParserFunction.php
@@ -4,7 +4,6 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\EntryPoints\ParserFunction;
 
-use MediaWiki\Context\RequestContext;
 use MediaWiki\Parser\Parser;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlQueryException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryLimits;
@@ -21,6 +20,7 @@ class SparqlRawParserFunction {
 
 	public function __construct(
 		private readonly SparqlQueryService $queryService,
+		private readonly SparqlQueryLimits $limits,
 	) {
 	}
 
@@ -32,7 +32,7 @@ class SparqlRawParserFunction {
 			$result = $this->queryService->execute(
 				new SparqlQueryRequest(
 					sparql: $query,
-					limits: SparqlQueryLimits::forUser( RequestContext::getMain()->getUser() ),
+					limits: $this->limits,
 				)
 			);
 		} catch ( SparqlQueryException $e ) {

--- a/src/GraphDatabasePlugins/Sparql/EntryPoints/REST/SparqlQueryApi.php
+++ b/src/GraphDatabasePlugins/Sparql/EntryPoints/REST/SparqlQueryApi.php
@@ -10,6 +10,7 @@ use MediaWiki\Rest\SimpleHandler;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\EmptySparqlQueryException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\InternalSparqlQueryException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlQueryException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlQueryPermissionDeniedException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlStoreUnavailableException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlSyntaxException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryLimits;
@@ -32,13 +33,7 @@ class SparqlQueryApi extends SimpleHandler {
 	}
 
 	public function run(): Response {
-		$authority = $this->getAuthority();
-
-		if ( !$authority->isAllowed( 'neowiki-query' ) ) {
-			return $this->errorResponse( 403, 'permissionDenied', 'You do not have permission to run queries.' );
-		}
-
-		$user = MediaWikiServices::getInstance()->getUserFactory()->newFromAuthority( $authority );
+		$user = MediaWikiServices::getInstance()->getUserFactory()->newFromAuthority( $this->getAuthority() );
 
 		if ( $user->pingLimiter( 'neowiki-query' ) ) {
 			return $this->errorResponse( 429, 'rateLimitExceeded', 'Query rate limit exceeded.' );
@@ -69,6 +64,7 @@ class SparqlQueryApi extends SimpleHandler {
 
 	private function mapException( SparqlQueryException $e ): Response {
 		$status = match ( true ) {
+			$e instanceof SparqlQueryPermissionDeniedException => 403,
 			$e instanceof EmptySparqlQueryException => 400,
 			$e instanceof SparqlSyntaxException => 400,
 			$e instanceof SparqlStoreUnavailableException => 503,

--- a/src/GraphDatabasePlugins/Sparql/EntryPoints/SparqlErrorMessage.php
+++ b/src/GraphDatabasePlugins/Sparql/EntryPoints/SparqlErrorMessage.php
@@ -25,6 +25,7 @@ readonly class SparqlErrorMessage {
 
 	public static function for( SparqlQueryException $error ): self {
 		return match ( $error->errorType() ) {
+			'permissionDenied' => new self( 'neowiki-sparql-error-permission-denied', [] ),
 			'emptyQuery' => new self( 'neowiki-sparql-error-empty-query', [] ),
 			'sparqlSyntaxError' => new self( 'neowiki-sparql-error-syntax', [ $error->getMessage() ] ),
 			'sparqlStoreUnavailable' => new self( 'neowiki-sparql-error-store-unavailable', [] ),

--- a/src/GraphDatabasePlugins/Sparql/SparqlPlugin.php
+++ b/src/GraphDatabasePlugins/Sparql/SparqlPlugin.php
@@ -103,7 +103,7 @@ readonly class SparqlPlugin {
 
 	/**
 	 * Parse-time queries run as the user the page is parsed for, and always at the default tier: the
-	 * output is parser-cached, so neither may depend on who happened to parse.
+	 * output is parser-cached under that user's access class, and may vary by nothing else.
 	 */
 	private function newParseTimeQueryService( Parser $parser ): SparqlQueryService {
 		return $this->newQueryService( ParserAuthority::of( $parser ) );

--- a/src/GraphDatabasePlugins/Sparql/SparqlPlugin.php
+++ b/src/GraphDatabasePlugins/Sparql/SparqlPlugin.php
@@ -6,14 +6,19 @@ namespace ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql;
 
 use MediaWiki\Http\HttpRequestFactory;
 use MediaWiki\Parser\Parser;
+use MediaWiki\Permissions\Authority;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphDatabasePlugin;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfNamespaces;
+use ProfessionalWiki\NeoWiki\EntryPoints\ParserAuthority;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\ProjectionResolver;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryLimits;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryService;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\EntryPoints\Lua\SparqlQueryRunner;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\EntryPoints\ParserFunction\SparqlRawParserFunction;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Persistence\HttpSparqlQueryEndpoint;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Persistence\HttpSparqlUpdateEndpoint;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Persistence\SparqlProjectionStore;
+use ProfessionalWiki\NeoWiki\Infrastructure\AuthorityBasedRawQueryAuthorizer;
 use ProfessionalWiki\NeoWiki\Infrastructure\Rdf\HardfRdfSerializer;
 use ProfessionalWiki\NeoWiki\SparqlStoreConfig;
 
@@ -57,13 +62,14 @@ readonly class SparqlPlugin {
 		return $this->projectionStore;
 	}
 
-	public function newQueryService(): SparqlQueryService {
+	public function newQueryService( Authority $authority ): SparqlQueryService {
 		return new SparqlQueryService(
 			new HttpSparqlQueryEndpoint(
 				httpRequestFactory: $this->httpRequestFactory,
 				queryUrl: $this->store->queryUrl,
 				accessToken: $this->store->accessToken,
-			)
+			),
+			new AuthorityBasedRawQueryAuthorizer( $authority ),
 		);
 	}
 
@@ -79,14 +85,28 @@ readonly class SparqlPlugin {
 	}
 
 	public function registerParserFunctions( Parser $parser ): void {
-		$queryService = $this->newQueryService();
-
 		$parser->setFunctionHook(
 			'sparql_raw',
-			static function ( Parser $parser, string $query ) use ( $queryService ): array {
-				return ( new SparqlRawParserFunction( $queryService ) )->handle( $parser, $query );
+			function ( Parser $parser, string $query ): array {
+				return $this->newRawParserFunction( $parser )->handle( $parser, $query );
 			}
 		);
+	}
+
+	public function newRawParserFunction( Parser $parser ): SparqlRawParserFunction {
+		return new SparqlRawParserFunction( $this->newParseTimeQueryService( $parser ), SparqlQueryLimits::defaultTier() );
+	}
+
+	public function newLuaQueryRunner( Parser $parser ): SparqlQueryRunner {
+		return new SparqlQueryRunner( $this->newParseTimeQueryService( $parser ), SparqlQueryLimits::defaultTier() );
+	}
+
+	/**
+	 * Parse-time queries run as the user the page is parsed for, and always at the default tier: the
+	 * output is parser-cached, so neither may depend on who happened to parse.
+	 */
+	private function newParseTimeQueryService( Parser $parser ): SparqlQueryService {
+		return $this->newQueryService( ParserAuthority::of( $parser ) );
 	}
 
 }

--- a/src/Infrastructure/AuthorityBasedRawQueryAuthorizer.php
+++ b/src/Infrastructure/AuthorityBasedRawQueryAuthorizer.php
@@ -1,0 +1,23 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Infrastructure;
+
+use MediaWiki\Permissions\Authority;
+use ProfessionalWiki\NeoWiki\Application\RawQueryAuthorizer;
+
+class AuthorityBasedRawQueryAuthorizer implements RawQueryAuthorizer {
+
+	public const string RIGHT = 'neowiki-query';
+
+	public function __construct(
+		private readonly Authority $authority,
+	) {
+	}
+
+	public function authorizeRawQuery(): bool {
+		return $this->authority->isAllowed( self::RIGHT );
+	}
+
+}

--- a/src/Infrastructure/UserAccessClass.php
+++ b/src/Infrastructure/UserAccessClass.php
@@ -1,0 +1,43 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Infrastructure;
+
+use MediaWiki\Permissions\PermissionManager;
+use MediaWiki\User\UserGroupManager;
+use MediaWiki\User\UserIdentity;
+
+/**
+ * The access class of a user, for keying parser-cached output that depends on what the parsing user
+ * may read: the user's effective groups plus the wiki-level `read` and `neowiki-query` decisions, as
+ * a readable string such as `*,autoconfirmed,user;read;query`.
+ *
+ * Group membership is a proxy for per-page read permission, exact wherever that permission is a
+ * function of groups (private wikis, namespace lockdowns) and wrong for hooks that grant per user.
+ * The wiki-level rights are in the class because hooks can grant them outside groups.
+ *
+ * Every reader has a class, the anonymous one included, so that an entry cached before NeoWiki began
+ * keying by class is never reused for a page that reads Subjects.
+ */
+class UserAccessClass {
+
+	public function __construct(
+		private readonly UserGroupManager $userGroupManager,
+		private readonly PermissionManager $permissionManager,
+	) {
+	}
+
+	public function of( UserIdentity $user ): string {
+		$groups = $this->userGroupManager->getUserEffectiveGroups( $user );
+		sort( $groups );
+
+		// Group names come from hooks and the database, so they can hold the separators, and the
+		// cache key turns spaces into underscores. Without encoding, a user in a group named
+		// "sysop,user" would describe exactly like a sysop and read that class's cached output.
+		return implode( ',', array_map( 'rawurlencode', $groups ) )
+			. ( $this->permissionManager->userHasRight( $user, 'read' ) ? ';read' : '' )
+			. ( $this->permissionManager->userHasRight( $user, AuthorityBasedRawQueryAuthorizer::RIGHT ) ? ';query' : '' );
+	}
+
+}

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -55,6 +55,7 @@ use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\Lua\CypherQu
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\EntryPoints\Lua\SparqlQueryRunner;
 use ProfessionalWiki\NeoWiki\Infrastructure\IdGenerator;
 use ProfessionalWiki\NeoWiki\Infrastructure\ProductionIdGenerator;
+use ProfessionalWiki\NeoWiki\Infrastructure\UserAccessClass;
 use ProfessionalWiki\NeoWiki\Persistence\CorePagePropertyProvider;
 use ProfessionalWiki\NeoWiki\Application\EditNotice\InterfaceMessageNoticeProvider;
 use ProfessionalWiki\NeoWiki\Application\Queries\GetSubjectEditNotices\GetSubjectEditNoticesPresenter;
@@ -1281,6 +1282,13 @@ class NeoWikiExtension {
 
 	public function newSubjectWriteAuthorizer( Authority $authority ): SubjectWriteAuthorizer {
 		return $this->newAuthorityBasedSubjectAuthorizer( $authority );
+	}
+
+	public function newUserAccessClass(): UserAccessClass {
+		return new UserAccessClass(
+			userGroupManager: MediaWikiServices::getInstance()->getUserGroupManager(),
+			permissionManager: MediaWikiServices::getInstance()->getPermissionManager(),
+		);
 	}
 
 	public function newPageReadAuthorizer( Authority $authority ): PageReadAuthorizer {

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -12,6 +12,7 @@ use Laudis\Neo4j\Contracts\ClientInterface;
 use MediaWiki\Context\RequestContext;
 use MediaWiki\Logger\LoggerFactory;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Parser\Parser;
 use MediaWiki\Permissions\Authority;
 use MediaWiki\Rest\Response;
 use MediaWiki\Revision\RevisionRecord;
@@ -50,6 +51,8 @@ use ProfessionalWiki\NeoWiki\Application\Queries\GetPageSubjects\GetPageSubjects
 use ProfessionalWiki\NeoWiki\Application\Queries\GetSubject\GetSubjectQuery;
 use ProfessionalWiki\NeoWiki\Application\Queries\ValidateSubject\ValidateSubjectQuery;
 use ProfessionalWiki\NeoWiki\Application\Queries\ValidateSubjectUpdate\ValidateSubjectUpdateQuery;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\Lua\CypherQueryRunner;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\EntryPoints\Lua\SparqlQueryRunner;
 use ProfessionalWiki\NeoWiki\Infrastructure\IdGenerator;
 use ProfessionalWiki\NeoWiki\Infrastructure\ProductionIdGenerator;
 use ProfessionalWiki\NeoWiki\Persistence\CorePagePropertyProvider;
@@ -223,6 +226,8 @@ class NeoWikiExtension {
 	private ClientInterface $readOnlyNeo4jClient;
 	private ?WikiConfigSource $wikiConfigSource = null;
 	private ?SchemaLookup $schemaLookup = null;
+	/** @var array<string, SchemaLookup> */
+	private array $schemaLookupsByUser = [];
 	private static ?self $instance = null;
 
 	public static function getInstance(): self {
@@ -763,14 +768,18 @@ class NeoWikiExtension {
 		return $plugin;
 	}
 
-	public function newSparqlQueryService(): SparqlQueryService {
-		return $this->requireFirstSparqlPlugin()->newQueryService();
+	public function newSparqlQueryService( Authority $authority ): SparqlQueryService {
+		return $this->requireFirstSparqlPlugin()->newQueryService( $authority );
+	}
+
+	public function newSparqlQueryRunner( Parser $parser ): SparqlQueryRunner {
+		return $this->requireFirstSparqlPlugin()->newLuaQueryRunner( $parser );
 	}
 
 	public static function newSparqlQueryApi(): SparqlQueryApi {
-		return new SparqlQueryApi(
-			self::getInstance()->newSparqlQueryService()
-		);
+		$extension = self::getInstance();
+
+		return new SparqlQueryApi( $extension->newSparqlQueryService( $extension->getRequestAuthority() ) );
 	}
 
 	private function buildSparqlPlugin( SparqlStoreConfig $store ): SparqlPlugin {
@@ -871,14 +880,18 @@ class NeoWikiExtension {
 		return $this->readOnlyNeo4jClient;
 	}
 
-	public function newCypherQueryService(): Neo4jQueryService {
-		return $this->requireNeo4jPlugin()->newQueryService();
+	public function newCypherQueryService( Authority $authority ): Neo4jQueryService {
+		return $this->requireNeo4jPlugin()->newQueryService( $authority );
+	}
+
+	public function newCypherQueryRunner( Parser $parser ): CypherQueryRunner {
+		return $this->requireNeo4jPlugin()->newLuaQueryRunner( $parser );
 	}
 
 	public static function newCypherQueryApi(): CypherQueryApi {
-		return new CypherQueryApi(
-			self::getInstance()->newCypherQueryService()
-		);
+		$extension = self::getInstance();
+
+		return new CypherQueryApi( $extension->newCypherQueryService( $extension->getRequestAuthority() ) );
 	}
 
 	public function getWriteQueryEngine(): Neo4jWriteQueryEngine {
@@ -979,7 +992,7 @@ class NeoWikiExtension {
 
 	public function newViewHtmlBuilder(): ViewHtmlBuilder {
 		return new ViewHtmlBuilder(
-			subjectContentRepository: $this->newSubjectContentRepository()
+			subjectContentRepository: $this->newSubjectContentRepository( $this->getRequestAuthority() )
 		);
 	}
 
@@ -997,20 +1010,20 @@ class NeoWikiExtension {
 		);
 	}
 
-	public function newSubjectContentRepository(): SubjectContentRepository {
+	public function newSubjectContentRepository( Authority $authority ): SubjectContentRepository {
 		return new MediaWikiSubjectContentRepository(
 			wikiPageFactory: MediaWikiServices::getInstance()->getWikiPageFactory(),
-			authority: RequestContext::getMain()->getUser(),
+			authority: $authority,
 			pageContentSaver: $this->getPageContentSaver(),
 			revisionLookup: MediaWikiServices::getInstance()->getRevisionLookup(),
 		);
 	}
 
-	public function newSubjectResolver(): SubjectResolver {
+	public function newSubjectResolver( Authority $authority ): SubjectResolver {
 		return new SubjectResolver(
-			subjectContentRepository: $this->newSubjectContentRepository(),
-			subjectLookup: $this->getSubjectRepository(),
+			subjectContentRepository: $this->newSubjectContentRepository( $authority ),
 			pageIdentifiersLookup: $this->getPageIdentifiersLookup(),
+			readAuthorizer: $this->newPageReadAuthorizer( $authority ),
 		);
 	}
 
@@ -1309,10 +1322,22 @@ class NeoWikiExtension {
 	// weaker to stronger — a login or account creation mutating the main context — where reusing the
 	// anonymous resolutions can only under-serve. Core's one switch the other way, beginAccountCreation()
 	// dropping a temp account to a fresh anonymous user, moves between two near-anonymous authorities.
+	// Not for parse-time reads: those run as the user the page is parsed for, which the request's user
+	// is not during the canonical parse of an edit; they use getSchemaLookupFor() instead.
 	public function getSchemaLookup(): SchemaLookup {
 		$this->schemaLookup ??= $this->newSchemaLookup( $this->getRequestAuthority() );
 
 		return $this->schemaLookup;
+	}
+
+	/**
+	 * One lookup per authority for the process, so a batch of parses under one canonical user keeps
+	 * the process-local cache tier across pages. The read gate runs per call before that cache.
+	 */
+	public function getSchemaLookupFor( Authority $authority ): SchemaLookup {
+		$this->schemaLookupsByUser[$authority->getUser()->getName()] ??= $this->newSchemaLookup( $authority );
+
+		return $this->schemaLookupsByUser[$authority->getUser()->getName()];
 	}
 
 	private function newSchemaLookup( Authority $authority ): SchemaLookup {

--- a/tests/RedHerb/src/Specials/SpecialRedHerbContentPageCount.php
+++ b/tests/RedHerb/src/Specials/SpecialRedHerbContentPageCount.php
@@ -26,7 +26,7 @@ class SpecialRedHerbContentPageCount extends SpecialPage {
 		$out = $this->getOutput();
 
 		try {
-			$result = NeoWikiExtension::getInstance()->newCypherQueryService()->execute( new Neo4jQueryRequest(
+			$result = NeoWikiExtension::getInstance()->newCypherQueryService( $this->getAuthority() )->execute( new Neo4jQueryRequest(
 				cypher: 'MATCH (page:Page) WHERE page.namespaceId = $namespaceId RETURN count(page) AS pageCount',
 				parameters: [ 'namespaceId' => NS_MAIN ],
 				limits: Neo4jQueryLimits::forUser( $this->getUser() ),

--- a/tests/phpunit/Application/SubjectResolverTest.php
+++ b/tests/phpunit/Application/SubjectResolverTest.php
@@ -7,8 +7,8 @@ namespace ProfessionalWiki\NeoWiki\Tests\Application;
 use MediaWiki\Title\Title;
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Application\PageIdentifiersLookup;
+use ProfessionalWiki\NeoWiki\Application\PageReadAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\SubjectContentRepository;
-use ProfessionalWiki\NeoWiki\Application\SubjectLookup;
 use ProfessionalWiki\NeoWiki\Application\SubjectResolver;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageIdentifiers;
@@ -24,6 +24,8 @@ use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectMap;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemoryPageIdentifiersLookup;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectContentRepository;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SelectivePageReadAuthorizer;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubPageReadAuthorizer;
 use RuntimeException;
 
 /**
@@ -51,47 +53,103 @@ class SubjectResolverTest extends TestCase {
 
 	private function newResolver(
 		SubjectContentRepository $contentRepository,
-		SubjectLookup $subjectLookup
+		?PageIdentifiersLookup $pageIdentifiersLookup = null,
+		?PageReadAuthorizer $readAuthorizer = null
 	): SubjectResolver {
-		return new SubjectResolver( $contentRepository, $subjectLookup, new InMemoryPageIdentifiersLookup() );
+		return new SubjectResolver(
+			$contentRepository,
+			$pageIdentifiersLookup ?? new InMemoryPageIdentifiersLookup(),
+			$readAuthorizer ?? new StubPageReadAuthorizer( true )
+		);
+	}
+
+	/**
+	 * The production lookups find a Subject through the page hosting it, so a Subject that exists
+	 * is one the page index maps to a page.
+	 */
+	private function hostedOnTargetPage( string $subjectId ): InMemoryPageIdentifiersLookup {
+		return new InMemoryPageIdentifiersLookup( [
+			[ new SubjectId( $subjectId ), $this->newTargetPageIdentifiers() ],
+		] );
+	}
+
+	private function repositoryHostingOnTargetPage( PageSubjects $pageSubjects ): InMemorySubjectContentRepository {
+		$repository = new InMemorySubjectContentRepository();
+		$repository->setContentForPageId( self::TARGET_PAGE_ID, $pageSubjects );
+
+		return $repository;
 	}
 
 	public function testResolveByIdReturnsSubject(): void {
 		$subject = $this->createSubject();
 
-		$lookup = $this->createStub( SubjectLookup::class );
-		$lookup->method( 'getSubject' )->willReturn( $subject );
-
-		$resolver = $this->newResolver( new InMemorySubjectContentRepository(), $lookup );
+		$resolver = $this->newResolver(
+			$this->repositoryHostingOnTargetPage( new PageSubjects( null, new SubjectMap( $subject ) ) ),
+			$this->hostedOnTargetPage( self::SUBJECT_ID )
+		);
 
 		$this->assertSame( $subject, $resolver->resolveById( self::SUBJECT_ID ) );
 	}
 
-	public function testResolveByIdReturnsNullForInvalidId(): void {
+	public function testResolveByIdReturnsNullWhenTheHostingPageIsNotReadable(): void {
 		$resolver = $this->newResolver(
-			new InMemorySubjectContentRepository(),
-			$this->createStub( SubjectLookup::class )
+			$this->repositoryHostingOnTargetPage( new PageSubjects( $this->createSubject(), new SubjectMap() ) ),
+			$this->hostedOnTargetPage( self::SUBJECT_ID ),
+			new SelectivePageReadAuthorizer( [ self::TARGET_PAGE_ID ] )
 		);
+
+		$this->assertNull( $resolver->resolveById( self::SUBJECT_ID ) );
+	}
+
+	public function testResolveByIdReturnsNullWhenNoPageHostsTheSubject(): void {
+		$resolver = $this->newResolver(
+			$this->repositoryHostingOnTargetPage( new PageSubjects( $this->createSubject(), new SubjectMap() ) )
+		);
+
+		$this->assertNull( $resolver->resolveById( self::SUBJECT_ID ) );
+	}
+
+	public function testResolveByIdReturnsNullWhenTheHostingPageNoLongerHoldsTheSubject(): void {
+		$resolver = $this->newResolver(
+			$this->repositoryHostingOnTargetPage( new PageSubjects( $this->createTargetSubject( 'Someone else' ), new SubjectMap() ) ),
+			$this->hostedOnTargetPage( self::SUBJECT_ID )
+		);
+
+		$this->assertNull( $resolver->resolveById( self::SUBJECT_ID ) );
+	}
+
+	public function testResolveByIdReturnsNullForInvalidId(): void {
+		$resolver = $this->newResolver( new InMemorySubjectContentRepository() );
 
 		$this->assertNull( $resolver->resolveById( 'invalid' ) );
 	}
 
-	public function testResolveByIdReturnsNullWhenLookupReturnsNull(): void {
-		$lookup = $this->createStub( SubjectLookup::class );
-		$lookup->method( 'getSubject' )->willReturn( null );
+	public function testResolveByIdReturnsNullWhenThePageLookupThrows(): void {
+		$pageIdentifiersLookup = $this->createStub( PageIdentifiersLookup::class );
+		$pageIdentifiersLookup->method( 'getPageIdOfSubject' )
+			->willThrowException( new RuntimeException( 'db error' ) );
 
-		$resolver = $this->newResolver( new InMemorySubjectContentRepository(), $lookup );
+		$resolver = $this->newResolver( new InMemorySubjectContentRepository(), $pageIdentifiersLookup );
 
 		$this->assertNull( $resolver->resolveById( self::SUBJECT_ID ) );
 	}
 
-	public function testResolveByIdReturnsNullWhenLookupThrows(): void {
-		$lookup = $this->createStub( SubjectLookup::class );
-		$lookup->method( 'getSubject' )->willThrowException( new RuntimeException( 'db error' ) );
+	public function testResolveMainByTitleReturnsNullWhenThePageIsNotReadable(): void {
+		$resolver = $this->newResolver(
+			$this->repositoryWithMainSubject( $this->createSubject() ),
+			readAuthorizer: new StubPageReadAuthorizer( false )
+		);
 
-		$resolver = $this->newResolver( new InMemorySubjectContentRepository(), $lookup );
+		$this->assertNull( $resolver->resolveMainByTitle( $this->createStub( Title::class ) ) );
+	}
 
-		$this->assertNull( $resolver->resolveById( self::SUBJECT_ID ) );
+	public function testGetPageSubjectsByTitleReturnsNullWhenThePageIsNotReadable(): void {
+		$resolver = $this->newResolver(
+			$this->repositoryWithMainSubject( $this->createSubject() ),
+			readAuthorizer: new StubPageReadAuthorizer( false )
+		);
+
+		$this->assertNull( $resolver->getPageSubjectsByTitle( $this->createStub( Title::class ) ) );
 	}
 
 	public function testResolveMainByTitleReturnsMainSubject(): void {
@@ -99,7 +157,6 @@ class SubjectResolverTest extends TestCase {
 
 		$resolver = $this->newResolver(
 			$this->repositoryWithMainSubject( $subject ),
-			$this->createStub( SubjectLookup::class )
 		);
 
 		$this->assertSame( $subject, $resolver->resolveMainByTitle( $this->createStub( Title::class ) ) );
@@ -108,7 +165,6 @@ class SubjectResolverTest extends TestCase {
 	public function testResolveMainByTitleReturnsNullWhenNoContent(): void {
 		$resolver = $this->newResolver(
 			new InMemorySubjectContentRepository(),
-			$this->createStub( SubjectLookup::class )
 		);
 
 		$this->assertNull( $resolver->resolveMainByTitle( $this->createStub( Title::class ) ) );
@@ -119,7 +175,6 @@ class SubjectResolverTest extends TestCase {
 
 		$resolver = $this->newResolver(
 			$this->repositoryWithMainSubject( $subject ),
-			$this->createStub( SubjectLookup::class )
 		);
 
 		$pageSubjects = $resolver->getPageSubjectsByTitle( $this->createStub( Title::class ) );
@@ -131,26 +186,19 @@ class SubjectResolverTest extends TestCase {
 	public function testGetPageSubjectsByTitleReturnsNullWhenNoContent(): void {
 		$resolver = $this->newResolver(
 			new InMemorySubjectContentRepository(),
-			$this->createStub( SubjectLookup::class )
 		);
 
 		$this->assertNull( $resolver->getPageSubjectsByTitle( $this->createStub( Title::class ) ) );
 	}
 
-	/**
-	 * The target Subject as the production lookups see one that exists: hosted by a page, whose
-	 * content holds it either as the Main Subject or as a child.
-	 */
-	private function newResolverWithTargetOnPage( PageSubjects $hostingPageSubjects ): SubjectResolver {
-		$contentRepository = new InMemorySubjectContentRepository();
-		$contentRepository->setContentForPageId( self::TARGET_PAGE_ID, $hostingPageSubjects );
-
-		return new SubjectResolver(
-			$contentRepository,
-			$this->createStub( SubjectLookup::class ),
-			new InMemoryPageIdentifiersLookup( [
-				[ new SubjectId( self::TARGET_SUBJECT_ID ), $this->newTargetPageIdentifiers() ],
-			] )
+	private function newResolverWithTargetOnPage(
+		PageSubjects $hostingPageSubjects,
+		?PageReadAuthorizer $readAuthorizer = null
+	): SubjectResolver {
+		return $this->newResolver(
+			$this->repositoryHostingOnTargetPage( $hostingPageSubjects ),
+			$this->hostedOnTargetPage( self::TARGET_SUBJECT_ID ),
+			$readAuthorizer
 		);
 	}
 
@@ -214,10 +262,21 @@ class SubjectResolverTest extends TestCase {
 		$this->assertSame( 'Person', $resolver->resolveRelationLabel( $this->newRelationToTarget() ) );
 	}
 
+	public function testResolveRelationLabelFallsBackToIdWhenTheHostingPageIsNotReadable(): void {
+		$resolver = $this->newResolverWithTargetOnPage(
+			new PageSubjects( $this->createTargetSubject( 'Jane Doe' ), new SubjectMap() ),
+			new SelectivePageReadAuthorizer( [ self::TARGET_PAGE_ID ] )
+		);
+
+		$this->assertSame(
+			self::TARGET_SUBJECT_ID,
+			$resolver->resolveRelationLabel( $this->newRelationToTarget() )
+		);
+	}
+
 	public function testResolveRelationLabelFallsBackToIdWhenTargetNotFound(): void {
 		$resolver = $this->newResolver(
 			new InMemorySubjectContentRepository(),
-			$this->createStub( SubjectLookup::class )
 		);
 
 		$this->assertSame(
@@ -242,9 +301,8 @@ class SubjectResolverTest extends TestCase {
 		$pageIdentifiersLookup->method( 'getPageIdOfSubject' )
 			->willThrowException( new RuntimeException( 'db error' ) );
 
-		$resolver = new SubjectResolver(
+		$resolver = $this->newResolver(
 			new InMemorySubjectContentRepository(),
-			$this->createStub( SubjectLookup::class ),
 			$pageIdentifiersLookup
 		);
 

--- a/tests/phpunit/EntryPoints/NeoWikiValueParserFunctionTest.php
+++ b/tests/phpunit/EntryPoints/NeoWikiValueParserFunctionTest.php
@@ -8,8 +8,8 @@ use MediaWiki\Parser\Parser;
 use MediaWiki\Title\Title;
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Application\PageIdentifiersLookup;
+use ProfessionalWiki\NeoWiki\Application\PageReadAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\SubjectContentRepository;
-use ProfessionalWiki\NeoWiki\Application\SubjectLookup;
 use ProfessionalWiki\NeoWiki\Application\SubjectResolver;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageIdentifiers;
@@ -33,6 +33,7 @@ use ProfessionalWiki\NeoWiki\Domain\Value\UnregisteredTypeValue;
 use ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiValueParserFunction;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemoryPageIdentifiersLookup;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectContentRepository;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubPageReadAuthorizer;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiValueParserFunction
@@ -64,27 +65,16 @@ class NeoWikiValueParserFunctionTest extends TestCase {
 		return new InMemorySubjectContentRepository( new PageSubjects( $subject, new SubjectMap() ) );
 	}
 
-	private function createDummyLookup(): SubjectLookup {
-		return $this->createStub( SubjectLookup::class );
-	}
-
-	private function createLookupReturning( Subject $subject ): SubjectLookup {
-		$lookup = $this->createStub( SubjectLookup::class );
-		$lookup->method( 'getSubject' )->willReturn( $subject );
-
-		return $lookup;
-	}
-
 	private function createPF(
 		SubjectContentRepository $repo,
-		?SubjectLookup $lookup = null,
-		?PageIdentifiersLookup $pageIdentifiersLookup = null
+		?PageIdentifiersLookup $pageIdentifiersLookup = null,
+		?PageReadAuthorizer $readAuthorizer = null
 	): NeoWikiValueParserFunction {
 		return new NeoWikiValueParserFunction(
 			new SubjectResolver(
 				$repo,
-				$lookup ?? $this->createDummyLookup(),
-				$pageIdentifiersLookup ?? new InMemoryPageIdentifiersLookup()
+				$pageIdentifiersLookup ?? new InMemoryPageIdentifiersLookup(),
+				$readAuthorizer ?? new StubPageReadAuthorizer( true )
 			)
 		);
 	}
@@ -131,6 +121,19 @@ class NeoWikiValueParserFunctionTest extends TestCase {
 			->handle( $this->createMockParser(), 'City' );
 
 		$this->assertNoParseHtml( 'Berlin', $result );
+	}
+
+	public function testReturnsEmptyWhenTheSubjectsPageIsNotReadable(): void {
+		$subject = $this->createSubject(
+			new Statement( new PropertyName( 'City' ), 'text', new StringValue( 'Berlin' ) )
+		);
+
+		$result = $this->createPF(
+			$this->repositoryWithSubject( $subject ),
+			readAuthorizer: new StubPageReadAuthorizer( false )
+		)->handle( $this->createMockParser(), 'City' );
+
+		$this->assertSame( '', $result );
 	}
 
 	public function testReturnsEmptyStringForValueOfUnregisteredType(): void {
@@ -262,7 +265,7 @@ class NeoWikiValueParserFunctionTest extends TestCase {
 
 		$repo = $this->repositoryWithSubject( $subject );
 
-		$result = $this->createPF( $repo, null, $this->placeOnOwnPages( $repo, $targetSubject ) )
+		$result = $this->createPF( $repo, $this->placeOnOwnPages( $repo, $targetSubject ) )
 			->handle( $this->createMockParser(), 'Process owner' );
 
 		$this->assertNoParseHtml( 'Sarah Naumann', $result );
@@ -324,7 +327,7 @@ class NeoWikiValueParserFunctionTest extends TestCase {
 
 		$repo = $this->repositoryWithSubject( $subject );
 
-		$result = $this->createPF( $repo, null, $this->placeOnOwnPages( $repo, $target1, $target2 ) )
+		$result = $this->createPF( $repo, $this->placeOnOwnPages( $repo, $target1, $target2 ) )
 			->handle( $this->createMockParser(), 'Members' );
 
 		$this->assertNoParseHtml( 'Alice, Bob', $result );
@@ -417,10 +420,8 @@ class NeoWikiValueParserFunctionTest extends TestCase {
 			] ),
 		);
 
-		$pf = $this->createPF(
-			new InMemorySubjectContentRepository(),
-			$this->createLookupReturning( $targetSubject )
-		);
+		$repo = new InMemorySubjectContentRepository();
+		$pf = $this->createPF( $repo, $this->placeOnOwnPages( $repo, $targetSubject ) );
 
 		$result = $pf->handle( $this->createMockParser(), 'City', 'subject=' . self::TARGET_SUBJECT_ID );
 
@@ -462,10 +463,8 @@ class NeoWikiValueParserFunctionTest extends TestCase {
 			new Statement( new PropertyName( 'City' ), 'text', new StringValue( 'FromPage' ) )
 		);
 
-		$result = $this->createPF(
-			$this->repositoryWithSubject( $subjectViaPage ),
-			$this->createLookupReturning( $subjectViaId )
-		)->handle(
+		$repo = $this->repositoryWithSubject( $subjectViaPage );
+		$result = $this->createPF( $repo, $this->placeOnOwnPages( $repo, $subjectViaId ) )->handle(
 			$this->createMockParser(),
 			'City',
 			'subject=' . self::TARGET_SUBJECT_ID,

--- a/tests/phpunit/EntryPoints/ParseTimeGatesTest.php
+++ b/tests/phpunit/EntryPoints/ParseTimeGatesTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints;
+
+use MediaWiki\Context\RequestContext;
+use MediaWiki\Parser\ParserOptions;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyName;
+use ProfessionalWiki\NeoWiki\Domain\Statement;
+use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
+use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Tests\ParseTimePermissionFixtures;
+
+/**
+ * Parse-time reads run as the user the page is parsed for, not as the request's user. The request
+ * belongs to a sysop throughout; only the parser options decide what a parse gets.
+ *
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\ParserAuthority
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiValueParserFunction
+ * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\ParserFunction\CypherRawParserFunction
+ * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\EntryPoints\ParserFunction\SparqlRawParserFunction
+ * @group Database
+ */
+class ParseTimeGatesTest extends NeoWikiIntegrationTestCase {
+
+	use ParseTimePermissionFixtures;
+
+	private const string RESTRICTED_PAGE = 'ParseTimeGatesRestrictedPage';
+	private const string SECRET = 'Only sysops may read this';
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		RequestContext::getMain()->setUser( $this->getTestSysop()->getUser() );
+
+		$this->createPageWithSubjects(
+			self::RESTRICTED_PAGE,
+			TestSubject::build( statements: new StatementList( [
+				new Statement( new PropertyName( 'Motto' ), 'text', new StringValue( self::SECRET ) ),
+			] ) )
+		);
+		$this->denyAnonymousReadOf( self::RESTRICTED_PAGE );
+	}
+
+	private function parseAs( ParserOptions $parserOptions, string $wikitext ): string {
+		return $this->parseWikitextOn( 'ParseTimeGatesTestPage', $wikitext, $parserOptions );
+	}
+
+	private function asSysop(): ParserOptions {
+		return ParserOptions::newFromUser( $this->getTestSysop()->getUser() );
+	}
+
+	private function valueFromRestrictedPage(): string {
+		return '{{#neowiki_value: Motto | page=' . self::RESTRICTED_PAGE . ' }}';
+	}
+
+	public function testAnonymousParseDoesNotReadTheRestrictedPageEvenThoughTheRequestIsASysops(): void {
+		$html = $this->parseAs( ParserOptions::newFromAnon(), $this->valueFromRestrictedPage() );
+
+		$this->assertStringNotContainsString( self::SECRET, $html );
+	}
+
+	public function testParseForAReaderOfThePageReadsIt(): void {
+		$html = $this->parseAs( $this->asSysop(), $this->valueFromRestrictedPage() );
+
+		$this->assertStringContainsString( self::SECRET, $html );
+	}
+
+	public function testAnonymousParseWithoutTheQueryRightRendersAnErrorEvenThoughTheRequestIsASysops(): void {
+		$this->grantTheQueryRightToSysopsOnly();
+
+		$html = $this->parseAs( ParserOptions::newFromAnon(), '{{#cypher_raw: RETURN 1 AS n }}' );
+
+		$this->assertStringContainsString( 'You do not have permission to run Cypher queries.', $html );
+		$this->assertStringNotContainsString( 'mw-neowiki-cypher-result', $html );
+	}
+
+	public function testParseForAUserWithTheQueryRightRunsTheQuery(): void {
+		$this->setUpNeo4j();
+		$this->grantTheQueryRightToSysopsOnly();
+
+		$html = $this->parseAs( $this->asSysop(), '{{#cypher_raw: RETURN 1 AS n }}' );
+
+		$this->assertStringContainsString( 'mw-neowiki-cypher-result', $html );
+	}
+
+	public function testParseTimeQueriesUseTheDefaultTierEvenForAUserWithHighLimits(): void {
+		$this->setUpNeo4j();
+		$this->capTheDefaultTierAtOneRow();
+
+		$html = html_entity_decode( $this->parseAs( $this->asSysop(), '{{#cypher_raw: UNWIND [1, 2] AS n RETURN n }}' ) );
+
+		$this->assertStringContainsString( '"n": 1', $html );
+		$this->assertStringNotContainsString( '"n": 2', $html );
+	}
+
+	public function testAnonymousParseWithoutTheQueryRightRendersASparqlErrorEvenThoughTheRequestIsASysops(): void {
+		$this->configureAnUnreachableSparqlStore();
+		$this->grantTheQueryRightToSysopsOnly();
+
+		$html = $this->parseAs( ParserOptions::newFromAnon(), '{{#sparql_raw: SELECT * WHERE { ?s ?p ?o } }}' );
+
+		$this->assertStringContainsString( 'You do not have permission to run SPARQL queries.', $html );
+		$this->assertStringNotContainsString( 'mw-neowiki-sparql-result', $html );
+	}
+
+}

--- a/tests/phpunit/EntryPoints/ParserAuthorityTest.php
+++ b/tests/phpunit/EntryPoints/ParserAuthorityTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints;
+
+use MediaWiki\CommentStore\CommentStoreComment;
+use MediaWiki\Content\WikitextContent;
+use MediaWiki\Extension\Scribunto\ScribuntoContent;
+use MediaWiki\Parser\ParserOptions;
+use MediaWiki\Parser\ParserOutput;
+use MediaWiki\Title\Title;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyName;
+use ProfessionalWiki\NeoWiki\Domain\Statement;
+use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectMap;
+use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
+use ProfessionalWiki\NeoWiki\EntryPoints\Content\SubjectContent;
+use ProfessionalWiki\NeoWiki\EntryPoints\ParserAuthority;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\MediaWikiSubjectRepository;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Tests\ParseTimePermissionFixtures;
+use WikiPage;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\ParserAuthority
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiHooks::onParserOptionsRegister
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiHooks::onParserFirstCallInit
+ * @group Database
+ */
+class ParserAuthorityTest extends NeoWikiIntegrationTestCase {
+
+	use ParseTimePermissionFixtures;
+
+	private const string SUBJECT_PAGE = 'ParserAuthorityTestSubjectPage';
+	private const string VALUE_FUNCTION = '{{#neowiki_value: Motto | page=' . self::SUBJECT_PAGE . ' }}';
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->createPageWithSubjects(
+			self::SUBJECT_PAGE,
+			TestSubject::build( statements: new StatementList( [
+				new Statement( new PropertyName( 'Motto' ), 'text', new StringValue( 'Cached per class' ) ),
+			] ) )
+		);
+	}
+
+	private function sysopOptions(): ParserOptions {
+		return ParserOptions::newFromUser( $this->getTestSysop()->getUser() );
+	}
+
+	private function parse(
+		string $wikitext,
+		ParserOptions $parserOptions,
+		string $pageName = 'ParserAuthorityTestPage'
+	): ParserOutput {
+		return $this->getServiceContainer()->getParserFactory()->create()->parse(
+			$wikitext,
+			Title::newFromText( $pageName ),
+			$parserOptions
+		);
+	}
+
+	/**
+	 * Entries cached before NeoWiki keyed by access class carry no such key, so a gated page must not
+	 * land on the key those entries used, not even for an anonymous reader.
+	 */
+	public function testAGatedPageDoesNotReuseAnEntryCachedWithoutTheAccessClass(): void {
+		$anonymousOptions = ParserOptions::newFromAnon();
+
+		$this->assertNotSame(
+			$anonymousOptions->optionsHash( [] ),
+			$anonymousOptions->optionsHash( [ ParserAuthority::ACCESS_CLASS_OPTION ] )
+		);
+	}
+
+	/**
+	 * Core compares every cache-varying option of the editor's options against the canonical ones on
+	 * save, and defers the parser-cache update for every page when they differ.
+	 */
+	public function testEditorsOptionsStillMatchTheCanonicalOnesForPagesWithoutGatedReads(): void {
+		$this->assertTrue( $this->sysopOptions()->matchesForCacheKey( ParserOptions::newFromAnon() ) );
+	}
+
+	public function testParseForALoggedInUserHasItsOwnCacheKey(): void {
+		$this->assertNotSame(
+			ParserOptions::newFromAnon()->optionsHash( [ ParserAuthority::ACCESS_CLASS_OPTION ] ),
+			$this->sysopOptions()->optionsHash( [ ParserAuthority::ACCESS_CLASS_OPTION ] )
+		);
+	}
+
+	public function testReadingASubjectPutsTheAccessClassInThePagesCacheKey(): void {
+		$output = $this->parse( self::VALUE_FUNCTION, ParserOptions::newFromAnon() );
+
+		$this->assertContains( ParserAuthority::ACCESS_CLASS_OPTION, $output->getUsedOptions() );
+	}
+
+	/**
+	 * The argument-less view reads its own page's Main Subject at parse time, and still only emits a marker.
+	 */
+	public function testRenderingAViewDoesNotFragmentTheCache(): void {
+		$output = $this->parse( '{{#view}}', ParserOptions::newFromAnon(), self::SUBJECT_PAGE );
+
+		$this->assertNotContains( ParserAuthority::ACCESS_CLASS_OPTION, $output->getUsedOptions() );
+	}
+
+	public function testRunningACypherQueryPutsTheAccessClassInThePagesCacheKey(): void {
+		$this->grantTheQueryRightToSysopsOnly();
+
+		$output = $this->parse( '{{#cypher_raw: RETURN 1 AS n }}', ParserOptions::newFromAnon() );
+
+		$this->assertContains( ParserAuthority::ACCESS_CLASS_OPTION, $output->getUsedOptions() );
+	}
+
+	public function testRunningASparqlQueryPutsTheAccessClassInThePagesCacheKey(): void {
+		$this->configureAnUnreachableSparqlStore();
+		$this->grantTheQueryRightToSysopsOnly();
+
+		$output = $this->parse( '{{#sparql_raw: SELECT * WHERE { ?s ?p ?o } }}', ParserOptions::newFromAnon() );
+
+		$this->assertContains( ParserAuthority::ACCESS_CLASS_OPTION, $output->getUsedOptions() );
+	}
+
+	public function testReadingASubjectFromLuaPutsTheAccessClassInThePagesCacheKey(): void {
+		$this->markTestSkippedIfExtensionNotLoaded( 'Scribunto' );
+		$this->editPage(
+			Title::makeTitle( NS_MODULE, 'ParserAuthorityTest' ),
+			new ScribuntoContent(
+				"local nw = require( 'mw.neowiki' )\n" .
+				"local p = {}\n" .
+				"function p.motto( frame ) return nw.getValue( 'Motto', { page = frame.args[1] } ) or '' end\n" .
+				"return p"
+			)
+		);
+
+		$output = $this->parse(
+			'{{#invoke:ParserAuthorityTest|motto|' . self::SUBJECT_PAGE . '}}',
+			ParserOptions::newFromAnon()
+		);
+
+		$this->assertContains( ParserAuthority::ACCESS_CLASS_OPTION, $output->getUsedOptions() );
+	}
+
+	/**
+	 * Wikitext holding a gated read, plus a Subject slot of its own, so the render combines two slots
+	 * as every NeoWiki page does: the option the read records must survive that merge to reach the
+	 * cache key.
+	 */
+	private function cachedGatedPage( ParserOptions $parserOptions ): WikiPage {
+		$page = $this->getServiceContainer()->getWikiPageFactory()
+			->newFromTitle( Title::makeTitle( NS_MAIN, 'ParserAuthorityTestCachedPage' ) );
+
+		$updater = $page->newPageUpdater( $this->getTestSysop()->getUser() );
+		$updater->setContent( 'main', new WikitextContent( self::VALUE_FUNCTION ) );
+		$updater->setContent(
+			MediaWikiSubjectRepository::SLOT_NAME,
+			SubjectContent::newFromData(
+				new PageSubjects( TestSubject::build( id: 's1cached1111111' ), new SubjectMap() )
+			)
+		);
+		$updater->saveRevision( CommentStoreComment::newUnsavedComment( 'Gated page' ) );
+
+		$this->getServiceContainer()->getParserOutputAccess()->getParserOutput( $page, $parserOptions );
+
+		return $page;
+	}
+
+	public function testCachedOutputOfOneClassIsNotServedToAnother(): void {
+		$anonymousOptions = ParserOptions::newFromAnon();
+		$page = $this->cachedGatedPage( $anonymousOptions );
+
+		$parserCache = $this->getServiceContainer()->getParserCache();
+
+		$this->assertNotFalse( $parserCache->get( $page, $anonymousOptions ), 'the anonymous parse is cached' );
+		$this->assertFalse( $parserCache->get( $page, $this->sysopOptions() ), 'a sysop does not get it' );
+	}
+
+	public function testCachedOutputIsSharedWithinAnAccessClass(): void {
+		$page = $this->cachedGatedPage( ParserOptions::newFromUser( $this->getTestUser( [ 'bot' ] )->getUser() ) );
+
+		$anotherBot = ParserOptions::newFromUser( $this->getMutableTestUser( [ 'bot' ] )->getUser() );
+
+		$this->assertNotFalse( $this->getServiceContainer()->getParserCache()->get( $page, $anotherBot ) );
+	}
+
+}

--- a/tests/phpunit/EntryPoints/Scribunto/NeoWikiLibraryPermissionTest.php
+++ b/tests/phpunit/EntryPoints/Scribunto/NeoWikiLibraryPermissionTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\Scribunto;
+
+if ( !class_exists( \MediaWiki\Extension\Scribunto\Tests\Engines\LuaCommon\LuaEngineTestBase::class ) ) {
+	return;
+}
+
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyName;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Statement;
+use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
+use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectMap;
+use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
+
+/**
+ * The library reads as the user the page is parsed for, which the engine under test makes the
+ * anonymous user, while the request belongs to a sysop who may read and query everything.
+ *
+ * @group Lua
+ * @group Database
+ */
+class NeoWikiLibraryPermissionTest extends NeoWikiLibraryTestBase {
+
+	private const string RESTRICTED_PAGE = 'NeoWikiLuaRestrictedPage';
+	private const string RESTRICTED_SCHEMA = 'RestrictedSchema';
+
+	// phpcs:ignore SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingAnyTypeHint -- parent class has no type hint
+	protected static $moduleName = 'NeoWikiLibraryPermissionTests';
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->grantTheQueryRightToSysopsOnly();
+
+		$this->createPageWithMainSubject(
+			self::RESTRICTED_PAGE,
+			mainSubject: new Subject(
+				id: new SubjectId( 's1test5eeeeeeee' ),
+				label: new SubjectLabel( 'Restricted Company' ),
+				schemaName: new SchemaName( 'Company' ),
+				statements: new StatementList( [
+					new Statement( new PropertyName( 'City' ), 'text', new StringValue( 'Secret City' ) ),
+				] ),
+			),
+			childSubjects: new SubjectMap(
+				new Subject(
+					id: new SubjectId( 's1test5ffffffff' ),
+					label: new SubjectLabel( 'Restricted Entry' ),
+					schemaName: new SchemaName( 'Entry' ),
+					statements: new StatementList(),
+				),
+			),
+		);
+		$this->createSchemaPage( self::RESTRICTED_SCHEMA, json_encode( [
+			'description' => 'Readable by logged-in users only',
+			'propertyDefinitions' => [ 'Name' => [ 'type' => 'text' ] ],
+		] ) );
+		$this->denyAnonymousReadOf( self::RESTRICTED_PAGE, 'Schema:' . self::RESTRICTED_SCHEMA );
+	}
+
+	protected function getTestModules(): array {
+		return parent::getTestModules() + [
+			'NeoWikiLibraryPermissionTests' => __DIR__ . '/NeoWikiLibraryPermissionTests.lua',
+		];
+	}
+
+}

--- a/tests/phpunit/EntryPoints/Scribunto/NeoWikiLibraryPermissionTests.lua
+++ b/tests/phpunit/EntryPoints/Scribunto/NeoWikiLibraryPermissionTests.lua
@@ -1,0 +1,72 @@
+local testframework = require 'Module:TestFramework'
+local nw = require( 'mw.neowiki' )
+
+local restrictedPage = 'NeoWikiLuaRestrictedPage'
+local openPage = 'NeoWikiLuaTestPage'
+
+local function testGetValueOnRestrictedPageIsNil()
+	return nw.getValue( 'City', { page = restrictedPage } )
+end
+
+local function testGetValueOnOpenPageStillReads()
+	return nw.getValue( 'City', { page = openPage } )
+end
+
+local function testGetMainSubjectOnRestrictedPageIsNil()
+	return nw.getMainSubject( restrictedPage )
+end
+
+local function testGetChildSubjectsOnRestrictedPageIsEmpty()
+	return #nw.getChildSubjects( restrictedPage )
+end
+
+local function testGetSchemaOnRestrictedPageIsNil()
+	return nw.getSchema( 'RestrictedSchema' )
+end
+
+local function testGetSchemaOnOpenPageStillReads()
+	return nw.getSchema( 'Employee' ) ~= nil
+end
+
+-- The full sentence, not a fragment: the generic fallback message would carry the service's
+-- "You do not have permission to run queries." as its detail and match a fragment too.
+local function isDeniedWith( message, call )
+	local ok, err = pcall( call )
+	if ok then
+		return 'unexpected success'
+	end
+	return type( err ) == 'string' and string.find( err, message, 1, true ) ~= nil
+end
+
+local function testQueryIsDeniedWithoutTheRight()
+	return isDeniedWith( 'You do not have permission to run Cypher queries.', function()
+		return nw.query( 'RETURN 1 AS n' )
+	end )
+end
+
+local function testSparqlQueryIsDeniedWithoutTheRight()
+	return isDeniedWith( 'You do not have permission to run SPARQL queries.', function()
+		return nw.sparqlQuery( 'SELECT * WHERE { ?s ?p ?o }' )
+	end )
+end
+
+local tests = {
+	{ name = 'getValue returns nil for a page the parsing user may not read',
+	  func = testGetValueOnRestrictedPageIsNil, expect = { nil } },
+	{ name = 'getValue still reads a page the parsing user may read',
+	  func = testGetValueOnOpenPageStillReads, expect = { 'Berlin' } },
+	{ name = 'getMainSubject returns nil for a page the parsing user may not read',
+	  func = testGetMainSubjectOnRestrictedPageIsNil, expect = { nil } },
+	{ name = 'getChildSubjects returns nothing for a page the parsing user may not read',
+	  func = testGetChildSubjectsOnRestrictedPageIsEmpty, expect = { 0 } },
+	{ name = 'getSchema returns nil for a Schema page the parsing user may not read',
+	  func = testGetSchemaOnRestrictedPageIsNil, expect = { nil } },
+	{ name = 'getSchema still reads a Schema page the parsing user may read',
+	  func = testGetSchemaOnOpenPageStillReads, expect = { true } },
+	{ name = 'query is denied without the neowiki-query right',
+	  func = testQueryIsDeniedWithoutTheRight, expect = { true } },
+	{ name = 'sparqlQuery is denied without the neowiki-query right',
+	  func = testSparqlQueryIsDeniedWithoutTheRight, expect = { true } },
+}
+
+return testframework.getTestProvider( tests )

--- a/tests/phpunit/EntryPoints/Scribunto/NeoWikiLibraryTest.php
+++ b/tests/phpunit/EntryPoints/Scribunto/NeoWikiLibraryTest.php
@@ -16,13 +16,4 @@ if ( !class_exists( \MediaWiki\Extension\Scribunto\Tests\Engines\LuaCommon\LuaEn
  */
 class NeoWikiLibraryTest extends NeoWikiLibraryTestBase {
 
-	/**
-	 * Scribunto 1.46 onwards has each concrete test class name one engine. LuaStandalone is the
-	 * pick because it needs no PHP extension and so is present wherever the suite runs, not
-	 * because the library is specific to it.
-	 */
-	protected function getEngineName(): string {
-		return 'LuaStandalone';
-	}
-
 }

--- a/tests/phpunit/EntryPoints/Scribunto/NeoWikiLibraryTestBase.php
+++ b/tests/phpunit/EntryPoints/Scribunto/NeoWikiLibraryTestBase.php
@@ -10,6 +10,7 @@ if ( !class_exists( \MediaWiki\Extension\Scribunto\Tests\Engines\LuaCommon\LuaEn
 
 use MediaWiki\CommentStore\CommentStoreComment;
 use MediaWiki\Content\TextContent;
+use MediaWiki\Context\RequestContext;
 use MediaWiki\Extension\Scribunto\Tests\Engines\LuaCommon\LuaEngineTestBase;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
@@ -28,6 +29,7 @@ use ProfessionalWiki\NeoWiki\EntryPoints\Content\SchemaContent;
 use ProfessionalWiki\NeoWiki\EntryPoints\Content\SubjectContent;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\MediaWikiSubjectRepository;
+use ProfessionalWiki\NeoWiki\Tests\ParseTimePermissionFixtures;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\EntryPoints\Scribunto\ScribuntoLuaLibrary
@@ -38,17 +40,31 @@ use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\MediaWikiSubjectRepos
  */
 abstract class NeoWikiLibraryTestBase extends LuaEngineTestBase {
 
+	use ParseTimePermissionFixtures;
+
 	// phpcs:ignore SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingAnyTypeHint -- parent class has no type hint
 	protected static $moduleName = 'NeoWikiLibraryTests';
+
+	/**
+	 * Scribunto 1.46 onwards has each concrete test class name one engine. LuaStandalone is the
+	 * pick because it needs no PHP extension and so is present wherever the suite runs, not
+	 * because the library is specific to it.
+	 */
+	protected function getEngineName(): string {
+		return 'LuaStandalone';
+	}
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		// Configure a SPARQL store so nw.sparqlQuery is registered in the Lua environment. The URL is
-		// never contacted: the only Lua test that calls it (empty query) fails before any HTTP. Resetting
-		// the singleton makes the extension rebuild with the store before the engine loads the library.
-		$this->overrideConfigValue( 'NeoWikiSparqlStores', [ [ 'updateUrl' => 'https://sparql.invalid/store' ] ] );
-		NeoWikiExtension::resetInstance();
+		// Registers nw.sparqlQuery in the Lua environment; the reset makes the extension rebuild with
+		// the store before the engine loads the library.
+		$this->configureAnUnreachableSparqlStore();
+
+		// The Lua engine under test parses as the anonymous user. The request belongs to a sysop, so a
+		// read that wrongly took the request's user or its tier shows up in the tests below.
+		RequestContext::getMain()->setUser( $this->getTestSysop()->getUser() );
+		$this->capTheDefaultTierAtOneRow();
 
 		// Suppress NeoWiki's revision handler during test data creation
 		// to avoid graph DB and property type registration dependencies
@@ -132,7 +148,7 @@ abstract class NeoWikiLibraryTestBase extends LuaEngineTestBase {
 		);
 	}
 
-	private function createSchemaPage( string $name, string $json ): void {
+	protected function createSchemaPage( string $name, string $json ): void {
 		$wikiPage = MediaWikiServices::getInstance()->getWikiPageFactory()->newFromTitle(
 			Title::newFromText( $name, NeoWikiExtension::NS_SCHEMA )
 		);
@@ -142,7 +158,7 @@ abstract class NeoWikiLibraryTestBase extends LuaEngineTestBase {
 		$updater->saveRevision( CommentStoreComment::newUnsavedComment( 'Lua test data' ) );
 	}
 
-	private function createPageWithMainSubject(
+	protected function createPageWithMainSubject(
 		string $pageName,
 		Subject $mainSubject,
 		SubjectMap $childSubjects = new SubjectMap(),

--- a/tests/phpunit/EntryPoints/Scribunto/NeoWikiLibraryTests.lua
+++ b/tests/phpunit/EntryPoints/Scribunto/NeoWikiLibraryTests.lua
@@ -107,6 +107,10 @@ local function testQueryRejectsWriteQuery()
 	return type( err ) == 'string' and string.find( err, 'read-only Cypher queries are allowed', 1, true ) ~= nil
 end
 
+local function testQueryCapsRowsAtTheDefaultTier()
+	return #nw.query( 'UNWIND [1, 2] AS n RETURN n' )
+end
+
 -- sparqlQuery tests
 
 local function testSparqlQueryRejectsEmptyString()
@@ -225,6 +229,8 @@ local tests = {
 	  func = testQueryRejectsEmptyString, expect = { true } },
 	{ name = 'query rejects write query with localized message',
 	  func = testQueryRejectsWriteQuery, expect = { true } },
+	{ name = 'query caps rows at the default tier, whatever the request user may have',
+	  func = testQueryCapsRowsAtTheDefaultTier, expect = { 1 } },
 
 	-- sparqlQuery
 	{ name = 'sparqlQuery rejects empty string with localized message',

--- a/tests/phpunit/EntryPoints/Scribunto/SubjectDataLookupTest.php
+++ b/tests/phpunit/EntryPoints/Scribunto/SubjectDataLookupTest.php
@@ -6,7 +6,6 @@ namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\Scribunto;
 
 use MediaWiki\Title\Title;
 use PHPUnit\Framework\TestCase;
-use ProfessionalWiki\NeoWiki\Application\SubjectLookup;
 use ProfessionalWiki\NeoWiki\Application\SubjectResolver;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageIdentifiers;
@@ -30,6 +29,7 @@ use ProfessionalWiki\NeoWiki\Domain\Value\UnregisteredTypeValue;
 use ProfessionalWiki\NeoWiki\EntryPoints\Scribunto\SubjectDataLookup;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemoryPageIdentifiersLookup;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectContentRepository;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubPageReadAuthorizer;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\EntryPoints\Scribunto\SubjectDataLookup
@@ -64,36 +64,28 @@ class SubjectDataLookupTest extends TestCase {
 		);
 	}
 
-	private function resolverWithMainSubject( Subject $subject, ?SubjectLookup $subjectLookup = null ): SubjectResolver {
-		return $this->resolverWithPageSubjects( new PageSubjects( $subject, new SubjectMap() ), $subjectLookup );
+	private function resolverWithMainSubject( Subject $subject ): SubjectResolver {
+		return $this->newResolver( new PageSubjects( $subject, new SubjectMap() ) );
 	}
 
-	private function resolverWithPageSubjects( ?PageSubjects $pageSubjects, ?SubjectLookup $subjectLookup = null ): SubjectResolver {
-		return $this->newResolver( $pageSubjects, $subjectLookup );
-	}
-
-	private function emptyResolver( ?SubjectLookup $subjectLookup = null ): SubjectResolver {
-		return $this->resolverWithPageSubjects( null, $subjectLookup );
+	private function emptyResolver(): SubjectResolver {
+		return $this->newResolver( null );
 	}
 
 	private function resolverWithMainSubjectAndRelationTargets( Subject $subject, Subject ...$targets ): SubjectResolver {
-		return $this->newResolver( new PageSubjects( $subject, new SubjectMap() ), null, ...$targets );
+		return $this->newResolver( new PageSubjects( $subject, new SubjectMap() ), ...$targets );
 	}
 
 	/**
-	 * Relation targets are resolved through the page hosting them, so a target that exists is one
-	 * placed on a page of its own, as that page's Main Subject.
+	 * Subjects reached by id, relation targets included, are resolved through the page hosting them,
+	 * so each one that exists is placed on a page of its own, as that page's Main Subject.
 	 */
-	private function newResolver(
-		?PageSubjects $pageSubjects,
-		?SubjectLookup $subjectLookup,
-		Subject ...$relationTargets
-	): SubjectResolver {
+	private function newResolver( ?PageSubjects $pageSubjects, Subject ...$hostedSubjects ): SubjectResolver {
 		$contentRepository = new InMemorySubjectContentRepository( $pageSubjects );
 		$pageIdentifiersLookup = new InMemoryPageIdentifiersLookup();
 		$pageId = 1000;
 
-		foreach ( $relationTargets as $target ) {
+		foreach ( $hostedSubjects as $target ) {
 			$pageId++;
 
 			$contentRepository->setContentForPageId( $pageId, new PageSubjects( $target, new SubjectMap() ) );
@@ -105,26 +97,9 @@ class SubjectDataLookupTest extends TestCase {
 
 		return new SubjectResolver(
 			$contentRepository,
-			$subjectLookup ?? $this->createStub( SubjectLookup::class ),
-			$pageIdentifiersLookup
+			$pageIdentifiersLookup,
+			new StubPageReadAuthorizer( true )
 		);
-	}
-
-	private function createSubjectLookupReturning( Subject ...$subjects ): SubjectLookup {
-		$lookup = $this->createStub( SubjectLookup::class );
-
-		if ( count( $subjects ) === 1 ) {
-			$lookup->method( 'getSubject' )->willReturn( $subjects[0] );
-		} else {
-			$map = [];
-			foreach ( $subjects as $subject ) {
-				$map[$subject->getId()->text] = $subject;
-			}
-			$lookup->method( 'getSubject' )
-				->willReturnCallback( fn( SubjectId $id ) => $map[$id->text] ?? null );
-		}
-
-		return $lookup;
 	}
 
 	// === getValue tests ===
@@ -333,8 +308,7 @@ class SubjectDataLookupTest extends TestCase {
 			] ),
 		);
 
-		$subjectLookup = $this->createSubjectLookupReturning( $targetSubject );
-		$lookup = new SubjectDataLookup( $this->emptyResolver( $subjectLookup ) );
+		$lookup = new SubjectDataLookup( $this->newResolver( null, $targetSubject ) );
 
 		$this->assertSame(
 			[ 'Munich' ],
@@ -528,7 +502,7 @@ class SubjectDataLookupTest extends TestCase {
 	public function testGetMainSubjectReturnsNullWhenPageHasNoMainSubject(): void {
 		$pageSubjects = new PageSubjects( null, new SubjectMap() );
 
-		$lookup = new SubjectDataLookup( $this->resolverWithPageSubjects( $pageSubjects ) );
+		$lookup = new SubjectDataLookup( $this->newResolver( $pageSubjects ) );
 
 		$this->assertSame( [ null ], $lookup->getMainSubjectData( $this->createTitle() ) );
 	}
@@ -545,8 +519,7 @@ class SubjectDataLookupTest extends TestCase {
 			] ),
 		);
 
-		$subjectLookup = $this->createSubjectLookupReturning( $subject );
-		$lookup = new SubjectDataLookup( $this->emptyResolver( $subjectLookup ) );
+		$lookup = new SubjectDataLookup( $this->newResolver( null, $subject ) );
 
 		$result = $lookup->getSubjectData( self::TARGET_SUBJECT_ID );
 
@@ -596,7 +569,7 @@ class SubjectDataLookupTest extends TestCase {
 		);
 
 		$lookup = new SubjectDataLookup(
-			$this->newResolver( null, $this->createSubjectLookupReturning( $subject ), $targetSubject )
+			$this->newResolver( null, $targetSubject, $subject )
 		);
 
 		$result = $lookup->getSubjectData( self::SUBJECT_ID );
@@ -630,7 +603,7 @@ class SubjectDataLookupTest extends TestCase {
 			new SubjectMap( $child1, $child2 )
 		);
 
-		$lookup = new SubjectDataLookup( $this->resolverWithPageSubjects( $pageSubjects ) );
+		$lookup = new SubjectDataLookup( $this->newResolver( $pageSubjects ) );
 
 		$result = $lookup->getChildSubjectsData( $this->createTitle() );
 
@@ -651,7 +624,7 @@ class SubjectDataLookupTest extends TestCase {
 
 		$pageSubjects = new PageSubjects( $this->createSubject(), new SubjectMap( $child ) );
 
-		$lookup = new SubjectDataLookup( $this->resolverWithPageSubjects( $pageSubjects ) );
+		$lookup = new SubjectDataLookup( $this->newResolver( $pageSubjects ) );
 
 		$result = $lookup->getChildSubjectsData( $this->createTitleNamed( 'Rijksmuseum' ) );
 
@@ -664,7 +637,7 @@ class SubjectDataLookupTest extends TestCase {
 
 		$pageSubjects = new PageSubjects( $mainSubject, new SubjectMap() );
 
-		$lookup = new SubjectDataLookup( $this->resolverWithPageSubjects( $pageSubjects ) );
+		$lookup = new SubjectDataLookup( $this->newResolver( $pageSubjects ) );
 
 		$this->assertSame( [ [] ], $lookup->getChildSubjectsData( $this->createTitle() ) );
 	}

--- a/tests/phpunit/EntryPoints/SpecialPages/SpecialNeoJsonTest.php
+++ b/tests/phpunit/EntryPoints/SpecialPages/SpecialNeoJsonTest.php
@@ -77,7 +77,7 @@ class SpecialNeoJsonTest extends SpecialPageTestBase {
 		}
 
 		$this->assertNull(
-			NeoWikiExtension::getInstance()->newSubjectContentRepository()->getSubjectContentByPageTitle( $title ),
+			NeoWikiExtension::getInstance()->newSubjectContentRepository( $user )->getSubjectContentByPageTitle( $title ),
 			'The rejected POST must not have written any Subject content'
 		);
 	}
@@ -96,7 +96,7 @@ class SpecialNeoJsonTest extends SpecialPageTestBase {
 		$this->executeSpecialPage( $title->getPrefixedText(), $this->newJsonPost(), null, $user );
 
 		$this->assertNotNull(
-			NeoWikiExtension::getInstance()->newSubjectContentRepository()->getSubjectContentByPageTitle( $title ),
+			NeoWikiExtension::getInstance()->newSubjectContentRepository( $user )->getSubjectContentByPageTitle( $title ),
 			'Precondition: the POST wrote Subject content'
 		);
 

--- a/tests/phpunit/EntryPoints/ViewParserFunctionTest.php
+++ b/tests/phpunit/EntryPoints/ViewParserFunctionTest.php
@@ -8,6 +8,8 @@ use MediaWiki\Language\RawMessage;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Title\Title;
 use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\PageSubjectsLookup;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
@@ -16,7 +18,7 @@ use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectMap;
 use ProfessionalWiki\NeoWiki\EntryPoints\ViewParserFunction;
-use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectContentRepository;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectRepository;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\EntryPoints\ViewParserFunction
@@ -26,6 +28,7 @@ class ViewParserFunctionTest extends TestCase {
 	private const string MAIN_SUBJECT_ID = 's11111111111111';
 	private const string EXPLICIT_SUBJECT_ID = 's22222222222222';
 	private const string OTHER_SUBJECT_ID = 's33333333333333';
+	private const int PAGE_ID = 7;
 
 	public function testEmitsPlaceholderWithExplicitPositionalSubject(): void {
 		$result = $this->callView( self::EXPLICIT_SUBJECT_ID );
@@ -82,17 +85,26 @@ class ViewParserFunctionTest extends TestCase {
 	}
 
 	public function testReturnsEmptyStringWhenNoSubjectAvailable(): void {
-		$parserFunction = new ViewParserFunction( new InMemorySubjectContentRepository() );
+		$parserFunction = new ViewParserFunction( new PageSubjectsLookup( new InMemorySubjectRepository() ) );
 
 		$result = $parserFunction->handle( $this->createMockParser() );
 
 		$this->assertSame( '', $result );
 	}
 
+	public function testReturnsEmptyStringWhileThePageIsBeingCreated(): void {
+		$unsavedPage = $this->createStub( Title::class );
+		$unsavedPage->method( 'getArticleID' )->willReturn( 0 );
+		$parser = $this->createStub( Parser::class );
+		$parser->method( 'getTitle' )->willReturn( $unsavedPage );
+
+		$result = ( new ViewParserFunction( $this->lookupWithMainSubject() ) )->handle( $parser );
+
+		$this->assertSame( '', $result );
+	}
+
 	public function testReturnsEmptyStringWhenPageHasNoMainSubject(): void {
-		$parserFunction = new ViewParserFunction(
-			new InMemorySubjectContentRepository( new PageSubjects( null, new SubjectMap() ) )
-		);
+		$parserFunction = new ViewParserFunction( $this->lookupWithPageSubjects( new PageSubjects( null, new SubjectMap() ) ) );
 
 		$result = $parserFunction->handle( $this->createMockParser() );
 
@@ -130,11 +142,18 @@ class ViewParserFunctionTest extends TestCase {
 	}
 
 	private function callView( string ...$args ): string|array {
-		return ( new ViewParserFunction( $this->repositoryWithMainSubject() ) )
+		return ( new ViewParserFunction( $this->lookupWithMainSubject() ) )
 			->handle( $this->createMockParser(), ...$args );
 	}
 
-	private function repositoryWithMainSubject(): InMemorySubjectContentRepository {
+	private function lookupWithPageSubjects( PageSubjects $pageSubjects ): PageSubjectsLookup {
+		$repository = new InMemorySubjectRepository();
+		$repository->savePageSubjects( $pageSubjects, new PageId( self::PAGE_ID ) );
+
+		return new PageSubjectsLookup( $repository );
+	}
+
+	private function lookupWithMainSubject(): PageSubjectsLookup {
 		$mainSubject = new Subject(
 			id: new SubjectId( self::MAIN_SUBJECT_ID ),
 			label: new SubjectLabel( 'Main' ),
@@ -142,11 +161,12 @@ class ViewParserFunctionTest extends TestCase {
 			statements: new StatementList(),
 		);
 
-		return new InMemorySubjectContentRepository( new PageSubjects( $mainSubject, new SubjectMap() ) );
+		return $this->lookupWithPageSubjects( new PageSubjects( $mainSubject, new SubjectMap() ) );
 	}
 
 	private function createMockParser(): Parser {
 		$title = $this->createStub( Title::class );
+		$title->method( 'getArticleID' )->willReturn( self::PAGE_ID );
 
 		$parser = $this->createStub( Parser::class );
 		$parser->method( 'getTitle' )->willReturn( $title );

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Application/Neo4jQueryLimitsTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Application/Neo4jQueryLimitsTest.php
@@ -45,11 +45,24 @@ class Neo4jQueryLimitsTest extends MediaWikiIntegrationTestCase {
 		$this->assertSame( 50000, $limits->maxRows );
 	}
 
-	public function testRespectsConfigOverridesForDefaultTier(): void {
+	private function overrideTiers(): void {
 		$this->overrideConfigValue( 'NeoWikiQueryLimits', [
 			'default'   => [ 'timeoutSeconds' => 5, 'maxRows' => 100 ],
 			'expensive' => [ 'timeoutSeconds' => 99, 'maxRows' => 999 ],
 		] );
+	}
+
+	public function testDefaultTierReadsTheDefaultTierConfig(): void {
+		$this->overrideTiers();
+
+		$limits = Neo4jQueryLimits::defaultTier();
+
+		$this->assertSame( 5, $limits->timeoutSeconds );
+		$this->assertSame( 100, $limits->maxRows );
+	}
+
+	public function testRespectsConfigOverridesForDefaultTier(): void {
+		$this->overrideTiers();
 
 		$user = $this->getServiceContainer()->getUserFactory()->newAnonymous();
 

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Application/Neo4jQueryServiceTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Application/Neo4jQueryServiceTest.php
@@ -10,12 +10,14 @@ use Laudis\Neo4j\Exception\Neo4jException;
 use Laudis\Neo4j\Types\CypherList;
 use Laudis\Neo4j\Types\CypherMap;
 use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\RawQueryAuthorizer;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\CypherQueryValidator;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\BackendUnavailableException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\CypherSyntaxException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\EmptyQueryException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\InternalQueryException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\ParameterMissingException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\QueryPermissionDeniedException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\QueryTimeoutException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\WriteQueryRejectedException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jQueryLimits;
@@ -23,6 +25,7 @@ use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jQueryRe
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jResultNormalizer;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jQueryService;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jReadQueryEngine;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubRawQueryAuthorizer;
 use RuntimeException;
 use Throwable;
 
@@ -295,14 +298,33 @@ class Neo4jQueryServiceTest extends TestCase {
 		$this->assertSame( [ 'x' => 'subject-42' ], $capturedParameters );
 	}
 
+	public function testDeniedRawQueryIsRejectedBeforeTheStoreIsAsked(): void {
+		$validatorReachingTheStore = new class implements CypherQueryValidator {
+			public function queryIsAllowed( string $cypher ): bool {
+				throw new RuntimeException( 'EXPLAIN reached the store' );
+			}
+		};
+		$service = $this->newService(
+			$this->stubEngineThrowing( new RuntimeException( 'the query reached the store' ) ),
+			validator: $validatorReachingTheStore,
+			authorizer: new StubRawQueryAuthorizer( false )
+		);
+
+		$this->expectException( QueryPermissionDeniedException::class );
+
+		$service->execute( $this->newRequest( 'MATCH (n) RETURN n' ) );
+	}
+
 	private function newService(
 		Neo4jReadQueryEngine $engine,
 		?CypherQueryValidator $validator = null,
+		?RawQueryAuthorizer $authorizer = null,
 	): Neo4jQueryService {
 		return new Neo4jQueryService(
 			$engine,
 			$validator ?? $this->fixedValidator( true ),
 			new Neo4jResultNormalizer(),
+			$authorizer ?? new StubRawQueryAuthorizer( true ),
 		);
 	}
 

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/EntryPoints/Lua/CypherQueryRunnerTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/EntryPoints/Lua/CypherQueryRunnerTest.php
@@ -12,10 +12,12 @@ use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\CypherQueryV
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\BackendUnavailableException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\EmptyQueryException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\WriteQueryRejectedException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jQueryLimits;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jResultNormalizer;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jQueryService;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\Lua\CypherQueryRunner;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jReadQueryEngine;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubRawQueryAuthorizer;
 use RuntimeException;
 
 /**
@@ -25,7 +27,8 @@ class CypherQueryRunnerTest extends TestCase {
 
 	private function newRunner(
 		Neo4jReadQueryEngine $engine,
-		?CypherQueryValidator $validator = null
+		?CypherQueryValidator $validator = null,
+		?Neo4jQueryLimits $limits = null
 	): CypherQueryRunner {
 		$validator ??= new class implements CypherQueryValidator {
 
@@ -40,14 +43,26 @@ class CypherQueryRunnerTest extends TestCase {
 				$engine,
 				$validator,
 				new Neo4jResultNormalizer(),
-			)
+				new StubRawQueryAuthorizer( true ),
+			),
+			$limits ?? new Neo4jQueryLimits( 30, 5000 ),
 		);
+	}
+
+	public function testRunsTheQueryWithTheInjectedLimits(): void {
+		$engine = $this->stubEngine( $this->emptyResult() );
+
+		$this->newRunner( $engine, limits: new Neo4jQueryLimits( timeoutSeconds: 17, maxRows: 5000 ) )
+			->run( 'MATCH (n) RETURN n', [] );
+
+		$this->assertSame( 17, $engine->lastTimeoutSeconds );
 	}
 
 	private function stubEngine( SummarizedResult $result ): Neo4jReadQueryEngine {
 		return new class( $result ) implements Neo4jReadQueryEngine {
 			public string $lastCypher = '';
 			public array $lastParams = [];
+			public ?int $lastTimeoutSeconds = null;
 
 			public function __construct( private readonly SummarizedResult $result ) {
 			}
@@ -55,6 +70,7 @@ class CypherQueryRunnerTest extends TestCase {
 			public function runReadQuery( string $cypher, array $parameters = [], ?int $timeoutSeconds = null ): SummarizedResult {
 				$this->lastCypher = $cypher;
 				$this->lastParams = $parameters;
+				$this->lastTimeoutSeconds = $timeoutSeconds;
 				return $this->result;
 			}
 		};
@@ -104,19 +120,12 @@ class CypherQueryRunnerTest extends TestCase {
 				throw new \LogicException( 'engine must not be called for a rejected query' );
 			}
 		};
-		$runner = new CypherQueryRunner(
-			new Neo4jQueryService(
-				$engine,
-				new class implements CypherQueryValidator {
-
-					public function queryIsAllowed( string $cypher ): bool {
-						return false;
-					}
-
-				},
-				new Neo4jResultNormalizer(),
-			)
-		);
+		$rejectingValidator = new class implements CypherQueryValidator {
+			public function queryIsAllowed( string $cypher ): bool {
+				return false;
+			}
+		};
+		$runner = $this->newRunner( $engine, $rejectingValidator );
 
 		$this->expectException( WriteQueryRejectedException::class );
 		$runner->run( 'CREATE (n)', [] );

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/EntryPoints/ParserFunction/CypherRawParserFunctionParsingTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/EntryPoints/ParserFunction/CypherRawParserFunctionParsingTest.php
@@ -11,10 +11,12 @@ use MediaWiki\Parser\ParserOptions;
 use MediaWiki\Title\Title;
 use MediaWikiIntegrationTestCase;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\KeywordCypherQueryValidator;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jQueryLimits;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jQueryService;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jReadQueryEngine;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\ParserFunction\CypherRawParserFunction;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jResultNormalizer;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubRawQueryAuthorizer;
 
 /**
  * What a reader ends up with, rather than what the parser function returns: the corruption this
@@ -35,7 +37,8 @@ class CypherRawParserFunctionParsingTest extends MediaWikiIntegrationTestCase {
 		$parser->setFunctionHook(
 			'cypher_raw',
 			static function ( Parser $parser, string $cypherQuery ) use ( $queryService ): string|array {
-				return ( new CypherRawParserFunction( $queryService ) )->handle( $parser, $cypherQuery );
+				return ( new CypherRawParserFunction( $queryService, new Neo4jQueryLimits( 30, 5000 ) ) )
+					->handle( $parser, $cypherQuery );
 			}
 		);
 
@@ -61,6 +64,7 @@ class CypherRawParserFunctionParsingTest extends MediaWikiIntegrationTestCase {
 			$queryEngine,
 			new KeywordCypherQueryValidator(),
 			new Neo4jResultNormalizer(),
+			new StubRawQueryAuthorizer( true ),
 		);
 	}
 

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/EntryPoints/ParserFunction/CypherRawParserFunctionTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/EntryPoints/ParserFunction/CypherRawParserFunctionTest.php
@@ -12,12 +12,15 @@ use Laudis\Neo4j\Types\CypherMap;
 use MediaWiki\Message\Message;
 use MediaWiki\Parser\Parser;
 use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\RawQueryAuthorizer;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\CypherQueryValidator;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jQueryLimits;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jResultNormalizer;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jQueryService;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\ParserFunction\CypherRawParserFunction;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\KeywordCypherQueryValidator;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jReadQueryEngine;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubRawQueryAuthorizer;
 use RuntimeException;
 
 /**
@@ -76,6 +79,7 @@ class CypherRawParserFunctionTest extends TestCase {
 	private function createParserFunction(
 		Neo4jReadQueryEngine $engine,
 		?CypherQueryValidator $validator = null,
+		?RawQueryAuthorizer $authorizer = null,
 	): CypherRawParserFunction {
 		$validator ??= new KeywordCypherQueryValidator();
 
@@ -84,7 +88,9 @@ class CypherRawParserFunctionTest extends TestCase {
 				$engine,
 				$validator,
 				new Neo4jResultNormalizer(),
-			)
+				$authorizer ?? new StubRawQueryAuthorizer( true ),
+			),
+			new Neo4jQueryLimits( 30, 5000 ),
 		);
 	}
 
@@ -103,6 +109,18 @@ class CypherRawParserFunctionTest extends TestCase {
 		$result = $parserFunction->handle( $this->createParser(), '' );
 
 		$this->assertStringContainsString( '[neowiki-cypher-error-empty-query]', $this->html( $result ) );
+	}
+
+	public function testDeniedQueryRightShowsLocalizedErrorInsteadOfRows(): void {
+		$parserFunction = $this->createParserFunction(
+			$this->createQueryEngineWithData( [ [ 'name' => 'Alice' ] ] ),
+			authorizer: new StubRawQueryAuthorizer( false )
+		);
+
+		$result = $parserFunction->handle( $this->createParser(), 'MATCH (n:Person) RETURN n' );
+
+		$this->assertStringContainsString( '[neowiki-cypher-error-permission-denied]', $this->html( $result ) );
+		$this->assertStringNotContainsString( 'Alice', $this->html( $result ) );
 	}
 
 	public function testWriteQueryShowsLocalizedError(): void {

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/EntryPoints/REST/CypherQueryApiTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/EntryPoints/REST/CypherQueryApiTest.php
@@ -11,6 +11,10 @@ use MediaWiki\Rest\ResponseInterface;
 use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
 use MediaWiki\Tests\Unit\Permissions\MockAuthorityTrait;
 use MediaWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\KeywordCypherQueryValidator;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Neo4jReadQueryEngine;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jResultNormalizer;
+use ProfessionalWiki\NeoWiki\Infrastructure\AuthorityBasedRawQueryAuthorizer;
 use Throwable;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\BackendUnavailableException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Application\Exception\CypherSyntaxException;
@@ -131,10 +135,17 @@ class CypherQueryApiTest extends MediaWikiIntegrationTestCase {
 	}
 
 	public function testReturns403WhenUserLacksNeowikiQueryRight(): void {
+		$authority = $this->mockAnonAuthorityWithPermissions( [] );
+
 		$response = $this->executeRequest(
-			$this->stubServiceReturning( $this->emptyResult() ),
+			new Neo4jQueryService(
+				$this->createStub( Neo4jReadQueryEngine::class ),
+				new KeywordCypherQueryValidator(),
+				new Neo4jResultNormalizer(),
+				new AuthorityBasedRawQueryAuthorizer( $authority ),
+			),
 			[ 'cypher' => 'MATCH (n) RETURN n' ],
-			authority: $this->mockAnonAuthorityWithPermissions( [] )
+			authority: $authority
 		);
 		$body = $this->decodeBody( $response );
 

--- a/tests/phpunit/GraphDatabasePlugins/Neo4j/Integration/QueryCypherEndToEndTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Neo4j/Integration/QueryCypherEndToEndTest.php
@@ -66,7 +66,7 @@ class QueryCypherEndToEndTest extends NeoWikiIntegrationTestCase {
 	public function testAdminQueryRejectedByProductionQueryService(): void {
 		// STOP DATABASE passes the keyword validator but the Explain layer rejects it, so this fails
 		// unless the production service composes the Explain validator, not just the keyword one.
-		$service = NeoWikiExtension::getInstance()->newCypherQueryService();
+		$service = NeoWikiExtension::getInstance()->newCypherQueryService( $this->getTestSysop()->getUser() );
 		$request = new Neo4jQueryRequest( 'STOP DATABASE neo4j', [], new Neo4jQueryLimits( 30, 5000 ) );
 
 		$this->expectException( WriteQueryRejectedException::class );

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/Application/SparqlQueryLimitsTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/Application/SparqlQueryLimitsTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\GraphDatabasePlugins\Sparql\Application;
+
+use MediaWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryLimits;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryLimits
+ * @group Database
+ */
+class SparqlQueryLimitsTest extends MediaWikiIntegrationTestCase {
+
+	private function overrideTiers(): void {
+		$this->overrideConfigValue( 'NeoWikiQueryLimits', [
+			'default'   => [ 'timeoutSeconds' => 5, 'maxRows' => 100 ],
+			'expensive' => [ 'timeoutSeconds' => 99, 'maxRows' => 999 ],
+		] );
+	}
+
+	public function testDefaultTierReadsTheDefaultTierConfig(): void {
+		$this->overrideTiers();
+
+		$this->assertSame( 5, SparqlQueryLimits::defaultTier()->timeoutSeconds );
+	}
+
+	public function testUserWithApiHighLimitsGetsTheExpensiveTierTimeout(): void {
+		$this->overrideTiers();
+
+		$limits = SparqlQueryLimits::forUser( $this->getTestUser( [ 'bot' ] )->getUser() );
+
+		$this->assertSame( 99, $limits->timeoutSeconds );
+	}
+
+}

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/Application/SparqlQueryServiceTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/Application/SparqlQueryServiceTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\EmptySparqlQueryException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\InternalSparqlQueryException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlQueryFailedException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlQueryPermissionDeniedException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlStoreUnavailableException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlSyntaxException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryLimits;
@@ -15,6 +16,7 @@ use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQuery
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryResult;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryService;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\FakeSparqlQueryEndpoint;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubRawQueryAuthorizer;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryService
@@ -79,7 +81,7 @@ class SparqlQueryServiceTest extends TestCase {
 	public function testAppliesTierTimeoutToTheEndpoint(): void {
 		$endpoint = FakeSparqlQueryEndpoint::returning( self::RESULTS );
 
-		( new SparqlQueryService( $endpoint ) )->execute(
+		( new SparqlQueryService( $endpoint, new StubRawQueryAuthorizer( true ) ) )->execute(
 			new SparqlQueryRequest( 'SELECT * WHERE { ?s ?p ?o }', new SparqlQueryLimits( 17 ) )
 		);
 
@@ -94,8 +96,18 @@ class SparqlQueryServiceTest extends TestCase {
 		$this->assertSame( 'SELECT * WHERE { ?s ?p ?o }', $endpoint->lastQuery );
 	}
 
+	public function testDeniedRawQueryIsRejectedBeforeTheStoreIsAsked(): void {
+		$endpoint = FakeSparqlQueryEndpoint::failingWith( new SparqlQueryFailedException( 'https://s.example', 500, 'reached the store' ) );
+
+		$this->expectException( SparqlQueryPermissionDeniedException::class );
+
+		( new SparqlQueryService( $endpoint, new StubRawQueryAuthorizer( false ) ) )->execute(
+			new SparqlQueryRequest( 'SELECT * WHERE { ?s ?p ?o }', new SparqlQueryLimits( 30 ) )
+		);
+	}
+
 	private function execute( FakeSparqlQueryEndpoint $endpoint, string $sparql ): SparqlQueryResult {
-		return ( new SparqlQueryService( $endpoint ) )->execute(
+		return ( new SparqlQueryService( $endpoint, new StubRawQueryAuthorizer( true ) ) )->execute(
 			new SparqlQueryRequest( $sparql, new SparqlQueryLimits( 30 ) )
 		);
 	}

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/EntryPoints/Lua/SparqlQueryRunnerTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/EntryPoints/Lua/SparqlQueryRunnerTest.php
@@ -8,9 +8,11 @@ use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\EmptySparqlQueryException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlQueryFailedException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlStoreUnavailableException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryLimits;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryService;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\EntryPoints\Lua\SparqlQueryRunner;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\FakeSparqlQueryEndpoint;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubRawQueryAuthorizer;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\EntryPoints\Lua\SparqlQueryRunner
@@ -54,10 +56,8 @@ class SparqlQueryRunnerTest extends TestCase {
 	}
 
 	public function testStoreFailurePropagatesAsStoreUnavailableException(): void {
-		$runner = new SparqlQueryRunner(
-			new SparqlQueryService(
-				FakeSparqlQueryEndpoint::failingWith( new SparqlQueryFailedException( 'https://s.example', 500, 'boom' ) )
-			)
+		$runner = $this->newRunner(
+			FakeSparqlQueryEndpoint::failingWith( new SparqlQueryFailedException( 'https://s.example', 500, 'boom' ) )
 		);
 
 		$this->expectException( SparqlStoreUnavailableException::class );
@@ -68,11 +68,22 @@ class SparqlQueryRunnerTest extends TestCase {
 	 * @return array<int|string, mixed>
 	 */
 	private function runViaRunner( string $results, string $query = 'SELECT * WHERE { ?s ?p ?o }' ): array {
-		$runner = new SparqlQueryRunner(
-			new SparqlQueryService( FakeSparqlQueryEndpoint::returning( $results ) )
-		);
+		return $this->newRunner( FakeSparqlQueryEndpoint::returning( $results ) )->run( $query );
+	}
 
-		return $runner->run( $query );
+	private function newRunner( FakeSparqlQueryEndpoint $endpoint, ?SparqlQueryLimits $limits = null ): SparqlQueryRunner {
+		return new SparqlQueryRunner(
+			new SparqlQueryService( $endpoint, new StubRawQueryAuthorizer( true ) ),
+			$limits ?? new SparqlQueryLimits( 30 ),
+		);
+	}
+
+	public function testRunsTheQueryWithTheInjectedLimits(): void {
+		$endpoint = FakeSparqlQueryEndpoint::returning( '{"head":{},"results":{"bindings":[]}}' );
+
+		$this->newRunner( $endpoint, new SparqlQueryLimits( 17 ) )->run( 'SELECT * WHERE { ?s ?p ?o }' );
+
+		$this->assertSame( 17, $endpoint->lastTimeoutSeconds );
 	}
 
 }

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/EntryPoints/ParserFunction/SparqlRawParserFunctionParsingTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/EntryPoints/ParserFunction/SparqlRawParserFunctionParsingTest.php
@@ -8,9 +8,11 @@ use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\ParserOptions;
 use MediaWiki\Title\Title;
 use MediaWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryLimits;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryService;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\EntryPoints\ParserFunction\SparqlRawParserFunction;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\FakeSparqlQueryEndpoint;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubRawQueryAuthorizer;
 
 /**
  * What a reader ends up with, rather than what the parser function returns: the corruption this
@@ -31,7 +33,8 @@ class SparqlRawParserFunctionParsingTest extends MediaWikiIntegrationTestCase {
 			'sparql_raw',
 			static function ( Parser $parser, string $query ) use ( $results ): string|array {
 				return ( new SparqlRawParserFunction(
-					new SparqlQueryService( FakeSparqlQueryEndpoint::returning( $results ) )
+					new SparqlQueryService( FakeSparqlQueryEndpoint::returning( $results ), new StubRawQueryAuthorizer( true ) ),
+					new SparqlQueryLimits( 30 ),
 				) )->handle( $parser, $query );
 			}
 		);

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/EntryPoints/ParserFunction/SparqlRawParserFunctionTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/EntryPoints/ParserFunction/SparqlRawParserFunctionTest.php
@@ -7,10 +7,13 @@ namespace ProfessionalWiki\NeoWiki\Tests\GraphDatabasePlugins\Sparql\EntryPoints
 use MediaWiki\Message\Message;
 use MediaWiki\Parser\Parser;
 use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\RawQueryAuthorizer;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlQueryFailedException;
+use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryLimits;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryService;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\EntryPoints\ParserFunction\SparqlRawParserFunction;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\FakeSparqlQueryEndpoint;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubRawQueryAuthorizer;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\EntryPoints\ParserFunction\SparqlRawParserFunction
@@ -36,8 +39,14 @@ class SparqlRawParserFunctionTest extends TestCase {
 		return $parser;
 	}
 
-	private function parserFunction( FakeSparqlQueryEndpoint $endpoint ): SparqlRawParserFunction {
-		return new SparqlRawParserFunction( new SparqlQueryService( $endpoint ) );
+	private function parserFunction(
+		FakeSparqlQueryEndpoint $endpoint,
+		?RawQueryAuthorizer $authorizer = null
+	): SparqlRawParserFunction {
+		return new SparqlRawParserFunction(
+			new SparqlQueryService( $endpoint, $authorizer ?? new StubRawQueryAuthorizer( true ) ),
+			new SparqlQueryLimits( 30 ),
+		);
 	}
 
 	/**
@@ -47,6 +56,14 @@ class SparqlRawParserFunctionTest extends TestCase {
 	 */
 	private function html( string|array $result ): string {
 		return is_array( $result ) ? $result[0] : $result;
+	}
+
+	public function testDeniedQueryRightShowsLocalizedErrorInsteadOfResults(): void {
+		$result = $this->parserFunction( FakeSparqlQueryEndpoint::returning( self::RESULTS ), new StubRawQueryAuthorizer( false ) )
+			->handle( $this->createParser(), 'SELECT * WHERE { ?s ?p ?o }' );
+
+		$this->assertStringContainsString( '[neowiki-sparql-error-permission-denied]', $this->html( $result ) );
+		$this->assertStringNotContainsString( 'Bach', $this->html( $result ) );
 	}
 
 	public function testEmptyQueryShowsLocalizedError(): void {

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/EntryPoints/REST/SparqlQueryApiTest.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/EntryPoints/REST/SparqlQueryApiTest.php
@@ -11,10 +11,13 @@ use MediaWiki\Rest\ResponseInterface;
 use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
 use MediaWiki\Tests\Unit\Permissions\MockAuthorityTrait;
 use MediaWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Application\RawQueryAuthorizer;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\Exception\SparqlQueryFailedException;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\Application\SparqlQueryService;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\EntryPoints\REST\SparqlQueryApi;
+use ProfessionalWiki\NeoWiki\Infrastructure\AuthorityBasedRawQueryAuthorizer;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\FakeSparqlQueryEndpoint;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubRawQueryAuthorizer;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\EntryPoints\REST\SparqlQueryApi
@@ -81,10 +84,12 @@ class SparqlQueryApiTest extends MediaWikiIntegrationTestCase {
 	}
 
 	public function testReturns403WhenUserLacksNeowikiQueryRight(): void {
+		$authority = $this->mockAnonAuthorityWithPermissions( [] );
+
 		$response = $this->executeRequest(
-			$this->serviceReturning( self::RESULTS ),
+			$this->serviceReturning( self::RESULTS, new AuthorityBasedRawQueryAuthorizer( $authority ) ),
 			[ 'query' => 'SELECT * WHERE { ?s ?p ?o }' ],
-			authority: $this->mockAnonAuthorityWithPermissions( [] )
+			authority: $authority
 		);
 		$body = $this->decodeBody( $response );
 
@@ -132,12 +137,15 @@ class SparqlQueryApiTest extends MediaWikiIntegrationTestCase {
 		return json_decode( $response->getBody()->getContents(), true );
 	}
 
-	private function serviceReturning( string $responseBody ): SparqlQueryService {
-		return new SparqlQueryService( FakeSparqlQueryEndpoint::returning( $responseBody ) );
+	private function serviceReturning( string $responseBody, ?RawQueryAuthorizer $authorizer = null ): SparqlQueryService {
+		return new SparqlQueryService(
+			FakeSparqlQueryEndpoint::returning( $responseBody ),
+			$authorizer ?? new StubRawQueryAuthorizer( true )
+		);
 	}
 
 	private function serviceFailingWith( SparqlQueryFailedException $failure ): SparqlQueryService {
-		return new SparqlQueryService( FakeSparqlQueryEndpoint::failingWith( $failure ) );
+		return new SparqlQueryService( FakeSparqlQueryEndpoint::failingWith( $failure ), new StubRawQueryAuthorizer( true ) );
 	}
 
 }

--- a/tests/phpunit/GraphDatabasePlugins/Sparql/Integration/QuerySparqlEndToEndTestCase.php
+++ b/tests/phpunit/GraphDatabasePlugins/Sparql/Integration/QuerySparqlEndToEndTestCase.php
@@ -392,7 +392,7 @@ abstract class QuerySparqlEndToEndTestCase extends NeoWikiIntegrationTestCase {
 	 * @return list<array<string, array<string, string>>> The query's solution bindings.
 	 */
 	private function runQuery( string $sparql ): array {
-		return NeoWikiExtension::getInstance()->newSparqlQueryService()->execute(
+		return NeoWikiExtension::getInstance()->newSparqlQueryService( $this->getTestSysop()->getUser() )->execute(
 			new SparqlQueryRequest(
 				sparql: $sparql,
 				limits: new SparqlQueryLimits( 30 ),

--- a/tests/phpunit/Infrastructure/UserAccessClassTest.php
+++ b/tests/phpunit/Infrastructure/UserAccessClassTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Infrastructure;
+
+use MediaWiki\User\User;
+use MediaWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Infrastructure\UserAccessClass;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Infrastructure\UserAccessClass
+ * @group Database
+ */
+class UserAccessClassTest extends MediaWikiIntegrationTestCase {
+
+	private function newAccessClass(): UserAccessClass {
+		return NeoWikiExtension::getInstance()->newUserAccessClass();
+	}
+
+	public function testAnonymousAndLoggedInReadersAreDifferentClasses(): void {
+		$accessClass = $this->newAccessClass();
+
+		$this->assertNotSame(
+			$accessClass->of( $this->getServiceContainer()->getUserFactory()->newAnonymous() ),
+			$accessClass->of( $this->getTestUser()->getUser() )
+		);
+	}
+
+	/**
+	 * Group names reach the class from hooks and the database, so a group whose name holds a separator
+	 * must not be able to describe like a different set of groups.
+	 */
+	public function testAGroupNamedAfterOtherGroupsDoesNotShareTheirClass(): void {
+		$impostor = $this->getMutableTestUser( [ 'sysop,user' ] )->getUser();
+
+		$accessClass = $this->newAccessClass();
+
+		$this->assertNotSame(
+			$accessClass->of( $this->getTestSysop()->getUser() ),
+			$accessClass->of( $impostor )
+		);
+	}
+
+	public function testUsersWithTheSameGroupsShareAClass(): void {
+		$accessClass = $this->newAccessClass();
+
+		$this->assertSame(
+			$accessClass->of( $this->getTestUser( [ 'bot' ] )->getUser() ),
+			$accessClass->of( $this->getMutableTestUser( [ 'bot' ] )->getUser() )
+		);
+	}
+
+	public function testUsersWithDifferentGroupsHaveDifferentClasses(): void {
+		$accessClass = $this->newAccessClass();
+
+		$this->assertNotSame(
+			$accessClass->of( $this->getTestUser()->getUser() ),
+			$accessClass->of( $this->getTestSysop()->getUser() )
+		);
+	}
+
+	/**
+	 * Installed before the first class is computed: the permission manager memoizes rights per user.
+	 */
+	private function grantRightOutsideGroups( User $grantee, string $right ): void {
+		$this->setTemporaryHook(
+			'UserGetRights',
+			static function ( User $user, array &$rights ) use ( $grantee, $right ): void {
+				if ( $user->equals( $grantee ) ) {
+					$rights[] = $right;
+				}
+			}
+		);
+	}
+
+	public function testTheQueryRightSeparatesUsersInTheSameGroups(): void {
+		$this->setGroupPermissions( '*', 'neowiki-query', false );
+		$granted = $this->getTestUser()->getUser();
+		$other = $this->getMutableTestUser()->getUser();
+		$this->grantRightOutsideGroups( $granted, 'neowiki-query' );
+
+		$accessClass = $this->newAccessClass();
+
+		$this->assertNotSame( $accessClass->of( $granted ), $accessClass->of( $other ) );
+	}
+
+	public function testTheReadRightSeparatesUsersInTheSameGroups(): void {
+		$this->setGroupPermissions( '*', 'read', false );
+		$this->setGroupPermissions( 'user', 'read', false );
+		$granted = $this->getTestUser()->getUser();
+		$other = $this->getMutableTestUser()->getUser();
+		$this->grantRightOutsideGroups( $granted, 'read' );
+
+		$accessClass = $this->newAccessClass();
+
+		$this->assertNotSame( $accessClass->of( $granted ), $accessClass->of( $other ) );
+	}
+
+}

--- a/tests/phpunit/NeoWikiIntegrationTestCase.php
+++ b/tests/phpunit/NeoWikiIntegrationTestCase.php
@@ -11,6 +11,7 @@ use MediaWiki\CommentStore\CommentStoreComment;
 use MediaWiki\Content\TextContent;
 use MediaWiki\Deferred\DeferredUpdates;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Parser\ParserOptions;
 use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Tests\User\TempUser\TempUserTestTrait;
 use MediaWiki\Title\Title;
@@ -77,6 +78,20 @@ class NeoWikiIntegrationTestCase extends MediaWikiIntegrationTestCase {
 		catch ( \Exception ) {
 			$this->markTestSkipped( 'Neo4j not available' );
 		}
+	}
+
+	/**
+	 * What a reader of $pageName ends up with, as the parser options' user: the parser functions run
+	 * for real, and the output pipeline applies, as on a page view.
+	 */
+	protected function parseWikitextOn( string $pageName, string $wikitext, ?ParserOptions $parserOptions = null ): string {
+		$parserOptions ??= ParserOptions::newFromAnon();
+
+		return $this->getServiceContainer()->getParserFactory()->create()->parse(
+			$wikitext,
+			Title::newFromText( $pageName ),
+			$parserOptions
+		)->runOutputPipeline( $parserOptions, [] )->getContentHolderText();
 	}
 
 	protected function createPageWithSubjects(

--- a/tests/phpunit/NoGraphBackendTest.php
+++ b/tests/phpunit/NoGraphBackendTest.php
@@ -9,7 +9,6 @@ use MediaWiki\Content\WikitextContent;
 use MediaWiki\Context\RequestContext;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Output\OutputPage;
-use MediaWiki\Parser\ParserOptions;
 use MediaWiki\Title\Title;
 use ProfessionalWiki\NeoWiki\Application\NullSubjectLabelLookup;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphBackendNotConfiguredException;
@@ -105,7 +104,7 @@ class NoGraphBackendTest extends NeoWikiIntegrationTestCase {
 		$html = $this->runWithoutGraphBackend( function (): string {
 			$this->createPageWithMottoSubject( 'NoBackendValuePage' );
 
-			return $this->parse(
+			return $this->parseWikitextOn(
 				'NoBackendValuePage',
 				'{{#neowiki_value: ' . self::PROPERTY . ' | subject=' . self::SUBJECT_ID . ' }}'
 			);
@@ -121,7 +120,8 @@ class NoGraphBackendTest extends NeoWikiIntegrationTestCase {
 	public function testLuaGetterReadsAValueBySubjectIdWithoutBackend(): void {
 		$value = $this->runWithoutGraphBackend( function (): array {
 			$this->createPageWithMottoSubject( 'NoBackendLuaPage' );
-			return ( new SubjectDataLookup( NeoWikiExtension::getInstance()->newSubjectResolver() ) )->getValue(
+			$resolver = NeoWikiExtension::getInstance()->newSubjectResolver( $this->getTestSysop()->getUser() );
+			return ( new SubjectDataLookup( $resolver ) )->getValue(
 				Title::newFromText( 'NoBackendLuaPage' ),
 				self::PROPERTY,
 				[ 'subject' => self::SUBJECT_ID ]
@@ -245,16 +245,6 @@ class NoGraphBackendTest extends NeoWikiIntegrationTestCase {
 		$value = $subject?->getStatements()->getStatement( new PropertyName( self::PROPERTY ) )?->getValue();
 
 		return $value instanceof StringValue ? $value->toScalars()[0] : null;
-	}
-
-	private function parse( string $pageName, string $wikitext ): string {
-		$parserOptions = ParserOptions::newFromAnon();
-
-		return $this->getServiceContainer()->getParserFactory()->getInstance()->parse(
-			$wikitext,
-			Title::newFromText( $pageName ),
-			$parserOptions
-		)->runOutputPipeline( $parserOptions, [] )->getContentHolderText();
 	}
 
 	private function newContentPageOutput( string $pageName ): OutputPage {

--- a/tests/phpunit/ParseTimePermissionFixtures.php
+++ b/tests/phpunit/ParseTimePermissionFixtures.php
@@ -1,0 +1,60 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests;
+
+use MediaWiki\Title\Title;
+use MediaWiki\User\User;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+
+/**
+ * Fixtures for the parse-time permission tests, which live in two class hierarchies (the NeoWiki
+ * integration base and Scribunto's Lua engine base) and so cannot share a base class.
+ */
+trait ParseTimePermissionFixtures {
+
+	/**
+	 * Denies anonymous users the read permission of the named pages, the way a per-page ACL
+	 * extension would, while the request's user keeps every right.
+	 */
+	protected function denyAnonymousReadOf( string ...$pageNames ): void {
+		$this->setTemporaryHook(
+			'getUserPermissionsErrors',
+			static function ( Title $title, User $user, string $action, &$result ) use ( $pageNames ): bool {
+				if ( $action === 'read' && $user->isAnon() && in_array( $title->getPrefixedText(), $pageNames, true ) ) {
+					$result = [ 'badaccess-group0' ];
+					return false;
+				}
+
+				return true;
+			}
+		);
+	}
+
+	protected function grantTheQueryRightToSysopsOnly(): void {
+		$this->setGroupPermissions( '*', 'neowiki-query', false );
+		$this->setGroupPermissions( 'sysop', 'neowiki-query', true );
+	}
+
+	/**
+	 * Sysops hold `apihighlimits`, so a query sized for a sysop gets the expensive tier and both
+	 * rows of a two-row query, while one sized for the default tier gets one.
+	 */
+	protected function capTheDefaultTierAtOneRow(): void {
+		$this->overrideConfigValue( 'NeoWikiQueryLimits', [
+			'default' => [ 'timeoutSeconds' => 30, 'maxRows' => 1 ],
+			'expensive' => [ 'timeoutSeconds' => 30, 'maxRows' => 100 ],
+		] );
+	}
+
+	/**
+	 * Registers the SPARQL surfaces without a reachable store. The URL is never contacted: every
+	 * test using this fails before any HTTP, on the permission gate or on an empty query.
+	 */
+	protected function configureAnUnreachableSparqlStore(): void {
+		$this->overrideConfigValue( 'NeoWikiSparqlStores', [ [ 'updateUrl' => 'https://sparql.invalid/store' ] ] );
+		NeoWikiExtension::resetInstance();
+	}
+
+}

--- a/tests/phpunit/TestDoubles/StubRawQueryAuthorizer.php
+++ b/tests/phpunit/TestDoubles/StubRawQueryAuthorizer.php
@@ -1,0 +1,23 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\TestDoubles;
+
+use ProfessionalWiki\NeoWiki\Application\RawQueryAuthorizer;
+
+/**
+ * Authorizes or denies every raw query.
+ */
+class StubRawQueryAuthorizer implements RawQueryAuthorizer {
+
+	public function __construct(
+		private readonly bool $allowed
+	) {
+	}
+
+	public function authorizeRawQuery(): bool {
+		return $this->allowed;
+	}
+
+}


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/NeoWiki/issues/1059

Every parse-time read now runs as the user the page is parsed for, taken from the parser rather than the request context, and is gated the way the REST endpoints are:

* `{{#cypher_raw}}`, `{{#sparql_raw}}`, `nw.query` and `nw.sparqlQuery` require the `neowiki-query` right. The check lives in the two query services, so every raw-query surface shares it, the REST endpoints included, which no longer check it themselves. Denial renders the function's error box, or raises a `LuaError`.
* `{{#neowiki_value}}` and the `nw` data functions check the `read` permission of the page hosting the Subject, through the existing `PageReadAuthorizer`. Denial is indistinguishable from absent data; a relation whose target sits on an unreadable page shows the target's Subject id instead of a label.
* `nw.getSchema` reads through a lookup built for the user the page is parsed for instead of the request-wide one.
* Parse-time query limits are pinned to the `default` tier: the output is parser-cached, so the tier must not vary by who parsed.

The request context's user was the wrong identity: it is the saver during the canonical parse of an edit and the job runner otherwise, neither of which matches the identity the parser cache files the output under.

**Do not deploy without #1347.** The parser cache still keeps one copy per page. On a wiki where anonymous users cannot read, the save-time parse runs as anonymous, so every edit caches a copy with all parse-time values blank and serves it to every logged-in reader until the next purge; on a public wiki with per-page restrictions the same happens for the restricted values. #1347 keys such output by the reader's permissions. The per-wiki switch to disable the parse-time functions is deferred; running with the parser cache off covers the residual case.

## Manual Browser Check

1. Restrict a page's read permission for anonymous users (for example with the Lockdown extension), and give it a Subject with a text property.
2. On another page, add `{{#neowiki_value: <property> | page=<restricted page>}}` and preview while logged in: the value shows. Log out, purge, and view the page: the value is absent.
3. Set `$wgGroupPermissions['*']['neowiki-query'] = false;`, purge a page holding `{{#cypher_raw: RETURN 1 AS n}}`, and view it logged out: "You do not have permission to run Cypher queries." renders in place of the result.

> <sub>AI-authored — Claude Code, `Fable 5.1` for the implementation, `Opus 5` for the review fixes; open question from @alistair3149, design agreed over three rounds, then a go-ahead with wording corrections during review; same-session AI review applied across six passes, diff not yet human-reviewed; unit and integration tests written first and mutation-checked, phpcs/phpstan clean, the full non-Database suite and the touched Database classes green locally, CI green.</sub>
