### PR TITLE
Trim the revision-policy comments to what the code does not say

### DIFF
--- a/src/Application/FailureIsolatingRevisionPolicy.php
+++ b/src/Application/FailureIsolatingRevisionPolicy.php
@@ -17,11 +17,11 @@ use Throwable;
  * back, and a throw on a read would take every Schema, Layout and Mapping read down with it. The other
  * extension-contributed plugins are wrapped the same way; see FailureIsolatingGraphDatabasePlugin.
  *
- * Two answers are refused as well as caught. A revision from another page: every caller keys its write
+ * Two answers are refused as well as caught. A revision of another page: every caller keys its write
  * or its export on the returned revision's page id, so accepting one would publish page B under page
- * A's name, behind A's read gate. And a revision whose text is suppressed: only the current revision
- * was ever published before this policy existed, and core refuses to suppress that one, so nothing
- * read a suppressed revision's Subjects — a policy naming an older one must not start to.
+ * A's name, behind A's read gate. And a revision whose text is suppressed: core refuses to suppress a
+ * page's current revision, so only a policy naming an older one could publish suppressed Subjects, and
+ * this refuses to.
  */
 class FailureIsolatingRevisionPolicy implements RevisionPolicy {
 

--- a/src/Application/NullRevisionPolicy.php
+++ b/src/Application/NullRevisionPolicy.php
@@ -7,11 +7,6 @@ namespace ProfessionalWiki\NeoWiki\Application;
 use MediaWiki\Permissions\Authority;
 use MediaWiki\Revision\RevisionRecord;
 
-/**
- * Publishes every revision, keeps whichever one the caller resolved, and hides none. This is what runs
- * when no extension registers a policy, so an installation without an approval extension behaves
- * exactly as it did before there was a policy at all.
- */
 class NullRevisionPolicy implements RevisionPolicy {
 
 	public function publishesRevision( RevisionRecord $revision ): bool {

--- a/src/Application/PageRebuilder.php
+++ b/src/Application/PageRebuilder.php
@@ -19,12 +19,11 @@ class PageRebuilder {
 	}
 
 	/**
-	 * Reprojects the page from the revision the registered policy publishes. This is the path an
-	 * approval extension calls when its answer changes. A page save takes the other path: it already
-	 * knows its revision and is only asked whether to publish it.
+	 * Reprojects the page from the revision the registered policy publishes, which is what an approval
+	 * extension calls when its answer changes.
 	 *
-	 * The handler this hands the substituted revision to must not index, since it would index the
-	 * published revision's Subjects in place of the latest one's. See NeoWikiExtension.
+	 * The handler must not index: it would record the published revision's Subjects in place of the
+	 * latest one's. NeoWikiExtension wires it with a NullSubjectPageIndex for that reason.
 	 */
 	public function rebuild( Title $title ): PageRefreshOutcome {
 		return $this->rebuildWithReadFlags( $title, IDBAccessObject::READ_NORMAL, substitute: true );

--- a/src/Application/RevisionPolicy.php
+++ b/src/Application/RevisionPolicy.php
@@ -11,22 +11,18 @@ use MediaWiki\Revision\RevisionRecord;
  * Which revision of a page NeoWiki publishes: projects to the graph stores, exports as RDF, and reads
  * Schemas, Layouts, Mappings and the on-wiki configuration from. Registered by an approval extension
  * such as ContentStabilization, which shows readers an approved revision rather than the newest one.
- * With no policy registered every page publishes its latest revision, as NeoWiki has always done.
+ * With no policy registered every page publishes its latest revision.
  *
  * A page save knows its revision and only needs to be told whether to publish it. A reprojection, a
- * configuration read and an RDF export are told nothing beyond the page, so they ask which revision
- * to publish. publishedRevision() therefore runs on every Schema, Layout and Mapping read and every
- * RDF export, not only on a rebuild, and an implementation must be cheap enough for that.
+ * configuration read and an RDF export know only the page, so they ask which revision to publish.
+ * publishedRevision() therefore runs on every Schema, Layout and Mapping read and every RDF export,
+ * and must be cheap.
  *
  * The answers must agree: publishesRevision() is true for whatever publishedRevision() names, since a
  * reprojection hands the named revision back to the save path's check.
  *
  * A policy answers for the wiki, not for a viewer: the graph and the RDF export are one state that
  * every reader sees. Only revisionIsReadableBy(), which serves a single request, takes a viewer.
- *
- * The subject-to-page index is deliberately not governed by any of this. It records where a Subject
- * lives, not whether it is published, and every read of it is re-checked against the revision the
- * caller actually reads ([[ADR 32]]).
  */
 interface RevisionPolicy {
 

--- a/src/Application/RevisionPolicyRegistry.php
+++ b/src/Application/RevisionPolicyRegistry.php
@@ -8,13 +8,10 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
 /**
- * The one revision policy an extension may contribute. Unlike the other extension points this holds a
- * single entry rather than a list: two policies cannot both decide which revision a page publishes,
- * and composing their answers would mean inventing a precedence nobody asked for.
- *
- * A second registration is refused with a warning, the way a graph database plugin repeating a name
- * is: keeping the first leaves the wiki publishing what it was already publishing, where dropping it
- * would silently hand the decision to whichever extension happened to load last.
+ * Holds the one revision policy an extension may contribute: two policies cannot both decide which
+ * revision a page publishes, and composing their answers would mean inventing a precedence nobody asked
+ * for. A second registration is refused with a warning and the first keeps deciding, so the outcome
+ * does not depend on which extension happened to load last.
  */
 class RevisionPolicyRegistry {
 

--- a/src/EntryPoints/NeoWikiRegistrar.php
+++ b/src/EntryPoints/NeoWikiRegistrar.php
@@ -62,12 +62,8 @@ readonly class NeoWikiRegistrar {
 	}
 
 	/**
-	 * Registers which revision of a page NeoWiki publishes: projects to the graph stores and exports
-	 * as RDF. For approval extensions, which show readers an approved revision rather than the newest
-	 * one.
-	 *
-	 * Only one extension can decide this, so unlike the other registrations this is a single slot: a
-	 * second policy is refused with a warning and the first one keeps deciding.
+	 * A single slot, unlike the add* registrations: a second policy is refused with a warning and the
+	 * first one keeps deciding.
 	 */
 	public function setRevisionPolicy( RevisionPolicy $policy ): void {
 		$this->revisionPolicyRegistry->setPolicy( $policy );

--- a/src/EntryPoints/OnRevisionCreatedHandler.php
+++ b/src/EntryPoints/OnRevisionCreatedHandler.php
@@ -74,9 +74,7 @@ class OnRevisionCreatedHandler {
 		// it or not at all, and a Subject too broken to deserialize is still indexed.
 		$this->subjectPageIndex->setSubjectsOfPage( $pageId, $content?->getSubjectIds() ?? [] );
 
-		// Indexed either way, projected only when published: what the graph already holds is what the
-		// policy last published, and leaving it there is the point. Withdrawing it belongs to page
-		// deletion, not to somebody saving a draft on a page that has nothing published yet.
+		// An unpublished revision leaves the graph holding what the policy last published.
 		if ( !$this->revisionPolicy->publishesRevision( $revisionRecord ) ) {
 			return PageRefreshOutcome::SkippedUnpublishableRevision;
 		}

--- a/src/EntryPoints/REST/GetSubjectApi.php
+++ b/src/EntryPoints/REST/GetSubjectApi.php
@@ -61,11 +61,6 @@ class GetSubjectApi extends SimpleHandler {
 		return NeoWikiExtension::getInstance()->newGetSubjectQueryForRevision( $presenter, $revision, $this->getAuthority() );
 	}
 
-	/**
-	 * A caller who names a revision is asking to see that one, so the registered revision policy is
-	 * asked directly whether this viewer may. Without one registered every revision of a readable page
-	 * is readable, as before.
-	 */
 	private function revisionIsReadable( RevisionRecord $revision ): bool {
 		return $this->revisionPageIsReadable( $revision->getPageId() )
 			&& NeoWikiExtension::getInstance()->getRevisionPolicy()

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -412,11 +412,8 @@ class NeoWikiExtension {
 	 * on.
 	 */
 	private function newRebuildStoreContentHandler(): OnRevisionCreatedHandler {
-		// The null index is load-bearing, not merely unneeded: PageRebuilder::rebuild() hands this handler
-		// the revision the policy publishes, and the handler indexes whatever it is given. A real index
-		// here would replace the latest revision's Subject set with the published one, making every
-		// Subject a draft added unaddressable — the exact failure keeping the index out of the policy
-		// exists to prevent. Only rebuildFromPrimary(), which does not substitute, may index.
+		// The null index is load-bearing: PageRebuilder::rebuild() hands this handler the revision the
+		// policy publishes, and indexing that would drop the Subjects a draft added. See PageRebuilder.
 		return $this->newStoreContentHandler(
 			$this->getGraphDatabasePlugin(),
 			new NullSubjectPageIndex(),

--- a/src/Persistence/MediaWiki/PageContentFetcher.php
+++ b/src/Persistence/MediaWiki/PageContentFetcher.php
@@ -17,13 +17,10 @@ use MediaWiki\Title\TitleValue;
 use ProfessionalWiki\NeoWiki\Application\RevisionPolicy;
 
 /**
- * The content a page publishes, which is its latest revision unless a registered revision policy
- * substitutes another. Everything read through here is configuration the whole wiki reads — Schemas,
- * Layouts, Mappings and the on-wiki configuration page — so on a wiki running an approval extension
- * an unapproved edit to one does not take effect until it is approved.
- *
- * Editing surfaces do not read through here: the Schema editor loads the page source from core's own
- * REST endpoint, so it still shows and saves over the latest revision.
+ * The content a page publishes: its latest revision, unless a registered revision policy substitutes
+ * another. Everything read through here — Schemas, Layouts, Mappings and the on-wiki configuration
+ * page — is configuration the whole wiki reads, so on a wiki running an approval extension an
+ * unapproved edit to one takes effect only once approved.
  */
 class PageContentFetcher {
 

--- a/tests/phpunit/EntryPoints/OnRevisionCreatedHandlerTest.php
+++ b/tests/phpunit/EntryPoints/OnRevisionCreatedHandlerTest.php
@@ -203,11 +203,6 @@ class OnRevisionCreatedHandlerTest extends NeoWikiIntegrationTestCase {
 		$this->assertSame( [], $this->graphStore->deletedPageIds, 'what was published stays published' );
 	}
 
-	/**
-	 * The index says where a Subject lives, not whether it is published. Every id-keyed read and write
-	 * addresses its page through it, so a Subject left out of it cannot be edited, moved or deleted,
-	 * and its id reads as free.
-	 */
 	public function testIndexesASubjectEvenWhenItsRevisionIsNotPublished(): void {
 		$revision = $this->createPageWithSubjects( 'Page whose draft adds a subject', TestSubject::build() );
 

--- a/tests/phpunit/EntryPoints/REST/GetSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/GetSubjectApiTest.php
@@ -208,10 +208,6 @@ JSON,
 		$this->assertSame( 404, $response->getStatusCode() );
 	}
 
-	/**
-	 * A revision the registered policy hides answers exactly like one that does not exist, so the
-	 * sequential revision ids cannot be swept to find out which drafts a page has.
-	 */
 	public function testRevisionHiddenByTheRevisionPolicyIsIndistinguishableFromAnAbsentRevision(): void {
 		$revisionId = $this->createPageWithSubjects(
 			'GetSubjectApiTest_HiddenRevision',


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1389

Each fact keeps one home: the index rationale on `OnRevisionCreatedHandler`, the single-slot rule on
`RevisionPolicyRegistry`, the default behaviour and the two-method split on the `RevisionPolicy` interface. Cut are
the restatements of those in `PageRebuilder`, `NeoWikiRegistrar`, `GetSubjectApi`, `NullRevisionPolicy` and two test
docblocks; the history phrases ("as NeoWiki has always done", "before this policy existed"); and the note in
`PageContentFetcher` on how the Schema editor loads, which describes another component and already lives in
`docs/extending/extending.md`. Comments only, no code changes.

Considered, omitted: the `[[ADR 32]]` pointer in the interface docblock. The wiki-link syntax resolves to nothing in
PHP, and `NullSubjectPageIndex` already cites the ADR where the index constraint is applied.

> <sub>AI-authored — Claude Code, `Fable 5.1 (max)`; one-line ask from @JeroenDeDauw to review the comments for removal, no revisions; diff not yet human-reviewed; phpcs and the two touched test classes run locally, CI pending.</sub>
