### PR TITLE
Special:Subject review fixes: keyboard "Open subject", read ordering, delete-dialog tests

### DIFF
--- a/resources/ext.neowiki/src/components/SubjectPage/SubjectPage.vue
+++ b/resources/ext.neowiki/src/components/SubjectPage/SubjectPage.vue
@@ -148,18 +148,31 @@ function toggleExpanded( toggled: Subject ): void {
 	expandedIds.value = next;
 }
 
+// The delete controls stay live while a re-read is in flight, so reads can overlap; only the one
+// started last decides what the rows show.
+let latestRead = 0;
+
 async function readSubject(): Promise<void> {
+	const read = ++latestRead;
+	const subjectEpoch = subjectStore.mutationEpoch;
 	const bundle = await subjectRepo.getSubjectWithReferencedSubjects( subjectId );
 	const requested = bundle.requestedSubject;
 
 	// Seeding the registry is what lets RelationDisplay resolve this Subject's relation targets,
-	// the same way the Data tab's own load does.
-	subjectStore.setSubject( requested );
-	bundle.referencedSubjects.forEach( ( referenced ) => subjectStore.setSubject( referenced ) );
+	// the same way the Data tab's own load does. A write acknowledged meanwhile may postdate what
+	// this read returned, so the registry is then left alone (ADR 30 rule 3).
+	if ( subjectEpoch === subjectStore.mutationEpoch ) {
+		subjectStore.setSubject( requested );
+		bundle.referencedSubjects.forEach( ( referenced ) => subjectStore.setSubject( referenced ) );
+	}
 	await Promise.all( [
 		loadSchemas( [ requested, ...bundle.referencedSubjects ] ),
 		seedRelationTargetsOf( bundle.referencedSubjects )
 	] );
+
+	if ( read !== latestRead ) {
+		return;
+	}
 
 	subject.value = requested;
 	referencedSubjects.value = bundle.referencedSubjects;
@@ -225,10 +238,15 @@ async function seedRelationTargetsOf( subjects: Subject[] ): Promise<void> {
 async function loadSchemas( subjects: Subject[] ): Promise<void> {
 	const names = [ ...new Set( subjects.map( ( each ) => each.getSchemaName() ) ) ]
 		.filter( ( name ) => !schemaStore.schemas.has( name ) );
+	const epoch = schemaStore.mutationEpoch;
 
 	await Promise.all( names.map( async ( name ) => {
 		try {
-			schemaStore.setSchema( name, await schemaRepo.getSchema( name ) );
+			const schema = await schemaRepo.getSchema( name );
+
+			if ( epoch === schemaStore.mutationEpoch ) {
+				schemaStore.setSchema( name, schema );
+			}
 		} catch ( error ) {
 			console.error( `Failed to load schema ${ name }:`, error );
 		}

--- a/resources/ext.neowiki/src/components/SubjectsManager/SubjectRow.vue
+++ b/resources/ext.neowiki/src/components/SubjectsManager/SubjectRow.vue
@@ -317,12 +317,10 @@ const menuItems = computed<MenuButtonItemData[]>( () => {
 	const items: MenuButtonItemData[] = [];
 
 	if ( props.subjectPageUrl !== null ) {
-		// A url makes Codex render the item as a link, so choosing it navigates by itself.
 		items.push( {
 			value: 'open',
 			label: mw.msg( 'neowiki-managesubjects-row-open' ),
-			icon: cdxIconNext,
-			url: props.subjectPageUrl
+			icon: cdxIconNext
 		} );
 	}
 
@@ -370,11 +368,13 @@ const menuItems = computed<MenuButtonItemData[]>( () => {
 
 const menuSelection = ref<string | number | null>( null );
 
-// 'open' is absent: that item carries a url, so Codex navigates without this being asked.
+// Codex selects an item chosen with the keyboard but never follows a url, so 'open' navigates here.
 function dispatchMenuAction( value: string | number | null ): void {
 	menuSelection.value = null;
 
-	if ( value === 'copy-link' ) {
+	if ( value === 'open' && props.subjectPageUrl !== null ) {
+		window.location.href = props.subjectPageUrl;
+	} else if ( value === 'copy-link' ) {
 		emit( 'copy-link', props.subject );
 	} else if ( value === 'edit' ) {
 		emit( 'edit', props.subject );

--- a/resources/ext.neowiki/tests/components/SubjectPage/SubjectPage.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectPage/SubjectPage.spec.ts
@@ -134,6 +134,12 @@ function stubExtension( repositories: { subject?: object; schema?: object } ): v
 	} as unknown as NeoWikiExtension );
 }
 
+// Renders its slot, so the Subject name the delete confirmation interpolates reaches the DOM.
+const I18nSlotStub = {
+	template: '<span>{{ messageKey }}<slot /></span>',
+	props: [ 'messageKey' ],
+};
+
 function silenceConsoleErrors(): void {
 	vi.spyOn( console, 'error' ).mockImplementation( () => undefined );
 }
@@ -157,7 +163,13 @@ function mountPage(): VueWrapper {
 			mocks: { $i18n: createI18nMock() },
 			// The row and the delete dialog are this page's own building blocks rather than
 			// collaborators to stand in for: the assertions below are about what they render.
-			stubs: { CdxIcon: true, CdxDialog: CdxDialogStub, SubjectRow: false, SubjectDeleteDialog: false },
+			stubs: {
+				CdxIcon: true,
+				CdxDialog: CdxDialogStub,
+				I18nSlot: I18nSlotStub,
+				SubjectRow: false,
+				SubjectDeleteDialog: false,
+			},
 			provide: {
 				[ Service.SubjectRepository ]: {
 					getSubjectWithReferencedSubjects: getSubjectWithReferencedSubjectsMock,
@@ -753,6 +765,26 @@ describe( 'SubjectPage', () => {
 				{ type: 'error' },
 			);
 			expect( wrapper.find( `${ REQUESTED_ROW } ${ ROW_LABEL }` ).text() ).toBe( 'ACME Inc' );
+		} );
+
+		// The close button, Escape and a click outside all close the dialog through this event.
+		it( 'closes the confirmation when the dialog asks to close', async () => {
+			const wrapper = await mountLoadedPage();
+			await wrapper.findAll( DELETE_CONTROL )[ 1 ].trigger( 'click' );
+
+			wrapper.findComponent( CdxDialogStub ).vm.$emit( 'update:open', false );
+			await flushPromises();
+
+			expect( wrapper.find( '.cdx-dialog-stub' ).exists() ).toBe( false );
+		} );
+
+		// A referenced row can be stored on another page, so the dialog names the Subject it deletes.
+		it( 'names the Subject about to be deleted', async () => {
+			const wrapper = await mountLoadedPage();
+
+			await wrapper.findAll( DELETE_CONTROL )[ 1 ].trigger( 'click' );
+
+			expect( wrapper.find( '.cdx-dialog-stub strong' ).text() ).toBe( 'Anvil' );
 		} );
 
 	} );

--- a/resources/ext.neowiki/tests/components/SubjectPage/SubjectPage.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectPage/SubjectPage.spec.ts
@@ -787,6 +787,70 @@ describe( 'SubjectPage', () => {
 			expect( wrapper.find( '.cdx-dialog-stub strong' ).text() ).toBe( 'Anvil' );
 		} );
 
+		// The delete controls stay live while a re-read is in flight, so a second delete can be
+		// acknowledged before the re-read the first one started lands (ADR 30 rule 3).
+		it( 'keeps a Subject deleted during a re-read out of the registry', async () => {
+			const other = subject( { id: OTHER_REFERENCED_ID, label: 'Rocket', schemaName: 'Product' } );
+			getSubjectWithReferencedSubjectsMock.mockResolvedValue( bundle( [ referencedSubject, other ] ) );
+			const wrapper = await mountLoadedPage();
+			const subjectStore = useSubjectStore();
+			vi.spyOn( subjectStore, 'deleteSubject' ).mockResolvedValue( undefined );
+			let landReRead!: ( value: SubjectWithReferencedSubjects ) => void;
+			getSubjectWithReferencedSubjectsMock.mockReturnValueOnce( new Promise( ( resolve ) => {
+				landReRead = resolve;
+			} ) );
+
+			await confirmDelete( wrapper, wrapper.findAll( DELETE_CONTROL )[ 1 ] );
+			// The second delete, acknowledged while that re-read is in flight.
+			subjectStore.subjects.delete( OTHER_REFERENCED_ID );
+			subjectStore.mutationEpoch++;
+			landReRead( bundle( [ other ] ) );
+			await flushPromises();
+
+			expect( subjectStore.subjects.has( OTHER_REFERENCED_ID ) ).toBe( false );
+		} );
+
+		it( 'keeps a Schema read that a Schema change overtook out of the store', async () => {
+			const wrapper = await mountLoadedPage();
+			const schemaStore = useSchemaStore();
+			vi.spyOn( useSubjectStore(), 'deleteSubject' ).mockResolvedValue( undefined );
+			getSubjectWithReferencedSubjectsMock.mockResolvedValue(
+				bundle( [ subject( { id: OTHER_REFERENCED_ID, label: 'Amsterdam', schemaName: 'Place' } ) ] ),
+			);
+			let landSchema!: ( value: Schema ) => void;
+			getSchemaMock.mockReturnValueOnce( new Promise( ( resolve ) => {
+				landSchema = resolve;
+			} ) );
+
+			await confirmDelete( wrapper, wrapper.findAll( DELETE_CONTROL )[ 1 ] );
+			// A Schema save, acknowledged while that read is in flight.
+			schemaStore.mutationEpoch++;
+			landSchema( newSchema( { title: 'Place' } ) );
+			await flushPromises();
+
+			expect( schemaStore.schemas.has( 'Place' ) ).toBe( false );
+		} );
+
+		it( 'shows what the latest re-read found when an earlier one lands after it', async () => {
+			const other = subject( { id: OTHER_REFERENCED_ID, label: 'Rocket', schemaName: 'Product' } );
+			getSubjectWithReferencedSubjectsMock.mockResolvedValue( bundle( [ referencedSubject, other ] ) );
+			const wrapper = await mountLoadedPage();
+			vi.spyOn( useSubjectStore(), 'deleteSubject' ).mockResolvedValue( undefined );
+			let landFirstReRead!: ( value: SubjectWithReferencedSubjects ) => void;
+			getSubjectWithReferencedSubjectsMock
+				.mockReturnValueOnce( new Promise( ( resolve ) => {
+					landFirstReRead = resolve;
+				} ) )
+				.mockResolvedValueOnce( bundle() );
+
+			await confirmDelete( wrapper, wrapper.findAll( DELETE_CONTROL )[ 1 ] );
+			await confirmDelete( wrapper, wrapper.findAll( DELETE_CONTROL )[ 2 ] );
+			landFirstReRead( bundle( [ other ] ) );
+			await flushPromises();
+
+			expect( wrapper.find( REFERENCED_ROW ).exists() ).toBe( false );
+		} );
+
 	} );
 
 } );

--- a/resources/ext.neowiki/tests/components/SubjectsManager/SubjectRow.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectsManager/SubjectRow.spec.ts
@@ -220,6 +220,10 @@ describe( 'SubjectRow', () => {
 		const OPEN = '[aria-label="neowiki-managesubjects-row-open"]';
 		const URL = '/wiki/Special:Subject/' + SUBJECT_ID;
 
+		afterEach( () => {
+			vi.unstubAllGlobals();
+		} );
+
 		it( 'is a link to the page the surface named', () => {
 			const wrapper = mountRow( { subjectPageUrl: URL } );
 
@@ -228,11 +232,15 @@ describe( 'SubjectRow', () => {
 			expect( open.attributes( 'href' ) ).toBe( URL );
 		} );
 
-		it( 'is in the overflow menu as a link too', () => {
+		// Codex selects a menu item chosen with the keyboard but does not follow its url.
+		it( 'goes there when chosen from the overflow menu', async () => {
+			vi.stubGlobal( 'location', { href: '' } );
 			const wrapper = mountRow( { subjectPageUrl: URL } );
 
-			const items = wrapper.findComponent( CdxMenuButton ).props( 'menuItems' );
-			expect( items[ 0 ] ).toMatchObject( { value: 'open', url: URL } );
+			wrapper.findComponent( CdxMenuButton ).vm.$emit( 'update:selected', 'open' );
+			await wrapper.vm.$nextTick();
+
+			expect( location.href ).toBe( URL );
 		} );
 
 		it( 'is absent on a row the reader is already on', () => {


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1408

One commit per fix; the last two touch the same spec, so take them in order.

- **"Open subject" from the keyboard.** Codex's menu does not follow an item's `url` when the item is chosen with
  Enter; it only emits the selection. On narrow viewports, where this menu replaces the inline actions, keyboard
  users could not reach Special:Subject. The row now navigates on `open` itself, and the item drops its `url`: with
  it, a ctrl-click would open a new tab and also navigate the current one. The menu item thus loses open-in-new-tab;
  the inline link on wider viewports keeps it. A new SubjectRow test fails without the change.
- **Delete confirmation tests.** Nothing covered `SubjectDeleteDialog`'s close passthrough or the Subject name it
  shows. Two SubjectPage tests now do, each seen failing under a mutation of what it covers; a local `I18nSlot`
  stub, as in `SubjectCreatorDialog.spec.ts`, lets the name render.
- **Overlapping reads on Special:Subject.** `readSubject` and `loadSchemas` wrote to the Subject and Schema stores
  without the epoch guard of ADR 30 rule 3. The delete controls stay live during a re-read, so two deletes confirmed
  within one round trip let the earlier re-read put the deleted Subject back. Both store writes are now guarded as
  page seeding guards them, and only the latest read assigns the rows. Three tests fail without the change.

## Manual Browser Check

1. Open `Special:Subject/s1demo1aaaaaaa1` in a window narrower than 640 px, or at 200% zoom.
2. Tab to a referenced row's "More actions" button, press ArrowDown to open the menu and again to highlight
   "Open subject", then press Enter: the browser goes to that Subject's page.
3. In a wide window, a middle click on the inline "Open subject" link still opens the page in a new tab.

> <sub>AI-authored — Claude Code, `Opus 5 (ultracode)`; `/pr-review` of #1408 run by @alistair3149, fixes chosen by the review with no redirections; diff not yet human-reviewed; each fix test-first (its new tests failed before the change), the dialog tests also confirmed by mutation, full vitest suite, eslint and build green locally (one unrelated flake passed on re-run), the keyboard fix driven in a browser against the dev stack; no PHP touched.</sub>
