### PR TITLE
Give the move-subject action an icon that is not the drag cursor

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -449,7 +449,7 @@
 						"cdxIconEdit",
 						"cdxIconDownload",
 						"cdxIconLink",
-						"cdxIconMove",
+						"cdxIconArticleRedirect",
 						"cdxIconCheck",
 						"cdxIconSearchCaseSensitive",
 						"cdxIconArticles",

--- a/resources/ext.neowiki/src/components/SubjectsManager/MoveSubjectDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectsManager/MoveSubjectDialog.vue
@@ -62,7 +62,7 @@
 				help-text=""
 				:save-button-label="$i18n( 'neowiki-managesubjects-move-confirm-button' ).text()"
 				:save-disabled="target === null || moving"
-				:save-button-icon="cdxIconMove"
+				:save-button-icon="cdxIconArticleRedirect"
 				@save="onMove"
 			/>
 		</template>
@@ -73,7 +73,7 @@
 import { ref, computed, watch } from 'vue';
 import { CdxCheckbox, CdxDialog, CdxField, CdxMessage } from '@wikimedia/codex';
 import type { ValidationStatusType } from '@wikimedia/codex';
-import { cdxIconMove } from '@wikimedia/codex-icons';
+import { cdxIconArticleRedirect } from '@wikimedia/codex-icons';
 import PagePicker from '@/components/common/PagePicker.vue';
 import SummaryAction from '@/components/common/SummaryAction.vue';
 import I18nSlot from '@/components/common/I18nSlot.vue';

--- a/resources/ext.neowiki/src/components/SubjectsManager/SubjectsManagerPage.vue
+++ b/resources/ext.neowiki/src/components/SubjectsManager/SubjectsManagerPage.vue
@@ -143,7 +143,7 @@
 								:title="$i18n( 'neowiki-managesubjects-row-move' ).text()"
 								@click.stop="openMoveDialog( mainSubject )"
 							>
-								<CdxIcon :icon="cdxIconMove" />
+								<CdxIcon :icon="cdxIconArticleRedirect" />
 							</CdxButton>
 							<CdxButton
 								v-if="canDelete"
@@ -335,7 +335,7 @@
 									:title="$i18n( 'neowiki-managesubjects-row-move' ).text()"
 									@click.stop="openMoveDialog( subject )"
 								>
-									<CdxIcon :icon="cdxIconMove" />
+									<CdxIcon :icon="cdxIconArticleRedirect" />
 								</CdxButton>
 								<CdxButton
 									v-if="canDelete"
@@ -499,13 +499,13 @@ import {
 import type { MenuButtonItemData } from '@wikimedia/codex';
 import {
 	cdxIconAdd,
+	cdxIconArticleRedirect,
 	cdxIconCollapse,
 	cdxIconDraggable,
 	cdxIconEdit,
 	cdxIconEllipsis,
 	cdxIconExpand,
 	cdxIconLink,
-	cdxIconMove,
 	cdxIconPushPin,
 	cdxIconTrash
 } from '@wikimedia/codex-icons';
@@ -661,7 +661,7 @@ const copyLinkMenuItem = computed<MenuButtonItemData>( () => ( {
 const moveMenuItem = computed<MenuButtonItemData>( () => ( {
 	value: 'move',
 	label: mw.msg( 'neowiki-managesubjects-row-move' ),
-	icon: cdxIconMove
+	icon: cdxIconArticleRedirect
 } ) );
 
 const deleteMenuItem = computed<MenuButtonItemData>( () => ( {


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1356

The Move action on the Data tab used `cdxIconMove`, the four-way arrow that is also the
browser's drag cursor, one button away from the row's drag handle in a list that is dragged to
reorder. A glyph that says "drag me" sat on the button that relocates a Subject to another page.

It now uses `cdxIconArticleRedirect`, a page with an arrow leading away from it: the
container-plus-arrow shape mail and file tools use for "move to", with a page as the container.
The dialog's confirm button and the overflow-menu entry carry the same icon, and the
ResourceLoader icon list follows.

Considered, omitted: a custom page-with-arrow glyph without the redirect association, and moving
the action into a labelled overflow menu on desktop.

> <sub>AI-authored — Claude Code, `Fable 5.1 (max)`; one-line ask from @JeroenDeDauw after an in-session icon discussion, no revisions; diff not yet human-reviewed; SubjectsManager vitest specs and eslint run locally, icon checked in the dev wiki, CI pending.</sub>
