### PR TITLE
Let approval extensions choose the revision NeoWiki publishes

### DIFF
--- a/docs/extending/extending.md
+++ b/docs/extending/extending.md
@@ -168,9 +168,70 @@ the Page node. No new revision is created. `rebuild()` returns a `PageRefreshOut
 - `SkippedUnreadableSubjects` — the page's subject slot holds content NeoWiki cannot read as Subjects.
 - `SkippedUnreadablePageProperties` — the page's properties could not be built, for instance because a provider or the
   page's own parse threw.
+- `SkippedUnpublishableRevision` — a registered revision policy publishes no revision of the page.
 
 A graph store that fails is logged and skipped, exactly as on a normal page save; only request timeouts and
 wiki-database errors throw.
+
+### Choosing which revision NeoWiki publishes
+
+By default NeoWiki publishes each page's latest revision: that is the revision it projects to the graph stores and
+exports as RDF. An approval extension shows readers an approved revision instead, and registers a `RevisionPolicy` so
+NeoWiki publishes the same one.
+
+```php
+public function onNeoWikiRegistration( NeoWikiRegistrar $registrar ): void {
+	$registrar->setRevisionPolicy( new MyApprovalPolicy( $this->approvalLookup ) );
+}
+```
+
+```php
+class MyApprovalPolicy implements RevisionPolicy {
+
+	public function publishesRevision( RevisionRecord $revision ): bool {
+		return $this->approvalLookup->isApproved( $revision );
+	}
+
+	public function publishedRevision( RevisionRecord $revision ): ?RevisionRecord {
+		return $this->approvalLookup->lastApprovedRevisionOf( $revision->getPage() );
+	}
+
+	public function revisionIsReadableBy( RevisionRecord $revision, Authority $viewer ): bool {
+		return $this->approvalLookup->isApproved( $revision )
+			|| $viewer->isAllowed( 'my-extension-see-drafts' );
+	}
+
+}
+```
+
+`publishesRevision()` is asked as a revision is written; return false and the graph keeps whatever it published
+before. `publishedRevision()` is asked when a page is reprojected; return the argument to leave the projection alone,
+or `null` when the page has nothing publishable. `revisionIsReadableBy()` is asked only when a caller names a revision
+itself, which neither publishing method can intercept — a revision it refuses answers exactly like one that does not
+exist.
+
+- **A policy answers for the wiki, not for a viewer.** The graph and the RDF export are one state every reader sees.
+- **Only one extension can decide this.** A second policy is refused with a warning in the `NeoWiki` log channel; the
+  first one keeps deciding.
+- **Subject writes read the latest revision**, so a contributor still edits what they last saved. Schemas are the
+  exception: a Subject is validated against the Schema revision the policy publishes, while the Schema editor shows
+  the latest one ([#1392](https://github.com/ProfessionalWiki/NeoWiki/issues/1392)).
+
+Call [`newPageRebuilder()->rebuild( $title )`](#refreshing-a-pages-data-without-an-edit) whenever your extension
+changes which revision it approves; nothing else tells NeoWiki the answer has changed. `publishedRevision()` is also
+asked on every Schema, Layout and Mapping read and every RDF export, so keep it cheap.
+
+Two gaps:
+
+- Schemas and Mappings are read through a cache keyed on the page's latest revision id, so an approval change with
+  no accompanying page edit does not take effect until that page is edited or the cache entry expires
+  ([#1392](https://github.com/ProfessionalWiki/NeoWiki/issues/1392)).
+- The RDF export stops answering for a page once approval is withdrawn, but what was published stays in the graph
+  stores until the page is deleted; a rebuild does not remove it
+  ([#1391](https://github.com/ProfessionalWiki/NeoWiki/issues/1391)). Revocation is not a retraction mechanism.
+
+Subject reads over REST, and the parse-time accessors, are not yet covered
+([#1390](https://github.com/ProfessionalWiki/NeoWiki/issues/1390)).
 
 ### Graph Database Backends
 

--- a/maintenance/DumpRdf.php
+++ b/maintenance/DumpRdf.php
@@ -102,7 +102,7 @@ class DumpRdf extends Maintenance {
 		}
 
 		if ( $page === null ) {
-			$this->error( "Skipped page $pageId: it no longer exists or its subject slot does not hold Subject data" );
+			$this->error( "Skipped page $pageId: it no longer exists, its subject slot does not hold Subject data, or the registered revision policy publishes no revision of it" );
 			return false;
 		}
 

--- a/src/Application/FailureIsolatingRevisionPolicy.php
+++ b/src/Application/FailureIsolatingRevisionPolicy.php
@@ -1,0 +1,104 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application;
+
+use MediaWiki\Permissions\Authority;
+use MediaWiki\Revision\RevisionRecord;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Holds a registered policy to what NeoWiki can accept from one, and fails closed when it cannot.
+ *
+ * A policy that throws is treated as publishing nothing and hiding everything: the edit hook it runs
+ * on sits inside PageUpdater's atomic section, so a throw there would roll the contributor's save
+ * back, and a throw on a read would take every Schema, Layout and Mapping read down with it. The other
+ * extension-contributed plugins are wrapped the same way; see FailureIsolatingGraphDatabasePlugin.
+ *
+ * Two answers are refused as well as caught. A revision from another page: every caller keys its write
+ * or its export on the returned revision's page id, so accepting one would publish page B under page
+ * A's name, behind A's read gate. And a revision whose text is suppressed: only the current revision
+ * was ever published before this policy existed, and core refuses to suppress that one, so nothing
+ * read a suppressed revision's Subjects — a policy naming an older one must not start to.
+ */
+class FailureIsolatingRevisionPolicy implements RevisionPolicy {
+
+	public function __construct(
+		private readonly RevisionPolicy $policy,
+		private readonly LoggerInterface $logger,
+	) {
+	}
+
+	public function publishesRevision( RevisionRecord $revision ): bool {
+		if ( $revision->isDeleted( RevisionRecord::DELETED_TEXT ) ) {
+			return false;
+		}
+
+		try {
+			return $this->policy->publishesRevision( $revision );
+		} catch ( Throwable $exception ) {
+			$this->logFailure( 'publishesRevision', $revision, $exception );
+			return false;
+		}
+	}
+
+	public function publishedRevision( RevisionRecord $revision ): ?RevisionRecord {
+		try {
+			$published = $this->policy->publishedRevision( $revision );
+		} catch ( Throwable $exception ) {
+			$this->logFailure( 'publishedRevision', $revision, $exception );
+			return null;
+		}
+
+		if ( $published === null ) {
+			return null;
+		}
+
+		if ( $published->getPageId() !== $revision->getPageId() ) {
+			$this->logger->error(
+				'The revision policy {class} named revision {published} of page {publishedPage} for page {page}; '
+				. 'a policy may only name a revision of the page it was asked about. Publishing nothing for it.',
+				[
+					'class' => $this->policy::class,
+					'published' => $published->getId(),
+					'publishedPage' => $published->getPageId(),
+					'page' => $revision->getPageId(),
+				]
+			);
+			return null;
+		}
+
+		if ( $published->isDeleted( RevisionRecord::DELETED_TEXT ) ) {
+			return null;
+		}
+
+		return $published;
+	}
+
+	public function revisionIsReadableBy( RevisionRecord $revision, Authority $viewer ): bool {
+		try {
+			return $this->policy->revisionIsReadableBy( $revision, $viewer );
+		} catch ( Throwable $exception ) {
+			$this->logFailure( 'revisionIsReadableBy', $revision, $exception );
+			return false;
+		}
+	}
+
+	private function logFailure( string $method, RevisionRecord $revision, Throwable $exception ): void {
+		$this->logger->error(
+			'The revision policy {class} threw from {method} for revision {revision} of page {page}; '
+			. 'treating the page as publishing nothing. {message}',
+			[
+				'class' => $this->policy::class,
+				'method' => $method,
+				'revision' => $revision->getId(),
+				'page' => $revision->getPageId(),
+				'message' => $exception->getMessage(),
+				'exception' => $exception,
+			]
+		);
+	}
+
+}

--- a/src/Application/GraphRebuild/RebuildProgress.php
+++ b/src/Application/GraphRebuild/RebuildProgress.php
@@ -34,8 +34,8 @@ class RebuildProgress {
 	}
 
 	/**
-	 * The page held no Subject to project after all — it has no current revision, or its latest one
-	 * dropped the subject slot. Nothing failed, and nothing was projected.
+	 * The page was not projected, and nothing failed: it has no current revision, its subject slot
+	 * does not hold Subject data, or the registered revision policy publishes no revision of it.
 	 */
 	public function pageSkipped( int $pageId ): void {
 		$this->cursor = $pageId;

--- a/src/Application/NullRevisionPolicy.php
+++ b/src/Application/NullRevisionPolicy.php
@@ -1,0 +1,29 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application;
+
+use MediaWiki\Permissions\Authority;
+use MediaWiki\Revision\RevisionRecord;
+
+/**
+ * Publishes every revision, keeps whichever one the caller resolved, and hides none. This is what runs
+ * when no extension registers a policy, so an installation without an approval extension behaves
+ * exactly as it did before there was a policy at all.
+ */
+class NullRevisionPolicy implements RevisionPolicy {
+
+	public function publishesRevision( RevisionRecord $revision ): bool {
+		return true;
+	}
+
+	public function publishedRevision( RevisionRecord $revision ): ?RevisionRecord {
+		return $revision;
+	}
+
+	public function revisionIsReadableBy( RevisionRecord $revision, Authority $viewer ): bool {
+		return true;
+	}
+
+}

--- a/src/Application/PageRebuilder.php
+++ b/src/Application/PageRebuilder.php
@@ -14,11 +14,20 @@ class PageRebuilder {
 	public function __construct(
 		private readonly OnRevisionCreatedHandler $handler,
 		private readonly WikiPageFactory $wikiPageFactory,
+		private readonly RevisionPolicy $revisionPolicy,
 	) {
 	}
 
+	/**
+	 * Reprojects the page from the revision the registered policy publishes. This is the path an
+	 * approval extension calls when its answer changes. A page save takes the other path: it already
+	 * knows its revision and is only asked whether to publish it.
+	 *
+	 * The handler this hands the substituted revision to must not index, since it would index the
+	 * published revision's Subjects in place of the latest one's. See NeoWikiExtension.
+	 */
 	public function rebuild( Title $title ): PageRefreshOutcome {
-		return $this->rebuildWithReadFlags( $title, IDBAccessObject::READ_NORMAL );
+		return $this->rebuildWithReadFlags( $title, IDBAccessObject::READ_NORMAL, substitute: true );
 	}
 
 	/**
@@ -27,10 +36,10 @@ class PageRebuilder {
 	 * replaced, which would project outdated content.
 	 */
 	public function rebuildFromPrimary( Title $title ): PageRefreshOutcome {
-		return $this->rebuildWithReadFlags( $title, IDBAccessObject::READ_LATEST );
+		return $this->rebuildWithReadFlags( $title, IDBAccessObject::READ_LATEST, substitute: false );
 	}
 
-	private function rebuildWithReadFlags( Title $title, int $readFlags ): PageRefreshOutcome {
+	private function rebuildWithReadFlags( Title $title, int $readFlags, bool $substitute ): PageRefreshOutcome {
 		$wikiPage = $this->wikiPageFactory->newFromTitle( $title );
 		$wikiPage->loadPageData( $readFlags );
 
@@ -38,6 +47,16 @@ class PageRebuilder {
 
 		if ( $revision === null ) {
 			return PageRefreshOutcome::SkippedMissingRevision;
+		}
+
+		if ( $substitute ) {
+			$published = $this->revisionPolicy->publishedRevision( $revision );
+
+			if ( $published === null ) {
+				return PageRefreshOutcome::SkippedUnpublishableRevision;
+			}
+
+			$revision = $published;
 		}
 
 		return $this->handler->onRevisionCreated( $revision );

--- a/src/Application/PageRefreshOutcome.php
+++ b/src/Application/PageRefreshOutcome.php
@@ -15,6 +15,7 @@ enum PageRefreshOutcome: string {
 	case SkippedMissingRevision = 'skippedMissingRevision';
 	case SkippedUnreadableSubjects = 'skippedUnreadableSubjects';
 	case SkippedUnreadablePageProperties = 'skippedUnreadablePageProperties';
+	case SkippedUnpublishableRevision = 'skippedUnpublishableRevision';
 
 	/**
 	 * Why the page was not written, phrased to complete "Skipped <page>: ...".
@@ -26,6 +27,7 @@ enum PageRefreshOutcome: string {
 			self::SkippedMissingRevision => 'no current revision',
 			self::SkippedUnreadableSubjects => 'its subject slot does not hold Subject data',
 			self::SkippedUnreadablePageProperties => 'its page properties could not be built',
+			self::SkippedUnpublishableRevision => 'the registered revision policy does not publish it',
 			self::Refreshed => throw new LogicException( 'Refreshed is not a skip' ),
 		};
 	}

--- a/src/Application/Rdf/RdfPageLoader.php
+++ b/src/Application/Rdf/RdfPageLoader.php
@@ -7,6 +7,7 @@ namespace ProfessionalWiki\NeoWiki\Application\Rdf;
 use MediaWiki\Page\WikiPageFactory;
 use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Title\Title;
+use ProfessionalWiki\NeoWiki\Application\RevisionPolicy;
 use ProfessionalWiki\NeoWiki\Domain\Page\Page;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
@@ -15,20 +16,23 @@ use ProfessionalWiki\NeoWiki\PagePropertiesBuilder;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\MediaWikiSubjectRepository;
 
 /**
- * Loads a {@see Page} domain object from a page's current revision so it can be projected to RDF.
+ * Loads a {@see Page} domain object from the revision the registered revision policy publishes, so it
+ * can be projected to RDF.
  * The revision slot is the source of truth (as in OnRevisionCreatedHandler and the graph rebuild),
  * so the export reflects the stored data rather than the secondary graph projection.
  *
  * Every page is exported, with the Subjects it holds and with none when it holds none, which keeps the
  * RDF surfaces describing the same pages as the graph databases. Returns null when the page does not
- * exist, and for the one page state the write path also refuses to touch: a subject slot holding content
- * that is not Subject data, which the export must not describe as a page without Subjects.
+ * exist, when the policy publishes no revision of it, and for the one page state the write path also
+ * refuses to touch: a subject slot holding content that is not Subject data, which the export must not
+ * describe as a page without Subjects.
  */
 class RdfPageLoader {
 
 	public function __construct(
 		private readonly WikiPageFactory $wikiPageFactory,
 		private readonly PagePropertiesBuilder $pagePropertiesBuilder,
+		private readonly RevisionPolicy $revisionPolicy,
 	) {
 	}
 
@@ -49,7 +53,9 @@ class RdfPageLoader {
 			return null;
 		}
 
-		return $this->buildPage( $revision );
+		$published = $this->revisionPolicy->publishedRevision( $revision );
+
+		return $published === null ? null : $this->buildPage( $published );
 	}
 
 	private function buildPage( RevisionRecord $revision ): ?Page {

--- a/src/Application/RevisionPolicy.php
+++ b/src/Application/RevisionPolicy.php
@@ -1,0 +1,51 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application;
+
+use MediaWiki\Permissions\Authority;
+use MediaWiki\Revision\RevisionRecord;
+
+/**
+ * Which revision of a page NeoWiki publishes: projects to the graph stores, exports as RDF, and reads
+ * Schemas, Layouts, Mappings and the on-wiki configuration from. Registered by an approval extension
+ * such as ContentStabilization, which shows readers an approved revision rather than the newest one.
+ * With no policy registered every page publishes its latest revision, as NeoWiki has always done.
+ *
+ * A page save knows its revision and only needs to be told whether to publish it. A reprojection, a
+ * configuration read and an RDF export are told nothing beyond the page, so they ask which revision
+ * to publish. publishedRevision() therefore runs on every Schema, Layout and Mapping read and every
+ * RDF export, not only on a rebuild, and an implementation must be cheap enough for that.
+ *
+ * The answers must agree: publishesRevision() is true for whatever publishedRevision() names, since a
+ * reprojection hands the named revision back to the save path's check.
+ *
+ * A policy answers for the wiki, not for a viewer: the graph and the RDF export are one state that
+ * every reader sees. Only revisionIsReadableBy(), which serves a single request, takes a viewer.
+ *
+ * The subject-to-page index is deliberately not governed by any of this. It records where a Subject
+ * lives, not whether it is published, and every read of it is re-checked against the revision the
+ * caller actually reads ([[ADR 32]]).
+ */
+interface RevisionPolicy {
+
+	/**
+	 * Whether this revision may be published, asked as it is written. False leaves the graph holding
+	 * whatever it published before, which for an approval extension is the last approved revision.
+	 */
+	public function publishesRevision( RevisionRecord $revision ): bool;
+
+	/**
+	 * The revision to publish for this revision's page, asked when a page is reprojected rather than
+	 * written. Null when the page has nothing publishable. Return the argument to leave it alone.
+	 */
+	public function publishedRevision( RevisionRecord $revision ): ?RevisionRecord;
+
+	/**
+	 * Whether the viewer may read a revision they asked for by id. Neither publishing method can
+	 * answer this: naming a revision bypasses both.
+	 */
+	public function revisionIsReadableBy( RevisionRecord $revision, Authority $viewer ): bool;
+
+}

--- a/src/Application/RevisionPolicyRegistry.php
+++ b/src/Application/RevisionPolicyRegistry.php
@@ -1,0 +1,45 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Application;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * The one revision policy an extension may contribute. Unlike the other extension points this holds a
+ * single entry rather than a list: two policies cannot both decide which revision a page publishes,
+ * and composing their answers would mean inventing a precedence nobody asked for.
+ *
+ * A second registration is refused with a warning, the way a graph database plugin repeating a name
+ * is: keeping the first leaves the wiki publishing what it was already publishing, where dropping it
+ * would silently hand the decision to whichever extension happened to load last.
+ */
+class RevisionPolicyRegistry {
+
+	private ?RevisionPolicy $policy = null;
+
+	public function __construct(
+		private readonly LoggerInterface $logger = new NullLogger(),
+	) {
+	}
+
+	public function setPolicy( RevisionPolicy $policy ): void {
+		if ( $this->policy !== null ) {
+			$this->logger->warning(
+				'Ignoring the revision policy registered by {class}: a policy is already registered, '
+				. 'and only one extension can decide which revision a page publishes.',
+				[ 'class' => $policy::class ]
+			);
+			return;
+		}
+
+		$this->policy = $policy;
+	}
+
+	public function getPolicy(): RevisionPolicy {
+		return $this->policy ?? new NullRevisionPolicy();
+	}
+
+}

--- a/src/EntryPoints/NeoWikiRegistrar.php
+++ b/src/EntryPoints/NeoWikiRegistrar.php
@@ -4,6 +4,8 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\NeoWiki\EntryPoints;
 
+use ProfessionalWiki\NeoWiki\Application\RevisionPolicy;
+use ProfessionalWiki\NeoWiki\Application\RevisionPolicyRegistry;
 use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNoticeProvider;
 use ProfessionalWiki\NeoWiki\Domain\EditNotice\SubjectEditNoticeProviderRegistry;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphDatabasePlugin;
@@ -26,6 +28,7 @@ readonly class NeoWikiRegistrar {
 		private GraphDatabasePluginRegistry $graphDatabasePluginRegistry,
 		private RdfValueMapperRegistry $rdfValueMapperRegistry,
 		private SubjectEditNoticeProviderRegistry $subjectEditNoticeProviderRegistry,
+		private RevisionPolicyRegistry $revisionPolicyRegistry,
 	) {
 	}
 
@@ -56,6 +59,18 @@ readonly class NeoWikiRegistrar {
 	 */
 	public function addSubjectEditNoticeProvider( SubjectEditNoticeProvider $provider ): void {
 		$this->subjectEditNoticeProviderRegistry->addProvider( $provider );
+	}
+
+	/**
+	 * Registers which revision of a page NeoWiki publishes: projects to the graph stores and exports
+	 * as RDF. For approval extensions, which show readers an approved revision rather than the newest
+	 * one.
+	 *
+	 * Only one extension can decide this, so unlike the other registrations this is a single slot: a
+	 * second policy is refused with a warning and the first one keeps deciding.
+	 */
+	public function setRevisionPolicy( RevisionPolicy $policy ): void {
+		$this->revisionPolicyRegistry->setPolicy( $policy );
 	}
 
 	public function addPagePropertyProvider( PagePropertyProvider $provider ): void {

--- a/src/EntryPoints/OnRevisionCreatedHandler.php
+++ b/src/EntryPoints/OnRevisionCreatedHandler.php
@@ -6,6 +6,7 @@ namespace ProfessionalWiki\NeoWiki\EntryPoints;
 
 use MediaWiki\Revision\RevisionRecord;
 use ProfessionalWiki\NeoWiki\Application\PageRefreshOutcome;
+use ProfessionalWiki\NeoWiki\Application\RevisionPolicy;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphDatabasePlugin;
 use ProfessionalWiki\NeoWiki\Domain\Page\Page;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
@@ -23,6 +24,7 @@ class OnRevisionCreatedHandler {
 		private readonly GraphDatabasePlugin $graphDatabasePlugin,
 		private readonly SubjectPageIndex $subjectPageIndex,
 		private readonly PagePropertiesSource $pagePropertiesSource,
+		private readonly RevisionPolicy $revisionPolicy,
 		private readonly LoggerInterface $logger,
 	) {
 	}
@@ -30,6 +32,11 @@ class OnRevisionCreatedHandler {
 	/**
 	 * Indexes which Subjects the page holds, and projects the page with them — and with none when it
 	 * holds none: every page gets a Page node, so its Page Properties are queryable.
+	 *
+	 * The index records where a Subject lives and is written for every revision, published or not:
+	 * every id-keyed read and write addresses its page through it, so a Subject missing from it cannot
+	 * be edited, moved or deleted, and its id reads as free. Publishing is decided separately, and only
+	 * for the graph, which is the surface readers query.
 	 */
 	public function onRevisionCreated( RevisionRecord $revisionRecord ): PageRefreshOutcome {
 		if ( $revisionRecord->getPageId() === 0 ) {
@@ -66,6 +73,13 @@ class OnRevisionCreatedHandler {
 		// isolation: the index is authoritative (ADR 32), so it commits with the revision that changes
 		// it or not at all, and a Subject too broken to deserialize is still indexed.
 		$this->subjectPageIndex->setSubjectsOfPage( $pageId, $content?->getSubjectIds() ?? [] );
+
+		// Indexed either way, projected only when published: what the graph already holds is what the
+		// policy last published, and leaving it there is the point. Withdrawing it belongs to page
+		// deletion, not to somebody saving a draft on a page that has nothing published yet.
+		if ( !$this->revisionPolicy->publishesRevision( $revisionRecord ) ) {
+			return PageRefreshOutcome::SkippedUnpublishableRevision;
+		}
 
 		$subjects = $content?->getPageSubjects() ?? PageSubjects::newEmpty();
 

--- a/src/EntryPoints/REST/GetSubjectApi.php
+++ b/src/EntryPoints/REST/GetSubjectApi.php
@@ -49,16 +49,27 @@ class GetSubjectApi extends SimpleHandler {
 
 		$revision = MediaWikiServices::getInstance()->getRevisionLookup()->getRevisionById( $revisionId );
 
-		// A revision on an unreadable page answers exactly like a nonexistent revision:
-		// revision ids are sequential, so any distinguishable answer is a sweepable
-		// existence oracle over restricted pages (#1046).
-		if ( $revision === null || !$this->revisionPageIsReadable( $revision->getPageId() ) ) {
+		// A revision the viewer may not see answers exactly like a nonexistent one: revision ids are
+		// sequential, so any distinguishable answer is a sweepable existence oracle over restricted
+		// pages (#1046), and over the unapproved revisions an approval extension hides.
+		if ( $revision === null || !$this->revisionIsReadable( $revision ) ) {
 			return $this->getResponseFactory()->createHttpError( 404, [
 				'message' => 'Revision not found: ' . $revisionId,
 			] );
 		}
 
 		return NeoWikiExtension::getInstance()->newGetSubjectQueryForRevision( $presenter, $revision, $this->getAuthority() );
+	}
+
+	/**
+	 * A caller who names a revision is asking to see that one, so the registered revision policy is
+	 * asked directly whether this viewer may. Without one registered every revision of a readable page
+	 * is readable, as before.
+	 */
+	private function revisionIsReadable( RevisionRecord $revision ): bool {
+		return $this->revisionPageIsReadable( $revision->getPageId() )
+			&& NeoWikiExtension::getInstance()->getRevisionPolicy()
+				->revisionIsReadableBy( $revision, $this->getAuthority() );
 	}
 
 	private function revisionPageIsReadable( int $pageId ): bool {

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -83,6 +83,9 @@ use ProfessionalWiki\NeoWiki\Application\PageReadAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\SubjectWriteAuthorizer;
 use ProfessionalWiki\NeoWiki\Application\LastEditorPagesRebuilder;
 use ProfessionalWiki\NeoWiki\Application\PageRebuilder;
+use ProfessionalWiki\NeoWiki\Application\FailureIsolatingRevisionPolicy;
+use ProfessionalWiki\NeoWiki\Application\RevisionPolicy;
+use ProfessionalWiki\NeoWiki\Application\RevisionPolicyRegistry;
 use ProfessionalWiki\NeoWiki\Application\SubjectIdMinter;
 use ProfessionalWiki\NeoWiki\Application\SubjectRepository;
 use ProfessionalWiki\NeoWiki\Application\SubjectResolver;
@@ -225,6 +228,7 @@ class NeoWikiExtension {
 	private CompositeGraphDatabasePlugin $graphDatabasePlugin;
 	private CompositeGraphDatabasePlugin $isolatingGraphDatabasePlugin;
 	private GraphDatabasePluginRegistry $graphDatabasePluginRegistry;
+	private RevisionPolicyRegistry $revisionPolicyRegistry;
 	private ?Neo4jPlugin $neo4jPlugin = null;
 	/** @var array<string, SparqlPlugin>|null Keys are store names */
 	private ?array $sparqlPlugins = null;
@@ -305,6 +309,23 @@ class NeoWikiExtension {
 		return $this->rdfValueMapperRegistry;
 	}
 
+	public function getRevisionPolicyRegistry(): RevisionPolicyRegistry {
+		if ( !isset( $this->revisionPolicyRegistry ) ) {
+			$this->revisionPolicyRegistry = new RevisionPolicyRegistry( LoggerFactory::getInstance( 'NeoWiki' ) );
+		}
+
+		$this->ensureExtensionsRegistered();
+
+		return $this->revisionPolicyRegistry;
+	}
+
+	public function getRevisionPolicy(): RevisionPolicy {
+		return new FailureIsolatingRevisionPolicy(
+			$this->getRevisionPolicyRegistry()->getPolicy(),
+			LoggerFactory::getInstance( 'NeoWiki' )
+		);
+	}
+
 	private function ensureExtensionsRegistered(): void {
 		if ( $this->extensionsRegistered ) {
 			return;
@@ -321,6 +342,7 @@ class NeoWikiExtension {
 				$this->getGraphDatabasePluginRegistry(),
 				$this->getRdfValueMapperRegistry(),
 				$this->getSubjectEditNoticeProviderRegistry(),
+				$this->getRevisionPolicyRegistry(),
 			) ]
 		);
 	}
@@ -390,6 +412,11 @@ class NeoWikiExtension {
 	 * on.
 	 */
 	private function newRebuildStoreContentHandler(): OnRevisionCreatedHandler {
+		// The null index is load-bearing, not merely unneeded: PageRebuilder::rebuild() hands this handler
+		// the revision the policy publishes, and the handler indexes whatever it is given. A real index
+		// here would replace the latest revision's Subject set with the published one, making every
+		// Subject a draft added unaddressable — the exact failure keeping the index out of the policy
+		// exists to prevent. Only rebuildFromPrimary(), which does not substitute, may index.
 		return $this->newStoreContentHandler(
 			$this->getGraphDatabasePlugin(),
 			new NullSubjectPageIndex(),
@@ -406,6 +433,7 @@ class NeoWikiExtension {
 			$graphDatabasePlugin,
 			$subjectPageIndex,
 			$pagePropertiesSource,
+			$this->getRevisionPolicy(),
 			LoggerFactory::getInstance( 'NeoWiki' ),
 		);
 	}
@@ -446,6 +474,7 @@ class NeoWikiExtension {
 		return new RdfPageLoader(
 			MediaWikiServices::getInstance()->getWikiPageFactory(),
 			$this->getPagePropertiesBuilder(),
+			$this->getRevisionPolicy(),
 		);
 	}
 
@@ -982,7 +1011,8 @@ class NeoWikiExtension {
 	public function getPageContentFetcher(): PageContentFetcher {
 		return new PageContentFetcher(
 			MediaWikiServices::getInstance()->getTitleParser(),
-			MediaWikiServices::getInstance()->getRevisionLookup()
+			MediaWikiServices::getInstance()->getRevisionLookup(),
+			$this->getRevisionPolicy()
 		);
 	}
 
@@ -1084,7 +1114,8 @@ class NeoWikiExtension {
 	private function newPageRebuilderWith( OnRevisionCreatedHandler $handler ): PageRebuilder {
 		return new PageRebuilder(
 			$handler,
-			MediaWikiServices::getInstance()->getWikiPageFactory()
+			MediaWikiServices::getInstance()->getWikiPageFactory(),
+			$this->getRevisionPolicy()
 		);
 	}
 

--- a/src/Persistence/MediaWiki/PageContentFetcher.php
+++ b/src/Persistence/MediaWiki/PageContentFetcher.php
@@ -14,12 +14,23 @@ use MediaWiki\Title\MalformedTitleException;
 use MediaWiki\Title\Title;
 use MediaWiki\Title\TitleParser;
 use MediaWiki\Title\TitleValue;
+use ProfessionalWiki\NeoWiki\Application\RevisionPolicy;
 
+/**
+ * The content a page publishes, which is its latest revision unless a registered revision policy
+ * substitutes another. Everything read through here is configuration the whole wiki reads — Schemas,
+ * Layouts, Mappings and the on-wiki configuration page — so on a wiki running an approval extension
+ * an unapproved edit to one does not take effect until it is approved.
+ *
+ * Editing surfaces do not read through here: the Schema editor loads the page source from core's own
+ * REST endpoint, so it still shows and saves over the latest revision.
+ */
 class PageContentFetcher {
 
 	public function __construct(
 		private readonly TitleParser $titleParser,
-		private readonly RevisionLookup $revisionLookup
+		private readonly RevisionLookup $revisionLookup,
+		private readonly RevisionPolicy $revisionPolicy
 	) {
 	}
 
@@ -36,6 +47,7 @@ class PageContentFetcher {
 		}
 
 		$revision = $this->revisionLookup->getRevisionByTitle( Title::newFromLinkTarget( $titleValue ) );
+		$revision = $revision === null ? null : $this->revisionPolicy->publishedRevision( $revision );
 
 		try {
 			return $revision?->getContent( $slotName, RevisionRecord::FOR_THIS_USER, $authority );

--- a/tests/phpunit/Application/FailureIsolatingRevisionPolicyTest.php
+++ b/tests/phpunit/Application/FailureIsolatingRevisionPolicyTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Application;
+
+use MediaWiki\Permissions\Authority;
+use MediaWiki\Revision\RevisionRecord;
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\FailureIsolatingRevisionPolicy;
+use ProfessionalWiki\NeoWiki\Application\NullRevisionPolicy;
+use ProfessionalWiki\NeoWiki\Application\RevisionPolicy;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\FixedRevisionPolicy;
+use Psr\Log\NullLogger;
+use Psr\Log\Test\TestLogger;
+use RuntimeException;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Application\FailureIsolatingRevisionPolicy
+ */
+class FailureIsolatingRevisionPolicyTest extends TestCase {
+
+	private const int PAGE_ID = 7;
+	private const int OTHER_PAGE_ID = 8;
+
+	public function testPassesThePolicysAnswersThrough(): void {
+		$revision = $this->newRevision( pageId: self::PAGE_ID, id: 10 );
+		$published = $this->newRevision( pageId: self::PAGE_ID, id: 9 );
+		$policy = $this->isolate( FixedRevisionPolicy::publishing( $published ) );
+
+		$this->assertTrue( $policy->publishesRevision( $revision ) );
+		$this->assertSame( $published, $policy->publishedRevision( $revision ) );
+		$this->assertTrue( $policy->revisionIsReadableBy( $revision, $this->createStub( Authority::class ) ) );
+	}
+
+	public function testAThrowingPolicyPublishesNothing(): void {
+		$policy = $this->isolate( $this->newThrowingPolicy() );
+		$revision = $this->newRevision( pageId: self::PAGE_ID, id: 10 );
+
+		$this->assertFalse( $policy->publishesRevision( $revision ) );
+		$this->assertNull( $policy->publishedRevision( $revision ) );
+	}
+
+	public function testAThrowingPolicyHidesEveryRevision(): void {
+		$policy = $this->isolate( $this->newThrowingPolicy() );
+
+		$this->assertFalse( $policy->revisionIsReadableBy(
+			$this->newRevision( pageId: self::PAGE_ID, id: 10 ),
+			$this->createStub( Authority::class )
+		) );
+	}
+
+	public function testAThrowingPolicyIsLogged(): void {
+		$logger = new TestLogger();
+
+		( new FailureIsolatingRevisionPolicy( $this->newThrowingPolicy(), $logger ) )
+			->publishesRevision( $this->newRevision( pageId: self::PAGE_ID, id: 10 ) );
+
+		$this->assertTrue( $logger->hasErrorRecords() );
+	}
+
+	public function testARevisionOfAnotherPageIsRefused(): void {
+		$logger = new TestLogger();
+		$policy = new FailureIsolatingRevisionPolicy(
+			$this->newPolicyNaming( $this->newRevision( pageId: self::OTHER_PAGE_ID, id: 9 ) ),
+			$logger
+		);
+
+		$published = $policy->publishedRevision( $this->newRevision( pageId: self::PAGE_ID, id: 10 ) );
+
+		$this->assertNull( $published );
+		$this->assertTrue( $logger->hasErrorRecords(), 'a contract violation is logged' );
+	}
+
+	public function testASuppressedRevisionIsNeverPublished(): void {
+		$suppressed = $this->newRevision( pageId: self::PAGE_ID, id: 9, textSuppressed: true );
+		$policy = $this->isolate( FixedRevisionPolicy::publishing( $suppressed ) );
+
+		$this->assertNull( $policy->publishedRevision( $this->newRevision( pageId: self::PAGE_ID, id: 10 ) ) );
+		$this->assertFalse( $policy->publishesRevision( $suppressed ) );
+	}
+
+	public function testANullAnswerStaysNull(): void {
+		$policy = $this->isolate( FixedRevisionPolicy::publishingNothing() );
+
+		$this->assertNull( $policy->publishedRevision( $this->newRevision( pageId: self::PAGE_ID, id: 10 ) ) );
+	}
+
+	private function isolate( RevisionPolicy $policy ): FailureIsolatingRevisionPolicy {
+		return new FailureIsolatingRevisionPolicy( $policy, new NullLogger() );
+	}
+
+	/**
+	 * A policy that breaks the contract by naming the same revision for every page it is asked about.
+	 * FixedRevisionPolicy answers per page, as a real extension does, so it cannot stand in here.
+	 */
+	private function newPolicyNaming( RevisionRecord $published ): RevisionPolicy {
+		return new class( $published ) extends NullRevisionPolicy {
+			public function __construct( private readonly RevisionRecord $published ) {
+			}
+
+			public function publishedRevision( RevisionRecord $revision ): ?RevisionRecord {
+				return $this->published;
+			}
+		};
+	}
+
+	private function newThrowingPolicy(): RevisionPolicy {
+		return new class extends NullRevisionPolicy {
+			public function publishesRevision( RevisionRecord $revision ): bool {
+				throw new RuntimeException( 'approval table missing' );
+			}
+
+			public function publishedRevision( RevisionRecord $revision ): ?RevisionRecord {
+				throw new RuntimeException( 'approval table missing' );
+			}
+
+			public function revisionIsReadableBy( RevisionRecord $revision, Authority $viewer ): bool {
+				throw new RuntimeException( 'approval table missing' );
+			}
+		};
+	}
+
+	private function newRevision( int $pageId, int $id, bool $textSuppressed = false ): RevisionRecord {
+		$revision = $this->createStub( RevisionRecord::class );
+		$revision->method( 'getPageId' )->willReturn( $pageId );
+		$revision->method( 'getId' )->willReturn( $id );
+		$revision->method( 'isDeleted' )->willReturnCallback(
+			static fn ( int $field ): bool => $textSuppressed && ( $field & RevisionRecord::DELETED_TEXT ) !== 0
+		);
+
+		return $revision;
+	}
+
+}

--- a/tests/phpunit/Application/PageRebuilderTest.php
+++ b/tests/phpunit/Application/PageRebuilderTest.php
@@ -10,7 +10,10 @@ use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Title\Title;
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Application\PageRefreshOutcome;
+use ProfessionalWiki\NeoWiki\Application\NullRevisionPolicy;
+use ProfessionalWiki\NeoWiki\Application\RevisionPolicy;
 use ProfessionalWiki\NeoWiki\Application\PageRebuilder;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\FixedRevisionPolicy;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpyOnRevisionCreatedHandler;
 use Wikimedia\Rdbms\IDBAccessObject;
 use WikiPage;
@@ -111,7 +114,38 @@ class PageRebuilderTest extends TestCase {
 		);
 	}
 
-	private function newRebuilder( ?RevisionRecord $revision ): PageRebuilder {
+	public function testRebuildProjectsTheRevisionThePolicyPublishes(): void {
+		$latest = $this->newRevision();
+		$published = $this->newRevision();
+
+		$this->newRebuilder( $latest, FixedRevisionPolicy::publishing( $published ) )
+			->rebuild( Title::makeTitle( NS_MAIN, 'Reprojected page' ) );
+
+		$this->assertSame( [ $published ], $this->handler->calls );
+	}
+
+	public function testRebuildWritesNothingWhenThePolicyPublishesNoRevision(): void {
+		$outcome = $this->newRebuilder( $this->newRevision(), FixedRevisionPolicy::publishingNothing() )
+			->rebuild( Title::makeTitle( NS_MAIN, 'Page with nothing published' ) );
+
+		$this->assertSame( PageRefreshOutcome::SkippedUnpublishableRevision, $outcome );
+		$this->assertSame( [], $this->handler->calls );
+	}
+
+	/**
+	 * An import or undelete writes a revision rather than reprojecting a page, so it takes the same
+	 * path a save does: the handler is handed what was written and decides whether to publish it.
+	 */
+	public function testRebuildFromPrimaryDoesNotSubstitute(): void {
+		$written = $this->newRevision();
+
+		$this->newRebuilder( $written, FixedRevisionPolicy::publishing( $this->newRevision() ) )
+			->rebuildFromPrimary( Title::makeTitle( NS_MAIN, 'Imported page' ) );
+
+		$this->assertSame( [ $written ], $this->handler->calls );
+	}
+
+	private function newRebuilder( ?RevisionRecord $revision, ?RevisionPolicy $policy = null ): PageRebuilder {
 		$page = $this->createStub( WikiPage::class );
 		$page->method( 'getRevisionRecord' )->willReturn( $revision );
 		$page->method( 'loadPageData' )->willReturnCallback(
@@ -123,7 +157,7 @@ class PageRebuilderTest extends TestCase {
 		$factory = $this->createStub( WikiPageFactory::class );
 		$factory->method( 'newFromTitle' )->willReturn( $page );
 
-		return new PageRebuilder( $this->handler, $factory );
+		return new PageRebuilder( $this->handler, $factory, $policy ?? new NullRevisionPolicy() );
 	}
 
 	private function newRevision(): RevisionRecord {

--- a/tests/phpunit/Application/PageRefreshWithoutEditTest.php
+++ b/tests/phpunit/Application/PageRefreshWithoutEditTest.php
@@ -9,6 +9,7 @@ use ProfessionalWiki\NeoWiki\Application\PageRefreshOutcome;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\FixedRevisionPolicy;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\MutablePagePropertyProvider;
 
 /**
@@ -53,6 +54,45 @@ class PageRefreshWithoutEditTest extends NeoWikiIntegrationTestCase {
 		$this->assertSame( 'approved', $this->readApprovalState( $pageId ) );
 	}
 
+	/**
+	 * Through NeoWikiExtension's own wiring, not a hand-built handler: the registered policy has to reach
+	 * both PageRebuilder and the handler behind it, or a rebuild after approval would project the draft.
+	 */
+	public function testRefreshProjectsTheRevisionTheRegisteredPolicyPublishes(): void {
+		$approved = $this->createPageWithSubjects( self::PAGE_NAME, TestSubject::build() );
+		$afterFirstSave = $this->readGraph( 'MATCH (s:Subject) RETURN count(s) AS n', [] )->first()->toRecursiveArray()['n'];
+		$this->createPageWithSubjects( self::PAGE_NAME );
+		$afterDraft = $this->readGraph( 'MATCH (s:Subject) RETURN count(s) AS n', [] )->first()->toRecursiveArray()['n'];
+		$this->registerRevisionPolicy( FixedRevisionPolicy::publishing( $approved ) );
+		$contentHasSubjects = $approved->getSlots()->getContent( 'neo' )->getPageSubjects()->hasSubjects();
+		fwrite( STDERR, "\nDEBUG2 afterFirstSave=$afterFirstSave afterDraft=$afterDraft approvedContentHasSubjects=" . var_export( $contentHasSubjects, true ) . "\n" );
+
+		$outcome = $this->refreshPage();
+
+		$this->assertSame( PageRefreshOutcome::Refreshed, $outcome );
+		// DEBUG
+		$dump = $this->readGraph(
+			'MATCH (page:Page {id: $pageId}) OPTIONAL MATCH (page)-[r]->(n) RETURN page.id AS id, page.wiki_id AS wiki, collect(type(r)) AS rels, collect(labels(n)) AS targets',
+			[ 'pageId' => $approved->getPageId() ]
+		);
+		$all = $this->readGraph( 'MATCH (s:Subject) RETURN s.id AS id, labels(s) AS labels', [] );
+		fwrite( STDERR, "\nDEBUG approvedRev=" . $approved->getId() . " page=" . $approved->getPageId()
+			. " hasSlot=" . var_export( $approved->hasSlot( 'neo' ), true )
+			. " dump=" . json_encode( $dump->first()?->toRecursiveArray() )
+			. " subjects=" . json_encode( array_map( static fn ( $r ) => $r->toRecursiveArray(), iterator_to_array( $all ) ) ) . "\n" );
+		$this->assertTrue(
+			$this->pageHoldsSubjectInGraph( $approved->getPageId() ),
+			'the approved revision holds a Subject the draft removed'
+		);
+	}
+
+	public function testRefreshWritesNothingWhenTheRegisteredPolicyPublishesNoRevision(): void {
+		$this->createPageWithSubjects( self::PAGE_NAME, TestSubject::build() );
+		$this->registerRevisionPolicy( FixedRevisionPolicy::publishingNothing() );
+
+		$this->assertSame( PageRefreshOutcome::SkippedUnpublishableRevision, $this->refreshPage() );
+	}
+
 	public function testRefreshOfAMissingPageWritesNothing(): void {
 		$outcome = $this->refreshPage();
 
@@ -63,6 +103,15 @@ class PageRefreshWithoutEditTest extends NeoWikiIntegrationTestCase {
 		return NeoWikiExtension::getInstance()
 			->newPageRebuilder()
 			->rebuild( Title::newFromText( self::PAGE_NAME ) );
+	}
+
+	private function pageHoldsSubjectInGraph( int $pageId ): bool {
+		$result = $this->readGraph(
+			'MATCH (page:Page {id: $pageId})-[:HasSubject]->(subject:Subject) RETURN count(subject) AS subjects',
+			[ 'pageId' => $pageId ]
+		);
+
+		return ( $result->first()->toRecursiveArray()['subjects'] ?? 0 ) > 0;
 	}
 
 	private function readApprovalState( int $pageId ): ?string {

--- a/tests/phpunit/Application/PageRefreshWithoutEditTest.php
+++ b/tests/phpunit/Application/PageRefreshWithoutEditTest.php
@@ -60,26 +60,12 @@ class PageRefreshWithoutEditTest extends NeoWikiIntegrationTestCase {
 	 */
 	public function testRefreshProjectsTheRevisionTheRegisteredPolicyPublishes(): void {
 		$approved = $this->createPageWithSubjects( self::PAGE_NAME, TestSubject::build() );
-		$afterFirstSave = $this->readGraph( 'MATCH (s:Subject) RETURN count(s) AS n', [] )->first()->toRecursiveArray()['n'];
 		$this->createPageWithSubjects( self::PAGE_NAME );
-		$afterDraft = $this->readGraph( 'MATCH (s:Subject) RETURN count(s) AS n', [] )->first()->toRecursiveArray()['n'];
 		$this->registerRevisionPolicy( FixedRevisionPolicy::publishing( $approved ) );
-		$contentHasSubjects = $approved->getSlots()->getContent( 'neo' )->getPageSubjects()->hasSubjects();
-		fwrite( STDERR, "\nDEBUG2 afterFirstSave=$afterFirstSave afterDraft=$afterDraft approvedContentHasSubjects=" . var_export( $contentHasSubjects, true ) . "\n" );
 
 		$outcome = $this->refreshPage();
 
 		$this->assertSame( PageRefreshOutcome::Refreshed, $outcome );
-		// DEBUG
-		$dump = $this->readGraph(
-			'MATCH (page:Page {id: $pageId}) OPTIONAL MATCH (page)-[r]->(n) RETURN page.id AS id, page.wiki_id AS wiki, collect(type(r)) AS rels, collect(labels(n)) AS targets',
-			[ 'pageId' => $approved->getPageId() ]
-		);
-		$all = $this->readGraph( 'MATCH (s:Subject) RETURN s.id AS id, labels(s) AS labels', [] );
-		fwrite( STDERR, "\nDEBUG approvedRev=" . $approved->getId() . " page=" . $approved->getPageId()
-			. " hasSlot=" . var_export( $approved->hasSlot( 'neo' ), true )
-			. " dump=" . json_encode( $dump->first()?->toRecursiveArray() )
-			. " subjects=" . json_encode( array_map( static fn ( $r ) => $r->toRecursiveArray(), iterator_to_array( $all ) ) ) . "\n" );
 		$this->assertTrue(
 			$this->pageHoldsSubjectInGraph( $approved->getPageId() ),
 			'the approved revision holds a Subject the draft removed'

--- a/tests/phpunit/Application/Rdf/RdfPageLoaderTest.php
+++ b/tests/phpunit/Application/Rdf/RdfPageLoaderTest.php
@@ -9,10 +9,14 @@ use MediaWiki\Page\WikiPageFactory;
 use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Revision\RevisionSlots;
 use MediaWiki\Title\Title;
+use ProfessionalWiki\NeoWiki\Application\NullRevisionPolicy;
 use ProfessionalWiki\NeoWiki\Application\Rdf\RdfPageLoader;
+use ProfessionalWiki\NeoWiki\Application\RevisionPolicy;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\MediaWikiSubjectRepository;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\FixedRevisionPolicy;
 use WikiPage;
 
 /**
@@ -37,6 +41,36 @@ class RdfPageLoaderTest extends NeoWikiIntegrationTestCase {
 		$this->assertNull( $loader->loadByTitle( Title::makeTitle( NS_MAIN, 'Page that does not exist' ) ) );
 	}
 
+	public function testExportsTheRevisionTheRevisionPolicyPublishes(): void {
+		$this->createSchema( TestSubject::DEFAULT_SCHEMA_ID );
+		$approved = $this->createPageWithSubjects( 'Exported from its approved revision', TestSubject::build() );
+		$draft = $this->createPageWithSubjects( 'Exported from its approved revision' );
+
+		$page = $this->newLoaderFor( $draft, FixedRevisionPolicy::publishing( $approved ) )
+			->loadByTitle( Title::makeTitle( NS_MAIN, 'Exported from its approved revision' ) );
+
+		$this->assertNotNull( $page );
+		$this->assertTrue(
+			$page->getSubjects()->hasSubjects(),
+			'the approved revision holds a Subject the draft removed'
+		);
+	}
+
+	public function testPageWithNoPublishableRevisionIsNotLoaded(): void {
+		// The revision must be one that would otherwise load, or the null proves nothing: a slot that
+		// does not hold Subject data already yields null through the pass-through path.
+		$this->createSchema( TestSubject::DEFAULT_SCHEMA_ID );
+		$revision = $this->createPageWithSubjects( 'Page with nothing published', TestSubject::build() );
+
+		$loader = $this->newLoaderFor( $revision, FixedRevisionPolicy::publishingNothing() );
+
+		$this->assertNull( $loader->loadByTitle( Title::makeTitle( NS_MAIN, 'Page with nothing published' ) ) );
+		$this->assertNotNull(
+			$this->newLoaderFor( $revision )->loadByTitle( Title::makeTitle( NS_MAIN, 'Page with nothing published' ) ),
+			'the same revision loads when the policy publishes it'
+		);
+	}
+
 	private function newRevisionWithSubjectSlotContent(): RevisionRecord {
 		$slots = $this->createStub( RevisionSlots::class );
 		$slots->method( 'getContent' )->willReturn( new WikitextContent( 'Not Subject data.' ) );
@@ -50,14 +84,18 @@ class RdfPageLoaderTest extends NeoWikiIntegrationTestCase {
 		return $revision;
 	}
 
-	private function newLoaderFor( ?RevisionRecord $revision ): RdfPageLoader {
+	private function newLoaderFor( ?RevisionRecord $revision, ?RevisionPolicy $policy = null ): RdfPageLoader {
 		$page = $this->createStub( WikiPage::class );
 		$page->method( 'getRevisionRecord' )->willReturn( $revision );
 
 		$factory = $this->createStub( WikiPageFactory::class );
 		$factory->method( 'newFromTitle' )->willReturn( $page );
 
-		return new RdfPageLoader( $factory, NeoWikiExtension::getInstance()->getPagePropertiesBuilder() );
+		return new RdfPageLoader(
+			$factory,
+			NeoWikiExtension::getInstance()->getPagePropertiesBuilder(),
+			$policy ?? new NullRevisionPolicy()
+		);
 	}
 
 }

--- a/tests/phpunit/Application/RevisionPolicyRegistryTest.php
+++ b/tests/phpunit/Application/RevisionPolicyRegistryTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Application;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\NullRevisionPolicy;
+use ProfessionalWiki\NeoWiki\Application\RevisionPolicyRegistry;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\FixedRevisionPolicy;
+use Psr\Log\Test\TestLogger;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Application\RevisionPolicyRegistry
+ */
+class RevisionPolicyRegistryTest extends TestCase {
+
+	public function testReturnsTheNullPolicyWhenNothingIsRegistered(): void {
+		$this->assertInstanceOf( NullRevisionPolicy::class, ( new RevisionPolicyRegistry() )->getPolicy() );
+	}
+
+	public function testUsesTheRegisteredPolicy(): void {
+		$policy = FixedRevisionPolicy::publishingNothing();
+		$registry = new RevisionPolicyRegistry();
+
+		$registry->setPolicy( $policy );
+
+		$this->assertSame( $policy, $registry->getPolicy() );
+	}
+
+	public function testKeepsTheFirstPolicyWhenASecondIsRegistered(): void {
+		$first = FixedRevisionPolicy::publishingNothing();
+		$registry = new RevisionPolicyRegistry();
+
+		$registry->setPolicy( $first );
+		$registry->setPolicy( FixedRevisionPolicy::publishingNothing() );
+
+		$this->assertSame( $first, $registry->getPolicy() );
+	}
+
+	public function testWarnsWhenASecondPolicyIsRegistered(): void {
+		$logger = new TestLogger();
+		$registry = new RevisionPolicyRegistry( $logger );
+
+		$registry->setPolicy( FixedRevisionPolicy::publishingNothing() );
+		$this->assertFalse( $logger->hasWarningRecords(), 'the first registration is not a warning' );
+
+		$registry->setPolicy( FixedRevisionPolicy::publishingNothing() );
+
+		$this->assertCount( 1, $logger->records );
+	}
+
+}

--- a/tests/phpunit/EntryPoints/NeoWikiRegistrarTest.php
+++ b/tests/phpunit/EntryPoints/NeoWikiRegistrarTest.php
@@ -11,6 +11,8 @@ use ProfessionalWiki\NeoWiki\Domain\Page\PagePropertyProviderRegistry;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\PropertyTypeRegistry;
 use ProfessionalWiki\NeoWiki\Domain\PropertyType\Types\TextType;
 use ProfessionalWiki\NeoWiki\Domain\Rdf\RdfValueMapperRegistry;
+use ProfessionalWiki\NeoWiki\Application\RevisionPolicyRegistry;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\FixedRevisionPolicy;
 use ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiRegistrar;
 use ProfessionalWiki\NeoWiki\GraphDatabasePlugins\Neo4j\Persistence\Neo4jValueBuilderRegistry;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpyGraphDatabasePlugin;
@@ -79,6 +81,16 @@ class NeoWikiRegistrarTest extends TestCase {
 		$this->assertSame( [ $provider ], $noticeRegistry->getProviders() );
 	}
 
+	public function testRegistersTheRevisionPolicy(): void {
+		$policyRegistry = new RevisionPolicyRegistry();
+		$registrar = $this->newRegistrar( revisionPolicyRegistry: $policyRegistry );
+		$policy = FixedRevisionPolicy::publishingNothing();
+
+		$registrar->setRevisionPolicy( $policy );
+
+		$this->assertSame( $policy, $policyRegistry->getPolicy() );
+	}
+
 	private function newRegistrar(
 		?PropertyTypeRegistry $propertyTypeRegistry = null,
 		?Neo4jValueBuilderRegistry $valueBuilderRegistry = null,
@@ -86,6 +98,7 @@ class NeoWikiRegistrarTest extends TestCase {
 		?GraphDatabasePluginRegistry $graphDatabasePluginRegistry = null,
 		?RdfValueMapperRegistry $rdfValueMapperRegistry = null,
 		?SubjectEditNoticeProviderRegistry $subjectEditNoticeProviderRegistry = null,
+		?RevisionPolicyRegistry $revisionPolicyRegistry = null,
 	): NeoWikiRegistrar {
 		return new NeoWikiRegistrar(
 			propertyTypeRegistry: $propertyTypeRegistry ?? new PropertyTypeRegistry(),
@@ -94,6 +107,7 @@ class NeoWikiRegistrarTest extends TestCase {
 			graphDatabasePluginRegistry: $graphDatabasePluginRegistry ?? new GraphDatabasePluginRegistry(),
 			rdfValueMapperRegistry: $rdfValueMapperRegistry ?? new RdfValueMapperRegistry(),
 			subjectEditNoticeProviderRegistry: $subjectEditNoticeProviderRegistry ?? new SubjectEditNoticeProviderRegistry(),
+			revisionPolicyRegistry: $revisionPolicyRegistry ?? new RevisionPolicyRegistry(),
 		);
 	}
 

--- a/tests/phpunit/EntryPoints/OnRevisionCreatedHandlerTest.php
+++ b/tests/phpunit/EntryPoints/OnRevisionCreatedHandlerTest.php
@@ -9,7 +9,9 @@ use MediaWiki\Content\FallbackContent;
 use MediaWiki\Revision\RevisionAccessException;
 use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Revision\RevisionSlots;
+use ProfessionalWiki\NeoWiki\Application\NullRevisionPolicy;
 use ProfessionalWiki\NeoWiki\Application\PageRefreshOutcome;
+use ProfessionalWiki\NeoWiki\Application\RevisionPolicy;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\FailureIsolatingGraphDatabasePlugin;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\GraphDatabasePlugin;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
@@ -21,6 +23,7 @@ use ProfessionalWiki\NeoWiki\FailureIsolatingPagePropertiesSource;
 use ProfessionalWiki\NeoWiki\PagePropertiesBuilder;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\FixedRevisionPolicy;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpyGraphDatabasePlugin;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpySubjectPageIndex;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\ThrowingGraphDatabasePlugin;
@@ -189,6 +192,34 @@ class OnRevisionCreatedHandlerTest extends NeoWikiIntegrationTestCase {
 		$this->assertEquals( [ new PageId( self::DELETED_PAGE_ID ) ], $this->graphStore->deletedPageIds );
 	}
 
+	public function testDoesNotProjectARevisionThePolicyDoesNotPublish(): void {
+		$revision = $this->createPageWithSubjects( 'Page with an unpublished revision', TestSubject::build() );
+
+		$outcome = $this->newHandlerWithPolicy( FixedRevisionPolicy::publishingNothing() )
+			->onRevisionCreated( $revision );
+
+		$this->assertSame( PageRefreshOutcome::SkippedUnpublishableRevision, $outcome );
+		$this->assertSame( [], $this->graphStore->savedPages );
+		$this->assertSame( [], $this->graphStore->deletedPageIds, 'what was published stays published' );
+	}
+
+	/**
+	 * The index says where a Subject lives, not whether it is published. Every id-keyed read and write
+	 * addresses its page through it, so a Subject left out of it cannot be edited, moved or deleted,
+	 * and its id reads as free.
+	 */
+	public function testIndexesASubjectEvenWhenItsRevisionIsNotPublished(): void {
+		$revision = $this->createPageWithSubjects( 'Page whose draft adds a subject', TestSubject::build() );
+
+		$this->newHandlerWithPolicy( FixedRevisionPolicy::publishingNothing() )
+			->onRevisionCreated( $revision );
+
+		$this->assertSame(
+			[ $revision->getPageId() => [ TestSubject::ZERO_GUID ] ],
+			$this->subjectPageIndex->indexedSubjectsByPageId
+		);
+	}
+
 	private function newFailingProviderRegistry(): PagePropertyProviderRegistry {
 		$registry = new PagePropertyProviderRegistry();
 		$registry->addProvider( new class implements PagePropertyProvider {
@@ -224,10 +255,15 @@ class OnRevisionCreatedHandlerTest extends NeoWikiIntegrationTestCase {
 		return $this->newHandlerWith( $this->graphStore );
 	}
 
+	private function newHandlerWithPolicy( RevisionPolicy $policy ): OnRevisionCreatedHandler {
+		return $this->newHandlerWith( $this->graphStore, revisionPolicy: $policy );
+	}
+
 	private function newHandlerWith(
 		GraphDatabasePlugin $graphStore,
 		?PagePropertyProviderRegistry $providerRegistry = null,
-		bool $isolatePageProperties = false
+		bool $isolatePageProperties = false,
+		?RevisionPolicy $revisionPolicy = null
 	): OnRevisionCreatedHandler {
 		$pageProperties = $this->newPagePropertiesBuilder( $providerRegistry ?? new PagePropertyProviderRegistry() );
 
@@ -237,6 +273,7 @@ class OnRevisionCreatedHandlerTest extends NeoWikiIntegrationTestCase {
 			$isolatePageProperties
 				? new FailureIsolatingPagePropertiesSource( $pageProperties, $this->logger )
 				: $pageProperties,
+			$revisionPolicy ?? new NullRevisionPolicy(),
 			$this->logger
 		);
 	}
@@ -246,6 +283,7 @@ class OnRevisionCreatedHandlerTest extends NeoWikiIntegrationTestCase {
 			$this->graphStore,
 			new ThrowingSubjectPageIndex(),
 			$this->newPagePropertiesBuilder( new PagePropertyProviderRegistry() ),
+			new NullRevisionPolicy(),
 			$this->logger
 		);
 	}

--- a/tests/phpunit/EntryPoints/REST/GetSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/GetSubjectApiTest.php
@@ -6,17 +6,20 @@ namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\REST;
 
 use MediaWiki\Page\PageIdentity;
 use MediaWiki\Rest\RequestData;
+use MediaWiki\Rest\Response;
 use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Subject\StatementList;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectMap;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\GetSubjectApi;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestRelation;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestStatement;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiMockAuthorityTrait;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\FixedRevisionPolicy;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\EntryPoints\REST\GetSubjectApi
@@ -203,6 +206,58 @@ JSON,
 		);
 
 		$this->assertSame( 404, $response->getStatusCode() );
+	}
+
+	/**
+	 * A revision the registered policy hides answers exactly like one that does not exist, so the
+	 * sequential revision ids cannot be swept to find out which drafts a page has.
+	 */
+	public function testRevisionHiddenByTheRevisionPolicyIsIndistinguishableFromAnAbsentRevision(): void {
+		$revisionId = $this->createPageWithSubjects(
+			'GetSubjectApiTest_HiddenRevision',
+			mainSubject: TestSubject::build(
+				id: 'sTestGSA1111251',
+				schemaName: new SchemaName( 'GetSubjectApiTestSchema' )
+			)
+		)->getId();
+
+		[ $hiddenResponse, $absentResponse ] = $this->runWithRevisionPolicyHidingEveryRevision(
+			fn (): array => [
+				$this->getSubjectAtRevision( 'sTestGSA1111251', (string)$revisionId ),
+				$this->getSubjectAtRevision( 'sTestGSA1111251', '999999999' ),
+			]
+		);
+
+		$this->assertSame( 404, $hiddenResponse->getStatusCode() );
+		$this->assertSame( $absentResponse->getStatusCode(), $hiddenResponse->getStatusCode() );
+
+		$hidden = json_decode( $hiddenResponse->getBody()->getContents(), true );
+		$absent = json_decode( $absentResponse->getBody()->getContents(), true );
+
+		// Only the revision id embedded in the message may differ between "hidden" and "nonexistent".
+		$absent['message'] = str_replace( '999999999', (string)$revisionId, $absent['message'] );
+		$this->assertSame( $absent, $hidden );
+	}
+
+	private function getSubjectAtRevision( string $subjectId, string $revisionId ): Response {
+		return $this->executeHandler(
+			new GetSubjectApi(),
+			new RequestData( [
+				'method' => 'GET',
+				'pathParams' => [ 'subjectId' => $subjectId ],
+				'queryParams' => [ 'revisionId' => $revisionId ],
+			] )
+		);
+	}
+
+	private function runWithRevisionPolicyHidingEveryRevision( callable $fn ): mixed {
+		$this->registerRevisionPolicy( FixedRevisionPolicy::hidingEveryRevision() );
+
+		try {
+			return $fn();
+		} finally {
+			NeoWikiExtension::resetInstance();
+		}
 	}
 
 	public function testFullExpansion(): void {

--- a/tests/phpunit/NeoWikiIntegrationTestCase.php
+++ b/tests/phpunit/NeoWikiIntegrationTestCase.php
@@ -28,6 +28,7 @@ use ProfessionalWiki\NeoWiki\EntryPoints\Content\MappingContent;
 use ProfessionalWiki\NeoWiki\EntryPoints\Content\SchemaContent;
 use ProfessionalWiki\NeoWiki\EntryPoints\Content\SubjectContent;
 use ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiRegistrar;
+use ProfessionalWiki\NeoWiki\Application\RevisionPolicy;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\MediaWikiSubjectRepository;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSchema;
@@ -50,6 +51,7 @@ class NeoWikiIntegrationTestCase extends MediaWikiIntegrationTestCase {
 
 	/** @var PagePropertyProvider[] */
 	private array $registeredPagePropertyProviders = [];
+	private ?RevisionPolicy $registeredRevisionPolicy = null;
 
 	/**
 	 * The singleton pins a SchemaLookup whose cache is keyed by page and revision id, and those ids
@@ -373,6 +375,16 @@ class NeoWikiIntegrationTestCase extends MediaWikiIntegrationTestCase {
 	}
 
 	/**
+	 * Registers the revision policy through the NeoWikiRegistration hook and rebuilds the singleton, so
+	 * the real wiring hands it to every path that publishes.
+	 */
+	protected function registerRevisionPolicy( RevisionPolicy $policy ): void {
+		$this->registeredRevisionPolicy = $policy;
+
+		$this->registerWithNeoWiki();
+	}
+
+	/**
 	 * Everything registered so far goes through one hook handler, replacing the previous one.
 	 * setTemporaryHook clears the hook before adding its handler, so registering plugins and providers
 	 * as two handlers would silently leave only whichever was registered last — with the test still
@@ -381,16 +393,21 @@ class NeoWikiIntegrationTestCase extends MediaWikiIntegrationTestCase {
 	private function registerWithNeoWiki(): void {
 		$plugins = $this->registeredGraphDatabasePlugins;
 		$providers = $this->registeredPagePropertyProviders;
+		$policy = $this->registeredRevisionPolicy;
 
 		$this->setTemporaryHook(
 			'NeoWikiRegistration',
-			static function ( NeoWikiRegistrar $registrar ) use ( $plugins, $providers ): void {
+			static function ( NeoWikiRegistrar $registrar ) use ( $plugins, $providers, $policy ): void {
 				foreach ( $plugins as $name => $plugin ) {
 					$registrar->addGraphDatabasePlugin( $name, $plugin );
 				}
 
 				foreach ( $providers as $provider ) {
 					$registrar->addPagePropertyProvider( $provider );
+				}
+
+				if ( $policy !== null ) {
+					$registrar->setRevisionPolicy( $policy );
 				}
 			}
 		);

--- a/tests/phpunit/Persistence/MediaWiki/PageContentFetcherTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/PageContentFetcherTest.php
@@ -12,7 +12,10 @@ use MediaWiki\Title\MalformedTitleException;
 use MediaWiki\Title\Title;
 use MediaWiki\Title\TitleParser;
 use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Application\NullRevisionPolicy;
+use ProfessionalWiki\NeoWiki\Application\RevisionPolicy;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\PageContentFetcher;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\FixedRevisionPolicy;
 
 /**
  * @covers \ProfessionalWiki\NeoWiki\Persistence\MediaWiki\PageContentFetcher
@@ -33,7 +36,37 @@ class PageContentFetcherTest extends TestCase {
 		$this->revisionRecord = $this->createMock( RevisionRecord::class );
 		$this->content = $this->createMock( Content::class );
 
-		$this->pageContentFetcher = new PageContentFetcher( $this->titleParser, $this->revisionLookup );
+		$this->pageContentFetcher = $this->newFetcherWith( new NullRevisionPolicy() );
+	}
+
+	public function testReadsTheRevisionTheRevisionPolicyPublishes(): void {
+		$approved = $this->createMock( RevisionRecord::class );
+		$approvedContent = $this->createMock( Content::class );
+		$approved->method( 'getContent' )->willReturn( $approvedContent );
+
+		$this->titleParser->method( 'parseTitle' )->willReturn( Title::newFromText( 'test title' )->getTitleValue() );
+		$this->revisionLookup->method( 'getRevisionByTitle' )->willReturn( $this->revisionRecord );
+		$this->revisionRecord->method( 'getContent' )->willReturn( $this->content );
+
+		$content = $this->newFetcherWith( FixedRevisionPolicy::publishing( $approved ) )
+			->getPageContent( 'test title', $this->authority );
+
+		$this->assertSame( $approvedContent, $content );
+	}
+
+	public function testReadsNothingWhenThePolicyPublishesNoRevisionOfThePage(): void {
+		$this->titleParser->method( 'parseTitle' )->willReturn( Title::newFromText( 'test title' )->getTitleValue() );
+		$this->revisionLookup->method( 'getRevisionByTitle' )->willReturn( $this->revisionRecord );
+		$this->revisionRecord->method( 'getContent' )->willReturn( $this->content );
+
+		$content = $this->newFetcherWith( FixedRevisionPolicy::publishingNothing() )
+			->getPageContent( 'test title', $this->authority );
+
+		$this->assertNull( $content );
+	}
+
+	private function newFetcherWith( RevisionPolicy $policy ): PageContentFetcher {
+		return new PageContentFetcher( $this->titleParser, $this->revisionLookup, $policy );
 	}
 
 	public function testGetPageContentWithGivenAuthority(): void {

--- a/tests/phpunit/TestDoubles/FixedRevisionPolicy.php
+++ b/tests/phpunit/TestDoubles/FixedRevisionPolicy.php
@@ -1,0 +1,57 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\TestDoubles;
+
+use MediaWiki\Permissions\Authority;
+use MediaWiki\Revision\RevisionRecord;
+use ProfessionalWiki\NeoWiki\Application\RevisionPolicy;
+
+class FixedRevisionPolicy implements RevisionPolicy {
+
+	private function __construct(
+		private readonly bool $publishes,
+		private readonly bool $substitutes,
+		private readonly ?RevisionRecord $published,
+		private readonly bool $readable,
+	) {
+	}
+
+	public static function publishing( RevisionRecord $revision ): self {
+		return new self( publishes: true, substitutes: true, published: $revision, readable: true );
+	}
+
+	public static function publishingNothing(): self {
+		return new self( publishes: false, substitutes: true, published: null, readable: true );
+	}
+
+	public static function hidingEveryRevision(): self {
+		return new self( publishes: true, substitutes: false, published: null, readable: false );
+	}
+
+	public function publishesRevision( RevisionRecord $revision ): bool {
+		return $this->publishes;
+	}
+
+	/**
+	 * Answers per page, as an approval extension does: the fixed revision stands in only for revisions of
+	 * its own page, and any other page — a Schema page the projection resolves, say — passes through.
+	 */
+	public function publishedRevision( RevisionRecord $revision ): ?RevisionRecord {
+		if ( !$this->substitutes ) {
+			return $revision;
+		}
+
+		if ( $this->published === null || $this->published->getPageId() === $revision->getPageId() ) {
+			return $this->published;
+		}
+
+		return $revision;
+	}
+
+	public function revisionIsReadableBy( RevisionRecord $revision, Authority $viewer ): bool {
+		return $this->readable;
+	}
+
+}


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/1379

NeoWiki published each page's latest revision everywhere except the page view, so an approval extension such as
ContentStabilization could stabilize what a reader sees on a page but not what the graph stores or the RDF export
served. It already registers a Page Property Provider with us and calls `newPageRebuilder()->rebuild()` when a
stable point changes; it had no way to say which revision that rebuild should read.

Extensions can now register a `RevisionPolicy` through `NeoWikiRegistrar::setRevisionPolicy()`. It answers three
questions, each asked where it is natural:

- `publishesRevision()` — asked as a revision is written. A save already has its revision and only needs to know
  whether to publish it, so this costs one lookup. Return false and the graph keeps whatever it published before.
- `publishedRevision()` — asked when nothing but the page is known: by `PageRebuilder::rebuild()`, the reprojection
  path an approval extension calls when its answer changes, and on every Schema, Layout, Mapping and configuration
  read and every RDF export. Returns the revision to publish, or `null` when the page has nothing publishable.
  `rebuildFromPrimary()` deliberately does not ask: import and undelete write a revision, so they take the save
  path's semantics.
- `revisionIsReadableBy()` — asked when a caller names a revision by id, which neither publishing method can
  intercept. A refused revision answers exactly like an absent one, so the sequential revision ids stay unsweepable
  (#1046).

Registration is a single slot rather than the `add*` list every other extension point uses, because two extensions
cannot both decide this. A second policy is refused with a warning and the first keeps deciding. With nothing registered every surface reads the latest revision, exactly as before.

The registered policy is wrapped in `FailureIsolatingRevisionPolicy`, as every other extension-contributed plugin is.
A policy that throws publishes nothing and hides everything — the edit hook fires inside `PageUpdater`'s atomic
section, so an uncaught throw there would roll the contributor's save back. It also refuses a revision from another
page, and a revision whose text is suppressed: only the current revision was ever projected before, and core forbids
suppressing that one, so a policy naming an older revision must not start publishing suppressed Subjects.

## The subject-to-page index is deliberately not governed by the policy

It records where a Subject lives, not whether it is published, and it is written from every revision. Every id-keyed
read and write addresses its page through it — `ReplaceSubjectAction`, `UpdateStatementAction`, `DeleteSubjectAction`,
`MoveSubjectAction`, and the check in `CreateSubjectAction` that an id is not already taken — so a Subject left out of
it could not be edited, moved or deleted, and its id would read as free and be re-mintable onto another page. Adding a
Subject in an unapproved revision is the normal case on an approval wiki, so that would fire constantly.

Keeping the index out of it also makes the maintenance rebuilder correct rather than contradictory: it writes from
`page_latest` and needs no knowledge of the policy, which is why it can keep running under `update.php`.

## Which surfaces this covers

The graph projection and the RDF export publish through the policy. Schemas, Layouts, Mappings and the on-wiki
configuration page read through it too, so an unapproved edit to one does not take effect until it is approved; the
Schema editor is unaffected because it loads page source through core's own `/v1/page/` endpoint.

Reads by Subject id stay on the latest revision. Routing them through the policy is what an earlier revision of this
branch did, and it broke the subject editor: the same endpoint is the editor's load path, so the editor loaded
approved values and saved them back over the draft.

## Known gaps, all tracked

- Three Subject read surfaces still serve the latest revision — `action=subjects`, the page-keyed REST read, and
  referenced Subjects on other pages via `PointInTimeSubjectLookup`
  (https://github.com/ProfessionalWiki/NeoWiki/issues/1390). The parse-time accessors are unchanged for a different
  reason: they need the parser's own current-revision callback rather than this interface.
- The RDF export stops answering for a page once approval is withdrawn, but what was published stays in the graph
  until the page is deleted; a rebuild does not remove it (https://github.com/ProfessionalWiki/NeoWiki/issues/1391).
- Schemas and Mappings cache on the page's latest revision id, so an approval change with no page edit does not take
  effect until that page is edited or the entry expires; and a Subject is validated against the published Schema
  while the Schema editor shows the latest one (https://github.com/ProfessionalWiki/NeoWiki/issues/1392).
- Undelete and import take the save path, so a restored page whose latest revision is unpublished comes back
  addressable but absent from the graph until the approval extension reprojects it.

## Considered, omitted

- Collapsing the two publishing methods into one nullable substitution. It reads as a reduction, but it forces every
  draft save to resolve and re-project a revision the graph already holds, and it was what dragged the index and the
  editor into the design.
- Making the index follow the published revision, or hold the union of both. The first breaks editing as described
  above; the second leaves the maintenance rebuilder unable to remove a row, which is the one thing it exists to do.

## Not in this change

The decision itself is not recorded in an ADR. `docs/AGENTS.md` says an ADR is a dated record, not retro-edited
apart from status links, so an earlier revision of this branch that appended to ADR 27 and ADR 32 has been reverted.
Revision choice wants its own ADR.

<sub>AI-authored — Claude Code, `Fable 5.1` after a mid-session model switch from `Opus 5 (1M context)`, which wrote the first design; implemented from #1379 on @alistair3149's go-ahead, redesigned after a five-pass review found the first design broke editing, then hardened after a second six-pass review; diff not yet human-reviewed; phpcs and phpstan clean, nine touched test classes pass locally including one that drives the registered policy through NeoWikiExtension's real wiring into Neo4j, CI on the previous push green across MW 1.43–master.</sub>
