### PR TITLE
Link the guides from the demo wiki and tidy the docs structure

### DIFF
--- a/DemoData/Page/Main_Page.wikitext
+++ b/DemoData/Page/Main_Page.wikitext
@@ -18,7 +18,7 @@ This is a public demo of [https://neowiki.ai NeoWiki]. Explore the examples belo
 
 * Edit through a form and watch it update live: [[Subject views]] shows one Subject in three layouts at once, with edits propagating between them.
 * See how a Schema constrains data, with required fields, value ranges, and formats: [[Validation Demo]].
-* Create your own: start any page, then use "Create subject" in the NeoWiki section of the sidebar.
+* Create your own: start any page, then use "Create subject" in the NeoWiki section of the sidebar. The [https://neowiki.ai/docs/guide/getting-started Getting started guide] walks through it.
 
 == Explore by use case ==
 

--- a/DemoData/Page/RDF_and_ontology_mappings.wikitext
+++ b/DemoData/Page/RDF_and_ontology_mappings.wikitext
@@ -27,6 +27,7 @@ You don't need these links to reach an export: on any subject page, the Data tab
 
 == Learn more ==
 
+* [https://neowiki.ai/docs/guide/author-an-ontology-mapping How to author an ontology mapping]: write your own Mapping page, step by step
 * [[Special:Mappings]]: every ontology Mapping on this wiki
 * [https://neowiki.ai/docs/rdf/rdf-export RDF export reference]
 * [https://neowiki.ai/docs/rdf/ontology-mapping Ontology mapping reference]

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -24,6 +24,15 @@ Every page sits in one genre. Write to that genre's reader and register.
 | `adr/` | Maintainers recording a decision | A dated record: context, decision, consequences; not retro-edited apart from status links |
 | `planning/` | Collaborators exploring an open question | A work-in-progress register, marked as such; not published to the site |
 
+## Where a new page goes
+
+The genre table picks the directory. Two placements it does not cover:
+
+- A page every audience needs, cutting across genres (the Glossary, Qualifiers and References) → the docs root.
+- A worked, end-to-end example → alongside the docs for the surface it walks through.
+
+Link the new page from `README.md`, under the section for its genre.
+
 ## Never write
 
 - The justification register: "note that", "importantly", "this ensures", "in order to", or restating the ask.

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,23 +59,6 @@ Project Subjects to RDF, natively or mapped onto standard ontologies.
 
 ### Understand the architecture
 
-* [Architecture Decision Records](adr/001-domain-centric-architecture.md) — numbered, dated architectural decisions
+* [Architecture Decision Records](adr/README.md) — numbered, dated architectural decisions
 * [Planning docs](https://github.com/ProfessionalWiki/NeoWiki/tree/master/docs/planning) — work-in-progress
   exploration (not published to the website)
-
----
-
-## Where each kind of doc lives
-
-For contributors adding to these docs:
-
-* A task guide for people using the wiki → `guide/`
-* Cross-cutting, and every audience needs it (the Glossary, Qualifiers and References) → the docs root
-* Wikitext or Lua authoring on the wiki → `authoring/`
-* An HTTP API or a JSON data format → `api/`
-* RDF projection or ontology mapping → `rdf/`
-* Extending NeoWiki from another extension → `extending/`
-* A worked, end-to-end example → alongside the docs for the surface it walks through
-* A sysadmin install, maintenance, or deployment guide → `operations/`
-* A numbered, dated decision → `adr/`
-* Work-in-progress exploration → `planning/` (not published to the website)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,41 @@
+---
+title: Architecture Decision Records
+order: 0
+---
+
+# Architecture Decision Records
+
+Every architectural decision on record, in the order it was made.
+
+* [ADR 1: Domain Centric Architecture](001-domain-centric-architecture.md)
+* [ADR 2: Store Data as JSON](002-store-data-as-json.md)
+* [ADR 3: Neo4j as Graph Database](003-neo4j-as-graph-database.md)
+* [ADR 4: Use a Dedicated MediaWiki Revision Slot](004-use-dedicated-slot.md)
+* [ADR 5: Subject GUIDs](005-subject-guids.md)
+* [ADR 6: Schemas](006-schemas.md)
+* [ADR 7: Multiple Subjects Per Page](007-multiple-subjects-per-page.md)
+* [ADR 8: One Schema per Subject](008-one-schema-per-subject.md)
+* [ADR 9: Move Away from JSON Schema](009-move-away-from-json-schema.md)
+* [ADR 10: Add GUIDs to Relations](010-add-guids-to-relations.md)
+* [ADR 11: Include Writer's Schema in Subjects](011-include-writers-schema.md)
+* [ADR 12: Backend Validation](012-backend-validation.md)
+* [ADR 13: Restrict Neo4j Access](013-restrict-neo4j-access.md)
+* [ADR 14: Improved ID Format](014-improved-id-format.md)
+* [ADR 15: Dedicated Editors](015-dedicated-editors.md)
+* [ADR 16: Frontend State Management](016-frontend-state-management.md)
+* [ADR 17: Names as Identifiers](017-names-as-identifiers.md)
+* [ADR 18: Views and Layouts](018-views.md)
+* [ADR 19: Graph Database Architecture](019-graph-database-architecture.md)
+* [ADR 20: Codex Styling Policy](020-codex-styling-policy.md)
+* [ADR 21: Add Backend Validation](021-add-backend-validation.md)
+* [ADR 22: Multi-wiki Graph Node Identity](022-multi-wiki-node-identity.md)
+* [ADR 23: Subject Sources](023-subject-sources.md)
+* [ADR 24: Frontend Extension Mechanism](024-frontend-extension-mechanism.md)
+* [ADR 25: Backend-driven Frontend Validation](025-backend-driven-frontend-validation.md)
+* [ADR 26: Validation Severity Levels](026-validation-severity-levels.md)
+* [ADR 27: Access Control](027-access-control.md)
+* [ADR 28: Relations Model](028-relations-model.md)
+* [ADR 29: Scalability Targets](029-scalability-targets.md)
+* [ADR 30: Frontend Stores Are Registries, Not Caches](030-frontend-store-registry-semantics.md)
+* [ADR 31: Optional Subject Labels](031-optional-subject-labels.md)
+* [ADR 32: Subject-to-Page Index](032-subject-page-index.md)

--- a/docs/operations/installation.md
+++ b/docs/operations/installation.md
@@ -143,15 +143,7 @@ php maintenance/run.php NeoWiki:RebuildGraphDatabases
 
 ### 5. Verify your install
 
-1. **Create a Schema.** Go to Special:Schemas and create your first Schema
-2. **Add a Subject.** On an ordinary wiki page, use "Create subject" or "Manage subjects" to create your first Subject
-3. **Render a View.** On that same page, source edit the wikitext and add the following. With no id it renders the
-   page's Main Subject:
-   ```
-   {{#view:}}
-   ```
-
-Your install is complete once those three steps work.
+Your install is complete once you can walk through [Getting started](../guide/getting-started.md) on it.
 
 With Neo4j configured, one more step checks its projection. On any page, add a Cypher query that lists the stored
 pages, independent of your data model:

--- a/docs/rdf/rdf-export.md
+++ b/docs/rdf/rdf-export.md
@@ -176,9 +176,15 @@ the operator's own routing concern.
 
 ### Finding these exports
 
-These exports are surfaced in the UI. The Data tab links to each Subject's JSON and per-projection Turtle/TriG,
-and the same for the whole page. Content pages that exist also emit `<link rel="alternate">` autodiscovery tags
-(Turtle and TriG, native projection) in the HTML head, on a wiki with a graph database configured.
+These exports are surfaced in the UI. A page's Data tab (`action=subjects`) carries an **Export** menu on each
+Subject row, and an **Export all** menu for the page once it holds at least one Subject. Both offer JSON, Turtle and
+TriG; the two RDF formats then ask which projection, listing `native` plus every Mapping the viewing user may read.
+A row menu targets that Subject's [JSON](../api/rest-api.md#subjects) and [RDF](#subject) endpoints; the page menu
+targets the page's [Subjects JSON](../api/rest-api.md#pages-and-subjects) and [RDF](#page). Each Subject row also
+shows that Subject's `neo-subj:` IRI with a control that copies it.
+
+Content pages that exist also emit `<link rel="alternate">` autodiscovery tags (Turtle and TriG, native
+projection) in the HTML head, on a wiki with a graph database configured.
 
 ## Bulk dump
 


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1337

The demo wiki's Main Page and RDF page now link the matching guide pages, so the demo no
longer dead-ends into reference material. Installation's "Verify your install" points at
Getting started instead of duplicating its steps. The landing page's contributor routing
moved into docs/AGENTS.md, and the ADRs got an index page the landing page links instead
of ADR 001. RDF Export now documents the Data tab's page-level downloads alongside the
per-Subject links.

Note: the demo-wiki bullets reach neowiki.dev on the next demo-content refresh, not on merge.

> <sub>AI-authored — Claude Code, `Opus 5 (max)` subagent from a `Fable 5 (max)` spec; asked by @JeroenDeDauw (items 2–5 of the structure review, one PR); diff reviewed by the Fable session, not yet human-reviewed; export-menu claims verified against the frontend source, links and anchors checked, site built against this branch with the ADR index and sidebar inspected in the output.</sub>
