### PR TITLE
Stop marking links to the project's own sites nofollow

### DIFF
--- a/Docker/SettingsTemplate.php
+++ b/Docker/SettingsTemplate.php
@@ -268,6 +268,14 @@ $wgCrossSiteAJAXdomains = [
 	'*'
 ];
 
+// Links to the project's own sites are meant to pass link equity.
+$wgNoFollowDomainExceptions = [
+	'neowiki.ai',
+	'neowiki.dev',
+	'professional.wiki',
+	'pro.wiki',
+];
+
 // Expose MediaWiki core's OpenAPI spec endpoints (T365753) so the
 // auto-generated NeoWiki REST spec is reachable at
 // /rest.php/specs/v0/module/- and /rest.php/specs/v0/discovery.

--- a/Docker/SettingsTemplate.php
+++ b/Docker/SettingsTemplate.php
@@ -268,7 +268,6 @@ $wgCrossSiteAJAXdomains = [
 	'*'
 ];
 
-// Links to the project's own sites are meant to pass link equity.
 $wgNoFollowDomainExceptions = [
 	'neowiki.ai',
 	'neowiki.dev',


### PR DESCRIPTION
Set $wgNoFollowDomainExceptions in the Docker settings template so links to
neowiki.ai, neowiki.dev, professional.wiki and pro.wiki are no longer rendered
with rel="nofollow". Both shipped images bake this template in as
LocalSettings.php, so the published demo image is covered as well.

The bundled demo data links to these sites from the Main Page, the Developers
page, the RDF and SPARQL pages and MediaWiki:Sidebar, and MediaWiki marks every
external link nofollow by default, so none of them passed link equity.

Verified with php -l and by rendering Main Page on a dev stack: the neowiki.ai
and professional.wiki anchors lost rel="nofollow", while the github.com ones
kept it.

> <sub>AI-authored — Claude Code, `Opus 5 (max)`; one-line ask from @JeroenDeDauw, no redirections; diff not yet human-reviewed; php -l, rendered Main Page checked in a worktree stack, CI green.</sub>
