### PR TITLE
Make a Subject's name the way to its own page, and match the Data tab's section spacing

### DIFF
--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -391,5 +391,5 @@
 	"neowiki-special-subject-referenced-heading": "Heading on [[Special:Subject]] above the Subjects the displayed Subject's relations point at.",
 	"neowiki-special-subject-not-found": "Shown on [[Special:Subject]] in place of the Subject when the wiki has no Subject with that ID. It is also shown for a Subject on a page the reader may not read, so the translation must not mention permissions.\n\nParameters:\n* $1 - the Subject ID that was asked for",
 	"neowiki-special-subject-load-error": "Shown on [[Special:Subject]] when loading a Subject failed with a network or server error: in place of the Subject on first load, and as a notification when a re-read after a change failed. Distinct from {{msg-neowiki|neowiki-special-subject-not-found}}, which says the wiki has no such Subject.",
-	"neowiki-managesubjects-row-open": "Aria/button label for the row action (an inline button on wide viewports, an overflow-menu item on narrow ones) that goes to [[Special:Subject]], the page showing that one Subject. It navigates; it does not expand the row."
+	"neowiki-managesubjects-row-open": "Label for the item in a Subject row's overflow menu, which replaces the row's inline actions on narrow viewports. It goes to [[Special:Subject]], the page showing that one Subject, which the Subject's name links to as well. It navigates; it does not expand the row."
 }

--- a/resources/ext.neowiki/src/components/SubjectPage/SubjectPage.vue
+++ b/resources/ext.neowiki/src/components/SubjectPage/SubjectPage.vue
@@ -371,18 +371,22 @@ onMounted( async () => {
 		font-style: italic;
 	}
 
-	&__subject,
+	// The spacing between the sections sits on the lists, as on the Data tab: the heading between
+	// them is the skin's, margins included.
+	// One row, so a plain block, like the Data tab's main slot.
+	&__subject {
+		list-style: none;
+		padding: 0;
+		margin: 0 0 @spacing-150;
+	}
+
 	&__referenced {
 		list-style: none;
 		padding: 0;
-		margin: 0;
+		margin: @spacing-100 0 0 0;
 		display: flex;
 		flex-direction: column;
 		gap: @spacing-50;
-	}
-
-	&__referenced-heading {
-		margin: @spacing-150 0 @spacing-75;
 	}
 }
 </style>

--- a/resources/ext.neowiki/src/components/SubjectsManager/SubjectRow.vue
+++ b/resources/ext.neowiki/src/components/SubjectsManager/SubjectRow.vue
@@ -38,7 +38,25 @@
 					/>
 				</template>
 				<span class="ext-neowiki-subject-row__title">
-					<span class="ext-neowiki-subject-row__label">
+					<a
+						v-if="subjectPageUrl !== null"
+						class="ext-neowiki-subject-row__name"
+						:href="subjectPageUrl"
+						@click.stop
+					>
+						<span class="ext-neowiki-subject-row__label">
+							{{ displayName }}
+						</span>
+						<CdxIcon
+							class="ext-neowiki-subject-row__name-arrow"
+							:icon="cdxIconArrowNext"
+							size="x-small"
+						/>
+					</a>
+					<span
+						v-else
+						class="ext-neowiki-subject-row__label"
+					>
 						{{ displayName }}
 					</span>
 					<span class="ext-neowiki-subject-row__subtitle">
@@ -54,16 +72,6 @@
 					</span>
 				</span>
 				<span class="ext-neowiki-subject-row__actions">
-					<a
-						v-if="subjectPageUrl !== null"
-						class="ext-neowiki-subject-row__open cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet"
-						:href="subjectPageUrl"
-						:aria-label="$i18n( 'neowiki-managesubjects-row-open' ).text()"
-						:title="$i18n( 'neowiki-managesubjects-row-open' ).text()"
-						@click.stop
-					>
-						<CdxIcon :icon="cdxIconNext" />
-					</a>
 					<CdxButton
 						weight="quiet"
 						:aria-label="$i18n( 'neowiki-managesubjects-row-copy-link' ).text()"
@@ -207,6 +215,7 @@ import { computed, ref } from 'vue';
 import { CdxButton, CdxIcon, CdxMenuButton } from '@wikimedia/codex';
 import type { MenuButtonItemData } from '@wikimedia/codex';
 import {
+	cdxIconArrowNext,
 	cdxIconArticleRedirect,
 	cdxIconCollapse,
 	cdxIconDraggable,
@@ -214,7 +223,6 @@ import {
 	cdxIconEllipsis,
 	cdxIconExpand,
 	cdxIconLink,
-	cdxIconNext,
 	cdxIconPushPin,
 	cdxIconTrash
 } from '@wikimedia/codex-icons';
@@ -241,7 +249,8 @@ const props = withDefaults( defineProps<{
 	subject: Subject;
 	expanded: boolean;
 	/**
-	 * The Subject's own page, offered as a row action. Null where the reader is on it already.
+	 * The Subject's own page, which the name links to and the overflow menu offers. Null where the
+	 * reader is on it already.
 	 */
 	subjectPageUrl?: string | null;
 	/**
@@ -310,7 +319,8 @@ function pageUrl( pageName: string ): string {
 }
 
 // Opening and copying a link lead: they change nothing. Edit and promote change the row in place;
-// move and delete take it out of the listing, with delete last. Mirrors the inline strip's order.
+// move and delete take it out of the listing, with delete last. The inline strip keeps this order,
+// less opening, which the name offers there.
 const menuItems = computed<MenuButtonItemData[]>( () => {
 	// Neither is permission-gated: everyone, read-only users included, may reach a Subject's page
 	// and copy a link to it.
@@ -320,7 +330,7 @@ const menuItems = computed<MenuButtonItemData[]>( () => {
 		items.push( {
 			value: 'open',
 			label: mw.msg( 'neowiki-managesubjects-row-open' ),
-			icon: cdxIconNext
+			icon: cdxIconArrowNext
 		} );
 	}
 
@@ -437,10 +447,6 @@ function copySubjectIri(): Promise<void> {
 			&:active {
 				background-color: @background-color-interactive;
 			}
-
-			.ext-neowiki-subject-row__label {
-				color: @color-progressive;
-			}
 		}
 	}
 
@@ -547,6 +553,36 @@ function copySubjectIri(): Promise<void> {
 		white-space: nowrap;
 	}
 
+	/* The way to the Subject's own page. Only as wide as the name and its arrow, so the rest of the
+		header still toggles the row. */
+	&__name {
+		display: inline-flex;
+		align-items: center;
+		gap: @spacing-25;
+		align-self: flex-start;
+		max-width: @size-full;
+		min-width: 0;
+	}
+
+	/* The cue that the name leads somewhere: shown while the name is pointed at or focused where the
+		pointer can hover, and always where it cannot, like the action strip. In the link's colour,
+		which Codex sets on `.cdx-icon` unless told otherwise. */
+	&__name-arrow.cdx-icon {
+		flex-shrink: 0;
+		color: inherit;
+
+		@media ( hover: hover ) {
+			opacity: 0;
+			// Slides the way it points as it appears.
+			transform: translateX( -@spacing-25 );
+			transition: opacity @transition-duration-base @transition-timing-function-system, transform @transition-duration-base @transition-timing-function-system;
+		}
+
+		@media ( prefers-reduced-motion: reduce ) {
+			transition-duration: 0s;
+		}
+	}
+
 	&__identifiers {
 		display: flex;
 		flex-direction: column;
@@ -643,16 +679,6 @@ function copySubjectIri(): Promise<void> {
 		}
 	}
 
-	/* A link styled as one of the row's quiet icon buttons — Codex's fake-button pattern. */
-	&__open.cdx-button {
-		min-width: @min-size-interactive-pointer;
-		padding: 0;
-
-		&:hover {
-			text-decoration: none;
-		}
-	}
-
 	&__drag-handle {
 		// Set off from the buttons: this is grabbed, not clicked, and delete sits right before it.
 		margin-inline-start: @spacing-50;
@@ -711,6 +737,56 @@ function copySubjectIri(): Promise<void> {
 		margin-top: @spacing-100;
 		padding-top: @spacing-75;
 		border-top: @border-width-base @border-style-base @border-color-subtle;
+	}
+}
+/* Codex's link colours, less the visited one: a Subject's name reads the same whether or not the
+	reader has been to its page. Every state is spelled out and qualified with `a`, because core
+	colours `a:visited` and underlines `a:hover, a:focus` at (0,1,1), as SchemaNameDisplay explains.
+	Hover and active come after focus, so that they still underline. */
+a.ext-neowiki-subject-row__name {
+	border-radius: @border-radius-base;
+
+	&,
+	&:visited {
+		color: @color-progressive;
+		text-decoration: @text-decoration-none;
+	}
+
+	&:focus {
+		text-decoration: @text-decoration-none;
+	}
+
+	// Also qualified with `:visited`: Vector paints `a:visited:hover` at (0,2,1), which a bare
+	// `a.<class>:hover` only ties and then loses to on source order.
+	&:hover,
+	&:visited:hover {
+		color: @color-progressive--hover;
+		text-decoration: @text-decoration-underline;
+	}
+
+	&:active,
+	&:visited:active {
+		color: @color-progressive--active;
+		text-decoration: @text-decoration-underline;
+	}
+
+	&:focus-visible {
+		outline: @border-style-base @border-width-thick @outline-color-progressive--focus;
+	}
+
+	// Vector styles every link with Codex's link mixin, which gives a trailing icon the size and
+	// padding of an external-link mark, at (0,3,1). The arrow is only a cue: x-small, spaced by the
+	// link's gap.
+	.ext-neowiki-subject-row__name-arrow.cdx-icon:last-child {
+		width: @size-icon-x-small;
+		height: @size-icon-x-small;
+		padding-left: 0;
+	}
+
+	&:hover .ext-neowiki-subject-row__name-arrow,
+	&:focus-visible .ext-neowiki-subject-row__name-arrow {
+		opacity: 1;
+		transform: translateX( 0 );
 	}
 }
 </style>

--- a/resources/ext.neowiki/src/components/SubjectsManager/SubjectsManagerPage.vue
+++ b/resources/ext.neowiki/src/components/SubjectsManager/SubjectsManagerPage.vue
@@ -663,10 +663,6 @@ onUnmounted( () => {
 		color: @color-subtle;
 	}
 
-	&__section-heading {
-		margin: @spacing-150 0 @spacing-75;
-	}
-
 	&__main-slot {
 		list-style: none;
 		padding: 0;

--- a/resources/ext.neowiki/tests/components/SubjectPage/SubjectPage.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectPage/SubjectPage.spec.ts
@@ -49,7 +49,7 @@ const EDIT_CONTROL = '[aria-label="neowiki-managesubjects-row-edit"]';
 const DELETE_CONTROL = '[aria-label="neowiki-managesubjects-row-delete"]';
 const COPY_LINK_CONTROL = '[aria-label="neowiki-managesubjects-row-copy-link"]';
 const PAGE_LINK = '.ext-neowiki-subject-row__page-value a';
-const OPEN_CONTROL = '[aria-label="neowiki-managesubjects-row-open"]';
+const NAME_LINK = 'a.ext-neowiki-subject-row__name';
 
 const SCHEMAS: Record<string, Schema> = {
 	Company: newSchema( { title: 'Company', description: 'An organisation' } ),
@@ -346,9 +346,9 @@ describe( 'SubjectPage', () => {
 
 		const wrapper = await mountLoadedPage();
 
-		expect( wrapper.find( `${ REFERENCED_ROW } ${ OPEN_CONTROL }` ).attributes( 'href' ) )
+		expect( wrapper.find( `${ REFERENCED_ROW } ${ NAME_LINK }` ).attributes( 'href' ) )
 			.toBe( '/wiki/Special:Subject/' + REFERENCED_ID );
-		expect( wrapper.find( `${ REQUESTED_ROW } ${ OPEN_CONTROL }` ).exists() ).toBe( false );
+		expect( wrapper.find( `${ REQUESTED_ROW } ${ NAME_LINK }` ).exists() ).toBe( false );
 	} );
 
 	it( 'lists referenced Subjects in the order the read returned them', async () => {
@@ -361,13 +361,14 @@ describe( 'SubjectPage', () => {
 		expect( names ).toEqual( [ 'Rocket', 'Anvil' ] );
 	} );
 
-	// The whole header toggles, as on the Data tab: nothing in it navigates.
-	it( 'opens a referenced row from anywhere in its header', async () => {
+	// The header still toggles where it is not a link, as on the Data tab; the statement count stands
+	// for the rest of it.
+	it( 'opens a referenced row from its header', async () => {
 		getSubjectWithReferencedSubjectsMock.mockResolvedValue( bundle( [ referencedSubject ] ) );
 
 		const wrapper = await mountLoadedPage();
 
-		await wrapper.find( `${ REFERENCED_ROW } ${ ROW_LABEL }` ).trigger( 'click' );
+		await wrapper.find( `${ REFERENCED_ROW } .ext-neowiki-subject-row__count` ).trigger( 'click' );
 
 		expect( isOpen( wrapper.find( REFERENCED_ROW ) ) ).toBe( true );
 	} );
@@ -520,7 +521,6 @@ describe( 'SubjectPage', () => {
 					'neowiki-managesubjects-row-delete',
 				],
 				[
-					'neowiki-managesubjects-row-open',
 					'neowiki-managesubjects-row-copy-link',
 					'neowiki-managesubjects-row-edit',
 					'neowiki-managesubjects-row-delete',

--- a/resources/ext.neowiki/tests/components/SubjectsManager/SubjectRow.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectsManager/SubjectRow.spec.ts
@@ -213,23 +213,25 @@ describe( 'SubjectRow', () => {
 
 	} );
 
-	// The header toggles the row wherever it is clicked, so reaching the Subject's page is an action
-	// of its own rather than a link buried in the name.
+	// The header toggles the row wherever it is clicked except on its links, and the name is one of
+	// them where the surface names a page for the Subject.
 	describe( 'the way to the Subject\'s own page', () => {
 
-		const OPEN = '[aria-label="neowiki-managesubjects-row-open"]';
+		const NAME_LINK = 'a.ext-neowiki-subject-row__name';
 		const URL = '/wiki/Special:Subject/' + SUBJECT_ID;
 
 		afterEach( () => {
 			vi.unstubAllGlobals();
 		} );
 
-		it( 'is a link to the page the surface named', () => {
+		it( 'is the Subject\'s name, linked to the page the surface named', () => {
 			const wrapper = mountRow( { subjectPageUrl: URL } );
 
-			const open = wrapper.find( OPEN );
-			expect( open.element.tagName ).toBe( 'A' );
-			expect( open.attributes( 'href' ) ).toBe( URL );
+			const link = wrapper.find( NAME_LINK );
+			expect( link.attributes( 'href' ) ).toBe( URL );
+			expect( link.find( '.ext-neowiki-subject-row__label' ).text() ).toBe( 'ACME Inc' );
+			// The cue that it leads somewhere, which CSS shows while the name is pointed at.
+			expect( link.find( '.ext-neowiki-subject-row__name-arrow' ).exists() ).toBe( true );
 		} );
 
 		// Codex selects a menu item chosen with the keyboard but does not follow its url.
@@ -243,21 +245,25 @@ describe( 'SubjectRow', () => {
 			expect( location.href ).toBe( URL );
 		} );
 
-		it( 'is absent on a row the reader is already on', () => {
+		it( 'leaves the name plain text on a row the reader is already on', () => {
 			const wrapper = mountRow();
 
-			expect( wrapper.find( OPEN ).exists() ).toBe( false );
+			expect( wrapper.find( NAME_LINK ).exists() ).toBe( false );
+			expect( wrapper.find( '.ext-neowiki-subject-row__label' ).text() ).toBe( 'ACME Inc' );
 			expect( wrapper.findComponent( CdxMenuButton ).props( 'menuItems' ).map( ( item ) => item.value ) )
 				.not.toContain( 'open' );
 		} );
 
-		// Clicking it must not also toggle the row it sits in.
-		it( 'keeps its click from reaching the header', async () => {
+		// Following the name must not also toggle the row it sits in, and must still be followed: the
+		// header one line above it cancels the clicks it handles.
+		it( 'keeps a click on the name from reaching the header, and follows it', () => {
 			const wrapper = mountRow( { subjectPageUrl: URL } );
 
-			await wrapper.find( OPEN ).trigger( 'click' );
+			const click = new Event( 'click', { bubbles: true, cancelable: true } );
+			wrapper.find( NAME_LINK ).element.dispatchEvent( click );
 
 			expect( wrapper.emitted( 'toggle' ) ).toBeUndefined();
+			expect( click.defaultPrevented ).toBe( false );
 		} );
 
 	} );

--- a/resources/ext.neowiki/tests/components/SubjectsManager/SubjectsManagerPage.spec.ts
+++ b/resources/ext.neowiki/tests/components/SubjectsManager/SubjectsManagerPage.spec.ts
@@ -301,7 +301,7 @@ describe( 'SubjectsManagerPage rows and the Subject pages behind them', () => {
 	it( 'links every row to that Subject\'s own page', async () => {
 		const wrapper = await mountPage();
 
-		expect( wrapper.findAll( '[aria-label="neowiki-managesubjects-row-open"]' )
+		expect( wrapper.findAll( 'a.ext-neowiki-subject-row__name' )
 			.map( ( link ) => link.attributes( 'href' ) ) )
 			.toEqual( [ '/wiki/Special:Subject/' + ID_A, '/wiki/Special:Subject/' + ID_B ] );
 	} );
@@ -553,10 +553,10 @@ describe( 'SubjectsManagerPage move action', () => {
 		expect( wrapper.findAll( '[aria-label="neowiki-managesubjects-row-move"]' ) ).toHaveLength( 2 );
 	} );
 
-	// Opening the Subject's page and copying a link change nothing, so they lead; edit and promote
-	// change the row in place; move and delete take the row out of the listing, with delete last.
-	// The main row's pin is its indicator, outside the strip.
-	it( 'orders each row\'s inline actions open, copy-link, edit, promote, move, delete', async () => {
+	// Copying a link changes nothing, so it leads; edit and promote change the row in place; move and
+	// delete take the row out of the listing, with delete last. The main row's pin is its indicator,
+	// outside the strip, and the Subject's own page is its name's link.
+	it( 'orders each row\'s inline actions copy-link, edit, promote, move, delete', async () => {
 		const wrapper = await mountPage();
 
 		const strips = wrapper.findAll( '.ext-neowiki-subject-row__actions' )
@@ -564,14 +564,12 @@ describe( 'SubjectsManagerPage move action', () => {
 
 		expect( strips ).toEqual( [
 			[
-				'neowiki-managesubjects-row-open',
 				'neowiki-managesubjects-row-copy-link',
 				'neowiki-managesubjects-row-edit',
 				'neowiki-managesubjects-row-move',
 				'neowiki-managesubjects-row-delete',
 			],
 			[
-				'neowiki-managesubjects-row-open',
 				'neowiki-managesubjects-row-copy-link',
 				'neowiki-managesubjects-row-edit',
 				'neowiki-managesubjects-row-promote',


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/NeoWiki/pull/1408. Stacked on #1418, which holds review fixes to
#1408; the name commit below builds on the one that makes the overflow menu's "Open subject" work from the keyboard,
so on #1408 alone that item would stay dead. The two commits here are independent of each other.

- **The Subject's name is the link to its own page.** On rows that name a Special:Subject page, the name links there,
  in Codex link colours without the visited one, and an arrow slides in beside it on hover or keyboard focus. Only the
  Subject a page is already about keeps a plain name. The inline "Open subject" button goes; the overflow menu keeps
  the item, with the same arrow.
  This reverses your choice of a row action over a link in the name. The button only appeared on hover, 190–460px from
  the name, and its right chevron read like the row's disclosure chevron and like the export menu's "opens a nested
  list" chevron. The name does not take the header's click: like the Schema badge beside it, it stops its own, and
  everywhere else in the header still toggles the row. The summary stays the toggle, and the link is one more
  focusable control inside it, as that badge already was.
- **Special:Subject spaces its sections like the Data tab.** Neither page's heading margin ever applied, because the
  skin's `.mw-body h2` outranks a single class. Special:Subject now uses the Data tab's list margins instead, and the
  heading stays the skin's.

## Manual Browser Check

1. On `Special:Subject/s1demo1aaaaaaa1`, hover a referenced Subject's name: it underlines and an arrow slides in.
   Clicking it opens that Subject's page.
2. Click the same row's header away from the name and the Schema badge: the row expands.
3. Tab to that name: the focus ring and the arrow show, and Enter follows the link.
4. On `Rijksmuseum/subjects`, the Main Subject's and the other rows' names link the same way, and no inline
   "Open subject" button remains.
5. The "Referenced subjects" heading sits as far from the rows around it as "Other Subjects on this Page" does on the
   Data tab.

## Considered, omitted

- A shared Subject list component: the Data tab's drag and drop needs its two lists as they are, and their styles had
  not drifted.
- Restyling the skin's h2 so the spacing holds on every skin; on Timeless its own heading margin wins on both pages.

> <sub>AI-authored — Claude Code, `Opus 5 (ultracode)`; directed by @alistair3149 while reviewing #1408, over roughly six rounds of correction; diff not yet human-reviewed, though the rendered result was checked in a browser by @alistair3149; each change test-first or confirmed by a surviving-mutant check, full vitest suite, eslint, stylelint and the build green locally, and the rest, hover, focus and spacing states measured in a browser against a dev wiki, with right-to-left, touch and night mode covered by the review passes below; no PHP touched.</sub>

<details><summary>Production notes</summary>

Reviewed before opening by six independent passes — code review, security, tests, design, accessibility and i18n, and
cross-skin CSS — plus adversarial verifiers for each blocking claim. What they confirmed is folded into these two
commits: `:visited:hover` and `:visited:active` had to be qualified, because Vector paints `a:visited:hover` at the
same specificity and wins on source order; a test now pins that a click on the name keeps its default action; and the
emphasized row's blue label rule went, since after this change blue means "link".

</details>
