### PR TITLE
Fix three findings from the review of #1398

### DIFF
--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -51,7 +51,7 @@ Read, change, and validate Subjects. New Subjects are created on a page — see
 
 | Endpoint | Description |
 |---|---|
-| `GET /neowiki/v0/subject/{subjectId}` | Fetch a Subject as the wiki publishes it. `latest` returns the hosting page's current revision instead, for editing, when the viewer may see it. Optional `revisionId`; `expand` with `page` or `relations`. |
+| `GET /neowiki/v0/subject/{subjectId}` | Fetch a Subject as the wiki publishes it. `latest=1` returns the hosting page's current revision instead, for editing, when the viewer may see it. Optional `revisionId`; `expand` with `page` or `relations`. |
 | `GET /neowiki/v0/subject/{subjectId}/rdf` | Export one Subject as RDF. `format` is `trig` (default) or `turtle`; `projection` is `native` (default) or an ontology target. See [RDF export](../rdf/rdf-export.md). |
 | `GET /neowiki/v0/entity/{subjectId}` | Dereference a Subject's concept URI. `303` to the Subject's RDF (`Accept: application/trig` or `text/turtle`) or to the hosting page (otherwise). See [Dereferencing subject IRIs](../rdf/rdf-export.md#dereferencing-subject-iris). |
 | `PUT /neowiki/v0/subject/{subjectId}` | Replace a Subject's label and statements. |

--- a/docs/extending/extending.md
+++ b/docs/extending/extending.md
@@ -437,8 +437,9 @@ schema, and layout stores for display; `nw.resolveDisplayProperties` together wi
 registry to render each value through its Property Type's component; and the shared `nw.SubjectEditorDialog` for
 editing when `canEditSubject` is true. Editing reads go through the repositories your component injects
 (`nw.NeoWikiServices.getSubjectRepository()`, `getSchemaRepository()`), not the stores, and reach the dialog as
-props. Saving updates the stores on its own: a Subject write answers with the Subject as persisted and the Schema
-it instantiates, and `nw.useSubjectStore()` records both.
+props. Seed the editor with `getSubjectForEditing()`: `getSubject()` answers with the revision the wiki publishes,
+which a save would overwrite. Saving updates the stores on its own: a Subject write answers with the Subject as
+persisted and the Schema it instantiates, and `nw.useSubjectStore()` records both.
 
 Relation fields inside the dialog offer creating the target Subject on the spot, but only when the dialog is given
 an `onCreate` handler alongside `onSave`. Creating a target writes a new Subject to a page, and which page that is

--- a/resources/ext.neowiki/src/persistence/RestSubjectRepository.ts
+++ b/resources/ext.neowiki/src/persistence/RestSubjectRepository.ts
@@ -198,16 +198,17 @@ export class RestSubjectRepository implements SubjectRepository {
 	}
 
 	/**
-	 * A repository built for a revision of the page reads that revision, whoever is asking: the
-	 * user is looking at an old revision, and the current one is not what they came for.
+	 * A write targets the page's current revision whatever revision was read, so an editing read is
+	 * never pinned. NeoWikiApp offers no editing on a pinned view, but a host that mounts an editor
+	 * itself has nothing stopping it.
 	 */
 	private async fetchSubjectBundle( id: SubjectId, latest: boolean ): Promise<SubjectBundleJson> {
 		let url = `${ this.mediaWikiRestApiUrl }/neowiki/v0/subject/${ id.text }?expand=page|relations`;
 
-		if ( this.revisionId !== undefined ) {
-			url += `&revisionId=${ this.revisionId }`;
-		} else if ( latest ) {
+		if ( latest ) {
 			url += '&latest=1';
+		} else if ( this.revisionId !== undefined ) {
+			url += `&revisionId=${ this.revisionId }`;
 		}
 
 		const response = await this.httpClient.get( url );

--- a/resources/ext.neowiki/tests/persistence/RestSubjectRepository.neo4j.spec.ts
+++ b/resources/ext.neowiki/tests/persistence/RestSubjectRepository.neo4j.spec.ts
@@ -172,20 +172,33 @@ describe( 'RestSubjectRepository', () => {
 			expect( get ).toHaveBeenCalledWith( subjectUrl() );
 		} );
 
-		it( 'asks for the revision it was built for rather than the current one', async () => {
+		it( 'asks for the revision it was built for when reading for display', async () => {
 			const httpClient = newHttpClient( subjectUrl( '&revisionId=7' ) );
 			const get = vi.spyOn( httpClient, 'get' );
 
-			await new RestSubjectRepository(
+			await newRepositoryForRevision( httpClient, 7 ).getSubject( subjectId );
+
+			expect( get ).toHaveBeenCalledWith( subjectUrl( '&revisionId=7' ) );
+		} );
+
+		it( 'asks for the current revision when reading for editing, pinned revision or not', async () => {
+			const httpClient = newHttpClient( subjectUrl( '&latest=1' ) );
+			const get = vi.spyOn( httpClient, 'get' );
+
+			await newRepositoryForRevision( httpClient, 7 ).getSubjectForEditing( subjectId );
+
+			expect( get ).toHaveBeenCalledWith( subjectUrl( '&latest=1' ) );
+		} );
+
+		function newRepositoryForRevision( httpClient: InMemoryHttpClient, revisionId: number ): RestSubjectRepository {
+			return new RestSubjectRepository(
 				'https://example.com/rest.php',
 				httpClient,
 				NeoWikiExtension.getInstance().getSubjectDeserializer(),
 				new SchemaDeserializer(),
-				7,
-			).getSubjectForEditing( subjectId );
-
-			expect( get ).toHaveBeenCalledWith( subjectUrl( '&revisionId=7' ) );
-		} );
+				revisionId,
+			);
+		}
 
 	} );
 

--- a/src/EntryPoints/REST/GetSubjectApi.php
+++ b/src/EntryPoints/REST/GetSubjectApi.php
@@ -107,7 +107,8 @@ class GetSubjectApi extends SimpleHandler {
 			return $this->getResponseFactory()->createJson( $presenter->getJsonArray() );
 		}
 
-		return NeoWikiExtension::getInstance()->newGetLatestSubjectQuery( $presenter, $this->getAuthority() );
+		return NeoWikiExtension::getInstance()
+			->newGetLatestSubjectQuery( $presenter, $this->getAuthority(), $revision );
 	}
 
 	private function getLatestRevisionOfSubjectPage( string $subjectId ): ?RevisionRecord {

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -155,6 +155,7 @@ use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\MediaWikiSubjectConte
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\MediaWikiSubjectRepository;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\PointInTimeSubjectLookup;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\PublishedSubjectLookup;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\LatestRevisionSubjectLookup;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\StatementDeserializer;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\SubjectContentDataDeserializer;
 use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\CachingMappingLookup;
@@ -1517,24 +1518,32 @@ class NeoWikiExtension {
 	public function newGetSubjectQuery( RestGetSubjectPresenter $presenter, Authority $authority ): GetSubjectQuery {
 		return new GetSubjectQuery(
 			presenter: $presenter,
-			subjectLookup: new PublishedSubjectLookup(
-				pageIdentifiersLookup: $this->getPageIdentifiersLookup(),
-				revisionLookup: MediaWikiServices::getInstance()->getRevisionLookup(),
-				revisionPolicy: $this->getRevisionPolicy(),
-			),
+			subjectLookup: $this->newPublishedSubjectLookup(),
 			pageIdentifiersLookup: $this->getPageIdentifiersLookup(),
 			pageSubjectsLookup: $this->newPageSubjectsLookup(),
 			readAuthorizer: $this->newPageReadAuthorizer( $authority ),
 		);
 	}
 
-	public function newGetLatestSubjectQuery( RestGetSubjectPresenter $presenter, Authority $authority ): GetSubjectQuery {
+	public function newGetLatestSubjectQuery(
+		RestGetSubjectPresenter $presenter,
+		Authority $authority,
+		RevisionRecord $currentRevision
+	): GetSubjectQuery {
 		return new GetSubjectQuery(
 			presenter: $presenter,
-			subjectLookup: $this->getSubjectRepository(),
+			subjectLookup: new LatestRevisionSubjectLookup( $currentRevision, $this->newPublishedSubjectLookup() ),
 			pageIdentifiersLookup: $this->getPageIdentifiersLookup(),
 			pageSubjectsLookup: $this->newPageSubjectsLookup(),
 			readAuthorizer: $this->newPageReadAuthorizer( $authority ),
+		);
+	}
+
+	private function newPublishedSubjectLookup(): PublishedSubjectLookup {
+		return new PublishedSubjectLookup(
+			pageIdentifiersLookup: $this->getPageIdentifiersLookup(),
+			revisionLookup: MediaWikiServices::getInstance()->getRevisionLookup(),
+			revisionPolicy: $this->getRevisionPolicy(),
 		);
 	}
 

--- a/src/Persistence/MediaWiki/Subject/LatestRevisionSubjectLookup.php
+++ b/src/Persistence/MediaWiki/Subject/LatestRevisionSubjectLookup.php
@@ -1,0 +1,61 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject;
+
+use MediaWiki\Revision\RevisionRecord;
+use ProfessionalWiki\NeoWiki\Application\SubjectLookup;
+use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectIdList;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectMap;
+
+/**
+ * The Subjects the given revision holds, and for the rest whatever their own pages answer. The
+ * caller has one page's revision in hand and has decided its reader may see it, so Subjects on that
+ * page come from it; the other pages the caller said nothing about, and are left to a lookup that
+ * answers for a page rather than a revision.
+ */
+readonly class LatestRevisionSubjectLookup implements SubjectLookup {
+
+	public function __construct(
+		private RevisionRecord $revision,
+		private SubjectLookup $otherPages,
+	) {
+	}
+
+	public function getSubject( SubjectId $subjectId ): ?Subject {
+		return $this->getSubjects( new SubjectIdList( [ $subjectId ] ) )->getSubject( $subjectId );
+	}
+
+	public function getSubjects( SubjectIdList $subjectIds ): SubjectMap {
+		// Reading the slot deserializes all of it, and a Subject with no relations asks for nothing.
+		if ( $subjectIds->asStringArray() === [] ) {
+			return new SubjectMap();
+		}
+
+		$subjects = $this->subjectsInRevision( $subjectIds );
+		$missingIds = $this->idsMissingFrom( $subjects, $subjectIds );
+
+		if ( $missingIds->asStringArray() === [] ) {
+			return $subjects;
+		}
+
+		return $subjects->union( $this->otherPages->getSubjects( $missingIds ) );
+	}
+
+	private function subjectsInRevision( SubjectIdList $subjectIds ): SubjectMap {
+		$content = SubjectSlotReader::read( $this->revision );
+
+		return $content === null ? new SubjectMap() : $content->getPageSubjects()->getAllSubjects()->onlyWithIds( $subjectIds );
+	}
+
+	private function idsMissingFrom( SubjectMap $subjects, SubjectIdList $subjectIds ): SubjectIdList {
+		return new SubjectIdList( array_filter(
+			$subjectIds->asArray(),
+			static fn ( SubjectId $subjectId ): bool => !$subjects->hasSubject( $subjectId )
+		) );
+	}
+
+}

--- a/tests/RedHerb/resources/RedHerbCard.vue
+++ b/tests/RedHerb/resources/RedHerbCard.vue
@@ -183,11 +183,13 @@ module.exports = exports = {
 
 		// Editing UIs read through the repositories rather than the stores
 		// (NeoWiki ADR 30 / ADR 16): the stores hold page state, not editor state.
+		// getSubjectForEditing, not getSubject: a save replaces the current
+		// revision, not the published one.
 		// Saving updates the stores, because the write answers with the Subject and
 		// Schema as the server has them.
 		function openEditor() {
 			Promise.all( [
-				subjectRepo.getSubject( props.subjectId ),
+				subjectRepo.getSubjectForEditing( props.subjectId ),
 				schemaRepo.getSchema( subject.value.getSchemaName() )
 			] ).then( ( [ freshSubject, freshSchema ] ) => {
 				editingSubject.value = freshSubject;

--- a/tests/RedHerb/resources/editMainSubject/EditMainSubjectDialog.vue
+++ b/tests/RedHerb/resources/editMainSubject/EditMainSubjectDialog.vue
@@ -65,7 +65,9 @@ module.exports = exports = {
 			// Editing UIs read through the repositories rather than the stores
 			// (NeoWiki ADR 30 / ADR 16), so the editor always opens on freshly
 			// fetched data instead of the page-load payload the stores hold.
-			subjectRepo.getSubject( subjectId )
+			// getSubjectForEditing, not getSubject: a save replaces the current
+			// revision, not the published one.
+			subjectRepo.getSubjectForEditing( subjectId )
 				.then( ( subject ) => {
 					loadedSubject.value = subject;
 					label.value = subject.getLabel() || '';

--- a/tests/phpunit/EntryPoints/REST/GetSubjectApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/GetSubjectApiTest.php
@@ -267,7 +267,7 @@ JSON,
 	}
 
 	private function labelOf( Response $response, string $subjectId ): ?string {
-		return json_decode( $response->getBody()->getContents(), true )['subjects'][$subjectId]['label'];
+		return json_decode( $response->getBody()->getContents(), true )['subjects'][$subjectId]['label'] ?? null;
 	}
 
 	private function newTestSubject( string $id, ?string $label = 'Test subject' ): Subject {
@@ -361,6 +361,108 @@ JSON,
 		);
 
 		$this->assertSame( 'published target', $this->labelOf( $response, 'sTestGSA1111256' ) );
+	}
+
+	public function testLatestServesReferencedSubjectsFromTheirOwnPagesPublishedRevision(): void {
+		$publishedTarget = $this->createPageWithSubjects(
+			'GetSubjectApiTest_LatestPublishedTarget',
+			mainSubject: $this->newTestSubject( 'sTestGSA1111263', 'published target' )
+		);
+
+		$this->createPageWithSubjects(
+			'GetSubjectApiTest_LatestPublishedTarget',
+			mainSubject: $this->newTestSubject( 'sTestGSA1111263', 'draft target' )
+		);
+
+		$this->createPageWithSubjects(
+			'GetSubjectApiTest_LatestRelationSource',
+			mainSubject: TestSubject::build(
+				id: 'sTestGSA1111264',
+				schemaName: new SchemaName( 'GetSubjectApiTestSchema' ),
+				statements: new StatementList( [
+					TestStatement::buildRelation( 'MyRelation', [
+						TestRelation::build( id: 'rTestGSA1111rr9', targetId: 'sTestGSA1111263' ),
+					] ),
+				] )
+			)
+		);
+
+		$response = $this->runWithRevisionPolicy(
+			FixedRevisionPolicy::publishing( $publishedTarget ),
+			fn (): Response => $this->requestSubject( 'sTestGSA1111264', [ 'latest' => '1', 'expand' => 'relations' ] )
+		);
+
+		$this->assertSame( 'published target', $this->labelOf( $response, 'sTestGSA1111263' ) );
+	}
+
+	/**
+	 * The gate cleared this page's current revision for this viewer, so a target sitting in that
+	 * same revision comes from it. Only the pages the caller said nothing about fall back to what
+	 * they publish.
+	 */
+	public function testLatestServesASamePageTargetFromTheRevisionItCleared(): void {
+		$published = $this->createPageWithSubjects(
+			'GetSubjectApiTest_LatestSamePage',
+			mainSubject: TestSubject::build(
+				id: 'sTestGSA1111266',
+				schemaName: new SchemaName( 'GetSubjectApiTestSchema' ),
+				statements: new StatementList( [
+					TestStatement::buildRelation( 'MyRelation', [
+						TestRelation::build( id: 'rTestGSA1111ra2', targetId: 'sTestGSA1111267' ),
+					] ),
+				] )
+			)
+		);
+
+		$this->createPageWithSubjects(
+			'GetSubjectApiTest_LatestSamePage',
+			mainSubject: TestSubject::build(
+				id: 'sTestGSA1111266',
+				schemaName: new SchemaName( 'GetSubjectApiTestSchema' ),
+				statements: new StatementList( [
+					TestStatement::buildRelation( 'MyRelation', [
+						TestRelation::build( id: 'rTestGSA1111ra2', targetId: 'sTestGSA1111267' ),
+					] ),
+				] )
+			),
+			childSubjects: new SubjectMap( $this->newTestSubject( 'sTestGSA1111267', 'draft sibling' ) )
+		);
+
+		$response = $this->runWithRevisionPolicy(
+			FixedRevisionPolicy::publishing( $published ),
+			fn (): Response => $this->requestSubject(
+				'sTestGSA1111266',
+				[ 'latest' => '1', 'expand' => 'relations' ]
+			)
+		);
+
+		$this->assertSame( 'draft sibling', $this->labelOf( $response, 'sTestGSA1111267' ) );
+	}
+
+	/**
+	 * Unlike the revisionId path, the latest path has no page gate in the handler: the read
+	 * authorizer inside GetSubjectQuery is all there is, and nothing pinned it.
+	 */
+	public function testLatestOnAnUnreadablePageIsIndistinguishableFromAnAbsentSubject(): void {
+		$this->createPageWithSubjects(
+			'GetSubjectApiTest_LatestUnreadable',
+			mainSubject: $this->newTestSubject( 'sTestGSA1111265' )
+		);
+
+		$denied = $this->executeHandler(
+			new GetSubjectApi(),
+			new RequestData( [
+				'method' => 'GET',
+				'pathParams' => [ 'subjectId' => 'sTestGSA1111265' ],
+				'queryParams' => [ 'latest' => '1' ],
+			] ),
+			authority: $this->authorityWithGlobalReadButNoPageRead()
+		);
+
+		$absent = $this->requestSubject( 'sTestGSA9999997', [ 'latest' => '1' ] );
+
+		$this->assertSame( 200, $denied->getStatusCode() );
+		$this->assertSame( $absent->getBody()->getContents(), $denied->getBody()->getContents() );
 	}
 
 	public function testLatestServesTheDraftToAViewerThePolicyLetsSeeIt(): void {

--- a/tests/phpunit/Persistence/MediaWiki/Subject/LatestRevisionSubjectLookupTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/Subject/LatestRevisionSubjectLookupTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\Persistence\MediaWiki\Subject;
+
+use MediaWiki\Content\Content;
+use MediaWiki\Content\TextContent;
+use MediaWiki\Revision\RevisionAccessException;
+use MediaWiki\Revision\RevisionRecord;
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageSubjects;
+use ProfessionalWiki\NeoWiki\Domain\Subject\Subject;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectIdList;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectMap;
+use ProfessionalWiki\NeoWiki\EntryPoints\Content\SubjectContent;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\LatestRevisionSubjectLookup;
+use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\MediaWikiSubjectRepository;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
+use ProfessionalWiki\NeoWiki\Tests\TestDoubles\InMemorySubjectLookup;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\Persistence\MediaWiki\Subject\LatestRevisionSubjectLookup
+ */
+class LatestRevisionSubjectLookupTest extends TestCase {
+
+	private const REQUESTED_ID = 's11111111111111';
+	private const SAME_PAGE_ID = 's11111111111112';
+	private const OTHER_PAGE_ID = 's11111111111113';
+
+	private function newLookup( RevisionRecord $revision, Subject ...$otherPages ): LatestRevisionSubjectLookup {
+		return new LatestRevisionSubjectLookup( $revision, new InMemorySubjectLookup( ...$otherPages ) );
+	}
+
+	private function newSubject( string $id, string $label ): Subject {
+		return TestSubject::build( id: $id, label: new SubjectLabel( $label ) );
+	}
+
+	/**
+	 * The Main Subject is the one a by-id read asks for most, and getAllSubjects() prepends it
+	 * rather than holding it alongside the rest.
+	 */
+	private function newRevisionHolding( ?Subject $mainSubject, Subject ...$childSubjects ): RevisionRecord {
+		$content = SubjectContent::newEmpty();
+		$content->setPageSubjects( new PageSubjects( $mainSubject, new SubjectMap( ...$childSubjects ) ) );
+
+		return $this->newRevisionWithSlotContent( $content );
+	}
+
+	private function newRevisionWithSlotContent( Content $content ): RevisionRecord {
+		$revision = $this->createMock( RevisionRecord::class );
+		$revision->method( 'getContent' )
+			->with( MediaWikiSubjectRepository::SLOT_NAME )
+			->willReturn( $content );
+
+		return $revision;
+	}
+
+	private function labelsOf( SubjectMap $subjects ): array {
+		return array_map( static fn ( Subject $subject ): ?string => $subject->getLabel()?->text, $subjects->asArray() );
+	}
+
+	public function testServesTheMainSubjectFromTheRevision(): void {
+		$lookup = $this->newLookup(
+			$this->newRevisionHolding( $this->newSubject( self::REQUESTED_ID, 'in the revision' ) ),
+			$this->newSubject( self::REQUESTED_ID, 'from the other lookup' )
+		);
+
+		$this->assertSame(
+			'in the revision',
+			$lookup->getSubject( new SubjectId( self::REQUESTED_ID ) )?->getLabel()?->text
+		);
+	}
+
+	public function testServesAChildSubjectFromTheRevision(): void {
+		$lookup = $this->newLookup(
+			$this->newRevisionHolding(
+				$this->newSubject( self::REQUESTED_ID, 'main' ),
+				$this->newSubject( self::SAME_PAGE_ID, 'in the revision' )
+			),
+			$this->newSubject( self::SAME_PAGE_ID, 'from the other lookup' )
+		);
+
+		$this->assertSame(
+			'in the revision',
+			$lookup->getSubject( new SubjectId( self::SAME_PAGE_ID ) )?->getLabel()?->text
+		);
+	}
+
+	public function testAsksTheOtherLookupOnlyForIdsTheRevisionDoesNotHold(): void {
+		$lookup = $this->newLookup(
+			$this->newRevisionHolding(
+				$this->newSubject( self::REQUESTED_ID, 'main' ),
+				$this->newSubject( self::SAME_PAGE_ID, 'same page' )
+			),
+			$this->newSubject( self::OTHER_PAGE_ID, 'other page' ),
+			$this->newSubject( self::SAME_PAGE_ID, 'must not be used' )
+		);
+
+		$subjects = $lookup->getSubjects( new SubjectIdList( [
+			new SubjectId( self::REQUESTED_ID ),
+			new SubjectId( self::SAME_PAGE_ID ),
+			new SubjectId( self::OTHER_PAGE_ID ),
+		] ) );
+
+		$this->assertSame( [ 'main', 'same page', 'other page' ], $this->labelsOf( $subjects ) );
+	}
+
+	public function testAnEmptyIdListReadsNeitherSource(): void {
+		$revision = $this->createMock( RevisionRecord::class );
+		$revision->expects( $this->never() )->method( 'getContent' );
+
+		$this->assertTrue(
+			( new LatestRevisionSubjectLookup( $revision, new InMemorySubjectLookup() ) )
+				->getSubjects( new SubjectIdList( [] ) )
+				->isEmpty()
+		);
+	}
+
+	public function testFallsBackWhenTheRevisionHasNoSubjectSlot(): void {
+		$revision = $this->createStub( RevisionRecord::class );
+		$revision->method( 'getContent' )->willThrowException( new RevisionAccessException( 'No such slot' ) );
+
+		$lookup = new LatestRevisionSubjectLookup(
+			$revision,
+			new InMemorySubjectLookup( $this->newSubject( self::REQUESTED_ID, 'from the other lookup' ) )
+		);
+
+		$this->assertSame(
+			'from the other lookup',
+			$lookup->getSubject( new SubjectId( self::REQUESTED_ID ) )?->getLabel()?->text
+		);
+	}
+
+	/**
+	 * A slot holding another content model stops a write, because a write would save over it, but a
+	 * read shows the Subjects it can and leaves the rest to the pages that do answer.
+	 */
+	public function testFallsBackWhenTheSlotHoldsOtherContent(): void {
+		$lookup = $this->newLookup(
+			$this->newRevisionWithSlotContent( new TextContent( 'not a Subject' ) ),
+			$this->newSubject( self::REQUESTED_ID, 'from the other lookup' )
+		);
+
+		$this->assertSame(
+			'from the other lookup',
+			$lookup->getSubject( new SubjectId( self::REQUESTED_ID ) )?->getLabel()?->text
+		);
+	}
+
+	public function testReturnsNullWhenNeitherSourceHoldsTheSubject(): void {
+		$lookup = $this->newLookup( $this->newRevisionHolding( $this->newSubject( self::REQUESTED_ID, 'main' ) ) );
+
+		$this->assertNull( $lookup->getSubject( new SubjectId( self::OTHER_PAGE_ID ) ) );
+	}
+
+}


### PR DESCRIPTION
Three findings from a review of #1398, plus what a review of these fixes turned up. Each commit stands alone; take them separately if you disagree with one.

Rebased onto 3c3bf30f. That commit already adds the page-read gate one of these fixes carried, through the shared `revisionIsReadable()` predicate rather than a second index read, so that part is dropped and its naming followed.

### `latest=1` served other pages' drafts, and re-found what its gate had already fetched

The gate in `GetSubjectApi` answers for the page hosting the requested Subject; `expand=relations` then read pages the caller said nothing about, through the same lookup. On an approval wiki a reader who may not see drafts got them for any Subject referenced from approved content, and the frontend sends `expand=page|relations` on every editing read. The handler also fetched the revision only to gate it and throw it away, so a save landing between the gate and the read was served unchecked.

`LatestRevisionSubjectLookup` answers from the revision the handler holds and asks `PublishedSubjectLookup` only for the ids that revision does not hold. Subjects on the page the gate cleared come from it — including a relation target on that same page — and the pages the caller never named answer with what they publish. `PointInTimeSubjectLookup` composes the same way for the `revisionId` read.

One lookup therefore serves both roles, which also keeps a Subject that targets itself answering as itself: `GetSubjectQuery` places the requested Subject and the relation loop then keys the same id, so two lookups there answer for it from the wrong one.

This is not a regression on master: the unparameterised read returned the same drafts to anyone, so #1398 already narrows it. It is the one case the "Still open" list does not mention.

### The editor was seeded from a revision its save does not target



`getSubjectForEditing()` sent `latest=1` only when the repository had no revision to pin, and `getRevisionId()` pins one whenever `wgRevisionId` differs from `wgCurRevisionId`. A write always targets the page's current revision, so an editor seeded from a pinned one saves those values over whatever the page holds now.

That is not only the `oldid` case. ContentStabilization renders a stabilized page at its approved revision and sets `wgRevisionId` to it ([`StabilizeContent::onArticleViewHeader`](https://github.com/wikimedia/mediawiki-extensions-ContentStabilization/blob/master/src/Hook/StabilizeContent.php) sets it unconditionally after the `explicitlyRequestedOldId()` branch). So on an approval wiki the ordinary article view is pinned, `latest=1` never left the browser, and the infobox editor loaded approved values and wrote them over the pending draft — the failure this branch exists to prevent. A display read still follows the revision the page is rendered at.

### `latest=1&expand=relations` served other pages' drafts

The gate in `GetSubjectApi` answers for the page hosting the requested Subject; `expand=relations` then reads pages the caller said nothing about, through the same lookup. On an approval wiki a reader who may not see drafts got them for any Subject referenced from approved content, and the frontend sends `expand=page|relations` on every editing read.

`GetSubjectQuery` now takes a second lookup for the referenced Subjects. The published and revision reads pass the same lookup twice, unchanged; the latest read pairs the write path's repository with `PublishedSubjectLookup`. Nothing consumes that set today — `getSubjectForEditing()` keeps only the requested Subject — and an external caller now gets the reader-facing answer for pages they did not name.

This is not a regression: on master the unparameterised read returned the same drafts to anyone, so #1398 already narrows it. It is the one case the "Still open" list does not mention.

### RedHerb still read the published copy and wrote it back

Both RedHerb editors read with `getSubject()` and save through `nw.useSubjectStore()`. Correct while `getSubject()` meant the current revision; after #1398 it means the published one. RedHerb is what an extension author copies, so `extending.md` now names which read to use. `rest-api.md` spells `latest=1`, because the REST validator reads a valueless `latest` as false.

### The latest read resolved its page and revision twice

`GetSubjectApi` fetches the current revision to ask the policy about it and then discards it; `MediaWikiSubjectRepository` resolved and fetched it again to read the slot. The handler now passes the revision it already has, and `RevisionSubjectLookup` reads the Subject out of it.

That also takes the write path's repository off a read path, which fixes a smaller reported defect: its slot reader throws for a slot holding another content model — right for a write, which would otherwise save over it — so `latest=1` answered 500 where the published read answers not-found. Both answer not-found now.

### Considered, omitted

* Giving the latest read one lookup that picks each page's current revision when `revisionIsReadableBy()` allows it and the published one otherwise. It keeps a draft-only sibling on the editor's own page visible, which the two-lookup split hides — but nothing reads that set.
* Collapsing the handler's `latest` gate into that lookup. It answers not-found for a draft the viewer may not see, which a per-page fallback would turn into a published Subject.
* Moving the `latest` gate out of the handler and into a per-page rule (latest revision when `revisionIsReadableBy()` allows it, published otherwise). It changes the contract: `latest=1` would answer with a silently substituted published Subject instead of not-found, and a client could no longer tell which it got — which matters precisely because one is safe to save back and the other is not.
* A guard in `GetSubjectQuery` against the relation loop replacing an already-placed Subject. With one lookup the replacement writes back the same Subject, so no test can pin the guard and it earns nothing.
* De-duplicating the read-the-slot-and-filter shape now shared by `LatestRevisionSubjectLookup` and `PointInTimeSubjectLookup::getSubjectsFromRevision()` — about ten lines, in a class this PR does not otherwise touch.
* The 500 that survives on all three reads: `PageSubjectsLookup`, behind the display-name fallback, still reads through the write repository, which throws for a foreign-model slot and for suppressed text. Wants a seam on `PageSubjectsLookup`, not a change here.
* `revisionIsReadableBy()` documents itself as answering for "a revision they asked for by id", while `latest=1` names no revision. Inherited from #1398 and load-bearing for it; worth reconciling with the interface docblock.
* The rest of the review's non-blocking items: the `latest` 500 on a foreign-model slot, `displayName` reading the latest revision's Main Subject, and the tests that cannot fail. Reported in the review, not touched here.

## Manual Browser Check

The draft-overwrite itself needs ContentStabilization, which is not in the dev stack. What is checkable here is that the editing read now asks for `latest`, on both the pinned and unpinned path:

1. Open any page with an infobox, e.g. `/index.php/Rijksmuseum` on your dev wiki, with the browser network tab recording.
2. Click the infobox's edit button. The request to `rest.php/neowiki/v0/subject/<id>` must carry `&latest=1`.
3. Reload the same page at an old revision (History → an older revision → `?oldid=<n>`), and click edit again. Before this branch that request carried `&revisionId=<n>`; it must now carry `&latest=1`.
4. Confirm the values shown in step 3 are the page's current ones, and that saving does not revert the page.
5. Page display is unchanged: on the `oldid` view the infobox itself must still render that old revision's values.

> <sub>AI-authored — Claude Code, `Opus 5 (1M context)`; fixes from a review of #1398 run on @alistair3149's `/pr-review`, then asked for as a PR; no revisions. Diff not yet human-reviewed. Each fix has a test seen failing before it and passing after (the leak reproduced as `draft target`); CI green, and steps 1-3 of the browser check confirmed on a dev wiki against the built bundle — an editing read sends `latest=1` on both the pinned and the unpinned path, a display read still sends `revisionId`. The approval-wiki behaviour is read from ContentStabilization's source, not run: it is not installable in the dev stack.</sub>


