### PR TITLE
Order the row actions by what they do to the row

### DIFF
--- a/resources/ext.neowiki/src/components/SubjectsManager/SubjectsManagerPage.vue
+++ b/resources/ext.neowiki/src/components/SubjectsManager/SubjectsManagerPage.vue
@@ -120,6 +120,14 @@
 						</span>
 						<span class="ext-neowiki-subjects-manager__row-actions">
 							<CdxButton
+								weight="quiet"
+								:aria-label="$i18n( 'neowiki-managesubjects-row-copy-link' ).text()"
+								:title="$i18n( 'neowiki-managesubjects-row-copy-link' ).text()"
+								@click.stop="copySubjectLink( mainSubject )"
+							>
+								<CdxIcon :icon="cdxIconLink" />
+							</CdxButton>
+							<CdxButton
 								v-if="canEdit"
 								weight="quiet"
 								:aria-label="$i18n( 'neowiki-managesubjects-row-edit' ).text()"
@@ -127,14 +135,6 @@
 								@click.stop="openEditor( mainSubject )"
 							>
 								<CdxIcon :icon="cdxIconEdit" />
-							</CdxButton>
-							<CdxButton
-								weight="quiet"
-								:aria-label="$i18n( 'neowiki-managesubjects-row-copy-link' ).text()"
-								:title="$i18n( 'neowiki-managesubjects-row-copy-link' ).text()"
-								@click.stop="copySubjectLink( mainSubject )"
-							>
-								<CdxIcon :icon="cdxIconLink" />
 							</CdxButton>
 							<CdxButton
 								v-if="canEdit"
@@ -303,13 +303,12 @@
 							</span>
 							<span class="ext-neowiki-subjects-manager__row-actions">
 								<CdxButton
-									v-if="canEdit"
 									weight="quiet"
-									:aria-label="$i18n( 'neowiki-managesubjects-row-promote' ).text()"
-									:title="$i18n( 'neowiki-managesubjects-row-promote' ).text()"
-									@click.stop="promoteToMain( subject )"
+									:aria-label="$i18n( 'neowiki-managesubjects-row-copy-link' ).text()"
+									:title="$i18n( 'neowiki-managesubjects-row-copy-link' ).text()"
+									@click.stop="copySubjectLink( subject )"
 								>
-									<CdxIcon :icon="cdxIconPushPin" />
+									<CdxIcon :icon="cdxIconLink" />
 								</CdxButton>
 								<CdxButton
 									v-if="canEdit"
@@ -321,12 +320,13 @@
 									<CdxIcon :icon="cdxIconEdit" />
 								</CdxButton>
 								<CdxButton
+									v-if="canEdit"
 									weight="quiet"
-									:aria-label="$i18n( 'neowiki-managesubjects-row-copy-link' ).text()"
-									:title="$i18n( 'neowiki-managesubjects-row-copy-link' ).text()"
-									@click.stop="copySubjectLink( subject )"
+									:aria-label="$i18n( 'neowiki-managesubjects-row-promote' ).text()"
+									:title="$i18n( 'neowiki-managesubjects-row-promote' ).text()"
+									@click.stop="promoteToMain( subject )"
 								>
-									<CdxIcon :icon="cdxIconLink" />
+									<CdxIcon :icon="cdxIconPushPin" />
 								</CdxButton>
 								<CdxButton
 									v-if="canEdit"
@@ -672,13 +672,9 @@ const deleteMenuItem = computed<MenuButtonItemData>( () => ( {
 } ) );
 
 const mainRowMenuItems = computed<MenuButtonItemData[]>( () => {
-	const items: MenuButtonItemData[] = [];
+	const items: MenuButtonItemData[] = [ copyLinkMenuItem.value ];
 	if ( canEdit.value ) {
-		items.push( editMenuItem.value );
-	}
-	items.push( copyLinkMenuItem.value );
-	if ( canEdit.value ) {
-		items.push( moveMenuItem.value );
+		items.push( editMenuItem.value, moveMenuItem.value );
 	}
 	if ( canDelete.value ) {
 		items.push( deleteMenuItem.value );
@@ -687,13 +683,9 @@ const mainRowMenuItems = computed<MenuButtonItemData[]>( () => {
 } );
 
 const otherRowMenuItems = computed<MenuButtonItemData[]>( () => {
-	const items: MenuButtonItemData[] = [];
+	const items: MenuButtonItemData[] = [ copyLinkMenuItem.value ];
 	if ( canEdit.value ) {
-		items.push( promoteMenuItem.value, editMenuItem.value );
-	}
-	items.push( copyLinkMenuItem.value );
-	if ( canEdit.value ) {
-		items.push( moveMenuItem.value );
+		items.push( editMenuItem.value, promoteMenuItem.value, moveMenuItem.value );
 	}
 	if ( canDelete.value ) {
 		items.push( deleteMenuItem.value );
@@ -1339,6 +1331,8 @@ onUnmounted( () => {
 	}
 
 	&__row-drag-handle {
+		// Set off from the buttons: this is grabbed, not clicked, and delete sits right before it.
+		margin-inline-start: @spacing-50;
 		min-width: @min-size-interactive-pointer;
 		min-height: @min-size-interactive-pointer;
 		padding-inline: @spacing-30;

--- a/resources/ext.neowiki/tests/components/SubjectsManager/SubjectsManagerPage.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectsManager/SubjectsManagerPage.spec.ts
@@ -464,31 +464,42 @@ describe( 'SubjectsManagerPage move action', () => {
 		expect( wrapper.findAll( '[aria-label="neowiki-managesubjects-row-move"]' ) ).toHaveLength( 2 );
 	} );
 
-	it( 'puts the move before the delete on every row', async () => {
+	// Copy-link changes nothing, so it leads; edit and promote change the row in place; move and
+	// delete take the row out of the listing, with delete last. The main row's pin is its
+	// indicator, outside the strip.
+	it( 'orders each row\'s inline actions copy-link, edit, promote, move, delete', async () => {
 		const wrapper = await mountPage();
 
-		const labels = wrapper.findAll( '.ext-neowiki-subjects-manager__row-actions [aria-label]' )
-			.map( ( element ) => element.attributes( 'aria-label' ) )
-			.filter( ( label ) => label === 'neowiki-managesubjects-row-move' || label === 'neowiki-managesubjects-row-delete' );
+		const strips = wrapper.findAll( '.ext-neowiki-subjects-manager__row-actions' )
+			.map( ( strip ) => strip.findAll( '[aria-label]' ).map( ( element ) => element.attributes( 'aria-label' ) ) );
 
-		expect( labels ).toEqual( [
-			'neowiki-managesubjects-row-move',
-			'neowiki-managesubjects-row-delete',
-			'neowiki-managesubjects-row-move',
-			'neowiki-managesubjects-row-delete',
+		expect( strips ).toEqual( [
+			[
+				'neowiki-managesubjects-row-copy-link',
+				'neowiki-managesubjects-row-edit',
+				'neowiki-managesubjects-row-move',
+				'neowiki-managesubjects-row-delete',
+			],
+			[
+				'neowiki-managesubjects-row-copy-link',
+				'neowiki-managesubjects-row-edit',
+				'neowiki-managesubjects-row-promote',
+				'neowiki-managesubjects-row-move',
+				'neowiki-managesubjects-row-delete',
+			],
 		] );
 	} );
 
-	it( 'offers the move in the overflow menu too, which is the only surface on mobile', async () => {
+	it( 'orders the overflow menu the same way as the inline actions', async () => {
 		const wrapper = await mountPage();
 
-		const menus = wrapper.findAllComponents( CdxMenuButton );
-		expect( menus ).toHaveLength( 2 );
-		for ( const menu of menus ) {
-			const values = menu.props( 'menuItems' ).map( ( item ) => item.value );
-			expect( values ).toContain( 'move' );
-			expect( values.indexOf( 'move' ) ).toBeLessThan( values.indexOf( 'delete' ) );
-		}
+		const menus = wrapper.findAllComponents( CdxMenuButton )
+			.map( ( menu ) => menu.props( 'menuItems' ).map( ( item ) => item.value ) );
+
+		expect( menus ).toEqual( [
+			[ 'copy-link', 'edit', 'move', 'delete' ],
+			[ 'copy-link', 'edit', 'promote', 'move', 'delete' ],
+		] );
 	} );
 
 	it( 'offers no move to a user who cannot edit', async () => {
@@ -689,63 +700,4 @@ describe( 'SubjectsManagerPage delete flow', () => {
 		expect( rowFor( wrapper, ID_A ).exists() ).toBe( true );
 	} );
 
-} );
-
-describe( 'SubjectsManagerPage row action order', () => {
-
-	beforeEach( () => {
-		storeSubjects = [ subject( ID_A ), subject( ID_B ) ];
-		mainSubjectId = new SubjectId( ID_A );
-		canEditSubjectRef.value = true;
-		canDeleteSubjectRef.value = true;
-		window.location.hash = '';
-		Element.prototype.scrollIntoView = vi.fn();
-		window.matchMedia = vi.fn().mockReturnValue( { matches: false } ) as unknown as typeof window.matchMedia;
-	} );
-
-	afterEach( () => {
-		document.body.innerHTML = '';
-		window.location.hash = '';
-		canEditSubjectRef.value = false;
-		canDeleteSubjectRef.value = false;
-		vi.restoreAllMocks();
-	} );
-
-	// Copy-link changes nothing, so it leads; edit and promote change the row in place; move and
-	// delete take the row out of the listing, with delete last. The main row's pin is its
-	// indicator, outside the strip.
-	it( 'orders each row\'s inline actions copy-link, edit, promote, move, delete', async () => {
-		const wrapper = await mountPage();
-
-		const strips = wrapper.findAll( '.ext-neowiki-subjects-manager__row-actions' )
-			.map( ( strip ) => strip.findAll( '[aria-label]' ).map( ( element ) => element.attributes( 'aria-label' ) ) );
-
-		expect( strips ).toEqual( [
-			[
-				'neowiki-managesubjects-row-copy-link',
-				'neowiki-managesubjects-row-edit',
-				'neowiki-managesubjects-row-move',
-				'neowiki-managesubjects-row-delete',
-			],
-			[
-				'neowiki-managesubjects-row-copy-link',
-				'neowiki-managesubjects-row-edit',
-				'neowiki-managesubjects-row-promote',
-				'neowiki-managesubjects-row-move',
-				'neowiki-managesubjects-row-delete',
-			],
-		] );
-	} );
-
-	it( 'orders the overflow menu the same way as the inline actions', async () => {
-		const wrapper = await mountPage();
-
-		const menus = wrapper.findAllComponents( CdxMenuButton )
-			.map( ( menu ) => menu.props( 'menuItems' ).map( ( item ) => item.value ) );
-
-		expect( menus ).toEqual( [
-			[ 'copy-link', 'edit', 'move', 'delete' ],
-			[ 'copy-link', 'edit', 'promote', 'move', 'delete' ],
-		] );
-	} );
 } );

--- a/resources/ext.neowiki/tests/components/SubjectsManager/SubjectsManagerPage.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectsManager/SubjectsManagerPage.spec.ts
@@ -690,3 +690,62 @@ describe( 'SubjectsManagerPage delete flow', () => {
 	} );
 
 } );
+
+describe( 'SubjectsManagerPage row action order', () => {
+
+	beforeEach( () => {
+		storeSubjects = [ subject( ID_A ), subject( ID_B ) ];
+		mainSubjectId = new SubjectId( ID_A );
+		canEditSubjectRef.value = true;
+		canDeleteSubjectRef.value = true;
+		window.location.hash = '';
+		Element.prototype.scrollIntoView = vi.fn();
+		window.matchMedia = vi.fn().mockReturnValue( { matches: false } ) as unknown as typeof window.matchMedia;
+	} );
+
+	afterEach( () => {
+		document.body.innerHTML = '';
+		window.location.hash = '';
+		canEditSubjectRef.value = false;
+		canDeleteSubjectRef.value = false;
+		vi.restoreAllMocks();
+	} );
+
+	// Copy-link changes nothing, so it leads; edit and promote change the row in place; move and
+	// delete take the row out of the listing, with delete last. The main row's pin is its
+	// indicator, outside the strip.
+	it( 'orders each row\'s inline actions copy-link, edit, promote, move, delete', async () => {
+		const wrapper = await mountPage();
+
+		const strips = wrapper.findAll( '.ext-neowiki-subjects-manager__row-actions' )
+			.map( ( strip ) => strip.findAll( '[aria-label]' ).map( ( element ) => element.attributes( 'aria-label' ) ) );
+
+		expect( strips ).toEqual( [
+			[
+				'neowiki-managesubjects-row-copy-link',
+				'neowiki-managesubjects-row-edit',
+				'neowiki-managesubjects-row-move',
+				'neowiki-managesubjects-row-delete',
+			],
+			[
+				'neowiki-managesubjects-row-copy-link',
+				'neowiki-managesubjects-row-edit',
+				'neowiki-managesubjects-row-promote',
+				'neowiki-managesubjects-row-move',
+				'neowiki-managesubjects-row-delete',
+			],
+		] );
+	} );
+
+	it( 'orders the overflow menu the same way as the inline actions', async () => {
+		const wrapper = await mountPage();
+
+		const menus = wrapper.findAllComponents( CdxMenuButton )
+			.map( ( menu ) => menu.props( 'menuItems' ).map( ( item ) => item.value ) );
+
+		expect( menus ).toEqual( [
+			[ 'copy-link', 'edit', 'move', 'delete' ],
+			[ 'copy-link', 'edit', 'promote', 'move', 'delete' ],
+		] );
+	} );
+} );


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1356

The Data tab's row actions ran Promote, Edit, Copy link, Move, Delete, then the drag handle.
Copy link, which changes nothing, sat between actions that do; the rarely used Promote led the
strip where the most used action, Edit, belongs; and the handle, which is grabbed rather than
clicked, followed Delete with nothing between them.

The strip now runs Copy link, Edit, Promote, Move, Delete: the one action that leaves the row
as it is first, then the two that change it in place, then the two that take it out of the
listing, with Delete last. The main row keeps its pin as the indicator beside the title. The
overflow menu follows the same order, and the drag handle stands a little apart from the buttons.

Considered, omitted: moving the drag handle to the row's left edge, the wider list convention,
which would put it beside the expand chevron and the main row's pin.

> <sub>AI-authored — Claude Code, `Fable 5.1 (max)`; one-line ask from @JeroenDeDauw after an in-session ordering discussion, no revisions; diff not yet human-reviewed; two order tests written first and seen failing, SubjectsManagerPage spec, eslint, stylelint and build run locally, both rows checked in the dev wiki, CI pending.</sub>
