### PR TITLE
Tighten the restricted-content page to the operator's decisions

### DIFF
--- a/docs/operations/installation.md
+++ b/docs/operations/installation.md
@@ -360,7 +360,7 @@ token, so keep that token secret.
 Oxigraph has no equivalent setting and will attempt the outbound request; the stacks' Oxigraph services federate
 for that reason. Other stores vary — consult their documentation. Where the store cannot be restricted, restrict
 around it: block its outbound traffic at the network layer, and narrow who holds the `neowiki-query` right — see
-[Choosing who may query](restricted-content.md#choosing-who-may-query).
+[Narrowing `neowiki-query`](restricted-content.md#narrowing-neowiki-query).
 
 ## Production hardening
 

--- a/docs/operations/restricted-content.md
+++ b/docs/operations/restricted-content.md
@@ -5,68 +5,53 @@ order: 5
 
 # Restricted content
 
-What NeoWiki restricts, and what it does not, on a wiki where some content is readable only by certain users or
-groups. Page protection and `$wgNamespaceProtection` do not restrict reading; see
-[Permissions](../api/rest-api.md#permissions).
+NeoWiki gates every read on the page that stores the data, with the reader's own rights, and has nothing finer than
+the page ([ADR 27](../adr/027-access-control.md)). Page protection and `$wgNamespaceProtection` do not restrict
+reading ([Permissions](../api/rest-api.md#permissions)).
 
-## What limits each surface
+## What each surface checks
 
-Enforced per page:
+| Surface | Gate | A denied reader gets |
+|---|---|---|
+| Subject, subject-label search, Schema, Layout, Mapping and RDF reads over [REST](../api/rest-api.md#permissions) | The storing page's `read` | Absent data, never `403` |
+| `{{#view}}` | The storing page's `read`, per viewer over REST | Nothing rendered |
+| `{{#neowiki_value}}` and the `nw.` accessors | The storing page's `read`, as the parsing user | Empty output, `nil`, or an empty table |
+| `{{#cypher_raw}}`, `{{#sparql_raw}}`, `nw.query`, `nw.sparqlQuery` | The parsing user's [`neowiki-query`](../api/query-api.md#permissions), a whole-store read | An error box; Lua throws |
+| `POST /query/cypher`, `POST /query/sparql` | The caller's `neowiki-query` | `403` |
+| Graph-store status and rebuilds | The caller's `neowiki-admin` (`sysop` by default) | `403` |
+| Subjects from a [Subject Source](../extending/subject-sources.md) | Nothing: no page to authorize against, so a Source must serve only what every reader may see | — |
 
-| Surface | What limits it |
-|---|---|
-| REST reads | The page's `read`. |
-| REST writes | The page's `edit`. |
-| `{{#view}}` | The source page's `read`. |
-| `{{#neowiki_value}}` and the `nw.` accessors | The parsing user's `read`. |
+On a wiki that requires login to read, `{{#view}}` renders nothing for anonymous readers on a page opened through
+`$wgWhitelistRead`: they get no [REST](../api/rest-api.md#permissions) at all.
 
-Enforced wiki-wide, or not at all:
+## Narrowing `neowiki-query`
 
-| Surface | What limits it |
-|---|---|
-| `POST /query/cypher`, `POST /query/sparql` | The caller's [`neowiki-query`](../api/query-api.md#permissions). |
-| `{{#cypher_raw}}`, `{{#sparql_raw}}`, `nw.query`, `nw.sparqlQuery` | The parsing user's `neowiki-query`. |
-| Graph-store status and rebuilds | The caller's `neowiki-admin`. |
-| Subjects from a [Subject Source](../extending/subject-sources.md) | Nothing. They have no page here to authorize against, so a Source must serve only what every reader may see. |
-| Graph stores, RDF dumps and their backups | Nothing. They hold restricted content in full. |
-
-## Choosing who may query
-
-NeoWiki grants `neowiki-query` to everyone (`*`) by default. Removing it helps only where anonymous readers can
-reach a query surface — on a wiki they cannot read at all, they cannot reach one either. To remove it:
+NeoWiki grants the right to `*`. Withdrawing it helps only where anonymous readers can reach a query surface.
 
 ```php
 $wgGroupPermissions['*']['neowiki-query'] = false;
+$wgGroupPermissions['user']['neowiki-query'] = true;
 ```
 
-Grant it to whichever groups should keep it, and check the result on `Special:ListGroupRights`. OAuth consumers
-and bot passwords need no separate change.
+Check `Special:ListGroupRights`, then load a page with a raw query while logged out. OAuth consumers and bot
+passwords need no separate change.
 
-## What readers see
+Saves, job-queue parses and Parsoid renders run as the anonymous user, so a page using `{{#cypher_raw}}` or
+`{{#sparql_raw}}` shows an error box in place of the results to readers without the right, and a page using
+`nw.query` or `nw.sparqlQuery` shows a script error and joins the pages-with-script-errors category unless the
+module wraps the call in `pcall`. Readers who hold the right get
+[their own cached parse](../authoring/parser-functions.md) and see results.
 
-After narrowing `neowiki-query`:
+## Where the protection stops
 
-- A page using `{{#cypher_raw}}` or `{{#sparql_raw}}` shows an error box where the results were, to anyone who no
-  longer holds the right.
-- A page using `nw.query` or `nw.sparqlQuery` shows a script error and joins the wiki's pages-with-script-errors
-  category, because the save and job-queue parses run as an anonymous user. A module can avoid that by wrapping
-  the call in `pcall`.
-- Readers who still hold the right see results as before.
-
-Whether or not you narrow it:
-
-- Restricting a page does not clear what is already cached. A page showing that data keeps showing it until it is
-  edited or purged, or `$wgParserCacheExpireTime` elapses. Purge it to apply the change at once.
-- Where readers who share the same groups may read different pages — because `read` is granted per account, per
-  IP or per session — a cached page can show one reader's data to another. Render Subjects through `{{#view}}`
-  there: it fetches per viewer instead of reading at parse time.
-- On a wiki where anonymous users cannot read, a category or page property that a template derives from a Subject
-  value is never set. That is expected, not a fault to report.
-
-## Stores and dumps
-
-Restricting a page removes nothing from a store, and a rebuild reprojects it, so a store that has once held
-restricted content keeps holding it. Do not expose a SPARQL store directly on a wiki with restricted content, and
-treat a [bulk dump](../api/rdf-export.md#bulk-dump) and any store backup as readable by whoever can reach it.
-
-The model behind all of this is [ADR 27: Access Control](../adr/027-access-control.md).
+- **Cached output outlives a restriction.** A page that showed now-restricted data keeps showing it until it is
+  edited or purged, or `$wgParserCacheExpireTime` (a day by default) elapses.
+- **Per-account `read` is unsupported.** Parse-time output is cached per the reader's groups and wiki-level rights:
+  exact for private wikis, namespace lockdowns, `$wgWhitelistRead` and group-configured ACL extensions, wrong for a
+  hook granting `read` per account, IP or session, where a cached page can show one reader's data to another.
+  Render Subjects through `{{#view}}` there; it fetches per viewer.
+- **Stores and dumps hold restricted content in full.** Restricting a page removes nothing from a graph store, and a
+  rebuild reprojects it; deleting the page does remove it. Do not expose a SPARQL store directly, and treat a
+  [bulk dump](../api/rdf-export.md#bulk-dump) and any store backup as readable by whoever can reach it.
+- **Derived data follows the anonymous parse.** On a wiki where anonymous users cannot read, a category or page
+  property a template derives from a Subject value is never set.


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1401

One table now answers which surface checks what and what a denied reader gets, replacing two tables and a prose
section that said it again for the query surfaces; the store-and-dump caveat appears once instead of twice. The
sections run in the order the operator decides: what is exposed, what to narrow, where the protection stops.

New facts an operator acts on, each derived from the code or ADR 27: `{{#view}}` renders nothing for anonymous
readers on a `$wgWhitelistRead` page, since a login-required wiki refuses them every REST request; which access
configurations the parser-cache key is exact for; how to verify the narrowed right; the default holder of
`neowiki-admin`; and that deleting a page, not restricting it, is what removes it from a store. Cut: the mechanism
behind each of those, and the sentences that restated the linked REST and query contracts. 57 lines against 72.

Spec: reader is the sysadmin of a wiki whose readers do not all see the same pages; decision is which surfaces can
expose restricted content, what to configure, what readers then see, and where NeoWiki's protection stops.

Considered, omitted: the REST status codes per read surface (home: `rest-api.md#permissions`); the write endpoints,
which cannot expose content; the rationale for keeping the `*` default (on the issue); `$wgParserCacheType =
CACHE_NONE`, which the page it replaces already declined to prescribe.

Found on the way, not addressed here: a page holding a `{{#view}}` of a Subject the viewer may not read appears to
render none of its views, because `StoreStateLoader.loadForSubject` has no catch and the rejection propagates
through the `Promise.all` in `NeoWikiApp.vue` before `viewsData` is assigned. The page states the contract ("nothing
rendered") rather than the bug.

> <sub>AI-authored — Claude Code, `Fable 5.1 (max)`; from @JeroenDeDauw's "use the writing skill to create them from scratch and then compare and optimize" on the merged page: a blind Opus draft derived from code and ADR 27 without sight of the page, a blind judge comparing the two, then this synthesis; text not yet human-reviewed; every added fact traced to a source file by the drafter, links and anchors checked by script.</sub>

