### PR TITLE
Give the picker's id-lookup fixture the generated-name flag

### DIFF
--- a/resources/ext.neowiki/tests/components/common/SubjectPicker.spec.ts
+++ b/resources/ext.neowiki/tests/components/common/SubjectPicker.spec.ts
@@ -84,7 +84,7 @@ describe( 'SubjectPicker', () => {
 	}
 
 	function labellessSubject( id: string, displayName: string, schemaName: string ): Subject {
-		return new Subject( new SubjectId( id ), null, displayName, schemaName, new StatementList( [] ) );
+		return new Subject( new SubjectId( id ), null, displayName, false, schemaName, new StatementList( [] ) );
 	}
 
 	function wikiHolds( subject: Subject ): void {


### PR DESCRIPTION
https://github.com/ProfessionalWiki/NeoWiki/pull/1357 reached master with a five-argument Subject constructor call after https://github.com/ProfessionalWiki/NeoWiki/pull/1359 had added the sixth, so master's TypeScript CI and Docker image build fail on `tests/components/common/SubjectPicker.spec.ts`.

> <sub>AI-authored — Claude Code, `Fable 5.1 (max)`; found while resolving conflicts on https://github.com/ProfessionalWiki/NeoWiki/pull/1345 for @JeroenDeDauw, no revisions; diff not yet human-reviewed; the picker spec (68 tests) passes locally with this line, and master's failing CI names exactly this call.</sub>