### PR TITLE
Move the Concepts list under the User guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,14 +12,7 @@ For people working in a wiki that runs NeoWiki.
   vocabulary
 * [Keep your wiki current](guide/keep-your-wiki-current.md) — upgrade an evaluation wiki
 
-Reference for wikitext and Lua authors:
-
-* [Parser Functions](authoring/parser-functions.md) — `{{#view}}`, `{{#neowiki_value}}`, and `{{#cypher_raw}}`
-* [Lua API](authoring/lua-api.md) — the `mw.neowiki` Scribunto library, including `nw.query()` for Cypher
-* [Edit Notices](authoring/edit-notices.md) — messages shown in the Subject editor, the Subject creator, and Manage
-  subjects
-
-## Concepts
+Concepts:
 
 * [Glossary](glossary.md) — the concepts (Subject, Schema, Statement, View, Layout, Page Property) used
   across the UI, the code, and these docs. Start here.
@@ -29,6 +22,13 @@ Reference for wikitext and Lua authors:
   Decision Records
 * [Planning docs](https://github.com/ProfessionalWiki/NeoWiki/tree/master/docs/planning) — work-in-progress
   exploration (not published to the website)
+
+Reference for wikitext and Lua authors:
+
+* [Parser Functions](authoring/parser-functions.md) — `{{#view}}`, `{{#neowiki_value}}`, and `{{#cypher_raw}}`
+* [Lua API](authoring/lua-api.md) — the `mw.neowiki` Scribunto library, including `nw.query()` for Cypher
+* [Edit Notices](authoring/edit-notices.md) — messages shown in the Subject editor, the Subject creator, and Manage
+  subjects
 
 ## Integration
 


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1407

A three-page section read as a placeholder in the website's section row, and its pages are what a new user reads
first, so the concept pages now sit between the guides and the authoring reference. Four sections remain, matching
the website's docs navigation (https://github.com/ProfessionalWiki/NeoWiki-Website/pull/120): User guide,
Integration, Extending, Install & run.

> <sub>AI-authored — Claude Code, `Fable 5.1 (max)`; from @JeroenDeDauw's agreement to fold Concepts into the User guide, no redirection; text not yet human-reviewed; links checked by script.</sub>
