### PR TITLE
Sort the RDF pages by reader and rename Integration to API

### DIFF
--- a/DemoData/EdmSparqlPage/EDM_queries.wikitext
+++ b/DemoData/EdmSparqlPage/EDM_queries.wikitext
@@ -44,5 +44,5 @@ Each store entry names one projection, and several entries may point at one endp
 
 == Learn more ==
 
-* [https://neowiki.ai/docs/rdf/ontology-mapping Ontology mapping reference]
-* [https://neowiki.ai/docs/rdf/person-to-edm Person-to-EDM worked example]
+* [https://neowiki.ai/docs/authoring/mapping-format Mapping format reference]
+* [https://neowiki.ai/docs/guide/person-to-edm Person-to-EDM worked example]

--- a/DemoData/Page/RDF_and_ontology_mappings.wikitext
+++ b/DemoData/Page/RDF_and_ontology_mappings.wikitext
@@ -29,7 +29,7 @@ You don't need these links to reach an export: on any subject page, the Data tab
 
 * [https://neowiki.ai/docs/guide/author-an-ontology-mapping How to author an ontology mapping]: write your own Mapping page, step by step
 * [[Special:Mappings]]: every ontology Mapping on this wiki
-* [https://neowiki.ai/docs/rdf/rdf-export RDF export reference]
-* [https://neowiki.ai/docs/rdf/ontology-mapping Ontology mapping reference]
-* [https://neowiki.ai/docs/rdf/person-to-edm Person-to-EDM worked example]
+* [https://neowiki.ai/docs/api/rdf-export RDF export reference]
+* [https://neowiki.ai/docs/authoring/mapping-format Mapping format reference]
+* [https://neowiki.ai/docs/guide/person-to-edm Person-to-EDM worked example]
 * Tell us what you need from RDF and ontology mapping: [https://github.com/ProfessionalWiki/NeoWiki/discussions/996 join the discussion].

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -18,7 +18,7 @@ Every page sits in one genre. Write to that genre's reader and register.
 | `guide/` | Wiki users and admins with a task to accomplish, deciding what to do next in the UI | Task steps in UI vocabulary (Special pages, buttons, tabs), linking to reference pages for contracts; no wire formats, no PHP, no restated contracts |
 | `glossary.md`, `qualifiers-and-references.md`, `architecture.md` | New users and evaluators forming the mental model | Intended design; no dev-state caveats, no mechanism |
 | `api/` | API consumers deciding what a request or response means and what to do next | Wire-format vocabulary; no PHP class names |
-| `authoring/`, `rdf/` | Admins and integrators looking up exact behavior | Contracts, signatures, examples; no narration |
+| `authoring/` | Wiki authors and modellers looking up exact behavior | Contracts, signatures, examples; no narration |
 | `operations/` | Sysadmins keeping an instance healthy | Tasks and remedies; system model only where needed to act |
 | `extending/` | Extension developers, whose interface is our internal identifiers | Point at working RedHerb code over prose |
 | `adr/` | Maintainers recording a decision | A dated record: context, decision, consequences; not retro-edited apart from status links |

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ For people working in a wiki that runs NeoWiki.
 * [Getting started](guide/getting-started.md) — your first Schema, Subject, View, and query
 * [Author an ontology mapping](guide/author-an-ontology-mapping.md) — publish Subjects in EDM, CIDOC-CRM, or another
   vocabulary
+* [Project a Person to EDM](guide/person-to-edm.md) — an ontology mapping walked end to end
 * [Keep your wiki current](guide/keep-your-wiki-current.md) — upgrade an evaluation wiki
 
 Concepts:
@@ -27,14 +28,14 @@ Reference for wikitext and Lua authors:
 
 * [Parser Functions](authoring/parser-functions.md) — `{{#view}}`, `{{#neowiki_value}}`, and `{{#cypher_raw}}`
 * [Lua API](authoring/lua-api.md) — the `mw.neowiki` Scribunto library, including `nw.query()` for Cypher
+* [Mapping Format](authoring/mapping-format.md) — the JSON of a Mapping page: projecting Schemas into EDM,
+  CIDOC-CRM, or another vocabulary
 * [Edit Notices](authoring/edit-notices.md) — messages shown in the Subject editor, the Subject creator, and Manage
   subjects
 
-## Integration
+## API
 
 For developers building on NeoWiki from outside the wiki.
-
-Over HTTP:
 
 * [REST API](api/rest-api.md) — the `/neowiki/v0/*` endpoints, plus the generated OpenAPI spec
 * [Schema Format](api/schema-format.md) — JSON format for Schema definitions
@@ -42,12 +43,7 @@ Over HTTP:
 * [Validation Codes](api/validation-codes.md) — stable `code` strings returned by backend validation
 * [Query API](api/query-api.md) — read-only Cypher endpoint over the graph backend
 * [Graph Model](api/graph-model.md) — Neo4j node and relationship structure
-
-As RDF:
-
-* [RDF Export](rdf/rdf-export.md) — native RDF projection: config, IRI scheme, endpoint, bulk dump
-* [Ontology Mapping](rdf/ontology-mapping.md) — projecting into EDM, Dublin Core, … via Mapping pages
-* [Worked example: Person to EDM](rdf/person-to-edm.md) — end-to-end mapping walkthrough
+* [RDF Export](api/rdf-export.md) — RDF per page, per Subject and in bulk: IRI scheme, endpoint, projections
 
 ## Extending
 

--- a/docs/api/query-api.md
+++ b/docs/api/query-api.md
@@ -154,8 +154,8 @@ Defaults shipped by NeoWiki:
 endpoint, it exists only when a store is configured; otherwise the route is absent and does not appear in the OpenAPI
 spec.
 
-For the RDF vocabulary (predicates, graph shape) to query, see [RDF Export](../rdf/rdf-export.md) and
-[Ontology Mapping](../rdf/ontology-mapping.md).
+For the RDF vocabulary (predicates, graph shape) to query, see [RDF Export](rdf-export.md) and
+[Mapping Format](../authoring/mapping-format.md).
 
 ### Request
 

--- a/docs/api/rdf-export.md
+++ b/docs/api/rdf-export.md
@@ -1,6 +1,6 @@
 ---
 title: RDF Export
-order: 1
+order: 7
 ---
 # RDF Export
 
@@ -11,7 +11,7 @@ This page is the reference for what NeoWiki emits. Why the projection is shaped 
 about it, is in [NativeRdfProjection.md](../planning/NativeRdfProjection.md).
 
 For an end-to-end example comparing the native and ontology-mapped output, see the
-[Person-to-EDM worked example](person-to-edm.md).
+[Person-to-EDM worked example](../guide/person-to-edm.md).
 
 ## Configuration
 
@@ -35,7 +35,7 @@ All NeoWiki IRIs live under `$base` (`$wgNeoWikiRdfBaseUri`). Standard vocabular
 | `neo-page:` | `$base/page/` | Page resource IRIs (`neo-page:42`) — the subject of the page-metadata triples |
 
 Each page's named-graph IRI is `$base/graph/{projection}/page/{id}`. The `{projection}` segment is `native` or a
-Mapping page name (e.g. `EDM`), encoded like the names below — see [Ontology Mapping](ontology-mapping.md). The page
+Mapping page name (e.g. `EDM`), encoded like the names below — see [Mapping Format](../authoring/mapping-format.md). The page
 *resource* IRI (`neo-page:42`)
 stays projection-independent and appears inside the triples.
 
@@ -98,7 +98,7 @@ nothing carries a page's namespace or wiki id.
 
 RDF is served per page or per Subject. Both take the same `projection` and `format` query parameters. `projection`
 selects the vocabulary: `native` (the default, described here) or the name of a Mapping page — see
-[Ontology Mapping](ontology-mapping.md); an unknown projection returns `400`. `format` picks the serialization,
+[Mapping Format](../authoring/mapping-format.md); an unknown projection returns `400`. `format` picks the serialization,
 falling back to the `Accept` header, then to TriG; a value other than `trig` or `turtle` returns `400`:
 
 | `format` | `Accept` | Content-Type | Named graph |
@@ -190,7 +190,7 @@ projection) in the HTML head, on a wiki with a graph database configured.
 
 `maintenance/DumpRdf.php` streams the projection of **every** page on the wiki to stdout as TriG, one named graph
 per page. Progress goes to stderr. It defaults to the native projection; `--projection=<name>` selects an ontology
-projection by its Mapping page name (see [Ontology Mapping](ontology-mapping.md)).
+projection by its Mapping page name (see [Ontology Mapping](../authoring/mapping-format.md)).
 
 ```sh
 php maintenance/run.php NeoWiki:DumpRdf > dump.trig

--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -53,8 +53,8 @@ of a `{subjectId}`, see [IDs](subject-format.md#ids).
 | Endpoint | Description |
 |---|---|
 | `GET /neowiki/v0/subject/{subjectId}` | Fetch a Subject as the wiki publishes it. `latest=1` returns the hosting page's current revision instead, for editing, when the viewer may see it; it takes no `revisionId` and no `expand=relations`. Optional `revisionId`; `expand` with `page` or `relations`. |
-| `GET /neowiki/v0/subject/{subjectId}/rdf` | Export one Subject as RDF. `format` is `trig` (default) or `turtle`; `projection` is `native` (default) or an ontology target. See [RDF export](../rdf/rdf-export.md). |
-| `GET /neowiki/v0/entity/{subjectId}` | Dereference a Subject's concept URI. `303` to the Subject's RDF (`Accept: application/trig` or `text/turtle`) or to the hosting page (otherwise). See [Dereferencing subject IRIs](../rdf/rdf-export.md#dereferencing-subject-iris). |
+| `GET /neowiki/v0/subject/{subjectId}/rdf` | Export one Subject as RDF. `format` is `trig` (default) or `turtle`; `projection` is `native` (default) or an ontology target. See [RDF export](rdf-export.md). |
+| `GET /neowiki/v0/entity/{subjectId}` | Dereference a Subject's concept URI. `303` to the Subject's RDF (`Accept: application/trig` or `text/turtle`) or to the hosting page (otherwise). See [Dereferencing subject IRIs](rdf-export.md#dereferencing-subject-iris). |
 | `PUT /neowiki/v0/subject/{subjectId}` | Replace a Subject's label and statements. |
 | `DELETE /neowiki/v0/subject/{subjectId}` | Delete a Subject. |
 | `POST /neowiki/v0/subject/{subjectId}/move` | Move a Subject to another page, keeping its ID so relations targeting it keep resolving. Body `targetPageId`, optional `makeMainSubject` and `comment`. Edits both pages. |
@@ -74,7 +74,7 @@ Subjects and arrange them.
 |---|---|
 | `GET /neowiki/v0/page/{pageId}/subjects` | List a page's main and child Subjects. `expand` with `schemas` or `relations`. |
 | `GET /neowiki/v0/page/{pageId}/editNotices` | List the notices to show before editing the page's Subjects, in display order. Optional `schema` adds notices scoped to that Schema. Returns `{notices: [{key, html}]}`. See [Edit notices](../authoring/edit-notices.md). |
-| `GET /neowiki/v0/page/{pageId}/rdf` | Export the page's Subjects and metadata as RDF. `format` is `trig` (default) or `turtle`; `projection` is `native` (default) or the name of a Mapping page. See [RDF export](../rdf/rdf-export.md) and [Ontology Mapping](../rdf/ontology-mapping.md). |
+| `GET /neowiki/v0/page/{pageId}/rdf` | Export the page's Subjects and metadata as RDF. `format` is `trig` (default) or `turtle`; `projection` is `native` (default) or the name of a Mapping page. See [RDF export](rdf-export.md) and [Mapping Format](../authoring/mapping-format.md). |
 | `POST /neowiki/v0/page/{pageId}/mainSubject` | Create the page's main Subject. |
 | `PUT /neowiki/v0/page/{pageId}/mainSubject` | Promote a child Subject to main, or clear it. |
 | `POST /neowiki/v0/page/{pageId}/childSubjects` | Create a child Subject on the page. |
@@ -103,7 +103,7 @@ A Layout defines how a Subject is displayed.
 ### Mappings
 
 An ontology Mapping defines one projection: it projects native Schemas into a target ontology. For the format
-and concepts, see [Ontology Mapping](../rdf/ontology-mapping.md).
+and concepts, see [Mapping Format](../authoring/mapping-format.md).
 
 | Endpoint | Description |
 |---|---|

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,7 +21,7 @@ vocabulary, which the UI and the code share.
 A wiki can connect to one or more graph stores: Neo4j, and any SPARQL 1.1 store. Each holds a Projection, a derived,
 query-optimized copy of the wiki's data, written on every save and rebuildable from page content at any time
 ([ADR 19](adr/019-graph-database-architecture.md)). A Projection is either the built-in native one or an ontology
-projection defined by a [Mapping](rdf/ontology-mapping.md), which expresses Subjects in a vocabulary such as EDM or
+projection defined by a [Mapping](authoring/mapping-format.md), which expresses Subjects in a vocabulary such as EDM or
 CIDOC-CRM.
 
 Queries are written in each backend's own language, Cypher for Neo4j and SPARQL for SPARQL stores, and run from

--- a/docs/authoring/edit-notices.md
+++ b/docs/authoring/edit-notices.md
@@ -1,6 +1,6 @@
 ---
 title: Edit Notices
-order: 3
+order: 4
 ---
 # Edit Notices
 

--- a/docs/authoring/lua-api.md
+++ b/docs/authoring/lua-api.md
@@ -265,7 +265,7 @@ Every call counts as an expensive parser function.
 #### Named graphs
 
 Pages are projected into named graphs, so which of them an unscoped query reaches depends on the store — see
-[RDF Export](../rdf/rdf-export.md#iri-scheme).
+[RDF Export](../api/rdf-export.md#iri-scheme).
 
 #### Examples
 

--- a/docs/authoring/mapping-format.md
+++ b/docs/authoring/mapping-format.md
@@ -1,20 +1,22 @@
 ---
-title: Ontology Mapping
-order: 2
+title: Mapping Format
+order: 3
 ---
-# Ontology Mapping
+# Mapping JSON Format
 
-Alongside the built-in [native projection](rdf-export.md), which needs no mapping, you can project to an
-established ontology such as EDM or CIDOC-CRM by defining an **ontology mapping**.
+Alongside the built-in [native projection](../api/rdf-export.md), which needs no mapping, you can project to an
+established ontology such as EDM or CIDOC-CRM by defining an **ontology mapping**: a Mapping page holding the JSON
+this page specifies.
 
 The native projection and each ontology mapping are sibling projections of the same source data. Several can
 run at once: an export request selects one by name, and a SPARQL store can hold
 [several side by side](../operations/installation.md#several-projections-in-one-store).
 
 The design and its open questions live in [planning/OntologyMapping.md](../planning/OntologyMapping.md); this
-page is the as-built reference for the shipped format. The
-[Person-to-EDM worked example](person-to-edm.md) walks through a Person Schema projected to EDM, with native
-and mapped output side by side.
+page is the as-built reference for the shipped format.
+[Author an ontology mapping](../guide/author-an-ontology-mapping.md) gives the steps, and
+[Project a Person to EDM](../guide/person-to-edm.md) walks through a Person Schema projected to EDM, with native and
+mapped output side by side.
 
 > **Scope.** A mapping reshapes the data as well as the vocabulary: it can **synthesize** the intermediate
 > nodes a target like CIDOC-CRM routes its paths through, and it can **contract** structure a flat
@@ -33,7 +35,7 @@ A single page holds an entry for **every mapped Schema** — map a Schema by add
 projection's page, not by creating a page. A Schema can take part in several projections, through one entry on
 each page.
 
-The name **`native`** is reserved for the built-in [native projection](rdf-export.md), so a `Mapping:Native`
+The name **`native`** is reserved for the built-in [native projection](../api/rdf-export.md), so a `Mapping:Native`
 page is rejected on save.
 
 ## Format (version 1)
@@ -129,8 +131,8 @@ rejected; non-authority schemes (`urn:`, `mailto:`, …) are out of scope.
 
 Terms are reproduced verbatim, never percent-encoded. A term or a declared prefix namespace that would expand
 to an IRI containing an IRIREF-illegal character (`< > " { } | ^ \` backtick, space, control characters) is
-**rejected at save time**, as is a `lang` tag that is not BCP-47-shaped and a property entry that sets both
-`lang` and `datatype`.
+**rejected at save time**, as is a `lang` tag that is not BCP-47-shaped, a property entry that sets both
+`lang` and `datatype`, a structural error, and a `node` or `parent` reference that does not resolve.
 
 The same checks re-run at **projection time**: a class, predicate, datatype, or prefix that does not re-expand
 safely is dropped, an unusable node takes everything below it with it, an invalid language tag falls back to a
@@ -141,7 +143,7 @@ plain literal, and each is logged. The projection degrades rather than aborting 
 For each Subject on a page whose Schema has an entry on the requested projection's Mapping page:
 
 - `rdf:type <subject.class>`, and the `labelPredicate` triple when one is set and the Subject has a stored label.
-- `rdfs:label "<label>"` — always, from the Subject's display name (see [RDF export](rdf-export.md#projected-triples)).
+- `rdfs:label "<label>"` — always, from the Subject's display name (see [RDF Export](../api/rdf-export.md#projected-triples)).
 - One triple per mapped property **value**, on the Subject or on the node the entry attaches it to;
   multi-valued properties repeat the predicate. Unmapped properties are absent.
 - A **relation** value becomes a direct triple to the target Subject's IRI. No `neo:Relation` reification node
@@ -158,7 +160,7 @@ Boundaries:
   bare IRI — no type, no label — as the target of a relation from a mapped Subject.
 - **Contributed triples live in the contributing page's graph**, not the target's, so a per-page export of the
   target does not carry them; a SPARQL store or a bulk dump holding both graphs does. Same rule as a relation
-  target's own type and label — see [Per-page vs bulk](person-to-edm.md#per-page-vs-bulk-the-relation-targets-type).
+  target's own type and label — see [Per-page vs bulk](../guide/person-to-edm.md#per-page-vs-bulk-the-relation-targets-type).
 - **No page-metadata triples** are emitted (no page node, `neo:hasSubject`, etc.).
 - Quads go in the per-page named graph for this target (`$base/graph/{target}/page/{id}`), where `{target}` is
   the projection name.
@@ -179,22 +181,5 @@ They are emitted in full rather than abbreviated: they have no `neo-` prefix of 
 The position-based case is stable only for unchanged data: reordering or removing a property's values
 renumbers the instances after the change.
 
-## Selecting a projection
-
-The RDF export surfaces — the per-page and per-Subject endpoints and the `DumpRdf` bulk dump — take a
-`projection` parameter whose value is a projection name — a Mapping page title without the `Mapping:`
-prefix (`EDM`), or `native` for the built-in projection. See
-[RDF Export](rdf-export.md#endpoint) for the contract.
-
-## Authoring a Mapping
-
-1. Create a page in the `Mapping:` namespace whose title is the projection name (`Mapping:EDM`), or edit an
-   existing one.
-2. Declare the page-level `prefixes` you will use.
-3. Add an entry under `schemas` for each Schema to project: give the Subject a `subject.class` and map the
-   properties to publish. Where the target routes a property through an intermediate node, declare the node
-   and point the property at it. Where the target wants a related Subject's structure flattened onto it, add a
-   contribution to the Schema that holds the structure.
-4. Save. Structural errors, unresolvable or unsafe terms, and node references that do not resolve are reported
-   on save.
-5. Export a page of a mapped Schema with `?projection=EDM` (the page title without the `Mapping:` prefix).
+The export surfaces select a projection by the Mapping page's title without the `Mapping:` prefix, or `native`;
+see [RDF Export](../api/rdf-export.md#endpoint).

--- a/docs/authoring/parser-functions.md
+++ b/docs/authoring/parser-functions.md
@@ -201,7 +201,7 @@ document — the standard `head` / `results` structure (or `boolean` for an `ASK
 - The output is wrapped in `<div class="mw-neowiki-sparql-result"><pre>` and the error message in
   `<div class="error">`, so you can target either with CSS.
 - Pages are projected into named graphs, so which of them an unscoped query reaches depends on the store — see
-  [RDF Export](../rdf/rdf-export.md#iri-scheme).
+  [RDF Export](../api/rdf-export.md#iri-scheme).
 
 ### Examples
 

--- a/docs/extending/property-types.md
+++ b/docs/extending/property-types.md
@@ -28,7 +28,7 @@ For Neo4j, register a builder that converts the Value to Neo4j scalars under the
 $registrar->addNeo4jValueBuilder( ColorType::NAME, static fn ( $value ) => $value->toScalars() );
 ```
 
-For the [RDF export](../rdf/rdf-export.md), register a mapper under the Property Type name with
+For the [RDF export](../api/rdf-export.md), register a mapper under the Property Type name with
 `NeoWikiRegistrar::addRdfValueMapper()`. It receives the Statement's `NeoValue` and returns a list of RDF terms —
 `Literal`s, or `Iri`s for values that denote a resource, as the built-in `url` mapper does — one per value part.
 Guard the value shape: the mapper receives whatever a Statement holds. RedHerb's

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -185,7 +185,7 @@ surfaces select a Projection by name.
 ## Mapping
 
 A Mapping defines how Subjects that follow native Schemas are expressed in an established ontology such as EDM
-or CIDOC-CRM ([Ontology Mapping](rdf/ontology-mapping.md)). Each Mapping is a page in the `Mapping:` namespace
+or CIDOC-CRM ([Mapping Format](authoring/mapping-format.md)). Each Mapping is a page in the `Mapping:` namespace
 and defines one ontology projection; the Mapping page's title is the projection name.
 
 

--- a/docs/guide/author-an-ontology-mapping.md
+++ b/docs/guide/author-an-ontology-mapping.md
@@ -6,8 +6,8 @@ order: 2
 # Author an ontology mapping
 
 A Mapping page defines an ontology projection of your wiki's Subjects: the same data expressed in EDM, CIDOC-CRM, or
-another vocabulary. The format is specified in [Ontology Mapping](../rdf/ontology-mapping.md), and
-[Person to EDM](../rdf/person-to-edm.md) walks one end to end.
+another vocabulary. The format is specified in [Mapping Format](../authoring/mapping-format.md), and
+[Project a Person to EDM](person-to-edm.md) walks one end to end.
 
 ## 1. Create the Mapping
 
@@ -29,7 +29,7 @@ and reports errors, and the page's read view shows a summary of the mapped Schem
 
 Exports are produced on demand from current data, so a new or edited Mapping takes effect right away.
 On any page with Subjects, the **Data** tab offers per-projection RDF downloads, as Turtle or TriG. Per-Subject
-exports, the REST endpoint, and the bulk dump are in [RDF Export](../rdf/rdf-export.md).
+exports, the REST endpoint, and the bulk dump are in [RDF Export](../api/rdf-export.md).
 
 ## 4. Query the projection over SPARQL
 

--- a/docs/guide/keep-your-wiki-current.md
+++ b/docs/guide/keep-your-wiki-current.md
@@ -1,6 +1,6 @@
 ---
 title: Keep your wiki current
-order: 3
+order: 4
 ---
 
 # Keep your wiki current

--- a/docs/guide/person-to-edm.md
+++ b/docs/guide/person-to-edm.md
@@ -1,10 +1,10 @@
 ---
-title: Person to EDM example
+title: Project a Person to EDM
 order: 3
 ---
 # Worked example: projecting a Person to EDM
 
-End-to-end walkthrough of an [Ontology Mapping](ontology-mapping.md) projection: a NeoWiki-native `Person`
+End-to-end walkthrough of an [ontology mapping](../authoring/mapping-format.md) projection: a NeoWiki-native `Person`
 Schema, an EDM Mapping, and a demo page projected into
 [Europeana Data Model](https://pro.europeana.eu/page/edm-documentation) (EDM) RDF, shown against the native projection.
 
@@ -52,7 +52,7 @@ The demo `City` Schema ([`DemoData/Schema/City.json`](../../DemoData/Schema/City
 ## 2. The Mapping
 
 One Mapping page, **[`Mapping:EDM`](../../DemoData/Mapping/EDM.json)**, holds an entry per mapped Schema; its title
-(`EDM`) is the projection name (see [Ontology Mapping](ontology-mapping.md) for the format). Abbreviated to the
+(`EDM`) is the projection name (see [Mapping Format](../authoring/mapping-format.md) for the format). Abbreviated to the
 two entries this walkthrough uses — the shipped file also maps `Birth`, `Place`, `Artwork` and `Artist` and declares
 the `dc`/`dcterms`/`xsd`/`ore` prefixes those need:
 
@@ -91,7 +91,7 @@ its `Birth place` relation pointing at [`Málaga`](../../DemoData/Subject/Málag
 
 ## 4. Running the projection
 
-Per page, via the [RDF export endpoint](rdf-export.md#endpoint) — the `projection` query parameter selects the
+Per page, via the [RDF export endpoint](../api/rdf-export.md#endpoint) — the `projection` query parameter selects the
 vocabulary:
 
 ```sh
@@ -110,7 +110,7 @@ php maintenance/run.php NeoWiki:DumpRdf --projection=EDM > dump-edm.trig
 ## 5. Native vs EDM output
 
 Real output from the demo wiki (Turtle; shared prefix header trimmed — the `neo*` CURIEs are the
-[IRI scheme](rdf-export.md#iri-scheme)). The **native** projection of `Pablo_Picasso` —
+[IRI scheme](../api/rdf-export.md#iri-scheme)). The **native** projection of `Pablo_Picasso` —
 NeoWiki's own vocabulary, lossless, with page metadata and the two-layer relation:
 
 ```turtle
@@ -229,7 +229,7 @@ For an ad-hoc load instead, feed the `DumpRdf --projection=EDM` output into any 
 
 The toy model's CIDOC-CRM column mediates birth through an `E67_Birth` event node and an `E52_Time-Span`, neither of
 which exists in NeoWiki's flat data. `Mapping:CIDOC-CRM`, also shipped as demo data, declares both as
-[synthesized nodes](ontology-mapping.md#synthesized-node-iris) and attaches `Birth place` and `Birth date` to them, so
+[synthesized nodes](../authoring/mapping-format.md#synthesized-node-iris) and attaches `Birth place` and `Birth date` to them, so
 the same `Pablo_Picasso` page exports as an `E21_Person` whose birth hangs off minted event nodes. Which formalism
 authors should ultimately write such mappings in stays open
 ([OntologyMapping.md Q1](../planning/OntologyMapping.md#open-questions),

--- a/docs/operations/installation.md
+++ b/docs/operations/installation.md
@@ -288,7 +288,7 @@ reverse proxy, and see [Restricting federation](#restricting-federation).
 ### Several projections in one store
 
 Each entry carries one projection, so a store that should hold several gets one entry per projection, all with
-the same `updateUrl`. Each projection writes its own [named graphs](../rdf/rdf-export.md#iri-scheme), so they never
+the same `updateUrl`. Each projection writes its own [named graphs](../api/rdf-export.md#iri-scheme), so they never
 overwrite one another:
 
 ```php
@@ -308,7 +308,7 @@ $wgNeoWikiSparqlStores = [
 
 Sibling projections mint the same entity IRIs, so one query can combine data from both — the target ontology's terms
 alongside a property that ontology does not model. The
-[Person-to-EDM example](../rdf/person-to-edm.md#querying-via-sparql) shows such a query.
+[Person-to-EDM example](../guide/person-to-edm.md#querying-via-sparql) shows such a query.
 
 A newly added entry only receives pages saved from then on. Backfill it, and only it, by
 [rebuilding that one store](maintenance.md#rebuilding-one-store).
@@ -331,7 +331,7 @@ Each is read-only: the query is sent as a SPARQL 1.1 *query* operation, posted o
 A projection configured on a different endpoint is therefore not reachable from these surfaces.
 
 NeoWiki writes pages into named graphs and nothing into the default graph, so whether an unscoped query finds them is
-the store's choice; see [RDF Export](../rdf/rdf-export.md#iri-scheme).
+the store's choice; see [RDF Export](../api/rdf-export.md#iri-scheme).
 
 Both bundled Docker stacks, demo and dev, ship working QLever and Oxigraph examples wired up this way — see
 [`Docker/README.md`](../../Docker/README.md#qlever-sparql-store) for the services, QLever's `--persist-updates`

--- a/docs/operations/performance.md
+++ b/docs/operations/performance.md
@@ -33,7 +33,7 @@ carries millions of them, and the wiki behind it held 4 000 pages rather than 10
 ## With a SPARQL store
 
 A [SPARQL store](installation.md#optional-sparql-graph-stores) adds the
-[RDF projection and its SPARQL query surface](../rdf/rdf-export.md) alongside Neo4j, and every write then pays for
+[RDF projection and its SPARQL query surface](../api/rdf-export.md) alongside Neo4j, and every write then pays for
 it — how much depends on the engine. Measured 2026-08-09 on `adbdd656`: a fresh wiki grown to 20 000 Subjects /
 590 000 triples (~30 triples per Subject), two projections per page into one store, whole-run means of two imports
 per engine. These rates are not comparable to the million-node table above; this corpus is fifty times smaller and

--- a/docs/planning/NativeRdfProjection.md
+++ b/docs/planning/NativeRdfProjection.md
@@ -10,9 +10,9 @@ Discussion: [#999](https://github.com/ProfessionalWiki/NeoWiki/discussions/999).
 > IRI/namespace regime — wiki-level, so subject IRIs are identical across stores — reused by every
 > sibling projection, and the per-page named graphs it defines, qualified by projection
 > ([#1053](https://github.com/ProfessionalWiki/NeoWiki/issues/1053)) so sibling projections can share one store. See
-> the [RDF Export reference](../rdf/rdf-export.md). Ontology (sibling) projections build on this shared
+> the [RDF Export reference](../api/rdf-export.md). Ontology (sibling) projections build on this shared
 > infrastructure — see [OntologyMapping.md](OntologyMapping.md) and the worked
-> [Person → EDM example](../rdf/person-to-edm.md). The sync into a configured SPARQL 1.1 store (e.g. QLever) has
+> [Person → EDM example](../guide/person-to-edm.md). The sync into a configured SPARQL 1.1 store (e.g. QLever) has
 > shipped too, as the per-page graph replacement this document specifies.
 
 ## Still open (2026-08)
@@ -54,7 +54,7 @@ this document.
 
 This design has shipped. What NeoWiki actually emits — the IRI and namespace regime, the triples
 for Subjects, Statements, Relations and page metadata, the per-page named graphs, and the export endpoints — is
-the [RDF Export reference](../rdf/rdf-export.md); the [Person → EDM example](../rdf/person-to-edm.md) shows a real
+the [RDF Export reference](../api/rdf-export.md); the [Person → EDM example](../guide/person-to-edm.md) shows a real
 page projected. A configured SPARQL store receives each save as a replace of that page's graph and each deletion as
 a drop ([store configuration](../operations/installation.md#optional-sparql-graph-stores)); the measured cost of
 that write path, and the targets it is held to, are in the
@@ -70,7 +70,7 @@ that write path, and the targets it is held to, are in the
   intermediate nodes that don't exist in NeoWiki's data. That node synthesis has shipped
   ([#1229](https://github.com/ProfessionalWiki/NeoWiki/pull/1229),
   [#1263](https://github.com/ProfessionalWiki/NeoWiki/pull/1263)); the
-  [Person → EDM example](../rdf/person-to-edm.md) walks a worked case.
+  [Person → EDM example](../guide/person-to-edm.md) walks a worked case.
   At the ECHOLOT meeting in Bilbao (March 2026), the consortium agreed that wiki admins should be able to define
   mappings between ontologies they care about and the NeoWiki Schemas of their wiki. This confirmed the
   separate-mapping approach, and is why Q1, Q2 and Q4 resolved toward keeping the native projection minimal (see
@@ -103,7 +103,7 @@ should mint URIs?
 followed up on.*
 
 *As built: the base URI is configurable — `$wgNeoWikiRdfBaseUri`, defaulting to the wiki's canonical URL
-(`$wgCanonicalServer`); see the [RDF Export reference](../rdf/rdf-export.md). What stays open is which value an
+(`$wgCanonicalServer`); see the [RDF Export reference](../api/rdf-export.md). What stays open is which value an
 ECCCH-integrated deployment should be given.*
 
 ### Q8: Writer's schema in RDF
@@ -133,7 +133,7 @@ Answered by shipping or by partner feedback. Numbers are the original question n
 - **Q2 — standard vocabulary.** The native projection stays minimal — `rdf:type`, `rdfs:label`, and
   `dcterms:created`/`dcterms:modified`. Further standard-vocabulary alignment belongs to an ontology mapping.
 - **Q3 — relation representation.** Wikibase-style reification alongside the direct triple, as specified
-  ([reference](../rdf/rdf-export.md#projected-triples)); George Bruseker (takin) confirmed having both
+  ([reference](../api/rdf-export.md#projected-triples)); George Bruseker (takin) confirmed having both
   representations is handy. Residue: `relationType` was flagged as a confusing term
   ([#999](https://github.com/ProfessionalWiki/NeoWiki/discussions/999)) and renaming it rides with the relations
   design pass ([#630](https://github.com/ProfessionalWiki/NeoWiki/issues/630)), which may reshape the Relation node.

--- a/docs/planning/OntologyMapping.md
+++ b/docs/planning/OntologyMapping.md
@@ -15,8 +15,8 @@ Discussion: [#996](https://github.com/ProfessionalWiki/NeoWiki/discussions/996).
 > selectable alongside the native one on the RDF export endpoint and `DumpRdf`.
 > The near-1:1 term-substitution tier shipped first (2026-07); the **structural tier** followed as an optional
 > addition to the same format: node synthesis with deterministic IRIs, and contraction as source-side
-> contributions. See the [Ontology Mapping reference](../rdf/ontology-mapping.md) and the worked
-> [Person → EDM example](../rdf/person-to-edm.md). The rule format is NeoWiki-native, so the
+> contributions. See the [Ontology Mapping reference](../authoring/mapping-format.md) and the worked
+> [Person → EDM example](../guide/person-to-edm.md). The rule format is NeoWiki-native, so the
 > mapping-formalism question (Q1, [#995](https://github.com/ProfessionalWiki/NeoWiki/issues/995)) stays open
 > at the authoring level; the stored format is provisional. The questions it answered are listed under
 > [Decided](#decided).
@@ -56,7 +56,7 @@ graph-to-graph transformation governed by reusable patterns.
 
 > Terminology note: ECHOLOT partners often say "RDF mapping" for ontology alignment — that is *this* document. The
 > native vocabulary and the infrastructure shared by all projections (IRIs, named graphs, sync) are specified in the
-> [RDF Export reference](../rdf/rdf-export.md).
+> [RDF Export reference](../api/rdf-export.md).
 
 ## Projections, not layers
 
@@ -114,7 +114,7 @@ are needed because a wiki serves several targets at once ([sibling projections](
 disagree about shape, so at least one mismatches whichever style the data is modelled in.
 
 Expressing both in one declarative form is what the mapping format had to solve, and does. The
-[Person → EDM example](../rdf/person-to-edm.md) walks a real projection, including the `E67_Birth` synthesis.
+[Person → EDM example](../guide/person-to-edm.md) walks a real projection, including the `E67_Birth` synthesis.
 
 ### Flat vs nested native modelling (open fork)
 
@@ -160,7 +160,7 @@ remove the requirement (Q10).
 
 A Mapping is a JSON page in the `Mapping:` namespace that defines one projection, declaring per Schema how the Subject,
 its properties, its synthesized nodes, and its contributions project. It is specified in the
-[Ontology Mapping reference](../rdf/ontology-mapping.md).
+[Ontology Mapping reference](../authoring/mapping-format.md).
 
 ## Import
 
@@ -199,7 +199,7 @@ Proposed division of labour: shape engines run in external quality tooling (T4.5
 NeoWiki's job is to keep projections checkable and findings traceable:
 
 - Export of projected RDF for a given mapping (per page and in bulk), so external validators have input.
-- Per-page named graphs ([RDF Export reference](../rdf/rdf-export.md#iri-scheme)) make re-validation incremental:
+- Per-page named graphs ([RDF Export reference](../api/rdf-export.md#iri-scheme)) make re-validation incremental:
   only pages whose graphs changed since the last run need re-checking.
 - **Traceability requirement.** A validation report references ontology-projection nodes, but the people acting on it
   work in the wiki. Reports must be translatable back to the originating page, Subject, and property. The anchors
@@ -220,7 +220,7 @@ native projection as the default target; the Mapping as a bidirectional definiti
 
 - The native projection and the shared projection infrastructure (IRIs, named graphs, sync) —
   [NativeRdfProjection.md](NativeRdfProjection.md) for the rationale, the
-  [RDF Export reference](../rdf/rdf-export.md) for what it emits.
+  [RDF Export reference](../api/rdf-export.md) for what it emits.
 - The import *pipeline* mechanics and orchestration — T4.1.
 - Reconciliation / entity linking / `owl:sameAs` minting — WP4 (T4.2); mapped IRIs are its input.
 - Rich chain-of-production provenance and rights — T2.4 model and a T3.4 plug-in (see [ECHOLOT.md](ECHOLOT.md)).
@@ -298,16 +298,16 @@ Answered by the shipped implementation. Numbers are the original question number
 
 - **Q2 — expressiveness for node synthesis.** The format expresses both directions natively: synthesized nodes for
   expansion, contributions for contraction. Neither SHACL Advanced Features nor `CONSTRUCT` became the substrate
-  ([reference](../rdf/ontology-mapping.md)).
+  ([reference](../authoring/mapping-format.md)).
 - **Q6 — one mapping per target vs combined.** One Mapping page per projection, holding an entry for every mapped
   Schema ([#1086](https://github.com/ProfessionalWiki/NeoWiki/pull/1086),
   [discussion #1065](https://github.com/ProfessionalWiki/NeoWiki/discussions/1065)). A projection is not an ontology:
   two Mapping pages can both use CIDOC-CRM terms, each defining its own shape
   ([#996 comment](https://github.com/ProfessionalWiki/NeoWiki/discussions/996#discussioncomment-17920073), 2026-08-06).
 - **Q7 — where Mappings live.** Pages in the `Mapping:` namespace, listed on `Special:Mappings` and gated by the
-  `neowiki-mapping-edit` right ([reference](../rdf/ontology-mapping.md#ontology-mappings-are-wiki-pages)).
+  `neowiki-mapping-edit` right ([reference](../authoring/mapping-format.md#ontology-mappings-are-wiki-pages)).
 - **Q8 — language tags in a mapping.** A mapped property or contribution takes a `lang` tag, applied to the plain-string
-  literals it produces ([reference](../rdf/ontology-mapping.md#format-version-1)); the native projection mints none.
+  literals it produces ([reference](../authoring/mapping-format.md#format-version-1)); the native projection mints none.
 - **Q9 — multiple projections per wiki.** A wiki serves several sibling projections at once, selected per request, with
   `native` always the baseline; named graphs are qualified by projection so one store can hold several
   ([#1055](https://github.com/ProfessionalWiki/NeoWiki/pull/1055),
@@ -315,7 +315,7 @@ Answered by the shipped implementation. Numbers are the original question number
 - **Identity for synthesized nodes.** Node IRIs are derived deterministically from the data — from the Relation's
   persistent ID where one exists ([ADR 10](../adr/010-add-guids-to-relations.md)), otherwise from the Subject IRI and
   the node key — so re-projecting a page is idempotent
-  ([reference](../rdf/ontology-mapping.md#synthesized-node-iris)).
+  ([reference](../authoring/mapping-format.md#synthesized-node-iris)).
 
 ## Related
 

--- a/docs/planning/Relations.md
+++ b/docs/planning/Relations.md
@@ -30,7 +30,7 @@ relation Property Definition carries `relation` (the edge-type name), `targetSch
 - **Projection.** The ontology mapping synthesizes intermediate nodes from flat Subjects at projection time
   ([#1229](https://github.com/ProfessionalWiki/NeoWiki/pull/1229),
   [#1263](https://github.com/ProfessionalWiki/NeoWiki/pull/1263)). The native RDF projection reifies each Relation
-  beside its direct triple ([RDF export](../rdf/rdf-export.md)); the reification shape is decided
+  beside its direct triple ([RDF export](../api/rdf-export.md)); the reification shape is decided
   ([NativeRdfProjection.md](NativeRdfProjection.md)), the predicate name follows decision 6.
 
 ## Decisions

--- a/docs/planning/ShapeLanguages.md
+++ b/docs/planning/ShapeLanguages.md
@@ -37,7 +37,7 @@ validator behind REST endpoints returns structured violations ([ADR 21](../adr/0
 amended by [ADR 25](../adr/025-backend-driven-frontend-validation.md); [codes reference](../api/validation-codes.md)),
 and the editing UI renders what the server returns. For RDF, the wiki's data is *projected*: a native projection
 ([NativeRdfProjection](NativeRdfProjection.md)) and per-store ontology projections
-([OntologyMapping](OntologyMapping.md); shipped, see the [reference](../rdf/ontology-mapping.md)).
+([OntologyMapping](OntologyMapping.md); shipped, see the [reference](../authoring/mapping-format.md)).
 
 ## Why not as the internal format or engine
 

--- a/docs/qualifiers-and-references.md
+++ b/docs/qualifiers-and-references.md
@@ -82,8 +82,8 @@ vs. historical values, or a status property for deprecated ones.
 ## In RDF
 
 A qualified value round-trips without loss: a linked Subject is its own resource, and a Relation keeps its ID and its
-properties ([Graph Model](api/graph-model.md)). See [RDF Export](rdf/rdf-export.md) for the native projection and
-[Ontology Mapping](rdf/ontology-mapping.md) for projecting into standard ontologies such as EDM.
+properties ([Graph Model](api/graph-model.md)). See [RDF Export](api/rdf-export.md) for the native projection and
+[Mapping Format](authoring/mapping-format.md) for projecting into standard ontologies such as EDM.
 
 ## Presentation
 
@@ -93,5 +93,5 @@ How a property renders is set by Display Attributes and [Layouts](glossary.md#la
 
 - [Glossary](glossary.md) — Subject, Statement, Relation, Schema, Layout
 - [Subject Format](api/subject-format.md) and [Graph Model](api/graph-model.md)
-- [Worked example: Person to EDM](rdf/person-to-edm.md) — ontology mapping end to end; its CIDOC-CRM tier
+- [Project a Person to EDM](guide/person-to-edm.md) — ontology mapping end to end; its CIDOC-CRM tier
   revisits intermediate-node modelling at the RDF level


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/NeoWiki/issues/1336

The three `rdf/` pages served three readers. RDF Export is the endpoint, the IRI scheme and the bulk dump, so it joins
the API pages; the Ontology Mapping page was already the Mapping format reference, so it becomes Mapping Format next
to the parser functions and Lua, since Mapping JSON is what authors write; the Person-to-EDM walkthrough is a guide.
The section they leave is renamed API. The format reference drops its authoring steps, which the guide already
gives, and its projection-parameter section, which RDF Export owns; the save-time structural checks the steps
mentioned moved into the safety section.

Every relative link and anchor across `docs/` checked by script; the demo pages' links to the published docs updated.
The website side (redirects for the old URLs, the section rename, and a sticky section row on desktop) is a
companion PR that merges first, so the old URLs never 404.

> <sub>AI-authored — Claude Code, `Fable 5.1 (max)`; from @JeroenDeDauw's agreement to the split, no redirection; text not yet human-reviewed; links checked by script.</sub>
