### PR TITLE
Document configuring NeoWiki for wikis with restricted content

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -72,3 +72,5 @@ For the people who operate the server.
 * [Upgrading](operations/upgrading.md) — moving your wiki to the latest NeoWiki
 * [Maintenance](operations/maintenance.md) — rebuilding the graph, Neo4j outage behavior, and backups
 * [Performance](operations/performance.md) — measured write throughput
+* [Restricted content](operations/restricted-content.md) — wikis where some content is readable only by certain
+  users or groups

--- a/docs/api/query-api.md
+++ b/docs/api/query-api.md
@@ -144,7 +144,7 @@ Defaults shipped by NeoWiki:
 
 | Right | Default groups | Purpose |
 |---|---|---|
-| `neowiki-query` | `*` (everyone, including anonymous visitors) | Required to call the query endpoints and to run queries from wikitext or Lua. |
+| `neowiki-query` | `*` (everyone, including anonymous visitors) | Required to call the query endpoints and to run queries from wikitext or Lua. A holder reads everything the wiki projects into the store; results are not filtered per page. |
 | `apihighlimits` | `bot`, `sysop` (core defaults) | Grants the `expensive` resource tier. |
 
 ## SPARQL query endpoint

--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -105,6 +105,9 @@ Report and rebuild the graph stores this wiki projects into. A rebuild's `202` m
 
 ## Permissions
 
+Where the wiki itself requires login to read, every endpoint answers an anonymous request with `403` and
+`"error": "rest-read-denied"`, before any of the per-page rules below apply.
+
 The Subject, page-subjects, edit-notices, subject-labels, Schema, Layout, Mapping, RDF export, and entity-dereference
 read endpoints
 enforce the caller's per-page `read` permission; page protection and `$wgNamespaceProtection` do not restrict them,

--- a/docs/authoring/parser-functions.md
+++ b/docs/authoring/parser-functions.md
@@ -23,8 +23,9 @@ Every parser function reads as the user the page is parsed for. Subjects that us
 treated as absent. `{{#cypher_raw}}` and `{{#sparql_raw}}` need the `neowiki-query` right.
 `{{#view}}` only places a marker at parse time; the Subject it shows is fetched per viewer over the
 REST API, under that viewer's permissions. Output of the other functions is cached separately for
-readers with different groups or rights, so what one reader may see does not reach another through
-the parser cache.
+readers with different groups or rights, so it tracks page access only where page access follows
+those; where a hook grants it per account, per IP or per session, see
+[Restricted content](../operations/restricted-content.md).
 
 ## `{{#view}}`
 

--- a/docs/operations/installation.md
+++ b/docs/operations/installation.md
@@ -187,9 +187,8 @@ default.
 `neowiki-schema-edit`, `neowiki-layout-edit` and `neowiki-mapping-edit` — gate editing in NeoWiki's own namespaces and
 are granted to logged-in users.
 
-Parser functions and Lua read as the user the page is parsed for, and their output is parser-cached per combination
-of user groups and wiki-level rights. A permission extension that grants page access per user rather than per group
-is not followed by that cache key: run such a wiki with the parser cache off (`$wgParserCacheType = CACHE_NONE`).
+A wiki whose readers do not all see the same pages needs more than these defaults; see
+[Restricted content](restricted-content.md).
 
 ## On-wiki configuration
 
@@ -360,8 +359,8 @@ token, so keep that token secret.
 
 Oxigraph has no equivalent setting and will attempt the outbound request; the stacks' Oxigraph services federate
 for that reason. Other stores vary — consult their documentation. Where the store cannot be restricted, restrict
-around it: block its outbound traffic at the network layer, and narrow the `neowiki-query` right, which by default
-is granted to everyone including anonymous visitors — see [Permissions](../api/query-api.md#permissions).
+around it: block its outbound traffic at the network layer, and narrow who holds the `neowiki-query` right — see
+[Choosing who may query](restricted-content.md#choosing-who-may-query).
 
 ## Production hardening
 

--- a/docs/operations/restricted-content.md
+++ b/docs/operations/restricted-content.md
@@ -67,6 +67,6 @@ Whether or not you narrow it:
 
 Restricting a page removes nothing from a store, and a rebuild reprojects it, so a store that has once held
 restricted content keeps holding it. Do not expose a SPARQL store directly on a wiki with restricted content, and
-treat a [bulk dump](../rdf/rdf-export.md#bulk-dump) and any store backup as readable by whoever can reach it.
+treat a [bulk dump](../api/rdf-export.md#bulk-dump) and any store backup as readable by whoever can reach it.
 
 The model behind all of this is [ADR 27: Access Control](../adr/027-access-control.md).

--- a/docs/operations/restricted-content.md
+++ b/docs/operations/restricted-content.md
@@ -1,0 +1,72 @@
+---
+title: Restricted content
+order: 5
+---
+
+# Restricted content
+
+What NeoWiki restricts, and what it does not, on a wiki where some content is readable only by certain users or
+groups. Page protection and `$wgNamespaceProtection` do not restrict reading; see
+[Permissions](../api/rest-api.md#permissions).
+
+## What limits each surface
+
+Enforced per page:
+
+| Surface | What limits it |
+|---|---|
+| REST reads | The page's `read`. |
+| REST writes | The page's `edit`. |
+| `{{#view}}` | The source page's `read`. |
+| `{{#neowiki_value}}` and the `nw.` accessors | The parsing user's `read`. |
+
+Enforced wiki-wide, or not at all:
+
+| Surface | What limits it |
+|---|---|
+| `POST /query/cypher`, `POST /query/sparql` | The caller's [`neowiki-query`](../api/query-api.md#permissions). |
+| `{{#cypher_raw}}`, `{{#sparql_raw}}`, `nw.query`, `nw.sparqlQuery` | The parsing user's `neowiki-query`. |
+| Graph-store status and rebuilds | The caller's `neowiki-admin`. |
+| Subjects from a [Subject Source](../extending/subject-sources.md) | Nothing. They have no page here to authorize against, so a Source must serve only what every reader may see. |
+| Graph stores, RDF dumps and their backups | Nothing. They hold restricted content in full. |
+
+## Choosing who may query
+
+NeoWiki grants `neowiki-query` to everyone (`*`) by default. Removing it helps only where anonymous readers can
+reach a query surface — on a wiki they cannot read at all, they cannot reach one either. To remove it:
+
+```php
+$wgGroupPermissions['*']['neowiki-query'] = false;
+```
+
+Grant it to whichever groups should keep it, and check the result on `Special:ListGroupRights`. OAuth consumers
+and bot passwords need no separate change.
+
+## What readers see
+
+After narrowing `neowiki-query`:
+
+- A page using `{{#cypher_raw}}` or `{{#sparql_raw}}` shows an error box where the results were, to anyone who no
+  longer holds the right.
+- A page using `nw.query` or `nw.sparqlQuery` shows a script error and joins the wiki's pages-with-script-errors
+  category, because the save and job-queue parses run as an anonymous user. A module can avoid that by wrapping
+  the call in `pcall`.
+- Readers who still hold the right see results as before.
+
+Whether or not you narrow it:
+
+- Restricting a page does not clear what is already cached. A page showing that data keeps showing it until it is
+  edited or purged, or `$wgParserCacheExpireTime` elapses. Purge it to apply the change at once.
+- Where readers who share the same groups may read different pages — because `read` is granted per account, per
+  IP or per session — a cached page can show one reader's data to another. Render Subjects through `{{#view}}`
+  there: it fetches per viewer instead of reading at parse time.
+- On a wiki where anonymous users cannot read, a category or page property that a template derives from a Subject
+  value is never set. That is expected, not a fault to report.
+
+## Stores and dumps
+
+Restricting a page removes nothing from a store, and a rebuild reprojects it, so a store that has once held
+restricted content keeps holding it. Do not expose a SPARQL store directly on a wiki with restricted content, and
+treat a [bulk dump](../rdf/rdf-export.md#bulk-dump) and any store backup as readable by whoever can reach it.
+
+The model behind all of this is [ADR 27: Access Control](../adr/027-access-control.md).


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/1342

The `neowiki-query` right stays granted to `*`. Gating a read or query surface behind a dedicated right is already the exception in MediaWiki, and a narrower default would break every wiki that runs raw queries at parse time rather than protect the exposed ones: the canonical parse runs as the anonymous user, so withholding the right from `*` denies raw queries in every save-time parse, job-queue parse and Parsoid render, restricted content or not.

What was missing was the other half of the question — how a deployment whose readers do not all see the same pages is expected to configure NeoWiki. That is a new operations page, with its sections in the order the operator decides.

Two facts had no home and now have one: that MediaWiki refuses every endpoint on a login-required wiki before NeoWiki's own checks run, and that a `neowiki-query` holder reads everything the wiki projects into the store.

`docs/authoring/parser-functions.md` promised without qualification that "what one reader may see does not reach another through the parser cache". That is false wherever page access is not group-derived, so it is corrected here rather than filed: same surface, same contract.

ADR 27 is left as it stands. Its Open decisions list records what was open at acceptance, which stays true of that date; the resolution lives on the issue it defers to.

## Scope decision recorded here

NeoWiki decides page `read` from the reader's effective groups plus the two wiki-level rights, and that is what the parser-cache key follows. A wiki deciding `read` per individual account, per IP or per session is outside what NeoWiki supports. The page states that boundary and points such a wiki at `{{#view}}`, which fetches per viewer over REST and performs no parse-time read. https://github.com/ProfessionalWiki/NeoWiki/issues/1405 stays open as the discussion record, with the expected disposition being to decline.

Relates to [ECHOLOT FR2.2](https://github.com/ECHOLOT-ECCCH/echolot-WP2/issues/19), which asks for flexible permission levels for different users and user groups. This PR does not build anything toward it; it documents which levers exist today and where each one stops, which is the starting point that requirement needs.

## Considered, omitted

- **`$wgParserCacheType = CACHE_NONE`.** The old wording in `installation.md` prescribed it, and it is deliberately not carried over. It disables every parser cache on the wiki, Parsoid's included, to close a leak confined to NeoWiki-derived output on a configuration NeoWiki does not support. The page names the boundary and the `{{#view}}` alternative instead.
- **How `$wgGroupPermissions` and `$wgRevokePermissions` behave.** MediaWiki's own manual owns rights semantics, and NeoWiki grants `neowiki-query` to `*` alone, so clearing it there is the whole recipe. Linked rather than restated.
- **Cross-wiki guidance.** A shared graph store makes `neowiki-query` a whole-farm read, but nothing in NeoWiki implements per-wiki scoping today (https://github.com/ProfessionalWiki/NeoWiki/issues/1341, https://github.com/ProfessionalWiki/NeoWiki/issues/1377), so the page would have described a problem with no lever.
- A recipe for un-configuring the Neo4j URLs to remove the Cypher surfaces. It contradicts the neighbouring statement that the right cannot be scoped per query language, and no operator drops their graph backend to fix permissions.
- The access-class and parser-cache mechanism, the per-endpoint read-gate contract, and the default-groups table. ADR 27, `rest-api.md` and `query-api.md` own those.
- The rationale for keeping the default. That belongs on the issue, not in operator docs.
- Naming the `temp` group in the recipe. Its only application is the hand-back case, where a temporary account silently not receiving a whole-store query right is the wanted outcome.

> <sub>AI-authored — Claude Code, `Opus 5 (1M context, xhigh)`; open question from @alistair3149 across a long analysis session, with the decision to keep the default, the scope call on per-account read, and the shape of the docs all his; text not yet human-reviewed; every claim re-derived from master and MediaWiki core source, a fresh-context blind judge and a fresh-context text review each found defects that are fixed, `DocsPathReferencesTest` green.</sub>



