### PR TITLE
Default the move dialog's promotion to the target kind, and link the new page

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -402,7 +402,8 @@
 				"vue",
 				"pinia",
 				"mediawiki.user",
-				"mediawiki.storage"
+				"mediawiki.storage",
+				"mediawiki.jqueryMsg"
 			],
 			"codexComponents": [
 				"CdxAccordion",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -296,7 +296,7 @@
 	"neowiki-managesubjects-move-demotes": "Note shown under the main-subject checkbox when the target page already has a main subject, which the move would demote to a child subject. Parameters:\n* $1 - the display name of the target page's current main subject",
 	"neowiki-managesubjects-move-source-loses-main": "Warning shown when the subject being moved is the main subject of the page it is moved away from. Parameters:\n* $1 - the title of the page the subject is moved away from",
 	"neowiki-managesubjects-move-confirm-button": "Label of the button that performs the move.",
-	"neowiki-managesubjects-move-success": "Notification shown after a subject was moved. Parameters:\n* $1 - the display name of the moved subject\n* $2 - the title of the page it was moved to",
+	"neowiki-managesubjects-move-success": "Notification shown after a subject was moved. Parameters:\n* $1 - the display name of the moved subject\n* $2 - a link to the page it was moved to, labelled with that page's title",
 	"neowiki-managesubjects-move-error": "Notification shown when moving a subject failed for an unrecognised reason. Parameters:\n* $1 - the display name of the subject that could not be moved",
 	"neowiki-managesubjects-move-page-taken": "Error shown when the page the move was going to create already exists.",
 	"neowiki-managesubjects-move-create-page-summary-default": "Default edit summary for the empty page created to hold a moved subject.",

--- a/resources/ext.neowiki/src/components/SubjectsManager/MoveSubjectDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectsManager/MoveSubjectDialog.vue
@@ -126,6 +126,11 @@ async function onTargetSelected( choice: PageChoice | null ): Promise<void> {
 	target.value = choice;
 	errorMessage.value = null;
 	demotedMainSubjectName.value = null;
+	// A page created for this Subject is about that Subject and has no main Subject to demote, so
+	// promoting is what the user means. A page that already exists keeps the main Subject it has
+	// unless the user says otherwise. Either way this is only the default: a manual choice stands
+	// until the target changes again.
+	makeMainSubject.value = targetIsNewPage.value;
 
 	if ( choice === null || choice.pageId === null ) {
 		return;

--- a/resources/ext.neowiki/src/components/SubjectsManager/SubjectsManagerPage.vue
+++ b/resources/ext.neowiki/src/components/SubjectsManager/SubjectsManagerPage.vue
@@ -954,7 +954,16 @@ function onSubjectMoved( targetTitle: string ): void {
 	const subjectName = movingSubject.value?.getDisplayName() ?? '';
 	movingSubject.value = null;
 
-	mw.notify( mw.msg( 'neowiki-managesubjects-move-success', subjectName, targetTitle ), { type: 'success' } );
+	const link = document.createElement( 'a' );
+	link.href = mw.util.getUrl( targetTitle, { action: 'subjects' } );
+	link.textContent = targetTitle;
+
+	// parseDom rather than a message string: it takes the link as a node, which leaves the subject
+	// name beside it escaped.
+	mw.notify(
+		mw.message( 'neowiki-managesubjects-move-success', subjectName, link ).parseDom(),
+		{ type: 'success' }
+	);
 }
 
 function confirmDelete( subject: Subject ): void {

--- a/resources/ext.neowiki/tests/VueTestHelpers.ts
+++ b/resources/ext.neowiki/tests/VueTestHelpers.ts
@@ -92,7 +92,7 @@ export function setupMwMock(
 
 	const mwMock: any = {};
 
-	const resolveMessage = ( key: string, params: string[] ): string => {
+	const resolveMessage = ( key: string, params: any[] ): string => {
 		// Rendered by real MediaWiki everywhere a Subject nobody named is shown, so the fake carries
 		// it rather than each spec restating the marker's shape.
 		if ( key === 'neowiki-subject-generated-name' && customMessages[ key ] === undefined ) {
@@ -113,9 +113,20 @@ export function setupMwMock(
 		config: () => ( {
 			get: vi.fn( ( key: string ) => customConfig[ key ] ),
 		} ),
-		message: () => vi.fn( ( key: string, ...params: string[] ) => ( {
+		message: () => vi.fn( ( key: string, ...params: any[] ) => ( {
 			text: () => resolveMessage( key, params ),
 			parse: () => resolveMessage( key, params ),
+			// jqueryMsg's parseDom yields nodes rather than a string, which is what lets a message
+			// carry a link. The fake keeps that: a node parameter stays a node, everything else
+			// reads as the key-plus-parameters text the other formats produce.
+			parseDom: () => {
+				const container = document.createElement( 'span' );
+				container.append(
+					key,
+					...params.map( ( param ) => param instanceof Node ? param : String( param ) ),
+				);
+				return container;
+			},
 		} ) ),
 		msg: () => vi.fn( ( key: string, ...params: string[] ) => resolveMessage( key, params ) ),
 		notify: () => vi.fn(),
@@ -128,7 +139,10 @@ export function setupMwMock(
 		} ),
 		util: () => ( {
 			wikiScript: vi.fn( () => '/rest.php' ),
-			getUrl: vi.fn( ( title: string ) => `/wiki/${ title }` ),
+			// Query parameters are part of the URL a caller asked for - a Data tab is the page's own
+			// URL plus action=subjects - so the fake carries them rather than dropping them.
+			getUrl: vi.fn( ( title: string, params?: Record<string, string> ) =>
+				`/wiki/${ title }` + ( params === undefined ? '' : `?${ new URLSearchParams( params ) }` ) ),
 		} ),
 	};
 

--- a/resources/ext.neowiki/tests/components/MappingsPage/MappingsPage.spec.ts
+++ b/resources/ext.neowiki/tests/components/MappingsPage/MappingsPage.spec.ts
@@ -310,6 +310,6 @@ describe( 'MappingsPage', () => {
 
 		await findEditButtons( wrapper )[ 0 ].trigger( 'click' );
 
-		expect( hrefSetter ).toHaveBeenCalledWith( '/wiki/Mapping:EDM' );
+		expect( hrefSetter ).toHaveBeenCalledWith( '/wiki/Mapping:EDM?action=edit' );
 	} );
 } );

--- a/resources/ext.neowiki/tests/components/SubjectsManager/MoveSubjectDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectsManager/MoveSubjectDialog.spec.ts
@@ -76,6 +76,10 @@ describe( 'MoveSubjectDialog', () => {
 		return wrapper.text();
 	}
 
+	function promotionChecked( wrapper: VueWrapper ): boolean {
+		return ( wrapper.find( 'input[type="checkbox"]' ).element as HTMLInputElement ).checked;
+	}
+
 	beforeEach( () => {
 		// One pinia, shared by the test and the mounted component: two instances would leave the
 		// component using a store this test never stubbed.
@@ -159,11 +163,51 @@ describe( 'MoveSubjectDialog', () => {
 		);
 	} );
 
-	it( 'leaves the promotion unchecked by default', async () => {
+	it( 'leaves the promotion unchecked for a target page that already exists', async () => {
 		const wrapper = mountDialog();
 		await pick( wrapper, { pageId: TARGET_PAGE_ID, title: 'Rembrandt van Rijn' } );
 
-		expect( ( wrapper.find( 'input[type="checkbox"]' ).element as HTMLInputElement ).checked ).toBe( false );
+		expect( promotionChecked( wrapper ) ).toBe( false );
+	} );
+
+	it( 'promotes by default for a target page that does not exist yet', async () => {
+		const wrapper = mountDialog();
+		await pick( wrapper, { pageId: null, title: 'Rembrandt van Rijn' } );
+
+		expect( promotionChecked( wrapper ) ).toBe( true );
+	} );
+
+	it( 'drops the promotion when the target changes to a page that already exists', async () => {
+		const wrapper = mountDialog();
+		await pick( wrapper, { pageId: null, title: 'Rembrandt van Rijn' } );
+
+		await pick( wrapper, { pageId: TARGET_PAGE_ID, title: 'Rembrandt Harmenszoon van Rijn' } );
+
+		expect( promotionChecked( wrapper ) ).toBe( false );
+	} );
+
+	it( 'promotes when the target changes to a page that does not exist yet', async () => {
+		const wrapper = mountDialog();
+		await pick( wrapper, { pageId: TARGET_PAGE_ID, title: 'Rembrandt van Rijn' } );
+
+		await pick( wrapper, { pageId: null, title: 'Rembrandt Harmenszoon van Rijn' } );
+
+		expect( promotionChecked( wrapper ) ).toBe( true );
+	} );
+
+	it( 'keeps the user\'s untick over the new page\'s default', async () => {
+		const wrapper = mountDialog();
+		await pick( wrapper, { pageId: null, title: 'Rembrandt van Rijn' } );
+
+		await wrapper.find( 'input[type="checkbox"]' ).setValue( false );
+		await clickMove( wrapper );
+
+		expect( subjectStore.moveSubject ).toHaveBeenCalledWith(
+			new SubjectId( SUBJECT_ID ),
+			99,
+			false,
+			undefined,
+		);
 	} );
 
 	it( 'names the main subject that promoting would demote', async () => {
@@ -238,7 +282,7 @@ describe( 'MoveSubjectDialog', () => {
 		expect( subjectStore.moveSubject ).toHaveBeenCalledWith(
 			new SubjectId( SUBJECT_ID ),
 			99,
-			false,
+			true,
 			undefined,
 		);
 	} );
@@ -336,7 +380,7 @@ describe( 'MoveSubjectDialog', () => {
 		await wrapper.setProps( { open: true, subjectId: 's11111111111bbb', subjectName: 'Another' } );
 
 		expect( wrapper.findComponent( SummaryAction ).props( 'saveDisabled' ) ).toBe( true );
-		expect( ( wrapper.find( 'input[type="checkbox"]' ).element as HTMLInputElement ).checked ).toBe( false );
+		expect( promotionChecked( wrapper ) ).toBe( false );
 	} );
 
 	it( 'clears a previous failure when it is reopened', async () => {

--- a/resources/ext.neowiki/tests/components/SubjectsManager/SubjectsManagerPage.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectsManager/SubjectsManagerPage.spec.ts
@@ -542,7 +542,7 @@ describe( 'SubjectsManagerPage move action', () => {
 		expect( wrapper.findComponent( MoveSubjectDialog ).props( 'open' ) ).toBe( true );
 	} );
 
-	it( 'reports the move once the dialog says it landed, naming the subject and its new page', async () => {
+	it( 'reports the move once the dialog says it landed, naming the subject and linking its new page', async () => {
 		const wrapper = await mountPage();
 		await wrapper.findAll( '[aria-label="neowiki-managesubjects-row-move"]' )[ 1 ].trigger( 'click' );
 		await flushPromises();
@@ -551,9 +551,11 @@ describe( 'SubjectsManagerPage move action', () => {
 		wrapper.findComponent( MoveSubjectDialog ).vm.$emit( 'moved', 'Rembrandt van Rijn' );
 		await flushPromises();
 
-		const [ message, options ] = ( mw.notify as ReturnType<typeof vi.fn> ).mock.calls[ 0 ];
-		expect( message ).toContain( 'neowiki-managesubjects-move-success' );
-		expect( message ).toContain( 'Rembrandt van Rijn' );
+		const [ content, options ] = ( mw.notify as ReturnType<typeof vi.fn> ).mock.calls[ 0 ];
+		const link = ( content as HTMLElement ).querySelector( 'a' );
+		expect( ( content as HTMLElement ).textContent ).toContain( 'neowiki-managesubjects-move-success' );
+		expect( link?.getAttribute( 'href' ) ).toBe( '/wiki/Rembrandt van Rijn?action=subjects' );
+		expect( link?.textContent ).toBe( 'Rembrandt van Rijn' );
 		expect( options ).toEqual( { type: 'success' } );
 
 		// The listing refresh belongs to the store's move action; refreshing here too would fetch


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1356

**The promotion default follows the target kind.** Moving a Subject onto a page that does not exist yet is how a Subject created in-flow on another page gets a page of its own: that page is about the Subject and has no main Subject to demote, so the "Make it the main subject" checkbox now arrives checked for it. An existing target page keeps its main Subject and leaves the box unchecked, as before. The default is applied whenever the target changes, so a manual tick or untick stands until the user picks a different page.

**The success notification links the page.** After the move, that page is where the user is headed, so the notification names it as a link to its Data tab instead of as plain text. The message is built with `parseDom`, which takes the link as a node and leaves the subject name beside it escaped; that needs `mediawiki.jqueryMsg`, now a declared module dependency rather than something the page happened to have loaded.

## Considered, omitted

- Prefilling the page lookup with the Subject's label.
- An Undo action in the notification.
- Navigating to the target page automatically after the move.

## Manual Browser Check

On a dev wiki, from the Data tab of `Rijksmuseum`, Move on an attendance Subject:

- typing a title no page has and picking "Use … as a new page" checks the box, with no demotion notice;
- picking an existing page instead unchecks it; picking the new-page option again re-checks it;
- confirming the move shows `Moved "Rijksmuseum attendance 2020" to <a href="/w/index.php?title=Attendance_scratch_1&action=subjects">Attendance scratch 1</a>.`, and that link opens the new page's Data tab with the Subject as its main Subject.

> <sub>AI-authored — Claude Code, `Opus 5 (max)`; written spec from @JeroenDeDauw's Fable session, no revisions; diff not yet human-reviewed; vitest (1930 tests), build and lint run locally plus the browser check above; CI pending.</sub>