### PR TITLE
Refactor the Subject move: read the source page once, drop dead paths

### DIFF
--- a/resources/ext.neowiki/src/persistence/RestSubjectRepository.ts
+++ b/resources/ext.neowiki/src/persistence/RestSubjectRepository.ts
@@ -368,7 +368,7 @@ export class RestSubjectRepository implements SubjectRepository {
 		// A move can fail for reasons the user can act on - the target page is protected, the Subject
 		// is already there - so the server's own message is carried through rather than collapsed into
 		// a status code. The production client rejects on every non-2xx but 422, so that message
-		// arrives on the rejection rather than on a response.
+		// arrives on the rejection.
 		try {
 			response = await this.httpClient.post(
 				`${ this.mediaWikiRestApiUrl }/neowiki/v0/subject/${ id.text }/move`,
@@ -388,7 +388,7 @@ export class RestSubjectRepository implements SubjectRepository {
 		}
 
 		if ( !response.ok ) {
-			throw new Error( await this.errorMessageOf( response ) ?? 'Error moving subject' );
+			throw new Error( 'Error moving subject' );
 		}
 	}
 
@@ -396,15 +396,6 @@ export class RestSubjectRepository implements SubjectRepository {
 		const message = ( error as { response?: { data?: { message?: unknown } } } )?.response?.data?.message;
 
 		return typeof message === 'string' ? message : null;
-	}
-
-	private async errorMessageOf( response: Response ): Promise<string | null> {
-		try {
-			const body = await response.json();
-			return typeof body?.message === 'string' ? body.message : null;
-		} catch {
-			return null;
-		}
 	}
 
 	public async validateSubject(

--- a/resources/ext.neowiki/tests/persistence/RestSubjectRepositoryMove.unit.spec.ts
+++ b/resources/ext.neowiki/tests/persistence/RestSubjectRepositoryMove.unit.spec.ts
@@ -72,14 +72,11 @@ describe( 'RestSubjectRepository.moveSubject', () => {
 			.rejects.toThrow( 'Error moving subject' );
 	} );
 
-	it( 'reads the message off a non-ok response too, for clients that do not reject', async () => {
-		const post = vi.fn().mockResolvedValue( {
-			ok: false,
-			json: async () => ( { status: 'error', message: 'Target page not found' } ),
-		} as unknown as Response );
+	it( 'reports a non-ok response as a failed move', async () => {
+		const post = vi.fn().mockResolvedValue( { ok: false } as Response );
 
 		await expect( newRepository( { post } ).moveSubject( SUBJECT_ID, 12, false ) )
-			.rejects.toThrow( 'Target page not found' );
+			.rejects.toThrow( 'Error moving subject' );
 	} );
 
 	it( 'resolves when the move lands', async () => {

--- a/src/Application/Actions/MoveSubject/MoveSubjectAction.php
+++ b/src/Application/Actions/MoveSubject/MoveSubjectAction.php
@@ -139,8 +139,10 @@ readonly class MoveSubjectAction {
 		// the last word on the moved Subject's node.
 		$sourceStatus = $this->subjectRepository->savePageSubjects( $sourceSubjectsAfterMove, $sourcePageId, $request->comment );
 
+		// The source page went away under the write, which from the caller's side is the Subject
+		// going away. Nothing has been written, as the source page is written first.
 		if ( $sourceStatus->status === PageContentSavingStatus::ERROR ) {
-			$this->presenter->presentSourcePageNotFound();
+			$this->presenter->presentSubjectNotFound();
 			return;
 		}
 

--- a/src/Application/Actions/MoveSubject/MoveSubjectAction.php
+++ b/src/Application/Actions/MoveSubject/MoveSubjectAction.php
@@ -96,14 +96,19 @@ readonly class MoveSubjectAction {
 			throw new RuntimeException( 'You do not have the necessary permissions to move this subject' );
 		}
 
-		// The source page as it stands, kept aside untouched: reading it again is how the rollback
-		// below restores the page exactly, ordering included, rather than reconstructing it.
-		$sourceSubjectsBeforeMove = $this->subjectRepository->getSubjectsByPageId( $sourcePageId );
-
-		$sourceSubjects->removeSubject( $subjectId );
+		// without() answers a copy, so $sourceSubjects stays the page as it was read - which is what
+		// the rollback below writes back, ordering included, rather than reconstructing it.
+		$sourceSubjectsAfterMove = $sourceSubjects->without( $subjectId );
 		$this->addToTarget( $targetSubjects, $subject, $request->makeMainSubject );
 
-		$this->write( $request, $sourceSubjects, $sourceSubjectsBeforeMove, $sourcePageId, $targetSubjects, $targetPageId );
+		$this->write(
+			request: $request,
+			sourcePageId: $sourcePageId,
+			sourceSubjectsAfterMove: $sourceSubjectsAfterMove,
+			sourceSubjectsBeforeMove: $sourceSubjects,
+			targetPageId: $targetPageId,
+			targetSubjects: $targetSubjects
+		);
 	}
 
 	private function addToTarget( PageSubjects $targetSubjects, Subject $subject, bool $makeMainSubject ): void {
@@ -124,15 +129,15 @@ readonly class MoveSubjectAction {
 
 	private function write(
 		MoveSubjectRequest $request,
-		PageSubjects $sourceSubjects,
-		PageSubjects $sourceSubjectsBeforeMove,
 		PageId $sourcePageId,
-		PageSubjects $targetSubjects,
-		PageId $targetPageId
+		PageSubjects $sourceSubjectsAfterMove,
+		PageSubjects $sourceSubjectsBeforeMove,
+		PageId $targetPageId,
+		PageSubjects $targetSubjects
 	): void {
 		// Source first, for the projection reason in the class docblock: the target write has to be
 		// the last word on the moved Subject's node.
-		$sourceStatus = $this->subjectRepository->savePageSubjects( $sourceSubjects, $sourcePageId, $request->comment );
+		$sourceStatus = $this->subjectRepository->savePageSubjects( $sourceSubjectsAfterMove, $sourcePageId, $request->comment );
 
 		if ( $sourceStatus->status === PageContentSavingStatus::ERROR ) {
 			$this->presenter->presentSourcePageNotFound();

--- a/src/Application/Actions/MoveSubject/MoveSubjectPresenter.php
+++ b/src/Application/Actions/MoveSubject/MoveSubjectPresenter.php
@@ -14,9 +14,11 @@ interface MoveSubjectPresenter {
 	public function presentNoChange(): void;
 
 	/**
-	 * Called when no page hosts the Subject, when the page that does no longer holds it, and when
-	 * the caller may not read that page. All three take this one shape so a Subject on a hidden page
-	 * cannot be told apart from one that does not exist.
+	 * Called when no page hosts the Subject, when the page that does no longer holds it, when the
+	 * caller may not read that page, and when that page went away between the read check and its
+	 * write - by which point nothing has been written, since the source page is written first. All
+	 * four take this one shape so a Subject on a hidden page cannot be told apart from one that does
+	 * not exist.
 	 */
 	public function presentSubjectNotFound(): void;
 
@@ -27,12 +29,6 @@ interface MoveSubjectPresenter {
 	 * revisions richer.
 	 */
 	public function presentTargetPageNotFound(): void;
-
-	/**
-	 * Called when the source page went away between the read check and its write. Nothing changed:
-	 * it is the first page written, so the target page has not been touched.
-	 */
-	public function presentSourcePageNotFound(): void;
 
 	public function presentSubjectAlreadyOnTargetPage(): void;
 

--- a/src/Domain/Page/PageSubjects.php
+++ b/src/Domain/Page/PageSubjects.php
@@ -65,6 +65,16 @@ class PageSubjects {
 	}
 
 	/**
+	 * A copy without the given Subject, leaving this instance untouched.
+	 */
+	public function without( SubjectId $id ): self {
+		return new self(
+			$this->isMainSubject( $id ) ? null : $this->mainSubject,
+			$this->childSubjects->without( $id )
+		);
+	}
+
+	/**
 	 * Updates the subject with the ID of the provided subject.
 	 * @throws OutOfBoundsException if the subject is not found
 	 */

--- a/src/Presentation/RestMoveSubjectPresenter.php
+++ b/src/Presentation/RestMoveSubjectPresenter.php
@@ -39,11 +39,6 @@ class RestMoveSubjectPresenter implements MoveSubjectPresenter {
 		$this->statusCode = 404;
 	}
 
-	public function presentSourcePageNotFound(): void {
-		$this->apiResponse = [ 'status' => 'error', 'message' => 'Page not found' ];
-		$this->statusCode = 404;
-	}
-
 	public function presentSubjectAlreadyOnTargetPage(): void {
 		$this->apiResponse = [ 'status' => 'error', 'message' => 'Subject is already on the target page' ];
 		$this->statusCode = 409;

--- a/tests/phpunit/Application/Actions/MoveSubjectActionTest.php
+++ b/tests/phpunit/Application/Actions/MoveSubjectActionTest.php
@@ -280,7 +280,7 @@ class MoveSubjectActionTest extends TestCase {
 		$presenter = $this->newSpyPresenter();
 		$this->newAction( $presenter, $repository )->moveSubject( $this->newRequest() );
 
-		$this->assertTrue( $presenter->sourcePageNotFound );
+		$this->assertTrue( $presenter->subjectNotFound );
 		$this->assertFalse( $presenter->moved );
 
 		$source = $repository->getSubjectsByPageId( new PageId( self::SOURCE_PAGE_ID ) );
@@ -476,7 +476,6 @@ class MoveSubjectActionTest extends TestCase {
 			public bool $noChange = false;
 			public bool $subjectNotFound = false;
 			public bool $targetPageNotFound = false;
-			public bool $sourcePageNotFound = false;
 			public bool $alreadyOnTargetPage = false;
 			public bool $moveIncomplete = false;
 
@@ -494,10 +493,6 @@ class MoveSubjectActionTest extends TestCase {
 
 			public function presentTargetPageNotFound(): void {
 				$this->targetPageNotFound = true;
-			}
-
-			public function presentSourcePageNotFound(): void {
-				$this->sourcePageNotFound = true;
 			}
 
 			public function presentSubjectAlreadyOnTargetPage(): void {

--- a/tests/phpunit/Domain/Page/PageSubjectsTest.php
+++ b/tests/phpunit/Domain/Page/PageSubjectsTest.php
@@ -63,6 +63,61 @@ class PageSubjectsTest extends TestCase {
 		);
 	}
 
+	public function testWithoutChildSubjectAnswersACopyLackingIt(): void {
+		$mainSubject = TestSubject::build( TestSubject::uniqueId() );
+		$firstChild = TestSubject::build( TestSubject::uniqueId() );
+		$secondChild = TestSubject::build( TestSubject::uniqueId() );
+		$thirdChild = TestSubject::build( TestSubject::uniqueId() );
+
+		$data = new PageSubjects( $mainSubject, new SubjectMap( $firstChild, $secondChild, $thirdChild ) );
+
+		$remaining = $data->without( $secondChild->id );
+
+		$this->assertSame( $mainSubject, $remaining->getMainSubject() );
+		$this->assertEquals(
+			new SubjectMap( $firstChild, $thirdChild ),
+			$remaining->getChildSubjects()
+		);
+	}
+
+	public function testWithoutMainSubjectAnswersACopyWithoutOne(): void {
+		$firstChild = TestSubject::build( TestSubject::uniqueId() );
+		$secondChild = TestSubject::build( TestSubject::uniqueId() );
+		$mainSubject = TestSubject::build( TestSubject::uniqueId() );
+
+		$data = new PageSubjects( $mainSubject, new SubjectMap( $firstChild, $secondChild ) );
+
+		$remaining = $data->without( $mainSubject->id );
+
+		$this->assertNull( $remaining->getMainSubject() );
+		$this->assertEquals(
+			new SubjectMap( $firstChild, $secondChild ),
+			$remaining->getChildSubjects()
+		);
+	}
+
+	public function testWithoutLeavesTheSubjectsItWasCalledOnAlone(): void {
+		// Moving a Subject keeps the page as it was read, so a failed move can write it back.
+		$mainSubject = TestSubject::build( TestSubject::uniqueId() );
+		$child = TestSubject::build( TestSubject::uniqueId() );
+
+		$data = new PageSubjects( $mainSubject, new SubjectMap( $child ) );
+
+		$data->without( $mainSubject->id );
+
+		$this->assertSame( $mainSubject, $data->getMainSubject() );
+		$this->assertEquals( new SubjectMap( $child ), $data->getChildSubjects() );
+	}
+
+	public function testWithoutAnIdThatIsNotOnThePageAnswersAnEqualCopy(): void {
+		$data = new PageSubjects(
+			TestSubject::build( TestSubject::uniqueId() ),
+			new SubjectMap( TestSubject::build( TestSubject::uniqueId() ) )
+		);
+
+		$this->assertEquals( $data, $data->without( TestSubject::uniqueId() ) );
+	}
+
 	public function testUpdateSubjectUpdatesTheMainSubject(): void {
 		$mainSubject = TestSubject::build( TestSubject::uniqueId(), new SubjectLabel( 'original' ) );
 		$updatedSubject = TestSubject::build( $mainSubject->id->text, new SubjectLabel( 'updated' ) );

--- a/tests/phpunit/EntryPoints/REST/MoveSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/MoveSubjectApiTest.php
@@ -125,16 +125,6 @@ class MoveSubjectApiTest extends NeoWikiIntegrationTestCase {
 		$this->assertTrue( $target->getChildSubjects()->hasSubject( new SubjectId( self::TARGET_MAIN_ID ) ) );
 	}
 
-	public function testBothPagesCarryTheSuppliedEditSummary(): void {
-		$this->executeHandler(
-			$this->newApi(),
-			$this->newRequest( body: [ 'targetPageId' => $this->targetPageId, 'comment' => 'Filed properly' ] )
-		);
-
-		$this->assertSame( 'Filed properly', $this->latestCommentOf( $this->sourcePageId ) );
-		$this->assertSame( 'Filed properly', $this->latestCommentOf( $this->targetPageId ) );
-	}
-
 	public function testMovingToThePageTheSubjectIsAlreadyOnIsUnchanged(): void {
 		$response = $this->executeHandler(
 			$this->newApi(),
@@ -184,16 +174,6 @@ class MoveSubjectApiTest extends NeoWikiIntegrationTestCase {
 		);
 	}
 
-	public function testUnreadableTargetPageLeavesTheSourcePageUntouched(): void {
-		$this->executeHandler(
-			$this->newApi(),
-			$this->newRequest(),
-			authority: $this->authorityThatCannotReadPageId( $this->targetPageId )
-		);
-
-		$this->assertTrue( $this->subjectsOf( $this->sourcePageId )->getAllSubjects()->hasSubject( $this->movedId() ) );
-	}
-
 	public function testReadableButNotEditableTargetPageReturns403(): void {
 		$response = $this->executeHandler(
 			$this->newApi(),
@@ -203,17 +183,6 @@ class MoveSubjectApiTest extends NeoWikiIntegrationTestCase {
 
 		$this->assertSame( 403, $response->getStatusCode() );
 		$this->assertTrue( $this->subjectsOf( $this->sourcePageId )->getAllSubjects()->hasSubject( $this->movedId() ) );
-		$this->assertFalse( $this->subjectsOf( $this->targetPageId )->getAllSubjects()->hasSubject( $this->movedId() ) );
-	}
-
-	public function testReadableButNotEditableSourcePageReturns403(): void {
-		$response = $this->executeHandler(
-			$this->newApi(),
-			$this->newRequest(),
-			authority: $this->authorityThatCannotEditPageId( $this->sourcePageId )
-		);
-
-		$this->assertSame( 403, $response->getStatusCode() );
 		$this->assertFalse( $this->subjectsOf( $this->targetPageId )->getAllSubjects()->hasSubject( $this->movedId() ) );
 	}
 
@@ -277,11 +246,6 @@ class MoveSubjectApiTest extends NeoWikiIntegrationTestCase {
 	private function subjectsOf( int $pageId ): PageSubjects {
 		return NeoWikiExtension::getInstance()->getSubjectRepository()
 			->getSubjectsByPageId( new PageId( $pageId ) );
-	}
-
-	private function latestCommentOf( int $pageId ): ?string {
-		return $this->getServiceContainer()->getRevisionLookup()
-			->getRevisionByPageId( $pageId )?->getComment()?->text;
 	}
 
 }


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1356, rebased onto master after it merged. One commit per item, so any of them can be dropped on its own. User-visible behaviour is unchanged; the one API-visible difference is under the second item.

- **One read of the source page.** `PageSubjects::without()` answers a copy without the Subject. The move writes the copy, and the rollback writes back the object it read, which nothing has mutated. The second read of the source page goes, and with it the reliance on repository reads handing out distinct objects, which `SubjectRepository` never promised.
- **One not-found outcome for the source.** A source page that vanishes between the read check and its write is presented as the Subject not found: it is written first, so nothing has been written yet. `presentSourcePageNotFound` goes. The response is still 404, with the message `Subject not found` instead of `Page not found`.
- **One error path in the REST client.** `moveSubject` no longer reads a server message off a non-ok Response. The production client rejects on every non-2xx but 422, so that branch never carried one. The rejection path still delivers the server's message to the dialog, unchanged.
- **Three `@group Database` tests dropped**: source-page 403, source untouched on an unreadable target, edit summary on both pages. `MoveSubjectActionTest` covers each; the target-page 403 test keeps proving the Authority wiring.

Considered, omitted:

- Moving page creation out of `MoveSubjectDialog` into a `PageCreator` service behind the registry: it takes the `mw.Api` call and error-code parsing out of the Vue component, but costs an interface, a class and three registration points for one caller. Worth doing only together with `MappingCreatorDialog`, which has the same inline `mw.Api().create`, as a second caller.
- Replacing `dropFromRegistryOnceUnlisted` with a plain listing reload: the moved Subject's registry copy carries its old page, so dropping it does real work.
- Sharing the Codex lookup handling between `PagePicker` and `SubjectPicker`: the largest duplication in the original PR, but it means reworking SubjectPicker; a PR of its own.

> <sub>AI-authored — Claude Code, `Fable 5.1 (max)`; @JeroenDeDauw asked for a follow-up PR that reduces complexity after an in-session assessment of the original, scope chosen by the assistant, then cut by one item at his direction; diff not yet human-reviewed; `make cs`, the move-related PHPUnit classes and the full `tsci` green locally on the final branch, the full PHPUnit suite green on the branch before the cut, each new test mutation-checked.</sub>

<details><summary>Production notes</summary>

Design, diff review and this text by `Fable 5.1 (max)`; implementation, tests and the rebase onto master by `Opus 5 (max)` subagents from written specs.

</details>
