### PR TITLE
Withdraw unpublished pages from the graph, ask the policy one question

### DIFF
--- a/docs/extending/extending.md
+++ b/docs/extending/extending.md
@@ -174,55 +174,45 @@ the Page node. No new revision is created. `rebuild()` returns a `PageRefreshOut
 A graph store that fails is logged and skipped, exactly as on a normal page save; only request timeouts and
 wiki-database errors throw.
 
-### Choosing which revision NeoWiki publishes
+### Revision policy
 
-By default NeoWiki publishes each page's latest revision: that is the revision it projects to the graph stores and
-exports as RDF. An approval extension shows readers an approved revision instead, and registers a `RevisionPolicy` so
-NeoWiki publishes the same one.
-
-```php
-public function onNeoWikiRegistration( NeoWikiRegistrar $registrar ): void {
-	$registrar->setRevisionPolicy( new MyApprovalPolicy( $this->approvalLookup ) );
-}
-```
+Choose which revision of a page NeoWiki publishes: to the graph stores, the RDF export, the Subject read
+`GET /neowiki/v0/subject/{subjectId}`, and its own Schema, Layout, Mapping and configuration reads. Without a policy
+every page publishes its latest revision.
 
 ```php
-class MyApprovalPolicy implements RevisionPolicy {
+class ApprovalRevisionPolicy implements RevisionPolicy {
 
 	public function publishedRevision( RevisionRecord $revision ): ?RevisionRecord {
 		return $this->approvalLookup->lastApprovedRevisionOf( $revision->getPage() );
 	}
 
 	public function revisionIsReadableBy( RevisionRecord $revision, Authority $viewer ): bool {
-		return $this->approvalLookup->isApproved( $revision )
-			|| $viewer->isAllowed( 'my-extension-see-drafts' );
+		return $this->approvalLookup->isApproved( $revision ) || $viewer->isAllowed( 'myext-see-drafts' );
 	}
 
 }
 ```
 
-`publishedRevision()` is asked whenever a page is written or reprojected: return the revision to publish, the argument
-to publish what was written, or `null` to publish nothing, which withdraws the page from the graph stores and the RDF
-export. `revisionIsReadableBy()` is asked only when a caller names a revision itself, which `publishedRevision()`
-cannot intercept — a revision it refuses answers exactly like one that does not exist.
+Register with `NeoWikiRegistrar::setRevisionPolicy()`; a second policy is refused with a warning on the `NeoWiki`
+log channel.
 
-- **A policy answers for the wiki, not for a viewer.** The graph and the RDF export are one state every reader sees.
-- **Only one extension can decide this.** A second policy is refused with a warning in the `NeoWiki` log channel; the
-  first one keeps deciding.
-- **Subject writes read the latest revision**, so a contributor still edits what they last saved. Schemas are the
-  exception: a Subject is validated against the Schema revision the policy publishes, while the Schema editor shows
-  the latest one ([#1392](https://github.com/ProfessionalWiki/NeoWiki/issues/1392)).
+- `publishedRevision()` receives the page's current revision and returns the one to publish, of the same page, or
+  `null`, which deletes the page's Page node and Subjects from the graph stores and makes the RDF export and the
+  Subject read answer not-found for it. A policy that throws counts as returning `null`, with the error logged. It
+  runs on every page save and rebuild and on every read above, so keep it cheap.
+- `revisionIsReadableBy()` is asked when a REST caller names a `revisionId` or asks for `latest`
+  ([REST API](../api/rest-api.md)); a refusal answers exactly like a revision that does not exist.
 
-Call [`newPageRebuilder()->rebuild( $title )`](#refreshing-a-pages-data-without-an-edit) whenever your extension
-changes which revision it approves; nothing else tells NeoWiki the answer has changed. `publishedRevision()` is also
-asked on every Schema, Layout and Mapping read and every RDF export, so keep it cheap.
+Approval changes outside an edit reach NeoWiki only through [`rebuild()`](#refreshing-a-pages-data-without-an-edit),
+and a newly registered policy reaches the graph stores only through a
+[full rebuild](../operations/maintenance.md#rebuilding-the-graph).
 
-One gap: Schemas and Mappings are read through a cache keyed on the page's latest revision id, so an approval change
-with no accompanying page edit does not take effect until that page is edited or the cache entry expires
+Editing reads the latest revision. So do `?action=subjects`, `GET /neowiki/v0/page/{pageId}/subjects` and the
+referenced Subjects on a `revisionId` read ([#1390](https://github.com/ProfessionalWiki/NeoWiki/issues/1390)), and
+the parse-time accessors. Schema and Mapping reads are cached under the latest revision id, so an approval change
+without an edit to that Schema or Mapping page takes effect on its next edit or when the entry expires
 ([#1392](https://github.com/ProfessionalWiki/NeoWiki/issues/1392)).
-
-Subject reads over REST, and the parse-time accessors, are not yet covered
-([#1390](https://github.com/ProfessionalWiki/NeoWiki/issues/1390)).
 
 ### Graph Database Backends
 

--- a/docs/extending/extending.md
+++ b/docs/extending/extending.md
@@ -164,11 +164,12 @@ NeoWiki re-runs every registered `PagePropertyProvider` for the page (and re-rea
 the Page node. No new revision is created. `rebuild()` returns a `PageRefreshOutcome`:
 
 - `Refreshed` — the Page node was updated.
+- `Unpublished` — a registered revision policy publishes no revision of the page, so it was withdrawn from the graph
+  stores.
 - `SkippedMissingRevision` — the page has no current revision.
 - `SkippedUnreadableSubjects` — the page's subject slot holds content NeoWiki cannot read as Subjects.
 - `SkippedUnreadablePageProperties` — the page's properties could not be built, for instance because a provider or the
   page's own parse threw.
-- `SkippedUnpublishableRevision` — a registered revision policy publishes no revision of the page.
 
 A graph store that fails is logged and skipped, exactly as on a normal page save; only request timeouts and
 wiki-database errors throw.
@@ -188,10 +189,6 @@ public function onNeoWikiRegistration( NeoWikiRegistrar $registrar ): void {
 ```php
 class MyApprovalPolicy implements RevisionPolicy {
 
-	public function publishesRevision( RevisionRecord $revision ): bool {
-		return $this->approvalLookup->isApproved( $revision );
-	}
-
 	public function publishedRevision( RevisionRecord $revision ): ?RevisionRecord {
 		return $this->approvalLookup->lastApprovedRevisionOf( $revision->getPage() );
 	}
@@ -204,11 +201,10 @@ class MyApprovalPolicy implements RevisionPolicy {
 }
 ```
 
-`publishesRevision()` is asked as a revision is written; return false and the graph keeps whatever it published
-before. `publishedRevision()` is asked when a page is reprojected; return the argument to leave the projection alone,
-or `null` when the page has nothing publishable. `revisionIsReadableBy()` is asked only when a caller names a revision
-itself, which neither publishing method can intercept — a revision it refuses answers exactly like one that does not
-exist.
+`publishedRevision()` is asked whenever a page is written or reprojected: return the revision to publish, the argument
+to publish what was written, or `null` to publish nothing, which withdraws the page from the graph stores and the RDF
+export. `revisionIsReadableBy()` is asked only when a caller names a revision itself, which `publishedRevision()`
+cannot intercept — a revision it refuses answers exactly like one that does not exist.
 
 - **A policy answers for the wiki, not for a viewer.** The graph and the RDF export are one state every reader sees.
 - **Only one extension can decide this.** A second policy is refused with a warning in the `NeoWiki` log channel; the
@@ -221,14 +217,9 @@ Call [`newPageRebuilder()->rebuild( $title )`](#refreshing-a-pages-data-without-
 changes which revision it approves; nothing else tells NeoWiki the answer has changed. `publishedRevision()` is also
 asked on every Schema, Layout and Mapping read and every RDF export, so keep it cheap.
 
-Two gaps:
-
-- Schemas and Mappings are read through a cache keyed on the page's latest revision id, so an approval change with
-  no accompanying page edit does not take effect until that page is edited or the cache entry expires
-  ([#1392](https://github.com/ProfessionalWiki/NeoWiki/issues/1392)).
-- The RDF export stops answering for a page once approval is withdrawn, but what was published stays in the graph
-  stores until the page is deleted; a rebuild does not remove it
-  ([#1391](https://github.com/ProfessionalWiki/NeoWiki/issues/1391)). Revocation is not a retraction mechanism.
+One gap: Schemas and Mappings are read through a cache keyed on the page's latest revision id, so an approval change
+with no accompanying page edit does not take effect until that page is edited or the cache entry expires
+([#1392](https://github.com/ProfessionalWiki/NeoWiki/issues/1392)).
 
 Subject reads over REST, and the parse-time accessors, are not yet covered
 ([#1390](https://github.com/ProfessionalWiki/NeoWiki/issues/1390)).

--- a/docs/operations/maintenance.md
+++ b/docs/operations/maintenance.md
@@ -18,8 +18,9 @@ time, from the shell or [from the wiki](#background-rebuilds). From the MediaWik
 php maintenance/run.php NeoWiki:RebuildGraphDatabases
 ```
 
-It re-projects every page on the wiki from its latest revision into every backend, and removes the pages MediaWiki
-no longer has. Run it to:
+It re-projects every page on the wiki from its latest revision, or from the one a registered
+[revision policy](../extending/extending.md#revision-policy) publishes, into every backend, and removes the pages
+MediaWiki no longer has. Run it to:
 
 - Recover after a graph store wipe or restore.
 - Fix any drift between a graph store's copy and the canonical revision slots.

--- a/src/Application/FailureIsolatingRevisionPolicy.php
+++ b/src/Application/FailureIsolatingRevisionPolicy.php
@@ -12,10 +12,14 @@ use Throwable;
 /**
  * Holds a registered policy to what NeoWiki can accept from one, and fails closed when it cannot.
  *
- * A policy that throws is treated as publishing nothing and hiding everything: the edit hook it runs
- * on sits inside PageUpdater's atomic section, so a throw there would roll the contributor's save
- * back, and a throw on a read would take every Schema, Layout and Mapping read down with it. The other
+ * A policy that throws publishes nothing and hides everything: the edit hook it runs on sits inside
+ * PageUpdater's atomic section, so a throw there would roll the contributor's save back, and a throw
+ * on a read would take every Schema, Layout and Mapping read down with it. The other
  * extension-contributed plugins are wrapped the same way; see FailureIsolatingGraphDatabasePlugin.
+ *
+ * Publishing nothing withdraws the page from the graph stores, so a broken policy costs the wiki its
+ * projection rather than publishing what it may not have. RebuildGraphDatabases puts back what was
+ * withdrawn once the policy answers again.
  *
  * Two answers are refused as well as caught. A revision of another page: every caller keys its write
  * or its export on the returned revision's page id, so accepting one would publish page B under page
@@ -29,19 +33,6 @@ class FailureIsolatingRevisionPolicy implements RevisionPolicy {
 		private readonly RevisionPolicy $policy,
 		private readonly LoggerInterface $logger,
 	) {
-	}
-
-	public function publishesRevision( RevisionRecord $revision ): bool {
-		if ( $revision->isDeleted( RevisionRecord::DELETED_TEXT ) ) {
-			return false;
-		}
-
-		try {
-			return $this->policy->publishesRevision( $revision );
-		} catch ( Throwable $exception ) {
-			$this->logFailure( 'publishesRevision', $revision, $exception );
-			return false;
-		}
 	}
 
 	public function publishedRevision( RevisionRecord $revision ): ?RevisionRecord {
@@ -59,7 +50,8 @@ class FailureIsolatingRevisionPolicy implements RevisionPolicy {
 		if ( $published->getPageId() !== $revision->getPageId() ) {
 			$this->logger->error(
 				'The revision policy {class} named revision {published} of page {publishedPage} for page {page}; '
-				. 'a policy may only name a revision of the page it was asked about. Publishing nothing for it.',
+				. 'a policy may only name a revision of the page it was asked about. Withdrawing it from the '
+				. 'graph stores.',
 				[
 					'class' => $this->policy::class,
 					'published' => $published->getId(),
@@ -89,7 +81,7 @@ class FailureIsolatingRevisionPolicy implements RevisionPolicy {
 	private function logFailure( string $method, RevisionRecord $revision, Throwable $exception ): void {
 		$this->logger->error(
 			'The revision policy {class} threw from {method} for revision {revision} of page {page}; '
-			. 'treating the page as publishing nothing. {message}',
+			. 'withdrawing it from the graph stores. {message}',
 			[
 				'class' => $this->policy::class,
 				'method' => $method,

--- a/src/Application/GraphRebuild/GraphRebuildExecutor.php
+++ b/src/Application/GraphRebuild/GraphRebuildExecutor.php
@@ -353,10 +353,28 @@ class GraphRebuildExecutor {
 			return ProjectedPageOutcome::projected();
 		}
 
+		if ( $outcome === PageRefreshOutcome::Unpublished ) {
+			$this->logWithdrawnPage( $pageId );
+			$progress->pageProjected( $pageId );
+			return ProjectedPageOutcome::projected();
+		}
+
 		$this->logSkippedPage( $pageId, $outcome->skipReason() );
 		$progress->pageSkipped( $pageId );
 
 		return ProjectedPageOutcome::skipped();
+	}
+
+	/**
+	 * A withdrawn page is reconciled rather than skipped, so it is counted with the pages that were
+	 * projected — and an operator reading the log has to be able to tell the two apart.
+	 */
+	private function logWithdrawnPage( int $pageId ): void {
+		$this->logger->info(
+			'NeoWiki graph rebuild reconciled page ' . $pageId . ': the registered revision policy '
+			. 'publishes no revision of it, so it was withdrawn from the store.',
+			[ 'pageId' => $pageId ]
+		);
 	}
 
 	/**

--- a/src/Application/GraphRebuild/RebuildProgress.php
+++ b/src/Application/GraphRebuild/RebuildProgress.php
@@ -34,8 +34,8 @@ class RebuildProgress {
 	}
 
 	/**
-	 * The page was not projected, and nothing failed: it has no current revision, its subject slot
-	 * does not hold Subject data, or the registered revision policy publishes no revision of it.
+	 * The page was not projected, and nothing failed: it has no current revision, or its subject slot
+	 * does not hold Subject data.
 	 */
 	public function pageSkipped( int $pageId ): void {
 		$this->cursor = $pageId;

--- a/src/Application/NullRevisionPolicy.php
+++ b/src/Application/NullRevisionPolicy.php
@@ -9,10 +9,6 @@ use MediaWiki\Revision\RevisionRecord;
 
 class NullRevisionPolicy implements RevisionPolicy {
 
-	public function publishesRevision( RevisionRecord $revision ): bool {
-		return true;
-	}
-
 	public function publishedRevision( RevisionRecord $revision ): ?RevisionRecord {
 		return $revision;
 	}

--- a/src/Application/PageRebuilder.php
+++ b/src/Application/PageRebuilder.php
@@ -14,19 +14,15 @@ class PageRebuilder {
 	public function __construct(
 		private readonly OnRevisionCreatedHandler $handler,
 		private readonly WikiPageFactory $wikiPageFactory,
-		private readonly RevisionPolicy $revisionPolicy,
 	) {
 	}
 
 	/**
-	 * Reprojects the page from the revision the registered policy publishes, which is what an approval
-	 * extension calls when its answer changes.
-	 *
-	 * The handler must not index: it would record the published revision's Subjects in place of the
-	 * latest one's. NeoWikiExtension wires it with a NullSubjectPageIndex for that reason.
+	 * Reprojects the page from its current revision, which is what an approval extension calls when its
+	 * answer changes. What that revision publishes is the handler's decision.
 	 */
 	public function rebuild( Title $title ): PageRefreshOutcome {
-		return $this->rebuildWithReadFlags( $title, IDBAccessObject::READ_NORMAL, substitute: true );
+		return $this->rebuildWithReadFlags( $title, IDBAccessObject::READ_NORMAL );
 	}
 
 	/**
@@ -35,10 +31,10 @@ class PageRebuilder {
 	 * replaced, which would project outdated content.
 	 */
 	public function rebuildFromPrimary( Title $title ): PageRefreshOutcome {
-		return $this->rebuildWithReadFlags( $title, IDBAccessObject::READ_LATEST, substitute: false );
+		return $this->rebuildWithReadFlags( $title, IDBAccessObject::READ_LATEST );
 	}
 
-	private function rebuildWithReadFlags( Title $title, int $readFlags, bool $substitute ): PageRefreshOutcome {
+	private function rebuildWithReadFlags( Title $title, int $readFlags ): PageRefreshOutcome {
 		$wikiPage = $this->wikiPageFactory->newFromTitle( $title );
 		$wikiPage->loadPageData( $readFlags );
 
@@ -46,16 +42,6 @@ class PageRebuilder {
 
 		if ( $revision === null ) {
 			return PageRefreshOutcome::SkippedMissingRevision;
-		}
-
-		if ( $substitute ) {
-			$published = $this->revisionPolicy->publishedRevision( $revision );
-
-			if ( $published === null ) {
-				return PageRefreshOutcome::SkippedUnpublishableRevision;
-			}
-
-			$revision = $published;
 		}
 
 		return $this->handler->onRevisionCreated( $revision );

--- a/src/Application/PageRefreshOutcome.php
+++ b/src/Application/PageRefreshOutcome.php
@@ -12,10 +12,10 @@ use LogicException;
  */
 enum PageRefreshOutcome: string {
 	case Refreshed = 'refreshed';
+	case Unpublished = 'unpublished';
 	case SkippedMissingRevision = 'skippedMissingRevision';
 	case SkippedUnreadableSubjects = 'skippedUnreadableSubjects';
 	case SkippedUnreadablePageProperties = 'skippedUnreadablePageProperties';
-	case SkippedUnpublishableRevision = 'skippedUnpublishableRevision';
 
 	/**
 	 * Why the page was not written, phrased to complete "Skipped <page>: ...".
@@ -27,8 +27,8 @@ enum PageRefreshOutcome: string {
 			self::SkippedMissingRevision => 'no current revision',
 			self::SkippedUnreadableSubjects => 'its subject slot does not hold Subject data',
 			self::SkippedUnreadablePageProperties => 'its page properties could not be built',
-			self::SkippedUnpublishableRevision => 'the registered revision policy does not publish it',
 			self::Refreshed => throw new LogicException( 'Refreshed is not a skip' ),
+			self::Unpublished => throw new LogicException( 'Unpublished is not a skip' ),
 		};
 	}
 }

--- a/src/Application/RevisionPolicy.php
+++ b/src/Application/RevisionPolicy.php
@@ -13,13 +13,8 @@ use MediaWiki\Revision\RevisionRecord;
  * such as ContentStabilization, which shows readers an approved revision rather than the newest one.
  * With no policy registered every page publishes its latest revision.
  *
- * A page save knows its revision and only needs to be told whether to publish it. A reprojection, a
- * configuration read and an RDF export know only the page, so they ask which revision to publish.
- * publishedRevision() therefore runs on every Schema, Layout and Mapping read and every RDF export,
- * and must be cheap.
- *
- * The answers must agree: publishesRevision() is true for whatever publishedRevision() names, since a
- * reprojection hands the named revision back to the save path's check.
+ * publishedRevision() runs on every Schema, Layout and Mapping read and every RDF export, as well as
+ * whenever a page is written or reprojected, and must be cheap.
  *
  * A policy answers for the wiki, not for a viewer: the graph and the RDF export are one state that
  * every reader sees. Only revisionIsReadableBy(), which serves a single request, takes a viewer.
@@ -27,20 +22,15 @@ use MediaWiki\Revision\RevisionRecord;
 interface RevisionPolicy {
 
 	/**
-	 * Whether this revision may be published, asked as it is written. False leaves the graph holding
-	 * whatever it published before, which for an approval extension is the last approved revision.
-	 */
-	public function publishesRevision( RevisionRecord $revision ): bool;
-
-	/**
-	 * The revision to publish for this revision's page, asked when a page is reprojected rather than
-	 * written. Null when the page has nothing publishable. Return the argument to leave it alone.
+	 * The revision to publish for this revision's page. Return the argument to publish what was
+	 * written, or null when the page has nothing publishable, which withdraws it from the graph
+	 * stores and the RDF export.
 	 */
 	public function publishedRevision( RevisionRecord $revision ): ?RevisionRecord;
 
 	/**
-	 * Whether the viewer may read a revision they asked for by id. Neither publishing method can
-	 * answer this: naming a revision bypasses both.
+	 * Whether the viewer may read a revision they asked for by id. publishedRevision() cannot answer
+	 * this: naming a revision bypasses it.
 	 */
 	public function revisionIsReadableBy( RevisionRecord $revision, Authority $viewer ): bool;
 

--- a/src/EntryPoints/OnRevisionCreatedHandler.php
+++ b/src/EntryPoints/OnRevisionCreatedHandler.php
@@ -30,8 +30,9 @@ class OnRevisionCreatedHandler {
 	}
 
 	/**
-	 * Indexes which Subjects the page holds, and projects the page with them — and with none when it
-	 * holds none: every page gets a Page node, so its Page Properties are queryable.
+	 * Indexes which Subjects the page holds, and projects the revision the registered policy publishes
+	 * for it — with no Subjects when that revision holds none: every page gets a Page node, so its Page
+	 * Properties are queryable. A page the policy publishes nothing for is withdrawn from the graph.
 	 *
 	 * The index records where a Subject lives and is written for every revision, published or not:
 	 * every id-keyed read and write addresses its page through it, so a Subject missing from it cannot
@@ -43,30 +44,12 @@ class OnRevisionCreatedHandler {
 			throw new RuntimeException( 'Page ID should not be 0' );
 		}
 
-		if ( !$revisionRecord->hasSlot( MediaWikiSubjectRepository::SLOT_NAME ) ) {
-			return $this->refreshPage( $revisionRecord, null );
+		$content = $this->readSubjectContent( $revisionRecord );
+
+		if ( $content instanceof PageRefreshOutcome ) {
+			return $content;
 		}
 
-		// The slot exists; a read failure here is a genuine error and must propagate —
-		// the refresh contract treats genuine failures as exceptions, not skips.
-		$content = $revisionRecord->getSlots()->getContent( MediaWikiSubjectRepository::SLOT_NAME );
-
-		// The slot holds something that is not Subject content, which happens when its content model is
-		// not registered, or an import wrote something else into it. Reading such a page as holding no
-		// Subjects would drop the Subjects it does hold, so nothing is written for it at all.
-		if ( !$content instanceof SubjectContent ) {
-			$this->logSkip(
-				$revisionRecord,
-				'its subject slot holds content that is not Subject data, so projecting the page would drop '
-				. 'the Subjects it holds from the graph'
-			);
-			return PageRefreshOutcome::SkippedUnreadableSubjects;
-		}
-
-		return $this->refreshPage( $revisionRecord, $content );
-	}
-
-	private function refreshPage( RevisionRecord $revisionRecord, ?SubjectContent $content ): PageRefreshOutcome {
 		$pageId = new PageId( $revisionRecord->getPageId() );
 
 		// Indexed before the Subjects are read as Subjects, and outside the projection's failure
@@ -74,17 +57,68 @@ class OnRevisionCreatedHandler {
 		// it or not at all, and a Subject too broken to deserialize is still indexed.
 		$this->subjectPageIndex->setSubjectsOfPage( $pageId, $content?->getSubjectIds() ?? [] );
 
-		// An unpublished revision leaves the graph holding what the policy last published.
-		if ( !$this->revisionPolicy->publishesRevision( $revisionRecord ) ) {
-			return PageRefreshOutcome::SkippedUnpublishableRevision;
+		$published = $this->revisionPolicy->publishedRevision( $revisionRecord );
+
+		if ( $published === null ) {
+			$this->graphDatabasePlugin->deletePage( $pageId );
+			return PageRefreshOutcome::Unpublished;
 		}
 
-		$subjects = $content?->getPageSubjects() ?? PageSubjects::newEmpty();
+		$publishedContent = $published === $revisionRecord ? $content : $this->readSubjectContent( $published );
 
+		if ( $publishedContent instanceof PageRefreshOutcome ) {
+			return $publishedContent;
+		}
+
+		return $this->projectPage( $pageId, $published, $publishedContent );
+	}
+
+	/**
+	 * What the revision holds in its subject slot, or null when it has no such slot.
+	 *
+	 * A slot holding something that is not Subject content — its content model is not registered, or an
+	 * import wrote something else into it — is neither, since reading such a page as holding no Subjects
+	 * would drop the Subjects it does hold. SkippedUnreadableSubjects then says to write nothing at all.
+	 */
+	private function readSubjectContent( RevisionRecord $revision ): SubjectContent|PageRefreshOutcome|null {
+		if ( !$revision->hasSlot( MediaWikiSubjectRepository::SLOT_NAME ) ) {
+			return null;
+		}
+
+		// The slot exists; a read failure here is a genuine error and must propagate —
+		// the refresh contract treats genuine failures as exceptions, not skips.
+		$content = $revision->getSlots()->getContent( MediaWikiSubjectRepository::SLOT_NAME );
+
+		if ( $content instanceof SubjectContent ) {
+			return $content;
+		}
+
+		$this->logSkip(
+			$revision,
+			'its subject slot holds content that is not Subject data, so projecting the page would drop '
+			. 'the Subjects it holds'
+		);
+
+		return PageRefreshOutcome::SkippedUnreadableSubjects;
+	}
+
+	private function logSkip( RevisionRecord $revisionRecord, string $reason ): void {
+		$this->logger->warning(
+			'NeoWiki did not project page ' . $revisionRecord->getPageId() . ' because ' . $reason
+			. '. The graph is out of sync for that page until the cause is resolved and the '
+			. 'RebuildGraphDatabases maintenance script is run.'
+		);
+	}
+
+	private function projectPage(
+		PageId $pageId,
+		RevisionRecord $published,
+		?SubjectContent $content
+	): PageRefreshOutcome {
 		// Null only from the isolating source the hook path is given, which has already logged the
 		// cause. The rebuild path is given the propagating one, so there the failure surfaces to the
 		// maintenance script instead, which reports it against the page.
-		$properties = $this->pagePropertiesSource->getPagePropertiesFor( $revisionRecord );
+		$properties = $this->pagePropertiesSource->getPagePropertiesFor( $published );
 
 		if ( $properties === null ) {
 			return PageRefreshOutcome::SkippedUnreadablePageProperties;
@@ -94,19 +128,11 @@ class OnRevisionCreatedHandler {
 			new Page(
 				id: $pageId,
 				properties: $properties,
-				subjects: $subjects
+				subjects: $content?->getPageSubjects() ?? PageSubjects::newEmpty()
 			)
 		);
 
 		return PageRefreshOutcome::Refreshed;
-	}
-
-	private function logSkip( RevisionRecord $revisionRecord, string $reason ): void {
-		$this->logger->warning(
-			'NeoWiki did not project page ' . $revisionRecord->getPageId() . ' because ' . $reason
-			. '. The graph is out of sync for that page until the cause is resolved and the '
-			. 'RebuildGraphDatabases maintenance script is run.'
-		);
 	}
 
 	public function onPageDelete( int $pageId ): void {

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -412,8 +412,6 @@ class NeoWikiExtension {
 	 * on.
 	 */
 	private function newRebuildStoreContentHandler(): OnRevisionCreatedHandler {
-		// The null index is load-bearing: PageRebuilder::rebuild() hands this handler the revision the
-		// policy publishes, and indexing that would drop the Subjects a draft added. See PageRebuilder.
 		return $this->newStoreContentHandler(
 			$this->getGraphDatabasePlugin(),
 			new NullSubjectPageIndex(),
@@ -1111,8 +1109,7 @@ class NeoWikiExtension {
 	private function newPageRebuilderWith( OnRevisionCreatedHandler $handler ): PageRebuilder {
 		return new PageRebuilder(
 			$handler,
-			MediaWikiServices::getInstance()->getWikiPageFactory(),
-			$this->getRevisionPolicy()
+			MediaWikiServices::getInstance()->getWikiPageFactory()
 		);
 	}
 

--- a/tests/phpunit/Application/FailureIsolatingRevisionPolicyTest.php
+++ b/tests/phpunit/Application/FailureIsolatingRevisionPolicyTest.php
@@ -28,17 +28,14 @@ class FailureIsolatingRevisionPolicyTest extends TestCase {
 		$published = $this->newRevision( pageId: self::PAGE_ID, id: 9 );
 		$policy = $this->isolate( FixedRevisionPolicy::publishing( $published ) );
 
-		$this->assertTrue( $policy->publishesRevision( $revision ) );
 		$this->assertSame( $published, $policy->publishedRevision( $revision ) );
 		$this->assertTrue( $policy->revisionIsReadableBy( $revision, $this->createStub( Authority::class ) ) );
 	}
 
 	public function testAThrowingPolicyPublishesNothing(): void {
 		$policy = $this->isolate( $this->newThrowingPolicy() );
-		$revision = $this->newRevision( pageId: self::PAGE_ID, id: 10 );
 
-		$this->assertFalse( $policy->publishesRevision( $revision ) );
-		$this->assertNull( $policy->publishedRevision( $revision ) );
+		$this->assertNull( $policy->publishedRevision( $this->newRevision( pageId: self::PAGE_ID, id: 10 ) ) );
 	}
 
 	public function testAThrowingPolicyHidesEveryRevision(): void {
@@ -54,7 +51,7 @@ class FailureIsolatingRevisionPolicyTest extends TestCase {
 		$logger = new TestLogger();
 
 		( new FailureIsolatingRevisionPolicy( $this->newThrowingPolicy(), $logger ) )
-			->publishesRevision( $this->newRevision( pageId: self::PAGE_ID, id: 10 ) );
+			->publishedRevision( $this->newRevision( pageId: self::PAGE_ID, id: 10 ) );
 
 		$this->assertTrue( $logger->hasErrorRecords() );
 	}
@@ -77,7 +74,6 @@ class FailureIsolatingRevisionPolicyTest extends TestCase {
 		$policy = $this->isolate( FixedRevisionPolicy::publishing( $suppressed ) );
 
 		$this->assertNull( $policy->publishedRevision( $this->newRevision( pageId: self::PAGE_ID, id: 10 ) ) );
-		$this->assertFalse( $policy->publishesRevision( $suppressed ) );
 	}
 
 	public function testANullAnswerStaysNull(): void {
@@ -107,10 +103,6 @@ class FailureIsolatingRevisionPolicyTest extends TestCase {
 
 	private function newThrowingPolicy(): RevisionPolicy {
 		return new class extends NullRevisionPolicy {
-			public function publishesRevision( RevisionRecord $revision ): bool {
-				throw new RuntimeException( 'approval table missing' );
-			}
-
 			public function publishedRevision( RevisionRecord $revision ): ?RevisionRecord {
 				throw new RuntimeException( 'approval table missing' );
 			}

--- a/tests/phpunit/Application/GraphRebuild/GraphRebuildTest.php
+++ b/tests/phpunit/Application/GraphRebuild/GraphRebuildTest.php
@@ -1026,6 +1026,34 @@ class GraphRebuildTest extends NeoWikiIntegrationTestCase {
 	}
 
 	/**
+	 * A page the registered revision policy publishes nothing for is withdrawn from the store rather
+	 * than left alone, which is a write like any other: the rebuild reconciled that page.
+	 */
+	public function testAWithdrawnPageCountsAsProjected(): void {
+		$pageId = $this->getExistingTestPage( 'Withdrawn page' )->getId();
+		$logger = new TestLogger( true );
+
+		$rebuilder = $this->createStub( PageRebuilder::class );
+		$rebuilder->method( 'rebuild' )->willReturn( PageRefreshOutcome::Unpublished );
+
+		$run = $this->newExecutor( new InMemoryPageIdsLookup( $pageId ), $logger )->execute(
+			run: $this->newRunRepository()->startRun( self::STORE, RebuildTrigger::Cli, RebuildStatus::Running ),
+			store: new SpyGraphDatabasePlugin(),
+			pageRebuilder: $rebuilder,
+			batchSize: 200,
+			observer: new NullRebuildBatchObserver()
+		);
+
+		$this->assertSame( 1, $run->processed );
+		$this->assertSame( 0, $run->failed );
+		$this->assertStringContainsString(
+			'withdrawn from the store',
+			$this->loggedText( $logger ),
+			'the operator can tell a withdrawn page from a projected one'
+		);
+	}
+
+	/**
 	 * Rebuilds $store over exactly the pages $pageIds walks, rather than over what the wiki holds.
 	 */
 	private function executeOver(

--- a/tests/phpunit/Application/PageRebuilderTest.php
+++ b/tests/phpunit/Application/PageRebuilderTest.php
@@ -10,10 +10,7 @@ use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Title\Title;
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\NeoWiki\Application\PageRefreshOutcome;
-use ProfessionalWiki\NeoWiki\Application\NullRevisionPolicy;
-use ProfessionalWiki\NeoWiki\Application\RevisionPolicy;
 use ProfessionalWiki\NeoWiki\Application\PageRebuilder;
-use ProfessionalWiki\NeoWiki\Tests\TestDoubles\FixedRevisionPolicy;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpyOnRevisionCreatedHandler;
 use Wikimedia\Rdbms\IDBAccessObject;
 use WikiPage;
@@ -22,6 +19,11 @@ use WikiPage;
  * @covers \ProfessionalWiki\NeoWiki\Application\PageRebuilder
  */
 class PageRebuilderTest extends TestCase {
+
+	/**
+	 * The outcomes of a page that was written rather than skipped.
+	 */
+	private const array WRITE_OUTCOMES = [ PageRefreshOutcome::Refreshed, PageRefreshOutcome::Unpublished ];
 
 	private SpyOnRevisionCreatedHandler $handler;
 
@@ -48,19 +50,29 @@ class PageRebuilderTest extends TestCase {
 	 */
 	public static function skipOutcomeProvider(): iterable {
 		foreach ( PageRefreshOutcome::cases() as $outcome ) {
-			if ( $outcome !== PageRefreshOutcome::Refreshed ) {
+			if ( !in_array( $outcome, self::WRITE_OUTCOMES, true ) ) {
 				yield $outcome->value => [ $outcome ];
 			}
 		}
 	}
 
 	/**
+	 * @dataProvider writeOutcomeProvider
 	 * @covers \ProfessionalWiki\NeoWiki\Application\PageRefreshOutcome::skipReason
 	 */
-	public function testRefreshedHasNoSkipReason(): void {
+	public function testAnOutcomeThatWroteHasNoSkipReason( PageRefreshOutcome $outcome ): void {
 		$this->expectException( LogicException::class );
 
-		PageRefreshOutcome::Refreshed->skipReason();
+		$outcome->skipReason();
+	}
+
+	/**
+	 * @return iterable<array{PageRefreshOutcome}>
+	 */
+	public static function writeOutcomeProvider(): iterable {
+		foreach ( self::WRITE_OUTCOMES as $outcome ) {
+			yield $outcome->value => [ $outcome ];
+		}
 	}
 
 	public function testReturnsRefreshedWhenHandlerWritesPage(): void {
@@ -88,7 +100,7 @@ class PageRebuilderTest extends TestCase {
 		$this->assertSame( [], $this->handler->calls );
 	}
 
-	public function testPassesTheCurrentRevisionToTheHandler(): void {
+	public function testRebuildPassesTheCurrentRevisionToTheHandler(): void {
 		$revision = $this->newRevision();
 
 		$this->newRebuilder( $revision )->rebuild( Title::makeTitle( NS_MAIN, 'AnyPage' ) );
@@ -114,38 +126,15 @@ class PageRebuilderTest extends TestCase {
 		);
 	}
 
-	public function testRebuildProjectsTheRevisionThePolicyPublishes(): void {
-		$latest = $this->newRevision();
-		$published = $this->newRevision();
+	public function testRebuildFromPrimaryPassesTheCurrentRevisionToTheHandler(): void {
+		$revision = $this->newRevision();
 
-		$this->newRebuilder( $latest, FixedRevisionPolicy::publishing( $published ) )
-			->rebuild( Title::makeTitle( NS_MAIN, 'Reprojected page' ) );
+		$this->newRebuilder( $revision )->rebuildFromPrimary( Title::makeTitle( NS_MAIN, 'Imported page' ) );
 
-		$this->assertSame( [ $published ], $this->handler->calls );
+		$this->assertSame( [ $revision ], $this->handler->calls );
 	}
 
-	public function testRebuildWritesNothingWhenThePolicyPublishesNoRevision(): void {
-		$outcome = $this->newRebuilder( $this->newRevision(), FixedRevisionPolicy::publishingNothing() )
-			->rebuild( Title::makeTitle( NS_MAIN, 'Page with nothing published' ) );
-
-		$this->assertSame( PageRefreshOutcome::SkippedUnpublishableRevision, $outcome );
-		$this->assertSame( [], $this->handler->calls );
-	}
-
-	/**
-	 * An import or undelete writes a revision rather than reprojecting a page, so it takes the same
-	 * path a save does: the handler is handed what was written and decides whether to publish it.
-	 */
-	public function testRebuildFromPrimaryDoesNotSubstitute(): void {
-		$written = $this->newRevision();
-
-		$this->newRebuilder( $written, FixedRevisionPolicy::publishing( $this->newRevision() ) )
-			->rebuildFromPrimary( Title::makeTitle( NS_MAIN, 'Imported page' ) );
-
-		$this->assertSame( [ $written ], $this->handler->calls );
-	}
-
-	private function newRebuilder( ?RevisionRecord $revision, ?RevisionPolicy $policy = null ): PageRebuilder {
+	private function newRebuilder( ?RevisionRecord $revision ): PageRebuilder {
 		$page = $this->createStub( WikiPage::class );
 		$page->method( 'getRevisionRecord' )->willReturn( $revision );
 		$page->method( 'loadPageData' )->willReturnCallback(
@@ -157,7 +146,7 @@ class PageRebuilderTest extends TestCase {
 		$factory = $this->createStub( WikiPageFactory::class );
 		$factory->method( 'newFromTitle' )->willReturn( $page );
 
-		return new PageRebuilder( $this->handler, $factory, $policy ?? new NullRevisionPolicy() );
+		return new PageRebuilder( $this->handler, $factory );
 	}
 
 	private function newRevision(): RevisionRecord {

--- a/tests/phpunit/Application/PageRefreshWithoutEditTest.php
+++ b/tests/phpunit/Application/PageRefreshWithoutEditTest.php
@@ -72,11 +72,15 @@ class PageRefreshWithoutEditTest extends NeoWikiIntegrationTestCase {
 		);
 	}
 
-	public function testRefreshWritesNothingWhenTheRegisteredPolicyPublishesNoRevision(): void {
-		$this->createPageWithSubjects( self::PAGE_NAME, TestSubject::build() );
+	public function testRefreshWithdrawsThePageWhenTheRegisteredPolicyPublishesNoRevision(): void {
+		$pageId = $this->createPageWithSubjects( self::PAGE_NAME, TestSubject::build() )->getPageId();
+		$this->assertTrue( $this->graphHoldsPage( $pageId ), 'precondition: saving the page projected it' );
 		$this->registerRevisionPolicy( FixedRevisionPolicy::publishingNothing() );
 
-		$this->assertSame( PageRefreshOutcome::SkippedUnpublishableRevision, $this->refreshPage() );
+		$outcome = $this->refreshPage();
+
+		$this->assertSame( PageRefreshOutcome::Unpublished, $outcome );
+		$this->assertFalse( $this->graphHoldsPage( $pageId ) );
 	}
 
 	public function testRefreshOfAMissingPageWritesNothing(): void {
@@ -98,6 +102,15 @@ class PageRefreshWithoutEditTest extends NeoWikiIntegrationTestCase {
 		);
 
 		return ( $result->first()->toRecursiveArray()['subjects'] ?? 0 ) > 0;
+	}
+
+	private function graphHoldsPage( int $pageId ): bool {
+		$result = $this->readGraph(
+			'MATCH (page:Page {id: $pageId}) RETURN count(page) AS pages',
+			[ 'pageId' => $pageId ]
+		);
+
+		return ( $result->first()->toRecursiveArray()['pages'] ?? 0 ) > 0;
 	}
 
 	private function readApprovalState( int $pageId ): ?string {

--- a/tests/phpunit/EntryPoints/OnRevisionCreatedHandlerTest.php
+++ b/tests/phpunit/EntryPoints/OnRevisionCreatedHandlerTest.php
@@ -21,6 +21,7 @@ use ProfessionalWiki\NeoWiki\Domain\Page\PagePropertyProviderRegistry;
 use ProfessionalWiki\NeoWiki\EntryPoints\OnRevisionCreatedHandler;
 use ProfessionalWiki\NeoWiki\FailureIsolatingPagePropertiesSource;
 use ProfessionalWiki\NeoWiki\PagePropertiesBuilder;
+use ProfessionalWiki\NeoWiki\Persistence\CorePagePropertyProvider;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
 use ProfessionalWiki\NeoWiki\Tests\TestDoubles\FixedRevisionPolicy;
@@ -39,6 +40,8 @@ use RuntimeException;
 class OnRevisionCreatedHandlerTest extends NeoWikiIntegrationTestCase {
 
 	private const int DELETED_PAGE_ID = 42;
+	private const int STUB_PAGE_ID = 43;
+	private const string APPROVED_PAGE = 'Page with an approved revision';
 
 	private SpyGraphDatabasePlugin $graphStore;
 	private SpySubjectPageIndex $subjectPageIndex;
@@ -128,7 +131,10 @@ class OnRevisionCreatedHandlerTest extends NeoWikiIntegrationTestCase {
 	public function testWritesNothingWhenTheSubjectSlotDoesNotHoldSubjectContent(): void {
 		// An unregistered content model hands back FallbackContent rather than SubjectContent. Projecting
 		// the page as holding no Subjects would wipe the ones it does hold, so nothing is written.
-		$revision = $this->newRevisionWithSlotContent( new FallbackContent( '{"subjects":{}}', 'unregistered-model' ) );
+		$revision = $this->newRevisionWithSlotContent(
+			self::STUB_PAGE_ID,
+			new FallbackContent( '{"subjects":{}}', 'unregistered-model' )
+		);
 
 		$outcome = $this->newHandler()->onRevisionCreated( $revision );
 
@@ -192,18 +198,69 @@ class OnRevisionCreatedHandlerTest extends NeoWikiIntegrationTestCase {
 		$this->assertEquals( [ new PageId( self::DELETED_PAGE_ID ) ], $this->graphStore->deletedPageIds );
 	}
 
-	public function testDoesNotProjectARevisionThePolicyDoesNotPublish(): void {
-		$revision = $this->createPageWithSubjects( 'Page with an unpublished revision', TestSubject::build() );
+	public function testProjectsTheSubjectsOfTheRevisionThePolicyPublishes(): void {
+		$approved = $this->createPageWithSubjects( self::APPROVED_PAGE, TestSubject::build() );
+		$draft = $this->createPageWithSubjects( self::APPROVED_PAGE );
+
+		$outcome = $this->newHandlerWithPolicy( FixedRevisionPolicy::publishing( $approved ) )
+			->onRevisionCreated( $draft );
+
+		$this->assertSame( PageRefreshOutcome::Refreshed, $outcome );
+		$this->assertTrue(
+			$this->graphStore->savedPages[0]->getSubjects()->hasSubjects(),
+			'the approved revision holds a Subject the draft removed'
+		);
+	}
+
+	public function testProjectsThePagePropertiesOfTheRevisionThePolicyPublishes(): void {
+		$approved = $this->createPageWithSubjects( self::APPROVED_PAGE, TestSubject::build() );
+		$draft = $this->editPage(
+			self::APPROVED_PAGE,
+			'A draft nobody approved',
+			'',
+			NS_MAIN,
+			$this->getTestUser()->getUser()
+		)->getNewRevision();
+
+		$this->newHandlerWith(
+			$this->graphStore,
+			$this->newCorePropertyRegistry(),
+			revisionPolicy: FixedRevisionPolicy::publishing( $approved )
+		)->onRevisionCreated( $draft );
+
+		$this->assertSame(
+			$this->getTestSysop()->getUser()->getName(),
+			$this->graphStore->savedPages[0]->getProperties()->get( 'lastEditor' ),
+			'the properties describe the approved revision, whose author is not the drafter'
+		);
+	}
+
+	public function testIndexesTheSubjectsOfTheGivenRevisionWhenAnotherIsPublished(): void {
+		$approved = $this->createPageWithSubjects( self::APPROVED_PAGE, TestSubject::build() );
+		$draft = $this->createPageWithSubjects( self::APPROVED_PAGE );
+
+		$this->newHandlerWithPolicy( FixedRevisionPolicy::publishing( $approved ) )
+			->onRevisionCreated( $draft );
+
+		$this->assertSame(
+			[ $draft->getPageId() => [] ],
+			$this->subjectPageIndex->indexedSubjectsByPageId,
+			'the index addresses the Subjects the page now holds, not the ones it publishes'
+		);
+	}
+
+	public function testWithdrawsThePageFromTheGraphWhenThePolicyPublishesNothing(): void {
+		$revision = $this->createPageWithSubjects( 'Page whose approval was revoked', TestSubject::build() );
 
 		$outcome = $this->newHandlerWithPolicy( FixedRevisionPolicy::publishingNothing() )
 			->onRevisionCreated( $revision );
 
-		$this->assertSame( PageRefreshOutcome::SkippedUnpublishableRevision, $outcome );
+		$this->assertSame( PageRefreshOutcome::Unpublished, $outcome );
+		$this->assertEquals( [ new PageId( $revision->getPageId() ) ], $this->graphStore->deletedPageIds );
 		$this->assertSame( [], $this->graphStore->savedPages );
-		$this->assertSame( [], $this->graphStore->deletedPageIds, 'what was published stays published' );
 	}
 
-	public function testIndexesASubjectEvenWhenItsRevisionIsNotPublished(): void {
+	public function testIndexesTheSubjectsOfAPageThatPublishesNothing(): void {
 		$revision = $this->createPageWithSubjects( 'Page whose draft adds a subject', TestSubject::build() );
 
 		$this->newHandlerWithPolicy( FixedRevisionPolicy::publishingNothing() )
@@ -211,8 +268,31 @@ class OnRevisionCreatedHandlerTest extends NeoWikiIntegrationTestCase {
 
 		$this->assertSame(
 			[ $revision->getPageId() => [ TestSubject::ZERO_GUID ] ],
-			$this->subjectPageIndex->indexedSubjectsByPageId
+			$this->subjectPageIndex->indexedSubjectsByPageId,
+			'a withdrawn page is still on the wiki, so its Subjects stay editable'
 		);
+	}
+
+	public function testWritesNothingWhenThePublishedRevisionHoldsNoSubjectContent(): void {
+		$revision = $this->createPageWithSubjects( 'Page with an unreadable approved revision', TestSubject::build() );
+		$published = $this->newRevisionWithSlotContent(
+			$revision->getPageId(),
+			new FallbackContent( '{"subjects":{}}', 'unregistered-model' )
+		);
+
+		$outcome = $this->newHandlerWithPolicy( FixedRevisionPolicy::publishing( $published ) )
+			->onRevisionCreated( $revision );
+
+		$this->assertSame( PageRefreshOutcome::SkippedUnreadableSubjects, $outcome );
+		$this->assertSame( [], $this->graphStore->savedPages );
+		$this->assertSame( [], $this->graphStore->deletedPageIds );
+	}
+
+	private function newCorePropertyRegistry(): PagePropertyProviderRegistry {
+		$registry = new PagePropertyProviderRegistry();
+		$registry->addProvider( new CorePagePropertyProvider() );
+
+		return $registry;
 	}
 
 	private function newFailingProviderRegistry(): PagePropertyProviderRegistry {
@@ -226,12 +306,12 @@ class OnRevisionCreatedHandlerTest extends NeoWikiIntegrationTestCase {
 		return $registry;
 	}
 
-	private function newRevisionWithSlotContent( Content $content ): RevisionRecord {
+	private function newRevisionWithSlotContent( int $pageId, Content $content ): RevisionRecord {
 		$slots = $this->createStub( RevisionSlots::class );
 		$slots->method( 'getContent' )->willReturn( $content );
 
 		$revision = $this->createStub( RevisionRecord::class );
-		$revision->method( 'getPageId' )->willReturn( 42 );
+		$revision->method( 'getPageId' )->willReturn( $pageId );
 		$revision->method( 'hasSlot' )->willReturn( true );
 		$revision->method( 'getSlots' )->willReturn( $slots );
 

--- a/tests/phpunit/EntryPoints/RevisionVisibilityGraphProjectionTest.php
+++ b/tests/phpunit/EntryPoints/RevisionVisibilityGraphProjectionTest.php
@@ -7,7 +7,11 @@ namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints;
 use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Title\Title;
 use MediaWiki\User\User;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\FixedRevisionPolicy;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\SpyGraphDatabasePlugin;
 
 /**
  * Hiding who made a revision creates no revision of its own, so none of the hooks the projection is
@@ -21,10 +25,18 @@ use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
 class RevisionVisibilityGraphProjectionTest extends NeoWikiIntegrationTestCase {
 
 	private const string PAGE_NAME = 'Page whose author gets hidden';
+	private const string APPROVED_PAGE_NAME = 'Page with an approved revision and a draft';
 
 	protected function setUp(): void {
 		parent::setUp();
 		$this->setUpNeo4j();
+	}
+
+	protected function tearDown(): void {
+		parent::tearDown();
+		// A test that registers a revision policy rebuilds the singleton with it; reset it so later
+		// tests get a clean instance rebuilt without the temporary hook.
+		NeoWikiExtension::resetInstance();
 	}
 
 	public function testHidingTheAuthorOfTheCurrentRevisionTakesTheirNameOutOfTheGraph(): void {
@@ -70,6 +82,27 @@ class RevisionVisibilityGraphProjectionTest extends NeoWikiIntegrationTestCase {
 		$this->hideRevisionAuthor( $this->pageTitle(), $firstRevision->getId() );
 
 		$this->assertSame( $lastAuthor->getName(), $this->readLastEditor( $lastRevision->getPageId() ) );
+	}
+
+	/**
+	 * The reprojection publishes what the registered policy names, not the revision whose visibility
+	 * changed: on a wiki with an approval extension, hiding an author must not publish a draft.
+	 */
+	public function testHidingAnAuthorReprojectsTheRevisionThePolicyPublishes(): void {
+		$this->createSchema( TestSubject::DEFAULT_SCHEMA_ID );
+		$approved = $this->createPageWithSubjects( self::APPROVED_PAGE_NAME, TestSubject::build() );
+		$draft = $this->createPageWithSubjects( self::APPROVED_PAGE_NAME );
+
+		$store = new SpyGraphDatabasePlugin();
+		$this->registerGraphDatabasePlugins( $store );
+		$this->registerRevisionPolicy( FixedRevisionPolicy::publishing( $approved ) );
+
+		$this->hideRevisionAuthor( Title::newFromText( self::APPROVED_PAGE_NAME ), $draft->getId() );
+
+		$this->assertTrue(
+			$store->savedPages[0]->getSubjects()->hasSubjects(),
+			'the approved revision holds a Subject the draft removed'
+		);
 	}
 
 	private function editPageAs( User $author ): RevisionRecord {

--- a/tests/phpunit/TestDoubles/FixedRevisionPolicy.php
+++ b/tests/phpunit/TestDoubles/FixedRevisionPolicy.php
@@ -11,7 +11,6 @@ use ProfessionalWiki\NeoWiki\Application\RevisionPolicy;
 class FixedRevisionPolicy implements RevisionPolicy {
 
 	private function __construct(
-		private readonly bool $publishes,
 		private readonly bool $substitutes,
 		private readonly ?RevisionRecord $published,
 		private readonly bool $readable,
@@ -19,19 +18,15 @@ class FixedRevisionPolicy implements RevisionPolicy {
 	}
 
 	public static function publishing( RevisionRecord $revision ): self {
-		return new self( publishes: true, substitutes: true, published: $revision, readable: true );
+		return new self( substitutes: true, published: $revision, readable: true );
 	}
 
 	public static function publishingNothing(): self {
-		return new self( publishes: false, substitutes: true, published: null, readable: true );
+		return new self( substitutes: true, published: null, readable: true );
 	}
 
 	public static function hidingEveryRevision(): self {
-		return new self( publishes: true, substitutes: false, published: null, readable: false );
-	}
-
-	public function publishesRevision( RevisionRecord $revision ): bool {
-		return $this->publishes;
+		return new self( substitutes: false, published: null, readable: false );
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/1391

Two simplifications of https://github.com/ProfessionalWiki/NeoWiki/pull/1389, and the fix that falls out
of them.

RevisionPolicy answers one question. publishesRevision() was derivable from publishedRevision() under the
interface's own "answers must agree" contract, so the method and the contract are both gone.

OnRevisionCreatedHandler decides what a page publishes; PageRebuilder only chooses the read source.
rebuild() and rebuildFromPrimary() both hand the handler the page's current revision, which indexes that
revision's Subjects, asks the policy, and projects the revision it names — reading that revision's own
subject slot and page properties when it is not the one the handler was given.

Every path therefore goes through that one decision, including the rebuildFromPrimary() callers
https://github.com/ProfessionalWiki/NeoWiki/pull/1389 exempted from substitution — import, undeletion, a
revision-visibility change and the hidden-user rebuild — which now project what the policy publishes for
the page rather than what they were handed: an import into a page with nothing approved is withdrawn
until the approval extension reprojects it, where before it was skipped and the graph left as it was. The
regression test on the visibility path locks that in.

The fix: a page the policy publishes nothing for is now withdrawn from the graph stores rather than left
as it was. Before this, a page whose approval had been revoked stayed queryable through Cypher and SPARQL
while the RDF export and the REST reads had already stopped answering for it, and no rebuild converged.
PageRefreshOutcome::Unpublished replaces SkippedUnpublishableRevision; a rebuild counts a withdrawn page
as reconciled and says so in the log. The subject-to-page index stays ungoverned by the policy: the page
still exists on the wiki, so its Subjects have to stay addressable for editing.

A consequence worth stating: FailureIsolatingRevisionPolicy turns a throwing policy, one naming a revision
of another page, and one naming a suppressed revision into null, so such a page is now withdrawn rather
than left alone. That is fail-closed for an approval feature; the error is logged on every call, and
RebuildGraphDatabases restores the graph once the policy works.

Considered, omitted:

- A third policy answer meaning "leave the graph alone", so a failing policy could be told apart from a
  deliberate revocation. The log and a rebuild cover that without new interface surface.
- Counting withdrawals on RebuildProgress and the persisted run records.
- Withdrawing on the reprojection path only, leaving the save path skipping. With the question asked once
  and in one place, that split would only make the two paths disagree.

## Documentation

The second commit rewrites the `extending.md` section for this interface and retitles it "Revision policy". Reader:
the developer of an approval extension who already registers a Page Property Provider and calls `rebuild()`.
Decision: whether to register a policy, what each method returns, what to call when approval changes, and which
surfaces still read the latest revision. Budget 35 lines; 39 landed. It documents the by-id Subject read as
https://github.com/ProfessionalWiki/NeoWiki/pull/1398 ships it, so that PR belongs alongside this one; the paragraph
it carried in this section is dropped there. The `RebuildGraphDatabases` sentence in `maintenance.md` no longer says
the rebuild projects each page's latest revision.

Considered, omitted from the section: the suppressed-revision refusal; a throwing `revisionIsReadableBy()` answering
false; the subject-to-page index staying ungoverned; the `Unpublished` outcome, documented in the section above it;
the `latest` parameter's semantics, whose home is `rest-api.md`; the Mapping-trigger half of
https://github.com/ProfessionalWiki/NeoWiki/issues/1392 and the Schema validation asymmetry, both inside that issue;
the wiki-not-viewer rationale, which the two signatures show.

> <sub>AI-authored — Claude Code, `Opus 5 (max)`; implemented from a written spec by a Fable 5.1 session on @JeroenDeDauw's go-ahead; diff not yet human-reviewed; tests written first and run locally, phpcs and phpstan clean, CI pending.</sub>

<details><summary>Production notes</summary>

Code by `Opus 5 (max)` from a Fable 5.1 spec. The documentation commit is by `Fable 5.1 (max)` on @JeroenDeDauw's
"use the optimal version": a blind from-scratch draft and a blind judge, then synthesized against the earlier
section. Links checked against their targets; rendered markdown not checked; not yet human-reviewed.

</details>
