### PR TITLE
Key parser-cached output by the parsing user's access class

### DIFF
--- a/docs/adr/027-access-control.md
+++ b/docs/adr/027-access-control.md
@@ -53,6 +53,17 @@ Constraints the model rests on:
   by the wiki-level `neowiki-query` right; granting that right gives read access to everything the wiki projects into
   the store. Exposing a store directly (which ADR 19 allows for SPARQL) is a different surface: see the projection
   decision below.
+- **Parse-time reads run as the user the page is parsed for, and their output is cached per access class.**
+  The parser functions and the Lua library read as the user recorded in the parser options: the viewer on a
+  page view, or the anonymous user for the save-time parse, the job queue, and Parsoid renders. They are gated
+  like the REST endpoints: page `read` for page-attributable reads, `neowiki-query` for raw queries. Query
+  limits use the default tier regardless of user. Output that depends on such a read is parser-cached under
+  the parsing user's access class, derived from the user's effective groups and the wiki-level `read` and
+  `neowiki-query` grants, so a cached copy is shared only within one class. The class is a proxy for the
+  permission hooks: exact wherever page access follows group membership, wrong for hooks that grant per
+  user (the revision-deletion rights included), so wikis with such hooks must run without a parser cache.
+  `{{#view}}` needs no class: it emits a marker at parse time, and the Subject behind it is fetched per
+  viewer over REST, under that viewer's permissions.
 - **Raw queries will support server-side filter injection.** A deployment can register scoping predicates (such as
   restricting to the current wiki) that core applies to every caller-supplied query, so scoping is enforced rather
   than left to each caller.
@@ -64,13 +75,6 @@ Constraints the model rests on:
 
 These decisions remain open at acceptance; each is deferred to the tracking issue named with it.
 
-- **Parse-time read semantics.** Today the parse path is inconsistent
-  ([#1059](https://github.com/ProfessionalWiki/NeoWiki/issues/1059)): Schema lookups are gated per user but their
-  output is parser-cached user-agnostically; subject accessors (`{{#neowiki_value}}` and the `nw` data accessors)
-  check only revision-deletion visibility, not page `read`; `{{#cypher_raw}}`, `{{#sparql_raw}}`, `nw.query` and
-  `nw.sparqlQuery` check nothing. `{{#view}}` is the leak-free pattern: a placeholder rendered at parse time, data
-  fetched per user over REST. Deferred to [#1059](https://github.com/ProfessionalWiki/NeoWiki/issues/1059): the
-  parse-path rule and what it means for each surface.
 - **Cross-wiki subject display.** Rendering a subject from another wiki goes through REST, not Cypher, so query-side
   scoping does not cover it. Deferred to [#1341](https://github.com/ProfessionalWiki/NeoWiki/issues/1341): the
   check and the degradation behavior when the schema or subject is not accessible. Relates to
@@ -87,8 +91,22 @@ These decisions remain open at acceptance; each is deferred to the tracking issu
 ## Consequences
 
 - Every new surface that exposes NeoWiki data must be classified: page-attributable (per-row gate), raw query
-  (whole-store semantics), projection/dump (no permission checks), or parse-time (pending above). There is no
-  unclassified option.
+  (whole-store semantics), projection/dump (no permission checks), or parse-time (parsing user's authority,
+  output keyed by access class). There is no unclassified option.
+- A page that reads Subjects or runs queries at parse time holds one parser-cache entry per access class
+  among its viewers. Current-revision views of other pages are unaffected; old-revision views are keyed per
+  class wiki-wide, because core's revision-output cache keys on every cache-varying option rather than the
+  ones a page used. Saving such a page parses it twice when the editor is logged in: once canonically, once
+  for the editor's class, as pages using `{{int:}}` already do for editors with a non-default interface
+  language.
+- Restricting content does not invalidate what is already cached: the class describes the reader, not the
+  page, so a page that embeds newly restricted data keeps serving it to its class until the page is edited
+  or purged, or `$wgParserCacheExpireTime` elapses.
+- Data derived from the canonical parse is computed as the anonymous user: the categories, page properties and
+  links tables written on save and by jobs, and the categories and parser properties of the Page node in graph
+  projections. On a wiki where anonymous users cannot read, a category or page property derived from a
+  parse-time read is therefore never set. A designated reader for canonical parses would lift this; it is not
+  decided.
 - Restricting a page does not remove its data from stores; it changes what the backend returns.
 - The filter-injection extension point must be designed and implemented for farms like BlueSpice Galaxy.
 - Dumps and projections contain restricted content (unless it is omitted via a non-permission mechanism such as the
@@ -100,6 +118,13 @@ These decisions remain open at acceptance; each is deferred to the tracking issu
   QLever, and unable to express hook-based MediaWiki permissions. Rejected, consistent with ADR 13.
 - **Project ACL state into the graph for pre-query trimming** (user groups, restriction markers): re-implements an
   open set of permission hooks as data and goes stale, because permission changes produce no revision to sync on.
+- **Evaluate parse-time reads as a fixed anonymous authority**: user-independent output by construction, but
+  every privileged reader sees less than they may read, and on a private wiki the functions show nothing.
+- **Cache the superset and trim per viewer after the cache**, as core does for section edit links: sound for opaque
+  display fragments, but the cache then holds restricted data for every consumer that bypasses the output pipeline,
+  and an ungated parse leaks through categories, page properties and Lua control flow, which no HTML trim retracts.
+- **Leave the cache alone and require wikis with restricted content to disable it**: no machinery, but nothing
+  detects a violation, and a privileged first parse silently caches restricted values for everyone.
 
 ## Related
 

--- a/docs/authoring/parser-functions.md
+++ b/docs/authoring/parser-functions.md
@@ -22,7 +22,9 @@ For definitions of terms like Subject, Schema, and Layout, see the [Glossary](..
 Every parser function reads as the user the page is parsed for. Subjects that user cannot read are
 treated as absent. `{{#cypher_raw}}` and `{{#sparql_raw}}` need the `neowiki-query` right.
 `{{#view}}` only places a marker at parse time; the Subject it shows is fetched per viewer over the
-REST API, under that viewer's permissions.
+REST API, under that viewer's permissions. Output of the other functions is cached separately for
+readers with different groups or rights, so what one reader may see does not reach another through
+the parser cache.
 
 ## `{{#view}}`
 

--- a/docs/operations/installation.md
+++ b/docs/operations/installation.md
@@ -195,6 +195,10 @@ default.
 `neowiki-schema-edit`, `neowiki-layout-edit` and `neowiki-mapping-edit` — gate editing in NeoWiki's own namespaces and
 are granted to logged-in users.
 
+Parser functions and Lua read as the user the page is parsed for, and their output is parser-cached per combination
+of user groups and wiki-level rights. A permission extension that grants page access per user rather than per group
+is not followed by that cache key: run such a wiki with the parser cache off (`$wgParserCacheType = CACHE_NONE`).
+
 ## On-wiki configuration
 
 A wiki administrator without server access can set part of NeoWiki's configuration on the `MediaWiki:NeoWiki`

--- a/docs/operations/upgrading.md
+++ b/docs/operations/upgrading.md
@@ -55,5 +55,9 @@ php maintenance/run.php NeoWiki:RebuildGraphDatabases
 [Rebuild](maintenance.md#rebuilding-the-graph) after every upgrade: with no release notes there is no way to tell
 whether the new version changed the projected shape, and rebuilds are quick at evaluation scale.
 
+If your install predates September 2026 and holds restricted content, run `php maintenance/run.php refreshLinks`
+once: categories and page properties that earlier parses derived from Subject data were recorded without a
+permission check, and MediaWiki rewrites those tables only on an edit, not on a view.
+
 If your Subjects predate the optional Subject label, run
 [clearing default Subject labels](maintenance.md#clearing-default-subject-labels) once, before that rebuild.

--- a/extension.json
+++ b/extension.json
@@ -44,6 +44,8 @@
 
 		"LoadExtensionSchemaUpdates": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onLoadExtensionSchemaUpdates",
 
+		"ParserOptionsRegister": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onParserOptionsRegister",
+		"PageRenderingHash": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onPageRenderingHash",
 		"ParserFirstCallInit": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onParserFirstCallInit",
 
 		"RevisionFromEditComplete": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onRevisionFromEditComplete",

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -21,6 +21,7 @@ use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Revision\SlotRoleRegistry;
 use MediaWiki\Title\ForeignTitle;
 use MediaWiki\Title\Title;
+use MediaWiki\User\User;
 use MediaWiki\User\UserIdentity;
 use MessageLocalizer;
 use ProfessionalWiki\NeoWiki\Application\Rdf\RdfPageProjector;
@@ -251,6 +252,22 @@ class NeoWikiHooks {
 		);
 	}
 
+	/**
+	 * @param array<string, mixed> $defaults
+	 * @param array<string, bool> $inCacheKey
+	 * @param array<string, callable> $lazyOptions
+	 */
+	public static function onParserOptionsRegister( array &$defaults, array &$inCacheKey, array &$lazyOptions ): void {
+		ParserAuthority::registerAccessClassOption( $defaults, $inCacheKey );
+	}
+
+	/**
+	 * @param string[] $forOptions
+	 */
+	public static function onPageRenderingHash( string &$confstr, User $user, array &$forOptions ): void {
+		ParserAuthority::appendAccessClassToRenderingHash( $confstr, $user, $forOptions );
+	}
+
 	public static function onParserFirstCallInit( Parser $parser ): void {
 		NeoWikiExtension::getInstance()->getNeo4jPlugin()?->registerParserFunctions( $parser );
 		NeoWikiExtension::getInstance()->getFirstSparqlPlugin()?->registerParserFunctions( $parser );
@@ -258,9 +275,7 @@ class NeoWikiHooks {
 		$parser->setFunctionHook(
 			'view',
 			static function ( Parser $parser, string ...$args ): string|array {
-				$parserFunction = new ViewParserFunction(
-					NeoWikiExtension::getInstance()->newSubjectContentRepository( ParserAuthority::of( $parser ) )
-				);
+				$parserFunction = new ViewParserFunction( NeoWikiExtension::getInstance()->newPageSubjectsLookup() );
 				return $parserFunction->handle( $parser, ...$args );
 			}
 		);

--- a/src/EntryPoints/ParserAuthority.php
+++ b/src/EntryPoints/ParserAuthority.php
@@ -7,6 +7,9 @@ namespace ProfessionalWiki\NeoWiki\EntryPoints;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Permissions\Authority;
+use MediaWiki\User\UserIdentity;
+use ProfessionalWiki\NeoWiki\Infrastructure\UserAccessClass;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 
 /**
  * The authority every parse-time read runs against: the user the page is being parsed for. That is
@@ -15,11 +18,52 @@ use MediaWiki\Permissions\Authority;
  * context's user is the wrong choice here: it is the saver during the canonical parse of an edit, and
  * whoever runs the job queue otherwise, neither of which matches the identity the parser cache files
  * the output under.
+ *
+ * Obtaining the authority is also what makes the parse's output depend on who that user is, so
+ * {@see self::of()} records the access-class parser option as used: the parser cache then files the
+ * output under the user's access class ({@see UserAccessClass}) instead of sharing it across users.
+ * Pages that never obtain a parsing authority keep one cache entry for everyone.
+ *
+ * The option itself carries no value. Its class enters the cache key through the PageRenderingHash
+ * hook, and only for a page that recorded the option: a lazily valued option would be loaded for
+ * every logged-in edit of every page by core's cache-key comparison, sending all of them down the
+ * deferred parser-cache path.
  */
 class ParserAuthority {
 
+	public const string ACCESS_CLASS_OPTION = 'neowikiAccessClass';
+
 	public static function of( Parser $parser ): Authority {
+		$parser->getOptions()->getOption( self::ACCESS_CLASS_OPTION );
+
 		return MediaWikiServices::getInstance()->getUserFactory()->newFromUserIdentity( $parser->getUserIdentity() );
+	}
+
+	/**
+	 * The ParserOptionsRegister hook body.
+	 *
+	 * @param array<string, mixed> $defaults
+	 * @param array<string, bool> $inCacheKey
+	 */
+	public static function registerAccessClassOption( array &$defaults, array &$inCacheKey ): void {
+		$defaults[self::ACCESS_CLASS_OPTION] = null;
+		$inCacheKey[self::ACCESS_CLASS_OPTION] = true;
+	}
+
+	/**
+	 * The PageRenderingHash hook body: the parsing user's access class, for a page that recorded the
+	 * option. Every reader gets one, so a page that reads Subjects also stops reusing whatever was
+	 * cached for it before NeoWiki began keying by class.
+	 *
+	 * @param string[] $usedOptions
+	 */
+	public static function appendAccessClassToRenderingHash( string &$hash, UserIdentity $user, array $usedOptions ): void {
+		if ( !in_array( self::ACCESS_CLASS_OPTION, $usedOptions, true ) ) {
+			return;
+		}
+
+		$hash .= '!' . self::ACCESS_CLASS_OPTION . '='
+			. NeoWikiExtension::getInstance()->newUserAccessClass()->of( $user );
 	}
 
 }

--- a/src/EntryPoints/Scribunto/ScribuntoLuaLibrary.php
+++ b/src/EntryPoints/Scribunto/ScribuntoLuaLibrary.php
@@ -63,7 +63,8 @@ class ScribuntoLuaLibrary extends LibraryBase {
 
 	/**
 	 * Every read this library performs runs against the user the page is parsed for
-	 * ({@see ParserAuthority}), so a module cannot read more than the reader may.
+	 * ({@see ParserAuthority}), so a module cannot read more than the reader may, and the parse
+	 * is keyed by that user's access class in the parser cache.
 	 */
 	private function getParserAuthority(): Authority {
 		return ParserAuthority::of( $this->getParser() );

--- a/src/EntryPoints/ViewParserFunction.php
+++ b/src/EntryPoints/ViewParserFunction.php
@@ -5,7 +5,8 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\EntryPoints;
 
 use MediaWiki\Parser\Parser;
-use ProfessionalWiki\NeoWiki\Application\SubjectContentRepository;
+use ProfessionalWiki\NeoWiki\Application\PageSubjectsLookup;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Presentation\ViewHtmlBuilder;
 
 class ViewParserFunction {
@@ -13,8 +14,13 @@ class ViewParserFunction {
 	private const string ARG_SUBJECT = 'subject';
 	private const string ARG_LAYOUT = 'layout';
 
+	/**
+	 * Emits a marker that the frontend fills per viewer over the REST API, so the parse-time work is
+	 * the same for every reader: the page's Main Subject id is read publicly, not as a parsing
+	 * authority ({@see ParserAuthority}), and the output stays out of the per-class cache keying.
+	 */
 	public function __construct(
-		private readonly SubjectContentRepository $subjectContentRepository
+		private readonly PageSubjectsLookup $pageSubjectsLookup
 	) {
 	}
 
@@ -138,12 +144,13 @@ class ViewParserFunction {
 			return null;
 		}
 
-		$subject = $this->subjectContentRepository
-			->getSubjectContentByPageTitle( $title )
-			?->getPageSubjects()
-			->getMainSubject();
+		$pageId = $title->getArticleID();
 
-		return $subject?->getId()->text;
+		if ( $pageId === 0 ) {
+			return null;
+		}
+
+		return $this->pageSubjectsLookup->getMainSubjectId( new PageId( $pageId ) )?->text;
 	}
 
 }

--- a/src/GraphDatabasePlugins/Neo4j/Neo4jPlugin.php
+++ b/src/GraphDatabasePlugins/Neo4j/Neo4jPlugin.php
@@ -113,7 +113,7 @@ readonly class Neo4jPlugin {
 
 	/**
 	 * Parse-time queries run as the user the page is parsed for, and always at the default tier: the
-	 * output is parser-cached, so neither may depend on who happened to parse.
+	 * output is parser-cached under that user's access class, and may vary by nothing else.
 	 */
 	private function newParseTimeQueryService( Parser $parser ): Neo4jQueryService {
 		return $this->newQueryService( ParserAuthority::of( $parser ) );

--- a/src/GraphDatabasePlugins/Sparql/SparqlPlugin.php
+++ b/src/GraphDatabasePlugins/Sparql/SparqlPlugin.php
@@ -103,7 +103,7 @@ readonly class SparqlPlugin {
 
 	/**
 	 * Parse-time queries run as the user the page is parsed for, and always at the default tier: the
-	 * output is parser-cached, so neither may depend on who happened to parse.
+	 * output is parser-cached under that user's access class, and may vary by nothing else.
 	 */
 	private function newParseTimeQueryService( Parser $parser ): SparqlQueryService {
 		return $this->newQueryService( ParserAuthority::of( $parser ) );

--- a/src/Infrastructure/UserAccessClass.php
+++ b/src/Infrastructure/UserAccessClass.php
@@ -1,0 +1,43 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Infrastructure;
+
+use MediaWiki\Permissions\PermissionManager;
+use MediaWiki\User\UserGroupManager;
+use MediaWiki\User\UserIdentity;
+
+/**
+ * The access class of a user, for keying parser-cached output that depends on what the parsing user
+ * may read: the user's effective groups plus the wiki-level `read` and `neowiki-query` decisions, as
+ * a readable string such as `*,autoconfirmed,user;read;query`.
+ *
+ * Group membership is a proxy for per-page read permission, exact wherever that permission is a
+ * function of groups (private wikis, namespace lockdowns) and wrong for hooks that grant per user.
+ * The wiki-level rights are in the class because hooks can grant them outside groups.
+ *
+ * Every reader has a class, the anonymous one included, so that an entry cached before NeoWiki began
+ * keying by class is never reused for a page that reads Subjects.
+ */
+class UserAccessClass {
+
+	public function __construct(
+		private readonly UserGroupManager $userGroupManager,
+		private readonly PermissionManager $permissionManager,
+	) {
+	}
+
+	public function of( UserIdentity $user ): string {
+		$groups = $this->userGroupManager->getUserEffectiveGroups( $user );
+		sort( $groups );
+
+		// Group names come from hooks and the database, so they can hold the separators, and the
+		// cache key turns spaces into underscores. Without encoding, a user in a group named
+		// "sysop,user" would describe exactly like a sysop and read that class's cached output.
+		return implode( ',', array_map( 'rawurlencode', $groups ) )
+			. ( $this->permissionManager->userHasRight( $user, 'read' ) ? ';read' : '' )
+			. ( $this->permissionManager->userHasRight( $user, AuthorityBasedRawQueryAuthorizer::RIGHT ) ? ';query' : '' );
+	}
+
+}

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -55,6 +55,7 @@ use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\EntryPoints\Lua\CypherQu
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\EntryPoints\Lua\SparqlQueryRunner;
 use ProfessionalWiki\NeoWiki\Infrastructure\IdGenerator;
 use ProfessionalWiki\NeoWiki\Infrastructure\ProductionIdGenerator;
+use ProfessionalWiki\NeoWiki\Infrastructure\UserAccessClass;
 use ProfessionalWiki\NeoWiki\Persistence\CorePagePropertyProvider;
 use ProfessionalWiki\NeoWiki\Application\EditNotice\InterfaceMessageNoticeProvider;
 use ProfessionalWiki\NeoWiki\Application\Queries\GetSubjectEditNotices\GetSubjectEditNoticesPresenter;
@@ -1281,6 +1282,13 @@ class NeoWikiExtension {
 
 	public function newSubjectWriteAuthorizer( Authority $authority ): SubjectWriteAuthorizer {
 		return $this->newAuthorityBasedSubjectAuthorizer( $authority );
+	}
+
+	public function newUserAccessClass(): UserAccessClass {
+		return new UserAccessClass(
+			userGroupManager: MediaWikiServices::getInstance()->getUserGroupManager(),
+			permissionManager: MediaWikiServices::getInstance()->getPermissionManager(),
+		);
 	}
 
 	public function newPageReadAuthorizer( Authority $authority ): PageReadAuthorizer {

--- a/tests/phpunit/EntryPoints/ParserAuthorityTest.php
+++ b/tests/phpunit/EntryPoints/ParserAuthorityTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints;
+
+use MediaWiki\CommentStore\CommentStoreComment;
+use MediaWiki\Content\WikitextContent;
+use MediaWiki\Extension\Scribunto\ScribuntoContent;
+use MediaWiki\Parser\ParserOptions;
+use MediaWiki\Parser\ParserOutput;
+use MediaWiki\Title\Title;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
+use ProfessionalWiki\NeoWiki\Domain\Schema\PropertyName;
+use ProfessionalWiki\NeoWiki\Domain\Statement;
+use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectMap;
+use ProfessionalWiki\NeoWiki\Domain\Value\StringValue;
+use ProfessionalWiki\NeoWiki\EntryPoints\Content\SubjectContent;
+use ProfessionalWiki\NeoWiki\EntryPoints\ParserAuthority;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\MediaWikiSubjectRepository;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Tests\ParseTimePermissionFixtures;
+use WikiPage;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\ParserAuthority
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiHooks::onParserOptionsRegister
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiHooks::onParserFirstCallInit
+ * @group Database
+ */
+class ParserAuthorityTest extends NeoWikiIntegrationTestCase {
+
+	use ParseTimePermissionFixtures;
+
+	private const string SUBJECT_PAGE = 'ParserAuthorityTestSubjectPage';
+	private const string VALUE_FUNCTION = '{{#neowiki_value: Motto | page=' . self::SUBJECT_PAGE . ' }}';
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->createPageWithSubjects(
+			self::SUBJECT_PAGE,
+			TestSubject::build( statements: new StatementList( [
+				new Statement( new PropertyName( 'Motto' ), 'text', new StringValue( 'Cached per class' ) ),
+			] ) )
+		);
+	}
+
+	private function sysopOptions(): ParserOptions {
+		return ParserOptions::newFromUser( $this->getTestSysop()->getUser() );
+	}
+
+	private function parse(
+		string $wikitext,
+		ParserOptions $parserOptions,
+		string $pageName = 'ParserAuthorityTestPage'
+	): ParserOutput {
+		return $this->getServiceContainer()->getParserFactory()->create()->parse(
+			$wikitext,
+			Title::newFromText( $pageName ),
+			$parserOptions
+		);
+	}
+
+	/**
+	 * Entries cached before NeoWiki keyed by access class carry no such key, so a gated page must not
+	 * land on the key those entries used, not even for an anonymous reader.
+	 */
+	public function testAGatedPageDoesNotReuseAnEntryCachedWithoutTheAccessClass(): void {
+		$anonymousOptions = ParserOptions::newFromAnon();
+
+		$this->assertNotSame(
+			$anonymousOptions->optionsHash( [] ),
+			$anonymousOptions->optionsHash( [ ParserAuthority::ACCESS_CLASS_OPTION ] )
+		);
+	}
+
+	/**
+	 * Core compares every cache-varying option of the editor's options against the canonical ones on
+	 * save, and defers the parser-cache update for every page when they differ.
+	 */
+	public function testEditorsOptionsStillMatchTheCanonicalOnesForPagesWithoutGatedReads(): void {
+		$this->assertTrue( $this->sysopOptions()->matchesForCacheKey( ParserOptions::newFromAnon() ) );
+	}
+
+	public function testParseForALoggedInUserHasItsOwnCacheKey(): void {
+		$this->assertNotSame(
+			ParserOptions::newFromAnon()->optionsHash( [ ParserAuthority::ACCESS_CLASS_OPTION ] ),
+			$this->sysopOptions()->optionsHash( [ ParserAuthority::ACCESS_CLASS_OPTION ] )
+		);
+	}
+
+	public function testReadingASubjectPutsTheAccessClassInThePagesCacheKey(): void {
+		$output = $this->parse( self::VALUE_FUNCTION, ParserOptions::newFromAnon() );
+
+		$this->assertContains( ParserAuthority::ACCESS_CLASS_OPTION, $output->getUsedOptions() );
+	}
+
+	/**
+	 * The argument-less view reads its own page's Main Subject at parse time, and still only emits a marker.
+	 */
+	public function testRenderingAViewDoesNotFragmentTheCache(): void {
+		$output = $this->parse( '{{#view}}', ParserOptions::newFromAnon(), self::SUBJECT_PAGE );
+
+		$this->assertNotContains( ParserAuthority::ACCESS_CLASS_OPTION, $output->getUsedOptions() );
+	}
+
+	public function testRunningACypherQueryPutsTheAccessClassInThePagesCacheKey(): void {
+		$this->grantTheQueryRightToSysopsOnly();
+
+		$output = $this->parse( '{{#cypher_raw: RETURN 1 AS n }}', ParserOptions::newFromAnon() );
+
+		$this->assertContains( ParserAuthority::ACCESS_CLASS_OPTION, $output->getUsedOptions() );
+	}
+
+	public function testRunningASparqlQueryPutsTheAccessClassInThePagesCacheKey(): void {
+		$this->configureAnUnreachableSparqlStore();
+		$this->grantTheQueryRightToSysopsOnly();
+
+		$output = $this->parse( '{{#sparql_raw: SELECT * WHERE { ?s ?p ?o } }}', ParserOptions::newFromAnon() );
+
+		$this->assertContains( ParserAuthority::ACCESS_CLASS_OPTION, $output->getUsedOptions() );
+	}
+
+	public function testReadingASubjectFromLuaPutsTheAccessClassInThePagesCacheKey(): void {
+		$this->markTestSkippedIfExtensionNotLoaded( 'Scribunto' );
+		$this->editPage(
+			Title::makeTitle( NS_MODULE, 'ParserAuthorityTest' ),
+			new ScribuntoContent(
+				"local nw = require( 'mw.neowiki' )\n" .
+				"local p = {}\n" .
+				"function p.motto( frame ) return nw.getValue( 'Motto', { page = frame.args[1] } ) or '' end\n" .
+				"return p"
+			)
+		);
+
+		$output = $this->parse(
+			'{{#invoke:ParserAuthorityTest|motto|' . self::SUBJECT_PAGE . '}}',
+			ParserOptions::newFromAnon()
+		);
+
+		$this->assertContains( ParserAuthority::ACCESS_CLASS_OPTION, $output->getUsedOptions() );
+	}
+
+	/**
+	 * Wikitext holding a gated read, plus a Subject slot of its own, so the render combines two slots
+	 * as every NeoWiki page does: the option the read records must survive that merge to reach the
+	 * cache key.
+	 */
+	private function cachedGatedPage( ParserOptions $parserOptions ): WikiPage {
+		$page = $this->getServiceContainer()->getWikiPageFactory()
+			->newFromTitle( Title::makeTitle( NS_MAIN, 'ParserAuthorityTestCachedPage' ) );
+
+		$updater = $page->newPageUpdater( $this->getTestSysop()->getUser() );
+		$updater->setContent( 'main', new WikitextContent( self::VALUE_FUNCTION ) );
+		$updater->setContent(
+			MediaWikiSubjectRepository::SLOT_NAME,
+			SubjectContent::newFromData(
+				new PageSubjects( TestSubject::build( id: 's1cached1111111' ), new SubjectMap() )
+			)
+		);
+		$updater->saveRevision( CommentStoreComment::newUnsavedComment( 'Gated page' ) );
+
+		$this->getServiceContainer()->getParserOutputAccess()->getParserOutput( $page, $parserOptions );
+
+		return $page;
+	}
+
+	public function testCachedOutputOfOneClassIsNotServedToAnother(): void {
+		$anonymousOptions = ParserOptions::newFromAnon();
+		$page = $this->cachedGatedPage( $anonymousOptions );
+
+		$parserCache = $this->getServiceContainer()->getParserCache();
+
+		$this->assertNotFalse( $parserCache->get( $page, $anonymousOptions ), 'the anonymous parse is cached' );
+		$this->assertFalse( $parserCache->get( $page, $this->sysopOptions() ), 'a sysop does not get it' );
+	}
+
+	public function testCachedOutputIsSharedWithinAnAccessClass(): void {
+		$page = $this->cachedGatedPage( ParserOptions::newFromUser( $this->getTestUser( [ 'bot' ] )->getUser() ) );
+
+		$anotherBot = ParserOptions::newFromUser( $this->getMutableTestUser( [ 'bot' ] )->getUser() );
+
+		$this->assertNotFalse( $this->getServiceContainer()->getParserCache()->get( $page, $anotherBot ) );
+	}
+
+}

--- a/tests/phpunit/EntryPoints/ViewParserFunctionTest.php
+++ b/tests/phpunit/EntryPoints/ViewParserFunctionTest.php
@@ -8,6 +8,8 @@ use MediaWiki\Language\RawMessage;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Title\Title;
 use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\PageSubjectsLookup;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
@@ -16,7 +18,7 @@ use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectMap;
 use ProfessionalWiki\NeoWiki\EntryPoints\ViewParserFunction;
-use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectContentRepository;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectRepository;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\EntryPoints\ViewParserFunction
@@ -26,6 +28,7 @@ class ViewParserFunctionTest extends TestCase {
 	private const string MAIN_SUBJECT_ID = 's11111111111111';
 	private const string EXPLICIT_SUBJECT_ID = 's22222222222222';
 	private const string OTHER_SUBJECT_ID = 's33333333333333';
+	private const int PAGE_ID = 7;
 
 	public function testEmitsPlaceholderWithExplicitPositionalSubject(): void {
 		$result = $this->callView( self::EXPLICIT_SUBJECT_ID );
@@ -82,17 +85,26 @@ class ViewParserFunctionTest extends TestCase {
 	}
 
 	public function testReturnsEmptyStringWhenNoSubjectAvailable(): void {
-		$parserFunction = new ViewParserFunction( new InMemorySubjectContentRepository() );
+		$parserFunction = new ViewParserFunction( new PageSubjectsLookup( new InMemorySubjectRepository() ) );
 
 		$result = $parserFunction->handle( $this->createMockParser() );
 
 		$this->assertSame( '', $result );
 	}
 
+	public function testReturnsEmptyStringWhileThePageIsBeingCreated(): void {
+		$unsavedPage = $this->createStub( Title::class );
+		$unsavedPage->method( 'getArticleID' )->willReturn( 0 );
+		$parser = $this->createStub( Parser::class );
+		$parser->method( 'getTitle' )->willReturn( $unsavedPage );
+
+		$result = ( new ViewParserFunction( $this->lookupWithMainSubject() ) )->handle( $parser );
+
+		$this->assertSame( '', $result );
+	}
+
 	public function testReturnsEmptyStringWhenPageHasNoMainSubject(): void {
-		$parserFunction = new ViewParserFunction(
-			new InMemorySubjectContentRepository( new PageSubjects( null, new SubjectMap() ) )
-		);
+		$parserFunction = new ViewParserFunction( $this->lookupWithPageSubjects( new PageSubjects( null, new SubjectMap() ) ) );
 
 		$result = $parserFunction->handle( $this->createMockParser() );
 
@@ -130,11 +142,18 @@ class ViewParserFunctionTest extends TestCase {
 	}
 
 	private function callView( string ...$args ): string|array {
-		return ( new ViewParserFunction( $this->repositoryWithMainSubject() ) )
+		return ( new ViewParserFunction( $this->lookupWithMainSubject() ) )
 			->handle( $this->createMockParser(), ...$args );
 	}
 
-	private function repositoryWithMainSubject(): InMemorySubjectContentRepository {
+	private function lookupWithPageSubjects( PageSubjects $pageSubjects ): PageSubjectsLookup {
+		$repository = new InMemorySubjectRepository();
+		$repository->savePageSubjects( $pageSubjects, new PageId( self::PAGE_ID ) );
+
+		return new PageSubjectsLookup( $repository );
+	}
+
+	private function lookupWithMainSubject(): PageSubjectsLookup {
 		$mainSubject = new Subject(
 			id: new SubjectId( self::MAIN_SUBJECT_ID ),
 			label: new SubjectLabel( 'Main' ),
@@ -142,11 +161,12 @@ class ViewParserFunctionTest extends TestCase {
 			statements: new StatementList(),
 		);
 
-		return new InMemorySubjectContentRepository( new PageSubjects( $mainSubject, new SubjectMap() ) );
+		return $this->lookupWithPageSubjects( new PageSubjects( $mainSubject, new SubjectMap() ) );
 	}
 
 	private function createMockParser(): Parser {
 		$title = $this->createStub( Title::class );
+		$title->method( 'getArticleID' )->willReturn( self::PAGE_ID );
 
 		$parser = $this->createStub( Parser::class );
 		$parser->method( 'getTitle' )->willReturn( $title );

--- a/tests/phpunit/Infrastructure/UserAccessClassTest.php
+++ b/tests/phpunit/Infrastructure/UserAccessClassTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Infrastructure;
+
+use MediaWiki\User\User;
+use MediaWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Infrastructure\UserAccessClass;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Infrastructure\UserAccessClass
+ * @group Database
+ */
+class UserAccessClassTest extends MediaWikiIntegrationTestCase {
+
+	private function newAccessClass(): UserAccessClass {
+		return NeoWikiExtension::getInstance()->newUserAccessClass();
+	}
+
+	public function testAnonymousAndLoggedInReadersAreDifferentClasses(): void {
+		$accessClass = $this->newAccessClass();
+
+		$this->assertNotSame(
+			$accessClass->of( $this->getServiceContainer()->getUserFactory()->newAnonymous() ),
+			$accessClass->of( $this->getTestUser()->getUser() )
+		);
+	}
+
+	/**
+	 * Group names reach the class from hooks and the database, so a group whose name holds a separator
+	 * must not be able to describe like a different set of groups.
+	 */
+	public function testAGroupNamedAfterOtherGroupsDoesNotShareTheirClass(): void {
+		$impostor = $this->getMutableTestUser( [ 'sysop,user' ] )->getUser();
+
+		$accessClass = $this->newAccessClass();
+
+		$this->assertNotSame(
+			$accessClass->of( $this->getTestSysop()->getUser() ),
+			$accessClass->of( $impostor )
+		);
+	}
+
+	public function testUsersWithTheSameGroupsShareAClass(): void {
+		$accessClass = $this->newAccessClass();
+
+		$this->assertSame(
+			$accessClass->of( $this->getTestUser( [ 'bot' ] )->getUser() ),
+			$accessClass->of( $this->getMutableTestUser( [ 'bot' ] )->getUser() )
+		);
+	}
+
+	public function testUsersWithDifferentGroupsHaveDifferentClasses(): void {
+		$accessClass = $this->newAccessClass();
+
+		$this->assertNotSame(
+			$accessClass->of( $this->getTestUser()->getUser() ),
+			$accessClass->of( $this->getTestSysop()->getUser() )
+		);
+	}
+
+	/**
+	 * Installed before the first class is computed: the permission manager memoizes rights per user.
+	 */
+	private function grantRightOutsideGroups( User $grantee, string $right ): void {
+		$this->setTemporaryHook(
+			'UserGetRights',
+			static function ( User $user, array &$rights ) use ( $grantee, $right ): void {
+				if ( $user->equals( $grantee ) ) {
+					$rights[] = $right;
+				}
+			}
+		);
+	}
+
+	public function testTheQueryRightSeparatesUsersInTheSameGroups(): void {
+		$this->setGroupPermissions( '*', 'neowiki-query', false );
+		$granted = $this->getTestUser()->getUser();
+		$other = $this->getMutableTestUser()->getUser();
+		$this->grantRightOutsideGroups( $granted, 'neowiki-query' );
+
+		$accessClass = $this->newAccessClass();
+
+		$this->assertNotSame( $accessClass->of( $granted ), $accessClass->of( $other ) );
+	}
+
+	public function testTheReadRightSeparatesUsersInTheSameGroups(): void {
+		$this->setGroupPermissions( '*', 'read', false );
+		$this->setGroupPermissions( 'user', 'read', false );
+		$granted = $this->getTestUser()->getUser();
+		$other = $this->getMutableTestUser()->getUser();
+		$this->grantRightOutsideGroups( $granted, 'read' );
+
+		$accessClass = $this->newAccessClass();
+
+		$this->assertNotSame( $accessClass->of( $granted ), $accessClass->of( $other ) );
+	}
+
+}


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/NeoWiki/issues/1059

Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1346

With the parse-time gates in place, the parser cache still served whatever the last parse produced to every reader: a sysop's parse cached restricted values for anonymous readers, and an anonymous parse cached gaps for sysops. Such output is now keyed by the parsing user's access class.

* A cache-varying parser option, `neowikiAccessClass`, registered through `ParserOptionsRegister`. It carries no value; the class enters the key through the `PageRenderingHash` hook, and only for a page whose parse recorded the option. A lazily valued option would instead be loaded for every logged-in edit of every page by core's cache-key comparison, pushing all of them onto the deferred parser-cache path.
* The class itself, from `UserAccessClass`, is the parsing user's effective groups plus the wiki-level `read` and `neowiki-query` decisions, as a readable string such as `*,autoconfirmed,user;read;query`. Group names are encoded, since they reach the class from hooks and the database and could otherwise be named to describe like another set of groups. Every reader gets a class, the anonymous one included, so a page that reads Subjects never reuses an entry cached before this change and no upgrade purge is needed.
* Obtaining the parsing authority (`ParserAuthority::of`) records the option, so every gated read keys its page by access class without a call site having to remember to. `{{#view}}` now resolves its page's Main Subject through the public `PageSubjectsLookup` instead of a parsing authority, so it keeps one entry as before.
* ADR 27's open decision on parse-time semantics resolves to this rule. The alternatives weighed (a fixed anonymous authority, post-cache trimming, a cache-off operating rule) are recorded under Alternatives Considered.

The class is a proxy for the permission hooks: exact wherever page access follows group membership, wrong for hooks that grant per user, which is why such wikis must run with the parser cache off. The installation docs now say so next to the rights. Installs with restricted content need one `refreshLinks` run, noted in the upgrading docs, because MediaWiki rewrites categories and page properties only on an edit.

Not solved here, and now stated in ADR 27's consequences: data derived from the canonical parse (categories, page properties, links tables, the Page node's categories in graph projections) is computed as the anonymous user, so on a wiki where anonymous users cannot read, a category derived from a parse-time read is never set. A designated reader for canonical parses would lift that; it needs a decision.

## Manual Browser Check

1. With the parser cache enabled, restrict a page's read permission for anonymous users (for example with the Lockdown extension) and give it a Subject with a text property.
2. On a second page, save `{{#neowiki_value: <property> | page=<restricted page>}}` as a sysop and view it: the value shows.
3. View that page logged out, without purging: the value is absent. Log back in and view it again: the value shows. Each access class keeps its own cached copy.

> <sub>AI-authored — Claude Code, `Fable 5.1` for the implementation, `Opus 5` for the review fixes; same design discussion as #1346, no redirects during implementation; same-session AI review applied across six passes, diff not yet human-reviewed; tests written first and mutation-checked, phpcs/phpstan clean, the full non-Database suite and the touched Database classes green locally, CI green.</sub>
