### PR TITLE
Find a relation's target Subject by its id

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -203,7 +203,7 @@
 	"neowiki-subject-editor-resize-navigator": "Resize structure panel",
 	"neowiki-subject-tree-not-linked": "Not linked here",
 
-	"neowiki-subject-picker-placeholder": "Search for a subject",
+	"neowiki-subject-picker-placeholder": "Search by name or subject ID",
 	"neowiki-subject-picker-no-results": "No subjects found",
 	"neowiki-subject-picker-no-match": "Please select a subject from the list.",
 	"neowiki-subject-picker-create": "Create a new $1",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -83,7 +83,7 @@
 	"neowiki-subject-tree-label": "Accessible name of the structure tree in the subject editor, listing the subjects reachable from the one being edited.",
 	"neowiki-subject-editor-resize-navigator": "Accessible name of the divider between the structure tree and the edit form in the subject editor. Dragging it, or moving it with the arrow keys, changes how wide the structure panel is. The panel itself is named by {{msg-mw|neowiki-subject-tree-label}}.",
 	"neowiki-subject-tree-not-linked": "Caption of the structure tree group holding subjects that are open or have unsaved changes but are not reachable through the relations of the subject being edited.",
-	"neowiki-subject-picker-placeholder": "Placeholder text shown in the subject search input field.",
+	"neowiki-subject-picker-placeholder": "Placeholder text shown in the subject picker input field, which matches typed text against subject names and accepts a complete subject ID.",
 	"neowiki-schema-picker-placeholder": "Placeholder text shown in the schema picker input field.",
 	"neowiki-subject-picker-no-results": "Message shown in the subject picker dropdown when no subjects match the search query.",
 	"neowiki-subject-picker-no-match": "Error message shown in the subject picker when the user types text but does not select a subject from the dropdown results.",

--- a/resources/ext.neowiki/src/components/common/SubjectPicker.vue
+++ b/resources/ext.neowiki/src/components/common/SubjectPicker.vue
@@ -47,6 +47,7 @@ import type { Icon } from '@wikimedia/codex-icons';
 import { useSubjectStore } from '@/stores/SubjectStore.ts';
 import { SubjectCreationKey } from '@/components/common/SubjectCreation.ts';
 import { SubjectId } from '@/domain/SubjectId.ts';
+import type { Subject } from '@/domain/Subject.ts';
 import { NeoWikiServices } from '@/NeoWikiServices.ts';
 
 interface SubjectPickerProps {
@@ -105,9 +106,12 @@ const selectedName = ref( '' );
 // Subjects this session invented, which no search can return. Read through the host on every
 // evaluation, so a draft renamed in the editor is renamed here too.
 const draftItems = computed( (): MenuItemData[] =>
-	( subjectCreation?.drafts( props.targetSchema ) ?? [] )
-		.map( ( subject ) => ( { value: subject.getId().text, label: subject.getDisplayName() } ) )
+	( subjectCreation?.drafts( props.targetSchema ) ?? [] ).map( menuItemFor )
 );
+
+function menuItemFor( subject: Subject ): MenuItemData {
+	return { value: subject.getId().text, label: subject.getDisplayName() };
+}
 
 function draftNameOf( id: string ): string | undefined {
 	const item = draftItems.value.find( ( candidate ) => candidate.value === id );
@@ -180,11 +184,16 @@ async function resolveName( id: string | null ): Promise<string> {
 		return draft;
 	}
 
+	return ( await fetchSubject( id ) )?.getDisplayName() ?? id;
+}
+
+// Answers with nothing rather than throwing for an id the wiki does not hold, or holds on a page
+// this user may not read.
+async function fetchSubject( id: string ): Promise<Subject | null> {
 	try {
-		const subject = await subjectStore.getOrFetchSubject( new SubjectId( id ) );
-		return subject?.getDisplayName() ?? id;
+		return await subjectStore.getOrFetchSubject( new SubjectId( id ) );
 	} catch {
-		return id;
+		return null;
 	}
 }
 
@@ -217,6 +226,13 @@ async function onLookupInput( value: string ): Promise<void> {
 	hasUnmatchedText.value = false;
 
 	if ( !value ) {
+		// Abandons a lookup still in flight, whose answer would otherwise fill the menu of a field
+		// the user has since emptied. Only then: the sequence is shared with createFromTypedText,
+		// and clearing the field is no reason to abandon a Subject the host is busy creating.
+		if ( searchStatus.value === 'pending' ) {
+			++requestSequence;
+		}
+
 		searchResults.value = [];
 		searchStatus.value = 'idle';
 		return;
@@ -225,27 +241,46 @@ async function onLookupInput( value: string ): Promise<void> {
 	searchStatus.value = 'pending';
 	const currentSequence = ++requestSequence;
 
+	const candidates = await candidatesFor( value );
+
+	if ( currentSequence !== requestSequence ) {
+		return;
+	}
+
+	searchResults.value = candidates;
+	searchStatus.value = 'done';
+}
+
+// An id names one Subject, so it is read rather than searched for. That read is how a Subject with
+// no label is reached at all, ADR 31 leaving such a Subject out of the label search. It does not
+// replace the search, though: the shape of an id is also the shape of an ordinary fifteen-letter
+// word, so text that names no usable Subject goes on to be searched for as a label.
+async function candidatesFor( value: string ): Promise<MenuItemData[]> {
+	const text = value.trim();
+
+	if ( SubjectId.isValid( text ) ) {
+		const subject = await fetchSubject( text );
+
+		// A Subject of another Schema cannot be this relation's target. One the user may not read
+		// never reaches here at all: the read fails instead of answering.
+		if ( subject !== null && subject.getSchemaName() === props.targetSchema ) {
+			return [ menuItemFor( subject ) ];
+		}
+	}
+
+	return searchLabels( text );
+}
+
+async function searchLabels( value: string ): Promise<MenuItemData[]> {
 	try {
 		const results = await subjectLabelSearch.searchSubjectLabels( value, props.targetSchema );
 
-		if ( currentSequence !== requestSequence ) {
-			return;
-		}
-
-		searchResults.value = results.map( ( result ) => ( {
+		return results.map( ( result ) => ( {
 			label: result.label,
 			value: result.id
 		} ) );
 	} catch {
-		if ( currentSequence !== requestSequence ) {
-			return;
-		}
-
-		searchResults.value = [];
-	} finally {
-		if ( currentSequence === requestSequence ) {
-			searchStatus.value = 'done';
-		}
+		return [];
 	}
 }
 

--- a/resources/ext.neowiki/tests/components/common/SubjectPicker.spec.ts
+++ b/resources/ext.neowiki/tests/components/common/SubjectPicker.spec.ts
@@ -83,6 +83,33 @@ describe( 'SubjectPicker', () => {
 		} );
 	}
 
+	function labellessSubject( id: string, displayName: string, schemaName: string ): Subject {
+		return new Subject( new SubjectId( id ), null, displayName, schemaName, new StatementList( [] ) );
+	}
+
+	function wikiHolds( subject: Subject ): void {
+		subjectStore.getOrFetchSubject = vi.fn().mockResolvedValue( subject );
+	}
+
+	function searchReturns( results: { id: string; label: string }[] ): void {
+		( mockSubjectLabelSearch.searchSubjectLabels as ReturnType<typeof vi.fn> ).mockResolvedValue( results );
+	}
+
+	function menuItemsOf( wrapper: VueWrapper ): MenuItemData[] {
+		return wrapper.findComponent( CdxLookupWithVModel ).props( 'menuItems' ) as MenuItemData[];
+	}
+
+	function menuLabelsOf( wrapper: VueWrapper ): string[] {
+		return menuItemsOf( wrapper ).map( ( item ) => String( item.label ) );
+	}
+
+	async function type( wrapper: VueWrapper, text: string ): Promise<void> {
+		const lookup = wrapper.findComponent( CdxLookupWithVModel );
+		lookup.vm.$emit( 'update:input-value', text );
+		lookup.vm.$emit( 'input', text );
+		await flushPromises();
+	}
+
 	beforeEach( () => {
 		pinia = createPinia();
 		setActivePinia( pinia );
@@ -420,6 +447,95 @@ describe( 'SubjectPicker', () => {
 		expect( wrapper.find( '.probe' ).text() ).toBe( 's11111111111111' );
 	} );
 
+	describe( 'finding the target by its id', () => {
+		const TARGET_ID = 's1demo1aaaaaaa1';
+		const OTHER_ID = 's1demo5sssssss1';
+
+		it( 'offers the Subject an entered id names, under its display name', async () => {
+			wikiHolds( labellessSubject( TARGET_ID, 'ACME Inc.', 'Company' ) );
+			const wrapper = createWrapperWithVModel( { targetSchema: 'Company' } );
+
+			await type( wrapper, TARGET_ID );
+
+			expect( menuItemsOf( wrapper ) ).toEqual( [ { label: 'ACME Inc.', value: TARGET_ID } ] );
+		} );
+
+		it( 'searches no labels once an id has named a usable Subject', async () => {
+			wikiHolds( labellessSubject( TARGET_ID, 'ACME Inc.', 'Company' ) );
+			const wrapper = createWrapperWithVModel( { targetSchema: 'Company' } );
+
+			await type( wrapper, TARGET_ID );
+
+			expect( mockSubjectLabelSearch.searchSubjectLabels ).not.toHaveBeenCalled();
+		} );
+
+		// An id is fifteen base58 characters, which is also the shape of an ordinary word: typing
+		// one must still search labels, or a Subject named after such a word becomes unfindable.
+		it( 'searches labels for an id-shaped word that names no Subject', async () => {
+			searchReturns( [ { id: TARGET_ID, label: 'Straightforward Solutions' } ] );
+			const wrapper = createWrapperWithVModel( { targetSchema: 'Company' } );
+
+			await type( wrapper, 'straightforward' );
+
+			expect( menuItemsOf( wrapper ) ).toEqual( [
+				{ label: 'Straightforward Solutions', value: TARGET_ID },
+			] );
+		} );
+
+		it( 'searches labels for an id naming a Subject of another Schema', async () => {
+			wikiHolds( labellessSubject( TARGET_ID, 'Ada Lovelace', 'Person' ) );
+			searchReturns( [ { id: OTHER_ID, label: 'Acme Anvils' } ] );
+			const wrapper = createWrapperWithVModel( { targetSchema: 'Company' } );
+
+			await type( wrapper, TARGET_ID );
+
+			expect( menuItemsOf( wrapper ) ).toEqual( [ { label: 'Acme Anvils', value: OTHER_ID } ] );
+		} );
+
+		it( 'offers nothing for an id naming a Subject of another Schema', async () => {
+			wikiHolds( labellessSubject( TARGET_ID, 'Ada Lovelace', 'Person' ) );
+			const wrapper = createWrapperWithVModel( { targetSchema: 'Company' } );
+
+			await type( wrapper, TARGET_ID );
+
+			expect( menuItemsOf( wrapper ) ).toEqual( [] );
+		} );
+
+		it( 'searches labels for a padded name without its padding', async () => {
+			const wrapper = createWrapperWithVModel( { targetSchema: 'Company' } );
+
+			await type( wrapper, '  Acme  ' );
+
+			expect( mockSubjectLabelSearch.searchSubjectLabels ).toHaveBeenCalledWith( 'Acme', 'Company' );
+		} );
+
+		it( 'reads the Subject named by a pasted id despite the whitespace around it', async () => {
+			wikiHolds( labellessSubject( TARGET_ID, 'ACME Inc.', 'Company' ) );
+			const wrapper = createWrapperWithVModel( { targetSchema: 'Company' } );
+
+			await type( wrapper, `  ${ TARGET_ID }\n` );
+
+			expect( menuItemsOf( wrapper ) ).toEqual( [ { label: 'ACME Inc.', value: TARGET_ID } ] );
+		} );
+
+		it( 'ignores an id lookup that lands after the field was cleared', async () => {
+			let answerLookup: ( subject: Subject ) => void;
+			subjectStore.getOrFetchSubject = vi.fn().mockReturnValue(
+				new Promise<Subject>( ( resolve ) => {
+					answerLookup = resolve;
+				} ),
+			);
+			const wrapper = createWrapperWithVModel( { targetSchema: 'Company' } );
+
+			await type( wrapper, TARGET_ID );
+			await type( wrapper, '' );
+			answerLookup!( labellessSubject( TARGET_ID, 'ACME Inc.', 'Company' ) );
+			await flushPromises();
+
+			expect( menuItemsOf( wrapper ) ).toEqual( [] );
+		} );
+	} );
+
 	describe( 'creating the target on the spot', () => {
 		const attachedWrappers: VueWrapper[] = [];
 
@@ -507,14 +623,6 @@ describe( 'SubjectPicker', () => {
 			return createWrapperOffering( subjectCreation, { selected: EXISTING_TARGET_ID, targetSchema: 'Company' } );
 		}
 
-		function menuItemsOf( wrapper: VueWrapper ): MenuItemData[] {
-			return wrapper.findComponent( CdxLookupWithVModel ).props( 'menuItems' ) as MenuItemData[];
-		}
-
-		function menuLabelsOf( wrapper: VueWrapper ): string[] {
-			return menuItemsOf( wrapper ).map( ( item ) => String( item.label ) );
-		}
-
 		function lastMenuLabelOf( wrapper: VueWrapper ): string {
 			const labels = menuLabelsOf( wrapper );
 			return labels[ labels.length - 1 ];
@@ -526,13 +634,6 @@ describe( 'SubjectPicker', () => {
 
 		function statusOf( wrapper: VueWrapper ): string {
 			return String( wrapper.findComponent( CdxLookupWithVModel ).props( 'status' ) );
-		}
-
-		async function type( wrapper: VueWrapper, text: string ): Promise<void> {
-			const lookup = wrapper.findComponent( CdxLookupWithVModel );
-			lookup.vm.$emit( 'update:input-value', text );
-			lookup.vm.$emit( 'input', text );
-			await flushPromises();
 		}
 
 		async function leaveField( wrapper: VueWrapper ): Promise<void> {
@@ -551,10 +652,6 @@ describe( 'SubjectPicker', () => {
 		async function chooseFirstMenuItem( wrapper: VueWrapper ): Promise<void> {
 			wrapper.findComponent( CdxLookupWithVModel ).vm.$emit( 'update:selected', menuItemsOf( wrapper )[ 0 ].value );
 			await flushPromises();
-		}
-
-		function searchReturns( results: { id: string; label: string }[] ): void {
-			( mockSubjectLabelSearch.searchSubjectLabels as ReturnType<typeof vi.fn> ).mockResolvedValue( results );
 		}
 
 		function searchNeverAnswers(): void {
@@ -613,6 +710,18 @@ describe( 'SubjectPicker', () => {
 			] );
 		} );
 
+		it( 'lists the Subject an id names above the create option, in place of the fruitless search', async () => {
+			wikiHolds( subjectNamed( EXISTING_TARGET_ID, 'Acme Anvil', 'Product' ) );
+			const wrapper = await createWrapperOffering( hostOffering( creatorReturning( null ) ) );
+
+			await type( wrapper, EXISTING_TARGET_ID );
+
+			expect( menuLabelsOf( wrapper ) ).toEqual( [
+				'Acme Anvil',
+				`Create "${ EXISTING_TARGET_ID }" as a new Product`,
+			] );
+		} );
+
 		it( 'names the typed text and the schema in the create option once the user has typed', async () => {
 			const wrapper = await createWrapperOffering(
 				hostOffering( creatorReturning( null ) ),
@@ -634,6 +743,18 @@ describe( 'SubjectPicker', () => {
 				label: 'No matches found',
 				disabled: true,
 			} );
+		} );
+
+		it( 'reports a fruitless search for an id no readable Subject has', async () => {
+			subjectStore.getOrFetchSubject = vi.fn().mockRejectedValue( new Error( 'not found' ) );
+			const wrapper = await createWrapperOffering( hostOffering( creatorReturning( null ) ) );
+
+			await type( wrapper, EXISTING_TARGET_ID );
+
+			expect( menuLabelsOf( wrapper ) ).toEqual( [
+				'No matches found',
+				`Create "${ EXISTING_TARGET_ID }" as a new Product`,
+			] );
 		} );
 
 		it( 'leaves the fruitless search to its own entry rather than the Codex slot', async () => {
@@ -764,6 +885,24 @@ describe( 'SubjectPicker', () => {
 
 			expect( inputTextOf( wrapper ) ).toBe( 'Widget X' );
 			expect( subjectStore.getOrFetchSubject ).not.toHaveBeenCalled();
+		} );
+
+		it( 'keeps a creation that lands after the field was cleared', async () => {
+			let finishCreating: ( subject: Subject ) => void;
+			const create = vi.fn<SubjectCreator>().mockReturnValue(
+				new Promise<Subject | null>( ( resolve ) => {
+					finishCreating = resolve as ( subject: Subject ) => void;
+				} ),
+			);
+			const wrapper = await createWrapperOffering( hostOffering( create ) );
+			await type( wrapper, 'Widget Co' );
+			await chooseLastMenuItem( wrapper );
+
+			await type( wrapper, '' );
+			finishCreating!( createdSubject( 'Widget Co', 'Widget Co' ) );
+			await flushPromises();
+
+			expect( wrapper.emitted( 'update:selected' ) ).toEqual( [ [ 's1demo1aaaaaaa1' ] ] );
 		} );
 
 		it( 'abandons a creation that lands after another Subject has been selected', async () => {


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/1326

The relation picker searched Subject labels only, which left a Subject with no label unreachable:
its graph node carries no `name` for the label search to match, as
[ADR 31](https://github.com/ProfessionalWiki/NeoWiki/blob/master/docs/adr/031-optional-subject-labels.md)
records, while Manage Subjects offers its id behind a copy button with nowhere to paste it.

Text that is a well-formed Subject id is now read as one, and the Subject it names becomes the
field's one candidate when its Schema is the one the relation targets. The picker already turned an
id into a named entry to label its own selection, so the read, its permission gate and the server's
display-name fallback all come along unchanged — including on a wiki with no graph store, where the
label search finds nothing at all.

The read **adds to** the label search rather than replacing it. An id is fifteen base58 characters,
which is also the shape of an ordinary word — `straightforward` and `standardization` both pass
`SubjectId.isValid` — so text that names no usable Subject goes on to be searched for as a label:
an id no Subject has, one the user may not read, one of another Schema, or a word that merely looks
like an id. Only a read that lands on a usable Subject ends there, so a real id still costs one
request and no search.

Both routes now see the same trimmed text. A pasted name kept its padding and so matched nothing,
while the create option beside it offered the trimmed one.

Clearing the field abandons a lookup still in flight, which could otherwise land and fill the menu
of a field the user had just emptied. Only a lookup: the sequence it bumps is shared with the
creation flow, which clearing the field is no reason to cancel.

The placeholder now says so.

## Manual Browser Check

First give the wiki a Subject the label search cannot reach. On the demo data, page 40 is
`ACME Engineering`; the response carries the new `subjectId`:

```sh
curl -b cookies.txt -X POST "$WIKI/w/rest.php/neowiki/v0/page/40/childSubjects" \
  -H 'Content-Type: application/json' -H "X-Csrf-Token: $CSRF" \
  -d '{"schema":"Department","statements":{}}'
```

Then open `ACME Inc` and press **Edit** on the infobox.

1. Every empty picker reads *Search by name or subject ID*.
2. In an empty **Departments** row, type `Department`. The menu says "No subjects found" — that is
   the bug.
3. Paste the `subjectId`. The menu offers **Department**, the display name the server derives for a
   Subject nobody named. Pick it: the row fills with that name and a new empty row appears.
4. Paste `s1demo1aaaaaaa2` (Acme Anvil, a Product), then `sZZZZZZZZZZZZZZ`. Neither is offered as a
   candidate; each falls through to a label search, which finds nothing, so the menu says "No
   subjects found".
5. Give some Subject of the target Schema the label `straightforward` — fifteen base58 characters,
   so it passes as an id — and type it. It is found by name. Before the fallback it was not.
6. Type `  ACME Eng  ` with the padding. It finds `ACME Engineering`; before, padding matched
   nothing while the create option beside it read `Create "ACME Eng"`.
7. With DevTools open on the Network tab: step 2 issues one `subject-labels` request and no read;
   step 3 issues one `subject/{id}` read and no search; steps 4 and 5 issue a read that misses and
   then a search; step 6 searches `search=ACME+Eng`, without the padding.

Discard the dialog rather than saving, and remove the Subject again with
`DELETE /neowiki/v0/subject/{subjectId}`.

## Testing

Eleven vitest cases cover the new behaviour, eight beside the existing picker tests and three in
the creation-enabled describe, which is the configuration the Subject editor actually uses. Four
fail against the unchanged component; the rest are negative cases that pass trivially without it,
so each was mutation-verified. Eleven mutations, all caught: removing the id branch, naming the row
by its id instead of the display name, dropping the trim, dropping and inverting the Schema check,
letting the read escape instead of answering, dropping the sequence guard, dropping the in-flight
abandon, widening that abandon back over the creation flow, and restoring the short-circuit so an
id-shaped word never reaches the label search — each broke exactly the test named after that
behaviour.

Full suite: 1849 vitest tests pass, lint and build clean. Verified in the browser on a dev wiki by
the steps above, against a rebuilt bundle with the ResourceLoader module store cleared; the network
log confirms one read for a real id, a read-then-search for an id-shaped word, and the trimmed
search.

## Considered, omitted

**A disabled menu entry naming both Schemas** when a pasted id belongs to a Subject of the wrong
one. The generic "No subjects found" costs no code at all, while the entry would have added a
sentinel value, its guard in the selection handler, a message in three files, and tests — for a row
the user still cannot act on.

**Finding a draft by its id** — a Subject invented in the current editor session and not yet saved.
`resolveName` consults the drafts before reading the server and this path does not, so a draft's id
resolves to nothing. Left alone because a draft's id is surfaced nowhere a user could copy it from:
it exists only in a DOM attribute and an internal pane key.

**A slimmer read for the id.** `getOrFetchSubject` fetches `?expand=page|relations` and uses two
fields of it. A dedicated read would be cheaper but would forfeit the registry entry that makes the
follow-up `resolveName` free when the user picks the item.

## Related

[#1313](https://github.com/ProfessionalWiki/NeoWiki/issues/1313) wants one suggestion
implementation across every backend configuration, so that `Neo4jSubjectLabelLookup` and
`NullSubjectLabelLookup` can both be deleted. It was blocked on #1283, which has landed. Whoever
takes it should fold this id read into that path rather than leave two finders; the id read is an
exact lookup rather than a suggestion, so it may survive as its own step.

## Known, not caused by this PR

Replacing an existing relation target via **Create "X" as a new Y** creates the Subject but leaves
the relation on its old target, with the field blank
([#1358](https://github.com/ProfessionalWiki/NeoWiki/issues/1358)). Found while reviewing this
branch and reproduced on `master` at `51fd2ec7`, so it predates the change; the unit tests cannot
see it because the spec stubs `CdxLookup` with an inert component that lacks Codex's own watchers.

> <sub>AI-authored — Claude Code, `Opus 5 (1M context) (xhigh)`; issue by @JeroenDeDauw, relayed by @alistair3149, who rejected the wrong-Schema entry I had recommended and approved the placeholder change; diff not yet human-reviewed, though it has been through `/code-review`, `/security-review`, `/review-tests`, a design pass and a four-angle cleanup, all in the authoring session — so a fresh-context human or agent review is still worth having; 1848 vitest tests, lint and build green locally, nine mutations caught, and the flow exercised end to end in a browser against a dev wiki with the network log checked.</sub>

<details><summary>Production notes</summary>

The first implementation ran the id read and the label search concurrently and merged the results in the menu. The cleanup pass showed the two are mutually exclusive — the label search cannot match a well-formed id unless a Subject is named after one — so the id branch now returns early. That removed a second piece of component state, both edits to `menuItems`, and a test whose only failure mode was the two halves disagreeing.

One review finding was dropped on measurement rather than judgement: an assertion that an unknown id leaves the menu empty stopped discriminating once the merge landed, because a read that throws also leaves it empty. It moved to the creation-enabled picker, where a finished-but-empty search has a visible entry of its own.

</details>
