### PR TITLE
Let every pane name itself, and shrink the dialog's header to suit

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -121,7 +121,7 @@
 	"neowiki-delete-success": "Deleted $1",
 	"neowiki-delete-error": "Failed to delete $1",
 
-	"neowiki-subject-editor-title": "Editing $1",
+	"neowiki-subject-editor-title": "Edit subject",
 	"neowiki-subject-editor-save": "Save changes",
 	"neowiki-subject-editor-label-field": "Subject label",
 	"neowiki-subject-editor-rename": "Rename subject",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -66,6 +66,7 @@
 	"neowiki-schema-editor-description-collapse": "Accessibility label and tooltip for the button that collapses an expanded schema description back to two lines.",
 	"neowiki-schema-editor-description-add": "Label of the button that starts writing a description for a schema that has none, shown in the schema editor dialog header.",
 
+	"neowiki-subject-editor-title": "Title of the subject editor dialog, and its accessible name. Names the task rather than a subject: the dialog can edit several at once, and each one is named by the pane that edits it.",
 	"neowiki-subject-editor-label-field": "Accessibility label for the input shown in place of the dialog title while renaming a subject in the subject editor dialog.",
 	"neowiki-subject-editor-rename": "Accessibility label for the button next to the subject editor dialog title that starts renaming the subject.",
 	"neowiki-subject-editor-edit-target": "Aria-label of the per-target edit button shown beside a selected relation target in the subject editor. Clicking it opens that target subject for editing in a pane.",

--- a/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditPane.vue
+++ b/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditPane.vue
@@ -1,15 +1,12 @@
 <template>
-	<!-- The root pane goes unnamed: the dialog around it already names that same Subject. -->
 	<section
 		class="ext-neowiki-subject-edit-pane"
-		:aria-label="props.nested ? paneName : undefined"
+		:aria-label="paneName"
 	>
-		<!-- Only a nested pane carries these: the dialog's own header names the root Subject
-			and holds the field that renames it. -->
-		<div
-			v-if="props.nested"
-			class="ext-neowiki-subject-edit-pane__header"
-		>
+		<!-- Named here rather than in the dialog's header, for the root as well as a nested
+			pane: a header naming the root goes stale the moment another pane is opened, and
+			cannot follow without re-rendering CdxDialog. -->
+		<div class="ext-neowiki-subject-edit-pane__header">
 			<h3 class="ext-neowiki-subject-edit-pane__name">
 				<EditableText
 					:model-value="label"
@@ -20,19 +17,37 @@
 				/>
 			</h3>
 
-			<div
-				v-if="pageName !== null"
-				class="ext-neowiki-subject-edit-pane__storage"
-			>
-				<I18nSlot message-key="neowiki-subject-editor-stored-on">
-					<!-- A new tab: following the link in this one discards unsaved edits. -->
-					<a
-						class="ext-neowiki-subject-edit-pane__page"
-						:href="pageUrl"
-						target="_blank"
-						rel="noopener"
-					>{{ pageName }}</a>
-				</I18nSlot>
+			<div class="ext-neowiki-subject-edit-pane__meta">
+				<!-- The Schema the pane's Subject uses, beside the name it belongs to rather
+					than in a dialog header that cannot follow the pane. A real link, so it
+					carries the badge's own interactive styling and a destination; a plain
+					click opens the Schema editor instead, as the old header link did.
+
+					A new tab, for the reason the storage link below gives: this dialog holds
+					unsaved edits for every open pane and nothing guards a navigation away
+					from it. `paneName` so a Subject already shown under its Schema name is
+					not named twice. -->
+				<SchemaNameDisplay
+					:schema-name="props.subject.getSchemaName()"
+					:display-name="paneName"
+					link="new-tab"
+					@click="openSchemaEditor"
+				/>
+
+				<div
+					v-if="props.nested && pageName !== null"
+					class="ext-neowiki-subject-edit-pane__storage"
+				>
+					<I18nSlot message-key="neowiki-subject-editor-stored-on">
+						<!-- A new tab: following the link in this one discards unsaved edits. -->
+						<a
+							class="ext-neowiki-subject-edit-pane__page"
+							:href="pageUrl"
+							target="_blank"
+							rel="noopener"
+						>{{ pageName }}</a>
+					</I18nSlot>
+				</div>
 			</div>
 		</div>
 
@@ -76,6 +91,7 @@ import SubjectViolationBanners from '@/components/common/SubjectViolationBanners
 import I18nSlot from '@/components/common/I18nSlot.vue';
 import { subjectLabelPlaceholder } from '@/presentation/subjectLabelPlaceholder.ts';
 import EditableText from '@/components/common/EditableText.vue';
+import SchemaNameDisplay from '@/components/common/SchemaNameDisplay.vue';
 import { StatementList } from '@/domain/StatementList.ts';
 import { Subject } from '@/domain/Subject.ts';
 import { enteredSubjectLabel } from '@/domain/enteredSubjectLabel.ts';
@@ -94,6 +110,8 @@ const props = defineProps<{
 	subject: Subject;
 	schema: Schema;
 	nested?: boolean;
+	// Whether this pane's Schema may be edited, so its name can offer the editor.
+	canEditSchema?: boolean;
 	// A Subject this editing session invented, which the server has never seen. It is validated
 	// as a creation rather than as an update, and the dialog writes it with a create.
 	isNew?: boolean;
@@ -104,6 +122,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
 	'edit-relation-target': [ SubjectId ];
+	'edit-schema': [];
 }>();
 
 provide( RelationTargetEditingKey, true );
@@ -139,6 +158,24 @@ const pageUrl = computed( (): string =>
 );
 
 const labelPlaceholder = computed( (): string => subjectLabelPlaceholder( props.subject ) );
+
+/**
+ * Opens the Schema editor in place of following the link, for a plain left click by someone
+ * who may edit it. Anything else — a modifier, the middle button, no edit right — is left to
+ * the browser, so the Schema page stays reachable and nothing here is a dead end.
+ */
+function openSchemaEditor( event: MouseEvent ): void {
+	if ( !props.canEditSchema || event.button !== 0 ) {
+		return;
+	}
+
+	if ( event.metaKey || event.ctrlKey || event.shiftKey || event.altKey ) {
+		return;
+	}
+
+	event.preventDefault();
+	emit( 'edit-schema' );
+}
 
 // EditableText commits once per edit, so a commit is both the change and the
 // end of the interaction: validate immediately rather than waiting for a blur.
@@ -290,26 +327,40 @@ defineExpose( {
 @import ( reference ) '@wikimedia/codex-design-tokens/theme-wikimedia-ui.less';
 
 .ext-neowiki-subject-edit-pane {
-	/* The name and where it is stored on one line, the name taking whatever the storage line
-		leaves. Baseline-aligned rather than centred, because the two differ in size. */
+	/* The name at the start, the Schema and where it is stored flush to the end. Baseline
+		rather than centre, because the three differ in size. Wrapping is the last resort: the
+		badge truncates first, and the row only breaks when even that leaves no room. */
 	&__header {
 		display: flex;
 		align-items: baseline;
-		justify-content: space-between;
-		gap: @spacing-50;
+		flex-wrap: wrap;
+		gap: @spacing-25 @spacing-50;
 		margin-bottom: @spacing-75;
 	}
 
-	/* Subordinate to the dialog's own title, which names the root Subject: a heading for
-		screen readers and outline tools, sized like the body around it. */
+	/* A heading for screen readers and outline tools, sized like the body around it. The
+		skin gives headings block padding of their own, which would push the row open.
+		It takes the free space, which is what puts the meta at the end of the row. */
 	&__name {
+		flex-grow: 1;
 		min-width: 0;
 		margin: 0;
+		padding-block: 0;
 		font-size: @font-size-medium;
 	}
 
+	/* Shrinkable, with `min-width: 0` so it may go below its content: the badge ellipsises
+		itself, but only once its parent is allowed to be narrower than the name inside it.
+		Under `flex-shrink: 0` a long Schema name pushed the row wider than the pane and the
+		whole form picked up a horizontal scrollbar. */
+	&__meta {
+		display: flex;
+		align-items: baseline;
+		gap: @spacing-50;
+		min-width: 0;
+	}
+
 	&__storage {
-		flex-shrink: 0;
 		color: @color-subtle;
 		font-size: @font-size-small;
 	}

--- a/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditorDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectEditor/SubjectEditorDialog.vue
@@ -7,59 +7,10 @@
 			:open="open"
 			class="ext-neowiki-ui ext-neowiki-subject-editor-dialog cdx-dialog--dividers"
 			:class="{ 'ext-neowiki-subject-editor-dialog--wide': showsNavigator }"
-			:title="$i18n( 'neowiki-subject-editor-title', props.subject.getDisplayName() ).text()"
+			:title="$i18n( 'neowiki-subject-editor-title' ).text()"
+			:use-close-button="true"
 			@update:open="onDialogUpdateOpen"
 		>
-			<template #header>
-				<div
-					class="cdx-dialog__header__title-group"
-					:inert="saving || undefined"
-				>
-					<div class="cdx-dialog__header__title ext-neowiki-subject-editor-dialog__title">
-						<EditableText
-							:model-value="subjectLabel"
-							:edit-button-label="$i18n( 'neowiki-subject-editor-rename' ).text()"
-							:input-aria-label="$i18n( 'neowiki-subject-editor-label-field' ).text()"
-							:placeholder="labelPlaceholder"
-							@update:model-value="onLabelEdited"
-						/>
-					</div>
-
-					<p class="cdx-dialog__header__subtitle">
-						<I18nSlot
-							message-key="neowiki-schema-label"
-							class="ext-neowiki-subject-editor-dialog-schema"
-							text-class="ext-neowiki-subject-editor-dialog-schema__label"
-						>
-							<a
-								v-if="canEditSchema"
-								class="ext-neowiki-subject-editor-dialog-schema__link"
-								href="#"
-								@click.prevent="isSchemaEditorOpen = true"
-							>
-								{{ props.subject.getSchemaName() }}
-							</a>
-							<span
-								v-else
-								class="ext-neowiki-subject-editor-dialog-schema__name"
-							>
-								{{ props.subject.getSchemaName() }}
-							</span>
-						</I18nSlot>
-					</p>
-				</div>
-
-				<CdxButton
-					class="cdx-dialog__header__close-button"
-					weight="quiet"
-					type="button"
-					:aria-label="$i18n( 'cdx-dialog-close-button-label' ).text()"
-					@click="closeRequested"
-				>
-					<CdxIcon :icon="cdxIconClose" />
-				</CdxButton>
-			</template>
-
 			<!-- Only the navigator's surface is ever conditionally rendered, and the panes container
 				is deliberately unkeyed: a pane must never unmount, because its unsaved values live in
 				the ValueInput refs inside it. -->
@@ -123,7 +74,9 @@
 								:nested="pane.id !== rootPaneId"
 								:is-new="pane.isNew"
 								:unsaved-target-ids="draftIds"
+								:can-edit-schema="pane.id === rootPaneId && canEditSchema"
 								@edit-relation-target="openRelationTargetFromForm"
+								@edit-schema="openSchemaEditor( pane.id )"
 							/>
 						</div>
 					</div>
@@ -171,11 +124,8 @@ import SubjectEditPane from '@/components/SubjectEditor/SubjectEditPane.vue';
 import type { SubjectEditPaneExposes } from '@/components/SubjectEditor/SubjectEditPane.vue';
 import SubjectTree from '@/components/SubjectEditor/SubjectTree.vue';
 import SummaryAction from '@/components/common/SummaryAction.vue';
-import I18nSlot from '@/components/common/I18nSlot.vue';
-import EditableText from '@/components/common/EditableText.vue';
 import EditNoticeList from '@/components/common/EditNoticeList.vue';
-import { CdxButton, CdxDialog, CdxIcon, CdxMessage, useGeneratedId } from '@wikimedia/codex';
-import { cdxIconClose } from '@wikimedia/codex-icons';
+import { CdxDialog, CdxMessage, useGeneratedId } from '@wikimedia/codex';
 import { Subject } from '@/domain/Subject.ts';
 import { enteredSubjectLabel } from '@/domain/enteredSubjectLabel.ts';
 import { SubjectWithContext } from '@/domain/SubjectWithContext.ts';
@@ -198,7 +148,6 @@ import { ValidationFailedError } from '@/persistence/ValidationFailedError';
 import type { UnparseableInput } from '@/components/common/UnparseableInput.ts';
 import { NeoWikiServices } from '@/NeoWikiServices.ts';
 import { relationTargetsOf } from '@/components/SubjectEditor/SubjectTreeModel.ts';
-import { subjectLabelPlaceholder } from '@/presentation/subjectLabelPlaceholder.ts';
 import { reachableTargetIds, writeOrder } from '@/components/SubjectEditor/SubjectDraftGraph.ts';
 import type { HeldSubject } from '@/components/SubjectEditor/SubjectDraftGraph.ts';
 
@@ -384,22 +333,25 @@ const showsNavigator = computed( (): boolean =>
 
 const openIds = computed( (): string[] => panes.value.map( ( pane ) => pane.id ) );
 
-// Owned by the pane that edits the Subject. Falls back to the prop for the first render,
-// before that pane has registered its ref.
-const subjectLabel = computed( (): string => rootPane.value?.label ?? props.subject.getLabel() ?? '' );
-
-const labelPlaceholder = computed( (): string => subjectLabelPlaceholder( props.subject ) );
-
-function onLabelEdited( value: string ): void {
-	rootPane.value?.setLabel( value );
-}
-
 // Keys the tree, and nothing else: re-keying the panes would unmount them and destroy
 // unsaved values. The tree remembers which fetches failed for the life of its mount, so
 // without a remount one transient failure would leave that branch empty for the rest of the
 // session. The two watchers further down bump it, an opening and a replaced root alike, and
 // a target fetch that outlives its opening is dropped by it: the hosts keep this dialog
 // mounted after it closes, so the fetch would otherwise land in the next opening.
+/**
+ * `SchemaEditorDialog` below is bound to the root's Schema, so only the root pane may open it —
+ * a nested pane would put the reader in front of a Schema they did not point at. The pane has a
+ * guard of its own; this one is where the consequence lives.
+ */
+function openSchemaEditor( paneId: string ): void {
+	if ( paneId !== rootPaneId.value ) {
+		return;
+	}
+
+	isSchemaEditorOpen.value = true;
+}
+
 const openEpoch = ref( 0 );
 
 // So a double-click on one target's edit button does not fire a second request. Keyed per
@@ -790,46 +742,15 @@ defineExpose( { hasChanged: anyChanged } );
 
 <style lang="less">
 @import ( reference ) '@wikimedia/codex-design-tokens/theme-wikimedia-ui.less';
-@import ( reference ) '@wikimedia/codex/mixins/link.less';
 
 .ext-neowiki-subject-editor-dialog {
-	&-schema {
-		&__link {
-			.cdx-mixin-link-base();
-		}
-
-		&__name {
-			color: @color-base;
-		}
-	}
-
-	/* Codex puts these on `.cdx-dialog__header--default`, a class it adds only to the header
-		it builds itself, so a slotted header never receives them and there is nothing here to
-		out-weigh — they are replicated, not overridden. */
+	/* Overrides, not replications: `.cdx-dialog__header`'s padding is unconditional in Codex,
+		and `align-items: baseline` comes from `--default`, which this header now carries again.
+		Both are deliberate departures — the header is one row of static text beside a 32px
+		close button, so the button sets the height and baseline sits the title high in it. */
 	.cdx-dialog__header {
-		display: flex;
-		align-items: baseline;
-		justify-content: flex-end;
-		box-sizing: @box-sizing-base;
-		width: @size-full;
-
-		/* Secondary to the title, like the statement-field labels below.
-			Nested under the header to out-rank Codex's runtime-injected
-			two-class subtitle rule. */
-		.cdx-dialog__header__subtitle {
-			font-size: @font-size-small;
-		}
-	}
-
-	/* The title row's edit button already provides vertical air; Codex's
-		default gap on top of it reads too wide. */
-	.cdx-dialog__header__title-group {
-		gap: 0;
-	}
-
-	&__title {
-		display: flex;
-		min-width: 0;
+		align-items: center;
+		padding-block: @spacing-50;
 	}
 
 	&--wide.cdx-dialog {

--- a/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditPane.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditPane.spec.ts
@@ -329,13 +329,13 @@ describe( 'SubjectEditPane', () => {
 			.toBe( 'Test Subject' );
 	} );
 
-	// The dialog already carries that name; a second region repeating it is one more boundary
-	// to cross on the way to the form.
-	it( 'leaves the root pane\'s region unnamed', () => {
+	// The dialog's own header no longer names any Subject, so the root's region carries the
+	// name like every other pane's.
+	it( 'names the root pane\'s region after its subject too', () => {
 		const wrapper = mountPane();
 
 		expect( wrapper.get( '.ext-neowiki-subject-edit-pane' ).attributes( 'aria-label' ) )
-			.toBeUndefined();
+			.toBe( 'Test Subject' );
 	} );
 
 	it( 'names the region of a label-less subject by its display name', () => {
@@ -581,7 +581,7 @@ describe( 'SubjectEditPane', () => {
 		} );
 	} );
 
-	describe( 'Renaming from a nested pane', () => {
+	describe( 'Renaming from a pane', () => {
 		async function rename( wrapper: VueWrapper, name: string ): Promise<void> {
 			await wrapper.get( 'button[aria-label="neowiki-subject-editor-rename"]' ).trigger( 'click' );
 			const input = wrapper.get( '.ext-neowiki-editable-text__input input' );
@@ -597,12 +597,12 @@ describe( 'SubjectEditPane', () => {
 			expect( ( ( wrapper.vm as any ).buildUpdatedSubject() as Subject ).getLabel() ).toBe( 'Renamed' );
 		} );
 
-		// The dialog's own header renames the root Subject; a second field for it would be two
-		// places to type one name.
-		it( 'leaves the root pane without a rename control', () => {
+		// The dialog's header names no Subject now, so the root is renamed where every other
+		// pane is renamed: in the pane itself.
+		it( 'gives the root pane a rename control, like every other pane', () => {
 			const wrapper = mountPane();
 
-			expect( wrapper.findComponent( EditableText ).exists() ).toBe( false );
+			expect( wrapper.findComponent( EditableText ).exists() ).toBe( true );
 		} );
 
 		// The empty field stands for "no label", so it previews the name that choice leaves the

--- a/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditorDialog.spec.ts
@@ -226,37 +226,101 @@ describe( 'SubjectEditorDialog', () => {
 		expect( editedPropertyNames( wrapper ) ).toEqual( [ 'nickname' ] );
 	} );
 
-	it( 'renders schema as a link when user has edit permissions', async () => {
+	// The Schema is shown by the pane that uses it, not by a header that names the root's
+	// whichever pane is on screen.
+	it( 'shows the schema in the pane rather than the dialog header', async () => {
 		const wrapper = mountComponent( true, {} );
 		await flushPromises();
 
-		const schemaLink = wrapper.find( '.ext-neowiki-subject-editor-dialog-schema__link' );
-		expect( schemaLink.exists() ).toBe( true );
-		expect( schemaLink.text() ).toBe( 'TestSchema' );
+		expect( wrapper.find( '.cdx-dialog__header__subtitle' ).exists() ).toBe( false );
+		expect( wrapper.get( '.ext-neowiki-subject-edit-pane__meta .ext-neowiki-schema-name__text' ).text() )
+			.toBe( 'TestSchema' );
 	} );
 
-	it( 'renders schema as plain text when user lacks edit permissions', async () => {
+	// The badge is a link to the Schema page whoever is looking, so it carries its own
+	// interactive styling; only the click is taken over, and only for someone who may edit.
+	it( 'lets the schema link navigate for a user who cannot edit it', async () => {
 		const wrapper = mountComponent( false, {} );
 		await flushPromises();
 
-		const schemaLink = wrapper.find( '.ext-neowiki-subject-editor-dialog-schema__link' );
-		expect( schemaLink.exists() ).toBe( false );
+		const badge = wrapper.get( '.ext-neowiki-subject-edit-pane__meta a.ext-neowiki-schema-name' );
+		const event = new MouseEvent( 'click', { button: 0, bubbles: true, cancelable: true } );
+		badge.element.dispatchEvent( event );
+		await flushPromises();
 
-		const schemaName = wrapper.find( '.ext-neowiki-subject-editor-dialog-schema__name' );
-		expect( schemaName.exists() ).toBe( true );
-		expect( schemaName.text() ).toBe( 'TestSchema' );
+		expect( event.defaultPrevented ).toBe( false );
+		expect( wrapper.findComponent( SchemaEditorDialog ).props( 'open' ) ).toBe( false );
 	} );
 
-	it( 'opens SchemaEditorDialog when schema link is clicked', async () => {
+	it( 'leaves a modified click to the browser, so the Schema page stays reachable', async () => {
 		const wrapper = mountComponent( true, {} );
 		await flushPromises();
 
-		const schemaLink = wrapper.find( 'a.ext-neowiki-subject-editor-dialog-schema__link' );
-		await schemaLink.trigger( 'click' );
+		const badge = wrapper.get( '.ext-neowiki-subject-edit-pane__meta a.ext-neowiki-schema-name' );
+		const event = new MouseEvent( 'click', { button: 0, ctrlKey: true, bubbles: true, cancelable: true } );
+		badge.element.dispatchEvent( event );
+		await flushPromises();
+
+		expect( event.defaultPrevented ).toBe( false );
+		expect( wrapper.findComponent( SchemaEditorDialog ).props( 'open' ) ).toBe( false );
+	} );
+
+	it( 'opens SchemaEditorDialog from the pane\'s schema badge', async () => {
+		const wrapper = mountComponent( true, {} );
+		await flushPromises();
+
+		const schemaBadge = wrapper.get( '.ext-neowiki-subject-edit-pane__meta a.ext-neowiki-schema-name' );
+		const event = new MouseEvent( 'click', { button: 0, bubbles: true, cancelable: true } );
+		schemaBadge.element.dispatchEvent( event );
+		await flushPromises();
 
 		const schemaEditorDialog = wrapper.findComponent( SchemaEditorDialog );
 		expect( schemaEditorDialog.exists() ).toBe( true );
 		expect( schemaEditorDialog.props( 'open' ) ).toBe( true );
+		// Asserted with the opening: without it the editor opens AND the link is followed,
+		// which in a dialog holding unsaved panes is the worse half of the pair.
+		expect( event.defaultPrevented ).toBe( true );
+	} );
+
+	// Every gesture a browser uses to open a link somewhere of the reader's choosing. Cmd is
+	// the one that matters most and the one a ctrl-only guard would silently drop on macOS.
+	it.each( [
+		[ 'a middle click', { button: 1 } ],
+		[ 'a ctrl click', { button: 0, ctrlKey: true } ],
+		[ 'a cmd click', { button: 0, metaKey: true } ],
+		[ 'a shift click', { button: 0, shiftKey: true } ],
+		[ 'an alt click', { button: 0, altKey: true } ],
+	] )( 'leaves %s to the browser rather than opening the schema editor', async ( _name, init ) => {
+		const wrapper = mountComponent( true, {} );
+		await flushPromises();
+
+		const schemaBadge = wrapper.get( '.ext-neowiki-subject-edit-pane__meta a.ext-neowiki-schema-name' );
+		const event = new MouseEvent( 'click', { bubbles: true, cancelable: true, ...init } );
+		schemaBadge.element.dispatchEvent( event );
+		await flushPromises();
+
+		expect( event.defaultPrevented ).toBe( false );
+		expect( wrapper.findComponent( SchemaEditorDialog ).props( 'open' ) ).toBe( false );
+	} );
+
+	// The dialog holds unsaved edits for every open pane and nothing guards a navigation away
+	// from it, so following this link must never replace the page the dialog is on.
+	it( 'opens the schema page in a new tab', async () => {
+		const wrapper = mountComponent( true, {} );
+		await flushPromises();
+
+		const badge = wrapper.get( '.ext-neowiki-subject-edit-pane__meta a.ext-neowiki-schema-name' );
+
+		expect( badge.attributes( 'target' ) ).toBe( '_blank' );
+		expect( badge.attributes( 'rel' ) ).toBe( 'noopener' );
+	} );
+
+	it( 'renders the dialog title as a visible heading', async () => {
+		const wrapper = mountComponent( true, {} );
+		await flushPromises();
+
+		expect( wrapper.get( '.cdx-dialog__header__title' ).text() )
+			.toBe( 'neowiki-subject-editor-title' );
 	} );
 
 	const saveButtonTestStubs = {
@@ -972,15 +1036,20 @@ describe( 'SubjectEditorDialog', () => {
 		} );
 
 		// Codex takes the dialog's accessible name from the title prop whenever a header slot
-		// replaces the rendered title.
-		it( 'names a label-less subject by its display name in the dialog\'s accessible name', async () => {
+		// replaces the rendered title. It names the task, not a Subject: the dialog edits
+		// several, and a name fixed at open would be wrong the moment another pane is shown.
+		it( 'names the dialog after the task rather than after a subject', async () => {
 			const wrapper = mountComponent(
 				false, validationTestStubs, undefined, mockSchema, {}, labellessSubject,
 			);
 			await flushPromises();
 
-			expect( wrapper.find( '.cdx-dialog' ).attributes( 'aria-label' ) )
-				.toBe( 'neowiki-subject-editor-title' + labellessSubject.getDisplayName() );
+			// Codex points the dialog at its own heading when nothing slots a header over it,
+			// so the announced name is the visible one rather than a parallel string.
+			const heading = wrapper.get( '.cdx-dialog__header__title' );
+			expect( wrapper.get( '.cdx-dialog' ).attributes( 'aria-labelledby' ) )
+				.toBe( heading.attributes( 'id' ) );
+			expect( heading.text() ).toBe( 'neowiki-subject-editor-title' );
 		} );
 
 		it( 'does not preview the removed label once a labelled subject is cleared', async () => {
@@ -1551,10 +1620,6 @@ describe( 'SubjectEditorDialog', () => {
 					return wrapper.get( '.ext-neowiki-subject-editor-dialog__content' );
 				}
 
-				function headerTitleGroup( wrapper: VueWrapper ): Omit<DOMWrapper<Element>, 'exists'> {
-					return wrapper.get( '.cdx-dialog__header__title-group' );
-				}
-
 				it( 'ignores a second Save', async () => {
 					const { onSave, settle } = deferredSave();
 					const { wrapper } = await mountWithSecondPaneOpen( { onSave } );
@@ -1596,19 +1661,35 @@ describe( 'SubjectEditorDialog', () => {
 					expect( wrapper.emitted( 'update:open' ) ).toBeUndefined();
 				} );
 
-				it( 'makes the form and the header inert until the save settles', async () => {
+				// The Schema editor is handed the root's Schema, so a nested pane's badge must
+				// not open it or it would edit a Schema the reader did not point at.
+				it( 'does not open the schema editor from a nested pane', async () => {
+					const { wrapper } = await mountWithSecondPaneOpen();
+
+					const badges = wrapper.findAll(
+						'.ext-neowiki-subject-edit-pane__meta a.ext-neowiki-schema-name',
+					);
+					expect( badges.length ).toBeGreaterThan( 1 );
+
+					const event = new MouseEvent( 'click', { button: 0, bubbles: true, cancelable: true } );
+					badges[ badges.length - 1 ].element.dispatchEvent( event );
+					await flushPromises();
+
+					expect( event.defaultPrevented ).toBe( false );
+					expect( wrapper.findComponent( SchemaEditorDialog ).props( 'open' ) ).toBe( false );
+				} );
+
+				it( 'makes the form inert until the save settles', async () => {
 					const { onSave, settle } = deferredSave();
 					const { wrapper } = await mountWithSecondPaneOpen( { onSave } );
 					await makePaneDirty( wrapper, 0 );
 
 					await triggerSave( wrapper, '' );
 					expect( content( wrapper ).attributes( 'inert' ) ).toBeDefined();
-					expect( headerTitleGroup( wrapper ).attributes( 'inert' ) ).toBeDefined();
 
 					settle( new Error( 'Boom' ) );
 					await flushPromises();
 					expect( content( wrapper ).attributes( 'inert' ) ).toBeUndefined();
-					expect( headerTitleGroup( wrapper ).attributes( 'inert' ) ).toBeUndefined();
 				} );
 			} );
 


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/NeoWiki/issues/1328

Stacked on #1345 — its base is `1328-schema-badge`, because this uses the badge that PR adds.
Review that one first; this diff is only the commit on top.

The dialog's header named the root Subject and carried the field that renamed it, so a nested
pane could not be renamed at all and the header described a Subject the user might not be looking
at. It named the root's Schema too, with the same problem. Neither could follow the active pane:
`title` is a `CdxDialog` prop, so binding it re-renders the dialog, and under the spec suite's
teleport stub that remounts every pane.

So the header stops naming anything. Its title is the task — "Edit subject" — and the Subject's
name, its rename control and its Schema move into the pane that edits them, where they are correct
by construction.

## Decisions worth challenging

**The Schema is a link that usually does not navigate.** It is the badge from #1345, so it carries
that component's interactive styling honestly rather than being a styled span with a click handler.
A plain left click opens the Schema editor, as the old header link did; a modified or middle click
is left to the browser, so the Schema page stays reachable and unsaved work is never at risk from
the primary gesture. Only the root pane offers the editor, since that is the Schema
`SchemaEditorDialog` is bound to — a nested pane's badge is a plain link. The Schema editor itself,
and the `onSaveSchema` prop three call sites pass, are untouched.

**The header keeps a title rather than losing one.** "Edit subject" names the task, which is the
only thing about this dialog that does not change as panes are switched. `neowiki-subject-editor-title`
therefore takes no parameter now, and the dialog's accessible name and its visible heading say the
same thing. A header that named the active pane would have to re-render `CdxDialog`.

**The root pane keeps no "Stored on" line.** The root's Subject is on the page the editor was
opened from, so the line would say what the reader already knows. `SubjectEditPane.spec` asserted
that before this change and still does.

## What the header costs now

49px, against the 81px a title over a subtitle needed — `align-items: center` and
`padding-block: @spacing-50`, since the row is one line of static text beside a 32px close button.
The two rules that existed to space the old title/subtitle pair go with it, as does the
`&-schema` block.

In the pane, the name takes the free space so the Schema and the storage line sit flush to the end,
and the row wraps rather than crushing either side once the pane is narrow enough — measured, it
holds one line down to about 260px and wraps by 200px.

## Testing

1858 tests pass. Five existing tests asserted the old arrangement — the root pane being unnamed and
without a rename control, the schema link living in the dialog header, and the dialog's accessible
name carrying a Subject's display name. Each was rewritten to pin the new contract rather than
deleted, and two were added for the click behaviour: that a user who cannot edit the Schema is left
to navigate, and that a modified click is too.

## Manual Browser Check

On a wiki with the demo data, logged in as a user who may edit Schemas:

1. Open `ACME Inc` and click the infobox pencil. The dialog header is one shallow row reading
   **Edit subject**, with no Subject name and no Schema.
2. The form's own header reads **ACME Inc** with a pencil, and a **Company** badge flush right.
   The badge is blue — it is a link.
3. Click the badge. The Schema editor opens; the page does not navigate.
4. Ctrl-click or middle-click it instead. `Schema:Company` opens in a new tab and the Schema editor
   does not open.
5. Click a child row in the navigator. That pane names itself, shows *its* Schema, and adds
   "Stored on <page>". Rename it from its own header — this was impossible before.
6. Return to the root. Its name is still there, and renaming it still works.
7. As a user without `neowiki-schema-edit`, the badge is still a link and still reaches the Schema
   page; clicking it navigates rather than opening the editor.
8. Narrow the window until the pane is around 200px. The pane header wraps; neither the name nor
   the badge is crushed.

> <sub>AI-authored — Claude Code, `Opus 5 (1M context)`; design chosen by @alistair3149 from options put to them in a design artifact, with the header treatment, the badge styling and the pane layout directed by them during the work; diff not yet human-reviewed; verified: 1858 vitest tests, lint and build green locally, and the header, badge states and wrap behaviour measured in a browser against a dev wiki.</sub>
