### PR TITLE
Take a withdrawn username out of the graph projection

### DIFF
--- a/docs/api/graph-model.md
+++ b/docs/api/graph-model.md
@@ -37,7 +37,7 @@ A single-wiki install has just one `wiki_id`.
 | `namespaceId` | integer | MediaWiki namespace ID of the page (e.g. `0` for the main namespace, `12` for Help) |
 | `creationTime` | datetime | When the page was created |
 | `lastUpdated` | datetime | When the page was last modified |
-| `lastEditor` | string | Username of the last editor |
+| `lastEditor` | string | Username of the last editor, empty where the wiki hides it |
 | `categories` | string[] | MediaWiki categories the page belongs to |
 
 Built-in namespaces have the same ID on every wiki, so `namespaceId` filters consistently across a shared graph.

--- a/extension.json
+++ b/extension.json
@@ -50,6 +50,9 @@
 		"PageDeleteComplete": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onPageDeleteComplete",
 		"PageUndeleteComplete": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onPageUndeleteComplete",
 		"AfterImportPage": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onAfterImportPage",
+		"ArticleRevisionVisibilitySet": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onArticleRevisionVisibilitySet",
+		"BlockIpComplete": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onBlockIpComplete",
+		"UnblockUserComplete": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onUnblockUserComplete",
 
 		"CodeEditorGetPageLanguage": "ProfessionalWiki\\NeoWiki\\EntryPoints\\NeoWikiHooks::onCodeEditorGetPageLanguage",
 
@@ -75,6 +78,10 @@
 	"JobClasses": {
 		"neowikiGraphRebuild": {
 			"class": "ProfessionalWiki\\NeoWiki\\EntryPoints\\Jobs\\GraphRebuildJob",
+			"needsPage": false
+		},
+		"neowikiRebuildLastEditorPages": {
+			"class": "ProfessionalWiki\\NeoWiki\\EntryPoints\\Jobs\\RebuildLastEditorPagesJob",
 			"needsPage": false
 		}
 	},

--- a/src/Application/LastEditorPagesRebuilder.php
+++ b/src/Application/LastEditorPagesRebuilder.php
@@ -1,0 +1,44 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application;
+
+use MediaWiki\Title\TitleFactory;
+use MediaWiki\User\UserIdentity;
+use ProfessionalWiki\NeoWiki\Persistence\LastEditorPageIdsLookup;
+use Wikimedia\Rdbms\IDBAccessObject;
+
+/**
+ * Reprojects every page a user is the last editor of, which is what has to happen when whether the
+ * wiki shows their name changes: hiding a name with RevisionDelete changes one revision, but hiding
+ * a user with a block changes every revision they made at once (#1246).
+ *
+ * Every read is from the primary database — the page ids, the titles they resolve to, and the
+ * revision each page is reprojected from. This runs out of band, and a replica that has yet to
+ * catch up would both miss pages the user had just come to head and write the very name this is
+ * undoing back onto the ones it did find.
+ *
+ * A page deleted since the work was queued is skipped, which is the right answer — it has no node
+ * left to correct.
+ */
+class LastEditorPagesRebuilder {
+
+	public function __construct(
+		private readonly LastEditorPageIdsLookup $pageIdsLookup,
+		private readonly PageRebuilder $pageRebuilder,
+		private readonly TitleFactory $titleFactory,
+	) {
+	}
+
+	public function rebuildPagesLastEditedBy( UserIdentity $user ): void {
+		foreach ( $this->pageIdsLookup->getPageIdsLastEditedBy( $user ) as $pageId ) {
+			$title = $this->titleFactory->newFromID( $pageId, IDBAccessObject::READ_LATEST );
+
+			if ( $title !== null ) {
+				$this->pageRebuilder->rebuildFromPrimary( $title );
+			}
+		}
+	}
+
+}

--- a/src/Application/PageRebuilder.php
+++ b/src/Application/PageRebuilder.php
@@ -40,7 +40,7 @@ class PageRebuilder {
 			return PageRefreshOutcome::SkippedMissingRevision;
 		}
 
-		return $this->handler->onRevisionCreated( $revision, $revision->getUser() );
+		return $this->handler->onRevisionCreated( $revision );
 	}
 
 }

--- a/src/Application/Rdf/RdfPageLoader.php
+++ b/src/Application/Rdf/RdfPageLoader.php
@@ -61,7 +61,7 @@ class RdfPageLoader {
 
 		return new Page(
 			id: new PageId( $revision->getPageId() ),
-			properties: $this->pagePropertiesBuilder->getPagePropertiesFor( $revision, $revision->getUser() ),
+			properties: $this->pagePropertiesBuilder->getPagePropertiesFor( $revision ),
 			subjects: $subjects
 		);
 	}

--- a/src/Domain/Page/PagePropertyProviderContext.php
+++ b/src/Domain/Page/PagePropertyProviderContext.php
@@ -12,7 +12,8 @@ readonly class PagePropertyProviderContext {
 	 * @param string $creationTime In the standard MediaWiki format, ie 20230726163439
 	 * @param string $modificationTime In the standard MediaWiki format, ie 20230726163439
 	 * @param string[] $categories
-	 * @param string $lastEditor Plain username of the last editor, e.g. "JohnDoe". Empty string if unknown.
+	 * @param string $lastEditor Plain username of the last editor, e.g. "JohnDoe". Empty string when the wiki
+	 *   names none, which includes a revision whose author RevisionDelete has hidden.
 	 * @param string $content Serialized main slot content of the revision, e.g. the wikitext.
 	 *   Empty string if the content is unavailable.
 	 * @param string $contentModel Content model of the main slot, e.g. "wikitext".

--- a/src/EntryPoints/Jobs/RebuildLastEditorPagesJob.php
+++ b/src/EntryPoints/Jobs/RebuildLastEditorPagesJob.php
@@ -1,0 +1,62 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\EntryPoints\Jobs;
+
+use GenericParameterJob;
+use Job;
+use JobSpecification;
+use MediaWiki\User\UserIdentity;
+use MediaWiki\User\UserIdentityValue;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+
+/**
+ * Reprojects the pages one user is the last editor of, out of band, after a block hid their name or
+ * an unblock showed it again (#1246). Out of band because a block changes every page the user last
+ * edited at once, where the graph write path handles one page at a time.
+ *
+ * Nothing is caught: a projection failure fails the job, and the queue runs it again. Reprojecting a
+ * page is idempotent, so a retry that redoes pages an earlier attempt already reached costs only the
+ * writes.
+ */
+class RebuildLastEditorPagesJob extends Job implements GenericParameterJob {
+
+	public const string TYPE = 'neowikiRebuildLastEditorPages';
+
+	public function __construct( array $params ) {
+		parent::__construct( self::TYPE, $params );
+	}
+
+	/**
+	 * Filed as deduplicable: the job carries no state of its own and reads whether the wiki shows the
+	 * name when it runs, so a second copy queued while the first is still waiting has nothing to add.
+	 */
+	public static function newSpecification( UserIdentity $user ): JobSpecification {
+		return new JobSpecification(
+			self::TYPE,
+			[ 'userId' => $user->getId(), 'userName' => $user->getName() ],
+			[ 'removeDuplicates' => true ]
+		);
+	}
+
+	/**
+	 * A job whose parameters are not what this version files — one queued by another version, or edited
+	 * by hand — names no user, and reprojects nothing rather than guessing at one.
+	 */
+	public function run(): bool {
+		$userId = (int)( $this->params['userId'] ?? 0 );
+		$userName = (string)( $this->params['userName'] ?? '' );
+
+		if ( $userId === 0 || $userName === '' ) {
+			return true;
+		}
+
+		NeoWikiExtension::getInstance()
+			->newLastEditorPagesRebuilder()
+			->rebuildPagesLastEditedBy( UserIdentityValue::newRegistered( $userId, $userName ) );
+
+		return true;
+	}
+
+}

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -6,6 +6,7 @@ namespace ProfessionalWiki\NeoWiki\EntryPoints;
 
 use Exception;
 use ManualLogEntry;
+use MediaWiki\Block\DatabaseBlock;
 use MediaWiki\Deferred\DeferredUpdates;
 use MediaWiki\EditPage\EditPage;
 use MediaWiki\Html\Html;
@@ -21,6 +22,7 @@ use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Revision\SlotRoleRegistry;
 use MediaWiki\Title\ForeignTitle;
 use MediaWiki\Title\Title;
+use MediaWiki\User\User;
 use MediaWiki\User\UserIdentity;
 use MessageLocalizer;
 use ProfessionalWiki\NeoWiki\Application\Rdf\RdfPageProjector;
@@ -32,6 +34,7 @@ use ProfessionalWiki\NeoWiki\EntryPoints\Content\SubjectContent;
 use ProfessionalWiki\NeoWiki\EntryPoints\Content\LayoutContent;
 use ProfessionalWiki\NeoWiki\EntryPoints\Content\MappingContent;
 use ProfessionalWiki\NeoWiki\EntryPoints\Actions\SubjectsAction;
+use ProfessionalWiki\NeoWiki\EntryPoints\Jobs\RebuildLastEditorPagesJob;
 use ProfessionalWiki\NeoWiki\EntryPoints\Scribunto\ScribuntoLuaLibrary;
 use ProfessionalWiki\NeoWiki\Maintenance\RebuildSubjectPageIndex;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
@@ -286,7 +289,7 @@ class NeoWikiHooks {
 		UserIdentity $user,
 		array &$tags
 	): void {
-		NeoWikiExtension::getInstance()->getStoreContentUC()->onRevisionCreated( $revision, $user );
+		NeoWikiExtension::getInstance()->getStoreContentUC()->onRevisionCreated( $revision );
 		$wikiPage->doPurge(); // clear cache
 
 		if ( self::changedTheContent( $revision ) ) {
@@ -382,7 +385,7 @@ class NeoWikiHooks {
 		int $sRevCount,
 		array $pageInfo
 	): void {
-		NeoWikiExtension::getInstance()->newImportPageRebuilder()->rebuildFromPrimary( $title );
+		NeoWikiExtension::getInstance()->newHookPageRebuilder()->rebuildFromPrimary( $title );
 	}
 
 	public static function onCodeEditorGetPageLanguage( Title $title, ?string &$lang, ?string $model, ?string $format ): void {
@@ -424,11 +427,76 @@ class NeoWikiHooks {
 	): void {
 		$title = Title::newFromPageIdentity( $page );
 
-		NeoWikiExtension::getInstance()->newImportPageRebuilder()->rebuildFromPrimary( $title );
+		NeoWikiExtension::getInstance()->newHookPageRebuilder()->rebuildFromPrimary( $title );
 
 		// Restoring a Mapping page puts a projection back that the stores holding it were rebuilt
 		// without, so it changes what their graphs should contain exactly as deleting it did.
 		self::rebuildStoresHoldingChangedMapping( $title );
+	}
+
+	/**
+	 * Reprojects a page whose revision visibility changed. RevisionDelete hides who made a revision, or
+	 * shows them again, without creating a revision, so no other entry point fires and the graph would
+	 * go on serving a name MediaWiki no longer shows (#1246).
+	 *
+	 * Which revisions changed is not examined: a page is projected from whichever revision is current, so
+	 * reprojecting it agrees with the wiki when that revision was one of them, and rewrites what the graph
+	 * already holds when it was not — a redundant write at the frequency RevisionDelete is used. The
+	 * current revision is read from the primary database, since the change has only just committed.
+	 *
+	 * @see ArticleRevisionVisibilitySetHook
+	 *
+	 * @param int[] $ids
+	 * @param array<int, array{oldBits: int, newBits: int}> $visibilityChangeMap
+	 */
+	public static function onArticleRevisionVisibilitySet( Title $title, array $ids, array $visibilityChangeMap ): void {
+		NeoWikiExtension::getInstance()->newHookPageRebuilder()->rebuildFromPrimary( $title );
+	}
+
+	/**
+	 * Reprojects the pages of a user a block has just hidden. Hiding a user hides the name on every
+	 * revision they made, by a direct write that fires no revision hook of its own, so nothing else
+	 * would take those names out of the graph (#1246).
+	 *
+	 * @see BlockIpCompleteHook
+	 */
+	public static function onBlockIpComplete( DatabaseBlock $block, User $blocker, ?DatabaseBlock $priorBlock ): void {
+		self::rebuildPagesOfHiddenUser( $block );
+	}
+
+	/**
+	 * The counterpart for an unblock, which shows a hidden user's name again.
+	 *
+	 * This hook runs *before* MediaWiki clears the hidden flags, so the work has to be queued rather
+	 * than done here: reading the revisions now would still find the name hidden and change nothing.
+	 *
+	 * @see UnblockUserCompleteHook
+	 */
+	public static function onUnblockUserComplete( DatabaseBlock $block, User $unblocker ): void {
+		self::rebuildPagesOfHiddenUser( $block );
+	}
+
+	/**
+	 * Queued rather than done in the request: a block changes every page the user last edited at once,
+	 * where the write path this reuses handles one page at a time. Nothing is queued for a block that
+	 * does not hide the user, which leaves the graph as it was.
+	 *
+	 * The queueing is itself deferred, because the unblock hook runs before the flags are cleared and
+	 * lazyPush is not lazy under the command line — it pushes there and then, where a runner could
+	 * claim the job while the revisions still read as hidden and reproject the name straight back out.
+	 */
+	private static function rebuildPagesOfHiddenUser( DatabaseBlock $block ): void {
+		$user = $block->getTargetUserIdentity();
+
+		if ( !$block->getHideName() || $user === null ) {
+			return;
+		}
+
+		DeferredUpdates::addCallableUpdate( static function () use ( $user ): void {
+			MediaWikiServices::getInstance()->getJobQueueGroup()->lazyPush(
+				RebuildLastEditorPagesJob::newSpecification( $user )
+			);
+		} );
 	}
 
 	public static function onSpecialPageInitList( array &$specialPages ): void {

--- a/src/EntryPoints/OnRevisionCreatedHandler.php
+++ b/src/EntryPoints/OnRevisionCreatedHandler.php
@@ -5,7 +5,6 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\EntryPoints;
 
 use MediaWiki\Revision\RevisionRecord;
-use MediaWiki\User\UserIdentity;
 use ProfessionalWiki\NeoWiki\Application\PageRefreshOutcome;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphDatabasePlugin;
 use ProfessionalWiki\NeoWiki\Domain\Page\Page;
@@ -32,13 +31,13 @@ class OnRevisionCreatedHandler {
 	 * Indexes which Subjects the page holds, and projects the page with them — and with none when it
 	 * holds none: every page gets a Page node, so its Page Properties are queryable.
 	 */
-	public function onRevisionCreated( RevisionRecord $revisionRecord, ?UserIdentity $user ): PageRefreshOutcome {
+	public function onRevisionCreated( RevisionRecord $revisionRecord ): PageRefreshOutcome {
 		if ( $revisionRecord->getPageId() === 0 ) {
 			throw new RuntimeException( 'Page ID should not be 0' );
 		}
 
 		if ( !$revisionRecord->hasSlot( MediaWikiSubjectRepository::SLOT_NAME ) ) {
-			return $this->refreshPage( $revisionRecord, $user, null );
+			return $this->refreshPage( $revisionRecord, null );
 		}
 
 		// The slot exists; a read failure here is a genuine error and must propagate —
@@ -57,14 +56,10 @@ class OnRevisionCreatedHandler {
 			return PageRefreshOutcome::SkippedUnreadableSubjects;
 		}
 
-		return $this->refreshPage( $revisionRecord, $user, $content );
+		return $this->refreshPage( $revisionRecord, $content );
 	}
 
-	private function refreshPage(
-		RevisionRecord $revisionRecord,
-		?UserIdentity $user,
-		?SubjectContent $content
-	): PageRefreshOutcome {
+	private function refreshPage( RevisionRecord $revisionRecord, ?SubjectContent $content ): PageRefreshOutcome {
 		$pageId = new PageId( $revisionRecord->getPageId() );
 
 		// Indexed before the Subjects are read as Subjects, and outside the projection's failure
@@ -77,7 +72,7 @@ class OnRevisionCreatedHandler {
 		// Null only from the isolating source the hook path is given, which has already logged the
 		// cause. The rebuild path is given the propagating one, so there the failure surfaces to the
 		// maintenance script instead, which reports it against the page.
-		$properties = $this->pagePropertiesSource->getPagePropertiesFor( $revisionRecord, $user );
+		$properties = $this->pagePropertiesSource->getPagePropertiesFor( $revisionRecord );
 
 		if ( $properties === null ) {
 			return PageRefreshOutcome::SkippedUnreadablePageProperties;

--- a/src/FailureIsolatingPagePropertiesSource.php
+++ b/src/FailureIsolatingPagePropertiesSource.php
@@ -6,7 +6,6 @@ namespace ProfessionalWiki\NeoWiki;
 
 use Exception;
 use MediaWiki\Revision\RevisionRecord;
-use MediaWiki\User\UserIdentity;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageProperties;
 use Psr\Log\LoggerInterface;
 use Wikimedia\Rdbms\DBError;
@@ -32,9 +31,9 @@ class FailureIsolatingPagePropertiesSource implements PagePropertiesSource {
 	) {
 	}
 
-	public function getPagePropertiesFor( RevisionRecord $revision, ?UserIdentity $user ): ?PageProperties {
+	public function getPagePropertiesFor( RevisionRecord $revision ): ?PageProperties {
 		try {
-			return $this->source->getPagePropertiesFor( $revision, $user );
+			return $this->source->getPagePropertiesFor( $revision );
 		} catch ( TimeoutException | DBError $e ) {
 			throw $e;
 		} catch ( Exception $e ) {

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -77,6 +77,7 @@ use ProfessionalWiki\NeoWiki\Application\LayoutLookup;
 use ProfessionalWiki\NeoWiki\Application\SubjectPermissionHints;
 use ProfessionalWiki\NeoWiki\Application\PageReadAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\SubjectWriteAuthorizer;
+use ProfessionalWiki\NeoWiki\Application\LastEditorPagesRebuilder;
 use ProfessionalWiki\NeoWiki\Application\PageRebuilder;
 use ProfessionalWiki\NeoWiki\Application\SubjectIdMinter;
 use ProfessionalWiki\NeoWiki\Application\SubjectRepository;
@@ -166,6 +167,7 @@ use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\EntryPoints\REST\Sparql
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\EntryPoints\REST\SparqlRouteRegistration;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Sparql\SparqlPlugin;
 use ProfessionalWiki\NeoWiki\Persistence\DeletedPageIdsLookup;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\DatabaseLastEditorPageIdsLookup;
 use ProfessionalWiki\NeoWiki\Persistence\NullSubjectPageIndex;
 use ProfessionalWiki\NeoWiki\Persistence\PageIdsLookup;
 use ProfessionalWiki\NeoWiki\Persistence\SubjectPageIndex;
@@ -376,9 +378,10 @@ class NeoWikiExtension {
 	}
 
 	/**
-	 * Maintenance rebuild path (RebuildGraphDatabases). Failures propagate so the script reports which
-	 * pages failed to reconcile and why, rather than the hook path's isolation swallowing them and
-	 * leaving the operator a skip they cannot act on.
+	 * Rebuild path (RebuildGraphDatabases, and the jobs that reproject pages in bulk). Failures
+	 * propagate so the script reports which pages failed to reconcile and why, and so a job fails and is
+	 * retried, rather than the hook path's isolation swallowing them and leaving a skip nobody can act
+	 * on.
 	 */
 	private function newRebuildStoreContentHandler(): OnRevisionCreatedHandler {
 		return $this->newStoreContentHandler(
@@ -1022,6 +1025,22 @@ class NeoWikiExtension {
 	}
 
 	/**
+	 * Reprojects the pages one user is the last editor of, after a block hid their name or an unblock
+	 * showed it again (#1246). Failures propagate, as on the rebuild path it is built from: this runs in
+	 * a job, where a failure is what makes the queue try again.
+	 */
+	public function newLastEditorPagesRebuilder(): LastEditorPagesRebuilder {
+		return new LastEditorPagesRebuilder(
+			new DatabaseLastEditorPageIdsLookup(
+				MediaWikiServices::getInstance()->getConnectionProvider()->getPrimaryDatabase(),
+				MediaWikiServices::getInstance()->getActorNormalization()
+			),
+			$this->newPageRebuilder(),
+			MediaWikiServices::getInstance()->getTitleFactory()
+		);
+	}
+
+	/**
 	 * Maintenance rebuild path: projects into the one store the run is scoped to, and no other. The
 	 * plugin is used unwrapped, so a projection failure escapes to the rebuild, which decides whether it
 	 * costs a page or the whole run — the hook path's isolation would swallow it and report every page
@@ -1038,11 +1057,13 @@ class NeoWikiExtension {
 	}
 
 	/**
-	 * Import and undelete paths: projects the current revision of a page like the rebuild path, but with
+	 * Hook paths that project a page they did not themselves write a revision for: import, undeletion,
+	 * and a revision-visibility change. Projects the current revision like the rebuild path, but with
 	 * the hook path's failure isolation, since a projection failure must not abort the user's operation.
-	 * These are revision writes rather than reprojections, so they index the page as an edit does.
+	 * The page is indexed as an edit does it, which costs one read and no write where, as on the
+	 * visibility path, no Subject changed.
 	 */
-	public function newImportPageRebuilder(): PageRebuilder {
+	public function newHookPageRebuilder(): PageRebuilder {
 		return $this->newPageRebuilderWith( $this->getStoreContentUC() );
 	}
 

--- a/src/PagePropertiesBuilder.php
+++ b/src/PagePropertiesBuilder.php
@@ -12,7 +12,6 @@ use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Revision\RevisionStore;
 use MediaWiki\Revision\SlotRecord;
 use MediaWiki\Title\TitleFormatter;
-use MediaWiki\User\UserIdentity;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageProperties;
 use ProfessionalWiki\NeoWiki\Domain\Page\PagePropertyProviderContext;
@@ -28,8 +27,8 @@ readonly class PagePropertiesBuilder implements PagePropertiesSource {
 	) {
 	}
 
-	public function getPagePropertiesFor( RevisionRecord $revision, ?UserIdentity $user ): PageProperties {
-		$context = $this->buildContext( $revision, $user );
+	public function getPagePropertiesFor( RevisionRecord $revision ): PageProperties {
+		$context = $this->buildContext( $revision );
 
 		$properties = [];
 
@@ -40,7 +39,7 @@ readonly class PagePropertiesBuilder implements PagePropertiesSource {
 		return new PageProperties( $properties );
 	}
 
-	private function buildContext( RevisionRecord $revision, ?UserIdentity $user ): PagePropertyProviderContext {
+	private function buildContext( RevisionRecord $revision ): PagePropertyProviderContext {
 		$linkTarget = $revision->getPageAsLinkTarget();
 		$content = $revision->getContent( SlotRecord::MAIN );
 		$parserOutput = $content === null ? null : $this->parse( $content, $revision );
@@ -52,7 +51,9 @@ readonly class PagePropertiesBuilder implements PagePropertiesSource {
 			creationTime: $this->getCreationTime( $revision ),
 			modificationTime: $this->getModificationTime( $revision ),
 			categories: $parserOutput === null ? [] : $parserOutput->getCategoryNames(),
-			lastEditor: $user?->getName() ?? '',
+			// The revision's author as the wiki shows them: RevisionRecord answers its default audience
+			// with nobody once RevisionDelete has hidden the name, so a hidden name is never projected.
+			lastEditor: $revision->getUser()?->getName() ?? '',
 			content: $content === null ? '' : $content->serialize(),
 			contentModel: $content === null ? '' : $content->getModel(),
 			parserProperties: $parserOutput === null ? [] : $parserOutput->getPageProperties(),

--- a/src/PagePropertiesSource.php
+++ b/src/PagePropertiesSource.php
@@ -5,7 +5,6 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki;
 
 use MediaWiki\Revision\RevisionRecord;
-use MediaWiki\User\UserIdentity;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageProperties;
 
 /**
@@ -23,6 +22,6 @@ use ProfessionalWiki\NeoWiki\Domain\Page\PageProperties;
  */
 interface PagePropertiesSource {
 
-	public function getPagePropertiesFor( RevisionRecord $revision, ?UserIdentity $user ): ?PageProperties;
+	public function getPagePropertiesFor( RevisionRecord $revision ): ?PageProperties;
 
 }

--- a/src/Persistence/LastEditorPageIdsLookup.php
+++ b/src/Persistence/LastEditorPageIdsLookup.php
@@ -1,0 +1,20 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Persistence;
+
+use MediaWiki\User\UserIdentity;
+
+interface LastEditorPageIdsLookup {
+
+	/**
+	 * The id of every page whose current revision the given user made, in ascending order — the pages
+	 * the graph names them the `lastEditor` of, and so the pages that have to be reprojected when
+	 * whether the wiki shows their name changes.
+	 *
+	 * @return int[]
+	 */
+	public function getPageIdsLastEditedBy( UserIdentity $user ): array;
+
+}

--- a/src/Persistence/MediaWiki/DatabaseLastEditorPageIdsLookup.php
+++ b/src/Persistence/MediaWiki/DatabaseLastEditorPageIdsLookup.php
@@ -1,0 +1,53 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Persistence\MediaWiki;
+
+use MediaWiki\User\ActorNormalization;
+use MediaWiki\User\UserIdentity;
+use ProfessionalWiki\NeoWiki\Persistence\LastEditorPageIdsLookup;
+use Wikimedia\Rdbms\IReadableDatabase;
+
+/**
+ * Answers from `page_latest`, so a page the user edited and someone else edited afterwards is not
+ * theirs any more — which matches what the projection holds, since a page is projected from its
+ * current revision alone.
+ *
+ * The whole set is returned rather than paged. What asks for it is a name being hidden or shown
+ * again, and MediaWiki refuses to hide the name of a user with more edits than
+ * `$wgHideUserContribLimit`, for this very reason. That bound is the default rather than a
+ * guarantee: it can be set to false, and it is checked when hiding a name, not when showing one
+ * again, so a user hidden under a laxer setting is walked in full.
+ */
+class DatabaseLastEditorPageIdsLookup implements LastEditorPageIdsLookup {
+
+	public function __construct(
+		private readonly IReadableDatabase $db,
+		private readonly ActorNormalization $actorNormalization,
+	) {
+	}
+
+	/**
+	 * @return int[]
+	 */
+	public function getPageIdsLastEditedBy( UserIdentity $user ): array {
+		$actorId = $this->actorNormalization->findActorId( $user, $this->db );
+
+		if ( $actorId === null ) {
+			return [];
+		}
+
+		return array_map( 'intval', $this->db->newSelectQueryBuilder()
+			->select( 'page_id' )
+			->from( 'page' )
+			// Joined on both keys: `page` has no index on page_latest, so pairing them alone means a full
+			// scan of it, while rev_page lets rev_actor_timestamp drive from the user's own revisions.
+			->join( 'revision', null, [ 'page_latest = rev_id', 'rev_page = page_id' ] )
+			->where( [ 'rev_actor' => $actorId ] )
+			->orderBy( 'page_id' )
+			->caller( __METHOD__ )
+			->fetchFieldValues() );
+	}
+
+}

--- a/tests/phpunit/Application/PageRebuilderTest.php
+++ b/tests/phpunit/Application/PageRebuilderTest.php
@@ -8,8 +8,6 @@ use LogicException;
 use MediaWiki\Page\WikiPageFactory;
 use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Title\Title;
-use MediaWiki\User\UserIdentity;
-use MediaWiki\User\UserIdentityValue;
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Application\PageRefreshOutcome;
 use ProfessionalWiki\NeoWiki\Application\PageRebuilder;
@@ -65,7 +63,7 @@ class PageRebuilderTest extends TestCase {
 	public function testReturnsRefreshedWhenHandlerWritesPage(): void {
 		$this->handler->outcome = PageRefreshOutcome::Refreshed;
 
-		$outcome = $this->newRebuilder( $this->newRevisionByUser( new UserIdentityValue( 42, 'RevisionAuthor' ) ) )
+		$outcome = $this->newRebuilder( $this->newRevision() )
 			->rebuild( Title::makeTitle( NS_MAIN, 'AnyPage' ) );
 
 		$this->assertSame( PageRefreshOutcome::Refreshed, $outcome );
@@ -74,7 +72,7 @@ class PageRebuilderTest extends TestCase {
 	public function testReturnsTheOutcomeOfTheHandlerForAnExistingPage(): void {
 		$this->handler->outcome = PageRefreshOutcome::SkippedUnreadableSubjects;
 
-		$outcome = $this->newRebuilder( $this->newRevisionByUser( new UserIdentityValue( 42, 'RevisionAuthor' ) ) )
+		$outcome = $this->newRebuilder( $this->newRevision() )
 			->rebuild( Title::makeTitle( NS_MAIN, 'AnyPage' ) );
 
 		$this->assertSame( PageRefreshOutcome::SkippedUnreadableSubjects, $outcome );
@@ -87,32 +85,23 @@ class PageRebuilderTest extends TestCase {
 		$this->assertSame( [], $this->handler->calls );
 	}
 
-	public function testRefreshesWithNullAuthorWhenRevisionHasNoVisibleAuthor(): void {
-		$outcome = $this->newRebuilder( $this->newRevisionWithoutAuthor() )
-			->rebuild( Title::makeTitle( NS_MAIN, 'AuthorlessPage' ) );
+	public function testPassesTheCurrentRevisionToTheHandler(): void {
+		$revision = $this->newRevision();
 
-		$this->assertSame( PageRefreshOutcome::Refreshed, $outcome );
-		$this->assertNull( $this->handler->calls[0]['user'] );
-	}
+		$this->newRebuilder( $revision )->rebuild( Title::makeTitle( NS_MAIN, 'AnyPage' ) );
 
-	public function testPassesRevisionAuthorToHandler(): void {
-		$author = new UserIdentityValue( 42, 'RevisionAuthor' );
-
-		$this->newRebuilder( $this->newRevisionByUser( $author ) )
-			->rebuild( Title::makeTitle( NS_MAIN, 'AnyPage' ) );
-
-		$this->assertSame( $author, $this->handler->calls[0]['user'] );
+		$this->assertSame( [ $revision ], $this->handler->calls );
 	}
 
 	public function testRebuildReadsPageStateFromReplica(): void {
-		$this->newRebuilder( $this->newRevisionByUser( new UserIdentityValue( 42, 'RevisionAuthor' ) ) )
+		$this->newRebuilder( $this->newRevision() )
 			->rebuild( Title::makeTitle( NS_MAIN, 'AnyPage' ) );
 
 		$this->assertSame( [ IDBAccessObject::READ_NORMAL ], $this->pageDataReads );
 	}
 
 	public function testRebuildFromPrimaryReadsPageStateFromPrimary(): void {
-		$this->newRebuilder( $this->newRevisionByUser( new UserIdentityValue( 42, 'RevisionAuthor' ) ) )
+		$this->newRebuilder( $this->newRevision() )
 			->rebuildFromPrimary( Title::makeTitle( NS_MAIN, 'AnyPage' ) );
 
 		$this->assertSame(
@@ -137,16 +126,8 @@ class PageRebuilderTest extends TestCase {
 		return new PageRebuilder( $this->handler, $factory );
 	}
 
-	private function newRevisionByUser( UserIdentity $user ): RevisionRecord {
-		$revision = $this->createStub( RevisionRecord::class );
-		$revision->method( 'getUser' )->willReturn( $user );
-		return $revision;
-	}
-
-	private function newRevisionWithoutAuthor(): RevisionRecord {
-		$revision = $this->createStub( RevisionRecord::class );
-		$revision->method( 'getUser' )->willReturn( null );
-		return $revision;
+	private function newRevision(): RevisionRecord {
+		return $this->createStub( RevisionRecord::class );
 	}
 
 }

--- a/tests/phpunit/EntryPoints/HiddenUserGraphProjectionTest.php
+++ b/tests/phpunit/EntryPoints/HiddenUserGraphProjectionTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints;
+
+use MediaWiki\Deferred\DeferredUpdates;
+use MediaWiki\MediaWikiServices;
+use MediaWiki\User\User;
+use ProfessionalWiki\NeoWiki\EntryPoints\Jobs\RebuildLastEditorPagesJob;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpyGraphDatabasePlugin;
+
+/**
+ * Hiding a user hides their name on every revision they made, by a write straight to the revision
+ * rows that fires no revision hook of its own — so without this the graph would go on naming them as
+ * the last editor of every page they last edited, readable by anyone the Cypher endpoint is open to
+ * (#1246). The RevisionDelete route to the same disclosure is covered by
+ * RevisionVisibilityGraphProjectionTest.
+ *
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiHooks::onBlockIpComplete
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiHooks::onUnblockUserComplete
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\Jobs\RebuildLastEditorPagesJob
+ * @covers \ProfessionalWiki\NeoWiki\Application\LastEditorPagesRebuilder
+ * @group Database
+ */
+class HiddenUserGraphProjectionTest extends NeoWikiIntegrationTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->setUpNeo4j();
+		// Core grants hideuser to the suppress group only.
+		$this->setGroupPermissions( 'sysop', 'hideuser', true );
+	}
+
+	public function testHidingAUserTakesTheirNameOffEveryPageTheyLastEdited(): void {
+		$author = $this->getTestUser()->getUser();
+		$first = $this->editPageAs( 'First page of a hidden user', $author );
+		$second = $this->editPageAs( 'Second page of a hidden user', $author );
+		$this->assertSame(
+			[ $author->getName(), $author->getName() ],
+			[ $this->readLastEditor( $first ), $this->readLastEditor( $second ) ],
+			'precondition: the graph names the author of both'
+		);
+
+		$this->hideUser( $author );
+
+		$this->assertSame( [ '', '' ], [ $this->readLastEditor( $first ), $this->readLastEditor( $second ) ] );
+	}
+
+	public function testShowingAUserAgainPutsTheirNameBack(): void {
+		$author = $this->getTestUser()->getUser();
+		$pageId = $this->editPageAs( 'Page of a user hidden and shown again', $author );
+		$this->hideUser( $author );
+		$this->assertSame( '', $this->readLastEditor( $pageId ), 'precondition: the name is gone' );
+
+		$this->showUser( $author );
+
+		$this->assertSame( $author->getName(), $this->readLastEditor( $pageId ) );
+	}
+
+	/**
+	 * A block that hides nobody withdraws no name, so it must queue no reprojection at all. Asserting
+	 * the projected name instead would prove nothing: reprojecting a page whose author is still public
+	 * writes the same name back, so the assertion holds either way.
+	 */
+	public function testAnOrdinaryBlockQueuesNoReprojection(): void {
+		$author = $this->getTestUser()->getUser();
+		$this->editPageAs( 'Page of a merely blocked user', $author );
+
+		$this->blockUser( $author, hidden: false );
+
+		$this->assertSame( 0, $this->queuedReprojections() );
+	}
+
+	public function testHidingAUserQueuesTheReprojection(): void {
+		$author = $this->getTestUser()->getUser();
+		$this->editPageAs( 'Page of a user about to be hidden', $author );
+
+		$this->blockUser( $author, hidden: true );
+
+		$this->assertSame( 1, $this->queuedReprojections() );
+	}
+
+	/**
+	 * Which pages get reprojected, rather than what they end up holding. A page someone else has edited
+	 * since no longer carries the hidden name, and reprojecting it would write back the name it already
+	 * has — so only the set of pages touched can tell a correctly scoped run from an over-broad one.
+	 */
+	public function testHidingAUserReprojectsOnlyThePagesTheyLastEdited(): void {
+		$author = $this->getTestUser()->getUser();
+		$stillTheirs = $this->editPageAs( 'Page still headed by the hidden user', $author );
+		$this->editPageAs( 'Page taken over from a hidden user', $author );
+		$this->editPageAs( 'Page taken over from a hidden user', $this->getTestSysop()->getUser() );
+
+		$store = new SpyGraphDatabasePlugin();
+		$this->registerGraphDatabasePlugins( $store );
+
+		$this->hideUser( $author );
+
+		$this->assertSame( [ $stillTheirs ], self::savedPageIds( $store ) );
+	}
+
+	private function editPageAs( string $pageName, User $author ): int {
+		return $this->editPage( $pageName, 'Edited by ' . $author->getName(), '', NS_MAIN, $author )
+			->getNewRevision()
+			->getPageId();
+	}
+
+	private function hideUser( User $target ): void {
+		$this->blockUser( $target, hidden: true );
+		$this->runQueuedReprojections();
+	}
+
+	private function showUser( User $target ): void {
+		$status = MediaWikiServices::getInstance()->getUnblockUserFactory()->newUnblockUser(
+			$target,
+			$this->getTestSysop()->getUser(),
+			'Unblocked in a test'
+		)->unblock();
+
+		$this->assertStatusGood( $status );
+		$this->runQueuedReprojections();
+	}
+
+	/**
+	 * Places the block and lets the deferred updates run, which is what files the reprojection, but
+	 * stops short of running it — so a caller can either count what was queued or run it.
+	 */
+	private function blockUser( User $target, bool $hidden ): void {
+		$status = MediaWikiServices::getInstance()->getBlockUserFactory()->newBlockUser(
+			$target,
+			$this->getTestSysop()->getUser(),
+			'infinity',
+			'Blocked in a test',
+			[ 'isHideUser' => $hidden ]
+		)->placeBlock();
+
+		$this->assertStatusGood( $status );
+		DeferredUpdates::doUpdates();
+	}
+
+	private function runQueuedReprojections(): void {
+		// minJobs 0: a block that hides nobody queues nothing, and that case is one of the assertions.
+		$this->runJobs( [ 'minJobs' => 0 ] );
+	}
+
+	private function queuedReprojections(): int {
+		return $this->getServiceContainer()
+			->getJobQueueGroup()
+			->get( RebuildLastEditorPagesJob::TYPE )
+			->getSize();
+	}
+
+	private function readLastEditor( int $pageId ): ?string {
+		$result = $this->readGraph(
+			'MATCH (page:Page {id: $pageId}) RETURN page.lastEditor AS lastEditor',
+			[ 'pageId' => $pageId ]
+		);
+
+		return $result->first()->toRecursiveArray()['lastEditor'] ?? null;
+	}
+
+}

--- a/tests/phpunit/EntryPoints/OnRevisionCreatedHandlerTest.php
+++ b/tests/phpunit/EntryPoints/OnRevisionCreatedHandlerTest.php
@@ -9,7 +9,6 @@ use MediaWiki\Content\FallbackContent;
 use MediaWiki\Revision\RevisionAccessException;
 use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Revision\RevisionSlots;
-use MediaWiki\User\UserIdentityValue;
 use ProfessionalWiki\NeoWiki\Application\PageRefreshOutcome;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\FailureIsolatingGraphDatabasePlugin;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphDatabasePlugin;
@@ -54,7 +53,7 @@ class OnRevisionCreatedHandlerTest extends NeoWikiIntegrationTestCase {
 	public function testSavesPageWithSubjects(): void {
 		$revision = $this->createPageWithSubjects( 'Page with subject', TestSubject::build() );
 
-		$outcome = $this->newHandler()->onRevisionCreated( $revision, new UserIdentityValue( 1, 'Tester' ) );
+		$outcome = $this->newHandler()->onRevisionCreated( $revision );
 
 		$this->assertSame( PageRefreshOutcome::Refreshed, $outcome );
 		$this->assertCount( 1, $this->graphStore->savedPages );
@@ -63,7 +62,7 @@ class OnRevisionCreatedHandlerTest extends NeoWikiIntegrationTestCase {
 	public function testIndexesTheSubjectsThePageHolds(): void {
 		$revision = $this->createPageWithSubjects( 'Page with indexed subject', TestSubject::build() );
 
-		$this->newHandler()->onRevisionCreated( $revision, new UserIdentityValue( 1, 'Tester' ) );
+		$this->newHandler()->onRevisionCreated( $revision );
 
 		$this->assertSame(
 			[ $revision->getPageId() => [ TestSubject::ZERO_GUID ] ],
@@ -74,7 +73,7 @@ class OnRevisionCreatedHandlerTest extends NeoWikiIntegrationTestCase {
 	public function testSavesPageWithoutSubjects(): void {
 		$revision = $this->newPlainPageRevision( 'Plain page' );
 
-		$outcome = $this->newHandler()->onRevisionCreated( $revision, new UserIdentityValue( 1, 'Tester' ) );
+		$outcome = $this->newHandler()->onRevisionCreated( $revision );
 
 		$this->assertSame( PageRefreshOutcome::Refreshed, $outcome );
 		$this->assertCount( 1, $this->graphStore->savedPages );
@@ -84,7 +83,7 @@ class OnRevisionCreatedHandlerTest extends NeoWikiIntegrationTestCase {
 	public function testSavesPageWhoseSubjectsWereAllDeleted(): void {
 		$revision = $this->createPageWithSubjects( 'Page that lost its subjects' );
 
-		$outcome = $this->newHandler()->onRevisionCreated( $revision, new UserIdentityValue( 1, 'Tester' ) );
+		$outcome = $this->newHandler()->onRevisionCreated( $revision );
 
 		$this->assertSame( PageRefreshOutcome::Refreshed, $outcome );
 		$this->assertCount( 1, $this->graphStore->savedPages );
@@ -101,7 +100,7 @@ class OnRevisionCreatedHandlerTest extends NeoWikiIntegrationTestCase {
 			$this->graphStore,
 			$this->newFailingProviderRegistry(),
 			isolatePageProperties: true
-		)->onRevisionCreated( $revision, new UserIdentityValue( 1, 'Tester' ) );
+		)->onRevisionCreated( $revision );
 
 		$this->assertSame( PageRefreshOutcome::SkippedUnreadablePageProperties, $outcome );
 		$this->assertSame( [], $this->graphStore->savedPages );
@@ -120,7 +119,7 @@ class OnRevisionCreatedHandlerTest extends NeoWikiIntegrationTestCase {
 		$this->expectExceptionMessage( 'unknown content model' );
 
 		$this->newHandlerWith( $this->graphStore, $this->newFailingProviderRegistry() )
-			->onRevisionCreated( $revision, new UserIdentityValue( 1, 'Tester' ) );
+			->onRevisionCreated( $revision );
 	}
 
 	public function testWritesNothingWhenTheSubjectSlotDoesNotHoldSubjectContent(): void {
@@ -128,7 +127,7 @@ class OnRevisionCreatedHandlerTest extends NeoWikiIntegrationTestCase {
 		// the page as holding no Subjects would wipe the ones it does hold, so nothing is written.
 		$revision = $this->newRevisionWithSlotContent( new FallbackContent( '{"subjects":{}}', 'unregistered-model' ) );
 
-		$outcome = $this->newHandler()->onRevisionCreated( $revision, new UserIdentityValue( 1, 'Tester' ) );
+		$outcome = $this->newHandler()->onRevisionCreated( $revision );
 
 		$this->assertSame( PageRefreshOutcome::SkippedUnreadableSubjects, $outcome );
 		$this->assertSame( [], $this->graphStore->savedPages );
@@ -148,7 +147,7 @@ class OnRevisionCreatedHandlerTest extends NeoWikiIntegrationTestCase {
 
 		$this->expectException( RevisionAccessException::class );
 
-		$this->newHandler()->onRevisionCreated( $revision, new UserIdentityValue( 1, 'Tester' ) );
+		$this->newHandler()->onRevisionCreated( $revision );
 	}
 
 	public function testUnreachableBackendDoesNotHardFailRevisionHandling(): void {
@@ -160,7 +159,7 @@ class OnRevisionCreatedHandlerTest extends NeoWikiIntegrationTestCase {
 			new FailureIsolatingGraphDatabasePlugin( new ThrowingGraphDatabasePlugin(), new NullLogger() )
 		);
 
-		$outcome = $handler->onRevisionCreated( $revision, new UserIdentityValue( 1, 'Tester' ) );
+		$outcome = $handler->onRevisionCreated( $revision );
 
 		$this->assertSame(
 			PageRefreshOutcome::Refreshed,

--- a/tests/phpunit/EntryPoints/RevisionVisibilityGraphProjectionTest.php
+++ b/tests/phpunit/EntryPoints/RevisionVisibilityGraphProjectionTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints;
+
+use MediaWiki\Revision\RevisionRecord;
+use MediaWiki\Title\Title;
+use MediaWiki\User\User;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+
+/**
+ * Hiding who made a revision creates no revision of its own, so none of the hooks the projection is
+ * driven from fires and the graph keeps serving a name MediaWiki no longer shows — readable by anyone
+ * the Cypher endpoint is open to (#1246). Changing the visibility of a page's current revision
+ * therefore has to reproject the page.
+ *
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiHooks::onArticleRevisionVisibilitySet
+ * @group Database
+ */
+class RevisionVisibilityGraphProjectionTest extends NeoWikiIntegrationTestCase {
+
+	private const string PAGE_NAME = 'Page whose author gets hidden';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->setUpNeo4j();
+	}
+
+	public function testHidingTheAuthorOfTheCurrentRevisionTakesTheirNameOutOfTheGraph(): void {
+		$author = $this->getTestUser()->getUser();
+		$revision = $this->editPageAs( $author );
+		$this->assertSame(
+			$author->getName(),
+			$this->readLastEditor( $revision->getPageId() ),
+			'precondition: the graph names the author'
+		);
+
+		$this->hideRevisionAuthor( $this->pageTitle(), $revision->getId() );
+
+		$this->assertSame( '', $this->readLastEditor( $revision->getPageId() ) );
+	}
+
+	public function testShowingTheAuthorOfTheCurrentRevisionAgainPutsTheirNameBack(): void {
+		$author = $this->getTestUser()->getUser();
+		$revision = $this->editPageAs( $author );
+		$this->hideRevisionAuthor( $this->pageTitle(), $revision->getId() );
+		$this->assertSame(
+			'',
+			$this->readLastEditor( $revision->getPageId() ),
+			'precondition: the name is gone'
+		);
+
+		$this->showRevisionAuthor( $this->pageTitle(), $revision->getId() );
+
+		$this->assertSame( $author->getName(), $this->readLastEditor( $revision->getPageId() ) );
+	}
+
+	/**
+	 * Only the current revision is projected, so hiding the author of an older one changes nothing the
+	 * graph holds — including the name of the author it does hold.
+	 */
+	public function testHidingTheAuthorOfAnOlderRevisionLeavesTheProjectedNameAlone(): void {
+		$firstAuthor = $this->getTestUser()->getUser();
+		$firstRevision = $this->editPageAs( $firstAuthor );
+
+		$lastAuthor = $this->getTestSysop()->getUser();
+		$lastRevision = $this->editPageAs( $lastAuthor );
+
+		$this->hideRevisionAuthor( $this->pageTitle(), $firstRevision->getId() );
+
+		$this->assertSame( $lastAuthor->getName(), $this->readLastEditor( $lastRevision->getPageId() ) );
+	}
+
+	private function editPageAs( User $author ): RevisionRecord {
+		return $this->editPage( self::PAGE_NAME, 'Edited by ' . $author->getName(), '', NS_MAIN, $author )
+			->getNewRevision();
+	}
+
+	private function pageTitle(): Title {
+		return Title::newFromText( self::PAGE_NAME );
+	}
+
+	private function readLastEditor( int $pageId ): ?string {
+		$result = $this->readGraph(
+			'MATCH (page:Page {id: $pageId}) RETURN page.lastEditor AS lastEditor',
+			[ 'pageId' => $pageId ]
+		);
+
+		return $result->first()->toRecursiveArray()['lastEditor'] ?? null;
+	}
+
+}

--- a/tests/phpunit/NeoWikiIntegrationTestCase.php
+++ b/tests/phpunit/NeoWikiIntegrationTestCase.php
@@ -9,6 +9,7 @@ use ImportStringSource;
 use Laudis\Neo4j\Databags\SummarizedResult;
 use MediaWiki\CommentStore\CommentStoreComment;
 use MediaWiki\Content\TextContent;
+use MediaWiki\Context\RequestContext;
 use MediaWiki\Deferred\DeferredUpdates;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Revision\RevisionRecord;
@@ -32,6 +33,7 @@ use ProfessionalWiki\NeoWiki\Tests\Data\TestSchema;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySchemaLookup;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpyGraphDatabasePlugin;
+use RevisionDeleter;
 use TestLogger;
 use WikiExporter;
 
@@ -122,6 +124,37 @@ class NeoWikiIntegrationTestCase extends MediaWikiIntegrationTestCase {
 		);
 
 		$this->assertStatusGood( $deletePage->deleteUnsafe( 'test deletion' ) );
+	}
+
+	/**
+	 * Hides who made a revision, as Special:RevisionDelete does. MediaWiki refuses to hide the *content*
+	 * of a page's current revision, so the author is the only part of the revision a page is projected
+	 * from that can be hidden after the fact.
+	 */
+	protected function hideRevisionAuthor( Title $title, int $revisionId ): void {
+		$this->setRevisionAuthorVisibility( $title, $revisionId, 1 );
+	}
+
+	protected function showRevisionAuthor( Title $title, int $revisionId ): void {
+		$this->setRevisionAuthorVisibility( $title, $revisionId, 0 );
+	}
+
+	/**
+	 * @param int $value 1 hides the author, 0 shows them again (RevisionDeleter::extractBitfield)
+	 */
+	private function setRevisionAuthorVisibility( Title $title, int $revisionId, int $value ): void {
+		// The change is logged, and a log entry needs an actor to attribute it to.
+		RequestContext::getMain()->setUser( $this->getTestSysop()->getUser() );
+
+		$list = RevisionDeleter::createList( 'revision', RequestContext::getMain(), $title, [ $revisionId ] );
+
+		$this->assertStatusGood( $list->setVisibility( [
+			'value' => [ RevisionRecord::DELETED_USER => $value ],
+			'comment' => 'Changing revision visibility in a test',
+		] ) );
+
+		// The hooks a visibility change fires are queued rather than run inline.
+		DeferredUpdates::doUpdates();
 	}
 
 	/**

--- a/tests/phpunit/PagePropertiesBuilderTest.php
+++ b/tests/phpunit/PagePropertiesBuilderTest.php
@@ -4,16 +4,21 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\Tests;
 
+use MediaWiki\Revision\RevisionRecord;
+use MediaWiki\Title\Title;
 use ProfessionalWiki\NeoWiki\Domain\Page\PagePropertyProviderContext;
 use ProfessionalWiki\NeoWiki\Domain\Page\PagePropertyProviderRegistry;
 use ProfessionalWiki\NeoWiki\PagePropertiesBuilder;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpyPagePropertyProvider;
+use Wikimedia\Rdbms\IDBAccessObject;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\PagePropertiesBuilder
  * @group Database
  */
 class PagePropertiesBuilderTest extends NeoWikiIntegrationTestCase {
+
+	private const string PAGE_NAME = 'PagePropertiesBuilderTestPage';
 
 	public function testProviderReceivesContent(): void {
 		$context = $this->getContextForNewPageWithContent( 'Some text [[Category:Cats]]' );
@@ -39,14 +44,51 @@ class PagePropertiesBuilderTest extends NeoWikiIntegrationTestCase {
 		$this->assertSame( [ 'Cats' ], $context->categories );
 	}
 
-	private function getContextForNewPageWithContent( string $wikitext ): PagePropertyProviderContext {
-		$revision = $this->editPage( 'PagePropertiesBuilderTestPage', $wikitext )->getNewRevision();
+	public function testProviderReceivesTheAuthorOfTheRevision(): void {
+		$author = $this->getTestUser()->getUser();
 
+		$revision = $this->editPage( self::PAGE_NAME, 'Some text', '', NS_MAIN, $author )->getNewRevision();
+
+		$this->assertSame( $author->getName(), $this->getContextFor( $revision )->lastEditor );
+	}
+
+	/**
+	 * RevisionDelete hides an author without creating a revision of its own, so a name the wiki no
+	 * longer shows must not reach the providers whose properties get projected (#1246).
+	 */
+	public function testProviderReceivesNoAuthorOnceRevisionDeleteHidTheirName(): void {
+		$revision = $this->editPage(
+			self::PAGE_NAME, 'Some text', '', NS_MAIN, $this->getTestUser()->getUser()
+		)->getNewRevision();
+
+		$this->hideRevisionAuthor( Title::newFromText( self::PAGE_NAME ), $revision->getId() );
+
+		$this->assertSame( '', $this->getContextFor( $this->reloadRevision( $revision ) )->lastEditor );
+	}
+
+	private function getContextForNewPageWithContent( string $wikitext ): PagePropertyProviderContext {
+		return $this->getContextFor( $this->editPage( self::PAGE_NAME, $wikitext )->getNewRevision() );
+	}
+
+	private function getContextFor( RevisionRecord $revision ): PagePropertyProviderContext {
 		$spy = new SpyPagePropertyProvider();
 
-		$this->newPagePropertiesBuilder( $spy )->getPagePropertiesFor( $revision, null );
+		$this->newPagePropertiesBuilder( $spy )->getPagePropertiesFor( $revision );
 
 		return $spy->getReceivedContext();
+	}
+
+	/**
+	 * The record an edit returns carries the visibility the revision had when it was made, which a
+	 * later RevisionDelete does not change.
+	 */
+	private function reloadRevision( RevisionRecord $revision ): RevisionRecord {
+		$reloaded = $this->getServiceContainer()->getRevisionStore()
+			->getRevisionById( $revision->getId(), IDBAccessObject::READ_LATEST );
+
+		$this->assertNotNull( $reloaded );
+
+		return $reloaded;
 	}
 
 	private function newPagePropertiesBuilder( SpyPagePropertyProvider $provider ): PagePropertiesBuilder {

--- a/tests/phpunit/Persistence/MediaWiki/DatabaseLastEditorPageIdsLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/DatabaseLastEditorPageIdsLookupTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Persistence\MediaWiki;
+
+use MediaWiki\User\User;
+use MediaWiki\User\UserIdentity;
+use MediaWiki\User\UserIdentityValue;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\DatabaseLastEditorPageIdsLookup;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Persistence\MediaWiki\DatabaseLastEditorPageIdsLookup
+ * @group Database
+ */
+class DatabaseLastEditorPageIdsLookupTest extends NeoWikiIntegrationTestCase {
+
+	public function testFindsThePagesTheUserEditedLast(): void {
+		$author = $this->getTestUser()->getUser();
+
+		$first = $this->editPageAs( 'Their first page', $author );
+		$second = $this->editPageAs( 'Their second page', $author );
+
+		$this->assertSame( [ $first, $second ], $this->getPageIdsLastEditedBy( $author ) );
+	}
+
+	/**
+	 * A page is projected from its current revision alone, so a page the user edited and someone else
+	 * edited afterwards no longer carries their name and must not be reprojected on their account.
+	 */
+	public function testSkipsAPageSomeoneElseEditedAfterwards(): void {
+		$author = $this->getTestUser()->getUser();
+
+		$stillTheirs = $this->editPageAs( 'Page still theirs', $author );
+		$this->editPageAs( 'Page taken over', $author );
+		$this->editPageAs( 'Page taken over', $this->getTestSysop()->getUser() );
+
+		$this->assertSame( [ $stillTheirs ], $this->getPageIdsLastEditedBy( $author ) );
+	}
+
+	public function testFindsNothingForAUserWhoNeverEdited(): void {
+		$this->editPageAs( 'A page by someone else', $this->getTestSysop()->getUser() );
+
+		$this->assertSame( [], $this->getPageIdsLastEditedBy( $this->getTestUser()->getUser() ) );
+	}
+
+	/**
+	 * findActorId answers null for a user who has never acted, which has to read as "no pages" rather
+	 * than reach the query with no actor to narrow by.
+	 */
+	public function testFindsNothingForAUserWithoutAnActor(): void {
+		$this->assertSame(
+			[],
+			$this->getPageIdsLastEditedBy( UserIdentityValue::newRegistered( 123456, 'Never acted here' ) )
+		);
+	}
+
+	private function editPageAs( string $pageName, User $author ): int {
+		return $this->editPage( $pageName, 'Edited by ' . $author->getName(), '', NS_MAIN, $author )
+			->getNewRevision()
+			->getPageId();
+	}
+
+	/**
+	 * @return int[]
+	 */
+	private function getPageIdsLastEditedBy( UserIdentity $user ): array {
+		$services = $this->getServiceContainer();
+
+		return ( new DatabaseLastEditorPageIdsLookup(
+			$services->getConnectionProvider()->getReplicaDatabase(),
+			$services->getActorNormalization()
+		) )->getPageIdsLastEditedBy( $user );
+	}
+
+}

--- a/tests/phpunit/TestDoubles/SpyOnRevisionCreatedHandler.php
+++ b/tests/phpunit/TestDoubles/SpyOnRevisionCreatedHandler.php
@@ -5,13 +5,12 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\NeoWiki\Tests\TestDoubles;
 
 use MediaWiki\Revision\RevisionRecord;
-use MediaWiki\User\UserIdentity;
 use ProfessionalWiki\NeoWiki\Application\PageRefreshOutcome;
 use ProfessionalWiki\NeoWiki\EntryPoints\OnRevisionCreatedHandler;
 
 class SpyOnRevisionCreatedHandler extends OnRevisionCreatedHandler {
 
-	/** @var list<array{revision: RevisionRecord, user: ?UserIdentity}> */
+	/** @var list<RevisionRecord> */
 	public array $calls = [];
 
 	public PageRefreshOutcome $outcome = PageRefreshOutcome::Refreshed;
@@ -19,8 +18,8 @@ class SpyOnRevisionCreatedHandler extends OnRevisionCreatedHandler {
 	public function __construct() {
 	}
 
-	public function onRevisionCreated( RevisionRecord $revisionRecord, ?UserIdentity $user ): PageRefreshOutcome {
-		$this->calls[] = [ 'revision' => $revisionRecord, 'user' => $user ];
+	public function onRevisionCreated( RevisionRecord $revisionRecord ): PageRefreshOutcome {
+		$this->calls[] = $revisionRecord;
 		return $this->outcome;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/1246

The graph and RDF projections stored `lastEditor` as the user who saved the revision. MediaWiki can
later withdraw that name from public view — with RevisionDelete on the revision, or a hideuser block
on the account — and the projection kept serving it. `neowiki-query` is granted to `*` by default, so
an anonymous Cypher query returned a name the wiki no longer shows anywhere.

`PagePropertiesBuilder` now takes the name from `$revision->getUser()`, whose default audience answers
with nobody once the name is hidden. That is what the RDF export path already did; the graph write
path was the outlier. The `?UserIdentity $user` parameter, which every caller derived from the
revision anyway, is gone, so no future call site can reintroduce a raw name.

Withdrawing a name creates no revision, so nothing reprojected the pages holding it. Two paths now do:

- `ArticleRevisionVisibilitySet` reprojects the page, reading its current revision from the primary
  since the change has only just committed.
- `BlockIpComplete` and `UnblockUserComplete` queue a job that reprojects every page the user is the
  last editor of. The queueing is itself deferred: the unblock hook runs before MediaWiki clears the
  flags, and `lazyPush` is not lazy under the command line.

Pages projected before this lands keep the name they were projected with until they are edited or the
graph is rebuilt.

## Notes for review

- Categories are not at stake. MediaWiki refuses to hide the *content* of a page's current revision,
  and only the current revision is projected.
- The job takes no cursor. `$wgHideUserContribLimit` (1000 by default) bounds the page set, though it
  can be disabled; the job is idempotent, so the queue's own retry covers failure.
- The lookup joins on `rev_page` as well as `page_latest`, because `page` carries no index on
  `page_latest` and pairing them alone means a full scan of it.
- ADR 27's consequence "Dumps and projections contain restricted content" now has an exception. That
  may warrant an Update note in the ADR; I have not written one.

## Manual check

Core grants neither right by default, so first:

```php
$wgGroupPermissions['sysop']['deleterevision'] = true;
$wgGroupPermissions['sysop']['hideuser'] = true;
```

Edit a page as some user, then read the graph anonymously:

```
POST /rest.php/neowiki/v0/query/cypher
{"cypher":"MATCH (p:Page) WHERE p.id = <page id> RETURN p.lastEditor AS name"}
```

Hide that revision's author on `Special:RevisionDelete` — the name goes empty at once, and comes back
when you show it again. Then block the author with "hide username" and run the job queue: the name
goes empty on every page they last edited.

## Known gaps

- The work list comes from `page_latest` in the database, but the leak lives in the graph. A page
  whose projection write was lost — the edit path is failure-isolated — is never revisited.
- `Special:MergeHistory` rewrites `page_latest` with no hook at all, so `lastEditor` goes stale there.
  Pre-existing, worth its own issue.
- A rename between queueing and running the job silently reprojects nothing. Core's own
  `RevisionDeleteUser` resolves the actor by name too, but runs synchronously, so it has no window.

> <sub>AI-authored — Claude Code, `Opus 5 (1M context; xhigh)`; one-line ask from @alistair3149, paused before opening for review, then rescoped on request to cover the block route; diff not yet human-reviewed; tests written and run locally, both routes verified end to end on a dev wiki, findings from an automated review round fixed and mutation-tested.</sub>

<details><summary>Production notes</summary>

Two verification caveats a reviewer should know. The automated `code-review` pass did not complete — it died on a session rate limit — so this change has had test, security, design and correctness review but not that one. And the full `@group Database` suite will not run to completion in my local environment (it hangs identically with this change reverted), so the affected classes were run individually and the whole-suite result rests on CI.

</details>
