### PR TITLE
Add Special:Subject, a Subject-centric view

### DIFF
--- a/docs/api/rdf-export.md
+++ b/docs/api/rdf-export.md
@@ -18,7 +18,7 @@ For an end-to-end example comparing the native and ontology-mapped output, see t
 | Setting | Default | Purpose |
 |---|---|---|
 | `$wgNeoWikiRdfBaseUri` | the wiki's canonical URL (`$wgCanonicalServer`) | Base URI under which all NeoWiki IRIs are minted. |
-| `$wgNeoWikiDereferenceSubjectsToDataTab` | `true` | Whether a browser dereferencing a Subject IRI lands on the hosting page's Data tab row (`true`) or the plain page (`false`). |
+| `$wgNeoWikiDereferenceSubjectsToHostingPage` | `false` | When `true`, sends a browser dereferencing a Subject IRI to the Subject's hosting page instead of to `Special:Subject`. |
 
 ## IRI scheme
 
@@ -149,12 +149,11 @@ content-negotiates it and answers `303 See Other` with an absolute `Location`:
 |---|---|
 | `application/trig` | the Subject's TriG RDF (`.../subject/{id}/rdf?format=trig`) |
 | `text/turtle` | the Subject's Turtle RDF (`.../subject/{id}/rdf?format=turtle`) |
-| `text/html`, `*/*`, absent, anything else | the Subject's hosting page |
+| `text/html`, `*/*`, absent, anything else | `Special:Subject/{id}` |
 
 TriG wins when both RDF types are acceptable; the RDF redirects use the native projection.
 
-The default HTML target is that page's Data tab (`/Example_Page/subjects`) opened on the Subject's row.
-When `$wgNeoWikiDereferenceSubjectsToDataTab` is set to `false`, the target is the wiki page itself (`/Example_Page`).
+When `$wgNeoWikiDereferenceSubjectsToHostingPage` is `true`, the HTML target is the Subject's hosting page instead.
 
 The negotiator is always reachable at the REST path, which needs no server configuration:
 

--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -29,7 +29,7 @@ of a `{subjectId}`, see [IDs](subject-format.md#ids).
 |---|---|
 | `GET /neowiki/v0/subject/{subjectId}` | Fetch a Subject as the wiki publishes it. `latest=1` returns the hosting page's current revision instead, for editing, when the viewer may see it; it takes no `revisionId` and no `expand=relations`. Optional `revisionId`; `expand` with `page` or `relations`. |
 | `GET /neowiki/v0/subject/{subjectId}/rdf` | Export one Subject as RDF. `format` is `trig` (default) or `turtle`; `projection` is `native` (default) or an ontology target. See [RDF export](rdf-export.md). |
-| `GET /neowiki/v0/entity/{subjectId}` | Dereference a Subject's concept URI. `303` to the Subject's RDF (`Accept: application/trig` or `text/turtle`) or to the hosting page (otherwise). See [Dereferencing subject IRIs](rdf-export.md#dereferencing-subject-iris). |
+| `GET /neowiki/v0/entity/{subjectId}` | Dereference a Subject's concept URI. `303` to the Subject's RDF (`Accept: application/trig` or `text/turtle`), otherwise to `Special:Subject`. See [Dereferencing subject IRIs](rdf-export.md#dereferencing-subject-iris). |
 | `PUT /neowiki/v0/subject/{subjectId}` | Replace a Subject's label and statements. |
 | `DELETE /neowiki/v0/subject/{subjectId}` | Delete a Subject. |
 | `POST /neowiki/v0/subject/{subjectId}/move` | Move a Subject to another page, keeping its ID so relations targeting it keep resolving. Body `targetPageId`, optional `makeMainSubject` and `comment`. Edits both pages. |

--- a/docs/operations/installation.md
+++ b/docs/operations/installation.md
@@ -192,12 +192,12 @@ A wiki whose readers do not all see the same pages needs more than these default
 
 ## On-wiki configuration
 
-A wiki administrator without server access can set part of NeoWiki's configuration on the `MediaWiki:NeoWiki`
-page. It holds JSON and, like other site configuration, is editable only with the `editinterface` and
-`editsitejson` rights. Two settings are exposed: `dereferenceSubjectsToDataTab` (overriding
-`$wgNeoWikiDereferenceSubjectsToDataTab`) and `autoRenderMainSubject` (overriding `$wgNeoWikiAutoRenderMainSubject`).
-Editing the page shows a reference table of the exposed keys and their accepted values, and creating it
-preloads a working example.
+A wiki administrator without server access can set part of NeoWiki's configuration on the `MediaWiki:NeoWiki` page.
+It holds JSON and, like other site configuration, is editable only with the `editinterface` and `editsitejson`
+rights. Two settings are exposed: `dereferenceSubjectsToHostingPage` (overriding
+`$wgNeoWikiDereferenceSubjectsToHostingPage`) and `autoRenderMainSubject` (overriding
+`$wgNeoWikiAutoRenderMainSubject`). Editing the page shows a reference table of the exposed keys and their accepted
+values, and creating it preloads a working example.
 
 A valid value on the page takes precedence over `LocalSettings.php`, per setting. A missing page, a
 wrong-shaped value, or an unavailable database falls back to the `LocalSettings.php` value, so a

--- a/extension.json
+++ b/extension.json
@@ -190,7 +190,8 @@
 		"Layouts": "ProfessionalWiki\\NeoWiki\\EntryPoints\\SpecialPages\\SpecialLayouts",
 		"Mappings": "ProfessionalWiki\\NeoWiki\\EntryPoints\\SpecialPages\\SpecialMappings",
 		"GraphStores": "ProfessionalWiki\\NeoWiki\\EntryPoints\\SpecialPages\\SpecialGraphStores",
-		"CreateSubject": "ProfessionalWiki\\NeoWiki\\EntryPoints\\SpecialPages\\SpecialCreateSubject"
+		"CreateSubject": "ProfessionalWiki\\NeoWiki\\EntryPoints\\SpecialPages\\SpecialCreateSubject",
+		"Subject": "ProfessionalWiki\\NeoWiki\\EntryPoints\\SpecialPages\\SpecialSubject"
 	},
 
 	"Actions": {
@@ -203,7 +204,7 @@
 			"value": false
 		},
 		"NeoWikiEnableInWikiConfig": {
-			"description": "Whether NeoWiki settings may also be set on the MediaWiki:NeoWiki JSON configuration page, which requires the editinterface and editsitejson rights to edit. When false, that page is never given the JSON content model, validated, or read, so only LocalSettings.php applies. The page exposes NeoWikiDereferenceSubjectsToDataTab and NeoWikiAutoRenderMainSubject; its values take precedence over LocalSettings.php.",
+			"description": "Whether NeoWiki settings may also be set on the MediaWiki:NeoWiki JSON configuration page, which requires the editinterface and editsitejson rights to edit. When false, that page is never given the JSON content model, validated, or read, so only LocalSettings.php applies. The page exposes NeoWikiDereferenceSubjectsToHostingPage and NeoWikiAutoRenderMainSubject; its values take precedence over LocalSettings.php.",
 			"value": true
 		},
 		"NeoWikiEnforceValidation": {
@@ -237,9 +238,9 @@
 			"description": "Base URI under which the RDF export mints all NeoWiki IRIs (entity, property, schema, page, etc.). When null, defaults to the wiki's canonical URL ($wgCanonicalServer). Wiki-level on purpose, so sibling projections describe the same entities with identical IRIs.",
 			"value": null
 		},
-		"NeoWikiDereferenceSubjectsToDataTab": {
-			"description": "Whether a browser dereferencing a Subject's concept URI (Accept: text/html) is sent to the hosting page's Data tab (?action=subjects) opened on the Subject's row (expanded, scrolled to, highlighted). True by default; when false, it is sent to the plain hosting page.",
-			"value": true
+		"NeoWikiDereferenceSubjectsToHostingPage": {
+			"description": "Whether a browser dereferencing a Subject's concept URI (Accept: text/html) is sent to the plain page the Subject is stored on. False by default, which sends it to Special:Subject, the view of that one Subject.",
+			"value": false
 		},
 		"NeoWikiAutoRebuildOnMappingChange": {
 			"description": "Whether saving, deleting or restoring a Mapping page automatically rebuilds, in the background, every configured graph store that holds that Mapping's projection. False by default: such a rebuild reprojects every page on the wiki into that store, which on a large wiki is substantial work an administrator should choose to take on. While it is false, Special:GraphStores reports such a store as stale and offers the rebuild.",
@@ -792,7 +793,12 @@
 				"neowiki-managesubjects-export-back",
 				"neowiki-managesubjects-export-choose-format",
 				"neowiki-managesubjects-export-choose-projection",
-				"neowiki-managesubjects-export-native"
+				"neowiki-managesubjects-export-native",
+				"neowiki-special-subject-page-label",
+				"neowiki-special-subject-referenced-heading",
+				"neowiki-special-subject-not-found",
+				"neowiki-special-subject-load-error",
+				"neowiki-managesubjects-row-open"
 			],
 			"@group:": "TODO: Load code separately while in development. Remove later.",
 			"group": "ext.neowiki"

--- a/i18n/_Aliases.php
+++ b/i18n/_Aliases.php
@@ -9,4 +9,5 @@ $specialPageAliases['en'] = [
 	'Mappings' => [ 'Mappings' ],
 	'GraphStores' => [ 'GraphStores' ],
 	'CreateSubject' => [ 'CreateSubject' ],
+	'Subject' => [ 'Subject' ],
 ];

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -449,5 +449,12 @@
 	"neowiki-graphstores-outcome-nothingtocancel": "\"$1\" has no rebuild to cancel.",
 	"neowiki-graphstores-outcome-unknownstore": "This wiki has no graph store called \"$1\".",
 	"neowiki-graphstores-outcome-notqueued": "A rebuild of \"$1\" could not be queued. The store is unchanged; the NeoWiki log channel says why.",
-	"neowiki-graphstores-outcome-sessionfailure": "Your session has expired, so nothing was changed. Try again."
+	"neowiki-graphstores-outcome-sessionfailure": "Your session has expired, so nothing was changed. Try again.",
+	"neowiki-special-subject": "Subject",
+	"neowiki-special-subject-invalid-id": "Special:Subject needs a subject ID, like Special:Subject/s1demo8aaaaaab5.",
+	"neowiki-special-subject-page-label": "Page:",
+	"neowiki-special-subject-referenced-heading": "Referenced subjects",
+	"neowiki-special-subject-not-found": "No subject with the ID $1 was found.",
+	"neowiki-special-subject-load-error": "Couldn't load this subject.",
+	"neowiki-managesubjects-row-open": "Open subject"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -317,7 +317,7 @@
 	"neowiki-managesubjects-move-create-page-error": "Error shown when the target page could not be created. Parameters:\n* $1 - the title of the page that could not be created",
 	"neowiki-managesubjects-row-promote": "Aria/button label for the pin button that promotes a child Subject to the page's Main Subject.",
 	"neowiki-managesubjects-row-demote": "Aria/button label for the pin button on the Main Subject row that clears it so the page has no Main Subject.",
-	"neowiki-managesubjects-row-copy-link": "Aria/button label for the row action (an inline button on wide viewports, an overflow-menu item on narrow ones) that copies a shareable deep link to this Subject's row on the Data tab.",
+	"neowiki-managesubjects-row-copy-link": "Aria/button label for the row action (an inline button on wide viewports, an overflow-menu item on narrow ones) that copies a shareable link to this Subject.",
 	"neowiki-managesubjects-row-more": "Aria/button label for the overflow (kebab) menu that lists per-row actions on narrow viewports.",
 	"neowiki-managesubjects-row-drag-handle": "Tooltip on the drag handle on each Subject row (sighted mouse users only — the handle is not in the focus order). Dragging a child row within the child list reorders it. Dragging a child row onto the Main Subject slot promotes it (and demotes the previous main into the dragged child's slot). Dragging the Main Subject row into the child list demotes it at the drop position.",
 	"neowiki-managesubjects-statement-count": "Shown on each collapsed Subject row to indicate how many Statements the Subject has. $1 is the count.",
@@ -384,5 +384,12 @@
 	"neowiki-graphstores-outcome-nothingtocancel": "Error shown on [[Special:GraphStores]] when a cancellation was asked for a store with no rebuild.\n\nParameters:\n* $1 - name of the graph store",
 	"neowiki-graphstores-outcome-unknownstore": "Error shown on [[Special:GraphStores]] when the named store is not configured.\n\nParameters:\n* $1 - name that was asked for",
 	"neowiki-graphstores-outcome-notqueued": "Error shown on [[Special:GraphStores]] when a rebuild could not be started at all — the job queue refused it, or something else held the store's start lock.\n\nParameters:\n* $1 - name of the graph store",
-	"neowiki-graphstores-outcome-sessionfailure": "Error shown on [[Special:GraphStores]] when the edit token of a rebuild or cancel form did not match."
+	"neowiki-graphstores-outcome-sessionfailure": "Error shown on [[Special:GraphStores]] when the edit token of a rebuild or cancel form did not match.",
+	"neowiki-special-subject": "Name of the [[Special:Subject]] page, which shows one Subject. Used in the list of special pages, and as the page's heading when it shows no Subject.\n{{Identical|Subject}}",
+	"neowiki-special-subject-invalid-id": "Error shown on [[Special:Subject]] when it is opened with no subject ID, or with something that is not one. The example ID stays as it is.",
+	"neowiki-special-subject-page-label": "Inline label shown before a link to the wiki page a Subject is stored on, in the footer of an expanded Subject row.",
+	"neowiki-special-subject-referenced-heading": "Heading on [[Special:Subject]] above the Subjects the displayed Subject's relations point at.",
+	"neowiki-special-subject-not-found": "Shown on [[Special:Subject]] in place of the Subject when the wiki has no Subject with that ID. It is also shown for a Subject on a page the reader may not read, so the translation must not mention permissions.\n\nParameters:\n* $1 - the Subject ID that was asked for",
+	"neowiki-special-subject-load-error": "Shown on [[Special:Subject]] when loading a Subject failed with a network or server error: in place of the Subject on first load, and as a notification when a re-read after a change failed. Distinct from {{msg-neowiki|neowiki-special-subject-not-found}}, which says the wiki has no such Subject.",
+	"neowiki-managesubjects-row-open": "Aria/button label for the row action (an inline button on wide viewports, an overflow-menu item on narrow ones) that goes to [[Special:Subject]], the page showing that one Subject. It navigates; it does not expand the row."
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -391,5 +391,5 @@
 	"neowiki-special-subject-referenced-heading": "Heading on [[Special:Subject]] above the Subjects the displayed Subject's relations point at.",
 	"neowiki-special-subject-not-found": "Shown on [[Special:Subject]] in place of the Subject when the wiki has no Subject with that ID. It is also shown for a Subject on a page the reader may not read, so the translation must not mention permissions.\n\nParameters:\n* $1 - the Subject ID that was asked for",
 	"neowiki-special-subject-load-error": "Shown on [[Special:Subject]] when loading a Subject failed with a network or server error: in place of the Subject on first load, and as a notification when a re-read after a change failed. Distinct from {{msg-neowiki|neowiki-special-subject-not-found}}, which says the wiki has no such Subject.",
-	"neowiki-managesubjects-row-open": "Aria/button label for the row action (an inline button on wide viewports, an overflow-menu item on narrow ones) that goes to [[Special:Subject]], the page showing that one Subject. It navigates; it does not expand the row."
+	"neowiki-managesubjects-row-open": "Label for the item in a Subject row's overflow menu, which replaces the row's inline actions on narrow viewports. It goes to [[Special:Subject]], the page showing that one Subject, which the Subject's name links to as well. It navigates; it does not expand the row."
 }

--- a/resources/ext.neowiki/src/components/SubjectPage/SubjectPage.vue
+++ b/resources/ext.neowiki/src/components/SubjectPage/SubjectPage.vue
@@ -148,18 +148,31 @@ function toggleExpanded( toggled: Subject ): void {
 	expandedIds.value = next;
 }
 
+// The delete controls stay live while a re-read is in flight, so reads can overlap; only the one
+// started last decides what the rows show.
+let latestRead = 0;
+
 async function readSubject(): Promise<void> {
+	const read = ++latestRead;
+	const subjectEpoch = subjectStore.mutationEpoch;
 	const bundle = await subjectRepo.getSubjectWithReferencedSubjects( subjectId );
 	const requested = bundle.requestedSubject;
 
 	// Seeding the registry is what lets RelationDisplay resolve this Subject's relation targets,
-	// the same way the Data tab's own load does.
-	subjectStore.setSubject( requested );
-	bundle.referencedSubjects.forEach( ( referenced ) => subjectStore.setSubject( referenced ) );
+	// the same way the Data tab's own load does. A write acknowledged meanwhile may postdate what
+	// this read returned, so the registry is then left alone (ADR 30 rule 3).
+	if ( subjectEpoch === subjectStore.mutationEpoch ) {
+		subjectStore.setSubject( requested );
+		bundle.referencedSubjects.forEach( ( referenced ) => subjectStore.setSubject( referenced ) );
+	}
 	await Promise.all( [
 		loadSchemas( [ requested, ...bundle.referencedSubjects ] ),
 		seedRelationTargetsOf( bundle.referencedSubjects )
 	] );
+
+	if ( read !== latestRead ) {
+		return;
+	}
 
 	subject.value = requested;
 	referencedSubjects.value = bundle.referencedSubjects;
@@ -225,10 +238,15 @@ async function seedRelationTargetsOf( subjects: Subject[] ): Promise<void> {
 async function loadSchemas( subjects: Subject[] ): Promise<void> {
 	const names = [ ...new Set( subjects.map( ( each ) => each.getSchemaName() ) ) ]
 		.filter( ( name ) => !schemaStore.schemas.has( name ) );
+	const epoch = schemaStore.mutationEpoch;
 
 	await Promise.all( names.map( async ( name ) => {
 		try {
-			schemaStore.setSchema( name, await schemaRepo.getSchema( name ) );
+			const schema = await schemaRepo.getSchema( name );
+
+			if ( epoch === schemaStore.mutationEpoch ) {
+				schemaStore.setSchema( name, schema );
+			}
 		} catch ( error ) {
 			console.error( `Failed to load schema ${ name }:`, error );
 		}

--- a/resources/ext.neowiki/src/components/SubjectPage/SubjectPage.vue
+++ b/resources/ext.neowiki/src/components/SubjectPage/SubjectPage.vue
@@ -371,18 +371,22 @@ onMounted( async () => {
 		font-style: italic;
 	}
 
-	&__subject,
+	// The spacing between the sections sits on the lists, as on the Data tab: the heading between
+	// them is the skin's, margins included.
+	// One row, so a plain block, like the Data tab's main slot.
+	&__subject {
+		list-style: none;
+		padding: 0;
+		margin: 0 0 @spacing-150;
+	}
+
 	&__referenced {
 		list-style: none;
 		padding: 0;
-		margin: 0;
+		margin: @spacing-100 0 0 0;
 		display: flex;
 		flex-direction: column;
 		gap: @spacing-50;
-	}
-
-	&__referenced-heading {
-		margin: @spacing-150 0 @spacing-75;
 	}
 }
 </style>

--- a/resources/ext.neowiki/src/components/SubjectPage/SubjectPage.vue
+++ b/resources/ext.neowiki/src/components/SubjectPage/SubjectPage.vue
@@ -1,0 +1,370 @@
+<template>
+	<div class="ext-neowiki-subject-page">
+		<p
+			v-if="errorText !== null"
+			class="ext-neowiki-subject-page__error"
+		>
+			{{ errorText }}
+		</p>
+
+		<template v-else-if="subject !== null">
+			<ul class="ext-neowiki-subject-page__subject">
+				<SubjectRow
+					:subject="subject as Subject"
+					emphasized
+					:expanded="expandedIds.has( subjectId.text )"
+					:can-edit="canEditSubject"
+					:can-delete="canDeleteSubject"
+					:page="hostingPage"
+					@toggle="toggleExpanded"
+					@edit="openEditor"
+					@delete="confirmDelete"
+					@copy-link="copySubjectLink"
+				/>
+			</ul>
+
+			<template v-if="referencedSubjects.length > 0">
+				<h2 class="ext-neowiki-subject-page__referenced-heading">
+					{{ $i18n( 'neowiki-special-subject-referenced-heading' ).text() }}
+				</h2>
+
+				<ul class="ext-neowiki-subject-page__referenced">
+					<SubjectRow
+						v-for="referenced in referencedSubjects"
+						:key="referenced.getId().text"
+						:subject="referenced"
+						:subject-page-url="subjectPageUrl( referenced.getId().text )"
+						:expanded="expandedIds.has( referenced.getId().text )"
+						:can-edit="canEditSubject"
+						:can-delete="canDeleteSubject"
+						:page="pageOf( referenced )"
+						@toggle="toggleExpanded"
+						@edit="openEditor"
+						@delete="confirmDelete"
+						@copy-link="copySubjectLink"
+					/>
+				</ul>
+			</template>
+		</template>
+
+		<p
+			v-else
+			class="ext-neowiki-subject-page__loading"
+		>
+			…
+		</p>
+
+		<SubjectEditorDialog
+			v-if="editingSubject !== null && editingSchema !== null"
+			v-model:open="editorOpen"
+			:subject="editingSubject as Subject"
+			:schema="editingSchema as Schema"
+			:on-save="handleEditSave"
+			:on-create="handleEditCreate"
+			:on-save-schema="handleSchemaSave"
+		/>
+
+		<SubjectDeleteDialog
+			v-model:open="deleteConfirmOpen"
+			:subject-name="deletingSubjectName"
+			@confirm="executeDelete"
+		/>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, shallowRef } from 'vue';
+import { NeoWikiServices } from '@/NeoWikiServices.ts';
+import { useSubjectStore } from '@/stores/SubjectStore.ts';
+import { useSchemaStore } from '@/stores/SchemaStore.ts';
+import { useSubjectPermissions } from '@/composables/useSubjectPermissions.ts';
+import { subjectDisplayName } from '@/presentation/subjectDisplayName.ts';
+import { Subject } from '@/domain/Subject.ts';
+import { Schema } from '@/domain/Schema.ts';
+import { SubjectId } from '@/domain/SubjectId.ts';
+import { SubjectWithContext } from '@/domain/SubjectWithContext.ts';
+import { PageIdentifiers } from '@/domain/PageIdentifiers.ts';
+import { SubjectNotFoundError } from '@/persistence/SubjectNotFoundError.ts';
+import { subjectPageUrl } from '@/presentation/subjectPageUrl.ts';
+import { copyToClipboard } from '@/presentation/copyToClipboard.ts';
+import SubjectRow from '@/components/SubjectsManager/SubjectRow.vue';
+import SubjectDeleteDialog from '@/components/SubjectsManager/SubjectDeleteDialog.vue';
+import SubjectEditorDialog from '@/components/SubjectEditor/SubjectEditorDialog.vue';
+
+const props = defineProps<{
+	subjectId: string;
+}>();
+
+const subjectId = new SubjectId( props.subjectId );
+
+const subjectStore = useSubjectStore();
+const schemaStore = useSchemaStore();
+const subjectRepo = NeoWikiServices.getSubjectRepository();
+const schemaRepo = NeoWikiServices.getSchemaRepository();
+const { canEditSubject, canDeleteSubject, checkPermissions } = useSubjectPermissions();
+
+// What the read returned, rather than a live read of the Subject registry: deleting a Subject takes
+// it out of that registry, and the registry's getter throws for an id it no longer holds. Every
+// write this page makes is followed by a re-read, so the rows still show what the wiki holds.
+//
+// These two are the page's whole state: neither set is the read in flight, an error is the read that
+// failed, and a Subject is the read that landed.
+const subject = shallowRef<Subject | null>( null );
+const errorText = ref<string | null>( null );
+// Bundle order, which is the order the Subject's relations name them.
+const referencedSubjects = shallowRef<Subject[]>( [] );
+
+// The Subject the page is about is open on arrival; the ones it references are not, so the page
+// opens on one Subject's data rather than on all of them.
+const expandedIds = ref<Set<string>>( new Set( [ subjectId.text ] ) );
+
+const hostingPage = computed<PageIdentifiers | null>( () => pageOf( subject.value ) );
+
+/**
+ * The page a Subject is stored on, or null when the read served none. Every Subject the
+ * deserializer builds carries PageIdentifiers, filled from a payload that omits both fields for a
+ * Subject whose hosting page the server could not resolve — so the values, not the type, decide.
+ */
+function pageOf( each: Subject | null ): PageIdentifiers | null {
+	if ( !( each instanceof SubjectWithContext ) ) {
+		return null;
+	}
+
+	const page = each.getPageIdentifiers();
+	const pageId = page.getPageId() as number | undefined;
+	const pageName = page.getPageName() as string | undefined;
+
+	return pageId === undefined || pageName === undefined ? null : page;
+}
+
+function toggleExpanded( toggled: Subject ): void {
+	const id = toggled.getId().text;
+	const next = new Set( expandedIds.value );
+	if ( next.has( id ) ) {
+		next.delete( id );
+	} else {
+		next.add( id );
+	}
+	expandedIds.value = next;
+}
+
+async function readSubject(): Promise<void> {
+	const bundle = await subjectRepo.getSubjectWithReferencedSubjects( subjectId );
+	const requested = bundle.requestedSubject;
+
+	// Seeding the registry is what lets RelationDisplay resolve this Subject's relation targets,
+	// the same way the Data tab's own load does.
+	subjectStore.setSubject( requested );
+	bundle.referencedSubjects.forEach( ( referenced ) => subjectStore.setSubject( referenced ) );
+	await Promise.all( [
+		loadSchemas( [ requested, ...bundle.referencedSubjects ] ),
+		seedRelationTargetsOf( bundle.referencedSubjects )
+	] );
+
+	subject.value = requested;
+	referencedSubjects.value = bundle.referencedSubjects;
+}
+
+async function loadSubject(): Promise<void> {
+	try {
+		await readSubject();
+	} catch ( error ) {
+		console.error( 'Failed to load subject:', error );
+		errorText.value = error instanceof SubjectNotFoundError ?
+			notFoundMessage() :
+			mw.msg( 'neowiki-special-subject-load-error' );
+	}
+}
+
+/**
+ * A re-read after a write. The write committed whatever this does, so a failure reports itself and
+ * leaves the page showing what was saved, rather than replacing it with "no such Subject".
+ */
+async function reloadSubject(): Promise<void> {
+	try {
+		await readSubject();
+	} catch ( error ) {
+		console.error( 'Failed to reload subject:', error );
+		mw.notify( mw.msg( 'neowiki-special-subject-load-error' ), { type: 'error' } );
+	}
+}
+
+function notFoundMessage(): string {
+	return mw.msg( 'neowiki-special-subject-not-found', props.subjectId );
+}
+
+/**
+ * The read expands relations one level, so a referenced Subject's own relation targets are not in
+ * it, and RelationDisplay renders a target it cannot resolve as an error. This fetches them, which
+ * is the depth the rows below render: their targets' targets are not shown, so not fetched.
+ */
+async function seedRelationTargetsOf( subjects: Subject[] ): Promise<void> {
+	const targets = new Map<string, SubjectId>();
+	for ( const each of subjects ) {
+		each.getStatements().getIdsOfReferencedSubjects()
+			.forEach( ( target ) => targets.set( target.text, target ) );
+	}
+
+	await Promise.all( [ ...targets.values() ].map( async ( target ) => {
+		try {
+			await subjectStore.getOrFetchSubject( target );
+		} catch ( error ) {
+			// RelationDisplay marks the unresolved target; the row around it still renders.
+			console.error( `Failed to load relation target ${ target.text }:`, error );
+		}
+	} ) );
+}
+
+/**
+ * The Subject read carries no Schemas, and SubjectStatementsView renders from the Schema store, so
+ * each distinct Schema the store does not hold yet is fetched into it — which after the first read
+ * is usually none, since a re-read shows the same Subjects. A Schema that fails to load leaves its
+ * Subjects rendered without their property definitions, which that view already handles; failing the
+ * whole page over one would not.
+ */
+async function loadSchemas( subjects: Subject[] ): Promise<void> {
+	const names = [ ...new Set( subjects.map( ( each ) => each.getSchemaName() ) ) ]
+		.filter( ( name ) => !schemaStore.schemas.has( name ) );
+
+	await Promise.all( names.map( async ( name ) => {
+		try {
+			schemaStore.setSchema( name, await schemaRepo.getSchema( name ) );
+		} catch ( error ) {
+			console.error( `Failed to load schema ${ name }:`, error );
+		}
+	} ) );
+}
+
+function copySubjectLink( target: Subject ): Promise<void> {
+	// This Subject's own page, absolute, rather than the address bar plus a fragment: every row here
+	// has a page of its own, so a link to the row means a link to that page.
+	return copyToClipboard(
+		new URL( subjectPageUrl( target.getId().text ), location.href ).toString(),
+		mw.msg( 'neowiki-managesubjects-link-copied' ),
+		mw.msg( 'neowiki-managesubjects-link-copy-error' )
+	);
+}
+
+// Editor state is component-local (ADR 16): the dialog opens on data fetched straight from the
+// repositories, not on the store this page renders from.
+const editingSubject = shallowRef<Subject | null>( null );
+const editingSchema = shallowRef<Schema | null>( null );
+const editorOpen = ref( false );
+
+async function openEditor( subjectToEdit: Subject ): Promise<void> {
+	try {
+		// Both, so the editor never opens against data another tab has moved on from.
+		const [ freshSubject, schema ] = await Promise.all( [
+			subjectRepo.getSubjectForEditing( subjectToEdit.getId() ),
+			schemaRepo.getSchema( subjectToEdit.getSchemaName() )
+		] );
+
+		editingSubject.value = freshSubject;
+		editingSchema.value = schema;
+		editorOpen.value = true;
+	} catch ( error ) {
+		mw.notify( error instanceof Error ? error.message : String( error ), { type: 'error' } );
+	}
+}
+
+// Re-read rather than patch: a save can add or drop relations, so the referenced Subjects below are
+// no longer the ones the page was built from.
+async function handleEditSave( updatedSubject: Subject, comment: string ): Promise<void> {
+	await subjectStore.updateSubject( updatedSubject, comment );
+	await reloadSubject();
+}
+
+// No reload of its own: a created Subject always comes with the update that points at it, and that
+// goes through handleEditSave.
+async function handleEditCreate( subject: Subject, targetPageId: number, comment: string ): Promise<void> {
+	await subjectStore.createSubject( subject, targetPageId, comment );
+}
+
+async function handleSchemaSave( updatedSchema: Schema, comment: string ): Promise<void> {
+	await schemaStore.saveSchema( updatedSchema, comment );
+}
+
+const deleteConfirmOpen = ref( false );
+const deletingSubject = shallowRef<Subject | null>( null );
+
+const deletingSubjectName = computed( () =>
+	deletingSubject.value === null ? '' : subjectDisplayName( deletingSubject.value ) );
+
+function confirmDelete( target: Subject ): void {
+	deletingSubject.value = target;
+	deleteConfirmOpen.value = true;
+}
+
+async function executeDelete( comment: string ): Promise<void> {
+	const target = deletingSubject.value;
+	deleteConfirmOpen.value = false;
+
+	if ( target === null ) {
+		return;
+	}
+
+	const name = subjectDisplayName( target );
+	const deletedTheSubjectShown = target.getId().text === subjectId.text;
+
+	try {
+		await subjectStore.deleteSubject(
+			target.getId(),
+			comment || mw.msg( 'neowiki-managesubjects-delete-summary-default' )
+		);
+		mw.notify( mw.msg( 'neowiki-managesubjects-delete-success' ), { type: 'success' } );
+
+		if ( deletedTheSubjectShown ) {
+			// Nothing left for this page to show, and the wiki now answers its id the way it answers
+			// one it never minted.
+			subject.value = null;
+			referencedSubjects.value = [];
+			errorText.value = notFoundMessage();
+		} else {
+			await reloadSubject();
+		}
+	} catch ( error ) {
+		console.error( 'Failed to delete subject:', error );
+		mw.notify( mw.msg( 'neowiki-managesubjects-delete-error', name ), { type: 'error' } );
+	} finally {
+		deletingSubject.value = null;
+	}
+}
+
+onMounted( async () => {
+	await loadSubject();
+
+	// Editing rights are the hosting page's. Without one there is nothing to ask about, and the
+	// controls stay hidden.
+	if ( hostingPage.value !== null ) {
+		await checkPermissions( hostingPage.value.getPageId() );
+	}
+} );
+</script>
+
+<style lang="less">
+@import ( reference ) '@wikimedia/codex-design-tokens/theme-wikimedia-ui.less';
+
+.ext-neowiki-subject-page {
+	max-width: 64rem;
+
+	&__loading,
+	&__error {
+		color: @color-subtle;
+		font-style: italic;
+	}
+
+	&__subject,
+	&__referenced {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: @spacing-50;
+	}
+
+	&__referenced-heading {
+		margin: @spacing-150 0 @spacing-75;
+	}
+}
+</style>

--- a/resources/ext.neowiki/src/components/SubjectsManager/SubjectDeleteDialog.vue
+++ b/resources/ext.neowiki/src/components/SubjectsManager/SubjectDeleteDialog.vue
@@ -1,0 +1,42 @@
+<template>
+	<CdxDialog
+		:open="open"
+		class="ext-neowiki-ui"
+		:title="$i18n( 'neowiki-managesubjects-delete-confirm-title' ).text()"
+		:use-close-button="true"
+		@update:open="emit( 'update:open', $event )"
+	>
+		<I18nSlot message-key="neowiki-managesubjects-delete-confirm-message">
+			<strong>{{ subjectName }}</strong>
+		</I18nSlot>
+		<template #footer>
+			<SummaryAction
+				help-text=""
+				:save-button-label="$i18n( 'neowiki-managesubjects-delete-confirm-button' ).text()"
+				:save-disabled="false"
+				save-button-action="destructive"
+				:save-button-icon="cdxIconTrash"
+				@save="emit( 'confirm', $event )"
+			/>
+		</template>
+	</CdxDialog>
+</template>
+
+<script setup lang="ts">
+import { CdxDialog } from '@wikimedia/codex';
+import { cdxIconTrash } from '@wikimedia/codex-icons';
+import I18nSlot from '@/components/common/I18nSlot.vue';
+import SummaryAction from '@/components/common/SummaryAction.vue';
+
+defineProps<{
+	open: boolean;
+	/** The name the confirmation asks about, so the user sees which Subject they are losing. */
+	subjectName: string;
+}>();
+
+const emit = defineEmits<{
+	'update:open': [ open: boolean ];
+	/** Confirmed, carrying the edit summary the user typed. */
+	confirm: [ summary: string ];
+}>();
+</script>

--- a/resources/ext.neowiki/src/components/SubjectsManager/SubjectRow.vue
+++ b/resources/ext.neowiki/src/components/SubjectsManager/SubjectRow.vue
@@ -317,12 +317,10 @@ const menuItems = computed<MenuButtonItemData[]>( () => {
 	const items: MenuButtonItemData[] = [];
 
 	if ( props.subjectPageUrl !== null ) {
-		// A url makes Codex render the item as a link, so choosing it navigates by itself.
 		items.push( {
 			value: 'open',
 			label: mw.msg( 'neowiki-managesubjects-row-open' ),
-			icon: cdxIconNext,
-			url: props.subjectPageUrl
+			icon: cdxIconNext
 		} );
 	}
 
@@ -370,11 +368,13 @@ const menuItems = computed<MenuButtonItemData[]>( () => {
 
 const menuSelection = ref<string | number | null>( null );
 
-// 'open' is absent: that item carries a url, so Codex navigates without this being asked.
+// Codex selects an item chosen with the keyboard but never follows a url, so 'open' navigates here.
 function dispatchMenuAction( value: string | number | null ): void {
 	menuSelection.value = null;
 
-	if ( value === 'copy-link' ) {
+	if ( value === 'open' && props.subjectPageUrl !== null ) {
+		window.location.href = props.subjectPageUrl;
+	} else if ( value === 'copy-link' ) {
 		emit( 'copy-link', props.subject );
 	} else if ( value === 'edit' ) {
 		emit( 'edit', props.subject );

--- a/resources/ext.neowiki/src/components/SubjectsManager/SubjectRow.vue
+++ b/resources/ext.neowiki/src/components/SubjectsManager/SubjectRow.vue
@@ -38,7 +38,25 @@
 					/>
 				</template>
 				<span class="ext-neowiki-subject-row__title">
-					<span class="ext-neowiki-subject-row__label">
+					<a
+						v-if="subjectPageUrl !== null"
+						class="ext-neowiki-subject-row__name"
+						:href="subjectPageUrl"
+						@click.stop
+					>
+						<span class="ext-neowiki-subject-row__label">
+							{{ displayName }}
+						</span>
+						<CdxIcon
+							class="ext-neowiki-subject-row__name-arrow"
+							:icon="cdxIconArrowNext"
+							size="x-small"
+						/>
+					</a>
+					<span
+						v-else
+						class="ext-neowiki-subject-row__label"
+					>
 						{{ displayName }}
 					</span>
 					<span class="ext-neowiki-subject-row__subtitle">
@@ -54,16 +72,6 @@
 					</span>
 				</span>
 				<span class="ext-neowiki-subject-row__actions">
-					<a
-						v-if="subjectPageUrl !== null"
-						class="ext-neowiki-subject-row__open cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet"
-						:href="subjectPageUrl"
-						:aria-label="$i18n( 'neowiki-managesubjects-row-open' ).text()"
-						:title="$i18n( 'neowiki-managesubjects-row-open' ).text()"
-						@click.stop
-					>
-						<CdxIcon :icon="cdxIconNext" />
-					</a>
 					<CdxButton
 						weight="quiet"
 						:aria-label="$i18n( 'neowiki-managesubjects-row-copy-link' ).text()"
@@ -207,6 +215,7 @@ import { computed, ref } from 'vue';
 import { CdxButton, CdxIcon, CdxMenuButton } from '@wikimedia/codex';
 import type { MenuButtonItemData } from '@wikimedia/codex';
 import {
+	cdxIconArrowNext,
 	cdxIconArticleRedirect,
 	cdxIconCollapse,
 	cdxIconDraggable,
@@ -214,7 +223,6 @@ import {
 	cdxIconEllipsis,
 	cdxIconExpand,
 	cdxIconLink,
-	cdxIconNext,
 	cdxIconPushPin,
 	cdxIconTrash
 } from '@wikimedia/codex-icons';
@@ -241,7 +249,8 @@ const props = withDefaults( defineProps<{
 	subject: Subject;
 	expanded: boolean;
 	/**
-	 * The Subject's own page, offered as a row action. Null where the reader is on it already.
+	 * The Subject's own page, which the name links to and the overflow menu offers. Null where the
+	 * reader is on it already.
 	 */
 	subjectPageUrl?: string | null;
 	/**
@@ -310,7 +319,8 @@ function pageUrl( pageName: string ): string {
 }
 
 // Opening and copying a link lead: they change nothing. Edit and promote change the row in place;
-// move and delete take it out of the listing, with delete last. Mirrors the inline strip's order.
+// move and delete take it out of the listing, with delete last. The inline strip keeps this order,
+// less opening, which the name offers there.
 const menuItems = computed<MenuButtonItemData[]>( () => {
 	// Neither is permission-gated: everyone, read-only users included, may reach a Subject's page
 	// and copy a link to it.
@@ -320,7 +330,7 @@ const menuItems = computed<MenuButtonItemData[]>( () => {
 		items.push( {
 			value: 'open',
 			label: mw.msg( 'neowiki-managesubjects-row-open' ),
-			icon: cdxIconNext
+			icon: cdxIconArrowNext
 		} );
 	}
 
@@ -437,10 +447,6 @@ function copySubjectIri(): Promise<void> {
 			&:active {
 				background-color: @background-color-interactive;
 			}
-
-			.ext-neowiki-subject-row__label {
-				color: @color-progressive;
-			}
 		}
 	}
 
@@ -547,6 +553,36 @@ function copySubjectIri(): Promise<void> {
 		white-space: nowrap;
 	}
 
+	/* The way to the Subject's own page. Only as wide as the name and its arrow, so the rest of the
+		header still toggles the row. */
+	&__name {
+		display: inline-flex;
+		align-items: center;
+		gap: @spacing-25;
+		align-self: flex-start;
+		max-width: @size-full;
+		min-width: 0;
+	}
+
+	/* The cue that the name leads somewhere: shown while the name is pointed at or focused where the
+		pointer can hover, and always where it cannot, like the action strip. In the link's colour,
+		which Codex sets on `.cdx-icon` unless told otherwise. */
+	&__name-arrow.cdx-icon {
+		flex-shrink: 0;
+		color: inherit;
+
+		@media ( hover: hover ) {
+			opacity: 0;
+			// Slides the way it points as it appears.
+			transform: translateX( -@spacing-25 );
+			transition: opacity @transition-duration-base @transition-timing-function-system, transform @transition-duration-base @transition-timing-function-system;
+		}
+
+		@media ( prefers-reduced-motion: reduce ) {
+			transition-duration: 0s;
+		}
+	}
+
 	&__identifiers {
 		display: flex;
 		flex-direction: column;
@@ -643,16 +679,6 @@ function copySubjectIri(): Promise<void> {
 		}
 	}
 
-	/* A link styled as one of the row's quiet icon buttons — Codex's fake-button pattern. */
-	&__open.cdx-button {
-		min-width: @min-size-interactive-pointer;
-		padding: 0;
-
-		&:hover {
-			text-decoration: none;
-		}
-	}
-
 	&__drag-handle {
 		// Set off from the buttons: this is grabbed, not clicked, and delete sits right before it.
 		margin-inline-start: @spacing-50;
@@ -711,6 +737,56 @@ function copySubjectIri(): Promise<void> {
 		margin-top: @spacing-100;
 		padding-top: @spacing-75;
 		border-top: @border-width-base @border-style-base @border-color-subtle;
+	}
+}
+/* Codex's link colours, less the visited one: a Subject's name reads the same whether or not the
+	reader has been to its page. Every state is spelled out and qualified with `a`, because core
+	colours `a:visited` and underlines `a:hover, a:focus` at (0,1,1), as SchemaNameDisplay explains.
+	Hover and active come after focus, so that they still underline. */
+a.ext-neowiki-subject-row__name {
+	border-radius: @border-radius-base;
+
+	&,
+	&:visited {
+		color: @color-progressive;
+		text-decoration: @text-decoration-none;
+	}
+
+	&:focus {
+		text-decoration: @text-decoration-none;
+	}
+
+	// Also qualified with `:visited`: Vector paints `a:visited:hover` at (0,2,1), which a bare
+	// `a.<class>:hover` only ties and then loses to on source order.
+	&:hover,
+	&:visited:hover {
+		color: @color-progressive--hover;
+		text-decoration: @text-decoration-underline;
+	}
+
+	&:active,
+	&:visited:active {
+		color: @color-progressive--active;
+		text-decoration: @text-decoration-underline;
+	}
+
+	&:focus-visible {
+		outline: @border-style-base @border-width-thick @outline-color-progressive--focus;
+	}
+
+	// Vector styles every link with Codex's link mixin, which gives a trailing icon the size and
+	// padding of an external-link mark, at (0,3,1). The arrow is only a cue: x-small, spaced by the
+	// link's gap.
+	.ext-neowiki-subject-row__name-arrow.cdx-icon:last-child {
+		width: @size-icon-x-small;
+		height: @size-icon-x-small;
+		padding-left: 0;
+	}
+
+	&:hover .ext-neowiki-subject-row__name-arrow,
+	&:focus-visible .ext-neowiki-subject-row__name-arrow {
+		opacity: 1;
+		transform: translateX( 0 );
 	}
 }
 </style>

--- a/resources/ext.neowiki/src/components/SubjectsManager/SubjectRow.vue
+++ b/resources/ext.neowiki/src/components/SubjectsManager/SubjectRow.vue
@@ -1,0 +1,716 @@
+<template>
+	<li
+		:id="subjectRowDomId( subject.getId().text )"
+		class="ext-neowiki-subject-row"
+		:class="{
+			'ext-neowiki-subject-row--emphasized': emphasized,
+			'ext-neowiki-subject-row--highlighted': highlighted,
+			'ext-neowiki-subject-row--focused': focused,
+			'ext-neowiki-subject-row--expanded': expanded
+		}"
+	>
+		<details :open="expanded">
+			<summary
+				class="ext-neowiki-subject-row__header"
+				@click.prevent="emit( 'toggle', subject )"
+			>
+				<CdxIcon
+					class="ext-neowiki-subject-row__chevron"
+					:icon="expanded ? cdxIconCollapse : cdxIconExpand"
+					size="small"
+				/>
+				<template v-if="mainSubjectControl === 'demote'">
+					<CdxButton
+						v-if="canEdit"
+						class="ext-neowiki-subject-row__main-indicator"
+						weight="quiet"
+						:aria-label="$i18n( 'neowiki-managesubjects-row-demote' ).text()"
+						:title="$i18n( 'neowiki-managesubjects-row-demote' ).text()"
+						@click.stop="emit( 'demote', subject )"
+					>
+						<CdxIcon :icon="cdxIconPushPin" />
+					</CdxButton>
+					<CdxIcon
+						v-else
+						class="ext-neowiki-subject-row__main-indicator"
+						:icon="cdxIconPushPin"
+						:icon-label="$i18n( 'neowiki-managesubjects-main-subject-indicator' ).text()"
+					/>
+				</template>
+				<span class="ext-neowiki-subject-row__title">
+					<span class="ext-neowiki-subject-row__label">
+						{{ displayName }}
+					</span>
+					<span class="ext-neowiki-subject-row__subtitle">
+						<SchemaNameDisplay
+							v-if="schemaName !== null"
+							class="ext-neowiki-subject-row__schema"
+							:schema-name="schemaName"
+							@click.stop
+						/>
+						<span class="ext-neowiki-subject-row__count">
+							{{ $i18n( 'neowiki-managesubjects-statement-count', statementCount ).text() }}
+						</span>
+					</span>
+				</span>
+				<span class="ext-neowiki-subject-row__actions">
+					<a
+						v-if="subjectPageUrl !== null"
+						class="ext-neowiki-subject-row__open cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet"
+						:href="subjectPageUrl"
+						:aria-label="$i18n( 'neowiki-managesubjects-row-open' ).text()"
+						:title="$i18n( 'neowiki-managesubjects-row-open' ).text()"
+						@click.stop
+					>
+						<CdxIcon :icon="cdxIconNext" />
+					</a>
+					<CdxButton
+						weight="quiet"
+						:aria-label="$i18n( 'neowiki-managesubjects-row-copy-link' ).text()"
+						:title="$i18n( 'neowiki-managesubjects-row-copy-link' ).text()"
+						@click.stop="emit( 'copy-link', subject )"
+					>
+						<CdxIcon :icon="cdxIconLink" />
+					</CdxButton>
+					<CdxButton
+						v-if="canEdit"
+						weight="quiet"
+						:aria-label="$i18n( 'neowiki-managesubjects-row-edit' ).text()"
+						:title="$i18n( 'neowiki-managesubjects-row-edit' ).text()"
+						@click.stop="emit( 'edit', subject )"
+					>
+						<CdxIcon :icon="cdxIconEdit" />
+					</CdxButton>
+					<CdxButton
+						v-if="canEdit && mainSubjectControl === 'promote'"
+						weight="quiet"
+						:aria-label="$i18n( 'neowiki-managesubjects-row-promote' ).text()"
+						:title="$i18n( 'neowiki-managesubjects-row-promote' ).text()"
+						@click.stop="emit( 'promote', subject )"
+					>
+						<CdxIcon :icon="cdxIconPushPin" />
+					</CdxButton>
+					<CdxButton
+						v-if="canMove"
+						weight="quiet"
+						:aria-label="$i18n( 'neowiki-managesubjects-row-move' ).text()"
+						:title="$i18n( 'neowiki-managesubjects-row-move' ).text()"
+						@click.stop="emit( 'move', subject )"
+					>
+						<CdxIcon :icon="cdxIconArticleRedirect" />
+					</CdxButton>
+					<CdxButton
+						v-if="canDelete"
+						weight="quiet"
+						action="destructive"
+						:aria-label="$i18n( 'neowiki-managesubjects-row-delete' ).text()"
+						:title="$i18n( 'neowiki-managesubjects-row-delete' ).text()"
+						@click.stop="emit( 'delete', subject )"
+					>
+						<CdxIcon :icon="cdxIconTrash" />
+					</CdxButton>
+					<span
+						v-if="showDragHandle"
+						class="ext-neowiki-subject-row__drag-handle"
+						:title="$i18n( 'neowiki-managesubjects-row-drag-handle' ).text()"
+						@click.stop
+					>
+						<CdxIcon
+							:icon="cdxIconDraggable"
+							:aria-hidden="true"
+						/>
+					</span>
+				</span>
+				<span
+					class="ext-neowiki-subject-row__actions-menu"
+					@click.stop
+				>
+					<CdxMenuButton
+						v-model:selected="menuSelection"
+						:menu-items="menuItems"
+						:aria-label="$i18n( 'neowiki-managesubjects-row-more' ).text()"
+						:title="$i18n( 'neowiki-managesubjects-row-more' ).text()"
+						@update:selected="dispatchMenuAction"
+					>
+						<CdxIcon :icon="cdxIconEllipsis" />
+					</CdxMenuButton>
+				</span>
+			</summary>
+			<div class="ext-neowiki-subject-row__expanded">
+				<SubjectStatementsView :subject="subject" />
+				<footer class="ext-neowiki-subject-row__footer">
+					<dl class="ext-neowiki-subject-row__identifiers">
+						<div class="ext-neowiki-subject-row__id">
+							<dt class="ext-neowiki-subject-row__id-label">
+								{{ $i18n( 'neowiki-managesubjects-id-label' ).text() }}
+							</dt>
+							<dd class="ext-neowiki-subject-row__id-value">
+								<button
+									type="button"
+									class="ext-neowiki-subject-row__id-button"
+									:title="$i18n( 'neowiki-managesubjects-id-copy', subject.getId().text ).text()"
+									:aria-label="$i18n( 'neowiki-managesubjects-id-copy', subject.getId().text ).text()"
+									@click="copySubjectId"
+								>
+									<data :value="subject.getId().text">
+										{{ subject.getId().text }}
+									</data>
+								</button>
+							</dd>
+						</div>
+						<div
+							v-if="iri"
+							class="ext-neowiki-subject-row__iri"
+						>
+							<dt class="ext-neowiki-subject-row__iri-label">
+								{{ $i18n( 'neowiki-managesubjects-iri-label' ).text() }}
+							</dt>
+							<dd class="ext-neowiki-subject-row__iri-value">
+								<button
+									type="button"
+									class="ext-neowiki-subject-row__iri-button"
+									:title="$i18n( 'neowiki-managesubjects-iri-copy', iri ).text()"
+									:aria-label="$i18n( 'neowiki-managesubjects-iri-copy', iri ).text()"
+									@click="copySubjectIri"
+								>
+									<data :value="iri">
+										{{ iri }}
+									</data>
+								</button>
+							</dd>
+						</div>
+						<div
+							v-if="page !== null"
+							class="ext-neowiki-subject-row__page"
+						>
+							<dt class="ext-neowiki-subject-row__page-label">
+								{{ $i18n( 'neowiki-special-subject-page-label' ).text() }}
+							</dt>
+							<dd class="ext-neowiki-subject-row__page-value">
+								<a :href="pageUrl( page.getPageName() )">{{ page.getPageName() }}</a>
+							</dd>
+						</div>
+					</dl>
+					<DataExportButton
+						:label="$i18n( 'neowiki-managesubjects-export-button' ).text()"
+						:projections="rdfProjections"
+						v-bind="exportUrls"
+					/>
+				</footer>
+			</div>
+		</details>
+	</li>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { CdxButton, CdxIcon, CdxMenuButton } from '@wikimedia/codex';
+import type { MenuButtonItemData } from '@wikimedia/codex';
+import {
+	cdxIconArticleRedirect,
+	cdxIconCollapse,
+	cdxIconDraggable,
+	cdxIconEdit,
+	cdxIconEllipsis,
+	cdxIconExpand,
+	cdxIconLink,
+	cdxIconNext,
+	cdxIconPushPin,
+	cdxIconTrash
+} from '@wikimedia/codex-icons';
+import { Subject } from '@/domain/Subject.ts';
+import type { PageIdentifiers } from '@/domain/PageIdentifiers.ts';
+import { subjectRowDomId } from '@/presentation/subjectRowAnchor.ts';
+import { subjectDisplayName } from '@/presentation/subjectDisplayName.ts';
+import { schemaNameToShow } from '@/presentation/schemaNameToShow.ts';
+import { subjectExportUrls } from '@/presentation/DataExportMenu.ts';
+import { subjectIri } from '@/presentation/subjectIri.ts';
+import { copyToClipboard } from '@/presentation/copyToClipboard.ts';
+import SchemaNameDisplay from '@/components/common/SchemaNameDisplay.vue';
+import SubjectStatementsView from '@/components/SubjectsManager/SubjectStatementsView.vue';
+import DataExportButton from '@/components/SubjectsManager/DataExportButton.vue';
+
+/**
+ * Which Main Subject control the row carries: the pin that demotes the page's Main Subject, the pin
+ * that promotes another Subject to it, or none, on a surface where a page's Main Subject is not a
+ * thing the row can change.
+ */
+type MainSubjectControl = 'none' | 'promote' | 'demote';
+
+const props = withDefaults( defineProps<{
+	subject: Subject;
+	expanded: boolean;
+	/**
+	 * The Subject's own page, offered as a row action. Null where the reader is on it already.
+	 */
+	subjectPageUrl?: string | null;
+	/**
+	 * Gives the row the prominence a surface's focal Subject gets: the page's Main Subject on the
+	 * Data tab, the Subject a page is about on Special:Subject. Says nothing about either by itself.
+	 */
+	emphasized?: boolean;
+	/** Arrived at through a deep link. */
+	highlighted?: boolean;
+	/** Just acted on, so the eye is drawn back to it. */
+	focused?: boolean;
+	canEdit?: boolean;
+	canDelete?: boolean;
+	/** Whether this surface offers moving the Subject to another page at all. */
+	canMove?: boolean;
+	mainSubjectControl?: MainSubjectControl;
+	showDragHandle?: boolean;
+	/**
+	 * The page the Subject is stored on, linked in the expanded footer. Null where naming it says
+	 * nothing — the Data tab is that page — or where the read resolved none.
+	 */
+	page?: PageIdentifiers | null;
+}>(), {
+	subjectPageUrl: null,
+	emphasized: false,
+	highlighted: false,
+	focused: false,
+	canEdit: false,
+	canDelete: false,
+	canMove: false,
+	mainSubjectControl: 'none',
+	showDragHandle: false,
+	page: null
+} );
+
+// Everything the page decides is emitted rather than done here: which Subject a promotion moves
+// aside, what a deletion confirms against, where a copied link points. The two clipboard copies
+// below are the exceptions — they need nothing but this row's own Subject.
+const emit = defineEmits<{
+	toggle: [ subject: Subject ];
+	edit: [ subject: Subject ];
+	promote: [ subject: Subject ];
+	demote: [ subject: Subject ];
+	move: [ subject: Subject ];
+	delete: [ subject: Subject ];
+	'copy-link': [ subject: Subject ];
+}>();
+
+// The projections the expanded footer's export menu offers, permission-filtered server-side. Set by
+// whichever surface mounts the row: the Data tab's action and Special:Subject alike.
+const rdfProjections = ( mw.config.get( 'wgNeoWikiRdfProjections' ) as string[] | null ) ?? [];
+
+const displayName = computed( () => subjectDisplayName( props.subject ) );
+const schemaName = computed( () => schemaNameToShow( props.subject ) );
+const statementCount = computed( () => props.subject.getNamesOfNonEmptyProperties().length );
+const exportUrls = computed( () => subjectExportUrls( props.subject.getId().text ) );
+
+/**
+ * The Subject's concept URI, shown and copyable in the expanded footer. Empty for a Subject of another
+ * Source, which this wiki mints no IRI for, and then not shown at all.
+ */
+const iri = computed( () => subjectIri( props.subject.getId().text ) );
+
+function pageUrl( pageName: string ): string {
+	return mw.util.getUrl( pageName );
+}
+
+// Opening and copying a link lead: they change nothing. Edit and promote change the row in place;
+// move and delete take it out of the listing, with delete last. Mirrors the inline strip's order.
+const menuItems = computed<MenuButtonItemData[]>( () => {
+	// Neither is permission-gated: everyone, read-only users included, may reach a Subject's page
+	// and copy a link to it.
+	const items: MenuButtonItemData[] = [];
+
+	if ( props.subjectPageUrl !== null ) {
+		// A url makes Codex render the item as a link, so choosing it navigates by itself.
+		items.push( {
+			value: 'open',
+			label: mw.msg( 'neowiki-managesubjects-row-open' ),
+			icon: cdxIconNext,
+			url: props.subjectPageUrl
+		} );
+	}
+
+	items.push( {
+		value: 'copy-link',
+		label: mw.msg( 'neowiki-managesubjects-row-copy-link' ),
+		icon: cdxIconLink
+	} );
+
+	if ( props.canEdit ) {
+		items.push( {
+			value: 'edit',
+			label: mw.msg( 'neowiki-managesubjects-row-edit' ),
+			icon: cdxIconEdit
+		} );
+
+		if ( props.mainSubjectControl === 'promote' ) {
+			items.push( {
+				value: 'promote',
+				label: mw.msg( 'neowiki-managesubjects-row-promote' ),
+				icon: cdxIconPushPin
+			} );
+		}
+	}
+
+	if ( props.canMove ) {
+		items.push( {
+			value: 'move',
+			label: mw.msg( 'neowiki-managesubjects-row-move' ),
+			icon: cdxIconArticleRedirect
+		} );
+	}
+
+	if ( props.canDelete ) {
+		items.push( {
+			value: 'delete',
+			label: mw.msg( 'neowiki-managesubjects-row-delete' ),
+			icon: cdxIconTrash,
+			action: 'destructive'
+		} );
+	}
+
+	return items;
+} );
+
+const menuSelection = ref<string | number | null>( null );
+
+// 'open' is absent: that item carries a url, so Codex navigates without this being asked.
+function dispatchMenuAction( value: string | number | null ): void {
+	menuSelection.value = null;
+
+	if ( value === 'copy-link' ) {
+		emit( 'copy-link', props.subject );
+	} else if ( value === 'edit' ) {
+		emit( 'edit', props.subject );
+	} else if ( value === 'promote' ) {
+		emit( 'promote', props.subject );
+	} else if ( value === 'move' ) {
+		emit( 'move', props.subject );
+	} else if ( value === 'delete' ) {
+		emit( 'delete', props.subject );
+	}
+}
+
+function copySubjectId(): Promise<void> {
+	const id = props.subject.getId().text;
+
+	return copyToClipboard(
+		id,
+		mw.msg( 'neowiki-managesubjects-id-copied', id ),
+		mw.msg( 'neowiki-managesubjects-id-copy-error' )
+	);
+}
+
+function copySubjectIri(): Promise<void> {
+	return copyToClipboard(
+		iri.value,
+		mw.msg( 'neowiki-managesubjects-iri-copied', iri.value ),
+		mw.msg( 'neowiki-managesubjects-iri-copy-error' )
+	);
+}
+</script>
+
+<style lang="less">
+@import ( reference ) '@wikimedia/codex-design-tokens/theme-wikimedia-ui.less';
+
+.ext-neowiki-subject-row {
+	border: @border-base;
+	border-radius: @border-radius-base;
+	background: @background-color-base;
+	// Baseline zero-color shadow so the focused-state ring can transition in/out smoothly
+	// rather than snap between "none" and a value.
+	box-shadow: @box-shadow-outset-small transparent;
+	transition: @transition-property-base @transition-duration-medium @transition-timing-function-system;
+
+	@media ( prefers-reduced-motion: reduce ) {
+		transition-duration: 0s;
+	}
+	font-size: @font-size-small;
+	line-height: 1.375rem; // Codex 2.0+ line-height-small
+
+	&--emphasized {
+		border-color: @border-color-progressive;
+
+		.ext-neowiki-subject-row__header {
+			background-color: @background-color-progressive-subtle;
+
+			&:hover {
+				background-color: @background-color-interactive-subtle;
+			}
+
+			&:active {
+				background-color: @background-color-interactive;
+			}
+
+			.ext-neowiki-subject-row__label {
+				color: @color-progressive;
+			}
+		}
+	}
+
+	&--highlighted {
+		background: @background-color-progressive-subtle;
+	}
+
+	&--focused {
+		border-color: @border-color-progressive--focus;
+		box-shadow: @box-shadow-outset-small @box-shadow-color-progressive--focus;
+		// Transparent 1px outline for Windows high-contrast mode — Codex focus pattern.
+		outline: @outline-base--focus;
+	}
+
+	&--ghost {
+		opacity: 0.5;
+		background-color: @background-color-interactive-subtle;
+	}
+
+	&__header {
+		display: flex;
+		align-items: center;
+		gap: @spacing-75;
+		padding: @spacing-75 @spacing-100;
+		cursor: pointer;
+		user-select: none;
+		list-style: none;
+		transition-property: background-color, color, border-color, box-shadow;
+		transition-duration: @transition-duration-base;
+		transition-timing-function: @transition-timing-function-system;
+
+		&::-webkit-details-marker {
+			display: none;
+		}
+
+		&:hover {
+			background-color: @background-color-interactive-subtle;
+		}
+
+		&:active {
+			background-color: @background-color-interactive;
+		}
+
+		&:focus-visible {
+			outline: @outline-base--focus;
+			box-shadow: inset 0 0 0 2px @box-shadow-color-progressive--focus;
+		}
+	}
+
+	&__chevron {
+		flex-shrink: 0;
+		color: @color-subtle;
+	}
+
+	&__main-indicator {
+		flex-shrink: 0;
+
+		// Codex sets an explicit `color` on `.cdx-icon`, matching our class's specificity.
+		// Chain the class to win the cascade regardless of Codex/bundle load order.
+		&.cdx-icon {
+			color: @color-progressive;
+		}
+
+		// When the user can edit, the indicator renders as a quiet CdxButton so clicking it
+		// demotes the subject. Paint the nested icon progressive to match the read-only case.
+		&.cdx-button .cdx-icon {
+			color: @color-progressive;
+		}
+	}
+
+	&__title {
+		display: flex;
+		flex-direction: column;
+		gap: @spacing-12;
+		flex-grow: 1;
+		min-width: 0;
+	}
+
+	&__subtitle {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0 @spacing-50;
+		min-width: 0;
+		font-size: @font-size-small;
+		color: @color-subtle;
+	}
+
+	/* The badge ellipsises its own text; the row only has to let it shrink. */
+	&__schema {
+		min-width: 0;
+	}
+
+	&__count {
+		white-space: nowrap;
+	}
+
+	&__label {
+		font-size: @font-size-medium;
+		font-weight: @font-weight-bold;
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	&__identifiers {
+		display: flex;
+		flex-direction: column;
+		min-width: 0;
+		margin: 0;
+		font-size: @font-size-x-small;
+		color: @color-subtle;
+	}
+
+	&__id,
+	&__iri,
+	&__page {
+		display: flex;
+		align-items: baseline;
+		gap: @spacing-25;
+		min-width: 0;
+	}
+
+	&__id-label,
+	&__iri-label,
+	&__page-label {
+		flex-shrink: 0;
+	}
+
+	&__id-value,
+	&__iri-value,
+	&__page-value {
+		display: flex;
+		min-width: 0;
+		margin: 0;
+	}
+
+	/* A page title, not an identifier: no monospace, and long ones ellipsize like the IRI. */
+	&__page-value a {
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	&__id-button,
+	&__iri-button {
+		appearance: none;
+		background: transparent;
+		border: 0;
+		padding: 0;
+		cursor: pointer;
+		color: inherit;
+		font: inherit;
+		font-family: @font-family-monospace;
+		// The IRI is a full URL: let a long one ellipsize instead of stretching the footer. The whole
+		// value stays in the button title and is what the click copies.
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+
+		&:hover {
+			color: @color-base;
+		}
+	}
+
+	/* The separator belongs to the pair: a row whose badge is withheld draws none. */
+	&__schema + &__count::before {
+		content: '•';
+		margin-inline-end: @spacing-50;
+	}
+
+	&__actions {
+		display: inline-flex;
+		gap: @spacing-25;
+		flex-shrink: 0;
+
+		@media ( max-width: @max-width-breakpoint-mobile ) {
+			display: none;
+		}
+
+		@media ( min-width: @min-width-breakpoint-tablet ) and ( hover: hover ) {
+			opacity: 0;
+			transform: translateX( @spacing-50 );
+			transition: opacity @transition-duration-medium @transition-timing-function-system, transform @transition-duration-medium @transition-timing-function-system;
+
+			.ext-neowiki-subject-row:hover &,
+			.ext-neowiki-subject-row:has( :focus-visible ) &,
+			.ext-neowiki-subject-row--highlighted &,
+			.ext-neowiki-subject-row--expanded & {
+				// :has( :focus-visible ) rather than :focus-within: keyboard focus must reveal the
+				// controls a user is tabbing through, but mouse clicks also focus what they hit (a copy
+				// button, the summary when toggling a row) and would pin the controls visible after the
+				// pointer leaves.
+				opacity: 1;
+				transform: translateX( 0 );
+			}
+		}
+	}
+
+	/* A link styled as one of the row's quiet icon buttons — Codex's fake-button pattern. */
+	&__open.cdx-button {
+		min-width: @min-size-interactive-pointer;
+		padding: 0;
+
+		&:hover {
+			text-decoration: none;
+		}
+	}
+
+	&__drag-handle {
+		// Set off from the buttons: this is grabbed, not clicked, and delete sits right before it.
+		margin-inline-start: @spacing-50;
+		min-width: @min-size-interactive-pointer;
+		min-height: @min-size-interactive-pointer;
+		padding-inline: @spacing-30;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		box-sizing: border-box;
+		cursor: grab;
+
+		&:active {
+			cursor: grabbing;
+		}
+
+		.cdx-icon {
+			color: @color-placeholder;
+		}
+	}
+
+	&__actions-menu {
+		flex-shrink: 0;
+
+		@media ( min-width: @min-width-breakpoint-tablet ) {
+			display: none;
+		}
+
+		@media ( max-width: @max-width-breakpoint-mobile ) and ( hover: hover ) {
+			opacity: 0;
+			transition: opacity @transition-duration-medium @transition-timing-function-system;
+
+			.ext-neowiki-subject-row:hover &,
+			.ext-neowiki-subject-row:has( :focus-visible ) &,
+			.ext-neowiki-subject-row--highlighted &,
+			.ext-neowiki-subject-row--expanded &,
+			&:has( [ aria-expanded='true' ] ) {
+				// Keyboard-only focus reveal for the same reason as __actions above.
+				opacity: 1;
+			}
+		}
+	}
+
+	&__expanded {
+		padding: @spacing-100;
+		border-top: @border-base;
+		background: @background-color-neutral-subtle;
+	}
+
+	&__footer {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		justify-content: space-between;
+		gap: @spacing-100;
+		margin-top: @spacing-100;
+		padding-top: @spacing-75;
+		border-top: @border-width-base @border-style-base @border-color-subtle;
+	}
+}
+</style>

--- a/resources/ext.neowiki/src/components/SubjectsManager/SubjectsManagerPage.vue
+++ b/resources/ext.neowiki/src/components/SubjectsManager/SubjectsManagerPage.vue
@@ -663,10 +663,6 @@ onUnmounted( () => {
 		color: @color-subtle;
 	}
 
-	&__section-heading {
-		margin: @spacing-150 0 @spacing-75;
-	}
-
 	&__main-slot {
 		list-style: none;
 		padding: 0;

--- a/resources/ext.neowiki/src/components/SubjectsManager/SubjectsManagerPage.vue
+++ b/resources/ext.neowiki/src/components/SubjectsManager/SubjectsManagerPage.vue
@@ -58,183 +58,32 @@
 		</div>
 
 		<template v-else>
-			<div
+			<ul
 				ref="mainSlotRef"
 				class="ext-neowiki-subjects-manager__main-slot"
 			>
-				<details
+				<SubjectRow
 					v-if="mainSubject !== null"
-					:id="subjectRowDomId( mainSubject.getId().text )"
-					class="ext-neowiki-subjects-manager__row ext-neowiki-subjects-manager__row--main"
-					:class="{
-						'ext-neowiki-subjects-manager__row--highlighted':
-							highlightedId === mainSubject.getId().text,
-						'ext-neowiki-subjects-manager__row--focused':
-							focusedId === mainSubject.getId().text,
-						'ext-neowiki-subjects-manager__row--expanded':
-							expandedIds.has( mainSubject.getId().text )
-					}"
-					:open="expandedIds.has( mainSubject.getId().text )"
-				>
-					<summary
-						class="ext-neowiki-subjects-manager__row-header"
-						@click.prevent="toggleExpanded( mainSubject.getId().text )"
-					>
-						<CdxIcon
-							class="ext-neowiki-subjects-manager__row-chevron"
-							:icon="expandedIds.has( mainSubject.getId().text ) ? cdxIconCollapse : cdxIconExpand"
-							size="small"
-						/>
-						<CdxButton
-							v-if="canEdit"
-							class="ext-neowiki-subjects-manager__row-main-indicator"
-							weight="quiet"
-							:aria-label="$i18n( 'neowiki-managesubjects-row-demote' ).text()"
-							:title="$i18n( 'neowiki-managesubjects-row-demote' ).text()"
-							@click.stop="demoteFromMain"
-						>
-							<CdxIcon :icon="cdxIconPushPin" />
-						</CdxButton>
-						<CdxIcon
-							v-else
-							class="ext-neowiki-subjects-manager__row-main-indicator"
-							:icon="cdxIconPushPin"
-							:icon-label="$i18n( 'neowiki-managesubjects-main-subject-indicator' ).text()"
-						/>
-						<span class="ext-neowiki-subjects-manager__row-title">
-							<span class="ext-neowiki-subjects-manager__row-label">
-								{{ subjectDisplayName( mainSubject ) }}
-							</span>
-							<span class="ext-neowiki-subjects-manager__row-subtitle">
-								<SchemaNameDisplay
-									v-if="schemaNameToShow( mainSubject ) !== null"
-									class="ext-neowiki-subjects-manager__row-schema"
-									:schema-name="mainSubject.getSchemaName()"
-									@click.stop
-								/>
-								<span class="ext-neowiki-subjects-manager__row-count">
-									{{ $i18n( 'neowiki-managesubjects-statement-count', statementCount( mainSubject ) ).text() }}
-								</span>
-							</span>
-						</span>
-						<span class="ext-neowiki-subjects-manager__row-actions">
-							<CdxButton
-								weight="quiet"
-								:aria-label="$i18n( 'neowiki-managesubjects-row-copy-link' ).text()"
-								:title="$i18n( 'neowiki-managesubjects-row-copy-link' ).text()"
-								@click.stop="copySubjectLink( mainSubject )"
-							>
-								<CdxIcon :icon="cdxIconLink" />
-							</CdxButton>
-							<CdxButton
-								v-if="canEdit"
-								weight="quiet"
-								:aria-label="$i18n( 'neowiki-managesubjects-row-edit' ).text()"
-								:title="$i18n( 'neowiki-managesubjects-row-edit' ).text()"
-								@click.stop="openEditor( mainSubject )"
-							>
-								<CdxIcon :icon="cdxIconEdit" />
-							</CdxButton>
-							<CdxButton
-								v-if="canEdit"
-								weight="quiet"
-								:aria-label="$i18n( 'neowiki-managesubjects-row-move' ).text()"
-								:title="$i18n( 'neowiki-managesubjects-row-move' ).text()"
-								@click.stop="openMoveDialog( mainSubject )"
-							>
-								<CdxIcon :icon="cdxIconArticleRedirect" />
-							</CdxButton>
-							<CdxButton
-								v-if="canDelete"
-								weight="quiet"
-								action="destructive"
-								:aria-label="$i18n( 'neowiki-managesubjects-row-delete' ).text()"
-								:title="$i18n( 'neowiki-managesubjects-row-delete' ).text()"
-								@click.stop="confirmDelete( mainSubject )"
-							>
-								<CdxIcon :icon="cdxIconTrash" />
-							</CdxButton>
-							<span
-								v-if="canEdit"
-								class="ext-neowiki-subjects-manager__row-drag-handle"
-								:title="$i18n( 'neowiki-managesubjects-row-drag-handle' ).text()"
-								@click.stop
-							>
-								<CdxIcon
-									:icon="cdxIconDraggable"
-									:aria-hidden="true"
-								/>
-							</span>
-						</span>
-						<span
-							class="ext-neowiki-subjects-manager__row-actions-menu"
-							@click.stop
-						>
-							<CdxMenuButton
-								v-model:selected="rowMenuSelection"
-								:menu-items="mainRowMenuItems"
-								:aria-label="$i18n( 'neowiki-managesubjects-row-more' ).text()"
-								:title="$i18n( 'neowiki-managesubjects-row-more' ).text()"
-								@update:selected="( value ) => dispatchRowAction( value, mainSubject as Subject )"
-							>
-								<CdxIcon :icon="cdxIconEllipsis" />
-							</CdxMenuButton>
-						</span>
-					</summary>
-					<div class="ext-neowiki-subjects-manager__row-expanded">
-						<SubjectStatementsView :subject="mainSubject" />
-						<footer class="ext-neowiki-subjects-manager__row-footer">
-							<dl class="ext-neowiki-subjects-manager__row-identifiers">
-								<div class="ext-neowiki-subjects-manager__row-id">
-									<dt class="ext-neowiki-subjects-manager__row-id-label">
-										{{ $i18n( 'neowiki-managesubjects-id-label' ).text() }}
-									</dt>
-									<dd class="ext-neowiki-subjects-manager__row-id-value">
-										<button
-											type="button"
-											class="ext-neowiki-subjects-manager__row-id-button"
-											:title="$i18n( 'neowiki-managesubjects-id-copy', mainSubject.getId().text ).text()"
-											:aria-label="$i18n( 'neowiki-managesubjects-id-copy', mainSubject.getId().text ).text()"
-											@click="copySubjectId( mainSubject.getId().text )"
-										>
-											<data :value="mainSubject.getId().text">
-												{{ mainSubject.getId().text }}
-											</data>
-										</button>
-									</dd>
-								</div>
-								<div
-									v-if="subjectIri( mainSubject.getId().text )"
-									class="ext-neowiki-subjects-manager__row-iri"
-								>
-									<dt class="ext-neowiki-subjects-manager__row-iri-label">
-										{{ $i18n( 'neowiki-managesubjects-iri-label' ).text() }}
-									</dt>
-									<dd class="ext-neowiki-subjects-manager__row-iri-value">
-										<button
-											type="button"
-											class="ext-neowiki-subjects-manager__row-iri-button"
-											:title="$i18n( 'neowiki-managesubjects-iri-copy', subjectIri( mainSubject.getId().text ) ).text()"
-											:aria-label="$i18n( 'neowiki-managesubjects-iri-copy', subjectIri( mainSubject.getId().text ) ).text()"
-											@click="copySubjectIri( subjectIri( mainSubject.getId().text ) )"
-										>
-											<data :value="subjectIri( mainSubject.getId().text )">
-												{{ subjectIri( mainSubject.getId().text ) }}
-											</data>
-										</button>
-									</dd>
-								</div>
-							</dl>
-							<DataExportButton
-								:label="$i18n( 'neowiki-managesubjects-export-button' ).text()"
-								:projections="rdfProjections"
-								v-bind="subjectExportUrls( mainSubject.getId().text )"
-							/>
-						</footer>
-					</div>
-				</details>
+					:subject="mainSubject as Subject"
+					emphasized
+					main-subject-control="demote"
+					:expanded="expandedIds.has( mainSubject.getId().text )"
+					:highlighted="highlightedId === mainSubject.getId().text"
+					:focused="focusedId === mainSubject.getId().text"
+					:can-edit="canEdit"
+					:can-delete="canDelete"
+					:can-move="canEdit"
+					:show-drag-handle="canEdit"
+					:subject-page-url="subjectPageUrl( mainSubject.getId().text )"
+					@toggle="toggleExpanded"
+					@edit="openEditor"
+					@demote="demoteFromMain"
+					@move="openMoveDialog"
+					@delete="confirmDelete"
+					@copy-link="copySubjectLink"
+				/>
 
-				<div
+				<li
 					v-else
 					class="ext-neowiki-subjects-manager__empty-state"
 				>
@@ -250,8 +99,8 @@
 							{{ $i18n( 'neowiki-managesubjects-no-main-description' ).text() }}
 						</div>
 					</div>
-				</div>
-			</div>
+				</li>
+			</ul>
 
 			<h2 class="ext-neowiki-subjects-manager__section-heading">
 				{{ $i18n( 'neowiki-managesubjects-other-subjects-heading' ).text() }}
@@ -262,172 +111,26 @@
 				class="ext-neowiki-subjects-manager__list"
 				:class="{ 'ext-neowiki-subjects-manager__list--empty': !hasChildSubjects && canEdit }"
 			>
-				<li
+				<SubjectRow
 					v-for="subject in otherSubjects"
-					:id="subjectRowDomId( subject.getId().text )"
 					:key="subject.getId().text"
-					class="ext-neowiki-subjects-manager__row"
-					:class="{
-						'ext-neowiki-subjects-manager__row--highlighted':
-							highlightedId === subject.getId().text,
-						'ext-neowiki-subjects-manager__row--focused':
-							focusedId === subject.getId().text,
-						'ext-neowiki-subjects-manager__row--expanded':
-							expandedIds.has( subject.getId().text )
-					}"
-				>
-					<details :open="expandedIds.has( subject.getId().text )">
-						<summary
-							class="ext-neowiki-subjects-manager__row-header"
-							@click.prevent="toggleExpanded( subject.getId().text )"
-						>
-							<CdxIcon
-								class="ext-neowiki-subjects-manager__row-chevron"
-								:icon="expandedIds.has( subject.getId().text ) ? cdxIconCollapse : cdxIconExpand"
-								size="small"
-							/>
-							<span class="ext-neowiki-subjects-manager__row-title">
-								<span class="ext-neowiki-subjects-manager__row-label">
-									{{ subjectDisplayName( subject ) }}
-								</span>
-								<span class="ext-neowiki-subjects-manager__row-subtitle">
-									<SchemaNameDisplay
-										v-if="schemaNameToShow( subject ) !== null"
-										class="ext-neowiki-subjects-manager__row-schema"
-										:schema-name="subject.getSchemaName()"
-										@click.stop
-									/>
-									<span class="ext-neowiki-subjects-manager__row-count">
-										{{ $i18n( 'neowiki-managesubjects-statement-count', statementCount( subject ) ).text() }}
-									</span>
-								</span>
-							</span>
-							<span class="ext-neowiki-subjects-manager__row-actions">
-								<CdxButton
-									weight="quiet"
-									:aria-label="$i18n( 'neowiki-managesubjects-row-copy-link' ).text()"
-									:title="$i18n( 'neowiki-managesubjects-row-copy-link' ).text()"
-									@click.stop="copySubjectLink( subject )"
-								>
-									<CdxIcon :icon="cdxIconLink" />
-								</CdxButton>
-								<CdxButton
-									v-if="canEdit"
-									weight="quiet"
-									:aria-label="$i18n( 'neowiki-managesubjects-row-edit' ).text()"
-									:title="$i18n( 'neowiki-managesubjects-row-edit' ).text()"
-									@click.stop="openEditor( subject )"
-								>
-									<CdxIcon :icon="cdxIconEdit" />
-								</CdxButton>
-								<CdxButton
-									v-if="canEdit"
-									weight="quiet"
-									:aria-label="$i18n( 'neowiki-managesubjects-row-promote' ).text()"
-									:title="$i18n( 'neowiki-managesubjects-row-promote' ).text()"
-									@click.stop="promoteToMain( subject )"
-								>
-									<CdxIcon :icon="cdxIconPushPin" />
-								</CdxButton>
-								<CdxButton
-									v-if="canEdit"
-									weight="quiet"
-									:aria-label="$i18n( 'neowiki-managesubjects-row-move' ).text()"
-									:title="$i18n( 'neowiki-managesubjects-row-move' ).text()"
-									@click.stop="openMoveDialog( subject )"
-								>
-									<CdxIcon :icon="cdxIconArticleRedirect" />
-								</CdxButton>
-								<CdxButton
-									v-if="canDelete"
-									weight="quiet"
-									action="destructive"
-									:aria-label="$i18n( 'neowiki-managesubjects-row-delete' ).text()"
-									:title="$i18n( 'neowiki-managesubjects-row-delete' ).text()"
-									@click.stop="confirmDelete( subject )"
-								>
-									<CdxIcon :icon="cdxIconTrash" />
-								</CdxButton>
-								<span
-									v-if="canEdit"
-									class="ext-neowiki-subjects-manager__row-drag-handle"
-									:title="$i18n( 'neowiki-managesubjects-row-drag-handle' ).text()"
-									@click.stop
-								>
-									<CdxIcon
-										:icon="cdxIconDraggable"
-										:aria-hidden="true"
-									/>
-								</span>
-							</span>
-							<span
-								class="ext-neowiki-subjects-manager__row-actions-menu"
-								@click.stop
-							>
-								<CdxMenuButton
-									v-model:selected="rowMenuSelection"
-									:menu-items="otherRowMenuItems"
-									:aria-label="$i18n( 'neowiki-managesubjects-row-more' ).text()"
-									:title="$i18n( 'neowiki-managesubjects-row-more' ).text()"
-									@update:selected="( value ) => dispatchRowAction( value, subject )"
-								>
-									<CdxIcon :icon="cdxIconEllipsis" />
-								</CdxMenuButton>
-							</span>
-						</summary>
-						<div class="ext-neowiki-subjects-manager__row-expanded">
-							<SubjectStatementsView :subject="subject" />
-							<footer class="ext-neowiki-subjects-manager__row-footer">
-								<dl class="ext-neowiki-subjects-manager__row-identifiers">
-									<div class="ext-neowiki-subjects-manager__row-id">
-										<dt class="ext-neowiki-subjects-manager__row-id-label">
-											{{ $i18n( 'neowiki-managesubjects-id-label' ).text() }}
-										</dt>
-										<dd class="ext-neowiki-subjects-manager__row-id-value">
-											<button
-												type="button"
-												class="ext-neowiki-subjects-manager__row-id-button"
-												:title="$i18n( 'neowiki-managesubjects-id-copy', subject.getId().text ).text()"
-												:aria-label="$i18n( 'neowiki-managesubjects-id-copy', subject.getId().text ).text()"
-												@click="copySubjectId( subject.getId().text )"
-											>
-												<data :value="subject.getId().text">
-													{{ subject.getId().text }}
-												</data>
-											</button>
-										</dd>
-									</div>
-									<div
-										v-if="subjectIri( subject.getId().text )"
-										class="ext-neowiki-subjects-manager__row-iri"
-									>
-										<dt class="ext-neowiki-subjects-manager__row-iri-label">
-											{{ $i18n( 'neowiki-managesubjects-iri-label' ).text() }}
-										</dt>
-										<dd class="ext-neowiki-subjects-manager__row-iri-value">
-											<button
-												type="button"
-												class="ext-neowiki-subjects-manager__row-iri-button"
-												:title="$i18n( 'neowiki-managesubjects-iri-copy', subjectIri( subject.getId().text ) ).text()"
-												:aria-label="$i18n( 'neowiki-managesubjects-iri-copy', subjectIri( subject.getId().text ) ).text()"
-												@click="copySubjectIri( subjectIri( subject.getId().text ) )"
-											>
-												<data :value="subjectIri( subject.getId().text )">
-													{{ subjectIri( subject.getId().text ) }}
-												</data>
-											</button>
-										</dd>
-									</div>
-								</dl>
-								<DataExportButton
-									:label="$i18n( 'neowiki-managesubjects-export-button' ).text()"
-									:projections="rdfProjections"
-									v-bind="subjectExportUrls( subject.getId().text )"
-								/>
-							</footer>
-						</div>
-					</details>
-				</li>
+					:subject="subject"
+					main-subject-control="promote"
+					:expanded="expandedIds.has( subject.getId().text )"
+					:highlighted="highlightedId === subject.getId().text"
+					:focused="focusedId === subject.getId().text"
+					:can-edit="canEdit"
+					:can-delete="canDelete"
+					:can-move="canEdit"
+					:show-drag-handle="canEdit"
+					:subject-page-url="subjectPageUrl( subject.getId().text )"
+					@toggle="toggleExpanded"
+					@edit="openEditor"
+					@promote="promoteToMain"
+					@move="openMoveDialog"
+					@delete="confirmDelete"
+					@copy-link="copySubjectLink"
+				/>
 			</ul>
 
 			<CdxButton
@@ -468,50 +171,20 @@
 			@moved="onSubjectMoved"
 		/>
 
-		<CdxDialog
-			:open="deleteConfirmOpen"
-			class="ext-neowiki-ui"
-			:title="$i18n( 'neowiki-managesubjects-delete-confirm-title' ).text()"
-			:use-close-button="true"
-			@update:open="deleteConfirmOpen = $event"
-		>
-			<I18nSlot message-key="neowiki-managesubjects-delete-confirm-message">
-				<strong>{{ deletingSubjectName }}</strong>
-			</I18nSlot>
-			<template #footer>
-				<SummaryAction
-					help-text=""
-					:save-button-label="$i18n( 'neowiki-managesubjects-delete-confirm-button' ).text()"
-					:save-disabled="false"
-					save-button-action="destructive"
-					:save-button-icon="cdxIconTrash"
-					@save="executeDelete"
-				/>
-			</template>
-		</CdxDialog>
+		<SubjectDeleteDialog
+			v-model:open="deleteConfirmOpen"
+			:subject-name="deletingSubjectName"
+			@confirm="executeDelete"
+		/>
 	</div>
 </template>
 
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, shallowRef, nextTick } from 'vue';
-import {
-	CdxButton,
-	CdxDialog,
-	CdxIcon,
-	CdxMenuButton
-} from '@wikimedia/codex';
-import type { MenuButtonItemData } from '@wikimedia/codex';
+import { CdxButton, CdxIcon } from '@wikimedia/codex';
 import {
 	cdxIconAdd,
-	cdxIconArticleRedirect,
-	cdxIconCollapse,
-	cdxIconDraggable,
-	cdxIconEdit,
-	cdxIconEllipsis,
-	cdxIconExpand,
-	cdxIconLink,
-	cdxIconPushPin,
-	cdxIconTrash
+	cdxIconPushPin
 } from '@wikimedia/codex-icons';
 import { NeoWikiServices } from '@/NeoWikiServices.ts';
 import { useSubjectStore } from '@/stores/SubjectStore.ts';
@@ -520,29 +193,24 @@ import { useSubjectPermissions } from '@/composables/useSubjectPermissions.ts';
 import { useSubjectDrag } from '@/composables/useSubjectDrag.ts';
 import { subjectRowDomId, subjectIdFromHash } from '@/presentation/subjectRowAnchor.ts';
 import { subjectDisplayName } from '@/presentation/subjectDisplayName.ts';
-import { schemaNameToShow } from '@/presentation/schemaNameToShow.ts';
+import { subjectPageUrl } from '@/presentation/subjectPageUrl.ts';
+import { copyToClipboard } from '@/presentation/copyToClipboard.ts';
 import { Subject } from '@/domain/Subject';
 import { Schema } from '@/domain/Schema';
 import { SubjectId } from '@/domain/SubjectId';
 import SubjectCreatorDialog from '@/components/SubjectCreator/SubjectCreatorDialog.vue';
 import SubjectEditorDialog from '@/components/SubjectEditor/SubjectEditorDialog.vue';
-import SummaryAction from '@/components/common/SummaryAction.vue';
 import MoveSubjectDialog from '@/components/SubjectsManager/MoveSubjectDialog.vue';
-import I18nSlot from '@/components/common/I18nSlot.vue';
-import SchemaNameDisplay from '@/components/common/SchemaNameDisplay.vue';
-import SubjectStatementsView from '@/components/SubjectsManager/SubjectStatementsView.vue';
+import SubjectDeleteDialog from '@/components/SubjectsManager/SubjectDeleteDialog.vue';
+import SubjectRow from '@/components/SubjectsManager/SubjectRow.vue';
 import DataExportButton from '@/components/SubjectsManager/DataExportButton.vue';
-import { subjectExportUrls, pageExportUrls } from '@/presentation/DataExportMenu.ts';
+import { pageExportUrls } from '@/presentation/DataExportMenu.ts';
 
 const pageId = Number( mw.config.get( 'wgNeoWikiManageSubjectsPageId' ) );
 
 // RDF projections readable by the viewing user (native + ontology mappings), permission-filtered
-// server-side. Drives the export menus; native is always present, so this is never truly empty.
+// server-side. Drives the export-all menu; native is always present, so this is never truly empty.
 const rdfProjections = ( mw.config.get( 'wgNeoWikiRdfProjections' ) as string[] | null ) ?? [];
-
-// The `$base/entity/` prefix a Subject id extends into its RDF concept URI, derived server-side from
-// the same rule the export mints IRIs with. The copy-IRI control appends the Subject id to it.
-const subjectIriBase = ( mw.config.get( 'wgNeoWikiSubjectIriBase' ) as string | null ) ?? '';
 
 const subjectStore = useSubjectStore();
 const schemaStore = useSchemaStore();
@@ -633,89 +301,8 @@ const isCompletelyEmpty = computed( () => !hasMainSubject.value && !hasChildSubj
 
 const deletingSubjectName = computed( () => deletingSubject.value === null ? '' : subjectDisplayName( deletingSubject.value ) );
 
-// A Subject of another Source is named under that Source's own base, which this wiki does not hold,
-// so none is derived for one — minting under this wiki's base would assert ownership of an entity
-// elsewhere, the same refusal SubjectIriResolver makes on the export side.
-function subjectIri( id: string ): string {
-	return SubjectId.isValidLocalId( id ) ? subjectIriBase + id : '';
-}
-
-function statementCount( subject: Subject ): number {
-	return subject.getStatements().withNonEmptyValues().getPropertyNames().length;
-}
-
-const promoteMenuItem = computed<MenuButtonItemData>( () => ( {
-	value: 'promote',
-	label: mw.msg( 'neowiki-managesubjects-row-promote' ),
-	icon: cdxIconPushPin
-} ) );
-
-const editMenuItem = computed<MenuButtonItemData>( () => ( {
-	value: 'edit',
-	label: mw.msg( 'neowiki-managesubjects-row-edit' ),
-	icon: cdxIconEdit
-} ) );
-
-// Not permission-gated: everyone, including read-only users, can copy a deep link to a row.
-const copyLinkMenuItem = computed<MenuButtonItemData>( () => ( {
-	value: 'copy-link',
-	label: mw.msg( 'neowiki-managesubjects-row-copy-link' ),
-	icon: cdxIconLink
-} ) );
-
-const moveMenuItem = computed<MenuButtonItemData>( () => ( {
-	value: 'move',
-	label: mw.msg( 'neowiki-managesubjects-row-move' ),
-	icon: cdxIconArticleRedirect
-} ) );
-
-const deleteMenuItem = computed<MenuButtonItemData>( () => ( {
-	value: 'delete',
-	label: mw.msg( 'neowiki-managesubjects-row-delete' ),
-	icon: cdxIconTrash,
-	action: 'destructive'
-} ) );
-
-const mainRowMenuItems = computed<MenuButtonItemData[]>( () => {
-	const items: MenuButtonItemData[] = [ copyLinkMenuItem.value ];
-	if ( canEdit.value ) {
-		items.push( editMenuItem.value, moveMenuItem.value );
-	}
-	if ( canDelete.value ) {
-		items.push( deleteMenuItem.value );
-	}
-	return items;
-} );
-
-const otherRowMenuItems = computed<MenuButtonItemData[]>( () => {
-	const items: MenuButtonItemData[] = [ copyLinkMenuItem.value ];
-	if ( canEdit.value ) {
-		items.push( editMenuItem.value, promoteMenuItem.value, moveMenuItem.value );
-	}
-	if ( canDelete.value ) {
-		items.push( deleteMenuItem.value );
-	}
-	return items;
-} );
-
-const rowMenuSelection = ref<string | number | null>( null );
-
-function dispatchRowAction( value: string | number | null, subject: Subject ): void {
-	rowMenuSelection.value = null;
-	if ( value === 'promote' ) {
-		promoteToMain( subject );
-	} else if ( value === 'edit' ) {
-		openEditor( subject );
-	} else if ( value === 'copy-link' ) {
-		copySubjectLink( subject );
-	} else if ( value === 'move' ) {
-		openMoveDialog( subject );
-	} else if ( value === 'delete' ) {
-		confirmDelete( subject );
-	}
-}
-
-function toggleExpanded( id: string ): void {
+function toggleExpanded( subject: Subject ): void {
+	const id = subject.getId().text;
 	// The arrival highlight is a one-time "you landed here" cue from a deep link. The first manual
 	// expand/collapse is the user taking over, so dismiss it: otherwise it would linger on the
 	// originally linked row while the address-bar fragment (rewritten below) moves to a different one,
@@ -739,39 +326,18 @@ function onAddClicked(): void {
 	subjectStore.openSubjectCreator();
 }
 
-async function copySubjectId( id: string ): Promise<void> {
-	try {
-		await navigator.clipboard.writeText( id );
-		mw.notify( mw.msg( 'neowiki-managesubjects-id-copied', id ), { type: 'success' } );
-	} catch ( error ) {
-		console.error( 'Failed to copy subject ID:', error );
-		mw.notify( mw.msg( 'neowiki-managesubjects-id-copy-error' ), { type: 'error' } );
-	}
-}
-
-async function copySubjectIri( iri: string ): Promise<void> {
-	try {
-		await navigator.clipboard.writeText( iri );
-		mw.notify( mw.msg( 'neowiki-managesubjects-iri-copied', iri ), { type: 'success' } );
-	} catch ( error ) {
-		console.error( 'Failed to copy subject IRI:', error );
-		mw.notify( mw.msg( 'neowiki-managesubjects-iri-copy-error' ), { type: 'error' } );
-	}
-}
-
-async function copySubjectLink( subject: Subject ): Promise<void> {
+function copySubjectLink( subject: Subject ): Promise<void> {
 	// Build the deep link from the live address bar rather than mw.util.getUrl, so it inherits the
 	// wiki's URL style (short URLs, action paths, query strings) as-served. The fragment is the bare
 	// Subject id — the same anchor the deep-link mount handler resolves to this row.
 	const url = new URL( location.href );
 	url.hash = subject.getId().text;
-	try {
-		await navigator.clipboard.writeText( url.toString() );
-		mw.notify( mw.msg( 'neowiki-managesubjects-link-copied' ), { type: 'success' } );
-	} catch ( error ) {
-		console.error( 'Failed to copy subject link:', error );
-		mw.notify( mw.msg( 'neowiki-managesubjects-link-copy-error' ), { type: 'error' } );
-	}
+
+	return copyToClipboard(
+		url.toString(),
+		mw.msg( 'neowiki-managesubjects-link-copied' ),
+		mw.msg( 'neowiki-managesubjects-link-copy-error' )
+	);
 }
 
 async function loadSubjects(): Promise<void> {
@@ -887,6 +453,7 @@ async function promoteToMain( subject: Subject ): Promise<void> {
 	focusSubject( subject.getId().text );
 }
 
+// Takes the Subject the row reported, which is the Main Subject, and reads the store for the rest.
 async function demoteFromMain(): Promise<void> {
 	const demoted = mainSubject.value;
 	try {
@@ -1101,7 +668,9 @@ onUnmounted( () => {
 	}
 
 	&__main-slot {
-		margin-bottom: @spacing-150;
+		list-style: none;
+		padding: 0;
+		margin: 0 0 @spacing-150;
 	}
 
 	&__list {
@@ -1117,290 +686,6 @@ onUnmounted( () => {
 			// target for demote-via-drag when the page has no other subjects.
 			min-height: @size-200;
 		}
-	}
-
-	&__row {
-		border: @border-base;
-		border-radius: @border-radius-base;
-		background: @background-color-base;
-		// Baseline zero-color shadow so the focused-state ring can transition in/out smoothly
-		// rather than snap between "none" and a value.
-		box-shadow: @box-shadow-outset-small transparent;
-		transition: @transition-property-base @transition-duration-medium @transition-timing-function-system;
-
-		@media ( prefers-reduced-motion: reduce ) {
-			transition-duration: 0s;
-		}
-		font-size: @font-size-small;
-		line-height: 1.375rem; // Codex 2.0+ line-height-small
-
-		&--main {
-			border-color: @border-color-progressive;
-
-			> .ext-neowiki-subjects-manager__row-header {
-				background-color: @background-color-progressive-subtle;
-
-				&:hover {
-					background-color: @background-color-interactive-subtle;
-				}
-
-				&:active {
-					background-color: @background-color-interactive;
-				}
-
-				.ext-neowiki-subjects-manager__row-label {
-					color: @color-progressive;
-				}
-			}
-		}
-
-		&--highlighted {
-			background: @background-color-progressive-subtle;
-		}
-
-		&--focused {
-			border-color: @border-color-progressive--focus;
-			box-shadow: @box-shadow-outset-small @box-shadow-color-progressive--focus;
-			// Transparent 1px outline for Windows high-contrast mode — Codex focus pattern.
-			outline: @outline-base--focus;
-		}
-
-		&--ghost {
-			opacity: 0.5;
-			background-color: @background-color-interactive-subtle;
-		}
-	}
-
-	&__row-header {
-		display: flex;
-		align-items: center;
-		gap: @spacing-75;
-		padding: @spacing-75 @spacing-100;
-		cursor: pointer;
-		user-select: none;
-		list-style: none;
-		transition-property: background-color, color, border-color, box-shadow;
-		transition-duration: @transition-duration-base;
-		transition-timing-function: @transition-timing-function-system;
-
-		&::-webkit-details-marker {
-			display: none;
-		}
-
-		&:hover {
-			background-color: @background-color-interactive-subtle;
-		}
-
-		&:active {
-			background-color: @background-color-interactive;
-		}
-
-		&:focus-visible {
-			outline: @outline-base--focus;
-			box-shadow: inset 0 0 0 2px @box-shadow-color-progressive--focus;
-		}
-	}
-
-	&__row-chevron {
-		flex-shrink: 0;
-		color: @color-subtle;
-	}
-
-	&__row-main-indicator {
-		flex-shrink: 0;
-
-		// Codex sets an explicit `color` on `.cdx-icon`, matching our class's specificity.
-		// Chain the class to win the cascade regardless of Codex/bundle load order.
-		&.cdx-icon {
-			color: @color-progressive;
-		}
-
-		// When the user can edit, the indicator renders as a quiet CdxButton so clicking it
-		// demotes the subject. Paint the nested icon progressive to match the read-only case.
-		&.cdx-button .cdx-icon {
-			color: @color-progressive;
-		}
-	}
-
-	&__row-title {
-		display: flex;
-		flex-direction: column;
-		gap: @spacing-12;
-		flex-grow: 1;
-		min-width: 0;
-	}
-
-	&__row-subtitle {
-		display: flex;
-		flex-wrap: wrap;
-		align-items: center;
-		gap: 0 @spacing-50;
-		min-width: 0;
-		font-size: @font-size-small;
-		color: @color-subtle;
-	}
-
-	/* The badge ellipsises its own text; the row only has to let it shrink. */
-	&__row-schema {
-		min-width: 0;
-	}
-
-	&__row-count {
-		white-space: nowrap;
-	}
-
-	&__row-label {
-		font-size: @font-size-medium;
-		font-weight: @font-weight-bold;
-		min-width: 0;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-	}
-
-	&__row-identifiers {
-		display: flex;
-		flex-direction: column;
-		min-width: 0;
-		margin: 0;
-		font-size: @font-size-x-small;
-		color: @color-subtle;
-	}
-
-	&__row-id,
-	&__row-iri {
-		display: flex;
-		align-items: baseline;
-		gap: @spacing-25;
-		min-width: 0;
-	}
-
-	&__row-id-label,
-	&__row-iri-label {
-		flex-shrink: 0;
-	}
-
-	&__row-id-value,
-	&__row-iri-value {
-		display: flex;
-		min-width: 0;
-		margin: 0;
-	}
-
-	&__row-id-button,
-	&__row-iri-button {
-		appearance: none;
-		background: transparent;
-		border: 0;
-		padding: 0;
-		cursor: pointer;
-		color: inherit;
-		font: inherit;
-		font-family: @font-family-monospace;
-		// The IRI is a full URL: let a long one ellipsize instead of stretching the footer. The whole
-		// value stays in the button title and is what the click copies.
-		min-width: 0;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-
-		&:hover {
-			color: @color-base;
-		}
-	}
-
-	/* The separator belongs to the pair: a row whose badge is withheld draws none. */
-	&__row-schema + &__row-count::before {
-		content: '•';
-		margin-inline-end: @spacing-50;
-	}
-
-	&__row-actions {
-		display: inline-flex;
-		gap: @spacing-25;
-		flex-shrink: 0;
-
-		@media ( max-width: @max-width-breakpoint-mobile ) {
-			display: none;
-		}
-
-		@media ( min-width: @min-width-breakpoint-tablet ) and ( hover: hover ) {
-			opacity: 0;
-			transform: translateX( @spacing-50 );
-			transition: opacity @transition-duration-medium @transition-timing-function-system, transform @transition-duration-medium @transition-timing-function-system;
-
-			.ext-neowiki-subjects-manager__row:hover &,
-			.ext-neowiki-subjects-manager__row:has( :focus-visible ) &,
-			.ext-neowiki-subjects-manager__row--highlighted &,
-			.ext-neowiki-subjects-manager__row--expanded & {
-				// :has( :focus-visible ) rather than :focus-within: keyboard focus must reveal the
-				// controls a user is tabbing through, but mouse clicks also focus what they hit (a copy
-				// button, the summary when toggling a row) and would pin the controls visible after the
-				// pointer leaves.
-				opacity: 1;
-				transform: translateX( 0 );
-			}
-		}
-	}
-
-	&__row-drag-handle {
-		// Set off from the buttons: this is grabbed, not clicked, and delete sits right before it.
-		margin-inline-start: @spacing-50;
-		min-width: @min-size-interactive-pointer;
-		min-height: @min-size-interactive-pointer;
-		padding-inline: @spacing-30;
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		box-sizing: border-box;
-		cursor: grab;
-
-		&:active {
-			cursor: grabbing;
-		}
-
-		.cdx-icon {
-			color: @color-placeholder;
-		}
-	}
-
-	&__row-actions-menu {
-		flex-shrink: 0;
-
-		@media ( min-width: @min-width-breakpoint-tablet ) {
-			display: none;
-		}
-
-		@media ( max-width: @max-width-breakpoint-mobile ) and ( hover: hover ) {
-			opacity: 0;
-			transition: opacity @transition-duration-medium @transition-timing-function-system;
-
-			.ext-neowiki-subjects-manager__row:hover &,
-			.ext-neowiki-subjects-manager__row:has( :focus-visible ) &,
-			.ext-neowiki-subjects-manager__row--highlighted &,
-			.ext-neowiki-subjects-manager__row--expanded &,
-			&:has( [ aria-expanded='true' ] ) {
-				// Keyboard-only focus reveal for the same reason as __row-actions above.
-				opacity: 1;
-			}
-		}
-	}
-
-	&__row-expanded {
-		padding: @spacing-100;
-		border-top: @border-base;
-		background: @background-color-neutral-subtle;
-	}
-
-	&__row-footer {
-		display: flex;
-		flex-wrap: wrap;
-		align-items: center;
-		justify-content: space-between;
-		gap: @spacing-100;
-		margin-top: @spacing-100;
-		padding-top: @spacing-75;
-		border-top: @border-width-base @border-style-base @border-color-subtle;
 	}
 
 	&__add-more.cdx-button {

--- a/resources/ext.neowiki/src/composables/useSubjectDrag.ts
+++ b/resources/ext.neowiki/src/composables/useSubjectDrag.ts
@@ -3,8 +3,8 @@ import { useSortable } from '@/composables/useSortable';
 import { SubjectId } from '@/domain/SubjectId';
 import { subjectIdFromRowDomId } from '@/presentation/subjectRowAnchor';
 
-const DRAG_HANDLE_SELECTOR = '.ext-neowiki-subjects-manager__row-drag-handle';
-const GHOST_CLASS = 'ext-neowiki-subjects-manager__row--ghost';
+const DRAG_HANDLE_SELECTOR = '.ext-neowiki-subject-row__drag-handle';
+const GHOST_CLASS = 'ext-neowiki-subject-row--ghost';
 const SORTABLE_GROUP_NAME = 'neowiki-subjects';
 
 export interface SubjectDragHandlers {

--- a/resources/ext.neowiki/src/neowiki.ts
+++ b/resources/ext.neowiki/src/neowiki.ts
@@ -13,6 +13,7 @@ import LayoutsPage from '@/components/LayoutsPage/LayoutsPage.vue';
 import MappingsPage from '@/components/MappingsPage/MappingsPage.vue';
 import SubjectsManagerPage from '@/components/SubjectsManager/SubjectsManagerPage.vue';
 import CreateSubjectPage from '@/components/CreateSubjectPage/CreateSubjectPage.vue';
+import SubjectPage from '@/components/SubjectPage/SubjectPage.vue';
 import { NeoWikiExtension } from '@/NeoWikiExtension.ts';
 import { SchemaName } from '@/domain/Schema.ts';
 import type { LayoutName } from '@/domain/Layout.ts';
@@ -228,6 +229,22 @@ function initializeCreateSubjectPage(): void {
 	} );
 }
 
+function initializeSubjectPage(): void {
+	queueMicrotask( () => {
+		const subjectPage = document.getElementById( 'ext-neowiki-subject' );
+
+		if ( subjectPage !== null ) {
+			const ext = NeoWikiExtension.getInstance();
+			const subjectId = subjectPage.dataset.mwNeowikiSubjectId;
+
+			const app = createMwApp( SubjectPage, { subjectId } ).directive( 'tooltip', CdxTooltip );
+			app.use( ext.getPinia() );
+			NeoWikiServices.registerServices( app );
+			mountNeoWikiApp( app, subjectPage );
+		}
+	} );
+}
+
 const isTestEnvironment = typeof window !== 'undefined' &&
 	( window as unknown as { neoWikiTestMode?: boolean } ).neoWikiTestMode === true;
 
@@ -241,4 +258,5 @@ if ( !isTestEnvironment ) {
 	initializeMappingsPage();
 	initializeSubjectsManagerPage();
 	initializeCreateSubjectPage();
+	initializeSubjectPage();
 }

--- a/resources/ext.neowiki/src/persistence/RestSubjectRepository.ts
+++ b/resources/ext.neowiki/src/persistence/RestSubjectRepository.ts
@@ -15,6 +15,7 @@ import type { Subject } from '@/domain/Subject';
 import type { SubjectViolation } from '@/domain/SubjectViolation';
 import { ValidationFailedError } from '@/persistence/ValidationFailedError';
 import { SubjectIdInUseError } from '@/persistence/SubjectIdInUseError';
+import { SubjectNotFoundError } from '@/persistence/SubjectNotFoundError';
 import { parseViolations } from '@/persistence/violationParsing';
 
 async function throwOn422IfPossible( response: Response ): Promise<void> {
@@ -225,7 +226,7 @@ export class RestSubjectRepository implements SubjectRepository {
 		const data = await response.json() as { requestedId?: string; subjects?: Record<string, SubjectJson> };
 
 		if ( !data.requestedId || !data.subjects || !data.subjects[ data.requestedId ] ) {
-			throw new Error( 'Subject not found' );
+			throw new SubjectNotFoundError( id.text );
 		}
 
 		return { requestedId: data.requestedId, subjects: data.subjects };

--- a/resources/ext.neowiki/src/persistence/SubjectNotFoundError.ts
+++ b/resources/ext.neowiki/src/persistence/SubjectNotFoundError.ts
@@ -1,0 +1,14 @@
+/**
+ * The wiki serves no Subject under this id. A Subject on a page the reader may not read answers the
+ * same way by design (#1046), so a caller must not report this as "it exists but is yours to unlock".
+ */
+export class SubjectNotFoundError extends Error {
+
+	public constructor( public readonly subjectId: string ) {
+		super( `Subject not found: ${ subjectId }` );
+		// Restores the prototype chain, so instanceof holds however this is compiled down.
+		Object.setPrototypeOf( this, SubjectNotFoundError.prototype );
+		this.name = 'SubjectNotFoundError';
+	}
+
+}

--- a/resources/ext.neowiki/src/persistence/__tests__/SubjectDeserializer.spec.ts
+++ b/resources/ext.neowiki/src/persistence/__tests__/SubjectDeserializer.spec.ts
@@ -106,6 +106,22 @@ describe( 'SubjectDeserializer', () => {
 		expect( subject.getDisplayName() ).toBe( 'SDPageTitle' );
 	} );
 
+	// The API omits both page fields for a Subject whose hosting page it could not resolve, and
+	// PageIdentifiers types them as present, so a consumer has to read the values rather than the type.
+	it( 'leaves the page identifiers unset when the payload carries no page', () => {
+		const subject = deserializer.deserialize( {
+			id: 's13333333333337',
+			label: 'SubjectDeserializer',
+			displayName: 'SubjectDeserializer',
+			displayNameIsGenerated: false,
+			schema: 'SDSchema',
+			statements: {},
+		} );
+
+		expect( subject.getPageIdentifiers().getPageId() ).toBeUndefined();
+		expect( subject.getPageIdentifiers().getPageName() ).toBeUndefined();
+	} );
+
 	it( 'deserializes Subject with Statements', () => {
 		const json = {
 			id: 's13333333333337',

--- a/resources/ext.neowiki/src/presentation/DataExportMenu.ts
+++ b/resources/ext.neowiki/src/presentation/DataExportMenu.ts
@@ -1,5 +1,5 @@
 /**
- * Builds the export endpoint URLs for the Data tab, for a single Subject or for all Subjects on a
+ * Builds the export endpoint URLs the Subject UI offers, for a single Subject or for all Subjects on a
  * page: a JSON URL, plus a function producing the RDF URL for a given projection and serialization
  * format. Kept as pure functions so URL derivation is unit-tested independently of the Vue component.
  */

--- a/resources/ext.neowiki/src/presentation/copyToClipboard.ts
+++ b/resources/ext.neowiki/src/presentation/copyToClipboard.ts
@@ -1,0 +1,13 @@
+/**
+ * Puts text on the clipboard and tells the user how it went. The messages are passed in rather than
+ * derived, because what was copied is what each caller reports.
+ */
+export async function copyToClipboard( text: string, copied: string, failed: string ): Promise<void> {
+	try {
+		await navigator.clipboard.writeText( text );
+		mw.notify( copied, { type: 'success' } );
+	} catch ( error ) {
+		console.error( 'Failed to copy to the clipboard:', error );
+		mw.notify( failed, { type: 'error' } );
+	}
+}

--- a/resources/ext.neowiki/src/presentation/subjectIri.ts
+++ b/resources/ext.neowiki/src/presentation/subjectIri.ts
@@ -1,0 +1,17 @@
+import { SubjectId } from '@/domain/SubjectId';
+
+/**
+ * A Subject's RDF concept URI. The `$base/entity/` prefix is derived server-side from the same rule
+ * the RDF export mints IRIs with, and reaches the frontend as a configuration variable.
+ *
+ * A Subject of another Source is named under that Source's own base, which this wiki does not hold,
+ * so none is derived for one — minting under this wiki's base would assert ownership of an entity
+ * elsewhere, the same refusal SubjectIriResolver makes on the export side.
+ */
+export function subjectIri( subjectId: string ): string {
+	if ( !SubjectId.isValidLocalId( subjectId ) ) {
+		return '';
+	}
+
+	return ( ( mw.config.get( 'wgNeoWikiSubjectIriBase' ) as string | null ) ?? '' ) + subjectId;
+}

--- a/resources/ext.neowiki/src/presentation/subjectPageUrl.ts
+++ b/resources/ext.neowiki/src/presentation/subjectPageUrl.ts
@@ -1,0 +1,7 @@
+/**
+ * The URL of `Special:Subject` for a Subject: the page that shows that one Subject, wherever it is
+ * stored. Built through mw.util so it follows the wiki's URL style.
+ */
+export function subjectPageUrl( subjectId: string ): string {
+	return mw.util.getUrl( 'Special:Subject/' + subjectId );
+}

--- a/resources/ext.neowiki/src/presentation/subjectRowAnchor.ts
+++ b/resources/ext.neowiki/src/presentation/subjectRowAnchor.ts
@@ -1,9 +1,9 @@
 import { SubjectId } from '@/domain/SubjectId';
 
-// The DOM id of a Subject's row on the Data tab (?action=subjects). Internal rendering detail — HTML
-// hygiene and in-page scroll targeting — not a public contract. A row's public deep-link anchor is the
-// bare Subject id in the URL fragment (see subjectIdFromHash), which the mount handler resolves to a row
-// itself, so the fragment and this DOM id are decoupled.
+// The DOM id of a Subject's row, on the Data tab (?action=subjects) and on Special:Subject alike.
+// Internal rendering detail — HTML hygiene and in-page scroll targeting — not a public contract. A row's
+// public deep-link anchor is the bare Subject id in the URL fragment (see subjectIdFromHash), which the
+// mount handler resolves to a row itself, so the fragment and this DOM id are decoupled.
 const ROW_ID_PREFIX = 'ext-neowiki-subject-row-';
 
 export function subjectRowDomId( subjectId: string ): string {
@@ -23,9 +23,9 @@ export function subjectIdFromRowDomId( domId: string ): string | null {
 }
 
 // The Subject id carried by a Data tab URL fragment, or null when the fragment is not a Subject id (an
-// unrelated anchor, or junk — either leaves the Data tab untouched). The dereference endpoint's data-tab
-// Location and manual row expansion both write a bare Subject id as the fragment, like Wikibase's
-// `#P123`; this reads it back. Deliberately the Subject id, not the row DOM id.
+// unrelated anchor, or junk — either leaves the Data tab untouched). Expanding a row, and copying its
+// link, write a bare Subject id as the fragment, like Wikibase's `#P123`; this reads it back.
+// Deliberately the Subject id, not the row DOM id.
 export function subjectIdFromHash( hash: string ): string | null {
 	return SubjectId.isValid( hash ) ? hash : null;
 }

--- a/resources/ext.neowiki/tests/VueTestHelpers.ts
+++ b/resources/ext.neowiki/tests/VueTestHelpers.ts
@@ -68,6 +68,16 @@ export function createTestWrapper<TComponent extends DefineComponent<any, any, a
 	) as VueWrapper<InstanceType<TComponent>>;
 }
 
+/**
+ * CdxDialog as a stub that still renders its slots. shallowMount's auto-stubs render none, and a
+ * dialog's controls live in its #footer slot, so a test driving one needs them in the tree.
+ */
+export const CdxDialogStub = {
+	template: '<div v-if="open" class="cdx-dialog-stub"><slot /><slot name="footer" /></div>',
+	props: [ 'open', 'title', 'useCloseButton' ],
+	emits: [ 'update:open' ],
+};
+
 export interface MwMockOptions {
 	messages?: Record<string, string | ( ( ...params: string[] ) => string )>;
 	config?: Record<string, any>;

--- a/resources/ext.neowiki/tests/components/SubjectPage/SubjectPage.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectPage/SubjectPage.spec.ts
@@ -134,6 +134,12 @@ function stubExtension( repositories: { subject?: object; schema?: object } ): v
 	} as unknown as NeoWikiExtension );
 }
 
+// Renders its slot, so the Subject name the delete confirmation interpolates reaches the DOM.
+const I18nSlotStub = {
+	template: '<span>{{ messageKey }}<slot /></span>',
+	props: [ 'messageKey' ],
+};
+
 function silenceConsoleErrors(): void {
 	vi.spyOn( console, 'error' ).mockImplementation( () => undefined );
 }
@@ -157,7 +163,13 @@ function mountPage(): VueWrapper {
 			mocks: { $i18n: createI18nMock() },
 			// The row and the delete dialog are this page's own building blocks rather than
 			// collaborators to stand in for: the assertions below are about what they render.
-			stubs: { CdxIcon: true, CdxDialog: CdxDialogStub, SubjectRow: false, SubjectDeleteDialog: false },
+			stubs: {
+				CdxIcon: true,
+				CdxDialog: CdxDialogStub,
+				I18nSlot: I18nSlotStub,
+				SubjectRow: false,
+				SubjectDeleteDialog: false,
+			},
 			provide: {
 				[ Service.SubjectRepository ]: {
 					getSubjectWithReferencedSubjects: getSubjectWithReferencedSubjectsMock,
@@ -753,6 +765,26 @@ describe( 'SubjectPage', () => {
 				{ type: 'error' },
 			);
 			expect( wrapper.find( `${ REQUESTED_ROW } ${ ROW_LABEL }` ).text() ).toBe( 'ACME Inc' );
+		} );
+
+		// The close button, Escape and a click outside all close the dialog through this event.
+		it( 'closes the confirmation when the dialog asks to close', async () => {
+			const wrapper = await mountLoadedPage();
+			await wrapper.findAll( DELETE_CONTROL )[ 1 ].trigger( 'click' );
+
+			wrapper.findComponent( CdxDialogStub ).vm.$emit( 'update:open', false );
+			await flushPromises();
+
+			expect( wrapper.find( '.cdx-dialog-stub' ).exists() ).toBe( false );
+		} );
+
+		// A referenced row can be stored on another page, so the dialog names the Subject it deletes.
+		it( 'names the Subject about to be deleted', async () => {
+			const wrapper = await mountLoadedPage();
+
+			await wrapper.findAll( DELETE_CONTROL )[ 1 ].trigger( 'click' );
+
+			expect( wrapper.find( '.cdx-dialog-stub strong' ).text() ).toBe( 'Anvil' );
 		} );
 
 	} );

--- a/resources/ext.neowiki/tests/components/SubjectPage/SubjectPage.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectPage/SubjectPage.spec.ts
@@ -787,6 +787,70 @@ describe( 'SubjectPage', () => {
 			expect( wrapper.find( '.cdx-dialog-stub strong' ).text() ).toBe( 'Anvil' );
 		} );
 
+		// The delete controls stay live while a re-read is in flight, so a second delete can be
+		// acknowledged before the re-read the first one started lands (ADR 30 rule 3).
+		it( 'keeps a Subject deleted during a re-read out of the registry', async () => {
+			const other = subject( { id: OTHER_REFERENCED_ID, label: 'Rocket', schemaName: 'Product' } );
+			getSubjectWithReferencedSubjectsMock.mockResolvedValue( bundle( [ referencedSubject, other ] ) );
+			const wrapper = await mountLoadedPage();
+			const subjectStore = useSubjectStore();
+			vi.spyOn( subjectStore, 'deleteSubject' ).mockResolvedValue( undefined );
+			let landReRead!: ( value: SubjectWithReferencedSubjects ) => void;
+			getSubjectWithReferencedSubjectsMock.mockReturnValueOnce( new Promise( ( resolve ) => {
+				landReRead = resolve;
+			} ) );
+
+			await confirmDelete( wrapper, wrapper.findAll( DELETE_CONTROL )[ 1 ] );
+			// The second delete, acknowledged while that re-read is in flight.
+			subjectStore.subjects.delete( OTHER_REFERENCED_ID );
+			subjectStore.mutationEpoch++;
+			landReRead( bundle( [ other ] ) );
+			await flushPromises();
+
+			expect( subjectStore.subjects.has( OTHER_REFERENCED_ID ) ).toBe( false );
+		} );
+
+		it( 'keeps a Schema read that a Schema change overtook out of the store', async () => {
+			const wrapper = await mountLoadedPage();
+			const schemaStore = useSchemaStore();
+			vi.spyOn( useSubjectStore(), 'deleteSubject' ).mockResolvedValue( undefined );
+			getSubjectWithReferencedSubjectsMock.mockResolvedValue(
+				bundle( [ subject( { id: OTHER_REFERENCED_ID, label: 'Amsterdam', schemaName: 'Place' } ) ] ),
+			);
+			let landSchema!: ( value: Schema ) => void;
+			getSchemaMock.mockReturnValueOnce( new Promise( ( resolve ) => {
+				landSchema = resolve;
+			} ) );
+
+			await confirmDelete( wrapper, wrapper.findAll( DELETE_CONTROL )[ 1 ] );
+			// A Schema save, acknowledged while that read is in flight.
+			schemaStore.mutationEpoch++;
+			landSchema( newSchema( { title: 'Place' } ) );
+			await flushPromises();
+
+			expect( schemaStore.schemas.has( 'Place' ) ).toBe( false );
+		} );
+
+		it( 'shows what the latest re-read found when an earlier one lands after it', async () => {
+			const other = subject( { id: OTHER_REFERENCED_ID, label: 'Rocket', schemaName: 'Product' } );
+			getSubjectWithReferencedSubjectsMock.mockResolvedValue( bundle( [ referencedSubject, other ] ) );
+			const wrapper = await mountLoadedPage();
+			vi.spyOn( useSubjectStore(), 'deleteSubject' ).mockResolvedValue( undefined );
+			let landFirstReRead!: ( value: SubjectWithReferencedSubjects ) => void;
+			getSubjectWithReferencedSubjectsMock
+				.mockReturnValueOnce( new Promise( ( resolve ) => {
+					landFirstReRead = resolve;
+				} ) )
+				.mockResolvedValueOnce( bundle() );
+
+			await confirmDelete( wrapper, wrapper.findAll( DELETE_CONTROL )[ 1 ] );
+			await confirmDelete( wrapper, wrapper.findAll( DELETE_CONTROL )[ 2 ] );
+			landFirstReRead( bundle( [ other ] ) );
+			await flushPromises();
+
+			expect( wrapper.find( REFERENCED_ROW ).exists() ).toBe( false );
+		} );
+
 	} );
 
 } );

--- a/resources/ext.neowiki/tests/components/SubjectPage/SubjectPage.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectPage/SubjectPage.spec.ts
@@ -49,7 +49,7 @@ const EDIT_CONTROL = '[aria-label="neowiki-managesubjects-row-edit"]';
 const DELETE_CONTROL = '[aria-label="neowiki-managesubjects-row-delete"]';
 const COPY_LINK_CONTROL = '[aria-label="neowiki-managesubjects-row-copy-link"]';
 const PAGE_LINK = '.ext-neowiki-subject-row__page-value a';
-const OPEN_CONTROL = '[aria-label="neowiki-managesubjects-row-open"]';
+const NAME_LINK = 'a.ext-neowiki-subject-row__name';
 
 const SCHEMAS: Record<string, Schema> = {
 	Company: newSchema( { title: 'Company', description: 'An organisation' } ),
@@ -346,9 +346,9 @@ describe( 'SubjectPage', () => {
 
 		const wrapper = await mountLoadedPage();
 
-		expect( wrapper.find( `${ REFERENCED_ROW } ${ OPEN_CONTROL }` ).attributes( 'href' ) )
+		expect( wrapper.find( `${ REFERENCED_ROW } ${ NAME_LINK }` ).attributes( 'href' ) )
 			.toBe( '/wiki/Special:Subject/' + REFERENCED_ID );
-		expect( wrapper.find( `${ REQUESTED_ROW } ${ OPEN_CONTROL }` ).exists() ).toBe( false );
+		expect( wrapper.find( `${ REQUESTED_ROW } ${ NAME_LINK }` ).exists() ).toBe( false );
 	} );
 
 	it( 'lists referenced Subjects in the order the read returned them', async () => {
@@ -361,13 +361,14 @@ describe( 'SubjectPage', () => {
 		expect( names ).toEqual( [ 'Rocket', 'Anvil' ] );
 	} );
 
-	// The whole header toggles, as on the Data tab: nothing in it navigates.
-	it( 'opens a referenced row from anywhere in its header', async () => {
+	// The header still toggles where it is not a link, as on the Data tab; the statement count stands
+	// for the rest of it.
+	it( 'opens a referenced row from its header', async () => {
 		getSubjectWithReferencedSubjectsMock.mockResolvedValue( bundle( [ referencedSubject ] ) );
 
 		const wrapper = await mountLoadedPage();
 
-		await wrapper.find( `${ REFERENCED_ROW } ${ ROW_LABEL }` ).trigger( 'click' );
+		await wrapper.find( `${ REFERENCED_ROW } .ext-neowiki-subject-row__count` ).trigger( 'click' );
 
 		expect( isOpen( wrapper.find( REFERENCED_ROW ) ) ).toBe( true );
 	} );
@@ -520,7 +521,6 @@ describe( 'SubjectPage', () => {
 					'neowiki-managesubjects-row-delete',
 				],
 				[
-					'neowiki-managesubjects-row-open',
 					'neowiki-managesubjects-row-copy-link',
 					'neowiki-managesubjects-row-edit',
 					'neowiki-managesubjects-row-delete',

--- a/resources/ext.neowiki/tests/components/SubjectPage/SubjectPage.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectPage/SubjectPage.spec.ts
@@ -1,0 +1,760 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+import { createPinia, setActivePinia } from 'pinia';
+import { flushPromises, shallowMount, VueWrapper } from '@vue/test-utils';
+import { CdxMenuButton } from '@wikimedia/codex';
+import SubjectPage from '@/components/SubjectPage/SubjectPage.vue';
+import SubjectStatementsView from '@/components/SubjectsManager/SubjectStatementsView.vue';
+import SubjectEditorDialog from '@/components/SubjectEditor/SubjectEditorDialog.vue';
+import DataExportButton from '@/components/SubjectsManager/DataExportButton.vue';
+import SchemaNameDisplay from '@/components/common/SchemaNameDisplay.vue';
+import SummaryAction from '@/components/common/SummaryAction.vue';
+import { CdxDialogStub, createI18nMock, setupMwMock } from '../../VueTestHelpers.ts';
+import { NeoWikiExtension } from '@/NeoWikiExtension.ts';
+import { Schema } from '@/domain/Schema.ts';
+import { Subject } from '@/domain/Subject.ts';
+import { SubjectId } from '@/domain/SubjectId.ts';
+import { SubjectWithContext } from '@/domain/SubjectWithContext.ts';
+import { PageIdentifiers } from '@/domain/PageIdentifiers.ts';
+import { StatementList } from '@/domain/StatementList.ts';
+import { Statement } from '@/domain/Statement.ts';
+import { PropertyName } from '@/domain/PropertyDefinition.ts';
+import { newRelation, RelationValue } from '@/domain/Value.ts';
+import { RelationType } from '@/domain/propertyTypes/Relation.ts';
+import type { SubjectWithReferencedSubjects } from '@/domain/SubjectRepository.ts';
+import { useSubjectStore } from '@/stores/SubjectStore.ts';
+import { useSchemaStore } from '@/stores/SchemaStore.ts';
+import { SubjectNotFoundError } from '@/persistence/SubjectNotFoundError.ts';
+import { Service } from '@/NeoWikiServices.ts';
+import { newSchema, newSubject } from '@/TestHelpers.ts';
+
+const SUBJECT_ID = 's1aaaaaaaaaaaa1';
+const REFERENCED_ID = 's1bbbbbbbbbbbb1';
+const OTHER_REFERENCED_ID = 's1ccccccccccc11';
+
+// The referenced Subject lives on its own page, so every assertion about "the page the Subject is
+// stored on" fails if the page is taken from the wrong Subject.
+const PAGE_ID = 42;
+const PAGE_NAME = 'ACME Inc';
+const REFERENCED_PAGE_ID = 77;
+const REFERENCED_PAGE_NAME = 'Anvil (product)';
+
+const PROJECTIONS = [ 'native', 'EDM' ];
+const IRI_BASE = 'https://data.example.org/entity/';
+
+const REQUESTED_ROW = '.ext-neowiki-subject-page__subject .ext-neowiki-subject-row';
+const REFERENCED_ROW = '.ext-neowiki-subject-page__referenced .ext-neowiki-subject-row';
+const ROW_LABEL = '.ext-neowiki-subject-row__label';
+const EDIT_CONTROL = '[aria-label="neowiki-managesubjects-row-edit"]';
+const DELETE_CONTROL = '[aria-label="neowiki-managesubjects-row-delete"]';
+const COPY_LINK_CONTROL = '[aria-label="neowiki-managesubjects-row-copy-link"]';
+const PAGE_LINK = '.ext-neowiki-subject-row__page-value a';
+const OPEN_CONTROL = '[aria-label="neowiki-managesubjects-row-open"]';
+
+const SCHEMAS: Record<string, Schema> = {
+	Company: newSchema( { title: 'Company', description: 'An organisation' } ),
+	Product: newSchema( { title: 'Product', description: 'Something sold' } ),
+};
+
+interface SubjectOptions {
+	id: string;
+	label: string | null;
+	/** Nobody named it, so it is shown under its Schema name. */
+	unnamed?: boolean;
+	schemaName?: string;
+	pageId?: number;
+	pageName?: string;
+	/** Gives it one relation statement, pointing at this Subject id. */
+	relatesTo?: string;
+}
+
+function subject( options: SubjectOptions ): SubjectWithContext {
+	return newSubject( {
+		id: options.id,
+		label: options.label,
+		displayNameIsGenerated: options.unnamed ?? false,
+		schemaName: options.schemaName ?? 'Company',
+		statements: options.relatesTo === undefined ? undefined : relationTo( options.relatesTo ),
+		pageIdentifiers: new PageIdentifiers( options.pageId ?? PAGE_ID, options.pageName ?? PAGE_NAME ),
+	} );
+}
+
+function relationTo( targetId: string ): StatementList {
+	return new StatementList( [
+		new Statement(
+			new PropertyName( 'Made in' ),
+			RelationType.typeName,
+			new RelationValue( [ newRelation( undefined, targetId ) ] ),
+		),
+	] );
+}
+
+const requestedSubject = subject( { id: SUBJECT_ID, label: 'ACME Inc' } );
+const referencedSubject = subject( {
+	id: REFERENCED_ID,
+	label: 'Anvil',
+	schemaName: 'Product',
+	pageId: REFERENCED_PAGE_ID,
+	pageName: REFERENCED_PAGE_NAME,
+} );
+
+const getSubjectWithReferencedSubjectsMock = vi.fn();
+const getSubjectForEditingMock = vi.fn();
+const getSchemaMock = vi.fn();
+const checkPermissionsMock = vi.fn();
+
+const canEditSubjectRef = ref( false );
+const canDeleteSubjectRef = ref( false );
+
+vi.mock( '@/composables/useSubjectPermissions.ts', () => ( {
+	useSubjectPermissions: () => ( {
+		canCreateMainSubject: ref( false ),
+		canCreateChildSubject: ref( false ),
+		canEditSubject: canEditSubjectRef,
+		canDeleteSubject: canDeleteSubjectRef,
+		checkPermissions: checkPermissionsMock,
+	} ),
+} ) );
+
+function bundle(
+	referencedSubjects: Subject[] = [],
+	requested: Subject = requestedSubject,
+): SubjectWithReferencedSubjects {
+	return { requestedSubject: requested, referencedSubjects };
+}
+
+/**
+ * Stands in for the singleton the Pinia stores read through, which is not the injected repository
+ * the page itself reads through.
+ */
+function stubExtension( repositories: { subject?: object; schema?: object } ): void {
+	vi.spyOn( NeoWikiExtension, 'getInstance' ).mockReturnValue( {
+		getSubjectRepository: () => repositories.subject ?? {},
+		getSchemaRepository: () => repositories.schema ?? {},
+	} as unknown as NeoWikiExtension );
+}
+
+function silenceConsoleErrors(): void {
+	vi.spyOn( console, 'error' ).mockImplementation( () => undefined );
+}
+
+function mountPage(): VueWrapper {
+	setupMwMock( {
+		functions: [ 'config', 'msg', 'message', 'notify', 'util' ],
+		config: {
+			wgNeoWikiRdfProjections: PROJECTIONS,
+			wgNeoWikiSubjectIriBase: IRI_BASE,
+		},
+	} );
+
+	const pinia = createPinia();
+	setActivePinia( pinia );
+
+	return shallowMount( SubjectPage, {
+		props: { subjectId: SUBJECT_ID },
+		global: {
+			plugins: [ pinia ],
+			mocks: { $i18n: createI18nMock() },
+			// The row and the delete dialog are this page's own building blocks rather than
+			// collaborators to stand in for: the assertions below are about what they render.
+			stubs: { CdxIcon: true, CdxDialog: CdxDialogStub, SubjectRow: false, SubjectDeleteDialog: false },
+			provide: {
+				[ Service.SubjectRepository ]: {
+					getSubjectWithReferencedSubjects: getSubjectWithReferencedSubjectsMock,
+					getSubjectForEditing: getSubjectForEditingMock,
+				},
+				[ Service.SchemaRepository ]: { getSchema: getSchemaMock },
+			},
+		},
+	} );
+}
+
+async function mountLoadedPage(): Promise<VueWrapper> {
+	const wrapper = mountPage();
+
+	// onMounted awaits the Subject read, then the Schema reads, then the permission check.
+	await flushPromises();
+
+	return wrapper;
+}
+
+function isOpen( row: ReturnType<VueWrapper['find']> ): boolean {
+	return ( row.find( 'details' ).element as HTMLDetailsElement ).open;
+}
+
+async function openEditorOn( control: ReturnType<VueWrapper['find']> ): Promise<void> {
+	await control.trigger( 'click' );
+	await flushPromises();
+}
+
+async function confirmDelete( wrapper: VueWrapper, control: ReturnType<VueWrapper['find']> ): Promise<void> {
+	await control.trigger( 'click' );
+	wrapper.findComponent( SummaryAction ).vm.$emit( 'save', 'no longer needed' );
+	await flushPromises();
+}
+
+describe( 'SubjectPage', () => {
+
+	beforeEach( () => {
+		getSubjectWithReferencedSubjectsMock.mockReset().mockResolvedValue( bundle() );
+		getSchemaMock.mockReset().mockImplementation( ( name: string ) =>
+			SCHEMAS[ name ] === undefined ?
+				Promise.reject( new Error( `Unknown schema: ${ name }` ) ) :
+				Promise.resolve( SCHEMAS[ name ] ) );
+		getSubjectForEditingMock.mockReset();
+		checkPermissionsMock.mockReset().mockResolvedValue( undefined );
+	} );
+
+	afterEach( () => {
+		canEditSubjectRef.value = false;
+		canDeleteSubjectRef.value = false;
+		vi.restoreAllMocks();
+	} );
+
+	it( 'reads the Subject its subjectId names', async () => {
+		await mountLoadedPage();
+
+		expect( getSubjectWithReferencedSubjectsMock )
+			.toHaveBeenCalledWith( expect.objectContaining( { text: SUBJECT_ID } ) );
+	} );
+
+	it( 'shows the loading placeholder until the read lands', () => {
+		// Deliberately never settled: the assertion is about the window before the read lands.
+		let land!: ( value: unknown ) => void;
+		getSubjectWithReferencedSubjectsMock.mockReturnValue( new Promise( ( resolve ) => {
+			land = resolve;
+		} ) );
+
+		const wrapper = mountPage();
+
+		expect( wrapper.find( '.ext-neowiki-subject-page__loading' ).exists() ).toBe( true );
+		expect( wrapper.find( REQUESTED_ROW ).exists() ).toBe( false );
+
+		land( bundle() );
+	} );
+
+	it( 'names the Subject and shows the Schema it instantiates', async () => {
+		const wrapper = await mountLoadedPage();
+
+		expect( wrapper.find( `${ REQUESTED_ROW } ${ ROW_LABEL }` ).text() ).toBe( 'ACME Inc' );
+		expect( wrapper.findComponent( SchemaNameDisplay ).props( 'schemaName' ) ).toBe( 'Company' );
+	} );
+
+	// The page is about one Subject, so it opens on that one's data rather than on everything at once.
+	it( 'opens on the requested Subject with the ones it references collapsed', async () => {
+		getSubjectWithReferencedSubjectsMock.mockResolvedValue( bundle( [ referencedSubject ] ) );
+
+		const wrapper = await mountLoadedPage();
+
+		expect( isOpen( wrapper.find( REQUESTED_ROW ) ) ).toBe( true );
+		expect( isOpen( wrapper.find( REFERENCED_ROW ) ) ).toBe( false );
+	} );
+
+	it( 'collapses and re-expands a row from its header', async () => {
+		const wrapper = await mountLoadedPage();
+		const header = wrapper.find( '.ext-neowiki-subject-row__header' );
+
+		await header.trigger( 'click' );
+		expect( isOpen( wrapper.find( REQUESTED_ROW ) ) ).toBe( false );
+
+		await header.trigger( 'click' );
+		expect( isOpen( wrapper.find( REQUESTED_ROW ) ) ).toBe( true );
+	} );
+
+	it( 'renders the statements of the Subject and of each Subject it references', async () => {
+		getSubjectWithReferencedSubjectsMock.mockResolvedValue( bundle( [ referencedSubject ] ) );
+
+		const wrapper = await mountLoadedPage();
+
+		const subjects = wrapper.findAllComponents( SubjectStatementsView ).map( ( view ) => view.props( 'subject' ) );
+		expect( subjects ).toStrictEqual( [ requestedSubject, referencedSubject ] );
+	} );
+
+	// Every row here names a Subject stored somewhere else, so each footer links its own page.
+	it( 'links each row\'s own hosting page from its footer', async () => {
+		getSubjectWithReferencedSubjectsMock.mockResolvedValue( bundle( [ referencedSubject ] ) );
+
+		const wrapper = await mountLoadedPage();
+
+		const requested = wrapper.find( `${ REQUESTED_ROW } ${ PAGE_LINK }` );
+		expect( requested.text() ).toBe( PAGE_NAME );
+		expect( requested.attributes( 'href' ) ).toBe( '/wiki/' + PAGE_NAME );
+
+		const referenced = wrapper.find( `${ REFERENCED_ROW } ${ PAGE_LINK }` );
+		expect( referenced.text() ).toBe( REFERENCED_PAGE_NAME );
+		expect( referenced.attributes( 'href' ) ).toBe( '/wiki/' + REFERENCED_PAGE_NAME );
+	} );
+
+	// The read omits both page fields for a Subject whose hosting page it could not resolve, and the
+	// deserializer puts them into PageIdentifiers unread, so the values decide rather than the type.
+	describe( 'a Subject served without a hosting page', () => {
+
+		const pagelessSubject = new SubjectWithContext(
+			new SubjectId( SUBJECT_ID ),
+			'Homeless',
+			'Homeless',
+			false,
+			'Company',
+			new StatementList( [] ),
+			new PageIdentifiers( undefined as unknown as number, undefined as unknown as string ),
+		);
+
+		beforeEach( () => {
+			getSubjectWithReferencedSubjectsMock.mockResolvedValue( bundle( [], pagelessSubject ) );
+		} );
+
+		it( 'still shows the Subject, naming no page', async () => {
+			const wrapper = await mountLoadedPage();
+
+			expect( wrapper.find( ROW_LABEL ).text() ).toBe( 'Homeless' );
+			expect( wrapper.find( PAGE_LINK ).exists() ).toBe( false );
+		} );
+
+		// Editing rights are the hosting page's, so without one there is nothing to ask about — and
+		// nothing grants editing, since the permission check is the only thing that ever does.
+		it( 'asks about no page, leaving the edit controls ungranted', async () => {
+			const wrapper = await mountLoadedPage();
+
+			expect( checkPermissionsMock ).not.toHaveBeenCalled();
+			expect( wrapper.find( EDIT_CONTROL ).exists() ).toBe( false );
+		} );
+
+	} );
+
+	it( 'checks edit permission against the page the Subject is stored on', async () => {
+		getSubjectWithReferencedSubjectsMock.mockResolvedValue( bundle( [ referencedSubject ] ) );
+
+		await mountLoadedPage();
+
+		expect( checkPermissionsMock ).toHaveBeenCalledWith( PAGE_ID );
+	} );
+
+	it( 'offers each referenced Subject its own page, and the requested one nothing', async () => {
+		getSubjectWithReferencedSubjectsMock.mockResolvedValue( bundle( [ referencedSubject ] ) );
+
+		const wrapper = await mountLoadedPage();
+
+		expect( wrapper.find( `${ REFERENCED_ROW } ${ OPEN_CONTROL }` ).attributes( 'href' ) )
+			.toBe( '/wiki/Special:Subject/' + REFERENCED_ID );
+		expect( wrapper.find( `${ REQUESTED_ROW } ${ OPEN_CONTROL }` ).exists() ).toBe( false );
+	} );
+
+	it( 'lists referenced Subjects in the order the read returned them', async () => {
+		const otherReferenced = subject( { id: OTHER_REFERENCED_ID, label: 'Rocket', schemaName: 'Product' } );
+		getSubjectWithReferencedSubjectsMock.mockResolvedValue( bundle( [ otherReferenced, referencedSubject ] ) );
+
+		const wrapper = await mountLoadedPage();
+
+		const names = wrapper.findAll( `${ REFERENCED_ROW } ${ ROW_LABEL }` ).map( ( link ) => link.text() );
+		expect( names ).toEqual( [ 'Rocket', 'Anvil' ] );
+	} );
+
+	// The whole header toggles, as on the Data tab: nothing in it navigates.
+	it( 'opens a referenced row from anywhere in its header', async () => {
+		getSubjectWithReferencedSubjectsMock.mockResolvedValue( bundle( [ referencedSubject ] ) );
+
+		const wrapper = await mountLoadedPage();
+
+		await wrapper.find( `${ REFERENCED_ROW } ${ ROW_LABEL }` ).trigger( 'click' );
+
+		expect( isOpen( wrapper.find( REFERENCED_ROW ) ) ).toBe( true );
+	} );
+
+	it( 'shows no referenced section for a Subject that references nothing', async () => {
+		const wrapper = await mountLoadedPage();
+
+		expect( wrapper.find( REQUESTED_ROW ).exists() ).toBe( true );
+		expect( wrapper.find( '.ext-neowiki-subject-page__referenced-heading' ).exists() ).toBe( false );
+	} );
+
+	// RelationDisplay resolves a relation target through the registry, so a target the page did not
+	// seed renders as an error rather than as the Subject it names.
+	it( 'seeds the subject store with the Subject and everything it references', async () => {
+		getSubjectWithReferencedSubjectsMock.mockResolvedValue( bundle( [ referencedSubject ] ) );
+
+		await mountLoadedPage();
+
+		const subjectStore = useSubjectStore();
+		expect( subjectStore.getSubject( new SubjectId( SUBJECT_ID ) ) ).toStrictEqual( requestedSubject );
+		expect( subjectStore.getSubject( new SubjectId( REFERENCED_ID ) ) ).toStrictEqual( referencedSubject );
+	} );
+
+	// The read expands relations one level only, and RelationDisplay resolves a target through the
+	// registry, so a referenced Subject's own relation targets render as errors unless they are seeded.
+	it( 'seeds the relation targets of the referenced Subjects too', async () => {
+		const nested = subject( { id: OTHER_REFERENCED_ID, label: 'Sheffield', schemaName: 'Product' } );
+		const getSubjectMock = vi.fn().mockResolvedValue( nested );
+		stubExtension( { subject: { getSubject: getSubjectMock } } );
+		getSubjectWithReferencedSubjectsMock.mockResolvedValue( bundle( [
+			subject( {
+				id: REFERENCED_ID,
+				label: 'Anvil',
+				schemaName: 'Product',
+				relatesTo: OTHER_REFERENCED_ID,
+			} ),
+		] ) );
+
+		await mountLoadedPage();
+
+		expect( getSubjectMock ).toHaveBeenCalledWith( expect.objectContaining( { text: OTHER_REFERENCED_ID } ) );
+		expect( useSubjectStore().getSubject( new SubjectId( OTHER_REFERENCED_ID ) ) ).toStrictEqual( nested );
+	} );
+
+	// A relation target can be on a page the reader may not read. RelationDisplay marks the one target
+	// it cannot resolve; losing the whole page over it would be worse.
+	it( 'renders the page when a relation target cannot be fetched', async () => {
+		silenceConsoleErrors();
+		stubExtension( { subject: { getSubject: vi.fn().mockRejectedValue( new Error( 'Forbidden' ) ) } } );
+		getSubjectWithReferencedSubjectsMock.mockResolvedValue( bundle( [
+			subject( {
+				id: REFERENCED_ID,
+				label: 'Anvil',
+				schemaName: 'Product',
+				relatesTo: OTHER_REFERENCED_ID,
+			} ),
+		] ) );
+
+		const wrapper = await mountLoadedPage();
+
+		expect( wrapper.find( `${ REQUESTED_ROW } ${ ROW_LABEL }` ).text() ).toBe( 'ACME Inc' );
+		expect( wrapper.find( `${ REFERENCED_ROW } ${ ROW_LABEL }` ).text() ).toBe( 'Anvil' );
+	} );
+
+	// SubjectStatementsView renders from the Schema store, and the Subject read carries no Schemas.
+	it( 'seeds the schema store with the Schema of every Subject shown', async () => {
+		getSubjectWithReferencedSubjectsMock.mockResolvedValue( bundle( [ referencedSubject ] ) );
+
+		await mountLoadedPage();
+
+		const schemaStore = useSchemaStore();
+		expect( schemaStore.getSchema( 'Company' ) ).toStrictEqual( SCHEMAS.Company );
+		expect( schemaStore.getSchema( 'Product' ) ).toStrictEqual( SCHEMAS.Product );
+	} );
+
+	it( 'fetches a Schema that several of the Subjects share only once', async () => {
+		const otherReferenced = subject( { id: OTHER_REFERENCED_ID, label: 'Rocket', schemaName: 'Product' } );
+		getSubjectWithReferencedSubjectsMock.mockResolvedValue( bundle( [ referencedSubject, otherReferenced ] ) );
+
+		await mountLoadedPage();
+
+		expect( getSchemaMock.mock.calls.map( ( [ name ] ) => name ).sort() ).toEqual( [ 'Company', 'Product' ] );
+	} );
+
+	// A Schema page can be deleted while Subjects still name it; the statements view already renders
+	// a Subject whose Schema it does not have.
+	it( 'keeps the Schemas that did load when another Schema cannot be loaded', async () => {
+		silenceConsoleErrors();
+		getSubjectWithReferencedSubjectsMock.mockResolvedValue( bundle( [ referencedSubject ] ) );
+		getSchemaMock.mockImplementation( ( name: string ) =>
+			name === 'Company' ?
+				Promise.reject( new Error( 'Schema page deleted' ) ) :
+				Promise.resolve( SCHEMAS[ name ] ) );
+
+		const wrapper = await mountLoadedPage();
+
+		expect( wrapper.find( ROW_LABEL ).text() ).toBe( 'ACME Inc' );
+		expect( useSchemaStore().getSchema( 'Product' ) ).toStrictEqual( SCHEMAS.Product );
+	} );
+
+	it( 'reports a Subject the wiki serves none of, naming the id that was asked for', async () => {
+		silenceConsoleErrors();
+		getSubjectWithReferencedSubjectsMock.mockRejectedValue( new SubjectNotFoundError( SUBJECT_ID ) );
+
+		const wrapper = await mountLoadedPage();
+
+		expect( wrapper.find( '.ext-neowiki-subject-page__error' ).text() )
+			.toBe( 'neowiki-special-subject-not-found' + SUBJECT_ID );
+		expect( wrapper.find( REQUESTED_ROW ).exists() ).toBe( false );
+	} );
+
+	it( 'reports a read that failed for any other reason as a load failure', async () => {
+		silenceConsoleErrors();
+		getSubjectWithReferencedSubjectsMock.mockRejectedValue( new Error( 'Network down' ) );
+
+		const wrapper = await mountLoadedPage();
+
+		expect( wrapper.find( '.ext-neowiki-subject-page__error' ).text() )
+			.toBe( 'neowiki-special-subject-load-error' );
+	} );
+
+	it( 'offers a read-only user neither editing nor deletion', async () => {
+		const wrapper = await mountLoadedPage();
+
+		expect( wrapper.find( REQUESTED_ROW ).exists() ).toBe( true );
+		expect( wrapper.find( EDIT_CONTROL ).exists() ).toBe( false );
+		expect( wrapper.find( DELETE_CONTROL ).exists() ).toBe( false );
+	} );
+
+	// Adding, moving and the Main Subject are a page's business, and this page is one Subject's. Both
+	// action sets are named in full, so a control that reappears fails this rather than going unnoticed.
+	describe( 'what an editor is offered', () => {
+
+		beforeEach( () => {
+			canEditSubjectRef.value = true;
+			canDeleteSubjectRef.value = true;
+			getSubjectWithReferencedSubjectsMock.mockResolvedValue( bundle( [ referencedSubject ] ) );
+		} );
+
+		it( 'offers each row exactly its own actions', async () => {
+			const wrapper = await mountLoadedPage();
+
+			const strips = wrapper.findAll( '.ext-neowiki-subject-row__actions' )
+				.map( ( strip ) => strip.findAll( '[aria-label]' ).map( ( control ) => control.attributes( 'aria-label' ) ) );
+
+			expect( strips ).toEqual( [
+				[
+					'neowiki-managesubjects-row-copy-link',
+					'neowiki-managesubjects-row-edit',
+					'neowiki-managesubjects-row-delete',
+				],
+				[
+					'neowiki-managesubjects-row-open',
+					'neowiki-managesubjects-row-copy-link',
+					'neowiki-managesubjects-row-edit',
+					'neowiki-managesubjects-row-delete',
+				],
+			] );
+		} );
+
+		it( 'orders each overflow menu the same way', async () => {
+			const wrapper = await mountLoadedPage();
+
+			expect( wrapper.findAllComponents( CdxMenuButton )
+				.map( ( menu ) => menu.props( 'menuItems' ).map( ( item ) => item.value ) ) )
+				.toEqual( [
+					[ 'copy-link', 'edit', 'delete' ],
+					[ 'open', 'copy-link', 'edit', 'delete' ],
+				] );
+		} );
+
+		// The add button is a page's affordance, and its label is button text rather than an aria-label.
+		it( 'offers no way to add a Subject', async () => {
+			const wrapper = await mountLoadedPage();
+
+			expect( wrapper.text() ).not.toContain( 'neowiki-managesubjects-add-button' );
+		} );
+
+	} );
+
+	// The reader is on one Subject's page while every row names another: a fragment of the current
+	// URL would point at whichever Subject the page happens to be about.
+	it( 'copies a row\'s own Special:Subject URL, absolute', async () => {
+		const writeText = vi.fn().mockResolvedValue( undefined );
+		Object.defineProperty( navigator, 'clipboard', { value: { writeText }, configurable: true } );
+		getSubjectWithReferencedSubjectsMock.mockResolvedValue( bundle( [ referencedSubject ] ) );
+
+		const wrapper = await mountLoadedPage();
+		await wrapper.findAll( COPY_LINK_CONTROL )[ 1 ].trigger( 'click' );
+		await flushPromises();
+
+		const copied = new URL( writeText.mock.calls[ 0 ][ 0 ] as string );
+		expect( copied.pathname ).toBe( '/wiki/Special:Subject/' + REFERENCED_ID );
+		expect( copied.origin ).toBe( location.origin );
+		expect( mw.notify ).toHaveBeenCalledWith( 'neowiki-managesubjects-link-copied', { type: 'success' } );
+	} );
+
+	it( 'reports a refused clipboard write instead of claiming the link was copied', async () => {
+		vi.spyOn( console, 'error' ).mockImplementation( () => undefined );
+		const writeText = vi.fn().mockRejectedValue( new Error( 'clipboard denied' ) );
+		Object.defineProperty( navigator, 'clipboard', { value: { writeText }, configurable: true } );
+
+		const wrapper = await mountLoadedPage();
+		await wrapper.find( COPY_LINK_CONTROL ).trigger( 'click' );
+		await flushPromises();
+
+		expect( mw.notify ).toHaveBeenCalledWith( 'neowiki-managesubjects-link-copy-error', { type: 'error' } );
+	} );
+
+	it( 'shows the wiki\'s export projections and each Subject\'s own IRI', async () => {
+		getSubjectWithReferencedSubjectsMock.mockResolvedValue( bundle( [ referencedSubject ] ) );
+
+		const wrapper = await mountLoadedPage();
+
+		expect( wrapper.findComponent( DataExportButton ).props( 'projections' ) ).toEqual( PROJECTIONS );
+		const iris = wrapper.findAll( '.ext-neowiki-subject-row__iri-value data' )
+			.map( ( element ) => element.attributes( 'value' ) );
+		expect( iris ).toEqual( [ IRI_BASE + SUBJECT_ID, IRI_BASE + REFERENCED_ID ] );
+	} );
+
+	describe( 'edit flow', () => {
+
+		// Values neither the page's own read nor its Schema store produced, so an assertion on them
+		// passes only if the dialog was handed what the repositories returned.
+		const freshSubject = subject( { id: SUBJECT_ID, label: 'Fetched label' } );
+		const freshSchema = newSchema( { title: 'Company', description: 'Freshly fetched' } );
+
+		beforeEach( () => {
+			canEditSubjectRef.value = true;
+			getSubjectForEditingMock.mockResolvedValue( freshSubject );
+		} );
+
+		it( 'opens the editor on the Subject and Schema fetched from the repositories', async () => {
+			const wrapper = await mountLoadedPage();
+			getSchemaMock.mockResolvedValue( freshSchema );
+
+			await openEditorOn( wrapper.find( EDIT_CONTROL ) );
+
+			expect( getSubjectForEditingMock ).toHaveBeenCalledWith( expect.objectContaining( { text: SUBJECT_ID } ) );
+			const dialog = wrapper.findComponent( SubjectEditorDialog );
+			expect( dialog.props( 'open' ) ).toBe( true );
+			expect( dialog.props( 'subject' ) ).toStrictEqual( freshSubject );
+			expect( dialog.props( 'schema' ) ).toStrictEqual( freshSchema );
+		} );
+
+		it( 'opens the editor on the referenced Subject whose row asked for it', async () => {
+			getSubjectWithReferencedSubjectsMock.mockResolvedValue( bundle( [ referencedSubject ] ) );
+
+			const wrapper = await mountLoadedPage();
+			await openEditorOn( wrapper.findAll( EDIT_CONTROL )[ 1 ] );
+
+			expect( getSubjectForEditingMock ).toHaveBeenCalledWith( expect.objectContaining( { text: REFERENCED_ID } ) );
+			expect( getSchemaMock ).toHaveBeenCalledWith( 'Product' );
+		} );
+
+		it( 'reports a failed fetch instead of opening the editor', async () => {
+			getSubjectForEditingMock.mockRejectedValue( new Error( 'Unknown subject' ) );
+
+			const wrapper = await mountLoadedPage();
+			await openEditorOn( wrapper.find( EDIT_CONTROL ) );
+
+			expect( wrapper.findComponent( SubjectEditorDialog ).exists() ).toBe( false );
+			expect( mw.notify ).toHaveBeenCalledWith( 'Unknown subject', { type: 'error' } );
+		} );
+
+		// A save can add or drop relations, so the referenced Subjects the page shows are re-read
+		// rather than left as the ones it was built from.
+		it( 'saves through the store and re-reads', async () => {
+			const wrapper = await mountLoadedPage();
+			const updateSubject = vi.spyOn( useSubjectStore(), 'updateSubject' ).mockResolvedValue( undefined );
+			await openEditorOn( wrapper.find( EDIT_CONTROL ) );
+			getSubjectWithReferencedSubjectsMock.mockClear();
+
+			await wrapper.findComponent( SubjectEditorDialog ).props( 'onSave' )( freshSubject, 'a comment' );
+			await flushPromises();
+
+			expect( updateSubject ).toHaveBeenCalledWith( freshSubject, 'a comment' );
+			expect( getSubjectWithReferencedSubjectsMock ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		// A Subject the editor created is always followed by the save that points at it, and that
+		// save re-reads; doing it here too would read the page twice for one edit.
+		it( 'creates a Subject the editor added without re-reading', async () => {
+			const created = subject( { id: OTHER_REFERENCED_ID, label: 'Rocket', schemaName: 'Product' } );
+
+			const wrapper = await mountLoadedPage();
+			const createSubject = vi.spyOn( useSubjectStore(), 'createSubject' )
+				.mockResolvedValue( created.getId() );
+			await openEditorOn( wrapper.find( EDIT_CONTROL ) );
+			getSubjectWithReferencedSubjectsMock.mockClear();
+
+			const onCreate = wrapper.findComponent( SubjectEditorDialog ).props( 'onCreate' );
+			await onCreate!( created, REFERENCED_PAGE_ID, 'a comment' );
+			await flushPromises();
+
+			expect( createSubject ).toHaveBeenCalledWith( created, REFERENCED_PAGE_ID, 'a comment' );
+			expect( getSubjectWithReferencedSubjectsMock ).not.toHaveBeenCalled();
+		} );
+
+		// The write committed whatever the re-read does, so telling the reader the Subject is gone
+		// would be a lie about their own save.
+		it( 'keeps the saved Subject on screen when the re-read after a save fails', async () => {
+			silenceConsoleErrors();
+
+			const wrapper = await mountLoadedPage();
+			vi.spyOn( useSubjectStore(), 'updateSubject' ).mockResolvedValue( undefined );
+			await openEditorOn( wrapper.find( EDIT_CONTROL ) );
+			getSubjectWithReferencedSubjectsMock.mockRejectedValue( new SubjectNotFoundError( SUBJECT_ID ) );
+
+			await wrapper.findComponent( SubjectEditorDialog ).props( 'onSave' )( freshSubject, 'a comment' );
+			await flushPromises();
+
+			expect( wrapper.find( `${ REQUESTED_ROW } ${ ROW_LABEL }` ).text() ).toBe( 'ACME Inc' );
+			expect( wrapper.find( '.ext-neowiki-subject-page__error' ).exists() ).toBe( false );
+			expect( mw.notify ).toHaveBeenCalledWith( 'neowiki-special-subject-load-error', { type: 'error' } );
+		} );
+
+		it( 'saves a Schema the editor changed', async () => {
+			const wrapper = await mountLoadedPage();
+			const saveSchema = vi.spyOn( useSchemaStore(), 'saveSchema' ).mockResolvedValue( undefined );
+			await openEditorOn( wrapper.find( EDIT_CONTROL ) );
+
+			await wrapper.findComponent( SubjectEditorDialog ).props( 'onSaveSchema' )( freshSchema, 'a comment' );
+
+			expect( saveSchema ).toHaveBeenCalledWith( freshSchema, 'a comment' );
+		} );
+
+	} );
+
+	describe( 'delete flow', () => {
+
+		beforeEach( () => {
+			canDeleteSubjectRef.value = true;
+			getSubjectWithReferencedSubjectsMock.mockResolvedValue( bundle( [ referencedSubject ] ) );
+		} );
+
+		it( 'deletes through the store and re-reads, since the relation to it is gone', async () => {
+			const wrapper = await mountLoadedPage();
+			const deleteSubject = vi.spyOn( useSubjectStore(), 'deleteSubject' ).mockResolvedValue( undefined );
+			getSubjectWithReferencedSubjectsMock.mockClear().mockResolvedValue( bundle() );
+
+			await confirmDelete( wrapper, wrapper.findAll( DELETE_CONTROL )[ 1 ] );
+
+			expect( deleteSubject ).toHaveBeenCalledWith(
+				expect.objectContaining( { text: REFERENCED_ID } ),
+				'no longer needed',
+			);
+			expect( mw.notify ).toHaveBeenCalledWith( 'neowiki-managesubjects-delete-success', { type: 'success' } );
+			expect( getSubjectWithReferencedSubjectsMock ).toHaveBeenCalledTimes( 1 );
+			expect( wrapper.find( REFERENCED_ROW ).exists() ).toBe( false );
+		} );
+
+		// Deleting drops the Subject from the store's registry, whose getter throws for an id it no
+		// longer holds: rendering the page off that getter is what crashed here.
+		it( 'reports the Subject the page is about as gone once it is deleted', async () => {
+			const wrapper = await mountLoadedPage();
+			vi.spyOn( useSubjectStore(), 'deleteSubject' ).mockResolvedValue( undefined );
+			getSubjectWithReferencedSubjectsMock.mockClear();
+
+			await confirmDelete( wrapper, wrapper.find( DELETE_CONTROL ) );
+
+			expect( mw.notify ).toHaveBeenCalledWith( 'neowiki-managesubjects-delete-success', { type: 'success' } );
+			expect( wrapper.find( '.ext-neowiki-subject-page__error' ).text() )
+				.toBe( 'neowiki-special-subject-not-found' + SUBJECT_ID );
+			expect( wrapper.find( REQUESTED_ROW ).exists() ).toBe( false );
+			// Nothing left to re-read for.
+			expect( getSubjectWithReferencedSubjectsMock ).not.toHaveBeenCalled();
+		} );
+
+		it( 'falls back to the default summary when the user typed none', async () => {
+			const wrapper = await mountLoadedPage();
+			const deleteSubject = vi.spyOn( useSubjectStore(), 'deleteSubject' ).mockResolvedValue( undefined );
+			getSubjectWithReferencedSubjectsMock.mockResolvedValue( bundle() );
+
+			await wrapper.findAll( DELETE_CONTROL )[ 1 ].trigger( 'click' );
+			wrapper.findComponent( SummaryAction ).vm.$emit( 'save', '' );
+			await flushPromises();
+
+			expect( deleteSubject ).toHaveBeenCalledWith(
+				expect.anything(),
+				'neowiki-managesubjects-delete-summary-default',
+			);
+		} );
+
+		it( 'keeps the Subject on screen when the delete fails', async () => {
+			silenceConsoleErrors();
+
+			const wrapper = await mountLoadedPage();
+			vi.spyOn( useSubjectStore(), 'deleteSubject' ).mockRejectedValue( new Error( 'boom' ) );
+
+			await confirmDelete( wrapper, wrapper.find( DELETE_CONTROL ) );
+
+			expect( mw.notify ).toHaveBeenCalledWith(
+				'neowiki-managesubjects-delete-errorACME Inc',
+				{ type: 'error' },
+			);
+			expect( wrapper.find( `${ REQUESTED_ROW } ${ ROW_LABEL }` ).text() ).toBe( 'ACME Inc' );
+		} );
+
+	} );
+
+} );

--- a/resources/ext.neowiki/tests/components/SubjectsManager/SubjectRow.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectsManager/SubjectRow.spec.ts
@@ -220,6 +220,10 @@ describe( 'SubjectRow', () => {
 		const OPEN = '[aria-label="neowiki-managesubjects-row-open"]';
 		const URL = '/wiki/Special:Subject/' + SUBJECT_ID;
 
+		afterEach( () => {
+			vi.unstubAllGlobals();
+		} );
+
 		it( 'is a link to the page the surface named', () => {
 			const wrapper = mountRow( { subjectPageUrl: URL } );
 
@@ -228,11 +232,15 @@ describe( 'SubjectRow', () => {
 			expect( open.attributes( 'href' ) ).toBe( URL );
 		} );
 
-		it( 'is in the overflow menu as a link too', () => {
+		// Codex selects a menu item chosen with the keyboard but does not follow its url.
+		it( 'goes there when chosen from the overflow menu', async () => {
+			vi.stubGlobal( 'location', { href: '' } );
 			const wrapper = mountRow( { subjectPageUrl: URL } );
 
-			const items = wrapper.findComponent( CdxMenuButton ).props( 'menuItems' );
-			expect( items[ 0 ] ).toMatchObject( { value: 'open', url: URL } );
+			wrapper.findComponent( CdxMenuButton ).vm.$emit( 'update:selected', 'open' );
+			await wrapper.vm.$nextTick();
+
+			expect( location.href ).toBe( URL );
 		} );
 
 		it( 'is absent on a row the reader is already on', () => {

--- a/resources/ext.neowiki/tests/components/SubjectsManager/SubjectRow.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectsManager/SubjectRow.spec.ts
@@ -213,23 +213,25 @@ describe( 'SubjectRow', () => {
 
 	} );
 
-	// The header toggles the row wherever it is clicked, so reaching the Subject's page is an action
-	// of its own rather than a link buried in the name.
+	// The header toggles the row wherever it is clicked except on its links, and the name is one of
+	// them where the surface names a page for the Subject.
 	describe( 'the way to the Subject\'s own page', () => {
 
-		const OPEN = '[aria-label="neowiki-managesubjects-row-open"]';
+		const NAME_LINK = 'a.ext-neowiki-subject-row__name';
 		const URL = '/wiki/Special:Subject/' + SUBJECT_ID;
 
 		afterEach( () => {
 			vi.unstubAllGlobals();
 		} );
 
-		it( 'is a link to the page the surface named', () => {
+		it( 'is the Subject\'s name, linked to the page the surface named', () => {
 			const wrapper = mountRow( { subjectPageUrl: URL } );
 
-			const open = wrapper.find( OPEN );
-			expect( open.element.tagName ).toBe( 'A' );
-			expect( open.attributes( 'href' ) ).toBe( URL );
+			const link = wrapper.find( NAME_LINK );
+			expect( link.attributes( 'href' ) ).toBe( URL );
+			expect( link.find( '.ext-neowiki-subject-row__label' ).text() ).toBe( 'ACME Inc' );
+			// The cue that it leads somewhere, which CSS shows while the name is pointed at.
+			expect( link.find( '.ext-neowiki-subject-row__name-arrow' ).exists() ).toBe( true );
 		} );
 
 		// Codex selects a menu item chosen with the keyboard but does not follow its url.
@@ -243,21 +245,25 @@ describe( 'SubjectRow', () => {
 			expect( location.href ).toBe( URL );
 		} );
 
-		it( 'is absent on a row the reader is already on', () => {
+		it( 'leaves the name plain text on a row the reader is already on', () => {
 			const wrapper = mountRow();
 
-			expect( wrapper.find( OPEN ).exists() ).toBe( false );
+			expect( wrapper.find( NAME_LINK ).exists() ).toBe( false );
+			expect( wrapper.find( '.ext-neowiki-subject-row__label' ).text() ).toBe( 'ACME Inc' );
 			expect( wrapper.findComponent( CdxMenuButton ).props( 'menuItems' ).map( ( item ) => item.value ) )
 				.not.toContain( 'open' );
 		} );
 
-		// Clicking it must not also toggle the row it sits in.
-		it( 'keeps its click from reaching the header', async () => {
+		// Following the name must not also toggle the row it sits in, and must still be followed: the
+		// header one line above it cancels the clicks it handles.
+		it( 'keeps a click on the name from reaching the header, and follows it', () => {
 			const wrapper = mountRow( { subjectPageUrl: URL } );
 
-			await wrapper.find( OPEN ).trigger( 'click' );
+			const click = new Event( 'click', { bubbles: true, cancelable: true } );
+			wrapper.find( NAME_LINK ).element.dispatchEvent( click );
 
 			expect( wrapper.emitted( 'toggle' ) ).toBeUndefined();
+			expect( click.defaultPrevented ).toBe( false );
 		} );
 
 	} );

--- a/resources/ext.neowiki/tests/components/SubjectsManager/SubjectRow.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectsManager/SubjectRow.spec.ts
@@ -1,0 +1,264 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { shallowMount, VueWrapper } from '@vue/test-utils';
+import { CdxMenuButton } from '@wikimedia/codex';
+import SubjectRow from '@/components/SubjectsManager/SubjectRow.vue';
+import { createI18nMock, setupMwMock } from '../../VueTestHelpers.ts';
+import { PageIdentifiers } from '@/domain/PageIdentifiers.ts';
+import { StatementList } from '@/domain/StatementList.ts';
+import { Statement } from '@/domain/Statement.ts';
+import { PropertyName } from '@/domain/PropertyDefinition.ts';
+import { newStringValue } from '@/domain/Value.ts';
+import { TextType } from '@/domain/propertyTypes/Text.ts';
+import { newSubject } from '@/TestHelpers.ts';
+
+const SUBJECT_ID = 's1aaaaaaaaaaaa1';
+const IRI_BASE = 'https://data.example.org/entity/';
+const IRI = IRI_BASE + SUBJECT_ID;
+
+const subject = newSubject( { id: SUBJECT_ID, label: 'ACME Inc', schemaName: 'Company' } );
+
+let writeText: ReturnType<typeof vi.fn>;
+
+function mountRow( props: Record<string, unknown> = {} ): VueWrapper {
+	setupMwMock( {
+		functions: [ 'config', 'msg', 'message', 'notify', 'util' ],
+		config: { wgNeoWikiSubjectIriBase: IRI_BASE },
+	} );
+
+	return shallowMount( SubjectRow, {
+		props: { subject, expanded: true, ...props },
+		global: {
+			mocks: { $i18n: createI18nMock() },
+			stubs: { CdxIcon: true },
+		},
+	} );
+}
+
+describe( 'SubjectRow', () => {
+
+	beforeEach( () => {
+		writeText = vi.fn().mockResolvedValue( undefined );
+		Object.defineProperty( navigator, 'clipboard', { value: { writeText }, configurable: true } );
+	} );
+
+	afterEach( () => {
+		vi.restoreAllMocks();
+	} );
+
+	describe( 'the identifiers in the expanded footer', () => {
+
+		it( 'copies the Subject id and says what it copied', async () => {
+			const wrapper = mountRow();
+
+			await wrapper.find( '.ext-neowiki-subject-row__id-button' ).trigger( 'click' );
+
+			expect( writeText ).toHaveBeenCalledWith( SUBJECT_ID );
+			expect( mw.notify ).toHaveBeenCalledWith(
+				'neowiki-managesubjects-id-copied' + SUBJECT_ID,
+				{ type: 'success' },
+			);
+		} );
+
+		it( 'copies the concept URI, not the bare id', async () => {
+			const wrapper = mountRow();
+
+			await wrapper.find( '.ext-neowiki-subject-row__iri-button' ).trigger( 'click' );
+
+			expect( writeText ).toHaveBeenCalledWith( IRI );
+			expect( mw.notify ).toHaveBeenCalledWith(
+				'neowiki-managesubjects-iri-copied' + IRI,
+				{ type: 'success' },
+			);
+		} );
+
+		// A Subject's page is worth naming only where the reader is not already on it, so the surface
+		// decides rather than the row reading it off the Subject.
+		it( 'links the page a surface names', () => {
+			const wrapper = mountRow( { page: new PageIdentifiers( 7, 'ACME Inc' ) } );
+
+			const link = wrapper.find( '.ext-neowiki-subject-row__page-value a' );
+			expect( link.text() ).toBe( 'ACME Inc' );
+			expect( link.attributes( 'href' ) ).toBe( '/wiki/ACME Inc' );
+		} );
+
+		it( 'names no page where the surface names none', () => {
+			expect( mountRow().find( '.ext-neowiki-subject-row__page' ).exists() ).toBe( false );
+		} );
+
+		// A Subject of another Source is named under that Source's own base, which this wiki does not
+		// hold, so the row shows an id and a page rather than an empty entry.
+		it( 'shows no concept URI for a Subject of another Source', () => {
+			const wrapper = mountRow( { subject: newSubject( { id: 'otherwiki:abc-123' } ) } );
+
+			expect( wrapper.find( '.ext-neowiki-subject-row__iri' ).exists() ).toBe( false );
+			expect( wrapper.find( '.ext-neowiki-subject-row__id' ).exists() ).toBe( true );
+		} );
+
+		// A clipboard write is refused outright in some browsers and permission setups.
+		it.each( [
+			[ 'id', 'neowiki-managesubjects-id-copy-error' ],
+			[ 'iri', 'neowiki-managesubjects-iri-copy-error' ],
+		] )( 'reports a refused %s copy instead of claiming success', async ( which, message ) => {
+			vi.spyOn( console, 'error' ).mockImplementation( () => undefined );
+			writeText.mockRejectedValue( new Error( 'clipboard denied' ) );
+
+			const wrapper = mountRow();
+			await wrapper.find( `.ext-neowiki-subject-row__${ which }-button` ).trigger( 'click' );
+			await Promise.resolve();
+
+			expect( mw.notify ).toHaveBeenCalledWith( message, { type: 'error' } );
+		} );
+
+	} );
+
+	// The row's only computation: a property the Subject leaves unset is not one of its statements.
+	it( 'counts only the statements that hold a value', () => {
+		const wrapper = mountRow( { subject: newSubject( {
+			id: SUBJECT_ID,
+			statements: new StatementList( [
+				new Statement( new PropertyName( 'Founded' ), TextType.typeName, newStringValue( '2005' ) ),
+				new Statement( new PropertyName( 'Slogan' ), TextType.typeName, undefined ),
+			] ),
+		} ) } );
+
+		expect( wrapper.find( '.ext-neowiki-subject-row__count' ).text() )
+			.toBe( 'neowiki-managesubjects-statement-count1' );
+	} );
+
+	describe( 'the Main Subject indicator', () => {
+
+		it( 'is a demote control for a user who may edit', async () => {
+			const wrapper = mountRow( { mainSubjectControl: 'demote', canEdit: true } );
+
+			const indicator = wrapper.find( '[aria-label="neowiki-managesubjects-row-demote"]' );
+			expect( indicator.exists() ).toBe( true );
+
+			await indicator.trigger( 'click' );
+			expect( wrapper.emitted( 'demote' ) ).toHaveLength( 1 );
+		} );
+
+		// Nothing to press: the pin only says which Subject the page is about.
+		it( 'is a plain marker for a user who may not edit', () => {
+			const wrapper = mountRow( { mainSubjectControl: 'demote' } );
+
+			expect( wrapper.find( '[aria-label="neowiki-managesubjects-row-demote"]' ).exists() ).toBe( false );
+			expect( wrapper.find( '.ext-neowiki-subject-row__main-indicator' ).exists() ).toBe( true );
+		} );
+
+		it( 'is absent where a page\'s Main Subject is not the row\'s business', () => {
+			const wrapper = mountRow( { canEdit: true } );
+
+			expect( wrapper.find( '.ext-neowiki-subject-row__main-indicator' ).exists() ).toBe( false );
+			expect( wrapper.find( '[aria-label="neowiki-managesubjects-row-promote"]' ).exists() ).toBe( false );
+		} );
+
+	} );
+
+	// The page decides what each action does to which Subject, so the row only reports it.
+	describe( 'the actions it reports rather than performs', () => {
+
+		const ACTIONS = [ 'copy-link', 'edit', 'promote', 'move', 'delete' ];
+
+		function rowWithEveryAction(): VueWrapper {
+			return mountRow( {
+				canEdit: true,
+				canDelete: true,
+				canMove: true,
+				mainSubjectControl: 'promote',
+			} );
+		}
+
+		it.each( ACTIONS )( 'emits %s when its control is used, without toggling the row', async ( action ) => {
+			const wrapper = rowWithEveryAction();
+
+			await wrapper.find( `[aria-label="neowiki-managesubjects-row-${ action }"]` ).trigger( 'click' );
+
+			expect( wrapper.emitted( action ) ).toHaveLength( 1 );
+			expect( wrapper.emitted( 'toggle' ) ).toBeUndefined();
+		} );
+
+		it.each( ACTIONS )( 'emits %s when it is chosen from the overflow menu', async ( action ) => {
+			const wrapper = rowWithEveryAction();
+
+			wrapper.findComponent( CdxMenuButton ).vm.$emit( 'update:selected', action );
+			await wrapper.vm.$nextTick();
+
+			expect( wrapper.emitted( action ) ).toHaveLength( 1 );
+			// Cleared, so the same entry can be chosen again straight away.
+			expect( wrapper.findComponent( CdxMenuButton ).props( 'selected' ) ).toBeNull();
+		} );
+
+		// Both sit inside the header, where a click would otherwise toggle the row.
+		it.each( [
+			[ 'the drag handle', '[title="neowiki-managesubjects-row-drag-handle"]' ],
+			[ 'the Schema badge', '.ext-neowiki-subject-row__schema' ],
+		] )( 'leaves the row alone when %s is clicked', async ( _name, selector ) => {
+			const wrapper = mountRow( { canEdit: true, showDragHandle: true } );
+
+			await wrapper.find( selector ).trigger( 'click' );
+
+			expect( wrapper.emitted( 'toggle' ) ).toBeUndefined();
+		} );
+
+		it( 'emits toggle rather than letting the disclosure open itself', async () => {
+			const wrapper = mountRow();
+
+			const click = new Event( 'click', { bubbles: true, cancelable: true } );
+			wrapper.find( '.ext-neowiki-subject-row__header' ).element.dispatchEvent( click );
+
+			expect( wrapper.emitted( 'toggle' ) ).toHaveLength( 1 );
+			// The page owns which rows are open; a summary left to itself would disagree with it.
+			expect( click.defaultPrevented ).toBe( true );
+		} );
+
+	} );
+
+	// The header toggles the row wherever it is clicked, so reaching the Subject's page is an action
+	// of its own rather than a link buried in the name.
+	describe( 'the way to the Subject\'s own page', () => {
+
+		const OPEN = '[aria-label="neowiki-managesubjects-row-open"]';
+		const URL = '/wiki/Special:Subject/' + SUBJECT_ID;
+
+		it( 'is a link to the page the surface named', () => {
+			const wrapper = mountRow( { subjectPageUrl: URL } );
+
+			const open = wrapper.find( OPEN );
+			expect( open.element.tagName ).toBe( 'A' );
+			expect( open.attributes( 'href' ) ).toBe( URL );
+		} );
+
+		it( 'is in the overflow menu as a link too', () => {
+			const wrapper = mountRow( { subjectPageUrl: URL } );
+
+			const items = wrapper.findComponent( CdxMenuButton ).props( 'menuItems' );
+			expect( items[ 0 ] ).toMatchObject( { value: 'open', url: URL } );
+		} );
+
+		it( 'is absent on a row the reader is already on', () => {
+			const wrapper = mountRow();
+
+			expect( wrapper.find( OPEN ).exists() ).toBe( false );
+			expect( wrapper.findComponent( CdxMenuButton ).props( 'menuItems' ).map( ( item ) => item.value ) )
+				.not.toContain( 'open' );
+		} );
+
+		// Clicking it must not also toggle the row it sits in.
+		it( 'keeps its click from reaching the header', async () => {
+			const wrapper = mountRow( { subjectPageUrl: URL } );
+
+			await wrapper.find( OPEN ).trigger( 'click' );
+
+			expect( wrapper.emitted( 'toggle' ) ).toBeUndefined();
+		} );
+
+	} );
+
+	it( 'shows the drag handle only where the page offers reordering', () => {
+		const handle = '[title="neowiki-managesubjects-row-drag-handle"]';
+
+		expect( mountRow( { canEdit: true } ).find( handle ).exists() ).toBe( false );
+		expect( mountRow( { canEdit: true, showDragHandle: true } ).find( handle ).exists() ).toBe( true );
+	} );
+
+} );

--- a/resources/ext.neowiki/tests/components/SubjectsManager/SubjectsManagerPage.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectsManager/SubjectsManagerPage.spec.ts
@@ -301,7 +301,7 @@ describe( 'SubjectsManagerPage rows and the Subject pages behind them', () => {
 	it( 'links every row to that Subject\'s own page', async () => {
 		const wrapper = await mountPage();
 
-		expect( wrapper.findAll( '[aria-label="neowiki-managesubjects-row-open"]' )
+		expect( wrapper.findAll( 'a.ext-neowiki-subject-row__name' )
 			.map( ( link ) => link.attributes( 'href' ) ) )
 			.toEqual( [ '/wiki/Special:Subject/' + ID_A, '/wiki/Special:Subject/' + ID_B ] );
 	} );
@@ -553,10 +553,10 @@ describe( 'SubjectsManagerPage move action', () => {
 		expect( wrapper.findAll( '[aria-label="neowiki-managesubjects-row-move"]' ) ).toHaveLength( 2 );
 	} );
 
-	// Opening the Subject's page and copying a link change nothing, so they lead; edit and promote
-	// change the row in place; move and delete take the row out of the listing, with delete last.
-	// The main row's pin is its indicator, outside the strip.
-	it( 'orders each row\'s inline actions open, copy-link, edit, promote, move, delete', async () => {
+	// Copying a link changes nothing, so it leads; edit and promote change the row in place; move and
+	// delete take the row out of the listing, with delete last. The main row's pin is its indicator,
+	// outside the strip, and the Subject's own page is its name's link.
+	it( 'orders each row\'s inline actions copy-link, edit, promote, move, delete', async () => {
 		const wrapper = await mountPage();
 
 		const strips = wrapper.findAll( '.ext-neowiki-subject-row__actions' )
@@ -564,14 +564,12 @@ describe( 'SubjectsManagerPage move action', () => {
 
 		expect( strips ).toEqual( [
 			[
-				'neowiki-managesubjects-row-open',
 				'neowiki-managesubjects-row-copy-link',
 				'neowiki-managesubjects-row-edit',
 				'neowiki-managesubjects-row-move',
 				'neowiki-managesubjects-row-delete',
 			],
 			[
-				'neowiki-managesubjects-row-open',
 				'neowiki-managesubjects-row-copy-link',
 				'neowiki-managesubjects-row-edit',
 				'neowiki-managesubjects-row-promote',

--- a/resources/ext.neowiki/tests/components/SubjectsManager/SubjectsManagerPage.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectsManager/SubjectsManagerPage.spec.ts
@@ -4,7 +4,7 @@ import { createPinia, setActivePinia } from 'pinia';
 import { shallowMount, VueWrapper, flushPromises } from '@vue/test-utils';
 import { CdxMenuButton } from '@wikimedia/codex';
 import SubjectsManagerPage from '@/components/SubjectsManager/SubjectsManagerPage.vue';
-import { createI18nMock, setupMwMock } from '../../VueTestHelpers.ts';
+import { CdxDialogStub, createI18nMock, setupMwMock } from '../../VueTestHelpers.ts';
 import { NeoWikiExtension } from '@/NeoWikiExtension.ts';
 import { Subject } from '@/domain/Subject.ts';
 import { SubjectId } from '@/domain/SubjectId.ts';
@@ -33,6 +33,7 @@ function labellessSubject( id: string, displayName: string, generated: boolean )
 
 const loadPageSubjectsMock = vi.fn().mockResolvedValue( undefined );
 const deleteSubjectMock = vi.fn().mockResolvedValue( undefined );
+const setPageMainSubjectMock = vi.fn().mockResolvedValue( undefined );
 let storeSubjects: Subject[] = [];
 let mainSubjectId: SubjectId | null = null;
 
@@ -55,6 +56,7 @@ vi.mock( '@/stores/SubjectStore.ts', async ( importOriginal ) => {
 			return {
 				loadPageSubjects: loadPageSubjectsMock,
 				deleteSubject: deleteSubjectMock,
+				setPageMainSubject: setPageMainSubjectMock,
 				getSubject: ( id: SubjectId ) => storeSubjects.find( ( s ) => s.getId().text === id.text ),
 				openSubjectCreator: vi.fn(),
 				get pageSubjects() {
@@ -99,21 +101,12 @@ vi.mock( '@/composables/useSubjectDrag.ts', () => ( {
 	useSubjectDrag: vi.fn(),
 } ) );
 
-const HIGHLIGHT_CLASS = 'ext-neowiki-subjects-manager__row--highlighted';
-const EXPANDED_CLASS = 'ext-neowiki-subjects-manager__row--expanded';
+const HIGHLIGHT_CLASS = 'ext-neowiki-subject-row--highlighted';
+const EXPANDED_CLASS = 'ext-neowiki-subject-row--expanded';
 
 function rowFor( wrapper: VueWrapper, id: string ): VueWrapper {
 	return wrapper.find( '#' + subjectRowDomId( id ) ) as unknown as VueWrapper;
 }
-
-// shallowMount's auto-stubs do not render slots by default, but the delete-confirmation flow
-// lives in CdxDialog's #footer slot (the SummaryAction that emits 'save'); a template-carrying
-// stub keeps that slot content in the tree so the delete-flow tests can reach it.
-const CdxDialogStub = {
-	template: '<div v-if="open" class="cdx-dialog-stub"><slot /><slot name="footer" /></div>',
-	props: [ 'open', 'title', 'useCloseButton' ],
-	emits: [ 'update:open' ],
-};
 
 async function mountPage(): Promise<VueWrapper> {
 	setupMwMock( {
@@ -139,7 +132,9 @@ async function mountPage(): Promise<VueWrapper> {
 				[ Service.SubjectRepository ]: { getSubjectForEditing: getSubjectForEditingRepoMock },
 				[ Service.SchemaRepository ]: { getSchema: getSchemaRepoMock },
 			},
-			stubs: { CdxIcon: true, CdxDialog: CdxDialogStub },
+			// The row and the delete dialog are this page's own building blocks rather than collaborators
+			// to stand in for: the assertions below are about what they render and offer.
+			stubs: { CdxIcon: true, CdxDialog: CdxDialogStub, SubjectRow: false, SubjectDeleteDialog: false },
 		},
 	} );
 
@@ -271,7 +266,7 @@ describe( 'SubjectsManagerPage rows without a stored label', () => {
 	it( 'names the main row after the page and marks the child row as unnamed', async () => {
 		const wrapper = await mountPage();
 
-		const names = wrapper.findAll( '.ext-neowiki-subjects-manager__row-label' ).map( ( el ) => el.text() );
+		const names = wrapper.findAll( '.ext-neowiki-subject-row__label' ).map( ( el ) => el.text() );
 		expect( names ).toEqual( [ 'Host Page', '(unnamed Person)' ] );
 	} );
 
@@ -282,6 +277,40 @@ describe( 'SubjectsManagerPage rows without a stored label', () => {
 
 		expect( rowFor( wrapper, ID_A ).findComponent( SchemaNameDisplay ).props( 'schemaName' ) ).toBe( 'Person' );
 		expect( rowFor( wrapper, ID_B ).findComponent( SchemaNameDisplay ).exists() ).toBe( false );
+	} );
+
+} );
+
+describe( 'SubjectsManagerPage rows and the Subject pages behind them', () => {
+
+	beforeEach( () => {
+		storeSubjects = [ subject( ID_A ), subject( ID_B ) ];
+		mainSubjectId = new SubjectId( ID_A );
+		window.location.hash = '';
+		Element.prototype.scrollIntoView = vi.fn();
+		window.matchMedia = vi.fn().mockReturnValue( { matches: false } ) as unknown as typeof window.matchMedia;
+	} );
+
+	afterEach( () => {
+		document.body.innerHTML = '';
+		window.location.hash = '';
+		vi.restoreAllMocks();
+	} );
+
+	// The Data tab is the only place a reader can discover that a Subject has a page of its own.
+	it( 'links every row to that Subject\'s own page', async () => {
+		const wrapper = await mountPage();
+
+		expect( wrapper.findAll( '[aria-label="neowiki-managesubjects-row-open"]' )
+			.map( ( link ) => link.attributes( 'href' ) ) )
+			.toEqual( [ '/wiki/Special:Subject/' + ID_A, '/wiki/Special:Subject/' + ID_B ] );
+	} );
+
+	// Every row is on the page the reader already has open, so naming it in each footer says nothing.
+	it( 'names no page in any row\'s footer', async () => {
+		const wrapper = await mountPage();
+
+		expect( wrapper.find( '.ext-neowiki-subject-row__page' ).exists() ).toBe( false );
 	} );
 
 } );
@@ -310,7 +339,7 @@ describe( 'SubjectsManagerPage row copy-link action', () => {
 		vi.restoreAllMocks();
 	} );
 
-	it( 'offers copy-link in the overflow menu to a read-only user on both the main and other rows', async () => {
+	it( 'offers the ungated actions in the overflow menu to a read-only user on every row', async () => {
 		storeSubjects = [ subject( ID_A ), subject( ID_B ) ];
 		mainSubjectId = new SubjectId( ID_A );
 
@@ -321,7 +350,7 @@ describe( 'SubjectsManagerPage row copy-link action', () => {
 		// The read-only user has neither edit nor delete rights, so copy-link is the whole menu: it is
 		// the one row action that is not permission-gated, and it makes the otherwise-empty ⋯ menu useful.
 		for ( const menu of menus ) {
-			expect( menu.props( 'menuItems' ).map( ( item ) => item.value ) ).toEqual( [ 'copy-link' ] );
+			expect( menu.props( 'menuItems' ).map( ( item ) => item.value ) ).toEqual( [ 'open', 'copy-link' ] );
 		}
 	} );
 
@@ -446,6 +475,56 @@ describe( 'SubjectsManagerPage edit flow', () => {
 	} );
 } );
 
+describe( 'SubjectsManagerPage main subject controls', () => {
+
+	beforeEach( () => {
+		storeSubjects = [ subject( ID_A ), subject( ID_B ) ];
+		mainSubjectId = new SubjectId( ID_A );
+		canEditSubjectRef.value = true;
+		setPageMainSubjectMock.mockClear();
+		window.location.hash = '';
+		Element.prototype.scrollIntoView = vi.fn();
+		window.matchMedia = vi.fn().mockReturnValue( { matches: false } ) as unknown as typeof window.matchMedia;
+	} );
+
+	afterEach( () => {
+		document.body.innerHTML = '';
+		window.location.hash = '';
+		canEditSubjectRef.value = false;
+		vi.restoreAllMocks();
+	} );
+
+	// Which pin a row carries is the page's to decide, not the row's: only the main slot's row can be
+	// demoted, and only a row outside it can be promoted.
+	it( 'pins the main row for demotion and every other row for promotion', async () => {
+		const wrapper = await mountPage();
+
+		expect( rowFor( wrapper, ID_A ).find( '[aria-label="neowiki-managesubjects-row-demote"]' ).exists() ).toBe( true );
+		expect( rowFor( wrapper, ID_A ).find( '[aria-label="neowiki-managesubjects-row-promote"]' ).exists() ).toBe( false );
+		expect( rowFor( wrapper, ID_B ).find( '[aria-label="neowiki-managesubjects-row-demote"]' ).exists() ).toBe( false );
+		expect( rowFor( wrapper, ID_B ).find( '[aria-label="neowiki-managesubjects-row-promote"]' ).exists() ).toBe( true );
+	} );
+
+	it( 'clears the page\'s Main Subject from the main row\'s pin', async () => {
+		const wrapper = await mountPage();
+
+		await rowFor( wrapper, ID_A ).find( '[aria-label="neowiki-managesubjects-row-demote"]' ).trigger( 'click' );
+		await flushPromises();
+
+		expect( setPageMainSubjectMock ).toHaveBeenCalledWith( PAGE_ID, null );
+	} );
+
+	it( 'makes another row\'s Subject the page\'s Main Subject from its pin', async () => {
+		const wrapper = await mountPage();
+
+		await rowFor( wrapper, ID_B ).find( '[aria-label="neowiki-managesubjects-row-promote"]' ).trigger( 'click' );
+		await flushPromises();
+
+		expect( setPageMainSubjectMock ).toHaveBeenCalledWith( PAGE_ID, expect.objectContaining( { text: ID_B } ) );
+	} );
+
+} );
+
 describe( 'SubjectsManagerPage move action', () => {
 
 	beforeEach( () => {
@@ -474,23 +553,25 @@ describe( 'SubjectsManagerPage move action', () => {
 		expect( wrapper.findAll( '[aria-label="neowiki-managesubjects-row-move"]' ) ).toHaveLength( 2 );
 	} );
 
-	// Copy-link changes nothing, so it leads; edit and promote change the row in place; move and
-	// delete take the row out of the listing, with delete last. The main row's pin is its
-	// indicator, outside the strip.
-	it( 'orders each row\'s inline actions copy-link, edit, promote, move, delete', async () => {
+	// Opening the Subject's page and copying a link change nothing, so they lead; edit and promote
+	// change the row in place; move and delete take the row out of the listing, with delete last.
+	// The main row's pin is its indicator, outside the strip.
+	it( 'orders each row\'s inline actions open, copy-link, edit, promote, move, delete', async () => {
 		const wrapper = await mountPage();
 
-		const strips = wrapper.findAll( '.ext-neowiki-subjects-manager__row-actions' )
+		const strips = wrapper.findAll( '.ext-neowiki-subject-row__actions' )
 			.map( ( strip ) => strip.findAll( '[aria-label]' ).map( ( element ) => element.attributes( 'aria-label' ) ) );
 
 		expect( strips ).toEqual( [
 			[
+				'neowiki-managesubjects-row-open',
 				'neowiki-managesubjects-row-copy-link',
 				'neowiki-managesubjects-row-edit',
 				'neowiki-managesubjects-row-move',
 				'neowiki-managesubjects-row-delete',
 			],
 			[
+				'neowiki-managesubjects-row-open',
 				'neowiki-managesubjects-row-copy-link',
 				'neowiki-managesubjects-row-edit',
 				'neowiki-managesubjects-row-promote',
@@ -507,8 +588,8 @@ describe( 'SubjectsManagerPage move action', () => {
 			.map( ( menu ) => menu.props( 'menuItems' ).map( ( item ) => item.value ) );
 
 		expect( menus ).toEqual( [
-			[ 'copy-link', 'edit', 'move', 'delete' ],
-			[ 'copy-link', 'edit', 'promote', 'move', 'delete' ],
+			[ 'open', 'copy-link', 'edit', 'move', 'delete' ],
+			[ 'open', 'copy-link', 'edit', 'promote', 'move', 'delete' ],
 		] );
 	} );
 

--- a/resources/ext.neowiki/tests/composables/useSubjectDrag.spec.ts
+++ b/resources/ext.neowiki/tests/composables/useSubjectDrag.spec.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import { ref, Ref } from 'vue';
-import { enableAutoUnmount, mount } from '@vue/test-utils';
+import { enableAutoUnmount, mount, shallowMount } from '@vue/test-utils';
 import { useSubjectDrag, SubjectDragHandlers } from '@/composables/useSubjectDrag';
 import { subjectRowDomId } from '@/presentation/subjectRowAnchor';
+import SubjectRow from '@/components/SubjectsManager/SubjectRow.vue';
+import { createI18nMock, setupMwMock } from '../VueTestHelpers.ts';
+import { newSubject } from '@/TestHelpers.ts';
 
 interface UseSortableCall {
 	containerRef: Ref<HTMLElement | null>;
@@ -122,6 +125,28 @@ describe( 'useSubjectDrag', () => {
 		findCallByContainer( mainSlot ).options.onDropIn( dragged, 0, 0 );
 
 		expect( handlers.onPromote ).not.toHaveBeenCalled();
+	} );
+
+	// The selectors are strings here and class names there, so nothing but a test relates them: a
+	// rename of the row's BEM block leaves dragging silently impossible.
+	it( 'drags by the handle and ghosts the block that SubjectRow renders', () => {
+		setupMwMock( { functions: [ 'config', 'msg', 'message', 'notify', 'util' ] } );
+		const row = shallowMount( SubjectRow, {
+			props: {
+				subject: newSubject( { id: VALID_ID } ),
+				expanded: false,
+				showDragHandle: true,
+			},
+			global: { mocks: { $i18n: createI18nMock() }, stubs: { CdxIcon: true } },
+		} ).element as HTMLElement;
+
+		mountComposable( document.createElement( 'ul' ), document.createElement( 'ul' ), newHandlers() );
+		const { handle, ghostClass } = useSortableCalls[ 0 ].options;
+
+		expect( row.querySelector( handle ) ).not.toBeNull();
+		// SortableJS puts the ghost class on the dragged row itself, where it only styles anything as a
+		// modifier of the block that row carries.
+		expect( [ ...row.classList ] ).toContain( ghostClass.replace( /--[a-z]+$/, '' ) );
 	} );
 
 	it( 'does not call onPromote when the prefix matches but the body is not a valid subject id', () => {

--- a/resources/ext.neowiki/tests/persistence/RestSubjectRepository.neo4j.spec.ts
+++ b/resources/ext.neowiki/tests/persistence/RestSubjectRepository.neo4j.spec.ts
@@ -14,6 +14,7 @@ import { NeoWikiExtension } from '@/NeoWikiExtension';
 import { SubjectWithContext } from '@/domain/SubjectWithContext.ts';
 import { ValidationFailedError } from '@/persistence/ValidationFailedError';
 import { SubjectIdInUseError } from '@/persistence/SubjectIdInUseError';
+import { SubjectNotFoundError } from '@/persistence/SubjectNotFoundError';
 import { SchemaDeserializer } from '@/persistence/SchemaDeserializer';
 
 function newRepository( apiUrl: string, httpClient: InMemoryHttpClient ): RestSubjectRepository {
@@ -115,17 +116,21 @@ describe( 'RestSubjectRepository', () => {
 			expect( subject.getLabel() ).toEqual( 'John Doe' );
 		} );
 
-		it( 'throws an error when getSubject is called with a missing subject', async () => {
+		// A Subject the wiki has none of, and one on a page the reader may not read, both answer 200
+		// with no Subject in the body. The caller may not tell them apart (#1046), so there is one error.
+		it( 'reports a Subject the response carries none of as not found', async () => {
 			const ID = 's22222222222222';
 			const url = `https://example.com/rest.php/neowiki/v0/subject/${ ID }?expand=page|relations`;
 			const inMemoryHttpClient = new InMemoryHttpClient( {
-				url: new Response( JSON.stringify( {} ), { status: 200 } ),
+				[ url ]: new Response( JSON.stringify( { subject: null } ), { status: 200 } ),
 			} );
 
 			const repository = newRepository( 'https://example.com/rest.php', inMemoryHttpClient );
 
-			await expect( repository.getSubject( new SubjectId( ID ) ) )
-				.rejects.toThrow( 'No response found for URL: ' + url );
+			const error = await repository.getSubject( new SubjectId( ID ) ).catch( ( rejection ) => rejection );
+
+			expect( error ).toBeInstanceOf( SubjectNotFoundError );
+			expect( error.subjectId ).toBe( ID );
 		} );
 
 	} );
@@ -297,7 +302,19 @@ describe( 'RestSubjectRepository', () => {
 			const repository = repositoryReturning( {} );
 
 			await expect( repository.getSubjectWithReferencedSubjects( new SubjectId( requestedId ) ) )
-				.rejects.toThrow( 'Subject not found' );
+				.rejects.toThrow( SubjectNotFoundError );
+		} );
+
+		// A bundle that names a requested id it does not carry would otherwise be deserialized as
+		// undefined, which reads as a malformed Subject rather than as one the wiki does not serve.
+		it( 'throws when the response carries Subjects but not the requested one', async () => {
+			const repository = repositoryReturning( {
+				requestedId: requestedId,
+				subjects: { [ referencedId1 ]: bundleResponse.subjects[ referencedId1 ] },
+			} );
+
+			await expect( repository.getSubjectWithReferencedSubjects( new SubjectId( requestedId ) ) )
+				.rejects.toThrow( SubjectNotFoundError );
 		} );
 
 		function subjectWithUnregisteredPropertyType( id: string ): object {

--- a/resources/ext.neowiki/tests/presentation/subjectIri.spec.ts
+++ b/resources/ext.neowiki/tests/presentation/subjectIri.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { subjectIri } from '@/presentation/subjectIri.ts';
+import { setupMwMock } from '../VueTestHelpers.ts';
+
+const IRI_BASE = 'https://data.example.org/entity/';
+const LOCAL_ID = 's1aaaaaaaaaaaa1';
+
+function setIriBase( base: string | null ): void {
+	setupMwMock( { functions: [ 'config' ], config: { wgNeoWikiSubjectIriBase: base } } );
+}
+
+describe( 'subjectIri', () => {
+
+	it( 'names a local Subject under the wiki\'s own base', () => {
+		setIriBase( IRI_BASE );
+
+		expect( subjectIri( LOCAL_ID ) ).toBe( IRI_BASE + LOCAL_ID );
+	} );
+
+	// A Subject of another Source is named under that Source's base, which this wiki does not hold:
+	// minting one here would assert ownership of an entity elsewhere.
+	it( 'names no Subject of another Source', () => {
+		setIriBase( IRI_BASE );
+
+		expect( subjectIri( 'other:' + LOCAL_ID ) ).toBe( '' );
+	} );
+
+	it( 'names nothing that is not a Subject id', () => {
+		setIriBase( IRI_BASE );
+
+		expect( subjectIri( 'Not an id' ) ).toBe( '' );
+	} );
+
+	// The wiki serves the base as a configuration variable; a page that never received it derives a
+	// relative IRI rather than concatenating "null".
+	it( 'falls back to the bare id when the wiki served no base', () => {
+		setIriBase( null );
+
+		expect( subjectIri( LOCAL_ID ) ).toBe( LOCAL_ID );
+	} );
+
+} );

--- a/src/Application/WikiConfig/ConfigExample.php
+++ b/src/Application/WikiConfig/ConfigExample.php
@@ -14,7 +14,7 @@ class ConfigExample {
 
 	public const string JSON = <<<'JSON'
 		{
-			"dereferenceSubjectsToDataTab": true,
+			"dereferenceSubjectsToHostingPage": false,
 			"autoRenderMainSubject": true
 		}
 		JSON;

--- a/src/Application/WikiConfig/ConfigSchema.php
+++ b/src/Application/WikiConfig/ConfigSchema.php
@@ -21,8 +21,8 @@ class ConfigSchema {
 	public function __construct() {
 		$this->settings = [
 			new ConfigSetting(
-				pageKey: 'dereferenceSubjectsToDataTab',
-				settingName: 'NeoWikiDereferenceSubjectsToDataTab',
+				pageKey: 'dereferenceSubjectsToHostingPage',
+				settingName: 'NeoWikiDereferenceSubjectsToHostingPage',
 			),
 			new ConfigSetting(
 				pageKey: 'autoRenderMainSubject',

--- a/src/EntryPoints/Actions/SubjectsAction.php
+++ b/src/EntryPoints/Actions/SubjectsAction.php
@@ -49,16 +49,8 @@ class SubjectsAction extends FormlessAction {
 		$extension->newFrontendModuleLoader()->load( $out, $this->getSkin() );
 
 		$out->addJsConfigVars( [
+			...$extension->getSubjectUiJsConfigVars( $this->getAuthority() ),
 			'wgNeoWikiManageSubjectsPageId' => $title->getArticleID(),
-			// The export UI (Data tab menus) is driven by this list. Filtered by the viewing user's
-			// read authority so restricted Mapping page titles never reach a reader who cannot see them.
-			'wgNeoWikiRdfProjections' => $extension->filterReadableProjectionNames(
-				$extension->getRdfProjectionNames(),
-				$this->getAuthority()
-			),
-			// The copy-IRI control appends the Subject id to this base to show the full neo-subj:
-			// concept URI, deriving it from the same server-side rule the RDF export mints IRIs with.
-			'wgNeoWikiSubjectIriBase' => $extension->getRdfNamespaces()->subjectIriBase(),
 		] );
 
 		return Html::element( 'div', [ 'id' => 'ext-neowiki-manage-subjects' ] );

--- a/src/EntryPoints/REST/ResolveSubjectIriApi.php
+++ b/src/EntryPoints/REST/ResolveSubjectIriApi.php
@@ -7,9 +7,9 @@ namespace ProfessionalWiki\NeoWiki\EntryPoints\REST;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Rest\Response;
 use MediaWiki\Rest\SimpleHandler;
-use MediaWiki\Title\Title;
+use MediaWiki\SpecialPage\SpecialPage;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageIdentifiers;
-use ProfessionalWiki\NeoWiki\EntryPoints\Actions\SubjectsAction;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use Wikimedia\ParamValidator\ParamValidator;
 
@@ -21,8 +21,8 @@ use Wikimedia\ParamValidator\ParamValidator;
  *   - `Accept` includes `application/trig` → the Subject's TriG RDF export.
  *   - else `Accept` includes `text/turtle` → the Subject's Turtle RDF export (TriG wins a tie, matching
  *     {@see RdfFormatNegotiation}).
- *   - else (a browser's `text/html`, `*&#47;*`, an absent or unrecognized `Accept`) → the hosting page's
- *     Data tab row by default, or the plain page when `$wgNeoWikiDereferenceSubjectsToDataTab` is disabled.
+ *   - else (a browser's `text/html`, `*&#47;*`, an absent or unrecognized `Accept`) → `Special:Subject` for
+ *     that Subject, or the page it is stored on when `$wgNeoWikiDereferenceSubjectsToHostingPage` is set.
  *
  * The RDF branches target the native projection: selecting an ontology target or a specific
  * serialization stays on the per-Subject RDF endpoint, keeping this concept-URI surface Accept-only.
@@ -57,15 +57,21 @@ class ResolveSubjectIriApi extends SimpleHandler {
 		$rdfFormat = $this->negotiatedRdfFormat();
 
 		if ( $rdfFormat !== null ) {
-			return $this->negotiatedRedirect( $this->subjectRdfUrl( $subjectId, $rdfFormat ) );
+			return $this->negotiatedRedirect( $this->subjectRdfUrl( $id->text, $rdfFormat ) );
 		}
 
-		return $this->hostingPageRedirect( $subjectId, $hostingPage );
+		$htmlUrl = $this->htmlUrl( $id, $hostingPage );
+
+		if ( $htmlUrl === null ) {
+			return $this->noDataResponse( $subjectId );
+		}
+
+		return $this->negotiatedRedirect( $htmlUrl );
 	}
 
 	/**
 	 * The RDF serialization the Accept header asks for, or null when it does not ask for RDF (so the
-	 * dereference lands on the hosting page).
+	 * dereference lands on an HTML view).
 	 */
 	private function negotiatedRdfFormat(): ?string {
 		$accept = $this->getRequest()->getHeaderLine( 'Accept' );
@@ -90,16 +96,20 @@ class ResolveSubjectIriApi extends SimpleHandler {
 		);
 	}
 
-	private function hostingPageRedirect( string $subjectId, PageIdentifiers $hostingPage ): Response {
-		$title = MediaWikiServices::getInstance()->getTitleFactory()->newFromID( $hostingPage->getId()->id );
-
-		// The resolver already authorized this page, so it resolves here; a null only means the page was
-		// deleted within this same request, which takes the same not-found as any other unservable Subject.
-		if ( $title === null ) {
-			return $this->noDataResponse( $subjectId );
+	/**
+	 * The Subject's own view, or the page it is stored on when the wiki asks for that. The hosting page
+	 * is authorized either way: it is what the resolver above gated on.
+	 *
+	 * The resolver already authorized that page, so it resolves here; a null only means it was deleted
+	 * within this same request, which takes the same not-found as any other unservable Subject.
+	 */
+	private function htmlUrl( SubjectId $id, PageIdentifiers $hostingPage ): ?string {
+		if ( !$this->dereferenceToHostingPage() ) {
+			return SpecialPage::getTitleFor( 'Subject', $id->text )->getCanonicalURL();
 		}
 
-		return $this->negotiatedRedirect( $this->hostingPageUrl( $title, $subjectId ) );
+		return MediaWikiServices::getInstance()->getTitleFactory()
+			->newFromID( $hostingPage->getId()->id )?->getCanonicalURL();
 	}
 
 	/**
@@ -113,20 +123,10 @@ class ResolveSubjectIriApi extends SimpleHandler {
 		return $response;
 	}
 
-	private function hostingPageUrl( Title $title, string $subjectId ): string {
-		if ( $this->dataTabDereference() ) {
-			// The Data tab reads this fragment on mount to expand, scroll to, and highlight the row. The
-			// fragment is the bare Subject id (like Wikibase's `#P123`), not the row's internal DOM id.
-			return $title->getCanonicalURL( [ 'action' => SubjectsAction::ACTION_NAME ] ) . '#' . $subjectId;
-		}
-
-		return $title->getCanonicalURL();
-	}
-
-	private function dataTabDereference(): bool {
-		// The effective flag combines the MediaWiki:NeoWiki page with $wgNeoWikiDereferenceSubjectsToDataTab
+	private function dereferenceToHostingPage(): bool {
+		// The effective flag combines the MediaWiki:NeoWiki page with $wgNeoWikiDereferenceSubjectsToHostingPage
 		// (the page wins when it sets a valid boolean; an invalid page value has already fallen back).
-		return NeoWikiExtension::getInstance()->dereferenceSubjectsToDataTab();
+		return NeoWikiExtension::getInstance()->dereferenceSubjectsToHostingPage();
 	}
 
 	private function noDataResponse( string $subjectId ): Response {

--- a/src/EntryPoints/SpecialPages/SpecialSubject.php
+++ b/src/EntryPoints/SpecialPages/SpecialSubject.php
@@ -1,0 +1,92 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\EntryPoints\SpecialPages;
+
+use MediaWiki\Html\Html;
+use MediaWiki\Language\RawMessage;
+use MediaWiki\Message\Message;
+use MediaWiki\SpecialPage\SpecialPage;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectId;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+use ProfessionalWiki\NeoWiki\Presentation\SubjectNamePresenter;
+
+class SpecialSubject extends SpecialPage {
+
+	public function __construct() {
+		parent::__construct( 'Subject' );
+	}
+
+	/**
+	 * @param ?string $subPage
+	 */
+	public function execute( $subPage ): void {
+		parent::execute( $subPage );
+
+		$out = $this->getOutput();
+		$extension = NeoWikiExtension::getInstance();
+		$subjectId = $extension->getSubjectIdParser()->parse( $subPage ?? '' );
+
+		if ( $subjectId === null ) {
+			$out->addHTML(
+				Html::errorBox( $this->msg( 'neowiki-special-subject-invalid-id' )->escaped() )
+			);
+			return;
+		}
+
+		$name = $this->subjectName( $extension, $subjectId );
+
+		if ( $name !== null ) {
+			$out->setPageTitleMsg( $name );
+		}
+
+		// What the body shows is decided by the read the frontend makes, on the same terms as the read
+		// behind the title: a Subject that does not exist and one on a page this user may not read
+		// answer alike (#1046).
+		$extension->newFrontendModuleLoader()->load( $out, $this->getSkin() );
+		$out->addJsConfigVars( $extension->getSubjectUiJsConfigVars( $this->getAuthority() ) );
+
+		$out->addHTML( Html::element( 'div', [
+			'id' => 'ext-neowiki-subject',
+			'data-mw-neowiki-subject-id' => $subjectId->text,
+		] ) );
+	}
+
+	/**
+	 * The Subject's own name, for the H1 and with it the browser tab, a bookmark and a history entry:
+	 * this page is where a concept URI leads, so those should name the thing rather than the page
+	 * showing it. Null leaves the page's description standing, which is what a Subject this wiki does
+	 * not hold gets — and, indistinguishably, one on a page the reader may not read (#1046).
+	 */
+	private function subjectName( NeoWikiExtension $extension, SubjectId $subjectId ): ?Message {
+		$presenter = new SubjectNamePresenter();
+
+		$extension->newGetSubjectQuery( $presenter, $this->getAuthority() )->execute(
+			subjectId: $subjectId->text,
+			includePageIdentifiers: false,
+			includeReferencedSubjects: false
+		);
+
+		$displayName = $presenter->getDisplayName();
+
+		if ( $displayName === null ) {
+			return null;
+		}
+
+		if ( $presenter->displayNameIsGenerated() ) {
+			return $this->msg( 'neowiki-subject-generated-name' )->plaintextParams( $displayName );
+		}
+
+		return ( new RawMessage( '$1' ) )->plaintextParams( $displayName );
+	}
+
+	public function getGroupName(): string {
+		return 'neowiki';
+	}
+
+	public function getDescription(): Message {
+		return $this->msg( 'neowiki-special-subject' );
+	}
+
+}

--- a/src/NeoWikiExtension.php
+++ b/src/NeoWikiExtension.php
@@ -50,6 +50,7 @@ use ProfessionalWiki\NeoWiki\Application\Queries\GetLayout\GetLayoutPresenter;
 use ProfessionalWiki\NeoWiki\Application\Queries\GetLayout\GetLayoutQuery;
 use ProfessionalWiki\NeoWiki\Application\Queries\GetPageSubjects\GetPageSubjectsPresenter;
 use ProfessionalWiki\NeoWiki\Application\Queries\GetPageSubjects\GetPageSubjectsQuery;
+use ProfessionalWiki\NeoWiki\Application\Queries\GetSubject\GetSubjectPresenter;
 use ProfessionalWiki\NeoWiki\Application\Queries\GetSubject\GetSubjectQuery;
 use ProfessionalWiki\NeoWiki\Application\Queries\ValidateSubject\ValidateSubjectQuery;
 use ProfessionalWiki\NeoWiki\Application\Queries\ValidateSubjectUpdate\ValidateSubjectUpdateQuery;
@@ -203,7 +204,6 @@ use ProfessionalWiki\NeoWiki\Persistence\MediaWiki\DatabaseLayoutNameLookup;
 use ProfessionalWiki\NeoWiki\Presentation\ConfigDocumentationBuilder;
 use ProfessionalWiki\NeoWiki\Presentation\CsrfValidator;
 use ProfessionalWiki\NeoWiki\Presentation\FrontendModuleLoader;
-use ProfessionalWiki\NeoWiki\Presentation\RestGetSubjectPresenter;
 use ProfessionalWiki\NeoWiki\Presentation\ViewHtmlBuilder;
 use ProfessionalWiki\NeoWiki\Presentation\SchemaPresentationSerializer;
 use ProfessionalWiki\NeoWiki\Presentation\LayoutPresentationSerializer;
@@ -727,6 +727,26 @@ class NeoWikiExtension {
 	}
 
 	/**
+	 * The configuration the Subject UI reads wherever it is mounted — the Data tab's action and
+	 * Special:Subject alike — so a row offers the same export menu and concept URI on both.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function getSubjectUiJsConfigVars( Authority $authority ): array {
+		return [
+			// Drives the export menus. Filtered by the viewing user's read authority so restricted
+			// Mapping page titles never reach a reader who cannot see them.
+			'wgNeoWikiRdfProjections' => $this->filterReadableProjectionNames(
+				$this->getRdfProjectionNames(),
+				$authority
+			),
+			// The copy-IRI control appends the Subject id to this base to show the full neo-subj:
+			// concept URI, deriving it from the same server-side rule the RDF export mints IRIs with.
+			'wgNeoWikiSubjectIriBase' => $this->getRdfNamespaces()->subjectIriBase(),
+		];
+	}
+
+	/**
 	 * The native prefixes (Subject IRIs stay native) plus the Mapping's declared ontology prefixes, for
 	 * readable output. Both the label and the namespace of each prefix are dropped defensively when unsafe,
 	 * so a Mapping can never inject a `@prefix` declaration (or a triple broken out of one) into the
@@ -1081,12 +1101,12 @@ class NeoWikiExtension {
 	}
 
 	/**
-	 * Whether a browser dereferencing a Subject concept URI is sent to the hosting page's Data tab,
-	 * combining the on-wiki configuration page with $wgNeoWikiDereferenceSubjectsToDataTab (the page wins
-	 * when it sets a valid boolean).
+	 * Whether a browser dereferencing a Subject concept URI is sent to the plain hosting page rather
+	 * than to Special:Subject, combining the on-wiki configuration page with
+	 * $wgNeoWikiDereferenceSubjectsToHostingPage (the page wins when it sets a valid boolean).
 	 */
-	public function dereferenceSubjectsToDataTab(): bool {
-		return $this->getWikiConfigLookup()->getEffectiveValue( 'dereferenceSubjectsToDataTab' ) === true;
+	public function dereferenceSubjectsToHostingPage(): bool {
+		return $this->getWikiConfigLookup()->getEffectiveValue( 'dereferenceSubjectsToHostingPage' ) === true;
 	}
 
 	/**
@@ -1662,7 +1682,7 @@ class NeoWikiExtension {
 		);
 	}
 
-	public function newGetSubjectQuery( RestGetSubjectPresenter $presenter, Authority $authority ): GetSubjectQuery {
+	public function newGetSubjectQuery( GetSubjectPresenter $presenter, Authority $authority ): GetSubjectQuery {
 		return new GetSubjectQuery(
 			presenter: $presenter,
 			subjectLookup: $this->getSourceRoutingSubjectLookup( new PublishedSubjectLookup(
@@ -1677,7 +1697,7 @@ class NeoWikiExtension {
 		);
 	}
 
-	public function newGetSubjectQueryForRevision( RestGetSubjectPresenter $presenter, RevisionRecord $revision, Authority $authority ): GetSubjectQuery {
+	public function newGetSubjectQueryForRevision( GetSubjectPresenter $presenter, RevisionRecord $revision, Authority $authority ): GetSubjectQuery {
 		return new GetSubjectQuery(
 			presenter: $presenter,
 			subjectLookup: new PointInTimeSubjectLookup(

--- a/src/Presentation/SubjectNamePresenter.php
+++ b/src/Presentation/SubjectNamePresenter.php
@@ -1,0 +1,44 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Presentation;
+
+use ProfessionalWiki\NeoWiki\Application\Queries\GetSubject\GetSubjectPresenter;
+use ProfessionalWiki\NeoWiki\Application\Queries\GetSubject\GetSubjectResponse;
+use ProfessionalWiki\NeoWiki\Application\Queries\GetSubject\GetSubjectResponseItem;
+
+/**
+ * Keeps the name of the Subject a {@see \ProfessionalWiki\NeoWiki\Application\Queries\GetSubject\GetSubjectQuery}
+ * was asked for, for a caller that wants to name it and nothing more. Both answers come from the one
+ * captured Subject, so they cannot disagree.
+ */
+class SubjectNamePresenter implements GetSubjectPresenter {
+
+	private ?GetSubjectResponseItem $requestedSubject = null;
+
+	public function presentSubject( GetSubjectResponse $response ): void {
+		$this->requestedSubject = $response->subjects[$response->requestedId] ?? null;
+	}
+
+	public function presentSubjectNotFound(): void {
+		$this->requestedSubject = null;
+	}
+
+	/**
+	 * The name to show, or null when the query served no Subject — because the wiki holds none with
+	 * that id, or because it is on a page the caller may not read (#1046).
+	 */
+	public function getDisplayName(): ?string {
+		return $this->requestedSubject?->displayName;
+	}
+
+	/**
+	 * Whether that name is the Schema-derived stand-in rather than one somebody chose, which every
+	 * surface marks as such.
+	 */
+	public function displayNameIsGenerated(): bool {
+		return $this->requestedSubject?->displayNameIsGenerated ?? false;
+	}
+
+}

--- a/tests/phpunit/Application/WikiConfig/ConfigSchemaTest.php
+++ b/tests/phpunit/Application/WikiConfig/ConfigSchemaTest.php
@@ -14,10 +14,10 @@ use ProfessionalWiki\NeoWiki\Application\WikiConfig\ConfigSchema;
 class ConfigSchemaTest extends TestCase {
 
 	public function testExposesTheDereferenceSetting(): void {
-		$setting = ( new ConfigSchema() )->getSetting( 'dereferenceSubjectsToDataTab' );
+		$setting = ( new ConfigSchema() )->getSetting( 'dereferenceSubjectsToHostingPage' );
 
 		$this->assertNotNull( $setting );
-		$this->assertSame( 'NeoWikiDereferenceSubjectsToDataTab', $setting->settingName );
+		$this->assertSame( 'NeoWikiDereferenceSubjectsToHostingPage', $setting->settingName );
 	}
 
 	public function testExposesTheAutoRenderSetting(): void {
@@ -33,7 +33,7 @@ class ConfigSchemaTest extends TestCase {
 			( new ConfigSchema() )->getSettings()
 		);
 
-		$this->assertSame( [ 'dereferenceSubjectsToDataTab', 'autoRenderMainSubject' ], $keys );
+		$this->assertSame( [ 'dereferenceSubjectsToHostingPage', 'autoRenderMainSubject' ], $keys );
 	}
 
 	public function testUnknownKeyHasNoSetting(): void {
@@ -41,7 +41,7 @@ class ConfigSchemaTest extends TestCase {
 	}
 
 	public function testSettingAcceptsOnlyRealBooleans(): void {
-		$setting = ( new ConfigSchema() )->getSetting( 'dereferenceSubjectsToDataTab' );
+		$setting = ( new ConfigSchema() )->getSetting( 'dereferenceSubjectsToHostingPage' );
 
 		$this->assertTrue( $setting->isValidValue( true ) );
 		$this->assertTrue( $setting->isValidValue( false ) );
@@ -51,11 +51,11 @@ class ConfigSchemaTest extends TestCase {
 	}
 
 	public function testSettingDescribesItselfAsBoolean(): void {
-		$setting = ( new ConfigSchema() )->getSetting( 'dereferenceSubjectsToDataTab' );
+		$setting = ( new ConfigSchema() )->getSetting( 'dereferenceSubjectsToHostingPage' );
 
 		$this->assertSame( [ 'neowiki-config-type-boolean' ], $setting->describe() );
 		$this->assertSame(
-			[ 'neowiki-config-error-invalid-boolean', 'dereferenceSubjectsToDataTab' ],
+			[ 'neowiki-config-error-invalid-boolean', 'dereferenceSubjectsToHostingPage' ],
 			$setting->invalidValueError()
 		);
 	}

--- a/tests/phpunit/Application/WikiConfig/ConfigValidatorTest.php
+++ b/tests/phpunit/Application/WikiConfig/ConfigValidatorTest.php
@@ -27,7 +27,7 @@ class ConfigValidatorTest extends TestCase {
 	public function testBothSettingsPopulatedIsValid(): void {
 		$this->assertSame(
 			[],
-			$this->validate( '{ "dereferenceSubjectsToDataTab": true, "autoRenderMainSubject": false }' )
+			$this->validate( '{ "dereferenceSubjectsToHostingPage": true, "autoRenderMainSubject": false }' )
 		);
 	}
 
@@ -63,8 +63,8 @@ class ConfigValidatorTest extends TestCase {
 
 	public function testWrongTypeForDereferenceSettingIsRejected(): void {
 		$this->assertSame(
-			[ [ 'neowiki-config-error-invalid-boolean', 'dereferenceSubjectsToDataTab' ] ],
-			$this->validate( '{ "dereferenceSubjectsToDataTab": "yes" }' )
+			[ [ 'neowiki-config-error-invalid-boolean', 'dereferenceSubjectsToHostingPage' ] ],
+			$this->validate( '{ "dereferenceSubjectsToHostingPage": "yes" }' )
 		);
 	}
 
@@ -72,9 +72,9 @@ class ConfigValidatorTest extends TestCase {
 		$this->assertEqualsCanonicalizing(
 			[
 				[ ConfigValidator::ERROR_UNKNOWN_KEY, 'nope' ],
-				[ 'neowiki-config-error-invalid-boolean', 'dereferenceSubjectsToDataTab' ],
+				[ 'neowiki-config-error-invalid-boolean', 'dereferenceSubjectsToHostingPage' ],
 			],
-			$this->validate( '{ "nope": 1, "dereferenceSubjectsToDataTab": "x" }' )
+			$this->validate( '{ "nope": 1, "dereferenceSubjectsToHostingPage": "x" }' )
 		);
 	}
 

--- a/tests/phpunit/Application/WikiConfig/WikiConfigLookupTest.php
+++ b/tests/phpunit/Application/WikiConfig/WikiConfigLookupTest.php
@@ -17,7 +17,7 @@ use ProfessionalWiki\NeoWiki\Tests\TestDoubles\StubWikiConfigSource;
 class WikiConfigLookupTest extends TestCase {
 
 	private const PHP_CONFIG = [
-		'NeoWikiDereferenceSubjectsToDataTab' => false,
+		'NeoWikiDereferenceSubjectsToHostingPage' => false,
 		'NeoWikiAutoRenderMainSubject' => true,
 	];
 
@@ -36,19 +36,19 @@ class WikiConfigLookupTest extends TestCase {
 	}
 
 	public function testUsesThePhpValueWhenThereIsNoConfigPage(): void {
-		$this->assertFalse( $this->newLookup( null )->getEffectiveValue( 'dereferenceSubjectsToDataTab' ) );
+		$this->assertFalse( $this->newLookup( null )->getEffectiveValue( 'dereferenceSubjectsToHostingPage' ) );
 	}
 
 	public function testUsesThePhpValueWhenTheKeyIsAbsentFromThePage(): void {
 		$lookup = $this->newLookup( [ 'autoRenderMainSubject' => false ] );
 
-		$this->assertFalse( $lookup->getEffectiveValue( 'dereferenceSubjectsToDataTab' ) );
+		$this->assertFalse( $lookup->getEffectiveValue( 'dereferenceSubjectsToHostingPage' ) );
 	}
 
 	public function testAValidPageValueWinsOverThePhpValue(): void {
-		$lookup = $this->newLookup( [ 'dereferenceSubjectsToDataTab' => true ] );
+		$lookup = $this->newLookup( [ 'dereferenceSubjectsToHostingPage' => true ] );
 
-		$this->assertTrue( $lookup->getEffectiveValue( 'dereferenceSubjectsToDataTab' ) );
+		$this->assertTrue( $lookup->getEffectiveValue( 'dereferenceSubjectsToHostingPage' ) );
 	}
 
 	public function testEachSettingIsResolvedIndependently(): void {
@@ -58,16 +58,16 @@ class WikiConfigLookupTest extends TestCase {
 	}
 
 	public function testAnInvalidPageValueFallsBackToThePhpValue(): void {
-		$lookup = $this->newLookup( [ 'dereferenceSubjectsToDataTab' => 'yes' ] );
+		$lookup = $this->newLookup( [ 'dereferenceSubjectsToHostingPage' => 'yes' ] );
 
-		$this->assertFalse( $lookup->getEffectiveValue( 'dereferenceSubjectsToDataTab' ) );
+		$this->assertFalse( $lookup->getEffectiveValue( 'dereferenceSubjectsToHostingPage' ) );
 	}
 
 	public function testAnInvalidPageValueLogsAWarning(): void {
 		$logger = new TestLogger();
 
-		$this->newLookup( [ 'dereferenceSubjectsToDataTab' => 'yes' ], logger: $logger )
-			->getEffectiveValue( 'dereferenceSubjectsToDataTab' );
+		$this->newLookup( [ 'dereferenceSubjectsToHostingPage' => 'yes' ], logger: $logger )
+			->getEffectiveValue( 'dereferenceSubjectsToHostingPage' );
 
 		$this->assertTrue( $logger->hasWarningRecords() );
 	}
@@ -75,22 +75,22 @@ class WikiConfigLookupTest extends TestCase {
 	public function testUnknownPageKeysAreToleratedOnRead(): void {
 		$logger = new TestLogger();
 		$lookup = $this->newLookup(
-			[ 'dereferenceSubjectsToDataTab' => true, 'someFutureKey' => 'whatever' ],
+			[ 'dereferenceSubjectsToHostingPage' => true, 'someFutureKey' => 'whatever' ],
 			logger: $logger
 		);
 
-		$this->assertTrue( $lookup->getEffectiveValue( 'dereferenceSubjectsToDataTab' ) );
+		$this->assertTrue( $lookup->getEffectiveValue( 'dereferenceSubjectsToHostingPage' ) );
 		$this->assertFalse( $logger->hasWarningRecords() );
 	}
 
 	public function testThePageIsIgnoredWhenInWikiConfigIsDisabled(): void {
-		$lookup = $this->newLookup( [ 'dereferenceSubjectsToDataTab' => true ], enabled: false );
+		$lookup = $this->newLookup( [ 'dereferenceSubjectsToHostingPage' => true ], enabled: false );
 
-		$this->assertFalse( $lookup->getEffectiveValue( 'dereferenceSubjectsToDataTab' ) );
+		$this->assertFalse( $lookup->getEffectiveValue( 'dereferenceSubjectsToHostingPage' ) );
 	}
 
 	public function testTheConfigPageIsReadAtMostOncePerLookup(): void {
-		$source = new StubWikiConfigSource( [ 'dereferenceSubjectsToDataTab' => true ] );
+		$source = new StubWikiConfigSource( [ 'dereferenceSubjectsToHostingPage' => true ] );
 		$lookup = new WikiConfigLookup(
 			new ConfigSchema(),
 			$source,
@@ -99,7 +99,7 @@ class WikiConfigLookupTest extends TestCase {
 			new TestLogger()
 		);
 
-		$lookup->getEffectiveValue( 'dereferenceSubjectsToDataTab' );
+		$lookup->getEffectiveValue( 'dereferenceSubjectsToHostingPage' );
 		$lookup->getEffectiveValue( 'autoRenderMainSubject' );
 
 		$this->assertSame( 1, $source->readCount );

--- a/tests/phpunit/EntryPoints/ConfigPageFramingHooksTest.php
+++ b/tests/phpunit/EntryPoints/ConfigPageFramingHooksTest.php
@@ -51,7 +51,7 @@ class ConfigPageFramingHooksTest extends MediaWikiIntegrationTestCase {
 
 		$this->assertTrue( $editPage->suppressIntro );
 		$this->assertStringContainsString( 'neowiki.ai', $editPage->editFormTextTop );
-		$this->assertStringContainsString( '$wgNeoWikiDereferenceSubjectsToDataTab', $editPage->editFormTextBottom );
+		$this->assertStringContainsString( '$wgNeoWikiDereferenceSubjectsToHostingPage', $editPage->editFormTextBottom );
 	}
 
 	public function testOtherMediaWikiPageEditIsNotFramed(): void {
@@ -92,7 +92,7 @@ class ConfigPageFramingHooksTest extends MediaWikiIntegrationTestCase {
 		$this->assertStringNotContainsString( 'Default intro', $html );
 		$this->assertStringContainsString( '<table class="mw-json"', $html );
 		$this->assertStringContainsString( 'neowiki.ai', $html );
-		$this->assertStringContainsString( '$wgNeoWikiDereferenceSubjectsToDataTab', $html );
+		$this->assertStringContainsString( '$wgNeoWikiDereferenceSubjectsToHostingPage', $html );
 	}
 
 	public function testFramedConfigViewEmitsBalancedDivs(): void {
@@ -113,21 +113,21 @@ class ConfigPageFramingHooksTest extends MediaWikiIntegrationTestCase {
 		);
 
 		$this->assertStringContainsString( 'diff-marker', $html );
-		$this->assertStringNotContainsString( '$wgNeoWikiDereferenceSubjectsToDataTab', $html );
+		$this->assertStringNotContainsString( '$wgNeoWikiDereferenceSubjectsToHostingPage', $html );
 	}
 
 	public function testConfigPageIsUntouchedForNonViewActions(): void {
 		$html = $this->renderView( $this->configTitle(), 'history' );
 
 		$this->assertStringContainsString( 'Default intro', $html );
-		$this->assertStringNotContainsString( '$wgNeoWikiDereferenceSubjectsToDataTab', $html );
+		$this->assertStringNotContainsString( '$wgNeoWikiDereferenceSubjectsToHostingPage', $html );
 	}
 
 	public function testOtherMediaWikiPageViewIsUntouched(): void {
 		$html = $this->renderView( Title::makeTitle( NS_MEDIAWIKI, 'NotNeoWiki' ), 'view' );
 
 		$this->assertStringContainsString( 'Default intro', $html );
-		$this->assertStringNotContainsString( '$wgNeoWikiDereferenceSubjectsToDataTab', $html );
+		$this->assertStringNotContainsString( '$wgNeoWikiDereferenceSubjectsToHostingPage', $html );
 	}
 
 	public function testConfigPageViewIsUntouchedWhenInWikiConfigDisabled(): void {
@@ -136,7 +136,7 @@ class ConfigPageFramingHooksTest extends MediaWikiIntegrationTestCase {
 		$html = $this->renderView( $this->configTitle(), 'view' );
 
 		$this->assertStringContainsString( 'Default intro', $html );
-		$this->assertStringNotContainsString( '$wgNeoWikiDereferenceSubjectsToDataTab', $html );
+		$this->assertStringNotContainsString( '$wgNeoWikiDereferenceSubjectsToHostingPage', $html );
 	}
 
 }

--- a/tests/phpunit/EntryPoints/ConfigPageHooksTest.php
+++ b/tests/phpunit/EntryPoints/ConfigPageHooksTest.php
@@ -74,15 +74,15 @@ class ConfigPageHooksTest extends MediaWikiIntegrationTestCase {
 	public function testValidConfigIsAccepted(): void {
 		$this->assertSame(
 			'',
-			$this->editFilterError( $this->configTitle(), '{ "dereferenceSubjectsToDataTab": true }' )
+			$this->editFilterError( $this->configTitle(), '{ "dereferenceSubjectsToHostingPage": true }' )
 		);
 	}
 
 	public function testWrongTypeForDereferenceIsRejectedWithItsMessage(): void {
-		$error = $this->editFilterError( $this->configTitle(), '{ "dereferenceSubjectsToDataTab": "sidebar" }' );
+		$error = $this->editFilterError( $this->configTitle(), '{ "dereferenceSubjectsToHostingPage": "sidebar" }' );
 
 		$this->assertNotSame( '', $error );
-		$this->assertStringContainsString( 'dereferenceSubjectsToDataTab', $error );
+		$this->assertStringContainsString( 'dereferenceSubjectsToHostingPage', $error );
 	}
 
 	public function testUnknownKeyIsRejectedWithItsMessage(): void {
@@ -109,7 +109,7 @@ class ConfigPageHooksTest extends MediaWikiIntegrationTestCase {
 
 		$this->assertSame(
 			'',
-			$this->editFilterError( $this->configTitle(), '{ "dereferenceSubjectsToDataTab": "sidebar" }' )
+			$this->editFilterError( $this->configTitle(), '{ "dereferenceSubjectsToHostingPage": "sidebar" }' )
 		);
 	}
 

--- a/tests/phpunit/EntryPoints/REST/InWikiConfigDereferenceTest.php
+++ b/tests/phpunit/EntryPoints/REST/InWikiConfigDereferenceTest.php
@@ -26,7 +26,7 @@ use TestLogger;
  * config, an invalid one falls back with a warning, and the kill switch stops the page from applying.
  *
  * @covers \ProfessionalWiki\NeoWiki\Application\WikiConfig\WikiConfigLookup
- * @covers \ProfessionalWiki\NeoWiki\NeoWikiExtension::dereferenceSubjectsToDataTab
+ * @covers \ProfessionalWiki\NeoWiki\NeoWikiExtension::dereferenceSubjectsToHostingPage
  * @covers \ProfessionalWiki\NeoWiki\Persistence\MediaWiki\MediaWikiWikiConfigSource
  * @group Database
  */
@@ -42,8 +42,8 @@ class InWikiConfigDereferenceTest extends NeoWikiIntegrationTestCase {
 		$this->setUpNeo4j();
 
 		// Pin the PHP config to false (the win case's page value is true) so a passing test proves the page
-		// value, not an ambient override; the fallback cases then land on the plain page.
-		$this->overrideConfigValue( 'NeoWikiDereferenceSubjectsToDataTab', false );
+		// value, not an ambient override; the fallback cases then land on Special:Subject.
+		$this->overrideConfigValue( 'NeoWikiDereferenceSubjectsToHostingPage', false );
 
 		$this->createSchema( self::SCHEMA );
 
@@ -95,33 +95,38 @@ class InWikiConfigDereferenceTest extends NeoWikiIntegrationTestCase {
 		return Title::newFromID( $this->pageId )->getCanonicalURL();
 	}
 
+	private function assertLandsOnSpecialSubject( string $location, string $message ): void {
+		$this->assertStringEndsWith( 'Special:Subject/' . self::SUBJECT_ID, $location, $message );
+	}
+
 	public function testAValidPageSettingWinsOverThePhpConfig(): void {
-		$this->saveConfigPage( '{ "dereferenceSubjectsToDataTab": true }' );
+		$this->saveConfigPage( '{ "dereferenceSubjectsToHostingPage": true }' );
 
-		$location = $this->htmlDereferenceLocation();
-
-		$this->assertStringContainsString( 'action=subjects', $location, 'The redirect opens the Data tab.' );
-		$this->assertStringEndsWith( '#' . self::SUBJECT_ID, $location, 'The redirect targets the Subject row.' );
+		$this->assertSame(
+			$this->hostingPageUrl(),
+			$this->htmlDereferenceLocation(),
+			'The page value sends the dereference to the hosting page.'
+		);
 	}
 
 	public function testAnInvalidPageSettingFallsBackToThePhpConfigAndWarns(): void {
 		$logger = new TestLogger( true );
 		$this->setLogger( 'NeoWiki', $logger );
 
-		$this->saveConfigPage( '{ "dereferenceSubjectsToDataTab": "yes" }' );
+		$this->saveConfigPage( '{ "dereferenceSubjectsToHostingPage": "yes" }' );
 
-		$location = $this->htmlDereferenceLocation();
-
-		$this->assertSame( $this->hostingPageUrl(), $location, 'The dereference falls back to the PHP config target.' );
+		$this->assertLandsOnSpecialSubject(
+			$this->htmlDereferenceLocation(),
+			'The dereference falls back to the PHP config target.'
+		);
 		$this->assertTrue( $this->loggedAWarning( $logger ), 'The invalid page value is logged.' );
 	}
 
 	public function testThePageSettingIsIgnoredWhenInWikiConfigIsDisabled(): void {
-		$this->saveConfigPage( '{ "dereferenceSubjectsToDataTab": true }' );
+		$this->saveConfigPage( '{ "dereferenceSubjectsToHostingPage": true }' );
 		$this->overrideConfigValue( 'NeoWikiEnableInWikiConfig', false );
 
-		$this->assertSame(
-			$this->hostingPageUrl(),
+		$this->assertLandsOnSpecialSubject(
 			$this->htmlDereferenceLocation(),
 			'With the kill switch off the page is not read, so the PHP config target applies.'
 		);

--- a/tests/phpunit/EntryPoints/REST/ResolveSubjectIriApiTest.php
+++ b/tests/phpunit/EntryPoints/REST/ResolveSubjectIriApiTest.php
@@ -12,6 +12,7 @@ use MediaWiki\Title\Title;
 use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
 use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectLabel;
 use ProfessionalWiki\NeoWiki\EntryPoints\REST\ResolveSubjectIriApi;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
 use ProfessionalWiki\NeoWiki\Tests\NeoWikiMockAuthorityTrait;
@@ -61,11 +62,11 @@ class ResolveSubjectIriApiTest extends NeoWikiIntegrationTestCase {
 	}
 
 	/**
-	 * NeoWiki ships the Data tab as the dereference target (extension.json). The plain-hosting-page tests
-	 * opt out explicitly; the default test leaves the setting unset to exercise the shipped default.
+	 * NeoWiki ships Special:Subject as the dereference target (extension.json). The hosting-page tests
+	 * opt in explicitly; the default tests leave the setting unset to exercise the shipped default.
 	 */
-	private function disableDataTabDereference(): void {
-		$this->overrideConfigValue( 'NeoWikiDereferenceSubjectsToDataTab', false );
+	private function dereferenceToHostingPage(): void {
+		$this->overrideConfigValue( 'NeoWikiDereferenceSubjectsToHostingPage', true );
 	}
 
 	public function testAcceptTriGRedirectsToTheSubjectTriGExport(): void {
@@ -89,56 +90,54 @@ class ResolveSubjectIriApiTest extends NeoWikiIntegrationTestCase {
 		$this->assertSubjectRdfLocation( $response, 'trig' );
 	}
 
-	public function testAcceptHtmlRedirectsToThePlainHostingPageWhenDataTabDisabled(): void {
-		$this->disableDataTabDereference();
-
+	public function testAcceptHtmlRedirectsToTheSubjectsOwnPage(): void {
 		$response = $this->deref( headers: [ 'Accept' => 'text/html' ] );
 
 		$this->assertSame( 303, $response->getStatusCode() );
-		$this->assertHostingPageLocation( $response );
+		$this->assertSpecialSubjectLocation( $response );
 	}
 
-	public function testWildcardAcceptRedirectsToThePlainHostingPageWhenDataTabDisabled(): void {
-		$this->disableDataTabDereference();
-
+	public function testWildcardAcceptRedirectsToTheSubjectsOwnPage(): void {
 		$response = $this->deref( headers: [ 'Accept' => '*/*' ] );
 
 		$this->assertSame( 303, $response->getStatusCode() );
-		$this->assertHostingPageLocation( $response );
+		$this->assertSpecialSubjectLocation( $response );
 	}
 
-	public function testAbsentAcceptRedirectsToThePlainHostingPageWhenDataTabDisabled(): void {
-		$this->disableDataTabDereference();
-
+	public function testAbsentAcceptRedirectsToTheSubjectsOwnPage(): void {
 		$response = $this->deref();
 
 		$this->assertSame( 303, $response->getStatusCode() );
+		$this->assertSpecialSubjectLocation( $response );
+	}
+
+	/**
+	 * An id naming this wiki as its Source names a local Subject, so the dereference lands on the
+	 * bare-id URL every other surface uses for it.
+	 */
+	public function testAnIdNamingThisWikiRedirectsToItsBareForm(): void {
+		$localSourceKey = NeoWikiExtension::getInstance()->getSubjectIdParser()->getLocalSourceKey();
+
+		$response = $this->deref(
+			headers: [ 'Accept' => 'text/html' ],
+			subjectId: $localSourceKey . ':' . self::SUBJECT_ID
+		);
+
+		$this->assertSame( 303, $response->getStatusCode() );
+		$this->assertSpecialSubjectLocation( $response );
+	}
+
+	public function testHtmlDereferenceRedirectsToTheHostingPageWhenTheWikiAsksForThat(): void {
+		$this->dereferenceToHostingPage();
+
+		$response = $this->deref( headers: [ 'Accept' => 'text/html' ] );
+
+		$this->assertSame( 303, $response->getStatusCode() );
 		$this->assertHostingPageLocation( $response );
 	}
 
-	public function testHtmlDereferenceRedirectsToTheSubjectsDataTabRowByDefault(): void {
-		// No config override: NeoWiki ships the Data tab as the default dereference target.
-		$response = $this->deref( headers: [ 'Accept' => 'text/html' ] );
-
-		$location = $response->getHeaderLine( 'Location' );
-
-		$this->assertSame( 303, $response->getStatusCode() );
-		$this->assertMatchesRegularExpression( '#^https?://#', $location, 'The Location is an absolute URL.' );
-		$this->assertStringContainsString(
-			Title::newFromID( $this->pageId )->getPrefixedDBkey(),
-			$location,
-			'The redirect targets the hosting page.'
-		);
-		$this->assertStringContainsString( 'action=subjects', $location, 'The redirect opens the Data tab.' );
-		$this->assertStringEndsWith(
-			'#' . self::SUBJECT_ID,
-			$location,
-			'The fragment is the bare Subject id the Data tab expands and highlights.'
-		);
-	}
-
-	public function testDataTabTargetLeavesTheRdfBranchesUnchanged(): void {
-		$this->overrideConfigValue( 'NeoWikiDereferenceSubjectsToDataTab', true );
+	public function testTheHostingPageTargetLeavesTheRdfBranchesUnchanged(): void {
+		$this->dereferenceToHostingPage();
 
 		$response = $this->deref( headers: [ 'Accept' => 'application/trig' ] );
 
@@ -183,6 +182,17 @@ class ResolveSubjectIriApiTest extends NeoWikiIntegrationTestCase {
 		);
 	}
 
+	public function testTheBrowserTargetIsGatedOnReadingTheHostingPageToo(): void {
+		// The Subject's own page needs no hosting page to build its URL, so without this gate the browser
+		// branch would confirm a restricted Subject exists where the RDF branches refuse to (#1046).
+		$response = $this->deref(
+			headers: [ 'Accept' => 'text/html' ],
+			authority: $this->authorityWithGlobalReadButNoPageRead()
+		);
+
+		$this->assertSame( 404, $response->getStatusCode() );
+	}
+
 	public function testReturns400ForAMalformedSubjectId(): void {
 		$response = $this->deref( subjectId: 'not-a-valid-id' );
 
@@ -200,6 +210,17 @@ class ResolveSubjectIriApiTest extends NeoWikiIntegrationTestCase {
 			'projection=',
 			$location,
 			'RDF dereferencing targets the native projection without an explicit projection parameter.'
+		);
+	}
+
+	private function assertSpecialSubjectLocation( Response $response ): void {
+		$location = $response->getHeaderLine( 'Location' );
+
+		$this->assertMatchesRegularExpression( '#^https?://#', $location, 'The Location is an absolute URL.' );
+		$this->assertStringEndsWith(
+			'Special:Subject/' . self::SUBJECT_ID,
+			$location,
+			'A browser dereference lands on the Subject\'s own page.'
 		);
 	}
 

--- a/tests/phpunit/EntryPoints/SpecialPages/SpecialSubjectTest.php
+++ b/tests/phpunit/EntryPoints/SpecialPages/SpecialSubjectTest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints\SpecialPages;
+
+use MediaWiki\Context\RequestContext;
+use MediaWiki\Output\OutputPage;
+use MediaWiki\Permissions\Authority;
+use MediaWiki\SpecialPage\SpecialPage;
+use ProfessionalWiki\NeoWiki\Domain\Schema\SchemaName;
+use ProfessionalWiki\NeoWiki\Domain\Subject\SubjectMap;
+use ProfessionalWiki\NeoWiki\EntryPoints\SpecialPages\SpecialSubject;
+use ProfessionalWiki\NeoWiki\NeoWikiExtension;
+use ProfessionalWiki\NeoWiki\Tests\Data\TestSubject;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiMockAuthorityTrait;
+
+/**
+ * The page is rendered in qqx, so what is asserted is which message the error box and the title use
+ * rather than what those messages happen to say in English.
+ *
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\SpecialPages\SpecialSubject
+ * @covers \ProfessionalWiki\NeoWiki\Presentation\SubjectNamePresenter
+ * @covers \ProfessionalWiki\NeoWiki\NeoWikiExtension::getSubjectUiJsConfigVars
+ * @group Database
+ */
+class SpecialSubjectTest extends NeoWikiIntegrationTestCase {
+
+	use NeoWikiMockAuthorityTrait;
+
+	private const string SUBJECT_ID = 's1demo8aaaaaab5';
+	private const string ABSENT_ID = 's1demo8aaaaaab6';
+	private const string INVALID_ID_ERROR = '(neowiki-special-subject-invalid-id)';
+	private const string PAGE_DESCRIPTION = '(neowiki-special-subject)';
+
+	private function outputFor( ?string $subPage ): string {
+		return $this->executeWith( $subPage )->getHTML();
+	}
+
+	public function testMountPointCarriesTheRequestedSubjectId(): void {
+		$output = $this->outputFor( self::SUBJECT_ID );
+
+		$this->assertStringContainsString( 'id="ext-neowiki-subject"', $output );
+		$this->assertStringContainsString( 'data-mw-neowiki-subject-id="' . self::SUBJECT_ID . '"', $output );
+		$this->assertStringNotContainsString( self::INVALID_ID_ERROR, $output );
+	}
+
+	public function testMountPointCarriesASubjectOfAnotherSource(): void {
+		$output = $this->outputFor( 'otherwiki:abc-123' );
+
+		$this->assertStringContainsString( 'data-mw-neowiki-subject-id="otherwiki:abc-123"', $output );
+		$this->assertStringNotContainsString( self::INVALID_ID_ERROR, $output );
+	}
+
+	/**
+	 * An id naming this wiki as its Source names a local Subject, so what the page mounts is the bare
+	 * local id every other surface uses for it.
+	 */
+	public function testAnIdNamingThisWikiIsMountedInItsBareForm(): void {
+		$localSourceKey = NeoWikiExtension::getInstance()->getSubjectIdParser()->getLocalSourceKey();
+
+		$output = $this->outputFor( $localSourceKey . ':' . self::SUBJECT_ID );
+
+		$this->assertStringContainsString( 'data-mw-neowiki-subject-id="' . self::SUBJECT_ID . '"', $output );
+	}
+
+	public function testAMalformedSubjectIdIsRefusedWithoutAMountPoint(): void {
+		$output = $this->outputFor( 'not-a-subject-id' );
+
+		$this->assertStringContainsString( self::INVALID_ID_ERROR, $output );
+		$this->assertStringNotContainsString( 'id="ext-neowiki-subject"', $output );
+	}
+
+	public function testTheBareSpecialPageAsksForASubjectId(): void {
+		$output = $this->outputFor( null );
+
+		$this->assertStringContainsString( self::INVALID_ID_ERROR, $output );
+		$this->assertStringNotContainsString( 'id="ext-neowiki-subject"', $output );
+	}
+
+	/**
+	 * The mount point is an empty div until the frontend fills it, so a page that forgot to load the
+	 * module renders as a blank page rather than as an error.
+	 */
+	public function testLoadsTheFrontendModule(): void {
+		$out = $this->executeWith( self::SUBJECT_ID );
+
+		$this->assertContains( 'ext.neowiki', $out->getModules() );
+	}
+
+	public function testExposesReadableRdfProjectionsAsConfigVar(): void {
+		$this->createMapping( 'EDM', '{ "version": 1, "schemas": {} }' );
+
+		$out = $this->executeWith( self::SUBJECT_ID );
+
+		$this->assertSame(
+			[ 'native', 'EDM' ],
+			$out->getJsConfigVars()['wgNeoWikiRdfProjections']
+		);
+	}
+
+	public function testOmitsRdfProjectionsTheViewingUserCannotRead(): void {
+		$this->createMapping( 'EDM', '{ "version": 1, "schemas": {} }' );
+
+		$out = $this->executeWith( self::SUBJECT_ID, $this->authorityWithGlobalReadButNoPageRead() );
+
+		$this->assertSame(
+			[ 'native' ],
+			$out->getJsConfigVars()['wgNeoWikiRdfProjections'],
+			'A read-restricted Mapping page name must not reach a reader who cannot see it.'
+		);
+	}
+
+	public function testExposesTheSubjectIriBaseAsConfigVar(): void {
+		$this->overrideConfigValue( 'NeoWikiRdfBaseUri', 'https://data.example.org' );
+		NeoWikiExtension::resetInstance();
+
+		$out = $this->executeWith( self::SUBJECT_ID );
+
+		$this->assertSame(
+			'https://data.example.org/entity/',
+			$out->getJsConfigVars()['wgNeoWikiSubjectIriBase']
+		);
+	}
+
+	/**
+	 * The page a concept URI leads to, so its title, the browser tab, a bookmark and a history entry
+	 * name the Subject rather than the page showing it.
+	 */
+	public function testTheTitleIsTheSubjectsName(): void {
+		$this->createPageWithSubjects(
+			'SpecialSubjectTest_Company',
+			mainSubject: TestSubject::build( id: self::SUBJECT_ID, label: 'ACME Inc' )
+		);
+
+		$this->assertSame( 'ACME Inc', $this->executeWith( self::SUBJECT_ID )->getPageTitle() );
+	}
+
+	public function testTheTitleMarksANameNobodyChoseAsTheStandInItIs(): void {
+		$this->createPageWithSubjects(
+			'SpecialSubjectTest_Unnamed',
+			childSubjects: new SubjectMap( TestSubject::build(
+				id: self::SUBJECT_ID,
+				label: null,
+				schemaName: new SchemaName( 'Company' )
+			) )
+		);
+
+		$this->assertSame(
+			'(neowiki-subject-generated-name: Company)',
+			$this->executeWith( self::SUBJECT_ID )->getPageTitle()
+		);
+	}
+
+	public function testTheTitleStaysThePagesOwnForASubjectTheWikiDoesNotHave(): void {
+		$this->assertSame( self::PAGE_DESCRIPTION, $this->executeWith( self::ABSENT_ID )->getPageTitle() );
+	}
+
+	/**
+	 * Naming a Subject in the title would tell a reader it exists, which the whole page must not do for
+	 * one on a page they may not read: that answers exactly as an id the wiki never minted (#1046).
+	 */
+	public function testASubjectOnAnUnreadablePageRendersExactlyLikeAnAbsentOne(): void {
+		$this->createPageWithSubjects(
+			'SpecialSubjectTest_Restricted',
+			mainSubject: TestSubject::build( id: self::SUBJECT_ID, label: 'Restricted Inc' )
+		);
+		$restricted = $this->authorityWithGlobalReadButNoPageRead();
+
+		$denied = $this->executeWith( self::SUBJECT_ID, $restricted );
+		$absent = $this->executeWith( self::ABSENT_ID, $restricted );
+
+		$this->assertSame( self::PAGE_DESCRIPTION, $denied->getPageTitle() );
+		$this->assertSame( $absent->getPageTitle(), $denied->getPageTitle() );
+		$this->assertSame(
+			str_replace( self::ABSENT_ID, self::SUBJECT_ID, $absent->getHTML() ),
+			$denied->getHTML(),
+			'Only the Subject id echoed into the mount point may differ.'
+		);
+	}
+
+	/**
+	 * Covers what instantiating the class directly cannot: that extension.json registers the page, and
+	 * that it is listed for everyone.
+	 */
+	public function testThePageIsRegisteredAndListedForEveryone(): void {
+		// The context argument is mandatory from MediaWiki 1.47 and ignored before 1.45, so it is always
+		// passed (as in SpecialGraphStoresTest).
+		$this->assertArrayHasKey(
+			'Subject',
+			$this->getServiceContainer()->getSpecialPageFactory()
+				->getUsablePages( RequestContext::getMain()->getUser(), RequestContext::getMain() )
+		);
+	}
+
+	/**
+	 * Runs the page against a context the test keeps hold of, which exposes the title and the
+	 * configuration variables alongside the HTML.
+	 */
+	private function executeWith( ?string $subPage, ?Authority $authority = null ): OutputPage {
+		$context = new RequestContext();
+		$context->setTitle( SpecialPage::getTitleFor( 'Subject' ) );
+		$context->setAuthority( $authority ?? $this->getTestSysop()->getAuthority() );
+		// After the authority, which invalidates the context's cached language.
+		$context->setLanguage( 'qqx' );
+
+		$page = new SpecialSubject();
+		$page->setContext( $context );
+		$page->execute( $subPage );
+
+		return $context->getOutput();
+	}
+
+}

--- a/tests/phpunit/Persistence/MediaWiki/MediaWikiWikiConfigSourceTest.php
+++ b/tests/phpunit/Persistence/MediaWiki/MediaWikiWikiConfigSourceTest.php
@@ -28,9 +28,9 @@ class MediaWikiWikiConfigSourceTest extends MediaWikiIntegrationTestCase {
 	}
 
 	public function testReturnsTheDecodedObjectFromAJsonPage(): void {
-		$source = $this->newSource( new JsonContent( '{ "dereferenceSubjectsToDataTab": true }' ) );
+		$source = $this->newSource( new JsonContent( '{ "dereferenceSubjectsToHostingPage": true }' ) );
 
-		$this->assertSame( [ 'dereferenceSubjectsToDataTab' => true ], $source->readConfig() );
+		$this->assertSame( [ 'dereferenceSubjectsToHostingPage' => true ], $source->readConfig() );
 	}
 
 	public function testReturnsNullWhenThePageIsMissing(): void {

--- a/tests/phpunit/Presentation/ConfigDocumentationBuilderTest.php
+++ b/tests/phpunit/Presentation/ConfigDocumentationBuilderTest.php
@@ -48,7 +48,7 @@ class ConfigDocumentationBuilderTest extends MediaWikiIntegrationTestCase {
 
 	public function testReferenceDoesNotWrapTheSettingKeysInCode(): void {
 		// The key and LocalSettings.php columns fill their cell, so they are plain text, not code chips.
-		$this->assertStringContainsString( '<td>dereferenceSubjectsToDataTab</td>', $this->newBuilder()->buildReference() );
+		$this->assertStringContainsString( '<td>dereferenceSubjectsToHostingPage</td>', $this->newBuilder()->buildReference() );
 	}
 
 	public function testReferenceCarriesTheAnchorThePointerLinksTo(): void {


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/NeoWiki/issues/1355

`Special:Subject/<id>` shows one Subject on its own, with the row UI a page's Data tab already has.

## What it does

- **`Special:Subject/<id>`** renders the Subject as a Data tab row, expanded on arrival: statements, the edit and
  delete controls, copy link, the overflow menu, and a footer with the id, the concept URI, the page it is stored on
  and the export menu. Under **Referenced subjects**, every Subject its relations point at gets the same row,
  collapsed. The H1 and browser title are the Subject's display name.
- **The concept URI resolver** (`GET /neowiki/v0/entity/{subjectId}`) sends browsers there instead of to the Data
  tab row, and redirects an id qualified with this wiki's own Source key to its bare form. RDF content negotiation
  is unchanged.
- **Data tab rows gain "Open subject"**, a row action leading to the Subject's own page: the one way a reader
  reaches this page from the wiki's UI.
- Reads go through the existing permission-enforced Subject read, for the title as for the body: a Subject on a
  page the reader may not read renders exactly like one the wiki never minted
  (https://github.com/ProfessionalWiki/NeoWiki/issues/1046).
- Left out as page-level operations: pin, reorder, add, and move, which needs the Main Subject flag the Subject
  read does not carry.

## Under the hood

- The Data tab's two inline row templates become `SubjectRow`, and its delete dialog `SubjectDeleteDialog`; the
  Data tab is unchanged to look at and to use.
- `$wgNeoWikiDereferenceSubjectsToDataTab` becomes `$wgNeoWikiDereferenceSubjectsToHostingPage`, default `false`:
  `true` is the plain-page opt-out that existed before; the Data-tab target is gone. A clean rename of the setting
  and of its `MediaWiki:NeoWiki` key, no shim: a `LocalSettings.php` still setting the old name takes the new
  default without notice.
- The repository throws `SubjectNotFoundError` for a Subject the wiki serves none of, so the page can tell that
  from a failed request.
- The referenced Subjects' own relation targets are fetched before the first paint, because `RelationDisplay`
  resolves a target from the store once, synchronously, and an unseeded one would show as an error inside those
  rows. Cost: one read per distinct Subject two relation hops away that the Subject read did not already return;
  three reads in total for the demo Subject with eight referenced Subjects, unbounded for a Subject whose
  referenced Subjects carry many relations.
- PHPUnit covers the special page (mount point, malformed and missing id, the title in all four states, the config
  variables) and the resolver under both settings and through the on-wiki configuration page; vitest covers the
  row, both pages, the not-found error and the Data tab's unchanged behaviour.

## Decisions worth challenging

- The requested row keeps the blue emphasis the Data tab gives its Main Subject row; here it marks the Subject the
  page is about, and the row stays collapsible.
- `Special:Subject` is listed on Special:SpecialPages, where opening it without an id shows an error asking for
  one.
- One server-side Subject read per view for the title; the frontend reads again for the body.

## Known gap

The editor dialog reads page-scoped `mw.config` values (`wgArticleId` for edit notices, `wgIsProbablyEditable` for
the unregistered-property-type notice), which are 0 and false on a special page, so neither notice appears here.
The fix belongs in the dialog; not filed as an issue yet.

## Manual browser check

- `Special:Subject/s1demo1aaaaaaa1`, logged in: the tab reads "ACME Inc"; edit, delete, copy link, the overflow
  menu, and the footer's id, IRI, page link and export menu work on the open row and on a referenced row opened by
  a header click; **Open subject** on a referenced row, and on a Data tab row, leads to that Subject's page.
- `curl -sI -H 'Accept: text/html' …/rest.php/neowiki/v0/entity/s1demo1aaaaaaa1` answers 303 to
  `Special:Subject/s1demo1aaaaaaa1`; with `Accept: text/turtle`, the Turtle export as before.
- `Special:Subject/nope` shows the error; `Special:Subject/s1zzzzzzzzzzzz9` the not-found message.

## Considered, omitted

- In-place editing on this page; incoming relations (https://github.com/ProfessionalWiki/NeoWiki/issues/904);
  creating a Subject here; relation links inside the row leading to Special:Subject rather than to the page; a
  user-guide entry.
- Extracting the editor and delete wiring this page shares with the Data tab and the infobox into composables;
  moving the shared components out of `components/SubjectsManager/`.
- A cheaper fetch for the nested relation targets; the real fix is a reactive `RelationDisplay`.

> <sub>AI-authored — Claude Code, `Fable 5.1 (max)` orchestrating `Opus 5 (max)` implementers; detailed spec from @JeroenDeDauw, redirected three times mid-task; diff not yet human-reviewed; full PHPUnit and vitest suites, phpcs, phpstan, eslint, stylelint and the TypeScript build green locally and on CI, some seventy production-code mutations each confirmed to fail their tests, both pages driven in a scripted browser against the dev stack.</sub>

<details><summary>Production notes</summary>

Design decisions and this description by `Fable 5.1 (max)`; the code by `Opus 5 (max)` subagents, reviewed by further subagents (code, security, tests, design) and by the orchestrator. The three redirections: the Data tab's row UI instead of a bespoke layout, the page link into the row footer, and "Open subject" as a row action instead of a link in the name. The in-browser check ran as a scripted Playwright session in a container, the interactive browser being held by another session.

</details>
