### PR TITLE
Make four of the pane divider's tests able to fail

### DIFF
--- a/resources/ext.neowiki/src/composables/usePaneSize.ts
+++ b/resources/ext.neowiki/src/composables/usePaneSize.ts
@@ -23,7 +23,7 @@ export interface PaneSizeOptions {
  * one, which is an invalid range to announce and reverses which pane gets squeezed.
  * Floored, the pane keeps its minimum and the one beside it gives up the difference.
  */
-export function paneMaxSize(
+function paneMaxSize(
 	containerWidth: number,
 	dividerSize: number,
 	options: Pick<PaneSizeOptions, 'minSize' | 'minOtherSize'>,

--- a/resources/ext.neowiki/tests/components/SchemaEditor/SchemaEditor.spec.ts
+++ b/resources/ext.neowiki/tests/components/SchemaEditor/SchemaEditor.spec.ts
@@ -401,10 +401,10 @@ describe( 'SchemaEditor pane divider', () => {
 	it( 'sits between the list and the editor', () => {
 		const wrapper = createWrapper( schemaWithProperty );
 
-		const children = [ ...wrapper.element.children ].map( ( child ) => child.tagName.toLowerCase() );
+		const children = [ ...wrapper.element.children ].map( ( child ) => child.className );
 
 		expect( wrapper.findComponent( PaneDivider ).exists() ).toBe( true );
-		expect( children[ 1 ] ).toBe( 'div' );
+		expect( children[ 1 ] ).toContain( 'ext-neowiki-pane-divider' );
 	} );
 
 	// The track list and the divider appear together or not at all: a divider left behind
@@ -457,6 +457,8 @@ describe( 'SchemaEditor pane divider', () => {
 		const divider = createWrapper( schemaWithProperty ).findComponent( PaneDivider );
 
 		expect( divider.props( 'min' ) ).toBe( 192 );
-		expect( divider.props( 'max' ) ).toBeGreaterThanOrEqual( divider.props( 'min' ) as number );
+		// jsdom measures nothing, so the bound is the current width and the divider still moves.
+		expect( divider.props( 'max' ) ).toBe( 320 );
+		expect( divider.props( 'disabled' ) ).toBe( false );
 	} );
 } );

--- a/resources/ext.neowiki/tests/components/SchemaEditor/SchemaEditorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SchemaEditor/SchemaEditorDialog.spec.ts
@@ -63,8 +63,6 @@ describe( 'SchemaEditorDialog', () => {
 		SchemaEditor: SchemaEditorStub,
 		SummaryAction: SummaryActionStub,
 		CloseConfirmationDialog: CloseConfirmationDialogStub,
-		// So the dialog renders inside the wrapper rather than at the document body.
-		teleport: true,
 	};
 
 	function mountComponent(): VueWrapper {
@@ -80,16 +78,6 @@ describe( 'SchemaEditorDialog', () => {
 			},
 		} );
 	}
-
-	// Mirrors the subject editor: the body never scrolls once the columns scroll
-	// themselves, so Codex would never add the dividers on its own, and the rule
-	// between the columns needs one to run into at each end.
-	it( 'asks Codex for the dividers variant', async () => {
-		const wrapper = mountComponent();
-		await flushPromises();
-
-		expect( wrapper.find( '.cdx-dialog' ).classes() ).toContain( 'cdx-dialog--dividers' );
-	} );
 
 	describe( 'Save button', () => {
 		it( 'disables save when there are no changes', async () => {

--- a/resources/ext.neowiki/tests/components/SchemasPage/SchemaCreatorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SchemasPage/SchemaCreatorDialog.spec.ts
@@ -104,17 +104,6 @@ describe( 'SchemaCreatorDialog', () => {
 		schemaStore.saveSchema = vi.fn().mockResolvedValue( undefined );
 	} );
 
-	// This creator's body is the scroller, so Codex adds the rules itself whenever the
-	// schema is long enough. The class is asked for by name to cover the case it misses:
-	// a schema short enough not to scroll, where the desktop rule between the columns is
-	// still drawn and needs one to run into at each end.
-	it( 'asks Codex for the dividers variant', async () => {
-		const wrapper = mountComponent();
-		await flushPromises();
-
-		expect( wrapper.find( '.cdx-dialog-stub' ).classes() ).toContain( 'cdx-dialog--dividers' );
-	} );
-
 	it( 'does not save when validation fails', async () => {
 		const wrapper = mountComponent();
 

--- a/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditorDialog.spec.ts
@@ -2424,7 +2424,30 @@ describe( 'SubjectEditorDialog', () => {
 				const divider = wrapper.findComponent( PaneDivider );
 
 				expect( divider.props( 'min' ) ).toBe( 256 );
-				expect( divider.props( 'max' ) ).toBeGreaterThanOrEqual( divider.props( 'min' ) as number );
+				// jsdom measures nothing, so the bound is the current width and the divider still moves.
+				expect( divider.props( 'max' ) ).toBe( 384 );
+				expect( divider.props( 'disabled' ) ).toBe( false );
+			} );
+
+			it( 'remembers the navigator width once the gesture ends, under its own key', async () => {
+				const global = globalThis as unknown as { mw?: Record<string, unknown> };
+				const before = global.mw;
+				const storage = { get: vi.fn( () => null ), set: vi.fn( () => true ) };
+				global.mw = { ...before, storage };
+
+				try {
+					const { wrapper } = await mountWithSecondPaneOpen( {
+						rootSchema: relationRootSchema,
+						rootSubject: relationRootSubject,
+					} );
+					wrapper.findComponent( PaneDivider ).vm.$emit( 'resize', 500 );
+					wrapper.findComponent( PaneDivider ).vm.$emit( 'commit' );
+					await nextTick();
+
+					expect( storage.set ).toHaveBeenCalledWith( 'neowiki-subject-editor-pane-size', '500' );
+				} finally {
+					global.mw = before;
+				}
 			} );
 
 			it( 'points the divider at the navigator it sizes', async () => {

--- a/resources/ext.neowiki/tests/components/common/PaneDivider.spec.ts
+++ b/resources/ext.neowiki/tests/components/common/PaneDivider.spec.ts
@@ -70,36 +70,18 @@ describe( 'PaneDivider', () => {
 
 	describe( 'the separator it exposes', () => {
 
-		it( 'is a separator', () => {
-			expect( mountDivider().attributes( 'role' ) ).toBe( 'separator' );
-		} );
-
-		it( 'is reachable by keyboard', () => {
-			expect( mountDivider().attributes( 'tabindex' ) ).toBe( '0' );
-		} );
-
-		it( 'declares the vertical orientation, which is not the role default', () => {
-			expect( mountDivider().attributes( 'aria-orientation' ) ).toBe( 'vertical' );
-		} );
-
-		it( 'carries the name the caller gave it', () => {
-			expect( mountDivider().attributes( 'aria-label' ) ).toBe( 'Resize the list' );
-		} );
-
-		it( 'points at the pane it sizes', () => {
-			expect( mountDivider().attributes( 'aria-controls' ) ).toBe( 'pane-1' );
-		} );
-
-		it( 'announces the current position and its bounds', () => {
+		it( 'exposes the separator contract', () => {
 			const wrapper = mountDivider();
 
+			expect( wrapper.attributes( 'role' ) ).toBe( 'separator' );
+			expect( wrapper.attributes( 'tabindex' ) ).toBe( '0' );
+			expect( wrapper.attributes( 'aria-orientation' ) ).toBe( 'vertical' );
+			expect( wrapper.attributes( 'aria-label' ) ).toBe( 'Resize the list' );
+			expect( wrapper.attributes( 'aria-controls' ) ).toBe( 'pane-1' );
 			expect( wrapper.attributes( 'aria-valuenow' ) ).toBe( '320' );
 			expect( wrapper.attributes( 'aria-valuemin' ) ).toBe( '192' );
 			expect( wrapper.attributes( 'aria-valuemax' ) ).toBe( '800' );
-		} );
-
-		it( 'is not marked disabled while it can move', () => {
-			expect( mountDivider().attributes( 'aria-disabled' ) ).toBeUndefined();
+			expect( wrapper.attributes( 'aria-disabled' ) ).toBeUndefined();
 		} );
 
 		it( 'is marked disabled where there is no room to move', () => {
@@ -176,48 +158,10 @@ describe( 'PaneDivider', () => {
 			expect( wrapper.emitted( 'commit' ) ).toHaveLength( 1 );
 		} );
 
-		// Key repeat sends a keydown per step and one keyup at the end.
-		it( 'commits once for a held key, however many steps it took', async () => {
-			const wrapper = mountDivider();
-
-			for ( let step = 0; step < 5; step++ ) {
-				await wrapper.trigger( 'keydown', { key: 'ArrowRight' } );
-			}
-			await wrapper.trigger( 'keyup', { key: 'ArrowRight' } );
-
-			expect( wrapper.emitted( 'resize' ) ).toHaveLength( 5 );
-			expect( wrapper.emitted( 'commit' ) ).toHaveLength( 1 );
-		} );
-
-		it( 'commits nothing when a key it ignores is let go', async () => {
-			const wrapper = mountDivider();
-
-			await wrapper.trigger( 'keydown', { key: 'Escape' } );
-			await wrapper.trigger( 'keyup', { key: 'Escape' } );
-
-			expect( wrapper.emitted( 'commit' ) ).toBeUndefined();
-		} );
-
-		it( 'leaves the vertical arrows to the surface behind it', async () => {
-			const wrapper = mountDivider();
-
-			await wrapper.trigger( 'keydown', { key: 'ArrowDown' } );
-
-			expect( wrapper.emitted( 'resize' ) ).toBeUndefined();
-		} );
-
 		it( 'leaves Escape alone, so the dialog still closes on it', async () => {
 			const wrapper = mountDivider();
 
 			await wrapper.trigger( 'keydown', { key: 'Escape' } );
-
-			expect( wrapper.emitted( 'resize' ) ).toBeUndefined();
-		} );
-
-		it( 'does not move where there is no room to move', async () => {
-			const wrapper = mountDivider( { disabled: true } );
-
-			await wrapper.trigger( 'keydown', { key: 'ArrowRight' } );
 
 			expect( wrapper.emitted( 'resize' ) ).toBeUndefined();
 		} );

--- a/resources/ext.neowiki/tests/components/common/PaneDivider.spec.ts
+++ b/resources/ext.neowiki/tests/components/common/PaneDivider.spec.ts
@@ -240,7 +240,7 @@ describe( 'PaneDivider', () => {
 			const wrapper = mountDivider();
 
 			await drag( wrapper, 500, 560 );
-			await wrapper.setProps( { size: 380 } );
+			await wrapper.setProps( { size: 350 } );
 			await pointer( wrapper, 'pointermove', { clientX: 520 } );
 
 			expect( lastResize( wrapper ) ).toBe( 340 );
@@ -412,6 +412,16 @@ describe( 'PaneDivider', () => {
 			wrapper.unmount();
 
 			expect( document.documentElement.classList.contains( 'ext-neowiki-pane-resizing' ) ).toBe( false );
+		} );
+
+		// A dialog closed on Escape mid-drag takes the divider with it before any pointerup.
+		it( 'commits a drag cut short by its own teardown', async () => {
+			const wrapper = mountDivider();
+
+			await drag( wrapper, 500, 560 );
+			wrapper.unmount();
+
+			expect( wrapper.emitted( 'commit' ) ).toHaveLength( 1 );
 		} );
 	} );
 

--- a/resources/ext.neowiki/tests/composables/usePaneSize.spec.ts
+++ b/resources/ext.neowiki/tests/composables/usePaneSize.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { computed, defineComponent, nextTick, ref } from 'vue';
 import { mount } from '@vue/test-utils';
-import { paneMaxSize, usePaneSize } from '@/composables/usePaneSize';
+import { usePaneSize } from '@/composables/usePaneSize';
 
 // jsdom resolves no layout, so the real observer never reports a width and every
 // bound that depends on the container would go unexercised.
@@ -61,10 +61,6 @@ describe( 'usePaneSize', () => {
 		it( 'starts at the default size', () => {
 			expect( withPane().size.value ).toBe( 320 );
 		} );
-
-		it( 'reports the minimum as the lower bound', () => {
-			expect( withPane().minSize.value ).toBe( 192 );
-		} );
 	} );
 
 	describe( 'resizing', () => {
@@ -111,20 +107,6 @@ describe( 'usePaneSize', () => {
 
 			expect( pane.size.value ).toBe( 5000 );
 		} );
-
-		it( 'reports the current size as the upper bound rather than inventing one', () => {
-			const pane = withPane();
-
-			expect( pane.maxSize.value ).toBe( 320 );
-		} );
-
-		it( 'keeps the announced range valid', () => {
-			const pane = withPane();
-
-			expect( pane.minSize.value ).toBeLessThanOrEqual( pane.maxSize.value );
-			expect( pane.size.value ).toBeGreaterThanOrEqual( pane.minSize.value );
-			expect( pane.size.value ).toBeLessThanOrEqual( pane.maxSize.value );
-		} );
 	} );
 
 	describe( 'storage', () => {
@@ -166,26 +148,9 @@ describe( 'usePaneSize', () => {
 
 			expect( storage.set ).toHaveBeenCalledWith( KEY, '400' );
 		} );
-
-		it( 'writes the size each commit left behind', () => {
-			const storage = stubStorage( null );
-			const pane = withPane();
-
-			pane.resizeTo( 340 );
-			pane.persist();
-			pane.resizeTo( 400 );
-			pane.persist();
-
-			expect( storage.set ).toHaveBeenCalledTimes( 2 );
-			expect( storage.set ).toHaveBeenLastCalledWith( KEY, '400' );
-		} );
 	} );
 
 	describe( 'without MediaWiki storage available', () => {
-
-		it( 'starts at the default when mw is absent entirely', () => {
-			expect( withPane().size.value ).toBe( 320 );
-		} );
 
 		it( 'starts at the default when mw.storage lacks get and set', () => {
 			( globalThis as unknown as { mw: unknown } ).mw = { storage: { session: {} } };
@@ -309,17 +274,6 @@ describe( 'usePaneSize', () => {
 			expect( pane.size.value ).toBe( 900 );
 		} );
 
-		it( 'keeps the chosen width when a gesture moves nothing at all', () => {
-			const storage = stubStorage( '900' );
-			const pane = withPane();
-			observedWidth.value = 666;
-
-			pane.resizeTo( pane.size.value );
-			pane.persist();
-
-			expect( storage.set ).toHaveBeenCalledWith( KEY, '900' );
-		} );
-
 		it( 'still records a width the reader genuinely narrows to', () => {
 			const storage = stubStorage( '900' );
 			const pane = withPane();
@@ -329,27 +283,6 @@ describe( 'usePaneSize', () => {
 			pane.persist();
 
 			expect( storage.set ).toHaveBeenCalledWith( KEY, '300' );
-		} );
-
-		// The overshoot the clamp exists for: a wild drag must not be replayed on a wider
-		// screen, so a request beyond the bound is still recorded AT the bound.
-		it( 'records the bound when a gesture overshoots from below it', () => {
-			const storage = stubStorage( '400' );
-			const pane = withPane();
-			observedWidth.value = 1278;
-
-			pane.resizeTo( 5000 );
-			pane.persist();
-
-			expect( storage.set ).toHaveBeenCalledWith( KEY, '990' );
-		} );
-
-		it( 'reports the divider as movable where there is room to move', () => {
-			const pane = withPane();
-			observedWidth.value = 1278;
-
-			expect( pane.resizable.value ).toBe( true );
-			expect( pane.maxSize.value ).toBeGreaterThan( pane.minSize.value );
 		} );
 
 		// A pane inside a dialog that is not displayed is measured as zero, which means
@@ -369,37 +302,5 @@ describe( 'usePaneSize', () => {
 			expect( pane.resizable.value ).toBe( false );
 			expect( pane.minSize.value ).toBe( pane.maxSize.value );
 		} );
-	} );
-} );
-
-describe( 'paneMaxSize', () => {
-
-	const BOUNDS = { minSize: 192, minOtherSize: 288 };
-
-	it( 'leaves the other pane its minimum', () => {
-		expect( paneMaxSize( 900, 1, BOUNDS ) ).toBe( 611 );
-	} );
-
-	it( 'never comes out below the pane\'s own minimum', () => {
-		expect( paneMaxSize( 400, 1, BOUNDS ) ).toBe( 192 );
-	} );
-
-	it( 'stays at the minimum where the two minimums no longer fit', () => {
-		// 192 + 1 + 288 = 481: the width at which the interval closes.
-		expect( paneMaxSize( 481, 1, BOUNDS ) ).toBe( 192 );
-		expect( paneMaxSize( 480, 1, BOUNDS ) ).toBe( 192 );
-		expect( paneMaxSize( 300, 1, BOUNDS ) ).toBe( 192 );
-	} );
-
-	it( 'never reports a range the wrong way round, at any container width', () => {
-		for ( let width = 0; width <= 1600; width += 1 ) {
-			expect( paneMaxSize( width, 1, BOUNDS ) ).toBeGreaterThanOrEqual( BOUNDS.minSize );
-		}
-	} );
-
-	it( 'reports a whole number, so a rounded size cannot land above it', () => {
-		for ( const width of [ 900.5, 613.7, 480.4, 1000.9 ] ) {
-			expect( Number.isInteger( paneMaxSize( width, 12, BOUNDS ) ) ).toBe( true );
-		}
 	} );
 } );


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1340

Two changes to that PR's tests, both from mutation runs during review, one commit each. Net effect on the PR: about 140 fewer lines.

**Five tests could not fail against the behaviour they name, or were missing.**

- The drag-anchoring test granted exactly the requested size, so measuring the next move from the granted size and from the drag's origin gave the same number. It now grants less than asked.
- Both hosts' bounds tests asserted only the minimum, so inverting the `disabled` binding or collapsing the maximum to the minimum passed. They now pin both.
- The subject editor's persistence wiring and storage key were untested, so dropping the commit handler or reusing the schema editor's key passed. Added the mirror of the schema editor's test.
- The schema editor's order test compared tag names, which are all `div`, so the divider passed in any position. It now asserts the divider's class.
- The divider's commit from `onBeforeUnmount`, which is what keeps a width dragged in the nested schema editor when Escape closes it mid-drag, had no test, so deleting it passed. Added one.

**Twenty-six tests restated the template or duplicated a sibling.** Eight one-attribute ARIA checks become a single contract test; the others failed on exactly the same change as a test beside them, or pinned a static class. Fourteen mutations the removed tests used to catch are each still caught by a surviving test. `paneMaxSize` loses its `export`, which served only the tests that exercised it on its own; that is the one production line touched.

> <sub>AI-authored — Claude Code, `Fable 5.1 (max)`; from a pr-review run asked for by @JeroenDeDauw, who redirected the scope twice (to the test findings, then to also slim the suite); diff not yet human-reviewed; each of the five tests seen failing under its targeted mutation and passing on the PR head, 14 mutations re-run against the slimmed suite, full suite, eslint and CI green.</sub>
