### PR TITLE
Fold a relation caption heading one row onto that row

### DIFF
--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -87,7 +87,7 @@
 	"neowiki-subject-editor-save-scope": "Note shown beside the subject editor's save button, naming what the save writes. Parameters:\n* $1 - how many subjects have unsaved changes\n* $2 - how many wiki pages hold them\nShown only when the user cannot see the whole scope already, so $1 is at least two or the one changed subject is not the one on screen.",
 	"neowiki-subject-tree-label": "Accessible name of the structure tree in the subject editor, listing the subjects reachable from the one being edited.",
 	"neowiki-subject-editor-resize-navigator": "Accessible name of the divider between the structure tree and the edit form in the subject editor. Dragging it, or moving it with the arrow keys, changes how wide the structure panel is. The panel itself is named by {{msg-mw|neowiki-subject-tree-label}}.",
-	"neowiki-subject-tree-not-linked": "Caption of the structure tree group holding subjects that are open or have unsaved changes but are not reachable through the relations of the subject being edited.",
+	"neowiki-subject-tree-not-linked": "Names the structure tree entries for subjects that are open or have unsaved changes but are not reachable through the relations of the subject being edited.",
 	"neowiki-subject-picker-placeholder": "Placeholder text shown in the subject picker input field, which matches typed text against subject names and accepts a complete subject ID.",
 	"neowiki-schema-picker-placeholder": "Placeholder text shown in the schema picker input field.",
 	"neowiki-subject-picker-no-results": "Message shown in the subject picker dropdown when no subjects match the search query.",

--- a/resources/ext.neowiki/src/components/SubjectEditor/SubjectTree.vue
+++ b/resources/ext.neowiki/src/components/SubjectEditor/SubjectTree.vue
@@ -5,16 +5,6 @@
 		:label="$i18n( 'neowiki-subject-tree-label' ).text()"
 		@select="selectItem"
 	>
-		<!-- Unlinked: the row is itself the click target. The dialog's own header still shows
-			the older "Schema: X" text until that header is converted. -->
-		<template #secondary="{ item }">
-			<SchemaNameDisplay
-				v-if="item.secondaryLabel"
-				:schema-name="item.secondaryLabel"
-				link="none"
-			/>
-		</template>
-
 		<!-- Rendered here rather than inside NeoTree: the dot carries an i18n message of its
 			own, and it belongs in the row a treeitem takes its accessible name from. -->
 		<template #trailing="{ item }">
@@ -27,7 +17,6 @@
 import { computed, shallowReactive, watch } from 'vue';
 import NeoTree from '@/components/common/NeoTree/NeoTree.vue';
 import UnsavedDot from '@/components/common/UnsavedDot.vue';
-import SchemaNameDisplay from '@/components/common/SchemaNameDisplay.vue';
 import type { NeoTreeItem } from '@/components/common/NeoTree/NeoTreeModel.ts';
 import { nodeFor, walkSubjectTree } from './SubjectTreeWalk.ts';
 import type { SubjectTreeWalkResult, WalkNode } from './SubjectTreeWalk.ts';
@@ -126,8 +115,9 @@ const strayNodes = computed( (): WalkNode[] => {
 		.map( ( id ) => nodeFor( `stray:${ id }`, id, props.editedSubjects.get( id ) ) );
 } );
 
-const treeShape = computed( (): WalkNode => {
-	const root = walk.value.root;
+// Captioned rather than given a relation they do not have.
+const treeItem = computed( (): NeoTreeItem<string> => {
+	const root = toTreeItem( walk.value.root );
 
 	if ( strayNodes.value.length === 0 ) {
 		return root;
@@ -138,31 +128,22 @@ const treeShape = computed( (): WalkNode => {
 	return {
 		...root,
 		children: [
-			...root.children,
-			...strayNodes.value.map( ( node ) => ( { ...node, propertyName: caption } ) )
+			...root.children ?? [],
+			...strayNodes.value.map( ( node ) => toTreeItem( node, caption ) )
 		]
 	};
 } );
 
-const treeItem = computed( (): NeoTreeItem<string> => toTreeItem( treeShape.value ) );
-
-function toTreeItem( node: WalkNode ): NeoTreeItem<string> {
+function toTreeItem( node: WalkNode, groupLabel?: string ): NeoTreeItem<string> {
 	return {
 		key: node.key,
 		label: node.label,
-		// Withheld where the name already names the Schema; the walk decides that per node.
-		secondaryLabel: node.schemaLabel ?? undefined,
+		groupLabel,
 		active: node.subjectId === props.activeId,
 		attrs: { 'data-mw-neowiki-subject-id': node.subjectId },
-		children: childItemsOf( node ),
+		children: node.children.map( ( child ) => toTreeItem( child, child.propertyName ) ),
 		data: node.subjectId
 	};
-}
-
-// Each child carries its relation property's name; NeoTree gathers the contiguous run of
-// children sharing one into a single captioned group.
-function childItemsOf( node: WalkNode ): NeoTreeItem<string>[] {
-	return node.children.map( ( child ) => ( { ...toTreeItem( child ), groupLabel: child.propertyName } ) );
 }
 
 function isUnsaved( subjectId: string ): boolean {

--- a/resources/ext.neowiki/src/components/SubjectEditor/SubjectTreeWalk.ts
+++ b/resources/ext.neowiki/src/components/SubjectEditor/SubjectTreeWalk.ts
@@ -6,7 +6,6 @@
 import { relationTargetsOf } from './SubjectTreeModel.ts';
 import type { Subject } from '@/domain/Subject.ts';
 import { subjectDisplayName } from '@/presentation/subjectDisplayName.ts';
-import { schemaNameToShow } from '@/presentation/schemaNameToShow.ts';
 import type { Schema, SchemaName } from '@/domain/Schema.ts';
 
 // Levels of relation targets to walk from the root: person -> birth event -> time span is 2.
@@ -18,8 +17,6 @@ export interface WalkNode {
 	key: string;
 	subjectId: string;
 	label: string;
-	// The Schema label set beside the name, or null where the name already names the Schema.
-	schemaLabel: string | null;
 	// The relation property this node hangs under; the root hangs under none. The children
 	// of one property are contiguous, in the Schema's order.
 	propertyName?: string;
@@ -34,7 +31,6 @@ export function nodeFor( key: string, subjectId: string, subject: Subject | unde
 		key,
 		subjectId,
 		label: subject === undefined ? subjectId : subjectDisplayName( subject ),
-		schemaLabel: subject === undefined ? null : schemaNameToShow( subject ),
 		children: [],
 	};
 }

--- a/resources/ext.neowiki/src/components/common/NeoTree/NeoTree.vue
+++ b/resources/ext.neowiki/src/components/common/NeoTree/NeoTree.vue
@@ -18,13 +18,6 @@
 				:select="selectItem"
 				:keydown="onKeydown"
 			>
-				<template #secondary="slotProps">
-					<slot
-						name="secondary"
-						v-bind="slotProps"
-					/>
-				</template>
-
 				<template #trailing="slotProps">
 					<slot
 						name="trailing"
@@ -55,15 +48,12 @@ const emit = defineEmits<{
 type NodeSlot = ( slotProps: { item: NeoTreeItem<T> } ) => unknown;
 
 defineSlots<{
-	// Replaces a node's plain `secondaryLabel` text, inside the same element, so a consumer
-	// can treat it without the tree knowing what it means.
-	secondary?: NodeSlot;
 	trailing?: NodeSlot;
 }>();
 
 // Printed order, which is both the order Up/Down move through and the order the element ids
-// are numbered in. A top-level item's `groupLabel` has nowhere to print: a caption may not sit
-// inside the tree container itself.
+// are numbered in. A top-level item's `groupLabel` is dropped: the tree renders its items
+// without grouping them, so nothing decides whether that caption takes a line or a row.
 const flatItems = computed( (): NeoTreeItem<T>[] => {
 	const items: NeoTreeItem<T>[] = [];
 
@@ -174,12 +164,19 @@ function onKeydown( event: KeyboardEvent, item: NeoTreeItem<T> ): void {
 		border-inline-start: @border-subtle;
 	}
 
+	/* The line-height is set rather than inherited: left to the skin it is whatever that
+		skin says. */
+	&__edge,
+	&__node-caption {
+		font-size: @font-size-x-small;
+		line-height: @line-height-xx-small;
+		color: @color-subtle;
+	}
+
 	/* The inline padding matches a row's, so a caption starts where the node labels start. */
 	&__edge {
 		display: block;
 		padding: @spacing-30 @spacing-35 @spacing-12;
-		font-size: @font-size-x-small;
-		color: @color-subtle;
 	}
 
 	&__node {
@@ -189,14 +186,19 @@ function onKeydown( event: KeyboardEvent, item: NeoTreeItem<T> ): void {
 		}
 	}
 
-	&__node-name {
+	&__node-name,
+	&__node-line {
 		display: flex;
 		align-items: center;
 		gap: @spacing-25;
+	}
+
+	&__node-name {
 		box-sizing: @box-sizing-base;
 		width: @size-full;
 		min-height: @size-200;
-		padding: 0 @spacing-35;
+		/* The block padding is absorbed by min-height until a row's content takes two lines. */
+		padding: @spacing-12 @spacing-35;
 		background-color: @background-color-transparent;
 		border-radius: @border-radius-base;
 		/* Only the row selects; the rest of the <li> is the subtree, which is not clickable. */
@@ -228,6 +230,7 @@ function onKeydown( event: KeyboardEvent, item: NeoTreeItem<T> ): void {
 		color: @color-emphasized;
 	}
 
+	/* Rows keep a common height, so a name gives way at its end. */
 	&__node-label {
 		min-width: 0;
 		font-weight: @font-weight-bold;
@@ -236,13 +239,33 @@ function onKeydown( event: KeyboardEvent, item: NeoTreeItem<T> ): void {
 		white-space: nowrap;
 	}
 
-	/* Set apart by colour rather than size: the row already sits a step below body text.
-		`min-width: 0` lets it shrink below its content, so a long label gives way to the
-		node's own name instead of squeezing it to nothing. */
-	&__node-secondary {
-		flex: 0 1 auto;
+	/* Never abbreviated, as on its own line it never was: property names are authored on-wiki. */
+	&__node-caption {
 		min-width: 0;
-		color: @color-subtle;
+	}
+
+	/* Transparent until a row folds, where it becomes the one item a wrap may move: otherwise
+		the trailing slot is left on a line of its own once the name has taken one. */
+	&__node-line {
+		display: contents;
+	}
+
+	/* The basis is the name's own `max-content` width, so the line breaks exactly when the
+		caption and the whole name cannot share it. A proportional basis gets both ends wrong. */
+	&__node-name--folded {
+		flex-wrap: wrap;
+		/* The boxes differ in height, so centring them leaves the text off by half of it. */
+		align-items: baseline;
+		align-content: center;
+		gap: 0 @spacing-50;
+	}
+
+	&__node-name--folded > &__node-line {
+		display: flex;
+		align-items: center;
+		gap: @spacing-25;
+		min-width: 0;
+		flex-basis: max-content;
 	}
 }
 </style>

--- a/resources/ext.neowiki/src/components/common/NeoTree/NeoTreeModel.ts
+++ b/resources/ext.neowiki/src/components/common/NeoTree/NeoTreeModel.ts
@@ -3,10 +3,11 @@ export interface NeoTreeItem<T> {
 	// by two paths is two items, and a shared key collapses them into one focus target.
 	key: string;
 	label: string;
-	secondaryLabel?: string;
 	active?: boolean;
-	// Caption printed once above this item and the contiguous siblings sharing it. One caption
-	// repeated after an interruption prints twice, as two groups.
+	// Caption for this item and the contiguous siblings sharing it: printed above them where
+	// there are several, and on the item's own row where it is alone, joining that row's
+	// accessible name. Repeated after an interruption it prints twice, as two groups. Dropped
+	// on a top-level item, which the tree renders without grouping.
 	groupLabel?: string;
 	attrs?: Record<string, string>;
 	children?: NeoTreeItem<T>[];

--- a/resources/ext.neowiki/src/components/common/NeoTree/NeoTreeNode.vue
+++ b/resources/ext.neowiki/src/components/common/NeoTree/NeoTreeNode.vue
@@ -1,5 +1,6 @@
-<!-- A group's caption names the group through `aria-labelledby`, and is `aria-hidden`
-	because only `treeitem` and `group` may be children of a tree. -->
+<!-- A group's caption names the group through `aria-labelledby`, and is `aria-hidden` because
+	only `treeitem` and `group` may be children of a tree. A caption heading a single row is
+	folded onto that row instead, where it names the treeitem directly. -->
 <template>
 	<li
 		:id="elementId"
@@ -18,20 +19,22 @@
 		<span
 			:id="`${ elementId }-name`"
 			class="ext-neowiki-tree__node-name"
+			:class="{ 'ext-neowiki-tree__node-name--folded': folded }"
 			@click.stop="select( item )"
 		>
-			<span class="ext-neowiki-tree__node-label">{{ item.label }}</span>
 			<span
-				v-if="item.secondaryLabel"
-				class="ext-neowiki-tree__node-secondary"
-			><slot
-				name="secondary"
-				:item="item"
-			>{{ item.secondaryLabel }}</slot></span>
-			<slot
-				name="trailing"
-				:item="item"
-			/>
+				v-if="folded"
+				class="ext-neowiki-tree__node-caption"
+			>{{ item.groupLabel }}</span>
+
+			<!-- One flex item, so a wrap cannot leave the trailing slot on a line of its own. -->
+			<span class="ext-neowiki-tree__node-line">
+				<span class="ext-neowiki-tree__node-label">{{ item.label }}</span>
+				<slot
+					name="trailing"
+					:item="item"
+				/>
+			</span>
 		</span>
 
 		<div
@@ -41,7 +44,7 @@
 			role="none"
 		>
 			<span
-				v-if="group.label !== undefined"
+				v-if="group.captionOnItsOwnLine"
 				:id="`${ groupId( index ) }-label`"
 				class="ext-neowiki-tree__edge"
 				aria-hidden="true"
@@ -51,24 +54,18 @@
 				:id="groupId( index )"
 				class="ext-neowiki-tree__group"
 				role="group"
-				:aria-labelledby="group.label === undefined ? undefined : `${ groupId( index ) }-label`"
+				:aria-labelledby="group.captionOnItsOwnLine ? `${ groupId( index ) }-label` : undefined"
 			>
 				<NeoTreeNode
 					v-for="child in group.items"
 					:key="child.key"
 					:item="child"
+					:folded="group.captionOnTheRow"
 					:element-ids="elementIds"
 					:roving-key="rovingKey"
 					:select="select"
 					:keydown="keydown"
 				>
-					<template #secondary="slotProps">
-						<slot
-							name="secondary"
-							v-bind="slotProps"
-						/>
-					</template>
-
 					<template #trailing="slotProps">
 						<slot
 							name="trailing"
@@ -92,6 +89,9 @@ type NodeSlot = ( slotProps: { item: NeoTreeItem<T> } ) => unknown;
 
 const props = defineProps<{
 	item: NeoTreeItem<T>;
+	// Whether this node prints its own `groupLabel` on its row. Only the parent knows, because
+	// it depends on how many siblings share that caption.
+	folded?: boolean;
 	// Minted by the tree over the whole flattened list: a node cannot see its own position in it.
 	elementIds: ReadonlyMap<string, string>;
 	rovingKey: string | null;
@@ -100,7 +100,6 @@ const props = defineProps<{
 }>();
 
 defineSlots<{
-	secondary?: NodeSlot;
 	trailing?: NodeSlot;
 }>();
 
@@ -109,6 +108,11 @@ const elementId = computed( (): string => props.elementIds.get( props.item.key )
 interface RenderGroup {
 	label: string | undefined;
 	items: NeoTreeItem<T>[];
+	// Over several rows a caption is doing a caption's job and keeps its line; over one it is a
+	// line of chrome introducing a line of content, so it moves onto that row. Decided here,
+	// where the run's size is known.
+	captionOnItsOwnLine: boolean;
+	captionOnTheRow: boolean;
 }
 
 // Contiguous children sharing a caption form one group; an unchanged caption continues it,
@@ -124,7 +128,17 @@ const groups = computed( (): RenderGroup[] => {
 			continue;
 		}
 
-		rendered.push( { label: child.groupLabel, items: [ child ] } );
+		rendered.push( {
+			label: child.groupLabel,
+			items: [ child ],
+			captionOnItsOwnLine: false,
+			captionOnTheRow: false
+		} );
+	}
+
+	for ( const group of rendered ) {
+		group.captionOnItsOwnLine = Boolean( group.label ) && group.items.length > 1;
+		group.captionOnTheRow = Boolean( group.label ) && group.items.length === 1;
 	}
 
 	return rendered;

--- a/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditorDialog.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectEditor/SubjectEditorDialog.spec.ts
@@ -1178,9 +1178,12 @@ describe( 'SubjectEditorDialog', () => {
 			return tree.exists() && tree.find( `[data-mw-neowiki-subject-id="${ id }"]` ).exists();
 		}
 
-		function edgeCaptions( wrapper: VueWrapper ): string[] {
+		// A relation is named by a caption line when it heads several rows and by the row itself
+		// when it heads one. Both are collected: these tests are about which relations the
+		// navigator shows, not about where each one is printed.
+		function relationNames( wrapper: VueWrapper ): string[] {
 			return wrapper.findComponent( SubjectTree )
-				.findAll( '.ext-neowiki-tree__edge' )
+				.findAll( '.ext-neowiki-tree__edge, .ext-neowiki-tree__node-caption' )
 				.map( ( caption ) => caption.text() );
 		}
 
@@ -2670,11 +2673,11 @@ describe( 'SubjectEditorDialog', () => {
 					stubs: { teleport: false },
 				} );
 				// The stored root reaches nothing, so the open Subject starts outside the walk.
-				expect( edgeCaptions( wrapper ) ).toEqual( [ 'Not linked here' ] );
+				expect( relationNames( wrapper ) ).toEqual( [ 'Not linked here' ] );
 
 				await setRootFormTargets( wrapper, 's22222222222222' );
 
-				expect( edgeCaptions( wrapper ) ).toEqual( [ 'Colleague' ] );
+				expect( relationNames( wrapper ) ).toEqual( [ 'Colleague' ] );
 				expect( treeHasNode( wrapper, 's22222222222222' ) ).toBe( true );
 
 				await makePaneDirty( wrapper, 1 );

--- a/resources/ext.neowiki/tests/components/SubjectEditor/SubjectTree.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectEditor/SubjectTree.spec.ts
@@ -2,7 +2,6 @@ import { mount, flushPromises, DOMWrapper, VueWrapper } from '@vue/test-utils';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createPinia, setActivePinia, type Pinia } from 'pinia';
 import SubjectTree from '@/components/SubjectEditor/SubjectTree.vue';
-import SchemaNameDisplay from '@/components/common/SchemaNameDisplay.vue';
 import { useSubjectStore } from '@/stores/SubjectStore.ts';
 import { SubjectId } from '@/domain/SubjectId.ts';
 import { createI18nMock, setupMwMock } from '../../VueTestHelpers.ts';
@@ -596,14 +595,24 @@ describe( 'SubjectTree', () => {
 		return node.get( '.ext-neowiki-tree__node-name' );
 	}
 
+	function childClassNames( row: Omit<DOMWrapper<Element>, 'exists'> ): string[] {
+		return [ ...row.element.children ].map( ( child ) => child.className );
+	}
+
+	// A relation is named on its own caption line when it heads several rows and on the row
+	// itself when it heads one. These tests care that it is named, not which of the two.
+	function relationNames( wrapper: VueWrapper ): string[] {
+		return wrapper.findAll( '.ext-neowiki-tree__edge, .ext-neowiki-tree__node-caption' )
+			.map( ( named ) => named.text() );
+	}
+
 	it( 'renders a node per relation target, labelled with the relation property', async () => {
 		// person --Birth event--> birth --Time span--> timespan
 		const wrapper = mountTree();
 		await flushPromises();
 
 		expect( targetNodeLabels( wrapper ) ).toContain( 'Birth of J. S. Bach' );
-		expect( wrapper.findAll( '.ext-neowiki-tree__edge' ).map( ( n ) => n.text() ) )
-			.toContain( 'Birth event' );
+		expect( relationNames( wrapper ) ).toContain( 'Birth event' );
 	} );
 
 	it( 'names a relation once per group, not once per sibling node', async () => {
@@ -616,6 +625,8 @@ describe( 'SubjectTree', () => {
 			.map( ( n ) => n.text() )
 			.filter( ( text ) => text === 'Sibling' );
 		expect( siblingLabels.length ).toBe( 1 );
+		// Named on the caption line or on the rows, never on both.
+		expect( wrapper.findAll( '.ext-neowiki-tree__node-caption' ) ).toHaveLength( 0 );
 	} );
 
 	// A declared relation earns a place in the navigator only once data fills it.
@@ -623,8 +634,7 @@ describe( 'SubjectTree', () => {
 		const wrapper = mountTree();
 		await flushPromises();
 
-		expect( wrapper.findAll( '.ext-neowiki-tree__edge' ).map( ( n ) => n.text() ) )
-			.toEqual( [ 'Spouse', 'Birth event', 'Time span' ] );
+		expect( relationNames( wrapper ) ).toEqual( [ 'Spouse', 'Birth event', 'Time span' ] );
 		expect( targetNodes( wrapper ) ).toHaveLength( 3 );
 	} );
 
@@ -670,9 +680,9 @@ describe( 'SubjectTree', () => {
 		expect( targetNodeLabels( wrapper ) ).not.toContain( SPOUSE_ID );
 	} );
 
-	// A label-less child is shown as "(unnamed Name)", which already carries its Schema, so
-	// printing the Schema beside it would read "(unnamed Name)  Name".
-	it( 'prints the schema of a label-less target only once', async () => {
+	// A label-less child is shown as "(unnamed Name)", the Schema in the name, ahead of which
+	// the row prints the relation that reaches it.
+	it( 'names a label-less target by its relation and its marked name', async () => {
 		const wrapper = mountWithServices(
 			rootSubject,
 			personSchema,
@@ -681,7 +691,7 @@ describe( 'SubjectTree', () => {
 		);
 		await flushPromises();
 
-		expect( nameRow( wrapper.get( `[data-mw-neowiki-subject-id="${ SPOUSE_ID }"]` ) ).text() ).toBe( '(unnamed Name)' );
+		expect( nameRow( wrapper.get( `[data-mw-neowiki-subject-id="${ SPOUSE_ID }"]` ) ).text() ).toBe( 'Spouse(unnamed Name)' );
 	} );
 
 	// The only way back to the root once a relation target is being edited.
@@ -811,41 +821,35 @@ describe( 'SubjectTree', () => {
 		// The tree is eagerly expanded and offers no per-node toggle, so it draws no disclosure
 		// glyph. Asserted as the row's whole content rather than as the absence of one class or
 		// character, so a re-introduced glyph is caught whatever it is made of.
-		it( 'renders nothing in a node\'s row but its name and its schema', async () => {
+		// The root is reached by no relation, so it carries a name and nothing else.
+		it( 'renders nothing in the root\'s row but its name', async () => {
 			const wrapper = mountTree();
 			await flushPromises();
 
-			const rows = wrapper.findAll( '.ext-neowiki-tree__node-name' );
-			expect( rows.length ).toBe( 4 );
+			const root = nameRow( rootTreeNode( wrapper ) );
+
+			expect( childClassNames( root ) ).toEqual( [ 'ext-neowiki-tree__node-line' ] );
+			// Text as well as elements: a bare glyph beside the spans lands here.
+			expect( root.text() ).toBe( 'Johann Sebastian Bach' );
+		} );
+
+		it( 'renders nothing in a child\'s row but its relation and its name', async () => {
+			const wrapper = mountTree();
+			await flushPromises();
+
+			const rows = targetNodes( wrapper ).map( ( node ) => nameRow( node ) );
+			expect( rows.length ).toBe( 3 );
 
 			for ( const row of rows ) {
-				expect( [ ...row.element.children ].map( ( child ) => child.className ) )
-					.toEqual( [ 'ext-neowiki-tree__node-label', 'ext-neowiki-tree__node-secondary' ] );
-				// Text as well as elements: a bare glyph beside the two spans lands here.
+				expect( childClassNames( row ) ).toEqual( [
+					'ext-neowiki-tree__node-caption',
+					'ext-neowiki-tree__node-line',
+				] );
 				expect( row.text() ).toBe(
-					row.get( '.ext-neowiki-tree__node-label' ).text() +
-					row.get( '.ext-neowiki-tree__node-secondary' ).text(),
+					row.get( '.ext-neowiki-tree__node-caption' ).text() +
+					row.get( '.ext-neowiki-tree__node-label' ).text(),
 				);
 			}
-		} );
-
-		it( 'shows a node\'s schema as the shared badge', async () => {
-			const wrapper = mountTree();
-			await flushPromises();
-
-			const badges = wrapper.findAllComponents( SchemaNameDisplay );
-
-			expect( badges.length ).toBe( 4 );
-			expect( badges.map( ( badge ) => badge.props( 'schemaName' ) ) )
-				.toEqual( [ 'Person', 'Name', 'Event', 'TimeSpan' ] );
-		} );
-
-		it( 'leaves the badge unlinked, so it cannot compete with the row it sits in', async () => {
-			const wrapper = mountTree();
-			await flushPromises();
-
-			expect( wrapper.findAll( '.ext-neowiki-tree__node-secondary a' ) ).toHaveLength( 0 );
-			expect( wrapper.findComponent( SchemaNameDisplay ).props( 'link' ) ).toBe( 'none' );
 		} );
 
 		it( 'marks the active node as selected', async () => {
@@ -1068,8 +1072,8 @@ describe( 'SubjectTree', () => {
 			await flushPromises();
 
 			expect( wrapper.findAll( `[data-mw-neowiki-subject-id="${ ROOT_ID }"]` ) ).toHaveLength( 1 );
-			expect( wrapper.findAll( '.ext-neowiki-tree__edge' ).map( ( n ) => n.text() ) )
-				.not.toContain( 'Not linked here' );
+			// A lone stray is named on its row rather than by a caption, so both are checked.
+			expect( relationNames( wrapper ) ).not.toContain( 'Not linked here' );
 		} );
 
 		it( 'emits select for an unreachable subject\'s node', async () => {

--- a/resources/ext.neowiki/tests/components/common/NeoTree/NeoTree.spec.ts
+++ b/resources/ext.neowiki/tests/components/common/NeoTree/NeoTree.spec.ts
@@ -60,6 +60,7 @@ function labelOf( key: string ): string {
 		first: 'First sonata',
 		second: 'Second sonata',
 		allegro: 'Allegro',
+		third: 'Third fugue',
 	};
 	return labels[ key ];
 }
@@ -341,11 +342,41 @@ describe( 'NeoTree', () => {
 			],
 		} ) ];
 
-		it( 'prints a caption once above a contiguous run of siblings sharing it', () => {
+		it( 'prints a caption once above a run of more than one sibling', () => {
 			const wrapper = mountTree( captioned );
 
 			expect( wrapper.findAll( '.ext-neowiki-tree__edge' ).map( ( edge ) => edge.text() ) )
-				.toEqual( [ 'Sonatas', 'Fugues' ] );
+				.toEqual( [ 'Sonatas' ] );
+		} );
+
+		// A caption over a single row is a line of chrome introducing a line of content, so it
+		// moves onto the row it introduces. A caption over several still heads them.
+		it( 'folds a caption heading a single row onto that row', () => {
+			const wrapper = mountTree( captioned );
+
+			expect( row( node( wrapper, 'third' ) ).get( '.ext-neowiki-tree__node-caption' ).text() )
+				.toBe( 'Fugues' );
+			expect( row( node( wrapper, 'first' ) ).find( '.ext-neowiki-tree__node-caption' ).exists() )
+				.toBe( false );
+		} );
+
+		// Folding moves the caption from naming the group to naming the row, which is the more
+		// reliable carrier: a group name is announced on entry and inconsistently across AT.
+		it( 'puts a folded caption inside the name the treeitem takes', () => {
+			const wrapper = mountTree( captioned );
+
+			const treeitem = node( wrapper, 'third' );
+			const named = wrapper.get( `#${ treeitem.attributes( 'aria-labelledby' ) }` );
+			expect( named.text() ).toBe( 'FuguesThird fugue' );
+		} );
+
+		// Otherwise the property is announced twice: once entering the group, once on the row.
+		it( 'leaves a group whose caption folded without a name of its own', () => {
+			const wrapper = mountTree( captioned );
+
+			const groups = wrapper.findAll( '[role="group"]' );
+			expect( groups[ 0 ].attributes( 'aria-labelledby' ) ).toBeDefined();
+			expect( groups[ 1 ].attributes( 'aria-labelledby' ) ).toBeUndefined();
 		} );
 
 		it( 'gathers the siblings sharing a caption into that caption\'s own group', () => {
@@ -375,6 +406,8 @@ describe( 'NeoTree', () => {
 			} ) ] );
 
 			expect( wrapper.findAll( '.ext-neowiki-tree__edge' ) ).toHaveLength( 0 );
+			// Nor folded onto the row, where an empty caption would still indent the name.
+			expect( wrapper.findAll( '.ext-neowiki-tree__node-caption' ) ).toHaveLength( 0 );
 			expect( wrapper.get( '[role="group"]' ).attributes( 'aria-labelledby' ) ).toBeUndefined();
 		} );
 	} );
@@ -391,64 +424,7 @@ describe( 'NeoTree', () => {
 		} );
 	} );
 
-	describe( 'The secondary slot', () => {
-		// Every item carries a secondary label: the slot decorates that label rather than
-		// replacing the decision to show one — see the last test in this block.
-		const labelled: NeoTreeItem<string> = item( 'root', 'Root', {
-			secondaryLabel: 'Person',
-			children: [ item( 'child', 'Child', { groupLabel: 'Born', secondaryLabel: 'Birth' } ) ],
-		} );
-
-		it( 'renders the slot for every item, nested ones included', () => {
-			const wrapper = mountTree( [ labelled ], {
-				slots: { secondary: '<i class="mark">{{ params.item.key }}</i>' },
-			} );
-
-			expect( wrapper.findAll( '.mark' ).map( ( mark ) => mark.text() ) )
-				.toEqual( [ 'root', 'child' ] );
-		} );
-
-		it( 'renders the slot inside the element the plain secondary label would occupy', () => {
-			const wrapper = mountTree(
-				[ item( 'root', 'Root', { secondaryLabel: 'Person' } ) ],
-				{ slots: { secondary: '<i class="mark">badge</i>' } },
-			);
-
-			const secondary = row( node( wrapper, 'root' ) ).get( '.ext-neowiki-tree__node-secondary' );
-
-			// The slot replaces the text rather than joining it, so nothing says "Person" twice.
-			expect( secondary.get( '.mark' ).text() ).toBe( 'badge' );
-			expect( secondary.text() ).toBe( 'badge' );
-		} );
-
-		// Pinning a real limit of the slot rather than an accident: the row shows a secondary
-		// element only when the item has a secondary label, so slot content alone cannot put
-		// one there. A consumer that wants to decorate must still supply the label.
-		it( 'renders nothing for an item with no secondary label, slot or not', () => {
-			const wrapper = mountTree(
-				[ item( 'root', 'Root' ) ],
-				{ slots: { secondary: '<i class="mark">badge</i>' } },
-			);
-
-			expect( wrapper.find( '.mark' ).exists() ).toBe( false );
-		} );
-	} );
-
 	describe( 'Item labels', () => {
-		it( 'prints the secondary label after the label, set apart from it', () => {
-			const wrapper = mountTree( [ item( 'root', 'Root', { secondaryLabel: 'Person' } ) ] );
-
-			expect( row( node( wrapper, 'root' ) ).get( '.ext-neowiki-tree__node-secondary' ).text() )
-				.toBe( 'Person' );
-		} );
-
-		it( 'prints nothing in place of an absent secondary label', () => {
-			const wrapper = mountTree( [ item( 'root', 'Root' ) ] );
-
-			expect( row( node( wrapper, 'root' ) ).find( '.ext-neowiki-tree__node-secondary' ).exists() )
-				.toBe( false );
-		} );
-
 		it( 'marks the active item as selected and highlighted', () => {
 			const wrapper = mountTree();
 


### PR DESCRIPTION
**This narrows the tree half of #1328, which #1345 unified two days ago.** The schema badge leaves the Subject editor's tree navigator entirely, taking `NeoTree`'s `secondaryLabel` and its `secondary` slot, which have no other consumer. Every other surface keeps it, including the pane a row opens.

The tree also printed a caption line above every group of relation targets. In the demo wiki 126 of 135 such groups hold one child, and captions were 37% of all printed lines. A caption heading one row now prints on that row; two or more targets keep the caption line. Where caption and name cannot share a line the row wraps rather than shortening either.

Accepted rather than solved: under ADR 31 a label-less target reads `(unnamed City)` while a labelled sibling under the same relation shows no Schema at all. A row also changes shape as its data changes, since a second target lifts the caption onto a line above and removing one puts it back.

## Manual Browser Check

1. Open `Birth of Johann Sebastian Bach` on the demo wiki and click **Edit** on its infobox. The navigator should print one row per Subject, no caption lines, no schema badges: nine lines become five. The pane on the right still shows the Schema badge.
2. Drag the navigator divider narrow. A row whose caption and name cannot share a line should wrap rather than shorten either; `Took place at Eisenach` stays on one line throughout.
3. Edit a nested Subject so its row shows the unsaved dot, then narrow again; the dot stays beside the name.
4. Open `ACME Inc`, which has two targets under one property: the caption line stays above rows that carry none.
5. Tab in and arrow through the tree: the focus ring sits on the row, which announces its caption, then its name.

> <sub>AI-authored — Claude Code, `Opus 5 (1M context, xhigh)`; opened as a design question from @alistair3149 about which of two labels to drop, settled over four rounds that redirected it three times; then a one-line ask to build it and a further round dropping the badge from the root as well; reviewed by a directed multi-pass review whose confirmed findings were applied, diff not yet human-reviewed; 1956 TS tests, lint and build green locally, browser-verified on a dev wiki, CI green.</sub>
