### PR TITLE
Offer Subject edits only where the server will allow them

### DIFF
--- a/resources/ext.neowiki/src/NeoWikiExtension.ts
+++ b/resources/ext.neowiki/src/NeoWikiExtension.ts
@@ -1,4 +1,5 @@
 import { RightsBasedSubjectPermissionHints } from '@/persistence/RightsBasedSubjectPermissionHints.ts';
+import { CurrentPageSubjectPermissionHints } from '@/persistence/CurrentPageSubjectPermissionHints.ts';
 import { SubjectPermissionHints } from '@/application/SubjectPermissionHints.ts';
 import { RightsFetcher, UserObjectBasedRightsFetcher } from '@/persistence/UserObjectBasedRightsFetcher.ts';
 import { TextType } from '@/domain/propertyTypes/Text.ts';
@@ -196,9 +197,26 @@ export class NeoWikiExtension {
 	}
 
 	public newSubjectPermissionHints(): SubjectPermissionHints {
-		return new RightsBasedSubjectPermissionHints(
+		const globalRightsHints = new RightsBasedSubjectPermissionHints(
 			this.getUserObjectBasedRightsFetcher(),
 		);
+
+		const config = this.getMediaWiki()?.config;
+		const canEditPageSubjects = config?.get( 'wgNeoWikiCanEditPageSubjects' );
+		const currentPageId = Number( config?.get( 'wgArticleId' ) );
+
+		// A decision arrives only from a page that holds Subjects, so Schema pages, Layout pages and
+		// special pages have none and keep the wiki-global rights. So does a title with no page
+		// behind it, whose id is 0 and whose decision therefore describes no page at all.
+		if ( typeof canEditPageSubjects === 'boolean' && currentPageId > 0 ) {
+			return new CurrentPageSubjectPermissionHints(
+				currentPageId,
+				canEditPageSubjects,
+				globalRightsHints,
+			);
+		}
+
+		return globalRightsHints;
 	}
 
 	public getUserObjectBasedRightsFetcher(): RightsFetcher {

--- a/resources/ext.neowiki/src/application/SubjectPermissionHints.ts
+++ b/resources/ext.neowiki/src/application/SubjectPermissionHints.ts
@@ -1,19 +1,20 @@
-import type { SubjectId } from '@/domain/SubjectId';
-
 /**
  * Hints for showing or hiding affordances. They are advisory, not a security control: the server
  * authorizes every Subject write, and it is the only thing that can. A positive answer here means
  * "offer the affordance", never "the write will succeed".
+ *
+ * Creating, editing and deleting a Subject are all edits of the page holding it, so each of those
+ * hints is asked about that page.
  */
 export interface SubjectPermissionHints {
 
 	canCreateChildSubject( pageId: number ): Promise<boolean>;
 
-	canEditSubject( subjectId: SubjectId ): Promise<boolean>;
+	canEditSubject( pageId: number ): Promise<boolean>;
 
-	canDeleteSubject( subjectId: SubjectId ): Promise<boolean>;
+	canDeleteSubject( pageId: number ): Promise<boolean>;
 
-	canCreateMainSubject(): Promise<boolean>;
+	canCreateMainSubject( pageId: number ): Promise<boolean>;
 
 	canCreateSubjectPage(): Promise<boolean>;
 }

--- a/resources/ext.neowiki/src/components/NeoWikiApp.vue
+++ b/resources/ext.neowiki/src/components/NeoWikiApp.vue
@@ -2,7 +2,7 @@
 <template>
 	<teleport
 		v-for="view in viewsData"
-		:key="`view-${view.id}`"
+		:key="`view-${view.subjectId.text}`"
 		:to="view.element"
 	>
 		<component
@@ -27,14 +27,19 @@ import SubjectCreatorDialog from '@/components/SubjectCreator/SubjectCreatorDial
 import { NeoWikiServices } from '@/NeoWikiServices.ts';
 import { NeoWikiExtension } from '@/NeoWikiExtension.ts';
 import { useLayoutStore } from '@/stores/LayoutStore.ts';
+import { useSubjectStore } from '@/stores/SubjectStore.ts';
+import { canEditSubjectOnItsPage } from '@/presentation/subjectEditPermission.ts';
 
-interface ViewData {
-	id: string;
+/** A View placeholder on the page, before its Subject is known. */
+interface View {
 	element: HTMLElement;
 	subjectId: SubjectId;
-	canEditSubject: boolean;
 	viewType?: string;
 	layoutName?: string;
+}
+
+interface ViewData extends View {
+	canEditSubject: boolean;
 }
 
 const props = defineProps<{
@@ -70,46 +75,39 @@ function isLatestRevision(): boolean {
 }
 
 onMounted( async (): Promise<void> => {
-	const localViewsData = await getViewsData( document.querySelectorAll( '.ext-neowiki-view' ) );
+	const views = collectViews( document.querySelectorAll( '.ext-neowiki-view' ) );
 	const storeStateLoader = NeoWikiExtension.getInstance().getStoreStateLoader();
 
 	await Promise.all( [
 		storeStateLoader.loadSubjectsAndSchemas(
-			new Set( localViewsData.map( ( viewData ) => viewData.subjectId.text ) )
+			new Set( views.map( ( view ) => view.subjectId.text ) )
 		),
 		storeStateLoader.loadLayouts(
-			new Set( localViewsData.map( ( v ) => v.layoutName ).filter( ( n ): n is string => n !== undefined ) )
+			new Set( views.map( ( v ) => v.layoutName ).filter( ( n ): n is string => n !== undefined ) )
 		)
 	] );
 
-	viewsData.value = localViewsData;
+	// Each View is told about the page holding its own Subject, which a View can render from
+	// anywhere, so the Subjects have to be loaded before there is a page to ask about.
+	viewsData.value = await Promise.all( views.map( withEditPermission ) );
 } );
 
 // eslint-disable-next-line no-undef
-async function getViewsData( elements: NodeListOf<HTMLElement> ): Promise<ViewData[]> {
-	const viewsData: ViewData[] = [];
-
-	for ( const element of elements ) {
-		const viewData = await getViewData( element );
-		if ( viewData ) {
-			viewsData.push( viewData );
-		}
-	}
-	return viewsData;
+function collectViews( elements: NodeListOf<HTMLElement> ): View[] {
+	return Array.from( elements )
+		.map( ( element ) => toView( element ) )
+		.filter( ( view ): view is View => view !== null );
 }
 
-async function getViewData( element: HTMLElement ): Promise<ViewData|null> {
+function toView( element: HTMLElement ): View|null {
 	if ( !element.dataset.mwNeowikiSubjectId ) {
 		return null;
 	}
 
 	try {
-		const subjectId = new SubjectId( element.dataset.mwNeowikiSubjectId );
 		return {
-			id: subjectId.text,
+			subjectId: new SubjectId( element.dataset.mwNeowikiSubjectId ),
 			element: element,
-			subjectId: subjectId,
-			canEditSubject: isLatestRevision() && await subjectPermissionHints.canEditSubject( subjectId ),
 			viewType: element.dataset.mwNeowikiViewType,
 			layoutName: element.dataset.mwNeowikiLayoutName
 		};
@@ -117,6 +115,16 @@ async function getViewData( element: HTMLElement ): Promise<ViewData|null> {
 		console.error( error );
 		return null;
 	}
+}
+
+async function withEditPermission( view: View ): Promise<ViewData> {
+	return {
+		...view,
+		canEditSubject: isLatestRevision() && await canEditSubjectOnItsPage(
+			useSubjectStore().findSubject( view.subjectId ),
+			subjectPermissionHints
+		)
+	};
 }
 
 </script>

--- a/resources/ext.neowiki/src/composables/useSubjectPermissions.ts
+++ b/resources/ext.neowiki/src/composables/useSubjectPermissions.ts
@@ -23,10 +23,10 @@ export function useSubjectPermissions(): SubjectPermissions {
 	async function checkPermissions( pageId: number ): Promise<void> {
 		try {
 			const [ createMain, createChild, edit, del ] = await Promise.all( [
-				hints.canCreateMainSubject(),
+				hints.canCreateMainSubject( pageId ),
 				hints.canCreateChildSubject( pageId ),
-				hints.canEditSubject( { text: '' } as never ),
-				hints.canDeleteSubject( { text: '' } as never ),
+				hints.canEditSubject( pageId ),
+				hints.canDeleteSubject( pageId ),
 			] );
 			canCreateMainSubject.value = createMain;
 			canCreateChildSubject.value = createChild;

--- a/resources/ext.neowiki/src/persistence/CurrentPageSubjectPermissionHints.ts
+++ b/resources/ext.neowiki/src/persistence/CurrentPageSubjectPermissionHints.ts
@@ -1,0 +1,49 @@
+import type { SubjectPermissionHints } from '@/application/SubjectPermissionHints';
+
+/**
+ * Answers for the page being viewed with the decision the server made for it, which is the check
+ * the server applies to the write as well. Any other page goes to the fallback, since the server
+ * was asked about this page only.
+ *
+ * The one decision answers creating, editing and deleting alike, because every Subject write is an
+ * edit of the page holding the Subject. Were the server ever to judge them apart, it would have to
+ * say so per question.
+ */
+export class CurrentPageSubjectPermissionHints implements SubjectPermissionHints {
+
+	public constructor(
+		private readonly currentPageId: number,
+		private readonly canEditCurrentPage: boolean,
+		private readonly otherPages: SubjectPermissionHints,
+	) {
+	}
+
+	public async canCreateChildSubject( pageId: number ): Promise<boolean> {
+		return this.decisionFor( pageId ) ?? this.otherPages.canCreateChildSubject( pageId );
+	}
+
+	public async canEditSubject( pageId: number ): Promise<boolean> {
+		return this.decisionFor( pageId ) ?? this.otherPages.canEditSubject( pageId );
+	}
+
+	public async canDeleteSubject( pageId: number ): Promise<boolean> {
+		return this.decisionFor( pageId ) ?? this.otherPages.canDeleteSubject( pageId );
+	}
+
+	public async canCreateMainSubject( pageId: number ): Promise<boolean> {
+		return this.decisionFor( pageId ) ?? this.otherPages.canCreateMainSubject( pageId );
+	}
+
+	/**
+	 * The page to hold the new Subject does not exist yet, so there is no page decision to use.
+	 */
+	public async canCreateSubjectPage(): Promise<boolean> {
+		return this.otherPages.canCreateSubjectPage();
+	}
+
+	/** Null where the server made no decision, which is every page but the one being viewed. */
+	private decisionFor( pageId: number ): boolean | null {
+		return pageId === this.currentPageId ? this.canEditCurrentPage : null;
+	}
+
+}

--- a/resources/ext.neowiki/src/persistence/RightsBasedSubjectPermissionHints.ts
+++ b/resources/ext.neowiki/src/persistence/RightsBasedSubjectPermissionHints.ts
@@ -1,14 +1,14 @@
 import type { SubjectPermissionHints } from '@/application/SubjectPermissionHints';
-import type { SubjectId } from '@/domain/SubjectId';
 import type { RightsFetcher } from '@/persistence/UserObjectBasedRightsFetcher';
 
 /**
  * Creating, editing and deleting a Subject are all edits of the page that holds it, so they all
  * hint on the 'edit' right. This matches the authorization the server applies to the write.
  *
- * TODO: the server checks 'edit' on the specific page, while these hints check the wiki-global
- * right. A user who may edit globally but not the page at hand is offered affordances that the
- * server then rejects.
+ * The wiki-global right is all these have, so they answer the same for every page, while the
+ * server decides per page. CurrentPageSubjectPermissionHints closes that gap for the page being
+ * viewed; elsewhere a user who may edit globally but not the page at hand is still offered
+ * affordances the server then rejects.
  */
 export class RightsBasedSubjectPermissionHints implements SubjectPermissionHints {
 
@@ -19,15 +19,15 @@ export class RightsBasedSubjectPermissionHints implements SubjectPermissionHints
 		return this.canEditPage();
 	}
 
-	public async canEditSubject( _subjectId: SubjectId ): Promise<boolean> {
+	public async canEditSubject( _pageId: number ): Promise<boolean> {
 		return this.canEditPage();
 	}
 
-	public async canDeleteSubject( _subjectId: SubjectId ): Promise<boolean> {
+	public async canDeleteSubject( _pageId: number ): Promise<boolean> {
 		return this.canEditPage();
 	}
 
-	public async canCreateMainSubject(): Promise<boolean> {
+	public async canCreateMainSubject( _pageId: number ): Promise<boolean> {
 		return this.canEditPage();
 	}
 

--- a/resources/ext.neowiki/src/presentation/subjectEditPermission.ts
+++ b/resources/ext.neowiki/src/presentation/subjectEditPermission.ts
@@ -1,0 +1,23 @@
+import type { Subject } from '@/domain/Subject';
+import { SubjectWithContext } from '@/domain/SubjectWithContext';
+import type { SubjectPermissionHints } from '@/application/SubjectPermissionHints';
+
+/**
+ * Whether to offer editing a Subject, asked of the page that holds it — the page the server
+ * authorizes the write against, which is not always the page the Subject is shown on.
+ *
+ * A Subject with no page holds nothing to ask about: one from another Source is read-only, and one
+ * that did not load cannot be edited either.
+ */
+export async function canEditSubjectOnItsPage(
+	subject: Subject | undefined,
+	hints: SubjectPermissionHints,
+): Promise<boolean> {
+	const pageId = subject instanceof SubjectWithContext ? subject.getPageIdentifiers().getPageId() : undefined;
+
+	if ( !Number.isInteger( pageId ) ) {
+		return false;
+	}
+
+	return hints.canEditSubject( pageId as number );
+}

--- a/resources/ext.neowiki/src/stores/SubjectStore.ts
+++ b/resources/ext.neowiki/src/stores/SubjectStore.ts
@@ -39,6 +39,13 @@ export const useSubjectStore = defineStore( 'subject', {
 
 			return subject as Subject;
 		},
+		/**
+		 * For a caller holding no listing that promises the Subject is there, such as a View whose
+		 * Subject may have failed to load.
+		 */
+		findSubject: ( state ) => function ( id: SubjectId ): Subject | undefined {
+			return state.subjects.get( id.text ) as Subject | undefined;
+		},
 	},
 	actions: {
 		setSubject( subject: Subject ): void { // TODO: just take Subject

--- a/resources/ext.neowiki/tests/NeoWikiExtension.spec.ts
+++ b/resources/ext.neowiki/tests/NeoWikiExtension.spec.ts
@@ -37,6 +37,24 @@ describe( 'NeoWikiExtension.getPinia', () => {
 	} );
 } );
 
+describe( 'NeoWikiExtension.newSubjectPermissionHints', () => {
+	it( 'answers for the page being viewed with the decision the wiki sent', async () => {
+		setupMwMock( { config: { wgArticleId: 42, wgNeoWikiCanEditPageSubjects: true } } );
+
+		const hints = NeoWikiExtension.getInstance().newSubjectPermissionHints();
+
+		expect( await hints.canEditSubject( 42 ) ).toBe( true );
+	} );
+
+	it( 'does not read the absence of a page as a page, as on a special page', async () => {
+		setupMwMock( { config: { wgArticleId: 0, wgNeoWikiCanEditPageSubjects: true } } );
+
+		const hints = NeoWikiExtension.getInstance().newSubjectPermissionHints();
+
+		expect( await hints.canEditSubject( 0 ) ).toBe( false );
+	} );
+} );
+
 describe( 'NeoWikiExtension.isValidationEnforced', () => {
 	it( 'is true only when the wiki says so', () => {
 		setupMwMock( { config: { wgNeoWikiEnforceValidation: true } } );

--- a/resources/ext.neowiki/tests/persistence/CurrentPageSubjectPermissionHints.unit.spec.ts
+++ b/resources/ext.neowiki/tests/persistence/CurrentPageSubjectPermissionHints.unit.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { CurrentPageSubjectPermissionHints } from '@/persistence/CurrentPageSubjectPermissionHints';
+import type { SubjectPermissionHints } from '@/application/SubjectPermissionHints';
+
+describe( 'Current Page Subject Permission Hints', () => {
+
+	const CURRENT_PAGE = 42;
+	const OTHER_PAGE = 43;
+
+	type Ask = ( hints: SubjectPermissionHints, pageId: number ) => Promise<boolean>;
+
+	const pageKeyedHints: [ string, Ask ][] = [
+		[ 'create a main subject', ( hints, pageId ) => hints.canCreateMainSubject( pageId ) ],
+		[ 'create a child subject', ( hints, pageId ) => hints.canCreateChildSubject( pageId ) ],
+		[ 'edit a subject', ( hints, pageId ) => hints.canEditSubject( pageId ) ],
+		[ 'delete a subject', ( hints, pageId ) => hints.canDeleteSubject( pageId ) ],
+	];
+
+	function hintsAnswering( answer: boolean ): SubjectPermissionHints {
+		return {
+			canCreateMainSubject: async () => answer,
+			canCreateChildSubject: async () => answer,
+			canEditSubject: async () => answer,
+			canDeleteSubject: async () => answer,
+			canCreateSubjectPage: async () => answer,
+		};
+	}
+
+	function newHints( canEditCurrentPage: boolean ): CurrentPageSubjectPermissionHints {
+		return new CurrentPageSubjectPermissionHints(
+			CURRENT_PAGE,
+			canEditCurrentPage,
+			hintsAnswering( !canEditCurrentPage ),
+		);
+	}
+
+	it.each( pageKeyedHints )( 'reports that the viewer may %s on the current page', async ( _name, ask ) => {
+		expect( await ask( newHints( true ), CURRENT_PAGE ) ).toBe( true );
+	} );
+
+	it.each( pageKeyedHints )( 'reports that the viewer may not %s on a current page they cannot edit', async ( _name, ask ) => {
+		expect( await ask( newHints( false ), CURRENT_PAGE ) ).toBe( false );
+	} );
+
+	it.each( pageKeyedHints )( 'asks the fallback whether the viewer may %s on another page', async ( _name, ask ) => {
+		const hints = new CurrentPageSubjectPermissionHints( CURRENT_PAGE, false, hintsAnswering( true ) );
+
+		expect( await ask( hints, OTHER_PAGE ) ).toBe( true );
+	} );
+
+	it( 'asks the fallback whether a Subject page can be created, which is about no page yet', async () => {
+		const hints = new CurrentPageSubjectPermissionHints( CURRENT_PAGE, false, hintsAnswering( true ) );
+
+		expect( await hints.canCreateSubjectPage() ).toBe( true );
+	} );
+
+} );

--- a/resources/ext.neowiki/tests/persistence/RightsBasedSubjectPermissionHintsTest.unit.spec.ts
+++ b/resources/ext.neowiki/tests/persistence/RightsBasedSubjectPermissionHintsTest.unit.spec.ts
@@ -1,11 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { RightsBasedSubjectPermissionHints } from '@/persistence/RightsBasedSubjectPermissionHints';
-import { SubjectId } from '@/domain/SubjectId';
 import { TestUserObjectBasedRightsFetcher } from './UserObjectBasedRightsFetcher.unit.spec';
 
 describe( 'Rights Based Subject Permission Hints', async () => {
 
-	const SUBJECT_ID = new SubjectId( 's11111111111117' );
+	const PAGE_ID = 42;
 
 	function newHints( rights: string[] ): RightsBasedSubjectPermissionHints {
 		return new RightsBasedSubjectPermissionHints( new TestUserObjectBasedRightsFetcher( rights ) );
@@ -20,59 +19,59 @@ describe( 'Rights Based Subject Permission Hints', async () => {
 	}
 
 	it( 'can edit subject with edit right', async () => {
-		expect( await withEditRight().canEditSubject( SUBJECT_ID ) ).toBe( true );
+		expect( await withEditRight().canEditSubject( PAGE_ID ) ).toBe( true );
 	} );
 
 	it( 'cannot edit subject without edit right', async () => {
-		expect( await withoutEditRight().canEditSubject( SUBJECT_ID ) ).toBe( false );
+		expect( await withoutEditRight().canEditSubject( PAGE_ID ) ).toBe( false );
 	} );
 
 	it( 'can delete subject with edit right', async () => {
-		expect( await withEditRight().canDeleteSubject( SUBJECT_ID ) ).toBe( true );
+		expect( await withEditRight().canDeleteSubject( PAGE_ID ) ).toBe( true );
 	} );
 
 	it( 'cannot delete subject without edit right', async () => {
-		expect( await withoutEditRight().canDeleteSubject( SUBJECT_ID ) ).toBe( false );
+		expect( await withoutEditRight().canDeleteSubject( PAGE_ID ) ).toBe( false );
 	} );
 
 	it( 'does not need the delete right to delete a subject', async () => {
 		const hints = newHints( [ 'foo', 'edit', 'bar' ] );
 
-		expect( await hints.canDeleteSubject( SUBJECT_ID ) ).toBe( true );
+		expect( await hints.canDeleteSubject( PAGE_ID ) ).toBe( true );
 	} );
 
 	it( 'cannot delete subject with only the delete right', async () => {
 		const hints = newHints( [ 'foo', 'delete', 'bar' ] );
 
-		expect( await hints.canDeleteSubject( SUBJECT_ID ) ).toBe( false );
+		expect( await hints.canDeleteSubject( PAGE_ID ) ).toBe( false );
 	} );
 
 	it( 'can create child subject with edit right', async () => {
-		expect( await withEditRight().canCreateChildSubject( 42 ) ).toBe( true );
+		expect( await withEditRight().canCreateChildSubject( PAGE_ID ) ).toBe( true );
 	} );
 
 	it( 'cannot create child subject without edit right', async () => {
-		expect( await withoutEditRight().canCreateChildSubject( 42 ) ).toBe( false );
+		expect( await withoutEditRight().canCreateChildSubject( PAGE_ID ) ).toBe( false );
 	} );
 
 	it( 'does not need the createpage right to create a child subject', async () => {
 		const hints = newHints( [ 'foo', 'edit', 'bar' ] );
 
-		expect( await hints.canCreateChildSubject( 42 ) ).toBe( true );
+		expect( await hints.canCreateChildSubject( PAGE_ID ) ).toBe( true );
 	} );
 
 	it( 'can create main subject with edit right', async () => {
-		expect( await withEditRight().canCreateMainSubject() ).toBe( true );
+		expect( await withEditRight().canCreateMainSubject( PAGE_ID ) ).toBe( true );
 	} );
 
 	it( 'cannot create main subject without edit right', async () => {
-		expect( await withoutEditRight().canCreateMainSubject() ).toBe( false );
+		expect( await withoutEditRight().canCreateMainSubject( PAGE_ID ) ).toBe( false );
 	} );
 
 	it( 'does not need the createpage right to create a main subject', async () => {
 		const hints = newHints( [ 'foo', 'edit', 'bar' ] );
 
-		expect( await hints.canCreateMainSubject() ).toBe( true );
+		expect( await hints.canCreateMainSubject( PAGE_ID ) ).toBe( true );
 	} );
 
 	it( 'can create a subject page with the createpage and edit rights', async () => {

--- a/resources/ext.neowiki/tests/presentation/subjectEditPermission.spec.ts
+++ b/resources/ext.neowiki/tests/presentation/subjectEditPermission.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { canEditSubjectOnItsPage } from '@/presentation/subjectEditPermission';
+import { Subject } from '@/domain/Subject';
+import { SubjectWithContext } from '@/domain/SubjectWithContext';
+import { SubjectId } from '@/domain/SubjectId';
+import { PageIdentifiers } from '@/domain/PageIdentifiers';
+import { StatementList } from '@/domain/StatementList';
+import type { SubjectPermissionHints } from '@/application/SubjectPermissionHints';
+
+describe( 'canEditSubjectOnItsPage', () => {
+
+	const HOSTING_PAGE = 42;
+
+	function hintsAllowingOnly( editablePageId: number ): SubjectPermissionHints & { askedAbout: number[] } {
+		const askedAbout: number[] = [];
+
+		return {
+			askedAbout,
+			canCreateChildSubject: async () => false,
+			canEditSubject: async ( pageId: number ) => {
+				askedAbout.push( pageId );
+				return pageId === editablePageId;
+			},
+			canDeleteSubject: async () => false,
+			canCreateMainSubject: async () => false,
+			canCreateSubjectPage: async () => false,
+		};
+	}
+
+	function subjectOnPage( pageId: number ): SubjectWithContext {
+		return new SubjectWithContext(
+			new SubjectId( 's11111111111117' ),
+			'Acme Rocket',
+			'Acme Rocket',
+			false,
+			'Product',
+			new StatementList( [] ),
+			new PageIdentifiers( pageId, 'Acme Rocket' ),
+		);
+	}
+
+	function subjectWithoutPage(): Subject {
+		return new Subject(
+			new SubjectId( 's11111111111117' ),
+			'Acme Rocket',
+			'Acme Rocket',
+			false,
+			'Product',
+			new StatementList( [] ),
+		);
+	}
+
+	it( 'asks about the page holding the Subject', async () => {
+		const hints = hintsAllowingOnly( HOSTING_PAGE );
+
+		expect( await canEditSubjectOnItsPage( subjectOnPage( HOSTING_PAGE ), hints ) ).toBe( true );
+		expect( hints.askedAbout ).toEqual( [ HOSTING_PAGE ] );
+	} );
+
+	it( 'reports a Subject on a page the viewer cannot edit as not editable', async () => {
+		const hints = hintsAllowingOnly( HOSTING_PAGE );
+
+		expect( await canEditSubjectOnItsPage( subjectOnPage( HOSTING_PAGE + 1 ), hints ) ).toBe( false );
+	} );
+
+	it( 'offers no editing for a Subject that carries no page, such as one from another Source', async () => {
+		const hints = hintsAllowingOnly( HOSTING_PAGE );
+
+		expect( await canEditSubjectOnItsPage( subjectWithoutPage(), hints ) ).toBe( false );
+		expect( hints.askedAbout ).toEqual( [] );
+	} );
+
+	it( 'offers no editing for a Subject that did not load', async () => {
+		const hints = hintsAllowingOnly( HOSTING_PAGE );
+
+		expect( await canEditSubjectOnItsPage( undefined, hints ) ).toBe( false );
+	} );
+
+} );

--- a/src/EntryPoints/Actions/SubjectsAction.php
+++ b/src/EntryPoints/Actions/SubjectsAction.php
@@ -9,6 +9,7 @@ use MediaWiki\Html\Html;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Message\Message;
 use MediaWiki\Title\Title;
+use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 use ProfessionalWiki\NeoWiki\NeoWikiExtension;
 
 class SubjectsAction extends FormlessAction {
@@ -46,7 +47,12 @@ class SubjectsAction extends FormlessAction {
 		}
 
 		$extension = NeoWikiExtension::getInstance();
-		$extension->newFrontendModuleLoader()->load( $out, $this->getSkin() );
+		$extension->newFrontendModuleLoader()->loadWithSubjectPermissions(
+			$out,
+			$this->getSkin(),
+			$extension->newSubjectPermissionHints( $this->getAuthority() )
+				->canEditSubject( new PageId( $title->getArticleID() ) )
+		);
 
 		$out->addJsConfigVars( [
 			'wgNeoWikiManageSubjectsPageId' => $title->getArticleID(),

--- a/src/EntryPoints/NeoWikiHooks.php
+++ b/src/EntryPoints/NeoWikiHooks.php
@@ -26,6 +26,7 @@ use MediaWiki\User\User;
 use MediaWiki\User\UserIdentity;
 use MessageLocalizer;
 use ProfessionalWiki\NeoWiki\Application\Rdf\RdfPageProjector;
+use ProfessionalWiki\NeoWiki\Application\SubjectPermissionHints;
 use ProfessionalWiki\NeoWiki\Application\WikiConfig\ConfigExample;
 use ProfessionalWiki\NeoWiki\Domain\GraphDatabase\BackendFailureMessage;
 use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
@@ -66,16 +67,23 @@ class NeoWikiHooks {
 	private static function handleContentPage( OutputPage $out, Skin $skin ): void {
 		self::warnAboutHalfConfiguredNeo4j();
 
-		NeoWikiExtension::getInstance()->newFrontendModuleLoader()->load( $out, $skin );
-		$out->addHtml( self::getNeoWikiAppHtml( $out ) );
+		$extension = NeoWikiExtension::getInstance();
+		$permissionHints = $extension->newSubjectPermissionHints( $out->getAuthority() );
+
+		$extension->newFrontendModuleLoader()->loadWithSubjectPermissions(
+			$out,
+			$skin,
+			$permissionHints->canEditSubject( new PageId( $out->getTitle()->getArticleID() ) )
+		);
+		$out->addHtml( self::getNeoWikiAppHtml( $out, $permissionHints ) );
 		self::addRdfAutodiscoveryLinks( $out );
 
-		if ( !NeoWikiExtension::getInstance()->shouldAutoRenderMainSubject() ) {
+		if ( !$extension->shouldAutoRenderMainSubject() ) {
 			return;
 		}
 
 		$revisionId = self::pageIsLatestRevision( $out ) ? null : $out->getRevisionId();
-		$builder = NeoWikiExtension::getInstance()->newViewHtmlBuilder();
+		$builder = $extension->newViewHtmlBuilder();
 
 		$html = $out->getHTML();
 		$out->clearHTML();
@@ -100,12 +108,12 @@ class NeoWikiHooks {
 		);
 	}
 
-	private static function getNeoWikiAppHtml( OutputPage $out ): string {
+	private static function getNeoWikiAppHtml( OutputPage $out, SubjectPermissionHints $permissionHints ): string {
 		$attrs = [
 			'id' => 'ext-neowiki-app',
 		];
 
-		if ( self::shouldShowSubjectCreator( $out ) ) {
+		if ( self::shouldShowSubjectCreator( $out, $permissionHints ) ) {
 			$attrs['data-mw-neowiki-create-subject'] = 'true';
 			$attrs['data-mw-neowiki-page-has-main-subject'] =
 				NeoWikiExtension::getInstance()->newPageSubjectsLookup()
@@ -117,9 +125,8 @@ class NeoWikiHooks {
 		return Html::element( 'div', $attrs );
 	}
 
-	private static function shouldShowSubjectCreator( OutputPage $out ): bool {
-		return NeoWikiExtension::getInstance()->newSubjectPermissionHints( $out->getAuthority() )
-				->canCreateMainSubject( new PageId( $out->getTitle()->getArticleID() ) )
+	private static function shouldShowSubjectCreator( OutputPage $out, SubjectPermissionHints $permissionHints ): bool {
+		return $permissionHints->canCreateMainSubject( new PageId( $out->getTitle()->getArticleID() ) )
 			&& self::pageIsLatestRevision( $out );
 	}
 

--- a/src/Infrastructure/AuthorityBasedSubjectAuthorizer.php
+++ b/src/Infrastructure/AuthorityBasedSubjectAuthorizer.php
@@ -13,6 +13,9 @@ use ProfessionalWiki\NeoWiki\Domain\Page\PageId;
 
 class AuthorityBasedSubjectAuthorizer implements SubjectPermissionHints, SubjectWriteAuthorizer {
 
+	/** @var array<int, bool> */
+	private array $canEditPageById = [];
+
 	public function __construct(
 		private Authority $authority,
 		private TitleFactory $titleFactory
@@ -31,11 +34,22 @@ class AuthorityBasedSubjectAuthorizer implements SubjectPermissionHints, Subject
 		return $this->canEditPage( $pageId );
 	}
 
+	/**
+	 * One page view asks this several times over — the page tools, the Subject creator and the
+	 * frontend's permission hints all want the same answer — and each ask costs a page row plus the
+	 * permission hooks. The answer cannot change within a request, so it is kept. Writes never come
+	 * through here: authorize() asks afresh, against the primary database.
+	 */
 	private function canEditPage( PageId $pageId ): bool {
-		$title = $this->newTitle( $pageId );
+		if ( !array_key_exists( $pageId->id, $this->canEditPageById ) ) {
+			$title = $this->newTitle( $pageId );
 
-		// definitelyCan reads permissions from a replica and only peeks at the edit rate limit.
-		return $title !== null && $this->authority->definitelyCan( 'edit', $title );
+			// definitelyCan reads permissions from a replica and only peeks at the edit rate limit.
+			$this->canEditPageById[$pageId->id] = $title !== null
+				&& $this->authority->definitelyCan( 'edit', $title );
+		}
+
+		return $this->canEditPageById[$pageId->id];
 	}
 
 	public function authorize( PageId $pageId ): bool {

--- a/src/Presentation/FrontendModuleLoader.php
+++ b/src/Presentation/FrontendModuleLoader.php
@@ -33,4 +33,17 @@ class FrontendModuleLoader {
 		$out->addModules( $modules );
 	}
 
+	/**
+	 * Loads the frontend for a page that holds Subjects, telling it whether this viewer may edit
+	 * them. The frontend has only the wiki-global edit right to go on otherwise, so on a page the
+	 * viewer cannot edit it would offer writes the server then rejects.
+	 */
+	public function loadWithSubjectPermissions( OutputPage $out, Skin $skin, bool $canEditPageSubjects ): void {
+		$this->load( $out, $skin );
+
+		$out->addJsConfigVars( [
+			'wgNeoWikiCanEditPageSubjects' => $canEditPageSubjects,
+		] );
+	}
+
 }

--- a/tests/phpunit/EntryPoints/Actions/SubjectsActionTest.php
+++ b/tests/phpunit/EntryPoints/Actions/SubjectsActionTest.php
@@ -78,6 +78,26 @@ class SubjectsActionTest extends NeoWikiIntegrationTestCase {
 		);
 	}
 
+	public function testExposesThatTheViewerMayEditTheSubjects(): void {
+		$out = $this->runOnView( 'SubjectsActionTest editable', $this->getTestSysop()->getAuthority() );
+
+		$this->assertTrue( $out->getJsConfigVars()['wgNeoWikiCanEditPageSubjects'] );
+	}
+
+	public function testExposesThatAViewerWhoMayNotEditThePageMayNotEditItsSubjects(): void {
+		$pageId = $this->getExistingTestPage( 'SubjectsActionTest protected' )->getId();
+
+		$out = $this->runOnView(
+			'SubjectsActionTest protected',
+			$this->authorityThatCannotEditPageId( $pageId )
+		);
+
+		$this->assertFalse(
+			$out->getJsConfigVars()['wgNeoWikiCanEditPageSubjects'],
+			'The decision must be the one made for the page whose Subjects are managed.'
+		);
+	}
+
 	public function testExposesTheSubjectIriBaseAsConfigVar(): void {
 		$this->overrideConfigValue( 'NeoWikiRdfBaseUri', 'https://data.example.org' );
 		NeoWikiExtension::resetInstance();

--- a/tests/phpunit/EntryPoints/SubjectEditPermissionHintTest.php
+++ b/tests/phpunit/EntryPoints/SubjectEditPermissionHintTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\NeoWiki\Tests\EntryPoints;
+
+use MediaWiki\Context\RequestContext;
+use MediaWiki\Output\OutputPage;
+use MediaWiki\Permissions\Authority;
+use MediaWiki\Title\Title;
+use ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiHooks;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiIntegrationTestCase;
+use ProfessionalWiki\NeoWiki\Tests\NeoWikiMockAuthorityTrait;
+
+/**
+ * @covers \ProfessionalWiki\NeoWiki\EntryPoints\NeoWikiHooks::onBeforePageDisplay
+ * @group Database
+ */
+class SubjectEditPermissionHintTest extends NeoWikiIntegrationTestCase {
+
+	use NeoWikiMockAuthorityTrait;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->setUpNeo4j();
+	}
+
+	public function testTellsTheFrontendTheViewerMayEditThePagesSubjects(): void {
+		$title = $this->getExistingTestPage( 'SubjectEditPermissionHintTest editable' )->getTitle();
+
+		$out = $this->renderContentPage( $title, $this->getTestSysop()->getAuthority() );
+
+		$this->assertTrue( $out->getJsConfigVars()['wgNeoWikiCanEditPageSubjects'] );
+	}
+
+	public function testTellsTheFrontendAViewerWhoMayNotEditThePageMayNotEditItsSubjects(): void {
+		$title = $this->getExistingTestPage( 'SubjectEditPermissionHintTest protected' )->getTitle();
+
+		$out = $this->renderContentPage(
+			$title,
+			$this->authorityThatCannotEditPageId( $title->getArticleID() )
+		);
+
+		$this->assertFalse(
+			$out->getJsConfigVars()['wgNeoWikiCanEditPageSubjects'],
+			'The decision must be the one made for the page being viewed.'
+		);
+	}
+
+	public function testOffersTheSubjectCreatorOnlyToAViewerWhoMayEditThePage(): void {
+		$title = $this->getExistingTestPage( 'SubjectEditPermissionHintTest creator' )->getTitle();
+
+		$editable = $this->renderContentPage( $title, $this->getTestSysop()->getAuthority() );
+		$protected = $this->renderContentPage(
+			$title,
+			$this->authorityThatCannotEditPageId( $title->getArticleID() )
+		);
+
+		$this->assertStringContainsString( 'data-mw-neowiki-create-subject', $editable->getHTML() );
+		$this->assertStringNotContainsString( 'data-mw-neowiki-create-subject', $protected->getHTML() );
+	}
+
+	private function renderContentPage( Title $title, Authority $authority ): OutputPage {
+		$context = new RequestContext();
+		$context->setTitle( $title );
+		$context->setAuthority( $authority );
+
+		$out = $context->getOutput();
+		$out->setArticleFlag( true );
+		$out->setRevisionId( $title->getLatestRevID() );
+
+		NeoWikiHooks::onBeforePageDisplay( $out, $context->getSkin() );
+
+		return $out;
+	}
+
+}

--- a/tests/phpunit/Infrastructure/AuthorityBasedSubjectAuthorizerTest.php
+++ b/tests/phpunit/Infrastructure/AuthorityBasedSubjectAuthorizerTest.php
@@ -92,6 +92,35 @@ class AuthorityBasedSubjectAuthorizerTest extends MediaWikiIntegrationTestCase {
 		$this->assertTrue( $authorizer->canEditSubject( $pageId ) );
 	}
 
+	public function testAsksTheAuthorityOncePerPageHoweverManyHintsWantTheAnswer(): void {
+		$authority = $this->createMock( Authority::class );
+		$authority->expects( $this->once() )->method( 'definitelyCan' )->willReturn( true );
+
+		$authorizer = $this->newAuthorizer( $authority );
+		$pageId = new PageId( self::PAGE_ID );
+
+		$authorizer->canCreateMainSubject( $pageId );
+		$authorizer->canCreateChildSubject( $pageId );
+		$authorizer->canEditSubject( $pageId );
+	}
+
+	public function testAnswersPerPageRatherThanReusingTheFirstPagesAnswer(): void {
+		$titleFactory = $this->createStub( TitleFactory::class );
+		$titleFactory->method( 'newFromID' )->willReturnCallback(
+			static fn ( int $id ): Title => Title::makeTitle( NS_MAIN, 'Page ' . $id )
+		);
+
+		$authority = $this->createMock( Authority::class );
+		$authority->method( 'definitelyCan' )->willReturnCallback(
+			static fn ( string $permission, PageIdentity $page ): bool => $page->getDBkey() === 'Page_42'
+		);
+
+		$authorizer = new AuthorityBasedSubjectAuthorizer( $authority, $titleFactory );
+
+		$this->assertTrue( $authorizer->canEditSubject( new PageId( self::PAGE_ID ) ) );
+		$this->assertFalse( $authorizer->canEditSubject( new PageId( self::PAGE_ID + 1 ) ) );
+	}
+
 	private function newAuthorizer( Authority $authority ): AuthorityBasedSubjectAuthorizer {
 		return new AuthorityBasedSubjectAuthorizer( $authority, $this->titleFactoryReturningPage() );
 	}

--- a/tests/phpunit/Presentation/FrontendModuleLoaderTest.php
+++ b/tests/phpunit/Presentation/FrontendModuleLoaderTest.php
@@ -97,6 +97,42 @@ class FrontendModuleLoaderTest extends MediaWikiIntegrationTestCase {
 		$this->assertFalse( $this->addedJsConfigVars['wgNeoWikiEnforceValidation'] ?? null );
 	}
 
+	public function testEmitsThatTheViewerMayEditThePagesSubjects(): void {
+		$this->clearHook( 'NeoWikiGetFrontendModules' );
+
+		$this->newLoader()->loadWithSubjectPermissions(
+			$this->newCapturingOutputPage(),
+			$this->createMock( Skin::class ),
+			true
+		);
+
+		$this->assertTrue( $this->addedJsConfigVars['wgNeoWikiCanEditPageSubjects'] ?? null );
+	}
+
+	public function testEmitsThatTheViewerMayNotEditThePagesSubjects(): void {
+		$this->clearHook( 'NeoWikiGetFrontendModules' );
+
+		$this->newLoader()->loadWithSubjectPermissions(
+			$this->newCapturingOutputPage(),
+			$this->createMock( Skin::class ),
+			false
+		);
+
+		$this->assertFalse( $this->addedJsConfigVars['wgNeoWikiCanEditPageSubjects'] ?? null );
+	}
+
+	public function testLoadsTheFrontendModuleAlongsideThePermission(): void {
+		$this->clearHook( 'NeoWikiGetFrontendModules' );
+
+		$this->newLoader()->loadWithSubjectPermissions(
+			$this->newCapturingOutputPage(),
+			$this->createMock( Skin::class ),
+			true
+		);
+
+		$this->assertSame( [ 'ext.neowiki' ], $this->addedModules );
+	}
+
 	private function newLoader( int $validationDebounceMs = 300, bool $validationEnforced = false ): FrontendModuleLoader {
 		return new FrontendModuleLoader(
 			$this->getServiceContainer()->getHookContainer(),


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/NeoWiki/issues/1047

The frontend's Subject permission hints asked for the wiki-global `edit` right, while
the server authorizes every Subject write against the page holding the Subject. On a
page the viewer may not edit — page protection, a restricted namespace, an ACL
extension — the manage-subjects UI still offered Create, Edit, Move and Delete, and a
View still offered its edit button, each answered with a 403 once used. The page tools
beside them already read the page's own decision, so one page contradicted itself.

The page view and the subjects action now send that same decision as the
`wgNeoWikiCanEditPageSubjects` config var, and the hints answer from it for that page.
`wgIsProbablyEditable` was the cheaper option and is not equivalent: `probablyCan`
skips the blocks, cascading protection and expensive permission hooks that
restricted-content wikis rely on.

The hints are keyed by the page each write targets now, like their PHP namesake, which
also retires the dummy Subject ids the composable passed for the edit and delete hints.
A View asks about the page holding its own Subject rather than the page it appears on,
since a View can render a Subject from anywhere; the Subjects are loaded first so that
page is known. A Subject that carries no page, one from a read-only Source among them,
is no longer offered an edit button that could not work.

The decision is now read once per page per request rather than once per asker, which
takes the three reads an ordinary page view already did down to one.

Still advisory: the server remains the only authorization. A Subject hosted on some
other page keeps the wiki-global answer, because the wiki was asked about this page
only — so an edit offered on such a View can still be refused.

## Manual Browser Check

Log in as a user who is not an administrator
(`php maintenance/run.php createAndPromote HintTester <password>`), and protect a page
that has a Subject (`php maintenance/run.php protect "Acme Rocket" --reason=Testing`).

1. Open `Acme Rocket`. The infobox shows its values, with no edit button, and no
   "Create subject" appears on the page.
2. Open `Acme Rocket?action=subjects`. Export, Copy link, Copy subject ID and Copy
   subject IRI are offered; Create subject, Edit, Move to another page, Delete and the
   main-subject pin are not.
3. Open `Acme Anvil` and `Acme Anvil?action=subjects`. Every one of those controls is
   back — the change must not take them away.
4. Create a protected page holding `{{#view: <id of a Subject on Acme Anvil>}}`. Its
   edit button stays offered: the Subject's own page is editable, and the write would
   succeed.

## Test plan

- [x] `npx vitest run` (host): 2070 tests, 144 files, all passing
- [x] `vue-tsc -b`, `eslint`, `stylelint`: clean
- [x] `make cs` (phpcs + phpstan): no errors
- [x] PHPUnit `FrontendModuleLoaderTest`, `SubjectsActionTest`, `SubjectEditPermissionHintTest`,
      `AuthorityBasedSubjectAuthorizerTest`, `AutoRenderMainSubjectTest`, `RdfAutodiscoveryLinksTest`:
      44 tests passing
- [x] Every new test seen failing against master's production code; the read-once behaviour and
      the subject-creator gate each mutation-verified
- [x] Browser-verified on the dev wiki: the four cases above, before and after

Considered, omitted: hinting a View's Subject that lives on another page, which needs a
per-page answer the wiki was never asked for; making the rights fetch lazy, so a page view
that never consults the wiki-global fallback stops requesting it; folding the three
near-identical `renderContentPage` helpers under `tests/phpunit/EntryPoints/` into one.

<sub>AI-authored — Claude Code, `Opus 5 (1M context)`; Alistair directed the pickup of #1047 and the choice to send the server's decision rather than read `wgIsProbablyEditable`; verified with the full vitest suite, vue-tsc, eslint, stylelint, phpcs, phpstan and the PHPUnit classes listed above, all green, plus a before-and-after browser check on protected and cross-page demo pages.</sub>

